### PR TITLE
Enable AgileAggs by default

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -67,6 +67,7 @@ func Test_ExtractConfigData(t *testing.T) {
  queryHostname: "abc:123"
  pqsEnabled: bad string
  analyticsEnabled: false
+ agileAggsEnabled: false
  safeMode: true
  log:
    logPrefix: "./pkg/ingestor/httpserver/"
@@ -99,6 +100,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				pqsEnabledConverted:        true,
 				AnalyticsEnabled:           "false",
 				analyticsEnabledConverted:  false,
+				AgileAggsEnabled:           "false",
+				AgileAggsEnabledConverted:  false,
 				SafeServerStart:            true,
 				Log:                        LogConfig{"./pkg/ingestor/httpserver/", 100, false},
 			},
@@ -132,6 +135,7 @@ func Test_ExtractConfigData(t *testing.T) {
  MaxParallelS3IngestBuffers: 10
  pqsEnabled: F
  analyticsEnabled: bad string
+ AgileAggsEnabled: bad string
  log:
    logPrefix: "./pkg/ingestor/httpserver/"
    logFileRotationSizeMB: 1000
@@ -165,6 +169,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				pqsEnabledConverted:        false,
 				AnalyticsEnabled:           "true",
 				analyticsEnabledConverted:  true,
+				AgileAggsEnabled:           "true",
+				AgileAggsEnabledConverted:  true,
 				SafeServerStart:            false,
 				Log:                        LogConfig{"./pkg/ingestor/httpserver/", 1000, true},
 			},
@@ -200,6 +206,8 @@ invalid input, we should error out
 				QueryHostname:              "",
 				AnalyticsEnabled:           "true",
 				analyticsEnabledConverted:  true,
+				AgileAggsEnabled:           "true",
+				AgileAggsEnabledConverted:  true,
 				Log:                        LogConfig{"", 100, false},
 			},
 		},
@@ -235,6 +243,8 @@ a: b
 				SafeServerStart:            false,
 				AnalyticsEnabled:           "true",
 				analyticsEnabledConverted:  true,
+				AgileAggsEnabled:           "true",
+				AgileAggsEnabledConverted:  true,
 				Log:                        LogConfig{"", 100, false},
 			},
 		},


### PR DESCRIPTION
# Description
Now when `agileAggsEnabled` is not set in server.yaml, it defaults to true instead of false.

# Testing
I haven't done much testing, I just printed the value of `config.IsAggregationsEnabled()`. When `server.yaml` has no changes or when it has `agileAggsEnabled: true`, this correctly prints `true`. When the config files has `agileAggsEnabled: false` this correctly prints `false`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
