### PR TITLE
Fix SPL queries with NOT on all columns

### DIFF
--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -55,8 +55,8 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 	case "!=":
 		opr = NotEquals
 	default:
-		log.Errorf("qid=%d, processPipeSearchMap: invalid comparison operator %v", qid, opr)
-		return nil, errors.New("processPipeSearchMap: invalid comparison operator")
+		log.Errorf("qid=%d, ProcessSingleFilter: invalid comparison operator %v", qid, opr)
+		return nil, errors.New("ProcessSingleFilter: invalid comparison operator")
 	}
 	switch t := colValue.(type) {
 	case string:
@@ -67,14 +67,14 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 				if valueIsRegex {
 					compiledRegex, err := regexp.Compile(t)
 					if err != nil {
-						log.Errorf("ProcessSingleFilter: Failed to compile regex for %s. This may cause search failures. Err: %v", t, err)
+						log.Errorf("qid=%d, ProcessSingleFilter: Failed to compile regex for %s. This may cause search failures. Err: %v", qid, t, err)
 					}
 					criteria := CreateTermFilterCriteria(colName, compiledRegex, opr, qid)
 					andFilterCondition = append(andFilterCondition, criteria)
 				} else {
 					negateMatch := (opr == NotEquals)
 					if opr != Equals && opr != NotEquals {
-						log.Errorf("qid=%d, processPipeSearchMap: invalid string comparison operator %v", qid, opr)
+						log.Errorf("qid=%d, ProcessSingleFilter: invalid string comparison operator %v", qid, opr)
 					}
 
 					cleanedColVal := strings.ReplaceAll(strings.TrimSpace(t), "\"", "")
@@ -106,7 +106,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 				}
 			}
 		} else {
-			return nil, errors.New("processPipeSearchMap: colValue/ search Text can not be empty ")
+			return nil, errors.New("ProcessSingleFilter: colValue/ search Text can not be empty ")
 		}
 	case json.Number:
 		if colValue.(json.Number) != "" {
@@ -117,15 +117,15 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 			andFilterCondition = append(andFilterCondition, criteria)
 
 		} else {
-			return nil, errors.New("processPipeSearchMap: colValue/ search Text can not be empty ")
+			return nil, errors.New("ProcessSingleFilter: colValue/ search Text can not be empty ")
 		}
 	case GrepValue:
 		cleanedColVal := strings.ReplaceAll(strings.TrimSpace(t.Field), "\"", "")
 		criteria := CreateTermFilterCriteria("*", cleanedColVal, opr, qid)
 		andFilterCondition = append(andFilterCondition, criteria)
 	default:
-		log.Errorf("processPipeSearchMap: Invalid colValue type %v", t)
-		return nil, errors.New("processPipeSearchMap: Invalid colValue type")
+		log.Errorf("ProcessSingleFilter: Invalid colValue type %v", t)
+		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
 	return andFilterCondition, nil
 }

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -171,7 +171,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 					allSearchResults.AddError(err)
 					break
 				}
-				if query.MatchFilter.NegateMatch {
+				if query.MatchFilter != nil && query.MatchFilter.NegateMatch {
 					if matched || blockHelper.DoesRecordMatch(i) {
 						blockHelper.ClearBit(i)
 					} else {

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -171,8 +171,16 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 					allSearchResults.AddError(err)
 					break
 				}
-				if matched {
-					blockHelper.AddMatchedRecord(i)
+				if query.MatchFilter.NegateMatch {
+					if matched || blockHelper.DoesRecordMatch(i) {
+						blockHelper.ClearBit(i)
+					} else {
+						blockHelper.AddMatchedRecord(i)
+					}
+				} else {
+					if matched {
+						blockHelper.AddMatchedRecord(i)
+					}
 				}
 			}
 		}

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -68,6 +68,7 @@ type MatchFilter struct {
 	MatchPhrase    []byte                 //whole string to search for in case of MatchPhrase query
 	MatchDictArray *MatchDictArrayRequest //array to search for in case of jaeger query
 	MatchType      MatchFilterType
+	NegateMatch    bool
 }
 
 type MatchDictArrayRequest struct {

--- a/pkg/segment/structs/searchhelpers.go
+++ b/pkg/segment/structs/searchhelpers.go
@@ -55,3 +55,11 @@ func (h *BlockSearchHelper) GetAllMatchedRecords() *pqmr.PQMatchResults {
 func (h *BlockSearchHelper) AddMatchedRecord(recNum uint) {
 	h.matchedRecs.AddMatchedRecord(recNum)
 }
+
+func (h *BlockSearchHelper) ClearBit(recNum uint) {
+	h.matchedRecs.ClearBit(recNum)
+}
+
+func (h *BlockSearchHelper) DoesRecordMatch(recNum uint) bool {
+	return h.matchedRecs.DoesRecordMatch(recNum)
+}


### PR DESCRIPTION
# Description
This fixes an issue with SPL queries where `NOT` was used for a search on all columns. For example, `NOT HEAD`

# Testing
I ingested data from sigscalr-client:
```
go run main.go ingest esbulk -n 10 -g benchmark -d http://localhost:8081/elastic -t 100_000
```

I tested the following queries. These all return correct results with the changes from this PR, but give incorrect results without this PR.
```
NOT HEAD
weekday=Tuesday NOT HEAD
NOT Arttalk
(GET OR POST) NOT Tuesday
NOT (HEAD OR POST OR DELETE)
```
(Arttalk was one of the `app_name` values in my dataset)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
