### PR TITLE
Fix ingestion issue

### DIFF
--- a/pkg/es/writer/esBulkHandler_test.go
+++ b/pkg/es/writer/esBulkHandler_test.go
@@ -100,7 +100,8 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 
 	flush := func() {
 		jsonBytes := []byte(`{"hello": "world"}`)
-		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), true, localIndexMap, orgId)
+		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), true, localIndexMap, orgId)
+		assert.Nil(t, err)
 	}
 
 	config.InitializeTestingConfig()
@@ -117,7 +118,8 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	}
 
 	for _, jsonBytes := range jsons {
-		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+		assert.Nil(t, err)
 	}
 	flush()
 
@@ -135,7 +137,8 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	}
 
 	for _, jsonBytes := range jsons {
-		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+		assert.Nil(t, err)
 	}
 	flush()
 

--- a/pkg/es/writer/esBulkHandler_test.go
+++ b/pkg/es/writer/esBulkHandler_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/siglens/siglens/pkg/config"
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	segwriter "github.com/siglens/siglens/pkg/segment/writer"
+	"github.com/siglens/siglens/pkg/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -85,6 +86,61 @@ func Test_ProcessDeleteIndex(t *testing.T) {
 	}
 
 	os.RemoveAll(dataPath)
+}
+
+// Test ingesting multiple types of values into one column.
+// Currently the only test is that it doesn't crash.
+func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
+	// Setup ingestion parameters.
+	now := utils.GetCurrentTimeInMs()
+	indexName := "traces"
+	shouldFlush := false
+	localIndexMap := make(map[string]string)
+	orgId := uint64(0)
+
+	flush := func() {
+		jsonBytes := []byte(`{"hello": "world"}`)
+		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), true, localIndexMap, orgId)
+	}
+
+	config.InitializeTestingConfig()
+	_ = vtable.InitVTable()
+
+	// Ingest some data that can all be converted to numbers.
+	jsons := [][]byte{
+		[]byte(`{"age": "171"}`),
+		[]byte(`{"age": 103}`),
+		[]byte(`{"age": 5.123}`),
+		[]byte(`{"age": "181"}`),
+		[]byte(`{"age": 30}`),
+		[]byte(`{"age": 6.321}`),
+	}
+
+	for _, jsonBytes := range jsons {
+		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+	}
+	flush()
+
+	// Ingest some data that will need to be converted to strings.
+	jsons = [][]byte{
+		[]byte(`{"age": "171"}`),
+		[]byte(`{"age": 103}`),
+		[]byte(`{"age": 5.123}`),
+		[]byte(`{"age": true}`),
+		[]byte(`{"age": "181"}`),
+		[]byte(`{"age": 30}`),
+		[]byte(`{"age": 6.321}`),
+		[]byte(`{"age": false}`),
+		[]byte(`{"age": "hello"}`),
+	}
+
+	for _, jsonBytes := range jsons {
+		ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId)
+	}
+	flush()
+
+	// Cleanup
+	os.RemoveAll(config.GetDataPath())
 }
 
 func setupData(t *testing.T, numberOfSegments int, indexName string) {

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -277,23 +277,17 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte, maxIdx u
 	}
 	var finalErr error
 	var colWip *ColWip
-	var recNum uint16
-	colWip, recNum, matchedCol = ss.initAndBackFillColumn(arraykey, data, matchedCol)
+	colWip, _, matchedCol = ss.initAndBackFillColumn(arraykey, data, matchedCol)
 	colBlooms := ss.wipBlock.columnBlooms
 	var bi *BloomIndex
 	var ok bool
 	bi, ok = colBlooms[arraykey]
 	if !ok {
-		// init bloom since this is the first record in this WIP
-		if recNum == 0 {
-			bi = &BloomIndex{}
-			bi.uniqueWordCount = 0
-			bCount := getBlockBloomSize(bi)
-			bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
-			colBlooms[arraykey] = bi
-		} else {
-			log.Errorf("encodeSingleDictArray: key=%v did not have bi initialized", arraykey)
-		}
+		bi = &BloomIndex{}
+		bi.uniqueWordCount = 0
+		bCount := getBlockBloomSize(bi)
+		bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
+		colBlooms[arraykey] = bi
 	}
 	s := colWip.cbufidx
 	copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_DICT_ARRAY[:])
@@ -409,24 +403,18 @@ func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte, maxIdx uint3
 		return maxIdx, matchedCol, nil
 	}
 	var colWip *ColWip
