### PR TITLE
PR: Make UI link clickable when installing through docker

### DIFF
--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -245,7 +245,7 @@ echo -e "ingestPort(8081) and queryPort(80) can be changed using in server.yaml.
 echo -e "queryPort(80) can also be changed by setting the environment variable $PORT."
 
 tput bold
-printf "\n===> ${GREEN_TEXT}Frontend can be accessed on http://localhost:${UI_PORT}${RESET_COLOR}"
+printf "\n===> ${GREEN_TEXT}Frontend can be accessed on http://localhost:${UI_PORT}\a${RESET_COLOR}"
 echo ""
 tput sgr0
 


### PR DESCRIPTION
# Description
Makes UI link clickable when siglens installed through docker by executing **`install_with_docker.sh`**

Fixes #304 (https://github.com/siglens/siglens/issues/304)

# Testing
<img width="751" alt="image" src="https://github.com/siglens/siglens/assets/113181307/a3202a6e-fdfa-4fd1-885f-37ea2ffe2f01">

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
