### PR TITLE
Fix issue serving queries with multiple GroupBys from AgileAggs

### DIFF
--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -148,8 +148,6 @@ func (str *AgileTreeReader) ReadTreeMeta() error {
 	lenMeta := toputils.BytesToUint32LittleEndian(str.metaBuf[idx : idx+4])
 	idx += 4
 
-	//	log.Infof("kunal ReadTreeMeta: metaBytesLen: %v", lenMeta)
-
 	// MetaData
 	meta, err := str.decodeMetadata(str.metaBuf[idx : idx+lenMeta])
 	if err != nil {
@@ -166,8 +164,6 @@ func (str *AgileTreeReader) ReadTreeMeta() error {
 		meta.levsSizes[i] = toputils.BytesToUint32LittleEndian(str.metaBuf[idx : idx+4])
 		idx += 4
 	}
-
-	//	log.Infof("kunal ReadTreeMeta: levsOffsets: %v, levsSizes: %v", meta.levsOffsets, meta.levsSizes)
 
 	str.treeMeta = meta
 	str.isMetaLoaded = true
@@ -408,7 +404,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 		}
 		idx += uint32(numAggValues) * 9
 	}
-	//		log.Infof("kunal decodeNodeDetailsJit: combiner: %+v", combiner)
+
 	return nil
 }
 
@@ -459,9 +455,6 @@ func (str *AgileTreeReader) ApplyGroupByJit(grpColNames []string,
 		measResIndices = append(measResIndices, tcidx*writer.TotalMeasFns+fnidx) // see where it is in agileTree
 	}
 
-	//	log.Infof("kunal ApplyGroupByJit: measResIndices: %v, internalMops: %v, maxGrpLevel: %v",
-	//		measResIndices, internalMops, maxGrpLevel)
-
 	combiner := make(map[string][]utils.NumTypeEnclosure)
 
 	err := str.computeAggsJit(combiner, maxGrpLevel, measResIndices, agileTreeBuf, grpTreeLevels)
@@ -470,7 +463,6 @@ func (str *AgileTreeReader) ApplyGroupByJit(grpColNames []string,
 		return err
 	}
 
