### PR TITLE
Aggs tree performance

### DIFF
--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -538,8 +538,13 @@ func (str *AgileTreeReader) computeAggsJit(combiner map[string][]utils.NumTypeEn
 func (str *AgileTreeReader) decodeRawValBytes(mkey string, grpTreeLevels []uint16,
 	grpColNames []string) (string, error) {
 
-	buf := []byte(mkey)
+	// Estimate how much space we need for the string builder to avoid
+	// reallocations. An int or float groupby column will take 9 bytes, and
+	// a string groupby column could take more or less space.
 	var sb strings.Builder
+	sb.Grow(len(grpTreeLevels) * 16)
+
+	buf := []byte(mkey)
 	idx := uint32(0)
 	for i, level := range grpTreeLevels {
 		nk := toputils.BytesToUint32LittleEndian(buf[idx : idx+4])

--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -316,7 +316,6 @@ func (str *AgileTreeReader) getRawVal(key uint32, dictEncoding map[uint32][]byte
 	rawVal, ok := dictEncoding[key]
 	if !ok {
 		return []byte{}, fmt.Errorf("failed to find raw value for idx %+v which has %+v keys", key, len(dictEncoding))
-
 	}
 	return rawVal, nil
 }
@@ -343,7 +342,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 	}
 
 	// Allocate all the memory we need for the group by keys upfront to avoid
-	// many small allocations this also allows us to convert a byte slice to
+	// many small allocations. This also allows us to convert a byte slice to
 	// a string without copying; this uses the unsafe package, but we never
 	// change that region of the byte slice, so it's safe.
 	wvBuf := make([]byte, len(grpTreeLevels)*4*int(numNodes))

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -320,7 +320,7 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey bytes.Buffer, measureResul
 	if b.GroupByAggregation == nil {
 		return
 	}
-	bKey := toputils.ByteSliceToString(currKey.Bytes())
+	bKey := toputils.UnsafeByteSliceToString(currKey.Bytes())
 	bucketIdx, ok := b.GroupByAggregation.StringBucketIdx[bKey]
 
 	var bucket *RunningBucketResults

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -248,6 +248,6 @@ func SearchStr(needle string, haystack []string) bool {
 }
 
 // returns string using unsafe. This is zero-copy and uses unsafe
-func ByteSliceToString(haystack []byte) string {
+func UnsafeByteSliceToString(haystack []byte) string {
 	return *(*string)(unsafe.Pointer(&haystack))
 }


### PR DESCRIPTION
# Description
This makes a few different changes, each of which improve the speed that we can use an AgileAggs tree to answer a query. 
1. Estimate how much space we need for a string builder so that we can allocate the slice upfront instead of doing multiple smaller allocations.
2. Avoid copying data to create a string from a []byte. We do this by using an unsafe conversion, but we don't change that data once we set it, so it should be safe.
3. Rearrange some logic for getting the raw value for an encoded value. With this change we only have to lookup `allDictEncodings[colName]` once instead of doing it for each bucket; this saves some time when there's a lot of buckets.

It might be easier for reviewers to review each commit one-by-one instead of looking at the whole PR.

# Testing
To make sure my queries used the AgileAggsTree, I added `agileAggsEnabled: true` to `server.yaml`, then ran
```
curl -X POST -d '{
    "tableName": "benchmark",
    "groupByColumns": ["cab_type", "passenger_count", "pickup_date", "trip_distance"],
    "measureColumns": ["total_amount"]
}' http://localhost/api/pqs/aggs
```
Next I ingested some data and restarted siglens to ensure the ingested data was flushed. The data I ingested was from 
```
for i in $(seq 0 19); do
    wget "https://datasets-documentation.s3.eu-west-3.amazonaws.com/nyc-taxi/trips_$i.gz" &
done
wait
```

## Data Quality
I ran this query with and without the commits in this PR and manually verified the results were identical for a handful of random buckets.
```
curl -X POST -d '{
    "searchText": "SELECT passenger_count, pickup_date, count(*) FROM trips GROUP BY passenger_count, pickup_date",
    "index": "benchmark",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "SQL"
}' http://localhost/api/search | python3 -m json.tool > tmp.json
```

## Performance
I ran this query several times and looked at the `Query Took <number> ms` log emitted in `siglens.log`.
```
curl -X POST -d '{
    "searchText": "SELECT passenger_count, pickup_date, trip_distance, count(*) FROM trips GROUP BY passenger_count, pickup_date, trip_distance",
    "index": "benchmark",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "SQL"
}' http://localhost/api/search | python3 -m json.tool | wc -l
```
Running this a few times on my local machine without these changes, the queries complete in:
446, 440, 451, 445, 429 (milliseconds)

Running the same query with these changes, the queries complete in:
389, 386, 389, 403, 377 (miliiseconds)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
