### PR TITLE
Fix Dockerfile not seeing server.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN useradd -m -u $UID -g $GID -o $UNAME
 
 WORKDIR /$UNAME
 COPY static static
+COPY server.yaml .
 
 RUN chown -R $UNAME:$GID static
 RUN chown -R $UNAME:$GID /siglens


### PR DESCRIPTION
# Description
When I run siglens in docker, it doesn't see the `server.yaml` file unless I add this line to the Dockerfile

# Testing
```
cd /path/to/siglens
docker build -t siglens-image .
docker run -p 80:80 -p 8081:8081 --name siglens-container siglens-image
```
(only tested on mac)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
