### PR TITLE
Fix AgileAggs bug

### DIFF
--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -369,7 +369,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 			}
 			kidx += 4
 		}
-		wvNodeKey := toputils.ByteSliceToString(wvBuf[:kidx])
+		wvNodeKey := string(wvBuf[:kidx])
 		idx += uint32(desiredLevel-1) * 4
 
 		aggVal, ok := combiner[wvNodeKey]


### PR DESCRIPTION
# Description
This fixes a bug in the AgileAggs tree, which was leading to incorrect results being returned. The tested query was the SQL query
```
SELECT passenger_count, avg(total_amount) FROM trips GROUP BY passenger_count
```

We were doing an explicitly unsafe conversion from []byte to string to avoid copying, but this caused some memory issues. In particular, the `combiner` map thought it had a certain string as a key when in fact it did not, because after we added that string as a key we changed the string's data; the map apparently does not handle this, as strings in Go are supposed to immutable.

# Testing
I've only done manual testing so far. We should add unit tests to make sure we don't run into this bug in the future. For manual testing, I followed this procedure:
1. Add `agileAggsEnabled: true` to `server.yaml`
2. Start siglens
3. Setup PQS by running:
```
curl -X POST -d '{
    "tableName": "benchmark",
    "groupByColumns": ["passenger_count"],
    "measureColumns": ["total_amount"]
}' http://localhost/api/pqs/aggs
```
4. Ingest some data. I ingested these rows:
```
{"cab_type":"yellow","dropoff":null,"dropoff_borocode":1,"dropoff_boroct2010":1010100,"dropoff_cdeligibil":"I","dropoff_ct2010":"Manhattan","dropoff_ctlabel":101,"dropoff_date":"2015-07-07","dropoff_datetime":"2015-07-07 20:05:24","dropoff_latitude":40.749141693115234,"dropoff_longitude":-73.99234008789062,"dropoff_ntacode":null,"dropoff_ntaname":"Midtown-Midtown South","dropoff_nyct2010_gid":131,"dropoff_puma":3807,"ehail_fee":0,"extra":1,"fare_amount":14.5,"improvement_surcharge":0.3,"mta_tax":0.5,"passenger_count":2,"payment_type":"CSH","pickup":null,"pickup_borocode":1,"pickup_boroct2010":1010602,"pickup_cdeligibil":"I","pickup_ct2010":"Manhattan","pickup_ctlabel":106.02,"pickup_date":"2015-07-07","pickup_datetime":"2015-07-07 19:45:07","pickup_latitude":40.75904846191406,"pickup_longitude":-73.95954895019531,"pickup_ntacode":null,"pickup_ntaname":"Lenox Hill-Roosevelt Island","pickup_nyct2010_gid":-36,"pickup_puma":3805,"rate_code_id":1,"store_and_fwd_flag":0,"tip_amount":3.26,"tolls_amount":0,"total_amount":19.56,"trip_distance":2.59,"trip_id":1199999902,"trip_type":0,"vendor_id":2}
{"cab_type":"yellow","dropoff":null,"dropoff_borocode":4,"dropoff_boroct2010":4030600,"dropoff_cdeligibil":"I","dropoff_ct2010":"Queens","dropoff_ctlabel":306,"dropoff_date":"2015-07-07","dropoff_datetime":"2015-07-07 20:33:21","dropoff_latitude":40.666263580322266,"dropoff_longitude":-73.78457641601562,"dropoff_ntacode":null,"dropoff_ntaname":"Springfield Gardens South-Brookville","dropoff_nyct2010_gid":7,"dropoff_puma":4105,"ehail_fee":0,"extra":0.5,"fare_amount":9,"improvement_surcharge":0.3,"mta_tax":0.5,"passenger_count":1,"payment_type":"CRE","pickup":null,"pickup_borocode":4,"pickup_boroct2010":4071600,"pickup_cdeligibil":"I","pickup_ct2010":"Queens","pickup_ctlabel":716,"pickup_date":"2015-07-07","pickup_datetime":"2015-07-07 20:26:29","pickup_latitude":40.644710540771484,"pickup_longitude":-73.78194427490234,"pickup_ntacode":null,"pickup_ntaname":"Airport","pickup_nyct2010_gid":8,"pickup_puma":4105,"rate_code_id":1,"store_and_fwd_flag":0,"tip_amount":0,"tolls_amount":0,"total_amount":10.3,"trip_distance":2.4,"trip_id":1199999919,"trip_type":0,"vendor_id":1}
{"cab_type":"yellow","dropoff":null,"dropoff_borocode":4,"dropoff_boroct2010":4030600,"dropoff_cdeligibil":"I","dropoff_ct2010":"Queens","dropoff_ctlabel":306,"dropoff_date":"2015-07-07","dropoff_datetime":"2015-07-07 20:33:21","dropoff_latitude":40.666263580322266,"dropoff_longitude":-73.78457641601562,"dropoff_ntacode":null,"dropoff_ntaname":"Springfield Gardens South-Brookville","dropoff_nyct2010_gid":7,"dropoff_puma":4105,"ehail_fee":0,"extra":0.5,"fare_amount":9,"improvement_surcharge":0.3,"mta_tax":0.5,"passenger_count":1,"payment_type":"CRE","pickup":null,"pickup_borocode":4,"pickup_boroct2010":4071600,"pickup_cdeligibil":"I","pickup_ct2010":"Queens","pickup_ctlabel":716,"pickup_date":"2015-07-07","pickup_datetime":"2015-07-07 20:26:29","pickup_latitude":40.644710540771484,"pickup_longitude":-73.78194427490234,"pickup_ntacode":null,"pickup_ntaname":"Airport","pickup_nyct2010_gid":8,"pickup_puma":4105,"rate_code_id":1,"store_and_fwd_flag":0,"tip_amount":0,"tolls_amount":0,"total_amount":20.7,"trip_distance":2.4,"trip_id":1199999919,"trip_type":0,"vendor_id":1}
{"cab_type":"yellow","dropoff":null,"dropoff_borocode":4,"dropoff_boroct2010":4030600,"dropoff_cdeligibil":"I","dropoff_ct2010":"Queens","dropoff_ctlabel":306,"dropoff_date":"2015-07-07","dropoff_datetime":"2015-07-07 20:33:21","dropoff_latitude":40.666263580322266,"dropoff_longitude":-73.78457641601562,"dropoff_ntacode":null,"dropoff_ntaname":"Springfield Gardens South-Brookville","dropoff_nyct2010_gid":7,"dropoff_puma":4105,"ehail_fee":0,"extra":0.5,"fare_amount":9,"improvement_surcharge":0.3,"mta_tax":0.5,"passenger_count":4,"payment_type":"CRE","pickup":null,"pickup_borocode":4,"pickup_boroct2010":4071600,"pickup_cdeligibil":"I","pickup_ct2010":"Queens","pickup_ctlabel":716,"pickup_date":"2015-07-07","pickup_datetime":"2015-07-07 20:26:29","pickup_latitude":40.644710540771484,"pickup_longitude":-73.78194427490234,"pickup_ntacode":null,"pickup_ntaname":"Airport","pickup_nyct2010_gid":8,"pickup_puma":4105,"rate_code_id":1,"store_and_fwd_flag":0,"tip_amount":0,"tolls_amount":0,"total_amount":42.5,"trip_distance":2.4,"trip_id":1199999919,"trip_type":0,"vendor_id":1}
```
5. Restart siglens to make sure the data gets flushed.
6. Query siglens with:
```
curl -X POST -d '{
    "searchText": "SELECT passenger_count, avg(total_amount) FROM trips GROUP BY passenger_count",
    "index": "benchmark",
    "startEpoch": "now-24h",
    "endEpoch": "now",
    "queryLanguage": "SQL"
}' http://localhost/api/search | python -m json.tool
```

Without this fix, when I ran that query I was incorrectly getting just one bucket in the results, giving the average `total_amount` for all the records. With this change I correctly get three buckets, each giving the average `total_results` for that specific `passenger_count` value

This happened because in lines 375-379:
```
aggVal, ok := combiner[wvNodeKey]
if !ok {
    aggVal = make([]utils.NumTypeEnclosure, lenMri)
    combiner[wvNodeKey] = aggVal
}
```
we were making `wvNodeKey` in an unsafe way, so even though its content was changing, the statement `aggVal, ok := combiner[wvNodeKey]` was giving `ok` as `true` even when that value of `wvNodeKey` was not in the map. So then we were incorrectly overwriting values in the map instead of inserting values into the map.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
