### PR TITLE
Clarify units of time

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -153,10 +153,10 @@ const (
 	SS_DT_RAW_JSON
 )
 
-const STALE_RECENTLY_ROTATED_ENTRY = 60_000                // one minute
-const SEGMENT_ROTATE_DURATION = 15 * 60                    // 15 mins
+const STALE_RECENTLY_ROTATED_ENTRY_MS = 60_000             // one minute
+const SEGMENT_ROTATE_DURATION_SECONDS = 15 * 60            // 15 mins
 var UPLOAD_INGESTNODE_DIR = time.Duration(1 * time.Minute) // one minute
-const SEGMENT_ROTATE_SLEEP_DURATION = 60                   // 1 min
+const SEGMENT_ROTATE_SLEEP_DURATION_SECONDS = 60           // 1 min
 
 var QUERY_EARLY_EXIT_LIMIT = uint64(10_000)
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -214,7 +214,7 @@ func cleanRecentlyRotatedInternal() {
 	recentlyRotatedSegmentFilesLock.Lock()
 	defer recentlyRotatedSegmentFilesLock.Unlock()
 	for key, value := range RecentlyRotatedSegmentFiles {
-		if currTime-value.TimeRotated > STALE_RECENTLY_ROTATED_ENTRY {
+		if currTime-value.TimeRotated > STALE_RECENTLY_ROTATED_ENTRY_MS {
 			delete(RecentlyRotatedSegmentFiles, key)
 		}
 	}
@@ -222,7 +222,7 @@ func cleanRecentlyRotatedInternal() {
 
 func cleanRecentlyRotatedInfo() {
 	for {
-		sleepDuration := time.Duration(STALE_RECENTLY_ROTATED_ENTRY)
+		sleepDuration := time.Millisecond * STALE_RECENTLY_ROTATED_ENTRY_MS
 		time.Sleep(sleepDuration)
 		cleanRecentlyRotatedInternal()
 	}
@@ -336,16 +336,16 @@ func timeBasedWIPFlushToFile() {
 }
 
 func rotateSegmentOnTime() {
-	segRotateDuration := time.Duration(SEGMENT_ROTATE_DURATION) * time.Second
+	segRotateDuration := time.Duration(SEGMENT_ROTATE_DURATION_SECONDS) * time.Second
 	allSegStoresLock.RLock()
 	wg := sync.WaitGroup{}
 	for sid, ss := range allSegStores {
 
 		if ss.firstTime {
-			rnm := rand.Intn(SEGMENT_ROTATE_DURATION) + 60
+			rnm := rand.Intn(SEGMENT_ROTATE_DURATION_SECONDS) + 60
 			segRotateDuration = time.Duration(rnm) * time.Second
 		} else {
-			segRotateDuration = time.Duration(SEGMENT_ROTATE_DURATION) * time.Second
+			segRotateDuration = time.Duration(SEGMENT_ROTATE_DURATION_SECONDS) * time.Second
 		}
 
 		if time.Since(ss.timeCreated) < segRotateDuration {
@@ -391,7 +391,7 @@ func ForceRotateSegmentsForTest() {
 
 func timeBasedRotateSegment() {
 	for {
-		time.Sleep(SEGMENT_ROTATE_SLEEP_DURATION * time.Second)
+		time.Sleep(SEGMENT_ROTATE_SLEEP_DURATION_SECONDS * time.Second)
 		rotateSegmentOnTime()
 	}
 


### PR DESCRIPTION
# Description
This clarifies the units of time for a few constants.

This should have no effect except for line 225 in segwriter.go. Previously that line had just been using the variable as if it was in nanoseconds, but the variable was specified in milliseconds. See https://pkg.go.dev/time#Duration

# Testing
I have not tested this other than making sure siglens compiles and runs.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