-	var recNum uint16
-	colWip, recNum, matchedCol = ss.initAndBackFillColumn(key, value, matchedCol)
+	colWip, _, matchedCol = ss.initAndBackFillColumn(key, value, matchedCol)
 	colBlooms := ss.wipBlock.columnBlooms
 	var bi *BloomIndex
 	var ok bool
 	if key != "_type" && key != "_index" && key != "tags" {
 		_, ok = colBlooms[key]
 		if !ok {
-			// init bloom since this is the first record in this WIP
-			if recNum == 0 {
-				bi = &BloomIndex{}
-				bi.uniqueWordCount = 0
-				bCount := getBlockBloomSize(bi)
-				bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
-				colBlooms[key] = bi
-			} else {
-				log.Errorf("EncodeColumns: key=%v did not have bi initialized", key)
-			}
+			bi = &BloomIndex{}
+			bi.uniqueWordCount = 0
+			bCount := getBlockBloomSize(bi)
+			bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
+			colBlooms[key] = bi
 		}
 	}
 	//[utils.VALTYPE_RAW_JSON][raw-byte-len][raw-byte]
@@ -458,16 +446,11 @@ func (ss *SegStore) encodeSingleString(key string, value string, maxIdx uint32,
 	if key != "_type" && key != "_index" {
 		bi, ok = colBlooms[key]
 		if !ok {
-			// init bloom since this is the first record in this WIP
-			if recNum == 0 {
-				bi = &BloomIndex{}
-				bi.uniqueWordCount = 0
-				bCount := getBlockBloomSize(bi)
-				bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
-				colBlooms[key] = bi
-			} else {
-				log.Errorf("EncodeColumns: key=%v did not have bi initialized", key)
-			}
+			bi = &BloomIndex{}
+			bi.uniqueWordCount = 0
+			bCount := getBlockBloomSize(bi)
+			bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
+			colBlooms[key] = bi
 		}
 	}
 	s := colWip.cbufidx
@@ -497,23 +480,18 @@ func (ss *SegStore) encodeSingleBool(key string, val bool, maxIdx uint32,
 		return maxIdx, matchedCol, nil
 	}
 	var colWip *ColWip
-	var recNum uint16
 	colBlooms := ss.wipBlock.columnBlooms
-	colWip, recNum, matchedCol = ss.initAndBackFillColumn(key, val, matchedCol)
+	colWip, _, matchedCol = ss.initAndBackFillColumn(key, val, matchedCol)
 	var bi *BloomIndex
 	var ok bool
 
 	bi, ok = colBlooms[key]
 	if !ok {
-		if recNum == 0 {
-			bi = &BloomIndex{}
-			bi.uniqueWordCount = 0
-			bCount := 10
-			bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
-			colBlooms[key] = bi
-		} else {
-			log.Errorf("EncodeColumns: key=%v did not have bi initialized", key)
-		}
+		bi = &BloomIndex{}
+		bi.uniqueWordCount = 0
+		bCount := 10
+		bi.Bf = bloom.NewWithEstimates(uint(bCount), BLOOM_COLL_PROBABILITY)
+		colBlooms[key] = bi
 	}
 	copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_ENC_BOOL[:])
 	colWip.cbufidx += 1
@@ -640,13 +618,9 @@ func encSingleNumber(key string, val interface{}, wipbuf []byte, idx uint32,
 
 	ri, ok := colRis[key]
 	if !ok {
-		if wRecNum == 0 {
-			ri = &RangeIndex{}
-			ri.Ranges = make(map[string]*Numbers, BLOCK_RI_MAP_SIZE)
-			colRis[key] = ri
-		} else {
-			log.Errorf("EncodeColumns: key=%v did not have ri initialized", key)
-		}
+		ri = &RangeIndex{}
+		ri.Ranges = make(map[string]*Numbers, BLOCK_RI_MAP_SIZE)
+		colRis[key] = ri
 	}
 
 	switch cval := val.(type) {

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -454,13 +454,8 @@ func (ss *SegStore) encodeSingleString(key string, value string, maxIdx uint32,
 		}
 	}
 	s := colWip.cbufidx
-	copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_ENC_SMALL_STRING[:])
-	colWip.cbufidx += 1
-	n := uint16(len(value))
-	copy(colWip.cbuf[colWip.cbufidx:], utils.Uint16ToBytesLittleEndian(n))
-	colWip.cbufidx += 2
-	copy(colWip.cbuf[colWip.cbufidx:], value)
-	colWip.cbufidx += uint32(n)
+	colWip.WriteSingleString(value)
+
 	if bi != nil {
 		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(value))
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -220,7 +221,157 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 	return nil
 }
 
