### PR TITLE
Fix: Dashboard Name Update Issue on Refresh

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -129,6 +129,7 @@ function updateDashboard() {
     )
         .then(res => {
             if (res.status == 200) {
+                displayDashboardName();
                 showToast('Dashboard Updated Successfully');
             }
             return res.json();


### PR DESCRIPTION
# Description
Fixed an issue where the dashboard name wasn't being refreshed on update.
Fixes #203 

# Testing
I utilized the existing method to display the dashboard name upon saving the DB settings and tested it by updating a dashboard name to verify that it's being updated without a refresh.

# Checklist:
- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
