### PR TITLE
Add PR and issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,20 +7,20 @@ assignees: ''
 
 ---
 
-**Description**
+# Description
 Clearly describe the bug and how to reproduce it. If applicable, include screenshots.
 
-**Steps to Reproduce**
+# Steps to Reproduce
 Give detailed step-by-step instructions to help us easily reproduce the issue.
 1. ...
 
-**Expected Behavior**
+# Expected Behavior
 Clearly describe what you expect to happen.
 
-**Environment**
+# Environment
 - Commit Hash: [e.g. 9ed5f0a]
 - OS: [e.g. MacOS 14.1.1 on apple silicon]
 - Browser and Version (if applicable): [e.g. chrome 119.0.6045.159 arm64, safari 19616.2.9.11.7]
 
-**(Optional) Additional Context**
+# (Optional) Additional Context
 Add anything else we should know about this problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a bug that we should fix
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Description**
+Clearly describe the bug and how to reproduce it. If applicable, include screenshots.
+
+**Steps to Reproduce**
+Give detailed step-by-step instructions to help us easily reproduce the issue.
+1. ...
+
+**Expected Behavior**
+Clearly describe what you expect to happen.
+
+**Environment**
+- Commit Hash: [e.g. 9ed5f0a]
+- OS: [e.g. MacOS 14.1.1 on apple silicon]
+- Browser and Version (if applicable): [e.g. chrome 119.0.6045.159 arm64, safari 19616.2.9.11.7]
+
+**(Optional) Additional Context**
+Add anything else we should know about this problem.

--- a/.github/ISSUE_TEMPLATE/new_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.md
@@ -1,0 +1,20 @@
+---
+name: New feature request
+about: Tell us about a feature you want us to add
+title: "[NEW] "
+labels: enhancement
+assignees: ''
+
+---
+
+**Description**
+Clearly describe the feature you want in as much detail as you can give. Include screenshots if appropriate.
+
+**Benefits**
+Describe why you want this feature.
+
+**(Optional) Possible Implementation**
+If you have any ideas on how this should be implemented, let us know here.
+
+**(Optional) Additional Context**
+Add anything else we should know about this.

--- a/.github/ISSUE_TEMPLATE/new_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.md
@@ -7,14 +7,14 @@ assignees: ''
 
 ---
 
-**Description**
+# Description
 Clearly describe the feature you want in as much detail as you can give. Include screenshots if appropriate.
 
-**Benefits**
+# Benefits
 Describe why you want this feature.
 
-**(Optional) Possible Implementation**
+# (Optional) Possible Implementation
 If you have any ideas on how this should be implemented, let us know here.
 
-**(Optional) Additional Context**
+# (Optional) Additional Context
 Add anything else we should know about this.

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,19 @@
+---
+name: Story
+about: Describe in detail how to implement a task.
+title: "[STORY] "
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+Clearly describe the task. Break it down as much as you can so it's easier to implement. Link to existing issues if appropriate using #<issue-number>.
+
+**(Optional) Testing**
+Describe how this should be tested and/or which files unit tests should be added to.
+
+For documentation changes or other similar scenarios, this section can be deleted.
+
+**Acceptance Criteria**
+List the concrete items that should be completed for this task to be considered completed. Be as clear and thorough as you can.

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,19 +1,19 @@
 ---
 name: Story
-about: Describe in detail how to implement a task.
+about: Describe in detail how to implement a task
 title: "[STORY] "
 labels: ''
 assignees: ''
 
 ---
 
-**Description**
+# Description
 Clearly describe the task. Break it down as much as you can so it's easier to implement. Link to existing issues if appropriate using #<issue-number>.
 
-**(Optional) Testing**
+# (Optional) Testing
 Describe how this should be tested and/or which files unit tests should be added to.
 
 For documentation changes or other similar scenarios, this section can be deleted.
 
-**Acceptance Criteria**
+# Acceptance Criteria
 List the concrete items that should be completed for this task to be considered completed. Be as clear and thorough as you can.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+Summarize the change.
+
+Use `Fixes #<issue-number>` to link all the GitHub issues this addresses.
+
+# Testing
+Describe how you tested this code. How can the reviewers reproduce your tests?
+
+# Checklist:
+Before marking your pull request as ready for review, complete the following.
+
+- [ ] I have self-reviewed this PR.
+- [ ] I have removed all print-debugging and commented-out code that should not be merged.
+- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
+- [ ] I have formatted the code with `goimports -w .`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Before marking your pull request as ready for review, complete the following.
 - [ ] I have self-reviewed this PR.
 - [ ] I have removed all print-debugging and commented-out code that should not be merged.
 - [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
-- [ ] I have formatted the code with `goimports -w .`.
+- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 # Description
 Summarize the change.
 
-Use `Fixes #<issue-number>` to link all the GitHub issues this addresses.
+Fixes #<issue-number> (link all the GitHub issues this addresses)
 
 # Testing
 Describe how you tested this code. How can the reviewers reproduce your tests?
@@ -12,4 +12,4 @@ Before marking your pull request as ready for review, complete the following.
 - [ ] I have self-reviewed this PR.
 - [ ] I have removed all print-debugging and commented-out code that should not be merged.
 - [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
-- [ ] I have formatted the code with `goimports -w .`
+- [ ] I have formatted the code with `goimports -w .`.


### PR DESCRIPTION
This adds templates for PRs and issues. For issues, you can either create a blank issue or use a template for a
* bug report
* feature request
* story describing how to implement a task