### PR TITLE
Fixed README.me link for sigscalr-client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ In another terminal, start the ingestion via `sigscalr-client` by running:
 go run main.go ingest esbulk -t 10_000 -d http://localhost:8081/elastic --processCount 1 -n 1 -b 500 -g dynamic-user
 ```
 
-Look through the [sigscalr-client ReadMe](https://github.com/sigscalr/sigscalr-client/README.md) to see all command arguments.
+Look through the [sigscalr-client ReadMe](https://github.com/sigscalr/sigscalr-client/blob/main/README.md) to see all command arguments.
 
 
 ### Send Queries on Siglens


### PR DESCRIPTION
# Description
In [CONTRIBUTING.md](https://github.com/siglens/siglens/blob/main/CONTRIBUTING.md?plain=1#L99):
The link to README.md of sigscalr-client is broken

Fixes #109 

# Testing
Checked link re-direction.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
