### PR TITLE
Load CMIs for all columns when rebalancing

### DIFF
--- a/pkg/segment/query/metadata/metadata.go
+++ b/pkg/segment/query/metadata/metadata.go
@@ -256,7 +256,7 @@ func (hm *allSegmentMetadata) loadParallel(idxToLoad []int, cmi bool) (uint64, i
 				if err != nil {
 					log.Errorf("loadParallel: error getting persistent columns: %v", err)
 				} else {
-					err = hm.allSegmentMicroIndex[myIdx].loadMicroIndices(map[uint16]map[string]bool{}, true, pqsCols, false)
+					err = hm.allSegmentMicroIndex[myIdx].loadMicroIndices(map[uint16]map[string]bool{}, true, pqsCols, true)
 					if err != nil {
 						log.Errorf("loadParallel: failed to load SSM at index %d. Error %v",
 							myIdx, err)


### PR DESCRIPTION
# Description
Previously when we did `rebalanceCmi()`, we only loaded the PQS columns. Then in `RunCmiCheck()` we don't load any CMIs if the `loadedMicroIndices` flag is true (line 120). This makes a temporary quick fix, so that during `rebalanceCmi()` we load the indices for all columns, not just the PQS columns.

Later, we should revert this PR and make fix this properly. That would mean `rebalanceCmi()` only loads the PQS columns, but `loadedMicroIndices` should be converted from a boolean value to a set of strings indicating for which columns we have the micro indices loaded.

# Testing
## Setup
1. Start siglens
2. Ingest some data
3. Stop siglens

## Checking the bug
1. In server.yaml, append `pqsEnabled: false`
2. Restart siglens
3. Run a query. I tested with just the SPL query `HEAD` (using dummy data from the sigscalr-client). For this query, you should get the expected results.
4. Wait until you see something like the following in the siglens.log
```
INFO[2023-12-21 15:30:58] rebalanceCmi: CMI, inMem: 5, allocated: 0 MB, evicted: 0, newloaded: 5, took: 10ms
```
5. Rerun the same query. Without this PR, you should incorrectly get no results. With thisi PR, you should get the same results you got before

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