+// For some types we use a bloom index and for others we use range indices. If
+// a column has both, we should convert all the values to one type.
+func consolidateColumnTypes(wipBlock *WipBlock) {
+	for colName := range wipBlock.columnsInBlock {
+		// Check if this column has both a bloom and a range index.
+		_, ok1 := wipBlock.columnBlooms[colName]
+		_, ok2 := wipBlock.columnRangeIndexes[colName]
+		if !(ok1 && ok2) {
+			continue
+		}
+
+		// Try converting this column to numbers, but if that fails convert it to
+		// strings.
+		ok := convertColumnToNumbers(wipBlock, colName)
+		if !ok {
+			convertColumnToStrings(wipBlock, colName)
+		}
+	}
+}
+
+// Returns true if the conversion succeeds.
+func convertColumnToNumbers(wipBlock *WipBlock, colName string) bool {
+	// Try converting all values to numbers.
+	oldColWip := wipBlock.colWips[colName]
+	newColWip := ColWip{
+		csgFname: wipBlock.colWips[colName].csgFname,
+		deMap:    wipBlock.colWips[colName].deMap,
+		deCount:  wipBlock.colWips[colName].deCount,
+	}
+	cbuf := oldColWip.cbuf
+
+	for i := uint32(0); i < oldColWip.cbufidx; {
+		valType := cbuf[i]
+		i++
+
+		switch valType {
+		case utils.VALTYPE_ENC_SMALL_STRING[0]:
+			// Parse the string.
+			numBytes := uint32(toputils.BytesToUint16LittleEndian(cbuf[i : i+2]))
+			i += 2
+			numberAsString := string(cbuf[i : i+numBytes])
+			i += numBytes
+
+			// Try converting to an integer.
+			intVal, err := strconv.ParseInt(numberAsString, 10, 64)
+			if err == nil {
+				// Conversion succeeded.
+				copy(newColWip.cbuf[newColWip.cbufidx:], utils.VALTYPE_ENC_INT64[:])
+				copy(newColWip.cbuf[newColWip.cbufidx+1:], toputils.Int64ToBytesLittleEndian(intVal))
+				newColWip.cbufidx += 1 + 8
+				continue
+			}
+
+			// Try converting to a float.
+			floatVal, err := strconv.ParseFloat(numberAsString, 64)
+			if err == nil {
+				// Conversion succeeded.
+				copy(newColWip.cbuf[newColWip.cbufidx:], utils.VALTYPE_ENC_FLOAT64[:])
+				copy(newColWip.cbuf[newColWip.cbufidx+1:], toputils.Float64ToBytesLittleEndian(floatVal))
+				newColWip.cbufidx += 1 + 8
+				continue
+			}
+
+			// Conversion failed.
+			return false
+		case utils.VALTYPE_ENC_INT64[0], utils.VALTYPE_ENC_FLOAT64[0]:
+			// Already a number, so just copy it.
+			copy(newColWip.cbuf[newColWip.cbufidx:], cbuf[i-1:i+8])
+			newColWip.cbufidx += 9
+			i += 8
+		case utils.VALTYPE_ENC_BOOL[0]:
+			// Cannot convert bool to number.
+			return false
+		default:
+			// Unknown type.
+			log.Errorf("convertColumnToNumbers: unknown type %v", valType)
+			return false
+		}
+	}
+
+	// Conversion succeeded, so replace the column with the new one.
+	wipBlock.colWips[colName] = &newColWip
+	delete(wipBlock.columnBlooms, colName)
+	return true
+}
+
+func convertColumnToStrings(wipBlock *WipBlock, colName string) {
+	oldColWip := wipBlock.colWips[colName]
+	newColWip := ColWip{
+		csgFname: oldColWip.csgFname,
+		deMap:    oldColWip.deMap,
+		deCount:  oldColWip.deCount,
+	}
+	cbuf := oldColWip.cbuf
+
+	for i := uint32(0); i < oldColWip.cbufidx; {
+		valType := cbuf[i]
+		i++
+
+		switch valType {
+		case utils.VALTYPE_ENC_SMALL_STRING[0]:
+			// Already a small string, so just copy it over.
+			numBytes := uint32(toputils.BytesToUint16LittleEndian(cbuf[i : i+2]))
+			i += 2
+			copy(newColWip.cbuf[newColWip.cbufidx:], cbuf[i-3:i+numBytes])
+			newColWip.cbufidx += 3 + numBytes
+			i += numBytes
+
+		case utils.VALTYPE_ENC_INT64[0]:
+			// Parse the integer.
+			intVal := toputils.BytesToInt64LittleEndian(cbuf[i : i+8])
+			i += 8
+
+			stringVal := strconv.FormatInt(intVal, 10)
+			newColWip.WriteSingleString(stringVal)
+
+		case utils.VALTYPE_ENC_FLOAT64[0]:
+			// Parse the float.
+			floatVal := toputils.BytesToFloat64LittleEndian(cbuf[i : i+8])
+			i += 8
+
+			stringVal := strconv.FormatFloat(floatVal, 'f', -1, 64)
+			newColWip.WriteSingleString(stringVal)
+
+		case utils.VALTYPE_ENC_BOOL[0]:
+			// Parse the bool.
+			boolVal := cbuf[i]
+			i++
+
+			if boolVal == 0 {
+				newColWip.WriteSingleString("false")
+			} else {
+				newColWip.WriteSingleString("true")
+			}
+
+		default:
+			// Unknown type.
+			log.Errorf("convertColumnsToStrings: unknown type %v when converting column %v", valType, colName)
+		}
+	}
+
+	// Replace the old column.
+	wipBlock.colWips[colName] = &newColWip
+	delete(wipBlock.columnRangeIndexes, colName)
+}
+
 func (segstore *SegStore) appendWipToSegfile(streamid string, forceRotate bool, isKibana bool, onTimeRotate bool) error {
+	// If there's columns that had both strings and numbers in them, we need to
+	// try converting them all to numbers, but if that doesn't work we'll
+	// convert them all to strings.
+	consolidateColumnTypes(&segstore.wipBlock)
 
 	if segstore.wipBlock.maxIdx > 0 {
 		var totalBytesWritten uint64 = 0

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -294,10 +294,8 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 
 		case utils.VALTYPE_ENC_BACKFILL[0]:
 			// This is a null value.
-			copy(newColWip.cbuf[newColWip.cbufidx:], utils.VALTYPE_ENC_INT64[:])
-			copy(newColWip.cbuf[newColWip.cbufidx+1:], toputils.Int64ToBytesLittleEndian(0))
-			newColWip.cbufidx += 1 + 8
-			addIntToRangeIndex(colName, 0, rangeIndex)
+			copy(newColWip.cbuf[newColWip.cbufidx:], utils.VALTYPE_ENC_BACKFILL[:])
+			newColWip.cbufidx += 1
 
 		case utils.VALTYPE_ENC_BOOL[0]:
 			// Cannot convert bool to number.
@@ -355,8 +353,8 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 
 		case utils.VALTYPE_ENC_BACKFILL[0]:
 			// This is a null value.
-			newColWip.WriteSingleString("")
-			bloom.uniqueWordCount += addToBlockBloom(bloom.Bf, []byte(""))
+			copy(newColWip.cbuf[newColWip.cbufidx:], utils.VALTYPE_ENC_BACKFILL[:])
+			newColWip.cbufidx += 1
 
 		case utils.VALTYPE_ENC_BOOL[0]:
 			// Parse the bool.

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -898,6 +898,16 @@ func (cw *ColWip) SetDeMap(val map[string][]uint16) {
 	cw.deMap = val
 }
 
+func (cw *ColWip) WriteSingleString(value string) {
+	copy(cw.cbuf[cw.cbufidx:], VALTYPE_ENC_SMALL_STRING[:])
+	cw.cbufidx += 1
+	n := uint16(len(value))
+	copy(cw.cbuf[cw.cbufidx:], utils.Uint16ToBytesLittleEndian(n))
+	cw.cbufidx += 2
+	copy(cw.cbuf[cw.cbufidx:], value)
+	cw.cbufidx += uint32(n)
+}
+
 func AddNewRotatedSegment(segmeta structs.SegMeta) {
 
 	smrLock.Lock()


### PR DESCRIPTION
This fixes an issue where siglens would crash when a single block had a column where both string and numeric values were being ingested. In particular, this caused siglens to crash when ingesting example traces when following the instructions in #38 but now you can follow those instructions to ingest example traces and siglens handles it properly.

Now when records are being added to a block, different records can have a string or numeric value for the same column. When the block is flushed, we try to convert all those values to numbers but if any of those conversions fail we abort and instead convert all the values to strings.