-	//	log.Infof("qid=%v, ApplyGroupByJit, numGrpKeys: %v", qid, len(combiner))
 	for mkey, ntAgvals := range combiner {
 		if len(ntAgvals) == 0 {
 			continue

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -63,6 +63,7 @@ var one = utils.CValueEnclosure{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(1)
 
 type Node struct {
 	myKey     uint32
+	parent    *Node
 	children  map[uint32]*Node
 	aggValues []utils.CValueEnclosure
 }
@@ -168,6 +169,7 @@ func (stb *StarTreeBuilder) setColValEnc(colNum int, colVal string) uint32 {
 func (stb *StarTreeBuilder) resetNodeData(wip *WipBlock) {
 
 	for _, node := range stb.nodePool {
+		node.parent = nil
 		for k := range node.children {
 			delete(node.children, k)
 		}
@@ -246,12 +248,12 @@ func (stb *StarTreeBuilder) Aggregate(cur *Node) error {
 	return nil
 }
 
-func (stb *StarTreeBuilder) insertIntoTree(node *Node, colVals []uint32, recNum uint16,
-	idx uint) *Node {
+func (stb *StarTreeBuilder) insertIntoTree(node *Node, colVals []uint32, recNum uint16, idx uint) *Node {
 	child, keyExists := node.children[colVals[idx]]
 	if !keyExists {
 		child = stb.newNode()
 		child.myKey = colVals[idx]
+		child.parent = node
 		node.children[colVals[idx]] = child
 	}
 

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -179,10 +179,20 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 		idx += 4
 
 		// add Parent keys, don't add parents for root (level-0) and level-1 (since their parent is root)
+		ancestor := n.parent
 		for i := 1; i < level; i++ {
-			// todo add parent's keys info
-			copy(stb.buf[idx:], utils.Uint32ToBytesLittleEndian(0))
+			if ancestor == nil {
+				log.Errorf("encodeNodeDetails: ancestor is nil, level: %v, nodeKey: %+v", level, n.myKey)
+			}
+
+			copy(stb.buf[idx:], utils.Uint32ToBytesLittleEndian(ancestor.myKey))
 			idx += 4
+			ancestor = ancestor.parent
+		}
+
+		// We should have reached the root.
+		if level > 0 && ancestor != stb.tree.Root {
+			log.Errorf("encodeNodeDetails: ancestor is not the root, level: %v, nodeKey: %+v", level, n.myKey)
 		}
 
 		for agIdx, e := range n.aggValues {

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -181,6 +181,7 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 		for i := 1; i < level; i++ {
 			if ancestor == nil {
 				log.Errorf("encodeNodeDetails: ancestor is nil, level: %v, nodeKey: %+v", level, n.myKey)
+				break
 			}
 
 			copy(stb.buf[idx:], utils.Uint32ToBytesLittleEndian(ancestor.myKey))

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -112,8 +112,6 @@ func (stb *StarTreeBuilder) encodeMetadata(strMFd *os.File) (uint32, error) {
 	// metaDataLen
 	copy(stb.buf[0:], utils.Uint32ToBytesLittleEndian(idx-4))
 
-	//	log.Infof("kunal EncodeStarTree: metaDataLen: %v", idx-4)
-
 	_, err := strMFd.Write(stb.buf[:idx])
 	if err != nil {
 		log.Errorf("encodeMetadata: meta write failed fname=%v, err=%v", strMFd.Name(), err)
@@ -222,7 +220,6 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 	strLevFileOff += int64(idx)
 	levsSizes[level] = idx
 
-	//	log.Infof("kunal encode , level: %v, size: %v", level, idx)
 	if len(nextLevelNodes) > 0 {
 		nSize, err := stb.encodeNodeDetails(strLevFd, nextLevelNodes, level+1, strLevFileOff, levsOffsets, levsSizes)
 		if err != nil {
@@ -332,7 +329,6 @@ func (stb *StarTreeBuilder) writeLevsInfo(strMFd *os.File, levsOffsets []int64,
 		idx += 4
 	}
 
-	//	log.Infof("kunal writeLevsInfo: levsOffsets: %v, levsSizes: %v", levsOffsets, levsSizes)
 	_, err := strMFd.Write(stb.buf[:idx])
 	if err != nil {
 		log.Errorf("writeLevsInfo: failed levOff writing, err: %v", err)


### PR DESCRIPTION
# Description
Previously, the AgileAggsTree didn't work properly when the query had multiple GroupBy columns. This fixes that issue. Each node in the tree is supposed to store its own key as well as its ancestors' keys all the way up to the root node. However, only the current node's key was being stored. These keys are used to determine the value of each GroupBy column that the tree accounts for.

# Testing
I've only done manual testing. We should add unit tests to ensure we never get this issue again.

For manual testing, I followed these steps:
1. Append `agileAggsEnabled: true` to server.yaml
2. Start siglens
3. Setup PQS with this API call:
```bash
curl -X POST -d '{
    "tableName": "benchmark",
    "groupByColumns": ["cab_type", "passenger_count", "pickup_date", "trip_distance"],
    "measureColumns": ["total_amount"]
}' http://localhost/api/pqs/aggs
```
4. Ingest some data. I got some data via
```bash
export NUM_FILES=20

cd sigscalr-client
mkdir benchmark_data
cd benchmark_data

# Download compressed data.
echo "Downloading $NUM_FILES of 20 files..."
for i in $(seq 0 $(($NUM_FILES - 1))); do
	wget "https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/trips_$i.gz" &
done
wait

# Decompress.
gunzip trips_*gz

# Go back to the sigscalr-client base directory.
cd ..

# Convert to JSON.
for i in $(seq 0 $(($NUM_FILES - 1))); do
	go run cmd/utils/converter.go --input "benchmark_data/trips_$i" --output "benchmark_data/trips_$i.json" &
done
wait
```
And ingested that. I tested with ingesting just `trips_0.json` and also with ingesting all 20 files.
5. Restart siglens to make sure all the data is flushed
6. Run a query. For instance:
```
curl -X POST -d '{
    "searchText": "SELECT passenger_count, pickup_date, count(*) FROM trips GROUP BY passenger_count, pickup_date",
    "index": "benchmark",
    "startEpoch": "now-72h",
    "endEpoch": "now",
    "queryLanguage": "SQL"
}' http://localhost/api/search | python -m json.tool
```

Without this fix, I was getting too few buckets for this query and other queries that have multiple GroupBy columns. With this fix, I'm getting the correct number of buckets and the results in those buckets are correct. You can also verify the tree structure is correct by printing the value of `wvNodeKey` in `decodeNodeDetailsJit()` in `agiletreereader.go`; before this change, it was all 0 except for the current node's key, but with this fix is appears to have valid data.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
