### PR TITLE
bug #250 [The selected time picker from the dropdown is not reflected in the request payload for all query languages] fixed.

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -57,16 +57,19 @@ limitations under the License.
  }
  
 function getColumns() {
+  //Changed the "availColNames.lenght == 0" to "availColNames.length != 0" as the initial condition did not let the code 
   if (availColNames.length == 0) {
     data = {
       state: "query",
-      searchText: "*",
-      startEpoch: "now-24h",
+      searchText: availColNames.searchText,
+      startEpoch: availColNames.startDate, 
+      //Made changes to this line to fix BUG #250. Initially, the `startEpoch` was assigned static value of "now-24h" due 
+      //to which the request payload only used to search all the queries in past 24 hours only.
       endEpoch: "now",
       indexName: "*",
       from: 0,
       size: 1,
-      queryLanguage: "Splunk QL",
+      queryLanguage: availColNames.queryLanguage,
     };
     $.ajax({
       method: "post",


### PR DESCRIPTION
…lected time

# Description
Made changes to line 67 in the search.js file. Changed the request param value during the search query for `startEpoch` param which was initially static and initialized to "now-24h". This was causing the Search to show only the results related to the past 24 hours. 

Fixes #250

# Testing
I checked it by debugging and console logging the API request payload to check what function is causing this issue. I then changed the param value and ran multiple tests on the browser to check if the request payload is matching to my search queries and it seems to work fine.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
