### PR TITLE
Fix: Allow the search block without using keyword "search"

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -47,6 +47,7 @@ search MintCream Thursday OR Monday,now-1d,now,*,total,eq,212,Splunk QL
 search NOT (city!=Boston OR NOT weekday=Friday),now-1d,now,*,total,gt,100,Splunk QL
 search batch=batch-*,now-1d,now,*,total,gt,100,Splunk QL
 latency<10000 | search latitude>0 | search longitude>0,now-1d,now,*,total,gt,10,Splunk QL
+latency<10000 | latitude>0 | search longitude>0,now-1d,now,*,total,gt,10,Splunk QL
 "search batch=batch-5 | regex city=""^[A-L][a-z]+\s[a-zA-Z]+$""",now-1d,now,*,total,gt,5,Splunk QL
 "search batch=batch-5 | regex city!=""^[A-L][a-z]+\s[a-zA-Z]+$""",now-1d,now,*,total,gt,50,Splunk QL
 batch=batch-10 | stats count,now-1d,now,*,group:count(*):*,eq,114,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -47,6 +47,7 @@ search MintCream Thursday OR Monday,now-1d,now,*,total,eq,212,Splunk QL
 search NOT (city!=Boston OR NOT weekday=Friday),now-1d,now,*,total,eq,135,Splunk QL
 search batch=batch-*,now-90d,now,*,total,eq,10000,Splunk QL
 latency<10000 | search latitude>0 | search longitude>0,now-1d,now,*,total,eq,27,Splunk QL
+latency<10000 | latitude>0 | search longitude>0,now-1d,now,*,total,gt,10,Splunk QL
 "search batch=batch-5 | regex city=""^[A-L][a-z]+\s[a-zA-Z]+$""",now-1d,now,*,total,eq,15,Splunk QL
 "search batch=batch-5 | regex city!=""^[A-L][a-z]+\s[a-zA-Z]+$""",now-1d,now,*,total,eq,77,Splunk QL
 batch=batch-10 | stats count,now-1d,now,*,group:count(*):*,eq,114,Splunk QL

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -255,15 +255,25 @@ var g = &grammar{
 				expr: &seqExpr{
 					pos: position{line: 221, col: 16, offset: 6404},
 					exprs: []any{
-						&ruleRefExpr{
-							pos:  position{line: 221, col: 16, offset: 6404},
-							name: "CMD_SEARCH",
+						&notExpr{
+							pos: position{line: 221, col: 16, offset: 6404},
+							expr: &ruleRefExpr{
+								pos:  position{line: 221, col: 18, offset: 6406},
+								name: "ALLCMD",
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 221, col: 26, offset: 6414},
+							expr: &ruleRefExpr{
+								pos:  position{line: 221, col: 26, offset: 6414},
+								name: "CMD_SEARCH",
+							},
 						},
 						&labeledExpr{
-							pos:   position{line: 221, col: 27, offset: 6415},
+							pos:   position{line: 221, col: 38, offset: 6426},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 221, col: 34, offset: 6422},
+								pos:  position{line: 221, col: 45, offset: 6433},
 								name: "ClauseLevel4",
 							},
 						},
@@ -273,29 +283,29 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 225, col: 1, offset: 6463},
+			pos:  position{line: 225, col: 1, offset: 6474},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 16, offset: 6478},
+				pos: position{line: 225, col: 16, offset: 6489},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 16, offset: 6478},
+					pos: position{line: 225, col: 16, offset: 6489},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 225, col: 16, offset: 6478},
+							pos:  position{line: 225, col: 16, offset: 6489},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 225, col: 21, offset: 6483},
+							pos:   position{line: 225, col: 21, offset: 6494},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 225, col: 28, offset: 6490},
+								pos: position{line: 225, col: 28, offset: 6501},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 225, col: 28, offset: 6490},
+										pos:  position{line: 225, col: 28, offset: 6501},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 225, col: 42, offset: 6504},
+										pos:  position{line: 225, col: 42, offset: 6515},
 										name: "RegexBlock",
 									},
 								},
@@ -307,50 +317,50 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 230, col: 1, offset: 6580},
+			pos:  position{line: 230, col: 1, offset: 6591},
 			expr: &actionExpr{
-				pos: position{line: 230, col: 25, offset: 6604},
+				pos: position{line: 230, col: 25, offset: 6615},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 230, col: 25, offset: 6604},
+					pos:   position{line: 230, col: 25, offset: 6615},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 230, col: 32, offset: 6611},
+						pos: position{line: 230, col: 32, offset: 6622},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 32, offset: 6611},
+								pos:  position{line: 230, col: 32, offset: 6622},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 51, offset: 6630},
+								pos:  position{line: 230, col: 51, offset: 6641},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 69, offset: 6648},
+								pos:  position{line: 230, col: 69, offset: 6659},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 81, offset: 6660},
+								pos:  position{line: 230, col: 81, offset: 6671},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 94, offset: 6673},
+								pos:  position{line: 230, col: 94, offset: 6684},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 106, offset: 6685},
+								pos:  position{line: 230, col: 106, offset: 6696},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 117, offset: 6696},
+								pos:  position{line: 230, col: 117, offset: 6707},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 134, offset: 6713},
+								pos:  position{line: 230, col: 134, offset: 6724},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 230, col: 148, offset: 6727},
+								pos:  position{line: 230, col: 148, offset: 6738},
 								name: "TimechartBlock",
 							},
 						},
@@ -360,37 +370,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 235, col: 1, offset: 6823},
+			pos:  position{line: 235, col: 1, offset: 6834},
 			expr: &actionExpr{
-				pos: position{line: 235, col: 21, offset: 6843},
+				pos: position{line: 235, col: 21, offset: 6854},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 235, col: 21, offset: 6843},
+					pos: position{line: 235, col: 21, offset: 6854},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 235, col: 21, offset: 6843},
+							pos:  position{line: 235, col: 21, offset: 6854},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 235, col: 26, offset: 6848},
+							pos:  position{line: 235, col: 26, offset: 6859},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 235, col: 37, offset: 6859},
+							pos:   position{line: 235, col: 37, offset: 6870},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 235, col: 40, offset: 6862},
+								pos: position{line: 235, col: 40, offset: 6873},
 								expr: &choiceExpr{
-									pos: position{line: 235, col: 41, offset: 6863},
+									pos: position{line: 235, col: 41, offset: 6874},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 235, col: 41, offset: 6863},
+											pos:        position{line: 235, col: 41, offset: 6874},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 235, col: 47, offset: 6869},
+											pos:        position{line: 235, col: 47, offset: 6880},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -400,14 +410,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 235, col: 53, offset: 6875},
+							pos:  position{line: 235, col: 53, offset: 6886},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 235, col: 68, offset: 6890},
+							pos:   position{line: 235, col: 68, offset: 6901},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 235, col: 75, offset: 6897},
+								pos:  position{line: 235, col: 75, offset: 6908},
 								name: "FieldNameList",
 							},
 						},
@@ -417,36 +427,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 253, col: 1, offset: 7401},
+			pos:  position{line: 253, col: 1, offset: 7412},
 			expr: &actionExpr{
-				pos: position{line: 253, col: 20, offset: 7420},
+				pos: position{line: 253, col: 20, offset: 7431},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 253, col: 20, offset: 7420},
+					pos: position{line: 253, col: 20, offset: 7431},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 253, col: 20, offset: 7420},
+							pos:  position{line: 253, col: 20, offset: 7431},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 253, col: 25, offset: 7425},
+							pos:  position{line: 253, col: 25, offset: 7436},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 253, col: 35, offset: 7435},
+							pos:   position{line: 253, col: 35, offset: 7446},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 253, col: 40, offset: 7440},
+								pos:  position{line: 253, col: 40, offset: 7451},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 253, col: 56, offset: 7456},
+							pos:   position{line: 253, col: 56, offset: 7467},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 253, col: 65, offset: 7465},
+								pos: position{line: 253, col: 65, offset: 7476},
 								expr: &ruleRefExpr{
-									pos:  position{line: 253, col: 66, offset: 7466},
+									pos:  position{line: 253, col: 66, offset: 7477},
 									name: "GroupbyBlock",
 								},
 							},
@@ -457,22 +467,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 298, col: 1, offset: 8960},
+			pos:  position{line: 298, col: 1, offset: 8971},
 			expr: &actionExpr{
-				pos: position{line: 298, col: 17, offset: 8976},
+				pos: position{line: 298, col: 17, offset: 8987},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 298, col: 17, offset: 8976},
+					pos: position{line: 298, col: 17, offset: 8987},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 298, col: 17, offset: 8976},
+							pos:  position{line: 298, col: 17, offset: 8987},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 298, col: 20, offset: 8979},
+							pos:   position{line: 298, col: 20, offset: 8990},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 298, col: 27, offset: 8986},
+								pos:  position{line: 298, col: 27, offset: 8997},
 								name: "FieldNameList",
 							},
 						},
@@ -482,31 +492,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 309, col: 1, offset: 9335},
+			pos:  position{line: 309, col: 1, offset: 9346},
 			expr: &actionExpr{
-				pos: position{line: 309, col: 15, offset: 9349},
+				pos: position{line: 309, col: 15, offset: 9360},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 309, col: 15, offset: 9349},
+					pos: position{line: 309, col: 15, offset: 9360},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 309, col: 15, offset: 9349},
+							pos:  position{line: 309, col: 15, offset: 9360},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 309, col: 25, offset: 9359},
+							pos:   position{line: 309, col: 25, offset: 9370},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 309, col: 34, offset: 9368},
+								pos: position{line: 309, col: 34, offset: 9379},
 								expr: &seqExpr{
-									pos: position{line: 309, col: 35, offset: 9369},
+									pos: position{line: 309, col: 35, offset: 9380},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 309, col: 35, offset: 9369},
+											pos:  position{line: 309, col: 35, offset: 9380},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 309, col: 45, offset: 9379},
+											pos:  position{line: 309, col: 45, offset: 9390},
 											name: "EqualityOperator",
 										},
 									},
@@ -514,10 +524,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 309, col: 64, offset: 9398},
+							pos:   position{line: 309, col: 64, offset: 9409},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 68, offset: 9402},
+								pos:  position{line: 309, col: 68, offset: 9413},
 								name: "QuotedString",
 							},
 						},
@@ -527,44 +537,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 337, col: 1, offset: 9981},
+			pos:  position{line: 337, col: 1, offset: 9992},
 			expr: &actionExpr{
-				pos: position{line: 337, col: 17, offset: 9997},
+				pos: position{line: 337, col: 17, offset: 10008},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 337, col: 17, offset: 9997},
+					pos: position{line: 337, col: 17, offset: 10008},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 337, col: 17, offset: 9997},
+							pos:   position{line: 337, col: 17, offset: 10008},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 337, col: 23, offset: 10003},
+								pos:  position{line: 337, col: 23, offset: 10014},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 337, col: 36, offset: 10016},
+							pos:   position{line: 337, col: 36, offset: 10027},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 337, col: 41, offset: 10021},
+								pos: position{line: 337, col: 41, offset: 10032},
 								expr: &seqExpr{
-									pos: position{line: 337, col: 42, offset: 10022},
+									pos: position{line: 337, col: 42, offset: 10033},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 337, col: 43, offset: 10023},
+											pos: position{line: 337, col: 43, offset: 10034},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 337, col: 43, offset: 10023},
+													pos:  position{line: 337, col: 43, offset: 10034},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 337, col: 49, offset: 10029},
+													pos:  position{line: 337, col: 49, offset: 10040},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 337, col: 56, offset: 10036},
+											pos:  position{line: 337, col: 56, offset: 10047},
 											name: "ClauseLevel3",
 										},
 									},
@@ -577,35 +587,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 355, col: 1, offset: 10413},
+			pos:  position{line: 355, col: 1, offset: 10424},
 			expr: &actionExpr{
-				pos: position{line: 355, col: 17, offset: 10429},
+				pos: position{line: 355, col: 17, offset: 10440},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 355, col: 17, offset: 10429},
+					pos: position{line: 355, col: 17, offset: 10440},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 355, col: 17, offset: 10429},
+							pos:   position{line: 355, col: 17, offset: 10440},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 355, col: 23, offset: 10435},
+								pos:  position{line: 355, col: 23, offset: 10446},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 36, offset: 10448},
+							pos:   position{line: 355, col: 36, offset: 10459},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 355, col: 41, offset: 10453},
+								pos: position{line: 355, col: 41, offset: 10464},
 								expr: &seqExpr{
-									pos: position{line: 355, col: 42, offset: 10454},
+									pos: position{line: 355, col: 42, offset: 10465},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 42, offset: 10454},
+											pos:  position{line: 355, col: 42, offset: 10465},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 45, offset: 10457},
+											pos:  position{line: 355, col: 45, offset: 10468},
 											name: "ClauseLevel2",
 										},
 									},
@@ -618,32 +628,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 373, col: 1, offset: 10822},
+			pos:  position{line: 373, col: 1, offset: 10833},
 			expr: &choiceExpr{
-				pos: position{line: 373, col: 17, offset: 10838},
+				pos: position{line: 373, col: 17, offset: 10849},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 373, col: 17, offset: 10838},
+						pos: position{line: 373, col: 17, offset: 10849},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 373, col: 17, offset: 10838},
+							pos: position{line: 373, col: 17, offset: 10849},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 373, col: 17, offset: 10838},
+									pos:   position{line: 373, col: 17, offset: 10849},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 373, col: 25, offset: 10846},
+										pos: position{line: 373, col: 25, offset: 10857},
 										expr: &ruleRefExpr{
-											pos:  position{line: 373, col: 25, offset: 10846},
+											pos:  position{line: 373, col: 25, offset: 10857},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 373, col: 30, offset: 10851},
+									pos:   position{line: 373, col: 30, offset: 10862},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 373, col: 36, offset: 10857},
+										pos:  position{line: 373, col: 36, offset: 10868},
 										name: "ClauseLevel1",
 									},
 								},
@@ -651,13 +661,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 11153},
+						pos: position{line: 384, col: 5, offset: 11164},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 384, col: 5, offset: 11153},
+							pos:   position{line: 384, col: 5, offset: 11164},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 384, col: 12, offset: 11160},
+								pos:  position{line: 384, col: 12, offset: 11171},
 								name: "ClauseLevel1",
 							},
 						},
@@ -667,43 +677,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 388, col: 1, offset: 11201},
+			pos:  position{line: 388, col: 1, offset: 11212},
 			expr: &choiceExpr{
-				pos: position{line: 388, col: 17, offset: 11217},
+				pos: position{line: 388, col: 17, offset: 11228},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 388, col: 17, offset: 11217},
+						pos: position{line: 388, col: 17, offset: 11228},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 388, col: 17, offset: 11217},
+							pos: position{line: 388, col: 17, offset: 11228},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 17, offset: 11217},
+									pos:  position{line: 388, col: 17, offset: 11228},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 388, col: 25, offset: 11225},
+									pos:   position{line: 388, col: 25, offset: 11236},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 388, col: 32, offset: 11232},
+										pos:  position{line: 388, col: 32, offset: 11243},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 45, offset: 11245},
+									pos:  position{line: 388, col: 45, offset: 11256},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 390, col: 5, offset: 11282},
+						pos: position{line: 390, col: 5, offset: 11293},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 390, col: 5, offset: 11282},
+							pos:   position{line: 390, col: 5, offset: 11293},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 10, offset: 11287},
+								pos:  position{line: 390, col: 10, offset: 11298},
 								name: "SearchTerm",
 							},
 						},
@@ -713,22 +723,22 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 396, col: 1, offset: 11445},
+			pos:  position{line: 396, col: 1, offset: 11456},
 			expr: &actionExpr{
-				pos: position{line: 396, col: 15, offset: 11459},
+				pos: position{line: 396, col: 15, offset: 11470},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 396, col: 15, offset: 11459},
+					pos:   position{line: 396, col: 15, offset: 11470},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 396, col: 21, offset: 11465},
+						pos: position{line: 396, col: 21, offset: 11476},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 396, col: 21, offset: 11465},
+								pos:  position{line: 396, col: 21, offset: 11476},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 396, col: 44, offset: 11488},
+								pos:  position{line: 396, col: 44, offset: 11499},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -738,47 +748,47 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 401, col: 1, offset: 11629},
+			pos:  position{line: 401, col: 1, offset: 11640},
 			expr: &actionExpr{
-				pos: position{line: 401, col: 19, offset: 11647},
+				pos: position{line: 401, col: 19, offset: 11658},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 401, col: 19, offset: 11647},
+					pos: position{line: 401, col: 19, offset: 11658},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 401, col: 19, offset: 11647},
+							pos:  position{line: 401, col: 19, offset: 11658},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 401, col: 24, offset: 11652},
+							pos:  position{line: 401, col: 24, offset: 11663},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 401, col: 38, offset: 11666},
+							pos:   position{line: 401, col: 38, offset: 11677},
 							label: "binOptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 401, col: 49, offset: 11677},
+								pos: position{line: 401, col: 49, offset: 11688},
 								expr: &ruleRefExpr{
-									pos:  position{line: 401, col: 50, offset: 11678},
+									pos:  position{line: 401, col: 50, offset: 11689},
 									name: "BinOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 401, col: 63, offset: 11691},
+							pos:   position{line: 401, col: 63, offset: 11702},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 401, col: 69, offset: 11697},
+								pos:  position{line: 401, col: 69, offset: 11708},
 								name: "SingleAggExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 401, col: 84, offset: 11712},
+							pos:   position{line: 401, col: 84, offset: 11723},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 401, col: 94, offset: 11722},
+								pos: position{line: 401, col: 94, offset: 11733},
 								expr: &ruleRefExpr{
-									pos:  position{line: 401, col: 95, offset: 11723},
+									pos:  position{line: 401, col: 95, offset: 11734},
 									name: "LimitExpr",
 								},
 							},
@@ -789,28 +799,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 462, col: 1, offset: 13764},
+			pos:  position{line: 462, col: 1, offset: 13775},
 			expr: &actionExpr{
-				pos: position{line: 462, col: 18, offset: 13781},
+				pos: position{line: 462, col: 18, offset: 13792},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 462, col: 18, offset: 13781},
+					pos: position{line: 462, col: 18, offset: 13792},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 462, col: 18, offset: 13781},
+							pos:   position{line: 462, col: 18, offset: 13792},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 462, col: 23, offset: 13786},
+								pos:  position{line: 462, col: 23, offset: 13797},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 462, col: 39, offset: 13802},
+							pos:   position{line: 462, col: 39, offset: 13813},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 462, col: 53, offset: 13816},
+								pos: position{line: 462, col: 53, offset: 13827},
 								expr: &ruleRefExpr{
-									pos:  position{line: 462, col: 54, offset: 13817},
+									pos:  position{line: 462, col: 54, offset: 13828},
 									name: "SplitByClause",
 								},
 							},
@@ -821,32 +831,32 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 476, col: 1, offset: 14157},
+			pos:  position{line: 476, col: 1, offset: 14168},
 			expr: &actionExpr{
-				pos: position{line: 476, col: 18, offset: 14174},
+				pos: position{line: 476, col: 18, offset: 14185},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 476, col: 18, offset: 14174},
+					pos: position{line: 476, col: 18, offset: 14185},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 476, col: 18, offset: 14174},
+							pos:  position{line: 476, col: 18, offset: 14185},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 21, offset: 14177},
+							pos:   position{line: 476, col: 21, offset: 14188},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 27, offset: 14183},
+								pos:  position{line: 476, col: 27, offset: 14194},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 37, offset: 14193},
+							pos:   position{line: 476, col: 37, offset: 14204},
 							label: "tcOptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 476, col: 47, offset: 14203},
+								pos: position{line: 476, col: 47, offset: 14214},
 								expr: &ruleRefExpr{
-									pos:  position{line: 476, col: 48, offset: 14204},
+									pos:  position{line: 476, col: 48, offset: 14215},
 									name: "TcOptions",
 								},
 							},
@@ -857,31 +867,31 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 487, col: 1, offset: 14432},
+			pos:  position{line: 487, col: 1, offset: 14443},
 			expr: &actionExpr{
-				pos: position{line: 487, col: 14, offset: 14445},
+				pos: position{line: 487, col: 14, offset: 14456},
 				run: (*parser).callonTcOptions1,
 				expr: &seqExpr{
-					pos: position{line: 487, col: 14, offset: 14445},
+					pos: position{line: 487, col: 14, offset: 14456},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 487, col: 14, offset: 14445},
+							pos:  position{line: 487, col: 14, offset: 14456},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 20, offset: 14451},
+							pos:   position{line: 487, col: 20, offset: 14462},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 487, col: 28, offset: 14459},
+								pos: position{line: 487, col: 28, offset: 14470},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 487, col: 28, offset: 14459},
+										pos:  position{line: 487, col: 28, offset: 14470},
 										name: "BinOptions",
 									},
 									&oneOrMoreExpr{
-										pos: position{line: 487, col: 41, offset: 14472},
+										pos: position{line: 487, col: 41, offset: 14483},
 										expr: &ruleRefExpr{
-											pos:  position{line: 487, col: 42, offset: 14473},
+											pos:  position{line: 487, col: 42, offset: 14484},
 											name: "TcOption",
 										},
 									},
@@ -894,34 +904,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 530, col: 1, offset: 16008},
+			pos:  position{line: 530, col: 1, offset: 16019},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 13, offset: 16020},
+				pos: position{line: 530, col: 13, offset: 16031},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 13, offset: 16020},
+					pos: position{line: 530, col: 13, offset: 16031},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 13, offset: 16020},
+							pos:  position{line: 530, col: 13, offset: 16031},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 19, offset: 16026},
+							pos:   position{line: 530, col: 19, offset: 16037},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 31, offset: 16038},
+								pos:  position{line: 530, col: 31, offset: 16049},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 530, col: 43, offset: 16050},
+							pos:  position{line: 530, col: 43, offset: 16061},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 530, col: 49, offset: 16056},
+							pos:   position{line: 530, col: 49, offset: 16067},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 53, offset: 16060},
+								pos:  position{line: 530, col: 53, offset: 16071},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -931,36 +941,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 535, col: 1, offset: 16173},
+			pos:  position{line: 535, col: 1, offset: 16184},
 			expr: &actionExpr{
-				pos: position{line: 535, col: 16, offset: 16188},
+				pos: position{line: 535, col: 16, offset: 16199},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 535, col: 16, offset: 16188},
+					pos:   position{line: 535, col: 16, offset: 16199},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 535, col: 24, offset: 16196},
+						pos: position{line: 535, col: 24, offset: 16207},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 535, col: 24, offset: 16196},
+								pos:        position{line: 535, col: 24, offset: 16207},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 535, col: 36, offset: 16208},
+								pos:        position{line: 535, col: 36, offset: 16219},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 535, col: 49, offset: 16221},
+								pos:        position{line: 535, col: 49, offset: 16232},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 535, col: 61, offset: 16233},
+								pos:        position{line: 535, col: 61, offset: 16244},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -972,15 +982,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 544, col: 1, offset: 16582},
+			pos:  position{line: 544, col: 1, offset: 16593},
 			expr: &actionExpr{
-				pos: position{line: 544, col: 15, offset: 16596},
+				pos: position{line: 544, col: 15, offset: 16607},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 544, col: 15, offset: 16596},
+					pos:   position{line: 544, col: 15, offset: 16607},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 544, col: 27, offset: 16608},
+						pos:  position{line: 544, col: 27, offset: 16619},
 						name: "SpanOptions",
 					},
 				},
@@ -988,26 +998,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 552, col: 1, offset: 16833},
+			pos:  position{line: 552, col: 1, offset: 16844},
 			expr: &actionExpr{
-				pos: position{line: 552, col: 16, offset: 16848},
+				pos: position{line: 552, col: 16, offset: 16859},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 552, col: 16, offset: 16848},
+					pos: position{line: 552, col: 16, offset: 16859},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 552, col: 16, offset: 16848},
+							pos:  position{line: 552, col: 16, offset: 16859},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 552, col: 25, offset: 16857},
+							pos:  position{line: 552, col: 25, offset: 16868},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 552, col: 31, offset: 16863},
+							pos:   position{line: 552, col: 31, offset: 16874},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 552, col: 42, offset: 16874},
+								pos:  position{line: 552, col: 42, offset: 16885},
 								name: "SpanLength",
 							},
 						},
@@ -1017,31 +1027,31 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 559, col: 1, offset: 17020},
+			pos:  position{line: 559, col: 1, offset: 17031},
 			expr: &actionExpr{
-				pos: position{line: 559, col: 15, offset: 17034},
+				pos: position{line: 559, col: 15, offset: 17045},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 559, col: 15, offset: 17034},
+					pos: position{line: 559, col: 15, offset: 17045},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 559, col: 15, offset: 17034},
+							pos:   position{line: 559, col: 15, offset: 17045},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 24, offset: 17043},
+								pos:  position{line: 559, col: 24, offset: 17054},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 559, col: 40, offset: 17059},
+							pos:   position{line: 559, col: 40, offset: 17070},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 50, offset: 17069},
+								pos:  position{line: 559, col: 50, offset: 17080},
 								name: "TimeScale",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 559, col: 60, offset: 17079},
+							pos:  position{line: 559, col: 60, offset: 17090},
 							name: "SPACE",
 						},
 					},
@@ -1050,46 +1060,46 @@ var g = &grammar{
 		},
 		{
 			name: "TimeScale",
-			pos:  position{line: 572, col: 1, offset: 17393},
+			pos:  position{line: 572, col: 1, offset: 17404},
 			expr: &actionExpr{
-				pos: position{line: 572, col: 14, offset: 17406},
+				pos: position{line: 572, col: 14, offset: 17417},
 				run: (*parser).callonTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 572, col: 14, offset: 17406},
+					pos:   position{line: 572, col: 14, offset: 17417},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 572, col: 24, offset: 17416},
+						pos: position{line: 572, col: 24, offset: 17427},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 24, offset: 17416},
+								pos:  position{line: 572, col: 24, offset: 17427},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 33, offset: 17425},
+								pos:  position{line: 572, col: 33, offset: 17436},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 42, offset: 17434},
+								pos:  position{line: 572, col: 42, offset: 17445},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 49, offset: 17441},
+								pos:  position{line: 572, col: 49, offset: 17452},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 54, offset: 17446},
+								pos:  position{line: 572, col: 54, offset: 17457},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 61, offset: 17453},
+								pos:  position{line: 572, col: 61, offset: 17464},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 69, offset: 17461},
+								pos:  position{line: 572, col: 69, offset: 17472},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 572, col: 78, offset: 17470},
+								pos:  position{line: 572, col: 78, offset: 17481},
 								name: "Subseconds",
 							},
 						},
@@ -1099,43 +1109,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 577, col: 1, offset: 17592},
+			pos:  position{line: 577, col: 1, offset: 17603},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 14, offset: 17605},
+				pos: position{line: 577, col: 14, offset: 17616},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 577, col: 14, offset: 17605},
+					pos: position{line: 577, col: 14, offset: 17616},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 14, offset: 17605},
+							pos:  position{line: 577, col: 14, offset: 17616},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 577, col: 20, offset: 17611},
+							pos:        position{line: 577, col: 20, offset: 17622},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 28, offset: 17619},
+							pos:  position{line: 577, col: 28, offset: 17630},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 34, offset: 17625},
+							pos:   position{line: 577, col: 34, offset: 17636},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 577, col: 41, offset: 17632},
+								pos: position{line: 577, col: 41, offset: 17643},
 								expr: &choiceExpr{
-									pos: position{line: 577, col: 42, offset: 17633},
+									pos: position{line: 577, col: 42, offset: 17644},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 577, col: 42, offset: 17633},
+											pos:        position{line: 577, col: 42, offset: 17644},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 577, col: 50, offset: 17641},
+											pos:        position{line: 577, col: 50, offset: 17652},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -1145,14 +1155,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 61, offset: 17652},
+							pos:  position{line: 577, col: 61, offset: 17663},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 577, col: 76, offset: 17667},
+							pos:   position{line: 577, col: 76, offset: 17678},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 577, col: 86, offset: 17677},
+								pos:  position{line: 577, col: 86, offset: 17688},
 								name: "IntegerAsString",
 							},
 						},
@@ -1162,22 +1172,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 603, col: 1, offset: 18269},
+			pos:  position{line: 603, col: 1, offset: 18280},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 19, offset: 18287},
+				pos: position{line: 603, col: 19, offset: 18298},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 19, offset: 18287},
+					pos: position{line: 603, col: 19, offset: 18298},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 603, col: 19, offset: 18287},
+							pos:  position{line: 603, col: 19, offset: 18298},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 603, col: 24, offset: 18292},
+							pos:   position{line: 603, col: 24, offset: 18303},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 38, offset: 18306},
+								pos:  position{line: 603, col: 38, offset: 18317},
 								name: "StatisticExpr",
 							},
 						},
@@ -1187,76 +1197,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 636, col: 1, offset: 19284},
+			pos:  position{line: 636, col: 1, offset: 19295},
 			expr: &actionExpr{
-				pos: position{line: 636, col: 18, offset: 19301},
+				pos: position{line: 636, col: 18, offset: 19312},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 636, col: 18, offset: 19301},
+					pos: position{line: 636, col: 18, offset: 19312},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 636, col: 18, offset: 19301},
+							pos:   position{line: 636, col: 18, offset: 19312},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 636, col: 23, offset: 19306},
+								pos: position{line: 636, col: 23, offset: 19317},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 636, col: 23, offset: 19306},
+										pos:  position{line: 636, col: 23, offset: 19317},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 636, col: 33, offset: 19316},
+										pos:  position{line: 636, col: 33, offset: 19327},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 43, offset: 19326},
+							pos:   position{line: 636, col: 43, offset: 19337},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 49, offset: 19332},
+								pos: position{line: 636, col: 49, offset: 19343},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 50, offset: 19333},
+									pos:  position{line: 636, col: 50, offset: 19344},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 67, offset: 19350},
+							pos:   position{line: 636, col: 67, offset: 19361},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 636, col: 78, offset: 19361},
+								pos: position{line: 636, col: 78, offset: 19372},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 636, col: 78, offset: 19361},
+										pos:  position{line: 636, col: 78, offset: 19372},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 636, col: 84, offset: 19367},
+										pos:  position{line: 636, col: 84, offset: 19378},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 99, offset: 19382},
+							pos:   position{line: 636, col: 99, offset: 19393},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 108, offset: 19391},
+								pos: position{line: 636, col: 108, offset: 19402},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 109, offset: 19392},
+									pos:  position{line: 636, col: 109, offset: 19403},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 636, col: 120, offset: 19403},
+							pos:   position{line: 636, col: 120, offset: 19414},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 636, col: 128, offset: 19411},
+								pos: position{line: 636, col: 128, offset: 19422},
 								expr: &ruleRefExpr{
-									pos:  position{line: 636, col: 129, offset: 19412},
+									pos:  position{line: 636, col: 129, offset: 19423},
 									name: "Options",
 								},
 							},
@@ -1267,25 +1277,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 678, col: 1, offset: 20452},
+			pos:  position{line: 678, col: 1, offset: 20463},
 			expr: &choiceExpr{
-				pos: position{line: 678, col: 19, offset: 20470},
+				pos: position{line: 678, col: 19, offset: 20481},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 678, col: 19, offset: 20470},
+						pos: position{line: 678, col: 19, offset: 20481},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 19, offset: 20470},
+							pos: position{line: 678, col: 19, offset: 20481},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 678, col: 19, offset: 20470},
+									pos:  position{line: 678, col: 19, offset: 20481},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 25, offset: 20476},
+									pos:   position{line: 678, col: 25, offset: 20487},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 678, col: 32, offset: 20483},
+										pos:  position{line: 678, col: 32, offset: 20494},
 										name: "IntegerAsString",
 									},
 								},
@@ -1293,30 +1303,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 3, offset: 20537},
+						pos: position{line: 681, col: 3, offset: 20548},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 3, offset: 20537},
+							pos: position{line: 681, col: 3, offset: 20548},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 3, offset: 20537},
+									pos:  position{line: 681, col: 3, offset: 20548},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 681, col: 9, offset: 20543},
+									pos:        position{line: 681, col: 9, offset: 20554},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 681, col: 17, offset: 20551},
+									pos:  position{line: 681, col: 17, offset: 20562},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 23, offset: 20557},
+									pos:   position{line: 681, col: 23, offset: 20568},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 681, col: 30, offset: 20564},
+										pos:  position{line: 681, col: 30, offset: 20575},
 										name: "IntegerAsString",
 									},
 								},
@@ -1328,17 +1338,17 @@ var g = &grammar{
 		},
 		{
 			name: "Options",
-			pos:  position{line: 686, col: 1, offset: 20662},
+			pos:  position{line: 686, col: 1, offset: 20673},
 			expr: &actionExpr{
-				pos: position{line: 686, col: 12, offset: 20673},
+				pos: position{line: 686, col: 12, offset: 20684},
 				run: (*parser).callonOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 686, col: 12, offset: 20673},
+					pos:   position{line: 686, col: 12, offset: 20684},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 686, col: 19, offset: 20680},
+						pos: position{line: 686, col: 19, offset: 20691},
 						expr: &ruleRefExpr{
-							pos:  position{line: 686, col: 20, offset: 20681},
+							pos:  position{line: 686, col: 20, offset: 20692},
 							name: "Option",
 						},
 					},
@@ -1347,34 +1357,34 @@ var g = &grammar{
 		},
 		{
 			name: "Option",
-			pos:  position{line: 735, col: 1, offset: 22228},
+			pos:  position{line: 735, col: 1, offset: 22239},
 			expr: &actionExpr{
-				pos: position{line: 735, col: 11, offset: 22238},
+				pos: position{line: 735, col: 11, offset: 22249},
 				run: (*parser).callonOption1,
 				expr: &seqExpr{
-					pos: position{line: 735, col: 11, offset: 22238},
+					pos: position{line: 735, col: 11, offset: 22249},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 735, col: 11, offset: 22238},
+							pos:  position{line: 735, col: 11, offset: 22249},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 735, col: 17, offset: 22244},
+							pos:   position{line: 735, col: 17, offset: 22255},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 27, offset: 22254},
+								pos:  position{line: 735, col: 27, offset: 22265},
 								name: "OptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 735, col: 37, offset: 22264},
+							pos:  position{line: 735, col: 37, offset: 22275},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 735, col: 43, offset: 22270},
+							pos:   position{line: 735, col: 43, offset: 22281},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 735, col: 49, offset: 22276},
+								pos:  position{line: 735, col: 49, offset: 22287},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -1384,48 +1394,48 @@ var g = &grammar{
 		},
 		{
 			name: "OptionCMD",
-			pos:  position{line: 740, col: 1, offset: 22385},
+			pos:  position{line: 740, col: 1, offset: 22396},
 			expr: &actionExpr{
-				pos: position{line: 740, col: 14, offset: 22398},
+				pos: position{line: 740, col: 14, offset: 22409},
 				run: (*parser).callonOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 740, col: 14, offset: 22398},
+					pos:   position{line: 740, col: 14, offset: 22409},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 740, col: 22, offset: 22406},
+						pos: position{line: 740, col: 22, offset: 22417},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 740, col: 22, offset: 22406},
+								pos:        position{line: 740, col: 22, offset: 22417},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 740, col: 37, offset: 22421},
+								pos:        position{line: 740, col: 37, offset: 22432},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 740, col: 51, offset: 22435},
+								pos:        position{line: 740, col: 51, offset: 22446},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 740, col: 64, offset: 22448},
+								pos:        position{line: 740, col: 64, offset: 22459},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 740, col: 76, offset: 22460},
+								pos:        position{line: 740, col: 76, offset: 22471},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 740, col: 93, offset: 22477},
+								pos:        position{line: 740, col: 93, offset: 22488},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -1437,25 +1447,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 748, col: 1, offset: 22664},
+			pos:  position{line: 748, col: 1, offset: 22675},
 			expr: &choiceExpr{
-				pos: position{line: 748, col: 13, offset: 22676},
+				pos: position{line: 748, col: 13, offset: 22687},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 748, col: 13, offset: 22676},
+						pos: position{line: 748, col: 13, offset: 22687},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 748, col: 13, offset: 22676},
+							pos: position{line: 748, col: 13, offset: 22687},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 748, col: 13, offset: 22676},
+									pos:  position{line: 748, col: 13, offset: 22687},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 748, col: 16, offset: 22679},
+									pos:   position{line: 748, col: 16, offset: 22690},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 748, col: 26, offset: 22689},
+										pos:  position{line: 748, col: 26, offset: 22700},
 										name: "FieldNameList",
 									},
 								},
@@ -1463,13 +1473,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 751, col: 3, offset: 22746},
+						pos: position{line: 751, col: 3, offset: 22757},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 751, col: 3, offset: 22746},
+							pos:   position{line: 751, col: 3, offset: 22757},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 751, col: 16, offset: 22759},
+								pos:  position{line: 751, col: 16, offset: 22770},
 								name: "GroupbyBlock",
 							},
 						},
@@ -1479,26 +1489,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 755, col: 1, offset: 22817},
+			pos:  position{line: 755, col: 1, offset: 22828},
 			expr: &actionExpr{
-				pos: position{line: 755, col: 16, offset: 22832},
+				pos: position{line: 755, col: 16, offset: 22843},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 755, col: 16, offset: 22832},
+					pos: position{line: 755, col: 16, offset: 22843},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 755, col: 16, offset: 22832},
+							pos:  position{line: 755, col: 16, offset: 22843},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 755, col: 21, offset: 22837},
+							pos:  position{line: 755, col: 21, offset: 22848},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 755, col: 32, offset: 22848},
+							pos:   position{line: 755, col: 32, offset: 22859},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 755, col: 43, offset: 22859},
+								pos:  position{line: 755, col: 43, offset: 22870},
 								name: "RenameExpr",
 							},
 						},
@@ -1508,33 +1518,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 771, col: 1, offset: 23234},
+			pos:  position{line: 771, col: 1, offset: 23245},
 			expr: &choiceExpr{
-				pos: position{line: 771, col: 15, offset: 23248},
+				pos: position{line: 771, col: 15, offset: 23259},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 771, col: 15, offset: 23248},
+						pos: position{line: 771, col: 15, offset: 23259},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 15, offset: 23248},
+							pos: position{line: 771, col: 15, offset: 23259},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 771, col: 15, offset: 23248},
+									pos:   position{line: 771, col: 15, offset: 23259},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 31, offset: 23264},
+										pos:  position{line: 771, col: 31, offset: 23275},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 771, col: 45, offset: 23278},
+									pos:  position{line: 771, col: 45, offset: 23289},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 771, col: 48, offset: 23281},
+									pos:   position{line: 771, col: 48, offset: 23292},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 59, offset: 23292},
+										pos:  position{line: 771, col: 59, offset: 23303},
 										name: "QuotedString",
 									},
 								},
@@ -1542,28 +1552,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 782, col: 3, offset: 23611},
+						pos: position{line: 782, col: 3, offset: 23622},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 782, col: 3, offset: 23611},
+							pos: position{line: 782, col: 3, offset: 23622},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 782, col: 3, offset: 23611},
+									pos:   position{line: 782, col: 3, offset: 23622},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 19, offset: 23627},
+										pos:  position{line: 782, col: 19, offset: 23638},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 33, offset: 23641},
+									pos:  position{line: 782, col: 33, offset: 23652},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 36, offset: 23644},
+									pos:   position{line: 782, col: 36, offset: 23655},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 47, offset: 23655},
+										pos:  position{line: 782, col: 47, offset: 23666},
 										name: "RenamePattern",
 									},
 								},
@@ -1575,48 +1585,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 804, col: 1, offset: 24221},
+			pos:  position{line: 804, col: 1, offset: 24232},
 			expr: &actionExpr{
-				pos: position{line: 804, col: 13, offset: 24233},
+				pos: position{line: 804, col: 13, offset: 24244},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 804, col: 13, offset: 24233},
+					pos: position{line: 804, col: 13, offset: 24244},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 13, offset: 24233},
+							pos:  position{line: 804, col: 13, offset: 24244},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 18, offset: 24238},
+							pos:  position{line: 804, col: 18, offset: 24249},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 804, col: 26, offset: 24246},
+							pos:        position{line: 804, col: 26, offset: 24257},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 34, offset: 24254},
+							pos:  position{line: 804, col: 34, offset: 24265},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 40, offset: 24260},
+							pos:   position{line: 804, col: 40, offset: 24271},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 804, col: 46, offset: 24266},
+								pos:  position{line: 804, col: 46, offset: 24277},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 804, col: 62, offset: 24282},
+							pos:  position{line: 804, col: 62, offset: 24293},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 804, col: 68, offset: 24288},
+							pos:   position{line: 804, col: 68, offset: 24299},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 804, col: 72, offset: 24292},
+								pos:  position{line: 804, col: 72, offset: 24303},
 								name: "QuotedString",
 							},
 						},
@@ -1626,43 +1636,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 831, col: 1, offset: 24977},
+			pos:  position{line: 831, col: 1, offset: 24988},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 14, offset: 24990},
+				pos: position{line: 831, col: 14, offset: 25001},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 831, col: 14, offset: 24990},
+					pos: position{line: 831, col: 14, offset: 25001},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 14, offset: 24990},
+							pos:  position{line: 831, col: 14, offset: 25001},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 831, col: 19, offset: 24995},
+							pos:  position{line: 831, col: 19, offset: 25006},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 28, offset: 25004},
+							pos:   position{line: 831, col: 28, offset: 25015},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 831, col: 34, offset: 25010},
+								pos:  position{line: 831, col: 34, offset: 25021},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 831, col: 45, offset: 25021},
+							pos:   position{line: 831, col: 45, offset: 25032},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 831, col: 50, offset: 25026},
+								pos: position{line: 831, col: 50, offset: 25037},
 								expr: &seqExpr{
-									pos: position{line: 831, col: 51, offset: 25027},
+									pos: position{line: 831, col: 51, offset: 25038},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 831, col: 51, offset: 25027},
+											pos:  position{line: 831, col: 51, offset: 25038},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 831, col: 57, offset: 25033},
+											pos:  position{line: 831, col: 57, offset: 25044},
 											name: "SingleEval",
 										},
 									},
@@ -1675,30 +1685,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 858, col: 1, offset: 25834},
+			pos:  position{line: 858, col: 1, offset: 25845},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 15, offset: 25848},
+				pos: position{line: 858, col: 15, offset: 25859},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 858, col: 15, offset: 25848},
+					pos: position{line: 858, col: 15, offset: 25859},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 858, col: 15, offset: 25848},
+							pos:   position{line: 858, col: 15, offset: 25859},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 21, offset: 25854},
+								pos:  position{line: 858, col: 21, offset: 25865},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 858, col: 31, offset: 25864},
+							pos:  position{line: 858, col: 31, offset: 25875},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 858, col: 37, offset: 25870},
+							pos:   position{line: 858, col: 37, offset: 25881},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 858, col: 42, offset: 25875},
+								pos:  position{line: 858, col: 42, offset: 25886},
 								name: "EvalExpression",
 							},
 						},
@@ -1708,15 +1718,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 871, col: 1, offset: 26276},
+			pos:  position{line: 871, col: 1, offset: 26287},
 			expr: &actionExpr{
-				pos: position{line: 871, col: 19, offset: 26294},
+				pos: position{line: 871, col: 19, offset: 26305},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 871, col: 19, offset: 26294},
+					pos:   position{line: 871, col: 19, offset: 26305},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 871, col: 25, offset: 26300},
+						pos:  position{line: 871, col: 25, offset: 26311},
 						name: "ValueExpr",
 					},
 				},
@@ -1724,57 +1734,57 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 879, col: 1, offset: 26447},
+			pos:  position{line: 879, col: 1, offset: 26458},
 			expr: &actionExpr{
-				pos: position{line: 879, col: 18, offset: 26464},
+				pos: position{line: 879, col: 18, offset: 26475},
 				run: (*parser).callonConditionExpr1,
 				expr: &seqExpr{
-					pos: position{line: 879, col: 18, offset: 26464},
+					pos: position{line: 879, col: 18, offset: 26475},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 879, col: 18, offset: 26464},
+							pos:        position{line: 879, col: 18, offset: 26475},
 							val:        "if",
 							ignoreCase: false,
 							want:       "\"if\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 23, offset: 26469},
+							pos:  position{line: 879, col: 23, offset: 26480},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 31, offset: 26477},
+							pos:   position{line: 879, col: 31, offset: 26488},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 41, offset: 26487},
+								pos:  position{line: 879, col: 41, offset: 26498},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 50, offset: 26496},
+							pos:  position{line: 879, col: 50, offset: 26507},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 56, offset: 26502},
+							pos:   position{line: 879, col: 56, offset: 26513},
 							label: "trueValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 66, offset: 26512},
+								pos:  position{line: 879, col: 66, offset: 26523},
 								name: "ValueExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 76, offset: 26522},
+							pos:  position{line: 879, col: 76, offset: 26533},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 879, col: 82, offset: 26528},
+							pos:   position{line: 879, col: 82, offset: 26539},
 							label: "falseValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 879, col: 93, offset: 26539},
+								pos:  position{line: 879, col: 93, offset: 26550},
 								name: "ValueExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 879, col: 103, offset: 26549},
+							pos:  position{line: 879, col: 103, offset: 26560},
 							name: "R_PAREN",
 						},
 					},
@@ -1783,65 +1793,65 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 891, col: 1, offset: 26799},
+			pos:  position{line: 891, col: 1, offset: 26810},
 			expr: &choiceExpr{
-				pos: position{line: 891, col: 13, offset: 26811},
+				pos: position{line: 891, col: 13, offset: 26822},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 891, col: 13, offset: 26811},
+						pos: position{line: 891, col: 13, offset: 26822},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 891, col: 14, offset: 26812},
+							pos: position{line: 891, col: 14, offset: 26823},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 891, col: 14, offset: 26812},
+									pos:   position{line: 891, col: 14, offset: 26823},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 891, col: 22, offset: 26820},
+										pos:        position{line: 891, col: 22, offset: 26831},
 										val:        "lower",
 										ignoreCase: false,
 										want:       "\"lower\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 891, col: 31, offset: 26829},
+									pos:  position{line: 891, col: 31, offset: 26840},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 891, col: 39, offset: 26837},
+									pos:   position{line: 891, col: 39, offset: 26848},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 891, col: 50, offset: 26848},
+										pos:  position{line: 891, col: 50, offset: 26859},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 891, col: 61, offset: 26859},
+									pos:  position{line: 891, col: 61, offset: 26870},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 905, col: 3, offset: 27171},
+						pos: position{line: 905, col: 3, offset: 27182},
 						run: (*parser).callonTextExpr10,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 4, offset: 27172},
+							pos: position{line: 905, col: 4, offset: 27183},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 905, col: 4, offset: 27172},
+									pos:   position{line: 905, col: 4, offset: 27183},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 905, col: 12, offset: 27180},
+										pos: position{line: 905, col: 12, offset: 27191},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 905, col: 12, offset: 27180},
+												pos:        position{line: 905, col: 12, offset: 27191},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 905, col: 20, offset: 27188},
+												pos:        position{line: 905, col: 20, offset: 27199},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -1850,31 +1860,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 27, offset: 27195},
+									pos:  position{line: 905, col: 27, offset: 27206},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 35, offset: 27203},
+									pos:   position{line: 905, col: 35, offset: 27214},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 44, offset: 27212},
+										pos:  position{line: 905, col: 44, offset: 27223},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 905, col: 55, offset: 27223},
+									pos:   position{line: 905, col: 55, offset: 27234},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 905, col: 60, offset: 27228},
+										pos: position{line: 905, col: 60, offset: 27239},
 										expr: &seqExpr{
-											pos: position{line: 905, col: 61, offset: 27229},
+											pos: position{line: 905, col: 61, offset: 27240},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 905, col: 61, offset: 27229},
+													pos:  position{line: 905, col: 61, offset: 27240},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 905, col: 67, offset: 27235},
+													pos:  position{line: 905, col: 67, offset: 27246},
 													name: "StringExpr",
 												},
 											},
@@ -1882,148 +1892,148 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 80, offset: 27248},
+									pos:  position{line: 905, col: 80, offset: 27259},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 928, col: 3, offset: 27942},
+						pos: position{line: 928, col: 3, offset: 27953},
 						run: (*parser).callonTextExpr25,
 						expr: &seqExpr{
-							pos: position{line: 928, col: 4, offset: 27943},
+							pos: position{line: 928, col: 4, offset: 27954},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 928, col: 4, offset: 27943},
+									pos:   position{line: 928, col: 4, offset: 27954},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 928, col: 12, offset: 27951},
+										pos:        position{line: 928, col: 12, offset: 27962},
 										val:        "urldecode",
 										ignoreCase: false,
 										want:       "\"urldecode\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 25, offset: 27964},
+									pos:  position{line: 928, col: 25, offset: 27975},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 928, col: 33, offset: 27972},
+									pos:   position{line: 928, col: 33, offset: 27983},
 									label: "url",
 									expr: &ruleRefExpr{
-										pos:  position{line: 928, col: 37, offset: 27976},
+										pos:  position{line: 928, col: 37, offset: 27987},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 928, col: 48, offset: 27987},
+									pos:  position{line: 928, col: 48, offset: 27998},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 940, col: 3, offset: 28326},
+						pos: position{line: 940, col: 3, offset: 28337},
 						run: (*parser).callonTextExpr33,
 						expr: &seqExpr{
-							pos: position{line: 940, col: 4, offset: 28327},
+							pos: position{line: 940, col: 4, offset: 28338},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 940, col: 4, offset: 28327},
+									pos:   position{line: 940, col: 4, offset: 28338},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 940, col: 12, offset: 28335},
+										pos:        position{line: 940, col: 12, offset: 28346},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 940, col: 21, offset: 28344},
+									pos:  position{line: 940, col: 21, offset: 28355},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 940, col: 29, offset: 28352},
+									pos:   position{line: 940, col: 29, offset: 28363},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 940, col: 40, offset: 28363},
+										pos:  position{line: 940, col: 40, offset: 28374},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 940, col: 51, offset: 28374},
+									pos:  position{line: 940, col: 51, offset: 28385},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 940, col: 57, offset: 28380},
+									pos:   position{line: 940, col: 57, offset: 28391},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 940, col: 63, offset: 28386},
+										pos:  position{line: 940, col: 63, offset: 28397},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 940, col: 74, offset: 28397},
+									pos:  position{line: 940, col: 74, offset: 28408},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 952, col: 3, offset: 28730},
+						pos: position{line: 952, col: 3, offset: 28741},
 						run: (*parser).callonTextExpr44,
 						expr: &seqExpr{
-							pos: position{line: 952, col: 4, offset: 28731},
+							pos: position{line: 952, col: 4, offset: 28742},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 952, col: 4, offset: 28731},
+									pos:   position{line: 952, col: 4, offset: 28742},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 952, col: 12, offset: 28739},
+										pos:        position{line: 952, col: 12, offset: 28750},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 22, offset: 28749},
+									pos:  position{line: 952, col: 22, offset: 28760},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 952, col: 30, offset: 28757},
+									pos:   position{line: 952, col: 30, offset: 28768},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 952, col: 41, offset: 28768},
+										pos:  position{line: 952, col: 41, offset: 28779},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 52, offset: 28779},
+									pos:  position{line: 952, col: 52, offset: 28790},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 952, col: 58, offset: 28785},
+									pos:   position{line: 952, col: 58, offset: 28796},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 952, col: 69, offset: 28796},
+										pos:  position{line: 952, col: 69, offset: 28807},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 952, col: 81, offset: 28808},
+									pos:   position{line: 952, col: 81, offset: 28819},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 952, col: 93, offset: 28820},
+										pos: position{line: 952, col: 93, offset: 28831},
 										expr: &seqExpr{
-											pos: position{line: 952, col: 94, offset: 28821},
+											pos: position{line: 952, col: 94, offset: 28832},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 952, col: 94, offset: 28821},
+													pos:  position{line: 952, col: 94, offset: 28832},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 952, col: 100, offset: 28827},
+													pos:  position{line: 952, col: 100, offset: 28838},
 													name: "NumericExpr",
 												},
 											},
@@ -2031,50 +2041,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 952, col: 114, offset: 28841},
+									pos:  position{line: 952, col: 114, offset: 28852},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 986, col: 3, offset: 30027},
+						pos: position{line: 986, col: 3, offset: 30038},
 						run: (*parser).callonTextExpr60,
 						expr: &seqExpr{
-							pos: position{line: 986, col: 3, offset: 30027},
+							pos: position{line: 986, col: 3, offset: 30038},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 986, col: 3, offset: 30027},
+									pos:        position{line: 986, col: 3, offset: 30038},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 986, col: 14, offset: 30038},
+									pos:  position{line: 986, col: 14, offset: 30049},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 986, col: 22, offset: 30046},
+									pos:   position{line: 986, col: 22, offset: 30057},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 986, col: 28, offset: 30052},
+										pos:  position{line: 986, col: 28, offset: 30063},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 986, col: 38, offset: 30062},
+									pos:   position{line: 986, col: 38, offset: 30073},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 986, col: 45, offset: 30069},
+										pos: position{line: 986, col: 45, offset: 30080},
 										expr: &seqExpr{
-											pos: position{line: 986, col: 46, offset: 30070},
+											pos: position{line: 986, col: 46, offset: 30081},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 986, col: 46, offset: 30070},
+													pos:  position{line: 986, col: 46, offset: 30081},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 986, col: 52, offset: 30076},
+													pos:  position{line: 986, col: 52, offset: 30087},
 													name: "StringExpr",
 												},
 											},
@@ -2082,32 +2092,32 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 986, col: 66, offset: 30090},
+									pos:  position{line: 986, col: 66, offset: 30101},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 999, col: 3, offset: 30460},
+						pos: position{line: 999, col: 3, offset: 30471},
 						run: (*parser).callonTextExpr72,
 						expr: &seqExpr{
-							pos: position{line: 999, col: 4, offset: 30461},
+							pos: position{line: 999, col: 4, offset: 30472},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 999, col: 4, offset: 30461},
+									pos:   position{line: 999, col: 4, offset: 30472},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 999, col: 12, offset: 30469},
+										pos: position{line: 999, col: 12, offset: 30480},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 999, col: 12, offset: 30469},
+												pos:        position{line: 999, col: 12, offset: 30480},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 999, col: 22, offset: 30479},
+												pos:        position{line: 999, col: 22, offset: 30490},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
@@ -2116,30 +2126,30 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 31, offset: 30488},
+									pos:  position{line: 999, col: 31, offset: 30499},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 39, offset: 30496},
+									pos:   position{line: 999, col: 39, offset: 30507},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 999, col: 45, offset: 30502},
+										pos:  position{line: 999, col: 45, offset: 30513},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 999, col: 57, offset: 30514},
+									pos:   position{line: 999, col: 57, offset: 30525},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 999, col: 73, offset: 30530},
+										pos: position{line: 999, col: 73, offset: 30541},
 										expr: &ruleRefExpr{
-											pos:  position{line: 999, col: 74, offset: 30531},
+											pos:  position{line: 999, col: 74, offset: 30542},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 999, col: 92, offset: 30549},
+									pos:  position{line: 999, col: 92, offset: 30560},
 									name: "R_PAREN",
 								},
 							},
@@ -2150,22 +2160,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 1024, col: 1, offset: 31152},
+			pos:  position{line: 1024, col: 1, offset: 31163},
 			expr: &actionExpr{
-				pos: position{line: 1024, col: 20, offset: 31171},
+				pos: position{line: 1024, col: 20, offset: 31182},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1024, col: 20, offset: 31171},
+					pos: position{line: 1024, col: 20, offset: 31182},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1024, col: 20, offset: 31171},
+							pos:  position{line: 1024, col: 20, offset: 31182},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 1024, col: 26, offset: 31177},
+							pos:   position{line: 1024, col: 26, offset: 31188},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1024, col: 38, offset: 31189},
+								pos:  position{line: 1024, col: 38, offset: 31200},
 								name: "String",
 							},
 						},
@@ -2175,20 +2185,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 1030, col: 1, offset: 31374},
+			pos:  position{line: 1030, col: 1, offset: 31385},
 			expr: &choiceExpr{
-				pos: position{line: 1030, col: 20, offset: 31393},
+				pos: position{line: 1030, col: 20, offset: 31404},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1030, col: 20, offset: 31393},
+						pos: position{line: 1030, col: 20, offset: 31404},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 1030, col: 20, offset: 31393},
+							pos: position{line: 1030, col: 20, offset: 31404},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 1030, col: 20, offset: 31393},
+									pos: position{line: 1030, col: 20, offset: 31404},
 									expr: &charClassMatcher{
-										pos:        position{line: 1030, col: 20, offset: 31393},
+										pos:        position{line: 1030, col: 20, offset: 31404},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -2197,9 +2207,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 1030, col: 31, offset: 31404},
+									pos: position{line: 1030, col: 31, offset: 31415},
 									expr: &litMatcher{
-										pos:        position{line: 1030, col: 33, offset: 31406},
+										pos:        position{line: 1030, col: 33, offset: 31417},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -2209,27 +2219,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1033, col: 3, offset: 31448},
+						pos: position{line: 1033, col: 3, offset: 31459},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 1033, col: 3, offset: 31448},
+							pos: position{line: 1033, col: 3, offset: 31459},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1033, col: 3, offset: 31448},
+									pos:        position{line: 1033, col: 3, offset: 31459},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1033, col: 7, offset: 31452},
+									pos:   position{line: 1033, col: 7, offset: 31463},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1033, col: 13, offset: 31458},
+										pos:  position{line: 1033, col: 13, offset: 31469},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1033, col: 23, offset: 31468},
+									pos:        position{line: 1033, col: 23, offset: 31479},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -2242,26 +2252,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 1038, col: 1, offset: 31536},
+			pos:  position{line: 1038, col: 1, offset: 31547},
 			expr: &actionExpr{
-				pos: position{line: 1038, col: 15, offset: 31550},
+				pos: position{line: 1038, col: 15, offset: 31561},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1038, col: 15, offset: 31550},
+					pos: position{line: 1038, col: 15, offset: 31561},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1038, col: 15, offset: 31550},
+							pos:  position{line: 1038, col: 15, offset: 31561},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1038, col: 20, offset: 31555},
+							pos:  position{line: 1038, col: 20, offset: 31566},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1038, col: 30, offset: 31565},
+							pos:   position{line: 1038, col: 30, offset: 31576},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1038, col: 40, offset: 31575},
+								pos:  position{line: 1038, col: 40, offset: 31586},
 								name: "BoolExpr",
 							},
 						},
@@ -2271,15 +2281,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 1050, col: 1, offset: 31868},
+			pos:  position{line: 1050, col: 1, offset: 31879},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 13, offset: 31880},
+				pos: position{line: 1050, col: 13, offset: 31891},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 1050, col: 13, offset: 31880},
+					pos:   position{line: 1050, col: 13, offset: 31891},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1050, col: 18, offset: 31885},
+						pos:  position{line: 1050, col: 18, offset: 31896},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -2287,35 +2297,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 1055, col: 1, offset: 31955},
+			pos:  position{line: 1055, col: 1, offset: 31966},
 			expr: &actionExpr{
-				pos: position{line: 1055, col: 19, offset: 31973},
+				pos: position{line: 1055, col: 19, offset: 31984},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1055, col: 19, offset: 31973},
+					pos: position{line: 1055, col: 19, offset: 31984},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1055, col: 19, offset: 31973},
+							pos:   position{line: 1055, col: 19, offset: 31984},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1055, col: 25, offset: 31979},
+								pos:  position{line: 1055, col: 25, offset: 31990},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1055, col: 40, offset: 31994},
+							pos:   position{line: 1055, col: 40, offset: 32005},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1055, col: 45, offset: 31999},
+								pos: position{line: 1055, col: 45, offset: 32010},
 								expr: &seqExpr{
-									pos: position{line: 1055, col: 46, offset: 32000},
+									pos: position{line: 1055, col: 46, offset: 32011},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1055, col: 46, offset: 32000},
+											pos:  position{line: 1055, col: 46, offset: 32011},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1055, col: 49, offset: 32003},
+											pos:  position{line: 1055, col: 49, offset: 32014},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -2328,35 +2338,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 1075, col: 1, offset: 32441},
+			pos:  position{line: 1075, col: 1, offset: 32452},
 			expr: &actionExpr{
-				pos: position{line: 1075, col: 19, offset: 32459},
+				pos: position{line: 1075, col: 19, offset: 32470},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1075, col: 19, offset: 32459},
+					pos: position{line: 1075, col: 19, offset: 32470},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1075, col: 19, offset: 32459},
+							pos:   position{line: 1075, col: 19, offset: 32470},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1075, col: 25, offset: 32465},
+								pos:  position{line: 1075, col: 25, offset: 32476},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1075, col: 40, offset: 32480},
+							pos:   position{line: 1075, col: 40, offset: 32491},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1075, col: 45, offset: 32485},
+								pos: position{line: 1075, col: 45, offset: 32496},
 								expr: &seqExpr{
-									pos: position{line: 1075, col: 46, offset: 32486},
+									pos: position{line: 1075, col: 46, offset: 32497},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1075, col: 46, offset: 32486},
+											pos:  position{line: 1075, col: 46, offset: 32497},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1075, col: 50, offset: 32490},
+											pos:  position{line: 1075, col: 50, offset: 32501},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -2369,47 +2379,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 1095, col: 1, offset: 32929},
+			pos:  position{line: 1095, col: 1, offset: 32940},
 			expr: &choiceExpr{
-				pos: position{line: 1095, col: 19, offset: 32947},
+				pos: position{line: 1095, col: 19, offset: 32958},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1095, col: 19, offset: 32947},
+						pos: position{line: 1095, col: 19, offset: 32958},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1095, col: 19, offset: 32947},
+							pos: position{line: 1095, col: 19, offset: 32958},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 19, offset: 32947},
+									pos:  position{line: 1095, col: 19, offset: 32958},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 23, offset: 32951},
+									pos:  position{line: 1095, col: 23, offset: 32962},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1095, col: 31, offset: 32959},
+									pos:   position{line: 1095, col: 31, offset: 32970},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1095, col: 37, offset: 32965},
+										pos:  position{line: 1095, col: 37, offset: 32976},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1095, col: 52, offset: 32980},
+									pos:  position{line: 1095, col: 52, offset: 32991},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1105, col: 3, offset: 33183},
+						pos: position{line: 1105, col: 3, offset: 33194},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1105, col: 3, offset: 33183},
+							pos:   position{line: 1105, col: 3, offset: 33194},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 9, offset: 33189},
+								pos:  position{line: 1105, col: 9, offset: 33200},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -2419,67 +2429,67 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 1110, col: 1, offset: 33260},
+			pos:  position{line: 1110, col: 1, offset: 33271},
 			expr: &choiceExpr{
-				pos: position{line: 1110, col: 19, offset: 33278},
+				pos: position{line: 1110, col: 19, offset: 33289},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1110, col: 19, offset: 33278},
+						pos: position{line: 1110, col: 19, offset: 33289},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1110, col: 19, offset: 33278},
+							pos: position{line: 1110, col: 19, offset: 33289},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 19, offset: 33278},
+									pos:  position{line: 1110, col: 19, offset: 33289},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1110, col: 27, offset: 33286},
+									pos:   position{line: 1110, col: 27, offset: 33297},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1110, col: 33, offset: 33292},
+										pos:  position{line: 1110, col: 33, offset: 33303},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1110, col: 48, offset: 33307},
+									pos:  position{line: 1110, col: 48, offset: 33318},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1113, col: 3, offset: 33343},
+						pos: position{line: 1113, col: 3, offset: 33354},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &seqExpr{
-							pos: position{line: 1113, col: 4, offset: 33344},
+							pos: position{line: 1113, col: 4, offset: 33355},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1113, col: 4, offset: 33344},
+									pos:   position{line: 1113, col: 4, offset: 33355},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 1113, col: 8, offset: 33348},
+										pos: position{line: 1113, col: 8, offset: 33359},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1113, col: 8, offset: 33348},
+												pos:        position{line: 1113, col: 8, offset: 33359},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1113, col: 19, offset: 33359},
+												pos:        position{line: 1113, col: 19, offset: 33370},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1113, col: 29, offset: 33369},
+												pos:        position{line: 1113, col: 29, offset: 33380},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1113, col: 39, offset: 33379},
+												pos:        position{line: 1113, col: 39, offset: 33390},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
@@ -2488,32 +2498,32 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 49, offset: 33389},
+									pos:  position{line: 1113, col: 49, offset: 33400},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1113, col: 57, offset: 33397},
+									pos:   position{line: 1113, col: 57, offset: 33408},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1113, col: 63, offset: 33403},
+										pos:  position{line: 1113, col: 63, offset: 33414},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 73, offset: 33413},
+									pos:  position{line: 1113, col: 73, offset: 33424},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1126, col: 3, offset: 33749},
+						pos: position{line: 1126, col: 3, offset: 33760},
 						run: (*parser).callonBoolExprLevel120,
 						expr: &labeledExpr{
-							pos:   position{line: 1126, col: 3, offset: 33749},
+							pos:   position{line: 1126, col: 3, offset: 33760},
 							label: "likeExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1126, col: 13, offset: 33759},
+								pos:  position{line: 1126, col: 13, offset: 33770},
 								name: "LikeExpr",
 							},
 						},
@@ -2523,43 +2533,43 @@ var g = &grammar{
 		},
 		{
 			name: "LikeExpr",
-			pos:  position{line: 1129, col: 1, offset: 33797},
+			pos:  position{line: 1129, col: 1, offset: 33808},
 			expr: &choiceExpr{
-				pos: position{line: 1129, col: 13, offset: 33809},
+				pos: position{line: 1129, col: 13, offset: 33820},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1129, col: 13, offset: 33809},
+						pos: position{line: 1129, col: 13, offset: 33820},
 						run: (*parser).callonLikeExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1129, col: 13, offset: 33809},
+							pos: position{line: 1129, col: 13, offset: 33820},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1129, col: 13, offset: 33809},
+									pos:   position{line: 1129, col: 13, offset: 33820},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1129, col: 18, offset: 33814},
+										pos:  position{line: 1129, col: 18, offset: 33825},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1129, col: 28, offset: 33824},
+									pos:  position{line: 1129, col: 28, offset: 33835},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1129, col: 34, offset: 33830},
+									pos:        position{line: 1129, col: 34, offset: 33841},
 									val:        "LIKE",
 									ignoreCase: false,
 									want:       "\"LIKE\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1129, col: 41, offset: 33837},
+									pos:  position{line: 1129, col: 41, offset: 33848},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1129, col: 47, offset: 33843},
+									pos:   position{line: 1129, col: 47, offset: 33854},
 									label: "right",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1129, col: 53, offset: 33849},
+										pos:  position{line: 1129, col: 53, offset: 33860},
 										name: "ValueExpr",
 									},
 								},
@@ -2567,154 +2577,154 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1138, col: 3, offset: 34069},
+						pos: position{line: 1138, col: 3, offset: 34080},
 						run: (*parser).callonLikeExpr11,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 3, offset: 34069},
+							pos: position{line: 1138, col: 3, offset: 34080},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1138, col: 3, offset: 34069},
+									pos:        position{line: 1138, col: 3, offset: 34080},
 									val:        "like",
 									ignoreCase: false,
 									want:       "\"like\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1138, col: 10, offset: 34076},
+									pos:  position{line: 1138, col: 10, offset: 34087},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 18, offset: 34084},
+									pos:   position{line: 1138, col: 18, offset: 34095},
 									label: "stringr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 26, offset: 34092},
+										pos:  position{line: 1138, col: 26, offset: 34103},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1138, col: 36, offset: 34102},
+									pos:  position{line: 1138, col: 36, offset: 34113},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 42, offset: 34108},
+									pos:   position{line: 1138, col: 42, offset: 34119},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 50, offset: 34116},
+										pos:  position{line: 1138, col: 50, offset: 34127},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1138, col: 60, offset: 34126},
+									pos:  position{line: 1138, col: 60, offset: 34137},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1147, col: 3, offset: 34357},
+						pos: position{line: 1147, col: 3, offset: 34368},
 						run: (*parser).callonLikeExpr21,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 3, offset: 34357},
+							pos: position{line: 1147, col: 3, offset: 34368},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1147, col: 3, offset: 34357},
+									pos:        position{line: 1147, col: 3, offset: 34368},
 									val:        "match",
 									ignoreCase: false,
 									want:       "\"match\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 11, offset: 34365},
+									pos:  position{line: 1147, col: 11, offset: 34376},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1147, col: 19, offset: 34373},
+									pos:   position{line: 1147, col: 19, offset: 34384},
 									label: "stringVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 29, offset: 34383},
+										pos:  position{line: 1147, col: 29, offset: 34394},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 39, offset: 34393},
+									pos:  position{line: 1147, col: 39, offset: 34404},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 1147, col: 45, offset: 34399},
+									pos:   position{line: 1147, col: 45, offset: 34410},
 									label: "pattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 53, offset: 34407},
+										pos:  position{line: 1147, col: 53, offset: 34418},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 63, offset: 34417},
+									pos:  position{line: 1147, col: 63, offset: 34428},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1156, col: 3, offset: 34651},
+						pos: position{line: 1156, col: 3, offset: 34662},
 						run: (*parser).callonLikeExpr31,
 						expr: &seqExpr{
-							pos: position{line: 1156, col: 3, offset: 34651},
+							pos: position{line: 1156, col: 3, offset: 34662},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1156, col: 3, offset: 34651},
+									pos:        position{line: 1156, col: 3, offset: 34662},
 									val:        "cidrmatch",
 									ignoreCase: false,
 									want:       "\"cidrmatch\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1156, col: 15, offset: 34663},
+									pos:  position{line: 1156, col: 15, offset: 34674},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1156, col: 23, offset: 34671},
+									pos:   position{line: 1156, col: 23, offset: 34682},
 									label: "cidr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1156, col: 28, offset: 34676},
+										pos:  position{line: 1156, col: 28, offset: 34687},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1156, col: 38, offset: 34686},
+									pos:  position{line: 1156, col: 38, offset: 34697},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 1156, col: 44, offset: 34692},
+									pos:   position{line: 1156, col: 44, offset: 34703},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1156, col: 47, offset: 34695},
+										pos:  position{line: 1156, col: 47, offset: 34706},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1156, col: 57, offset: 34705},
+									pos:  position{line: 1156, col: 57, offset: 34716},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1165, col: 3, offset: 34925},
+						pos: position{line: 1165, col: 3, offset: 34936},
 						run: (*parser).callonLikeExpr41,
 						expr: &labeledExpr{
-							pos:   position{line: 1165, col: 3, offset: 34925},
+							pos:   position{line: 1165, col: 3, offset: 34936},
 							label: "inExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1165, col: 11, offset: 34933},
+								pos:  position{line: 1165, col: 11, offset: 34944},
 								name: "InExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1168, col: 3, offset: 34969},
+						pos: position{line: 1168, col: 3, offset: 34980},
 						run: (*parser).callonLikeExpr44,
 						expr: &labeledExpr{
-							pos:   position{line: 1168, col: 3, offset: 34969},
+							pos:   position{line: 1168, col: 3, offset: 34980},
 							label: "boolComparisonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1168, col: 22, offset: 34988},
+								pos:  position{line: 1168, col: 22, offset: 34999},
 								name: "BoolComparisonExpr",
 							},
 						},
@@ -2724,34 +2734,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 1172, col: 1, offset: 35047},
+			pos:  position{line: 1172, col: 1, offset: 35058},
 			expr: &actionExpr{
-				pos: position{line: 1172, col: 23, offset: 35069},
+				pos: position{line: 1172, col: 23, offset: 35080},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1172, col: 23, offset: 35069},
+					pos: position{line: 1172, col: 23, offset: 35080},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1172, col: 23, offset: 35069},
+							pos:   position{line: 1172, col: 23, offset: 35080},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 28, offset: 35074},
+								pos:  position{line: 1172, col: 28, offset: 35085},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 38, offset: 35084},
+							pos:   position{line: 1172, col: 38, offset: 35095},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 41, offset: 35087},
+								pos:  position{line: 1172, col: 41, offset: 35098},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1172, col: 62, offset: 35108},
+							pos:   position{line: 1172, col: 62, offset: 35119},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1172, col: 68, offset: 35114},
+								pos:  position{line: 1172, col: 68, offset: 35125},
 								name: "ValueExpr",
 							},
 						},
@@ -2761,60 +2771,60 @@ var g = &grammar{
 		},
 		{
 			name: "InExpr",
-			pos:  position{line: 1184, col: 1, offset: 35340},
+			pos:  position{line: 1184, col: 1, offset: 35351},
 			expr: &choiceExpr{
-				pos: position{line: 1184, col: 11, offset: 35350},
+				pos: position{line: 1184, col: 11, offset: 35361},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1184, col: 11, offset: 35350},
+						pos: position{line: 1184, col: 11, offset: 35361},
 						run: (*parser).callonInExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1184, col: 11, offset: 35350},
+							pos: position{line: 1184, col: 11, offset: 35361},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1184, col: 11, offset: 35350},
+									pos:   position{line: 1184, col: 11, offset: 35361},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 16, offset: 35355},
+										pos:  position{line: 1184, col: 16, offset: 35366},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1184, col: 26, offset: 35365},
+									pos:  position{line: 1184, col: 26, offset: 35376},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1184, col: 32, offset: 35371},
+									pos:        position{line: 1184, col: 32, offset: 35382},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1184, col: 37, offset: 35376},
+									pos:  position{line: 1184, col: 37, offset: 35387},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 45, offset: 35384},
+									pos:   position{line: 1184, col: 45, offset: 35395},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1184, col: 58, offset: 35397},
+										pos:  position{line: 1184, col: 58, offset: 35408},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1184, col: 68, offset: 35407},
+									pos:   position{line: 1184, col: 68, offset: 35418},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1184, col: 73, offset: 35412},
+										pos: position{line: 1184, col: 73, offset: 35423},
 										expr: &seqExpr{
-											pos: position{line: 1184, col: 74, offset: 35413},
+											pos: position{line: 1184, col: 74, offset: 35424},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1184, col: 74, offset: 35413},
+													pos:  position{line: 1184, col: 74, offset: 35424},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1184, col: 80, offset: 35419},
+													pos:  position{line: 1184, col: 80, offset: 35430},
 													name: "ValueExpr",
 												},
 											},
@@ -2822,50 +2832,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1184, col: 92, offset: 35431},
+									pos:  position{line: 1184, col: 92, offset: 35442},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1203, col: 3, offset: 35982},
+						pos: position{line: 1203, col: 3, offset: 35993},
 						run: (*parser).callonInExpr17,
 						expr: &seqExpr{
-							pos: position{line: 1203, col: 3, offset: 35982},
+							pos: position{line: 1203, col: 3, offset: 35993},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1203, col: 3, offset: 35982},
+									pos:        position{line: 1203, col: 3, offset: 35993},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1203, col: 8, offset: 35987},
+									pos:  position{line: 1203, col: 8, offset: 35998},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 16, offset: 35995},
+									pos:   position{line: 1203, col: 16, offset: 36006},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1203, col: 29, offset: 36008},
+										pos:  position{line: 1203, col: 29, offset: 36019},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1203, col: 39, offset: 36018},
+									pos:   position{line: 1203, col: 39, offset: 36029},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 1203, col: 44, offset: 36023},
+										pos: position{line: 1203, col: 44, offset: 36034},
 										expr: &seqExpr{
-											pos: position{line: 1203, col: 45, offset: 36024},
+											pos: position{line: 1203, col: 45, offset: 36035},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1203, col: 45, offset: 36024},
+													pos:  position{line: 1203, col: 45, offset: 36035},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1203, col: 51, offset: 36030},
+													pos:  position{line: 1203, col: 51, offset: 36041},
 													name: "ValueExpr",
 												},
 											},
@@ -2873,7 +2883,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1203, col: 63, offset: 36042},
+									pos:  position{line: 1203, col: 63, offset: 36053},
 									name: "R_PAREN",
 								},
 							},
@@ -2884,116 +2894,116 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 1228, col: 1, offset: 36832},
+			pos:  position{line: 1228, col: 1, offset: 36843},
 			expr: &choiceExpr{
-				pos: position{line: 1228, col: 14, offset: 36845},
+				pos: position{line: 1228, col: 14, offset: 36856},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1228, col: 14, offset: 36845},
+						pos: position{line: 1228, col: 14, offset: 36856},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 1228, col: 14, offset: 36845},
+							pos:   position{line: 1228, col: 14, offset: 36856},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1228, col: 24, offset: 36855},
+								pos:  position{line: 1228, col: 24, offset: 36866},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1237, col: 3, offset: 37045},
+						pos: position{line: 1237, col: 3, offset: 37056},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 1237, col: 3, offset: 37045},
+							pos: position{line: 1237, col: 3, offset: 37056},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1237, col: 3, offset: 37045},
+									pos:  position{line: 1237, col: 3, offset: 37056},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1237, col: 12, offset: 37054},
+									pos:   position{line: 1237, col: 12, offset: 37065},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1237, col: 22, offset: 37064},
+										pos:  position{line: 1237, col: 22, offset: 37075},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1237, col: 37, offset: 37079},
+									pos:  position{line: 1237, col: 37, offset: 37090},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1246, col: 3, offset: 37263},
+						pos: position{line: 1246, col: 3, offset: 37274},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 1246, col: 3, offset: 37263},
+							pos:   position{line: 1246, col: 3, offset: 37274},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1246, col: 11, offset: 37271},
+								pos:  position{line: 1246, col: 11, offset: 37282},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1255, col: 3, offset: 37451},
+						pos: position{line: 1255, col: 3, offset: 37462},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 1255, col: 3, offset: 37451},
+							pos:   position{line: 1255, col: 3, offset: 37462},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1255, col: 7, offset: 37455},
+								pos:  position{line: 1255, col: 7, offset: 37466},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1264, col: 3, offset: 37627},
+						pos: position{line: 1264, col: 3, offset: 37638},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 1264, col: 3, offset: 37627},
+							pos: position{line: 1264, col: 3, offset: 37638},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1264, col: 3, offset: 37627},
+									pos:  position{line: 1264, col: 3, offset: 37638},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1264, col: 12, offset: 37636},
+									pos:   position{line: 1264, col: 12, offset: 37647},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1264, col: 16, offset: 37640},
+										pos:  position{line: 1264, col: 16, offset: 37651},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1264, col: 28, offset: 37652},
+									pos:  position{line: 1264, col: 28, offset: 37663},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1273, col: 3, offset: 37821},
+						pos: position{line: 1273, col: 3, offset: 37832},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 1273, col: 3, offset: 37821},
+							pos: position{line: 1273, col: 3, offset: 37832},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 3, offset: 37821},
+									pos:  position{line: 1273, col: 3, offset: 37832},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1273, col: 11, offset: 37829},
+									pos:   position{line: 1273, col: 11, offset: 37840},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1273, col: 19, offset: 37837},
+										pos:  position{line: 1273, col: 19, offset: 37848},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1273, col: 28, offset: 37846},
+									pos:  position{line: 1273, col: 28, offset: 37857},
 									name: "R_PAREN",
 								},
 							},
@@ -3004,28 +3014,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 1283, col: 1, offset: 38027},
+			pos:  position{line: 1283, col: 1, offset: 38038},
 			expr: &choiceExpr{
-				pos: position{line: 1283, col: 15, offset: 38041},
+				pos: position{line: 1283, col: 15, offset: 38052},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1283, col: 15, offset: 38041},
+						pos: position{line: 1283, col: 15, offset: 38052},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1283, col: 15, offset: 38041},
+							pos: position{line: 1283, col: 15, offset: 38052},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1283, col: 15, offset: 38041},
+									pos:   position{line: 1283, col: 15, offset: 38052},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 20, offset: 38046},
+										pos:  position{line: 1283, col: 20, offset: 38057},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1283, col: 29, offset: 38055},
+									pos: position{line: 1283, col: 29, offset: 38066},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1283, col: 31, offset: 38057},
+										pos:  position{line: 1283, col: 31, offset: 38068},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -3033,23 +3043,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1291, col: 3, offset: 38227},
+						pos: position{line: 1291, col: 3, offset: 38238},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 1291, col: 3, offset: 38227},
+							pos: position{line: 1291, col: 3, offset: 38238},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1291, col: 3, offset: 38227},
+									pos:   position{line: 1291, col: 3, offset: 38238},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 7, offset: 38231},
+										pos:  position{line: 1291, col: 7, offset: 38242},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1291, col: 20, offset: 38244},
+									pos: position{line: 1291, col: 20, offset: 38255},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1291, col: 22, offset: 38246},
+										pos:  position{line: 1291, col: 22, offset: 38257},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -3057,46 +3067,46 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1299, col: 3, offset: 38411},
+						pos: position{line: 1299, col: 3, offset: 38422},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 1299, col: 3, offset: 38411},
+							pos: position{line: 1299, col: 3, offset: 38422},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1299, col: 3, offset: 38411},
+									pos:   position{line: 1299, col: 3, offset: 38422},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1299, col: 9, offset: 38417},
+										pos:  position{line: 1299, col: 9, offset: 38428},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1299, col: 25, offset: 38433},
+									pos: position{line: 1299, col: 25, offset: 38444},
 									expr: &choiceExpr{
-										pos: position{line: 1299, col: 27, offset: 38435},
+										pos: position{line: 1299, col: 27, offset: 38446},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1299, col: 27, offset: 38435},
+												pos:  position{line: 1299, col: 27, offset: 38446},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1299, col: 36, offset: 38444},
+												pos:  position{line: 1299, col: 36, offset: 38455},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1299, col: 46, offset: 38454},
+												pos:  position{line: 1299, col: 46, offset: 38465},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1299, col: 54, offset: 38462},
+												pos:  position{line: 1299, col: 54, offset: 38473},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1299, col: 62, offset: 38470},
+												pos:  position{line: 1299, col: 62, offset: 38481},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 1299, col: 76, offset: 38484},
+												pos:        position{line: 1299, col: 76, offset: 38495},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3108,13 +3118,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1307, col: 3, offset: 38634},
+						pos: position{line: 1307, col: 3, offset: 38645},
 						run: (*parser).callonStringExpr26,
 						expr: &labeledExpr{
-							pos:   position{line: 1307, col: 3, offset: 38634},
+							pos:   position{line: 1307, col: 3, offset: 38645},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1307, col: 10, offset: 38641},
+								pos:  position{line: 1307, col: 10, offset: 38652},
 								name: "ConcatExpr",
 							},
 						},
@@ -3124,35 +3134,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 1317, col: 1, offset: 38847},
+			pos:  position{line: 1317, col: 1, offset: 38858},
 			expr: &actionExpr{
-				pos: position{line: 1317, col: 15, offset: 38861},
+				pos: position{line: 1317, col: 15, offset: 38872},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1317, col: 15, offset: 38861},
+					pos: position{line: 1317, col: 15, offset: 38872},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1317, col: 15, offset: 38861},
+							pos:   position{line: 1317, col: 15, offset: 38872},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1317, col: 21, offset: 38867},
+								pos:  position{line: 1317, col: 21, offset: 38878},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1317, col: 32, offset: 38878},
+							pos:   position{line: 1317, col: 32, offset: 38889},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1317, col: 37, offset: 38883},
+								pos: position{line: 1317, col: 37, offset: 38894},
 								expr: &seqExpr{
-									pos: position{line: 1317, col: 38, offset: 38884},
+									pos: position{line: 1317, col: 38, offset: 38895},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1317, col: 38, offset: 38884},
+											pos:  position{line: 1317, col: 38, offset: 38895},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1317, col: 50, offset: 38896},
+											pos:  position{line: 1317, col: 50, offset: 38907},
 											name: "ConcatAtom",
 										},
 									},
@@ -3160,28 +3170,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 1317, col: 63, offset: 38909},
+							pos: position{line: 1317, col: 63, offset: 38920},
 							expr: &choiceExpr{
-								pos: position{line: 1317, col: 65, offset: 38911},
+								pos: position{line: 1317, col: 65, offset: 38922},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 65, offset: 38911},
+										pos:  position{line: 1317, col: 65, offset: 38922},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 74, offset: 38920},
+										pos:  position{line: 1317, col: 74, offset: 38931},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 84, offset: 38930},
+										pos:  position{line: 1317, col: 84, offset: 38941},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1317, col: 92, offset: 38938},
+										pos:  position{line: 1317, col: 92, offset: 38949},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 1317, col: 100, offset: 38946},
+										pos:        position{line: 1317, col: 100, offset: 38957},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -3195,54 +3205,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 1335, col: 1, offset: 39352},
+			pos:  position{line: 1335, col: 1, offset: 39363},
 			expr: &choiceExpr{
-				pos: position{line: 1335, col: 15, offset: 39366},
+				pos: position{line: 1335, col: 15, offset: 39377},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1335, col: 15, offset: 39366},
+						pos: position{line: 1335, col: 15, offset: 39377},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 1335, col: 15, offset: 39366},
+							pos:   position{line: 1335, col: 15, offset: 39377},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1335, col: 20, offset: 39371},
+								pos:  position{line: 1335, col: 20, offset: 39382},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1344, col: 3, offset: 39535},
+						pos: position{line: 1344, col: 3, offset: 39546},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 1344, col: 3, offset: 39535},
+							pos:   position{line: 1344, col: 3, offset: 39546},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1344, col: 7, offset: 39539},
+								pos:  position{line: 1344, col: 7, offset: 39550},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1352, col: 3, offset: 39678},
+						pos: position{line: 1352, col: 3, offset: 39689},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 1352, col: 3, offset: 39678},
+							pos:   position{line: 1352, col: 3, offset: 39689},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1352, col: 10, offset: 39685},
+								pos:  position{line: 1352, col: 10, offset: 39696},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1360, col: 3, offset: 39824},
+						pos: position{line: 1360, col: 3, offset: 39835},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 1360, col: 3, offset: 39824},
+							pos:   position{line: 1360, col: 3, offset: 39835},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1360, col: 9, offset: 39830},
+								pos:  position{line: 1360, col: 9, offset: 39841},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3252,32 +3262,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 1370, col: 1, offset: 39999},
+			pos:  position{line: 1370, col: 1, offset: 40010},
 			expr: &actionExpr{
-				pos: position{line: 1370, col: 16, offset: 40014},
+				pos: position{line: 1370, col: 16, offset: 40025},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1370, col: 16, offset: 40014},
+					pos: position{line: 1370, col: 16, offset: 40025},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1370, col: 16, offset: 40014},
+							pos:   position{line: 1370, col: 16, offset: 40025},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1370, col: 21, offset: 40019},
+								pos:  position{line: 1370, col: 21, offset: 40030},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1370, col: 39, offset: 40037},
+							pos: position{line: 1370, col: 39, offset: 40048},
 							expr: &choiceExpr{
-								pos: position{line: 1370, col: 41, offset: 40039},
+								pos: position{line: 1370, col: 41, offset: 40050},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1370, col: 41, offset: 40039},
+										pos:  position{line: 1370, col: 41, offset: 40050},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 1370, col: 55, offset: 40053},
+										pos:        position{line: 1370, col: 55, offset: 40064},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -3291,44 +3301,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 1375, col: 1, offset: 40118},
+			pos:  position{line: 1375, col: 1, offset: 40129},
 			expr: &actionExpr{
-				pos: position{line: 1375, col: 22, offset: 40139},
+				pos: position{line: 1375, col: 22, offset: 40150},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1375, col: 22, offset: 40139},
+					pos: position{line: 1375, col: 22, offset: 40150},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1375, col: 22, offset: 40139},
+							pos:   position{line: 1375, col: 22, offset: 40150},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1375, col: 28, offset: 40145},
+								pos:  position{line: 1375, col: 28, offset: 40156},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1375, col: 46, offset: 40163},
+							pos:   position{line: 1375, col: 46, offset: 40174},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1375, col: 51, offset: 40168},
+								pos: position{line: 1375, col: 51, offset: 40179},
 								expr: &seqExpr{
-									pos: position{line: 1375, col: 52, offset: 40169},
+									pos: position{line: 1375, col: 52, offset: 40180},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1375, col: 53, offset: 40170},
+											pos: position{line: 1375, col: 53, offset: 40181},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1375, col: 53, offset: 40170},
+													pos:  position{line: 1375, col: 53, offset: 40181},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1375, col: 62, offset: 40179},
+													pos:  position{line: 1375, col: 62, offset: 40190},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1375, col: 71, offset: 40188},
+											pos:  position{line: 1375, col: 71, offset: 40199},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -3341,44 +3351,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 1396, col: 1, offset: 40689},
+			pos:  position{line: 1396, col: 1, offset: 40700},
 			expr: &actionExpr{
-				pos: position{line: 1396, col: 22, offset: 40710},
+				pos: position{line: 1396, col: 22, offset: 40721},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 1396, col: 22, offset: 40710},
+					pos: position{line: 1396, col: 22, offset: 40721},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1396, col: 22, offset: 40710},
+							pos:   position{line: 1396, col: 22, offset: 40721},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1396, col: 28, offset: 40716},
+								pos:  position{line: 1396, col: 28, offset: 40727},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1396, col: 46, offset: 40734},
+							pos:   position{line: 1396, col: 46, offset: 40745},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1396, col: 51, offset: 40739},
+								pos: position{line: 1396, col: 51, offset: 40750},
 								expr: &seqExpr{
-									pos: position{line: 1396, col: 52, offset: 40740},
+									pos: position{line: 1396, col: 52, offset: 40751},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1396, col: 53, offset: 40741},
+											pos: position{line: 1396, col: 53, offset: 40752},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1396, col: 53, offset: 40741},
+													pos:  position{line: 1396, col: 53, offset: 40752},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1396, col: 61, offset: 40749},
+													pos:  position{line: 1396, col: 61, offset: 40760},
 													name: "OpDiv",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1396, col: 68, offset: 40756},
+											pos:  position{line: 1396, col: 68, offset: 40767},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -3391,22 +3401,22 @@ var g = &grammar{
 		},
 		{
 			name: "RoundPrecisionExpr",
-			pos:  position{line: 1416, col: 1, offset: 41225},
+			pos:  position{line: 1416, col: 1, offset: 41236},
 			expr: &actionExpr{
-				pos: position{line: 1416, col: 23, offset: 41247},
+				pos: position{line: 1416, col: 23, offset: 41258},
 				run: (*parser).callonRoundPrecisionExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1416, col: 23, offset: 41247},
+					pos: position{line: 1416, col: 23, offset: 41258},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1416, col: 23, offset: 41247},
+							pos:  position{line: 1416, col: 23, offset: 41258},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 1416, col: 29, offset: 41253},
+							pos:   position{line: 1416, col: 29, offset: 41264},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1416, col: 34, offset: 41258},
+								pos:  position{line: 1416, col: 34, offset: 41269},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -3416,67 +3426,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 1426, col: 1, offset: 41506},
+			pos:  position{line: 1426, col: 1, offset: 41517},
 			expr: &choiceExpr{
-				pos: position{line: 1426, col: 22, offset: 41527},
+				pos: position{line: 1426, col: 22, offset: 41538},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1426, col: 22, offset: 41527},
+						pos: position{line: 1426, col: 22, offset: 41538},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1426, col: 22, offset: 41527},
+							pos: position{line: 1426, col: 22, offset: 41538},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1426, col: 22, offset: 41527},
+									pos:  position{line: 1426, col: 22, offset: 41538},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1426, col: 30, offset: 41535},
+									pos:   position{line: 1426, col: 30, offset: 41546},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1426, col: 35, offset: 41540},
+										pos:  position{line: 1426, col: 35, offset: 41551},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1426, col: 53, offset: 41558},
+									pos:  position{line: 1426, col: 53, offset: 41569},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1429, col: 3, offset: 41593},
+						pos: position{line: 1429, col: 3, offset: 41604},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1429, col: 3, offset: 41593},
+							pos:   position{line: 1429, col: 3, offset: 41604},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1429, col: 20, offset: 41610},
+								pos:  position{line: 1429, col: 20, offset: 41621},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1432, col: 3, offset: 41664},
+						pos: position{line: 1432, col: 3, offset: 41675},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 1432, col: 3, offset: 41664},
+							pos:   position{line: 1432, col: 3, offset: 41675},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1432, col: 9, offset: 41670},
+								pos:  position{line: 1432, col: 9, offset: 41681},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1442, col: 3, offset: 41889},
+						pos: position{line: 1442, col: 3, offset: 41900},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 1442, col: 3, offset: 41889},
+							pos:   position{line: 1442, col: 3, offset: 41900},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1442, col: 10, offset: 41896},
+								pos:  position{line: 1442, col: 10, offset: 41907},
 								name: "NumberAsString",
 							},
 						},
@@ -3486,48 +3496,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 1454, col: 1, offset: 42154},
+			pos:  position{line: 1454, col: 1, offset: 42165},
 			expr: &choiceExpr{
-				pos: position{line: 1454, col: 20, offset: 42173},
+				pos: position{line: 1454, col: 20, offset: 42184},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1454, col: 20, offset: 42173},
+						pos: position{line: 1454, col: 20, offset: 42184},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1454, col: 21, offset: 42174},
+							pos: position{line: 1454, col: 21, offset: 42185},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1454, col: 21, offset: 42174},
+									pos:   position{line: 1454, col: 21, offset: 42185},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 1454, col: 29, offset: 42182},
+										pos: position{line: 1454, col: 29, offset: 42193},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 1454, col: 29, offset: 42182},
+												pos:        position{line: 1454, col: 29, offset: 42193},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1454, col: 37, offset: 42190},
+												pos:        position{line: 1454, col: 37, offset: 42201},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1454, col: 46, offset: 42199},
+												pos:        position{line: 1454, col: 46, offset: 42210},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1454, col: 54, offset: 42207},
+												pos:        position{line: 1454, col: 54, offset: 42218},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 1454, col: 63, offset: 42216},
+												pos:        position{line: 1454, col: 63, offset: 42227},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
@@ -3536,84 +3546,84 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1454, col: 70, offset: 42223},
+									pos:  position{line: 1454, col: 70, offset: 42234},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1454, col: 78, offset: 42231},
+									pos:   position{line: 1454, col: 78, offset: 42242},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1454, col: 84, offset: 42237},
+										pos:  position{line: 1454, col: 84, offset: 42248},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1454, col: 103, offset: 42256},
+									pos:  position{line: 1454, col: 103, offset: 42267},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1474, col: 3, offset: 42772},
+						pos: position{line: 1474, col: 3, offset: 42783},
 						run: (*parser).callonNumericEvalExpr15,
 						expr: &seqExpr{
-							pos: position{line: 1474, col: 3, offset: 42772},
+							pos: position{line: 1474, col: 3, offset: 42783},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1474, col: 3, offset: 42772},
+									pos:   position{line: 1474, col: 3, offset: 42783},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 1474, col: 13, offset: 42782},
+										pos:        position{line: 1474, col: 13, offset: 42793},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1474, col: 21, offset: 42790},
+									pos:  position{line: 1474, col: 21, offset: 42801},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 29, offset: 42798},
+									pos:   position{line: 1474, col: 29, offset: 42809},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1474, col: 35, offset: 42804},
+										pos:  position{line: 1474, col: 35, offset: 42815},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1474, col: 54, offset: 42823},
+									pos:   position{line: 1474, col: 54, offset: 42834},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1474, col: 69, offset: 42838},
+										pos: position{line: 1474, col: 69, offset: 42849},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1474, col: 70, offset: 42839},
+											pos:  position{line: 1474, col: 70, offset: 42850},
 											name: "RoundPrecisionExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1474, col: 91, offset: 42860},
+									pos:  position{line: 1474, col: 91, offset: 42871},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1495, col: 3, offset: 43484},
+						pos: position{line: 1495, col: 3, offset: 43495},
 						run: (*parser).callonNumericEvalExpr26,
 						expr: &seqExpr{
-							pos: position{line: 1495, col: 3, offset: 43484},
+							pos: position{line: 1495, col: 3, offset: 43495},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1495, col: 3, offset: 43484},
+									pos:        position{line: 1495, col: 3, offset: 43495},
 									val:        "now",
 									ignoreCase: false,
 									want:       "\"now\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1495, col: 9, offset: 43490},
+									pos:        position{line: 1495, col: 9, offset: 43501},
 									val:        "()",
 									ignoreCase: false,
 									want:       "\"()\"",
@@ -3622,43 +3632,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1501, col: 3, offset: 43598},
+						pos: position{line: 1501, col: 3, offset: 43609},
 						run: (*parser).callonNumericEvalExpr30,
 						expr: &seqExpr{
-							pos: position{line: 1501, col: 3, offset: 43598},
+							pos: position{line: 1501, col: 3, offset: 43609},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1501, col: 3, offset: 43598},
+									pos:        position{line: 1501, col: 3, offset: 43609},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1501, col: 14, offset: 43609},
+									pos:  position{line: 1501, col: 14, offset: 43620},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1501, col: 22, offset: 43617},
+									pos:   position{line: 1501, col: 22, offset: 43628},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1501, col: 33, offset: 43628},
+										pos:  position{line: 1501, col: 33, offset: 43639},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1501, col: 44, offset: 43639},
+									pos:   position{line: 1501, col: 44, offset: 43650},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1501, col: 53, offset: 43648},
+										pos: position{line: 1501, col: 53, offset: 43659},
 										expr: &seqExpr{
-											pos: position{line: 1501, col: 54, offset: 43649},
+											pos: position{line: 1501, col: 54, offset: 43660},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1501, col: 54, offset: 43649},
+													pos:  position{line: 1501, col: 54, offset: 43660},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1501, col: 60, offset: 43655},
+													pos:  position{line: 1501, col: 60, offset: 43666},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -3666,42 +3676,42 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1501, col: 80, offset: 43675},
+									pos:  position{line: 1501, col: 80, offset: 43686},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1529, col: 3, offset: 44522},
+						pos: position{line: 1529, col: 3, offset: 44533},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 1529, col: 3, offset: 44522},
+							pos: position{line: 1529, col: 3, offset: 44533},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1529, col: 3, offset: 44522},
+									pos:   position{line: 1529, col: 3, offset: 44533},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 1529, col: 12, offset: 44531},
+										pos:        position{line: 1529, col: 12, offset: 44542},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1529, col: 18, offset: 44537},
+									pos:  position{line: 1529, col: 18, offset: 44548},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1529, col: 26, offset: 44545},
+									pos:   position{line: 1529, col: 26, offset: 44556},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1529, col: 31, offset: 44550},
+										pos:  position{line: 1529, col: 31, offset: 44561},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1529, col: 39, offset: 44558},
+									pos:  position{line: 1529, col: 39, offset: 44569},
 									name: "R_PAREN",
 								},
 							},
@@ -3712,28 +3722,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 1533, col: 1, offset: 44592},
+			pos:  position{line: 1533, col: 1, offset: 44603},
 			expr: &choiceExpr{
-				pos: position{line: 1533, col: 12, offset: 44603},
+				pos: position{line: 1533, col: 12, offset: 44614},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1533, col: 12, offset: 44603},
+						pos: position{line: 1533, col: 12, offset: 44614},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 1533, col: 12, offset: 44603},
+							pos: position{line: 1533, col: 12, offset: 44614},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1533, col: 12, offset: 44603},
+									pos:   position{line: 1533, col: 12, offset: 44614},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1533, col: 16, offset: 44607},
+										pos:  position{line: 1533, col: 16, offset: 44618},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1533, col: 29, offset: 44620},
+									pos: position{line: 1533, col: 29, offset: 44631},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1533, col: 31, offset: 44622},
+										pos:  position{line: 1533, col: 31, offset: 44633},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -3741,46 +3751,46 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1549, col: 3, offset: 44987},
+						pos: position{line: 1549, col: 3, offset: 44998},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 1549, col: 3, offset: 44987},
+							pos: position{line: 1549, col: 3, offset: 44998},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1549, col: 3, offset: 44987},
+									pos:   position{line: 1549, col: 3, offset: 44998},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1549, col: 9, offset: 44993},
+										pos:  position{line: 1549, col: 9, offset: 45004},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 1549, col: 25, offset: 45009},
+									pos: position{line: 1549, col: 25, offset: 45020},
 									expr: &choiceExpr{
-										pos: position{line: 1549, col: 27, offset: 45011},
+										pos: position{line: 1549, col: 27, offset: 45022},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 27, offset: 45011},
+												pos:  position{line: 1549, col: 27, offset: 45022},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 36, offset: 45020},
+												pos:  position{line: 1549, col: 36, offset: 45031},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 46, offset: 45030},
+												pos:  position{line: 1549, col: 46, offset: 45041},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 54, offset: 45038},
+												pos:  position{line: 1549, col: 54, offset: 45049},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1549, col: 62, offset: 45046},
+												pos:  position{line: 1549, col: 62, offset: 45057},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 1549, col: 76, offset: 45060},
+												pos:        position{line: 1549, col: 76, offset: 45071},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -3796,47 +3806,47 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 1567, col: 1, offset: 45452},
+			pos:  position{line: 1567, col: 1, offset: 45463},
 			expr: &choiceExpr{
-				pos: position{line: 1567, col: 14, offset: 45465},
+				pos: position{line: 1567, col: 14, offset: 45476},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1567, col: 14, offset: 45465},
+						pos: position{line: 1567, col: 14, offset: 45476},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1567, col: 14, offset: 45465},
+							pos: position{line: 1567, col: 14, offset: 45476},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1567, col: 14, offset: 45465},
+									pos:  position{line: 1567, col: 14, offset: 45476},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1567, col: 19, offset: 45470},
+									pos:  position{line: 1567, col: 19, offset: 45481},
 									name: "CMD_HEAD",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 1567, col: 28, offset: 45479},
+									pos: position{line: 1567, col: 28, offset: 45490},
 									expr: &seqExpr{
-										pos: position{line: 1567, col: 29, offset: 45480},
+										pos: position{line: 1567, col: 29, offset: 45491},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 1567, col: 29, offset: 45480},
+												pos:        position{line: 1567, col: 29, offset: 45491},
 												val:        "limit",
 												ignoreCase: false,
 												want:       "\"limit\"",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1567, col: 37, offset: 45488},
+												pos:  position{line: 1567, col: 37, offset: 45499},
 												name: "EQUAL",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1567, col: 45, offset: 45496},
+									pos:   position{line: 1567, col: 45, offset: 45507},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1567, col: 54, offset: 45505},
+										pos:  position{line: 1567, col: 54, offset: 45516},
 										name: "IntegerAsString",
 									},
 								},
@@ -3844,17 +3854,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1582, col: 3, offset: 45921},
+						pos: position{line: 1582, col: 3, offset: 45932},
 						run: (*parser).callonHeadBlock12,
 						expr: &seqExpr{
-							pos: position{line: 1582, col: 3, offset: 45921},
+							pos: position{line: 1582, col: 3, offset: 45932},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1582, col: 3, offset: 45921},
+									pos:  position{line: 1582, col: 3, offset: 45932},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1582, col: 8, offset: 45926},
+									pos:  position{line: 1582, col: 8, offset: 45937},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -3865,44 +3875,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 1595, col: 1, offset: 46376},
+			pos:  position{line: 1595, col: 1, offset: 46387},
 			expr: &actionExpr{
-				pos: position{line: 1595, col: 20, offset: 46395},
+				pos: position{line: 1595, col: 20, offset: 46406},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 1595, col: 20, offset: 46395},
+					pos: position{line: 1595, col: 20, offset: 46406},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1595, col: 20, offset: 46395},
+							pos:   position{line: 1595, col: 20, offset: 46406},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1595, col: 26, offset: 46401},
+								pos:  position{line: 1595, col: 26, offset: 46412},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1595, col: 37, offset: 46412},
+							pos:   position{line: 1595, col: 37, offset: 46423},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1595, col: 42, offset: 46417},
+								pos: position{line: 1595, col: 42, offset: 46428},
 								expr: &seqExpr{
-									pos: position{line: 1595, col: 43, offset: 46418},
+									pos: position{line: 1595, col: 43, offset: 46429},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1595, col: 44, offset: 46419},
+											pos: position{line: 1595, col: 44, offset: 46430},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1595, col: 44, offset: 46419},
+													pos:  position{line: 1595, col: 44, offset: 46430},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1595, col: 52, offset: 46427},
+													pos:  position{line: 1595, col: 52, offset: 46438},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1595, col: 59, offset: 46434},
+											pos:  position{line: 1595, col: 59, offset: 46445},
 											name: "Aggregator",
 										},
 									},
@@ -3915,28 +3925,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 1612, col: 1, offset: 46937},
+			pos:  position{line: 1612, col: 1, offset: 46948},
 			expr: &actionExpr{
-				pos: position{line: 1612, col: 15, offset: 46951},
+				pos: position{line: 1612, col: 15, offset: 46962},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 1612, col: 15, offset: 46951},
+					pos: position{line: 1612, col: 15, offset: 46962},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1612, col: 15, offset: 46951},
+							pos:   position{line: 1612, col: 15, offset: 46962},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1612, col: 23, offset: 46959},
+								pos:  position{line: 1612, col: 23, offset: 46970},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1612, col: 35, offset: 46971},
+							pos:   position{line: 1612, col: 35, offset: 46982},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1612, col: 43, offset: 46979},
+								pos: position{line: 1612, col: 43, offset: 46990},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1612, col: 43, offset: 46979},
+									pos:  position{line: 1612, col: 43, offset: 46990},
 									name: "AsField",
 								},
 							},
@@ -3947,46 +3957,46 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 1628, col: 1, offset: 47820},
+			pos:  position{line: 1628, col: 1, offset: 47831},
 			expr: &actionExpr{
-				pos: position{line: 1628, col: 16, offset: 47835},
+				pos: position{line: 1628, col: 16, offset: 47846},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 1628, col: 16, offset: 47835},
+					pos:   position{line: 1628, col: 16, offset: 47846},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 1628, col: 21, offset: 47840},
+						pos: position{line: 1628, col: 21, offset: 47851},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 21, offset: 47840},
+								pos:  position{line: 1628, col: 21, offset: 47851},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 32, offset: 47851},
+								pos:  position{line: 1628, col: 32, offset: 47862},
 								name: "AggDistinctCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 51, offset: 47870},
+								pos:  position{line: 1628, col: 51, offset: 47881},
 								name: "AggAvg",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 60, offset: 47879},
+								pos:  position{line: 1628, col: 60, offset: 47890},
 								name: "AggMin",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 69, offset: 47888},
+								pos:  position{line: 1628, col: 69, offset: 47899},
 								name: "AggMax",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 78, offset: 47897},
+								pos:  position{line: 1628, col: 78, offset: 47908},
 								name: "AggRange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 89, offset: 47908},
+								pos:  position{line: 1628, col: 89, offset: 47919},
 								name: "AggSum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1628, col: 98, offset: 47917},
+								pos:  position{line: 1628, col: 98, offset: 47928},
 								name: "AggValues",
 							},
 						},
@@ -3996,22 +4006,22 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 1632, col: 1, offset: 47953},
+			pos:  position{line: 1632, col: 1, offset: 47964},
 			expr: &actionExpr{
-				pos: position{line: 1632, col: 12, offset: 47964},
+				pos: position{line: 1632, col: 12, offset: 47975},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 1632, col: 12, offset: 47964},
+					pos: position{line: 1632, col: 12, offset: 47975},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1632, col: 12, offset: 47964},
+							pos:  position{line: 1632, col: 12, offset: 47975},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1632, col: 15, offset: 47967},
+							pos:   position{line: 1632, col: 15, offset: 47978},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1632, col: 21, offset: 47973},
+								pos:  position{line: 1632, col: 21, offset: 47984},
 								name: "FieldName",
 							},
 						},
@@ -4021,27 +4031,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 1642, col: 1, offset: 48180},
+			pos:  position{line: 1642, col: 1, offset: 48191},
 			expr: &choiceExpr{
-				pos: position{line: 1642, col: 13, offset: 48192},
+				pos: position{line: 1642, col: 13, offset: 48203},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1642, col: 13, offset: 48192},
+						pos: position{line: 1642, col: 13, offset: 48203},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 1642, col: 13, offset: 48192},
+							pos: position{line: 1642, col: 13, offset: 48203},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 1642, col: 14, offset: 48193},
+									pos: position{line: 1642, col: 14, offset: 48204},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1642, col: 14, offset: 48193},
+											pos:        position{line: 1642, col: 14, offset: 48204},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1642, col: 24, offset: 48203},
+											pos:        position{line: 1642, col: 24, offset: 48214},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -4049,47 +4059,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1642, col: 29, offset: 48208},
+									pos:  position{line: 1642, col: 29, offset: 48219},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1642, col: 37, offset: 48216},
+									pos:        position{line: 1642, col: 37, offset: 48227},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1642, col: 44, offset: 48223},
+									pos:   position{line: 1642, col: 44, offset: 48234},
 									label: "boolExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1642, col: 53, offset: 48232},
+										pos:  position{line: 1642, col: 53, offset: 48243},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1642, col: 62, offset: 48241},
+									pos:  position{line: 1642, col: 62, offset: 48252},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1657, col: 3, offset: 48591},
+						pos: position{line: 1657, col: 3, offset: 48602},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 1657, col: 3, offset: 48591},
+							pos: position{line: 1657, col: 3, offset: 48602},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 1657, col: 4, offset: 48592},
+									pos: position{line: 1657, col: 4, offset: 48603},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1657, col: 4, offset: 48592},
+											pos:        position{line: 1657, col: 4, offset: 48603},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1657, col: 14, offset: 48602},
+											pos:        position{line: 1657, col: 14, offset: 48613},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -4097,38 +4107,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1657, col: 19, offset: 48607},
+									pos:  position{line: 1657, col: 19, offset: 48618},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1657, col: 27, offset: 48615},
+									pos:   position{line: 1657, col: 27, offset: 48626},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1657, col: 33, offset: 48621},
+										pos:  position{line: 1657, col: 33, offset: 48632},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1657, col: 43, offset: 48631},
+									pos:  position{line: 1657, col: 43, offset: 48642},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1664, col: 5, offset: 48782},
+						pos: position{line: 1664, col: 5, offset: 48793},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 1664, col: 6, offset: 48783},
+							pos: position{line: 1664, col: 6, offset: 48794},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 1664, col: 6, offset: 48783},
+									pos:        position{line: 1664, col: 6, offset: 48794},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 1664, col: 16, offset: 48793},
+									pos:        position{line: 1664, col: 16, offset: 48804},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -4141,27 +4151,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggDistinctCount",
-			pos:  position{line: 1673, col: 1, offset: 48930},
+			pos:  position{line: 1673, col: 1, offset: 48941},
 			expr: &choiceExpr{
-				pos: position{line: 1673, col: 21, offset: 48950},
+				pos: position{line: 1673, col: 21, offset: 48961},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1673, col: 21, offset: 48950},
+						pos: position{line: 1673, col: 21, offset: 48961},
 						run: (*parser).callonAggDistinctCount2,
 						expr: &seqExpr{
-							pos: position{line: 1673, col: 21, offset: 48950},
+							pos: position{line: 1673, col: 21, offset: 48961},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 1673, col: 22, offset: 48951},
+									pos: position{line: 1673, col: 22, offset: 48962},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1673, col: 22, offset: 48951},
+											pos:        position{line: 1673, col: 22, offset: 48962},
 											val:        "distinct_count",
 											ignoreCase: false,
 											want:       "\"distinct_count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1673, col: 41, offset: 48970},
+											pos:        position{line: 1673, col: 41, offset: 48981},
 											val:        "dc",
 											ignoreCase: false,
 											want:       "\"dc\"",
@@ -4169,47 +4179,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1673, col: 47, offset: 48976},
+									pos:  position{line: 1673, col: 47, offset: 48987},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1673, col: 55, offset: 48984},
+									pos:        position{line: 1673, col: 55, offset: 48995},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1673, col: 62, offset: 48991},
+									pos:   position{line: 1673, col: 62, offset: 49002},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1673, col: 72, offset: 49001},
+										pos:  position{line: 1673, col: 72, offset: 49012},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1673, col: 82, offset: 49011},
+									pos:  position{line: 1673, col: 82, offset: 49022},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1683, col: 3, offset: 49245},
+						pos: position{line: 1683, col: 3, offset: 49256},
 						run: (*parser).callonAggDistinctCount12,
 						expr: &seqExpr{
-							pos: position{line: 1683, col: 3, offset: 49245},
+							pos: position{line: 1683, col: 3, offset: 49256},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 1683, col: 4, offset: 49246},
+									pos: position{line: 1683, col: 4, offset: 49257},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1683, col: 4, offset: 49246},
+											pos:        position{line: 1683, col: 4, offset: 49257},
 											val:        "distinct_count",
 											ignoreCase: false,
 											want:       "\"distinct_count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1683, col: 23, offset: 49265},
+											pos:        position{line: 1683, col: 23, offset: 49276},
 											val:        "dc",
 											ignoreCase: false,
 											want:       "\"dc\"",
@@ -4217,19 +4227,19 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1683, col: 29, offset: 49271},
+									pos:  position{line: 1683, col: 29, offset: 49282},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1683, col: 37, offset: 49279},
+									pos:   position{line: 1683, col: 37, offset: 49290},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1683, col: 43, offset: 49285},
+										pos:  position{line: 1683, col: 43, offset: 49296},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1683, col: 53, offset: 49295},
+									pos:  position{line: 1683, col: 53, offset: 49306},
 									name: "R_PAREN",
 								},
 							},
@@ -4240,81 +4250,81 @@ var g = &grammar{
 		},
 		{
 			name: "AggAvg",
-			pos:  position{line: 1692, col: 1, offset: 49451},
+			pos:  position{line: 1692, col: 1, offset: 49462},
 			expr: &choiceExpr{
-				pos: position{line: 1692, col: 11, offset: 49461},
+				pos: position{line: 1692, col: 11, offset: 49472},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1692, col: 11, offset: 49461},
+						pos: position{line: 1692, col: 11, offset: 49472},
 						run: (*parser).callonAggAvg2,
 						expr: &seqExpr{
-							pos: position{line: 1692, col: 11, offset: 49461},
+							pos: position{line: 1692, col: 11, offset: 49472},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1692, col: 11, offset: 49461},
+									pos:        position{line: 1692, col: 11, offset: 49472},
 									val:        "avg",
 									ignoreCase: false,
 									want:       "\"avg\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1692, col: 17, offset: 49467},
+									pos:  position{line: 1692, col: 17, offset: 49478},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1692, col: 25, offset: 49475},
+									pos:        position{line: 1692, col: 25, offset: 49486},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1692, col: 32, offset: 49482},
+									pos:  position{line: 1692, col: 32, offset: 49493},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1692, col: 40, offset: 49490},
+									pos:   position{line: 1692, col: 40, offset: 49501},
 									label: "boolComparisonExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1692, col: 59, offset: 49509},
+										pos:  position{line: 1692, col: 59, offset: 49520},
 										name: "BoolComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1692, col: 78, offset: 49528},
+									pos:  position{line: 1692, col: 78, offset: 49539},
 									name: "R_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1692, col: 86, offset: 49536},
+									pos:  position{line: 1692, col: 86, offset: 49547},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1707, col: 3, offset: 49894},
+						pos: position{line: 1707, col: 3, offset: 49905},
 						run: (*parser).callonAggAvg12,
 						expr: &seqExpr{
-							pos: position{line: 1707, col: 3, offset: 49894},
+							pos: position{line: 1707, col: 3, offset: 49905},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1707, col: 3, offset: 49894},
+									pos:        position{line: 1707, col: 3, offset: 49905},
 									val:        "avg",
 									ignoreCase: false,
 									want:       "\"avg\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1707, col: 9, offset: 49900},
+									pos:  position{line: 1707, col: 9, offset: 49911},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1707, col: 17, offset: 49908},
+									pos:   position{line: 1707, col: 17, offset: 49919},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1707, col: 23, offset: 49914},
+										pos:  position{line: 1707, col: 23, offset: 49925},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1707, col: 33, offset: 49924},
+									pos:  position{line: 1707, col: 33, offset: 49935},
 									name: "R_PAREN",
 								},
 							},
@@ -4325,81 +4335,81 @@ var g = &grammar{
 		},
 		{
 			name: "AggMin",
-			pos:  position{line: 1716, col: 1, offset: 50072},
+			pos:  position{line: 1716, col: 1, offset: 50083},
 			expr: &choiceExpr{
-				pos: position{line: 1716, col: 11, offset: 50082},
+				pos: position{line: 1716, col: 11, offset: 50093},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1716, col: 11, offset: 50082},
+						pos: position{line: 1716, col: 11, offset: 50093},
 						run: (*parser).callonAggMin2,
 						expr: &seqExpr{
-							pos: position{line: 1716, col: 11, offset: 50082},
+							pos: position{line: 1716, col: 11, offset: 50093},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1716, col: 11, offset: 50082},
+									pos:        position{line: 1716, col: 11, offset: 50093},
 									val:        "min",
 									ignoreCase: false,
 									want:       "\"min\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1716, col: 17, offset: 50088},
+									pos:  position{line: 1716, col: 17, offset: 50099},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1716, col: 25, offset: 50096},
+									pos:        position{line: 1716, col: 25, offset: 50107},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1716, col: 32, offset: 50103},
+									pos:  position{line: 1716, col: 32, offset: 50114},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1716, col: 40, offset: 50111},
+									pos:   position{line: 1716, col: 40, offset: 50122},
 									label: "boolComparisonExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1716, col: 59, offset: 50130},
+										pos:  position{line: 1716, col: 59, offset: 50141},
 										name: "BoolComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1716, col: 78, offset: 50149},
+									pos:  position{line: 1716, col: 78, offset: 50160},
 									name: "R_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1716, col: 86, offset: 50157},
+									pos:  position{line: 1716, col: 86, offset: 50168},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1731, col: 3, offset: 50515},
+						pos: position{line: 1731, col: 3, offset: 50526},
 						run: (*parser).callonAggMin12,
 						expr: &seqExpr{
-							pos: position{line: 1731, col: 3, offset: 50515},
+							pos: position{line: 1731, col: 3, offset: 50526},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1731, col: 3, offset: 50515},
+									pos:        position{line: 1731, col: 3, offset: 50526},
 									val:        "min",
 									ignoreCase: false,
 									want:       "\"min\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1731, col: 9, offset: 50521},
+									pos:  position{line: 1731, col: 9, offset: 50532},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1731, col: 17, offset: 50529},
+									pos:   position{line: 1731, col: 17, offset: 50540},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1731, col: 23, offset: 50535},
+										pos:  position{line: 1731, col: 23, offset: 50546},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1731, col: 33, offset: 50545},
+									pos:  position{line: 1731, col: 33, offset: 50556},
 									name: "R_PAREN",
 								},
 							},
@@ -4410,81 +4420,81 @@ var g = &grammar{
 		},
 		{
 			name: "AggMax",
-			pos:  position{line: 1740, col: 1, offset: 50693},
+			pos:  position{line: 1740, col: 1, offset: 50704},
 			expr: &choiceExpr{
-				pos: position{line: 1740, col: 11, offset: 50703},
+				pos: position{line: 1740, col: 11, offset: 50714},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1740, col: 11, offset: 50703},
+						pos: position{line: 1740, col: 11, offset: 50714},
 						run: (*parser).callonAggMax2,
 						expr: &seqExpr{
-							pos: position{line: 1740, col: 11, offset: 50703},
+							pos: position{line: 1740, col: 11, offset: 50714},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1740, col: 11, offset: 50703},
+									pos:        position{line: 1740, col: 11, offset: 50714},
 									val:        "max",
 									ignoreCase: false,
 									want:       "\"max\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1740, col: 17, offset: 50709},
+									pos:  position{line: 1740, col: 17, offset: 50720},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1740, col: 25, offset: 50717},
+									pos:        position{line: 1740, col: 25, offset: 50728},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1740, col: 32, offset: 50724},
+									pos:  position{line: 1740, col: 32, offset: 50735},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1740, col: 41, offset: 50733},
+									pos:   position{line: 1740, col: 41, offset: 50744},
 									label: "boolComparisonExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1740, col: 60, offset: 50752},
+										pos:  position{line: 1740, col: 60, offset: 50763},
 										name: "BoolComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1740, col: 79, offset: 50771},
+									pos:  position{line: 1740, col: 79, offset: 50782},
 									name: "R_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1740, col: 87, offset: 50779},
+									pos:  position{line: 1740, col: 87, offset: 50790},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1755, col: 3, offset: 51137},
+						pos: position{line: 1755, col: 3, offset: 51148},
 						run: (*parser).callonAggMax12,
 						expr: &seqExpr{
-							pos: position{line: 1755, col: 3, offset: 51137},
+							pos: position{line: 1755, col: 3, offset: 51148},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1755, col: 3, offset: 51137},
+									pos:        position{line: 1755, col: 3, offset: 51148},
 									val:        "max",
 									ignoreCase: false,
 									want:       "\"max\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1755, col: 9, offset: 51143},
+									pos:  position{line: 1755, col: 9, offset: 51154},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1755, col: 17, offset: 51151},
+									pos:   position{line: 1755, col: 17, offset: 51162},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1755, col: 23, offset: 51157},
+										pos:  position{line: 1755, col: 23, offset: 51168},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1755, col: 33, offset: 51167},
+									pos:  position{line: 1755, col: 33, offset: 51178},
 									name: "R_PAREN",
 								},
 							},
@@ -4495,81 +4505,81 @@ var g = &grammar{
 		},
 		{
 			name: "AggRange",
-			pos:  position{line: 1764, col: 1, offset: 51315},
+			pos:  position{line: 1764, col: 1, offset: 51326},
 			expr: &choiceExpr{
-				pos: position{line: 1764, col: 13, offset: 51327},
+				pos: position{line: 1764, col: 13, offset: 51338},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1764, col: 13, offset: 51327},
+						pos: position{line: 1764, col: 13, offset: 51338},
 						run: (*parser).callonAggRange2,
 						expr: &seqExpr{
-							pos: position{line: 1764, col: 13, offset: 51327},
+							pos: position{line: 1764, col: 13, offset: 51338},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1764, col: 13, offset: 51327},
+									pos:        position{line: 1764, col: 13, offset: 51338},
 									val:        "range",
 									ignoreCase: false,
 									want:       "\"range\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 21, offset: 51335},
+									pos:  position{line: 1764, col: 21, offset: 51346},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1764, col: 29, offset: 51343},
+									pos:        position{line: 1764, col: 29, offset: 51354},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 36, offset: 51350},
+									pos:  position{line: 1764, col: 36, offset: 51361},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1764, col: 44, offset: 51358},
+									pos:   position{line: 1764, col: 44, offset: 51369},
 									label: "boolComparisonExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1764, col: 63, offset: 51377},
+										pos:  position{line: 1764, col: 63, offset: 51388},
 										name: "BoolComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 82, offset: 51396},
+									pos:  position{line: 1764, col: 82, offset: 51407},
 									name: "R_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1764, col: 90, offset: 51404},
+									pos:  position{line: 1764, col: 90, offset: 51415},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1779, col: 3, offset: 51764},
+						pos: position{line: 1779, col: 3, offset: 51775},
 						run: (*parser).callonAggRange12,
 						expr: &seqExpr{
-							pos: position{line: 1779, col: 3, offset: 51764},
+							pos: position{line: 1779, col: 3, offset: 51775},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1779, col: 3, offset: 51764},
+									pos:        position{line: 1779, col: 3, offset: 51775},
 									val:        "range",
 									ignoreCase: false,
 									want:       "\"range\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1779, col: 11, offset: 51772},
+									pos:  position{line: 1779, col: 11, offset: 51783},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1779, col: 19, offset: 51780},
+									pos:   position{line: 1779, col: 19, offset: 51791},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1779, col: 25, offset: 51786},
+										pos:  position{line: 1779, col: 25, offset: 51797},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1779, col: 35, offset: 51796},
+									pos:  position{line: 1779, col: 35, offset: 51807},
 									name: "R_PAREN",
 								},
 							},
@@ -4580,81 +4590,81 @@ var g = &grammar{
 		},
 		{
 			name: "AggSum",
-			pos:  position{line: 1788, col: 1, offset: 51946},
+			pos:  position{line: 1788, col: 1, offset: 51957},
 			expr: &choiceExpr{
-				pos: position{line: 1788, col: 11, offset: 51956},
+				pos: position{line: 1788, col: 11, offset: 51967},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1788, col: 11, offset: 51956},
+						pos: position{line: 1788, col: 11, offset: 51967},
 						run: (*parser).callonAggSum2,
 						expr: &seqExpr{
-							pos: position{line: 1788, col: 11, offset: 51956},
+							pos: position{line: 1788, col: 11, offset: 51967},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1788, col: 11, offset: 51956},
+									pos:        position{line: 1788, col: 11, offset: 51967},
 									val:        "sum",
 									ignoreCase: false,
 									want:       "\"sum\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1788, col: 17, offset: 51962},
+									pos:  position{line: 1788, col: 17, offset: 51973},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1788, col: 25, offset: 51970},
+									pos:        position{line: 1788, col: 25, offset: 51981},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1788, col: 32, offset: 51977},
+									pos:  position{line: 1788, col: 32, offset: 51988},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1788, col: 40, offset: 51985},
+									pos:   position{line: 1788, col: 40, offset: 51996},
 									label: "boolComparisonExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1788, col: 59, offset: 52004},
+										pos:  position{line: 1788, col: 59, offset: 52015},
 										name: "BoolComparisonExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1788, col: 78, offset: 52023},
+									pos:  position{line: 1788, col: 78, offset: 52034},
 									name: "R_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1788, col: 86, offset: 52031},
+									pos:  position{line: 1788, col: 86, offset: 52042},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1803, col: 3, offset: 52389},
+						pos: position{line: 1803, col: 3, offset: 52400},
 						run: (*parser).callonAggSum12,
 						expr: &seqExpr{
-							pos: position{line: 1803, col: 3, offset: 52389},
+							pos: position{line: 1803, col: 3, offset: 52400},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1803, col: 3, offset: 52389},
+									pos:        position{line: 1803, col: 3, offset: 52400},
 									val:        "sum",
 									ignoreCase: false,
 									want:       "\"sum\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1803, col: 9, offset: 52395},
+									pos:  position{line: 1803, col: 9, offset: 52406},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1803, col: 17, offset: 52403},
+									pos:   position{line: 1803, col: 17, offset: 52414},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1803, col: 23, offset: 52409},
+										pos:  position{line: 1803, col: 23, offset: 52420},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1803, col: 33, offset: 52419},
+									pos:  position{line: 1803, col: 33, offset: 52430},
 									name: "R_PAREN",
 								},
 							},
@@ -4665,73 +4675,73 @@ var g = &grammar{
 		},
 		{
 			name: "AggValues",
-			pos:  position{line: 1812, col: 1, offset: 52567},
+			pos:  position{line: 1812, col: 1, offset: 52578},
 			expr: &choiceExpr{
-				pos: position{line: 1812, col: 14, offset: 52580},
+				pos: position{line: 1812, col: 14, offset: 52591},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1812, col: 14, offset: 52580},
+						pos: position{line: 1812, col: 14, offset: 52591},
 						run: (*parser).callonAggValues2,
 						expr: &seqExpr{
-							pos: position{line: 1812, col: 14, offset: 52580},
+							pos: position{line: 1812, col: 14, offset: 52591},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1812, col: 14, offset: 52580},
+									pos:        position{line: 1812, col: 14, offset: 52591},
 									val:        "values",
 									ignoreCase: false,
 									want:       "\"values\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1812, col: 23, offset: 52589},
+									pos:  position{line: 1812, col: 23, offset: 52600},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 1812, col: 31, offset: 52597},
+									pos:        position{line: 1812, col: 31, offset: 52608},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1812, col: 38, offset: 52604},
+									pos:   position{line: 1812, col: 38, offset: 52615},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1812, col: 48, offset: 52614},
+										pos:  position{line: 1812, col: 48, offset: 52625},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1812, col: 58, offset: 52624},
+									pos:  position{line: 1812, col: 58, offset: 52635},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1822, col: 3, offset: 52853},
+						pos: position{line: 1822, col: 3, offset: 52864},
 						run: (*parser).callonAggValues10,
 						expr: &seqExpr{
-							pos: position{line: 1822, col: 3, offset: 52853},
+							pos: position{line: 1822, col: 3, offset: 52864},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1822, col: 3, offset: 52853},
+									pos:        position{line: 1822, col: 3, offset: 52864},
 									val:        "values",
 									ignoreCase: false,
 									want:       "\"values\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1822, col: 12, offset: 52862},
+									pos:  position{line: 1822, col: 12, offset: 52873},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1822, col: 20, offset: 52870},
+									pos:   position{line: 1822, col: 20, offset: 52881},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1822, col: 26, offset: 52876},
+										pos:  position{line: 1822, col: 26, offset: 52887},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1822, col: 36, offset: 52886},
+									pos:  position{line: 1822, col: 36, offset: 52897},
 									name: "R_PAREN",
 								},
 							},
@@ -4742,22 +4752,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 1831, col: 1, offset: 53037},
+			pos:  position{line: 1831, col: 1, offset: 53048},
 			expr: &actionExpr{
-				pos: position{line: 1831, col: 25, offset: 53061},
+				pos: position{line: 1831, col: 25, offset: 53072},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 1831, col: 25, offset: 53061},
+					pos:   position{line: 1831, col: 25, offset: 53072},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 1831, col: 39, offset: 53075},
+						pos: position{line: 1831, col: 39, offset: 53086},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1831, col: 39, offset: 53075},
+								pos:  position{line: 1831, col: 39, offset: 53086},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1831, col: 67, offset: 53103},
+								pos:  position{line: 1831, col: 67, offset: 53114},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -4767,43 +4777,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 1835, col: 1, offset: 53166},
+			pos:  position{line: 1835, col: 1, offset: 53177},
 			expr: &actionExpr{
-				pos: position{line: 1835, col: 30, offset: 53195},
+				pos: position{line: 1835, col: 30, offset: 53206},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 1835, col: 30, offset: 53195},
+					pos: position{line: 1835, col: 30, offset: 53206},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1835, col: 30, offset: 53195},
+							pos:   position{line: 1835, col: 30, offset: 53206},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1835, col: 34, offset: 53199},
+								pos:  position{line: 1835, col: 34, offset: 53210},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1835, col: 44, offset: 53209},
+							pos:   position{line: 1835, col: 44, offset: 53220},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 1835, col: 48, offset: 53213},
+								pos: position{line: 1835, col: 48, offset: 53224},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1835, col: 48, offset: 53213},
+										pos:  position{line: 1835, col: 48, offset: 53224},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1835, col: 67, offset: 53232},
+										pos:  position{line: 1835, col: 67, offset: 53243},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1835, col: 87, offset: 53252},
+							pos:   position{line: 1835, col: 87, offset: 53263},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1835, col: 93, offset: 53258},
+								pos:  position{line: 1835, col: 93, offset: 53269},
 								name: "Number",
 							},
 						},
@@ -4813,15 +4823,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 1848, col: 1, offset: 53492},
+			pos:  position{line: 1848, col: 1, offset: 53503},
 			expr: &actionExpr{
-				pos: position{line: 1848, col: 32, offset: 53523},
+				pos: position{line: 1848, col: 32, offset: 53534},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 1848, col: 32, offset: 53523},
+					pos:   position{line: 1848, col: 32, offset: 53534},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1848, col: 38, offset: 53529},
+						pos:  position{line: 1848, col: 38, offset: 53540},
 						name: "Number",
 					},
 				},
@@ -4829,22 +4839,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 1861, col: 1, offset: 53746},
+			pos:  position{line: 1861, col: 1, offset: 53757},
 			expr: &actionExpr{
-				pos: position{line: 1861, col: 25, offset: 53770},
+				pos: position{line: 1861, col: 25, offset: 53781},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 1861, col: 25, offset: 53770},
+					pos:   position{line: 1861, col: 25, offset: 53781},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 1861, col: 39, offset: 53784},
+						pos: position{line: 1861, col: 39, offset: 53795},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1861, col: 39, offset: 53784},
+								pos:  position{line: 1861, col: 39, offset: 53795},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1861, col: 67, offset: 53812},
+								pos:  position{line: 1861, col: 67, offset: 53823},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -4854,34 +4864,34 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 1865, col: 1, offset: 53875},
+			pos:  position{line: 1865, col: 1, offset: 53886},
 			expr: &actionExpr{
-				pos: position{line: 1865, col: 30, offset: 53904},
+				pos: position{line: 1865, col: 30, offset: 53915},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 1865, col: 30, offset: 53904},
+					pos: position{line: 1865, col: 30, offset: 53915},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1865, col: 30, offset: 53904},
+							pos:   position{line: 1865, col: 30, offset: 53915},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1865, col: 34, offset: 53908},
+								pos:  position{line: 1865, col: 34, offset: 53919},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1865, col: 44, offset: 53918},
+							pos:   position{line: 1865, col: 44, offset: 53929},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1865, col: 47, offset: 53921},
+								pos:  position{line: 1865, col: 47, offset: 53932},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1865, col: 64, offset: 53938},
+							pos:   position{line: 1865, col: 64, offset: 53949},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1865, col: 70, offset: 53944},
+								pos:  position{line: 1865, col: 70, offset: 53955},
 								name: "String",
 							},
 						},
@@ -4891,15 +4901,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 1877, col: 1, offset: 54177},
+			pos:  position{line: 1877, col: 1, offset: 54188},
 			expr: &actionExpr{
-				pos: position{line: 1877, col: 32, offset: 54208},
+				pos: position{line: 1877, col: 32, offset: 54219},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 1877, col: 32, offset: 54208},
+					pos:   position{line: 1877, col: 32, offset: 54219},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1877, col: 38, offset: 54214},
+						pos:  position{line: 1877, col: 38, offset: 54225},
 						name: "String",
 					},
 				},
@@ -4907,35 +4917,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 1891, col: 1, offset: 54545},
+			pos:  position{line: 1891, col: 1, offset: 54556},
 			expr: &actionExpr{
-				pos: position{line: 1891, col: 18, offset: 54562},
+				pos: position{line: 1891, col: 18, offset: 54573},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 1891, col: 18, offset: 54562},
+					pos: position{line: 1891, col: 18, offset: 54573},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1891, col: 18, offset: 54562},
+							pos:   position{line: 1891, col: 18, offset: 54573},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1891, col: 24, offset: 54568},
+								pos:  position{line: 1891, col: 24, offset: 54579},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1891, col: 34, offset: 54578},
+							pos:   position{line: 1891, col: 34, offset: 54589},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1891, col: 39, offset: 54583},
+								pos: position{line: 1891, col: 39, offset: 54594},
 								expr: &seqExpr{
-									pos: position{line: 1891, col: 40, offset: 54584},
+									pos: position{line: 1891, col: 40, offset: 54595},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1891, col: 40, offset: 54584},
+											pos:  position{line: 1891, col: 40, offset: 54595},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1891, col: 46, offset: 54590},
+											pos:  position{line: 1891, col: 46, offset: 54601},
 											name: "FieldName",
 										},
 									},
@@ -4948,15 +4958,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 1911, col: 1, offset: 55353},
+			pos:  position{line: 1911, col: 1, offset: 55364},
 			expr: &actionExpr{
-				pos: position{line: 1911, col: 14, offset: 55366},
+				pos: position{line: 1911, col: 14, offset: 55377},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 1911, col: 14, offset: 55366},
+					pos: position{line: 1911, col: 14, offset: 55377},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 1911, col: 14, offset: 55366},
+							pos:        position{line: 1911, col: 14, offset: 55377},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4964,9 +4974,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1911, col: 27, offset: 55379},
+							pos: position{line: 1911, col: 27, offset: 55390},
 							expr: &charClassMatcher{
-								pos:        position{line: 1911, col: 27, offset: 55379},
+								pos:        position{line: 1911, col: 27, offset: 55390},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -4980,22 +4990,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 1915, col: 1, offset: 55432},
+			pos:  position{line: 1915, col: 1, offset: 55443},
 			expr: &actionExpr{
-				pos: position{line: 1915, col: 11, offset: 55442},
+				pos: position{line: 1915, col: 11, offset: 55453},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 1915, col: 11, offset: 55442},
+					pos:   position{line: 1915, col: 11, offset: 55453},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 1915, col: 16, offset: 55447},
+						pos: position{line: 1915, col: 16, offset: 55458},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1915, col: 16, offset: 55447},
+								pos:  position{line: 1915, col: 16, offset: 55458},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1915, col: 31, offset: 55462},
+								pos:  position{line: 1915, col: 31, offset: 55473},
 								name: "UnquotedString",
 							},
 						},
@@ -5005,23 +5015,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 1919, col: 1, offset: 55503},
+			pos:  position{line: 1919, col: 1, offset: 55514},
 			expr: &actionExpr{
-				pos: position{line: 1919, col: 17, offset: 55519},
+				pos: position{line: 1919, col: 17, offset: 55530},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 1919, col: 17, offset: 55519},
+					pos: position{line: 1919, col: 17, offset: 55530},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1919, col: 17, offset: 55519},
+							pos:        position{line: 1919, col: 17, offset: 55530},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1919, col: 21, offset: 55523},
+							pos: position{line: 1919, col: 21, offset: 55534},
 							expr: &charClassMatcher{
-								pos:        position{line: 1919, col: 21, offset: 55523},
+								pos:        position{line: 1919, col: 21, offset: 55534},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -5029,7 +5039,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1919, col: 27, offset: 55529},
+							pos:        position{line: 1919, col: 27, offset: 55540},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -5040,42 +5050,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 1924, col: 1, offset: 55640},
+			pos:  position{line: 1924, col: 1, offset: 55651},
 			expr: &actionExpr{
-				pos: position{line: 1924, col: 19, offset: 55658},
+				pos: position{line: 1924, col: 19, offset: 55669},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1924, col: 19, offset: 55658},
+					pos: position{line: 1924, col: 19, offset: 55669},
 					expr: &choiceExpr{
-						pos: position{line: 1924, col: 20, offset: 55659},
+						pos: position{line: 1924, col: 20, offset: 55670},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1924, col: 20, offset: 55659},
+								pos:        position{line: 1924, col: 20, offset: 55670},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 1924, col: 27, offset: 55666},
+								pos: position{line: 1924, col: 27, offset: 55677},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 1924, col: 27, offset: 55666},
+										pos: position{line: 1924, col: 27, offset: 55677},
 										expr: &choiceExpr{
-											pos: position{line: 1924, col: 29, offset: 55668},
+											pos: position{line: 1924, col: 29, offset: 55679},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1924, col: 29, offset: 55668},
+													pos:  position{line: 1924, col: 29, offset: 55679},
 													name: "MAJOR_BREAK",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1924, col: 43, offset: 55682},
+													pos:  position{line: 1924, col: 43, offset: 55693},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 1924, col: 48, offset: 55687,
+										line: 1924, col: 48, offset: 55698,
 									},
 								},
 							},
@@ -5086,14 +5096,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 1931, col: 1, offset: 55861},
+			pos:  position{line: 1931, col: 1, offset: 55872},
 			expr: &actionExpr{
-				pos: position{line: 1931, col: 18, offset: 55878},
+				pos: position{line: 1931, col: 18, offset: 55889},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1931, col: 18, offset: 55878},
+					pos: position{line: 1931, col: 18, offset: 55889},
 					expr: &charClassMatcher{
-						pos:        position{line: 1931, col: 18, offset: 55878},
+						pos:        position{line: 1931, col: 18, offset: 55889},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -5105,15 +5115,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 1935, col: 1, offset: 55929},
+			pos:  position{line: 1935, col: 1, offset: 55940},
 			expr: &actionExpr{
-				pos: position{line: 1935, col: 11, offset: 55939},
+				pos: position{line: 1935, col: 11, offset: 55950},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 1935, col: 11, offset: 55939},
+					pos:   position{line: 1935, col: 11, offset: 55950},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1935, col: 18, offset: 55946},
+						pos:  position{line: 1935, col: 18, offset: 55957},
 						name: "NumberAsString",
 					},
 				},
@@ -5121,53 +5131,53 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 1941, col: 1, offset: 56135},
+			pos:  position{line: 1941, col: 1, offset: 56146},
 			expr: &actionExpr{
-				pos: position{line: 1941, col: 19, offset: 56153},
+				pos: position{line: 1941, col: 19, offset: 56164},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 1941, col: 19, offset: 56153},
+					pos: position{line: 1941, col: 19, offset: 56164},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1941, col: 19, offset: 56153},
+							pos:   position{line: 1941, col: 19, offset: 56164},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1941, col: 27, offset: 56161},
+								pos: position{line: 1941, col: 27, offset: 56172},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1941, col: 27, offset: 56161},
+										pos:  position{line: 1941, col: 27, offset: 56172},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1941, col: 43, offset: 56177},
+										pos:  position{line: 1941, col: 43, offset: 56188},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 1941, col: 60, offset: 56194},
+							pos: position{line: 1941, col: 60, offset: 56205},
 							expr: &choiceExpr{
-								pos: position{line: 1941, col: 62, offset: 56196},
+								pos: position{line: 1941, col: 62, offset: 56207},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1941, col: 62, offset: 56196},
+										pos:  position{line: 1941, col: 62, offset: 56207},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 1941, col: 70, offset: 56204},
+										pos:        position{line: 1941, col: 70, offset: 56215},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1941, col: 76, offset: 56210},
+										pos:        position{line: 1941, col: 76, offset: 56221},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1941, col: 82, offset: 56216},
+										pos:  position{line: 1941, col: 82, offset: 56227},
 										name: "EOF",
 									},
 								},
@@ -5179,17 +5189,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 1947, col: 1, offset: 56345},
+			pos:  position{line: 1947, col: 1, offset: 56356},
 			expr: &actionExpr{
-				pos: position{line: 1947, col: 18, offset: 56362},
+				pos: position{line: 1947, col: 18, offset: 56373},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 1947, col: 18, offset: 56362},
+					pos: position{line: 1947, col: 18, offset: 56373},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1947, col: 18, offset: 56362},
+							pos: position{line: 1947, col: 18, offset: 56373},
 							expr: &charClassMatcher{
-								pos:        position{line: 1947, col: 18, offset: 56362},
+								pos:        position{line: 1947, col: 18, offset: 56373},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -5197,9 +5207,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 1947, col: 24, offset: 56368},
+							pos: position{line: 1947, col: 24, offset: 56379},
 							expr: &charClassMatcher{
-								pos:        position{line: 1947, col: 24, offset: 56368},
+								pos:        position{line: 1947, col: 24, offset: 56379},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5207,15 +5217,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1947, col: 31, offset: 56375},
+							pos:        position{line: 1947, col: 31, offset: 56386},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1947, col: 35, offset: 56379},
+							pos: position{line: 1947, col: 35, offset: 56390},
 							expr: &charClassMatcher{
-								pos:        position{line: 1947, col: 35, offset: 56379},
+								pos:        position{line: 1947, col: 35, offset: 56390},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5228,17 +5238,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 1952, col: 1, offset: 56474},
+			pos:  position{line: 1952, col: 1, offset: 56485},
 			expr: &actionExpr{
-				pos: position{line: 1952, col: 20, offset: 56493},
+				pos: position{line: 1952, col: 20, offset: 56504},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 1952, col: 20, offset: 56493},
+					pos: position{line: 1952, col: 20, offset: 56504},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1952, col: 20, offset: 56493},
+							pos: position{line: 1952, col: 20, offset: 56504},
 							expr: &charClassMatcher{
-								pos:        position{line: 1952, col: 20, offset: 56493},
+								pos:        position{line: 1952, col: 20, offset: 56504},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -5246,9 +5256,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 1952, col: 26, offset: 56499},
+							pos: position{line: 1952, col: 26, offset: 56510},
 							expr: &charClassMatcher{
-								pos:        position{line: 1952, col: 26, offset: 56499},
+								pos:        position{line: 1952, col: 26, offset: 56510},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5261,31 +5271,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 1956, col: 1, offset: 56542},
+			pos:  position{line: 1956, col: 1, offset: 56553},
 			expr: &actionExpr{
-				pos: position{line: 1956, col: 21, offset: 56562},
+				pos: position{line: 1956, col: 21, offset: 56573},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 1956, col: 21, offset: 56562},
+					pos: position{line: 1956, col: 21, offset: 56573},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 21, offset: 56562},
+							pos:  position{line: 1956, col: 21, offset: 56573},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1956, col: 36, offset: 56577},
+							pos:   position{line: 1956, col: 36, offset: 56588},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 1956, col: 40, offset: 56581},
+								pos: position{line: 1956, col: 40, offset: 56592},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1956, col: 40, offset: 56581},
+										pos:        position{line: 1956, col: 40, offset: 56592},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1956, col: 46, offset: 56587},
+										pos:        position{line: 1956, col: 46, offset: 56598},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -5294,7 +5304,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1956, col: 52, offset: 56593},
+							pos:  position{line: 1956, col: 52, offset: 56604},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5303,43 +5313,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 1964, col: 1, offset: 56774},
+			pos:  position{line: 1964, col: 1, offset: 56785},
 			expr: &actionExpr{
-				pos: position{line: 1964, col: 23, offset: 56796},
+				pos: position{line: 1964, col: 23, offset: 56807},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 1964, col: 23, offset: 56796},
+					pos: position{line: 1964, col: 23, offset: 56807},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1964, col: 23, offset: 56796},
+							pos:  position{line: 1964, col: 23, offset: 56807},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1964, col: 38, offset: 56811},
+							pos:   position{line: 1964, col: 38, offset: 56822},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 1964, col: 42, offset: 56815},
+								pos: position{line: 1964, col: 42, offset: 56826},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 1964, col: 42, offset: 56815},
+										pos:        position{line: 1964, col: 42, offset: 56826},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1964, col: 49, offset: 56822},
+										pos:        position{line: 1964, col: 49, offset: 56833},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1964, col: 55, offset: 56828},
+										pos:        position{line: 1964, col: 55, offset: 56839},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 1964, col: 62, offset: 56835},
+										pos:        position{line: 1964, col: 62, offset: 56846},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -5348,7 +5358,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1964, col: 67, offset: 56840},
+							pos:  position{line: 1964, col: 67, offset: 56851},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5357,30 +5367,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 1972, col: 1, offset: 57023},
+			pos:  position{line: 1972, col: 1, offset: 57034},
 			expr: &choiceExpr{
-				pos: position{line: 1972, col: 25, offset: 57047},
+				pos: position{line: 1972, col: 25, offset: 57058},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1972, col: 25, offset: 57047},
+						pos: position{line: 1972, col: 25, offset: 57058},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 1972, col: 25, offset: 57047},
+							pos:   position{line: 1972, col: 25, offset: 57058},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1972, col: 28, offset: 57050},
+								pos:  position{line: 1972, col: 28, offset: 57061},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1975, col: 3, offset: 57092},
+						pos: position{line: 1975, col: 3, offset: 57103},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 1975, col: 3, offset: 57092},
+							pos:   position{line: 1975, col: 3, offset: 57103},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1975, col: 6, offset: 57095},
+								pos:  position{line: 1975, col: 6, offset: 57106},
 								name: "InequalityOperator",
 							},
 						},
@@ -5390,25 +5400,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 1979, col: 1, offset: 57138},
+			pos:  position{line: 1979, col: 1, offset: 57149},
 			expr: &actionExpr{
-				pos: position{line: 1979, col: 11, offset: 57148},
+				pos: position{line: 1979, col: 11, offset: 57159},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 1979, col: 11, offset: 57148},
+					pos: position{line: 1979, col: 11, offset: 57159},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1979, col: 11, offset: 57148},
+							pos:  position{line: 1979, col: 11, offset: 57159},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1979, col: 26, offset: 57163},
+							pos:        position{line: 1979, col: 26, offset: 57174},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1979, col: 30, offset: 57167},
+							pos:  position{line: 1979, col: 30, offset: 57178},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5417,25 +5427,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 1983, col: 1, offset: 57207},
+			pos:  position{line: 1983, col: 1, offset: 57218},
 			expr: &actionExpr{
-				pos: position{line: 1983, col: 12, offset: 57218},
+				pos: position{line: 1983, col: 12, offset: 57229},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 1983, col: 12, offset: 57218},
+					pos: position{line: 1983, col: 12, offset: 57229},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1983, col: 12, offset: 57218},
+							pos:  position{line: 1983, col: 12, offset: 57229},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1983, col: 27, offset: 57233},
+							pos:        position{line: 1983, col: 27, offset: 57244},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1983, col: 31, offset: 57237},
+							pos:  position{line: 1983, col: 31, offset: 57248},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5444,25 +5454,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 1987, col: 1, offset: 57277},
+			pos:  position{line: 1987, col: 1, offset: 57288},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 10, offset: 57286},
+				pos: position{line: 1987, col: 10, offset: 57297},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 1987, col: 10, offset: 57286},
+					pos: position{line: 1987, col: 10, offset: 57297},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1987, col: 10, offset: 57286},
+							pos:  position{line: 1987, col: 10, offset: 57297},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1987, col: 25, offset: 57301},
+							pos:        position{line: 1987, col: 25, offset: 57312},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1987, col: 29, offset: 57305},
+							pos:  position{line: 1987, col: 29, offset: 57316},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5471,25 +5481,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 1991, col: 1, offset: 57345},
+			pos:  position{line: 1991, col: 1, offset: 57356},
 			expr: &actionExpr{
-				pos: position{line: 1991, col: 10, offset: 57354},
+				pos: position{line: 1991, col: 10, offset: 57365},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 1991, col: 10, offset: 57354},
+					pos: position{line: 1991, col: 10, offset: 57365},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1991, col: 10, offset: 57354},
+							pos:  position{line: 1991, col: 10, offset: 57365},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1991, col: 25, offset: 57369},
+							pos:        position{line: 1991, col: 25, offset: 57380},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1991, col: 29, offset: 57373},
+							pos:  position{line: 1991, col: 29, offset: 57384},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5498,39 +5508,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 1996, col: 1, offset: 57437},
+			pos:  position{line: 1996, col: 1, offset: 57448},
 			expr: &actionExpr{
-				pos: position{line: 1996, col: 11, offset: 57447},
+				pos: position{line: 1996, col: 11, offset: 57458},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 1996, col: 12, offset: 57448},
+					pos: position{line: 1996, col: 12, offset: 57459},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 1996, col: 12, offset: 57448},
+							pos:        position{line: 1996, col: 12, offset: 57459},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1996, col: 24, offset: 57460},
+							pos:        position{line: 1996, col: 24, offset: 57471},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1996, col: 35, offset: 57471},
+							pos:        position{line: 1996, col: 35, offset: 57482},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1996, col: 44, offset: 57480},
+							pos:        position{line: 1996, col: 44, offset: 57491},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 1996, col: 52, offset: 57488},
+							pos:        position{line: 1996, col: 52, offset: 57499},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -5541,39 +5551,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 2000, col: 1, offset: 57529},
+			pos:  position{line: 2000, col: 1, offset: 57540},
 			expr: &actionExpr{
-				pos: position{line: 2000, col: 11, offset: 57539},
+				pos: position{line: 2000, col: 11, offset: 57550},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 2000, col: 12, offset: 57540},
+					pos: position{line: 2000, col: 12, offset: 57551},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2000, col: 12, offset: 57540},
+							pos:        position{line: 2000, col: 12, offset: 57551},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2000, col: 24, offset: 57552},
+							pos:        position{line: 2000, col: 24, offset: 57563},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2000, col: 35, offset: 57563},
+							pos:        position{line: 2000, col: 35, offset: 57574},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2000, col: 44, offset: 57572},
+							pos:        position{line: 2000, col: 44, offset: 57583},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2000, col: 52, offset: 57580},
+							pos:        position{line: 2000, col: 52, offset: 57591},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -5584,39 +5594,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 2004, col: 1, offset: 57621},
+			pos:  position{line: 2004, col: 1, offset: 57632},
 			expr: &actionExpr{
-				pos: position{line: 2004, col: 9, offset: 57629},
+				pos: position{line: 2004, col: 9, offset: 57640},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 2004, col: 10, offset: 57630},
+					pos: position{line: 2004, col: 10, offset: 57641},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2004, col: 10, offset: 57630},
+							pos:        position{line: 2004, col: 10, offset: 57641},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2004, col: 20, offset: 57640},
+							pos:        position{line: 2004, col: 20, offset: 57651},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2004, col: 29, offset: 57649},
+							pos:        position{line: 2004, col: 29, offset: 57660},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2004, col: 37, offset: 57657},
+							pos:        position{line: 2004, col: 37, offset: 57668},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2004, col: 44, offset: 57664},
+							pos:        position{line: 2004, col: 44, offset: 57675},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -5627,27 +5637,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 2008, col: 1, offset: 57703},
+			pos:  position{line: 2008, col: 1, offset: 57714},
 			expr: &actionExpr{
-				pos: position{line: 2008, col: 8, offset: 57710},
+				pos: position{line: 2008, col: 8, offset: 57721},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 2008, col: 9, offset: 57711},
+					pos: position{line: 2008, col: 9, offset: 57722},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2008, col: 9, offset: 57711},
+							pos:        position{line: 2008, col: 9, offset: 57722},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2008, col: 18, offset: 57720},
+							pos:        position{line: 2008, col: 18, offset: 57731},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2008, col: 26, offset: 57728},
+							pos:        position{line: 2008, col: 26, offset: 57739},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -5658,27 +5668,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 2012, col: 1, offset: 57766},
+			pos:  position{line: 2012, col: 1, offset: 57777},
 			expr: &actionExpr{
-				pos: position{line: 2012, col: 9, offset: 57774},
+				pos: position{line: 2012, col: 9, offset: 57785},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 2012, col: 10, offset: 57775},
+					pos: position{line: 2012, col: 10, offset: 57786},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2012, col: 10, offset: 57775},
+							pos:        position{line: 2012, col: 10, offset: 57786},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 20, offset: 57785},
+							pos:        position{line: 2012, col: 20, offset: 57796},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2012, col: 29, offset: 57794},
+							pos:        position{line: 2012, col: 29, offset: 57805},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -5689,27 +5699,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 2016, col: 1, offset: 57833},
+			pos:  position{line: 2016, col: 1, offset: 57844},
 			expr: &actionExpr{
-				pos: position{line: 2016, col: 10, offset: 57842},
+				pos: position{line: 2016, col: 10, offset: 57853},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 2016, col: 11, offset: 57843},
+					pos: position{line: 2016, col: 11, offset: 57854},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2016, col: 11, offset: 57843},
+							pos:        position{line: 2016, col: 11, offset: 57854},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2016, col: 22, offset: 57854},
+							pos:        position{line: 2016, col: 22, offset: 57865},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2016, col: 32, offset: 57864},
+							pos:        position{line: 2016, col: 32, offset: 57875},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -5720,39 +5730,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 2020, col: 1, offset: 57906},
+			pos:  position{line: 2020, col: 1, offset: 57917},
 			expr: &actionExpr{
-				pos: position{line: 2020, col: 12, offset: 57917},
+				pos: position{line: 2020, col: 12, offset: 57928},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 2020, col: 13, offset: 57918},
+					pos: position{line: 2020, col: 13, offset: 57929},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2020, col: 13, offset: 57918},
+							pos:        position{line: 2020, col: 13, offset: 57929},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2020, col: 26, offset: 57931},
+							pos:        position{line: 2020, col: 26, offset: 57942},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2020, col: 38, offset: 57943},
+							pos:        position{line: 2020, col: 38, offset: 57954},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2020, col: 47, offset: 57952},
+							pos:        position{line: 2020, col: 47, offset: 57963},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2020, col: 55, offset: 57960},
+							pos:        position{line: 2020, col: 55, offset: 57971},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -5763,33 +5773,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 2025, col: 1, offset: 58094},
+			pos:  position{line: 2025, col: 1, offset: 58105},
 			expr: &actionExpr{
-				pos: position{line: 2025, col: 15, offset: 58108},
+				pos: position{line: 2025, col: 15, offset: 58119},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 2025, col: 16, offset: 58109},
+					pos: position{line: 2025, col: 16, offset: 58120},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2025, col: 16, offset: 58109},
+							pos:        position{line: 2025, col: 16, offset: 58120},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2025, col: 23, offset: 58116},
+							pos:        position{line: 2025, col: 23, offset: 58127},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2025, col: 30, offset: 58123},
+							pos:        position{line: 2025, col: 30, offset: 58134},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2025, col: 37, offset: 58130},
+							pos:        position{line: 2025, col: 37, offset: 58141},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -5799,19 +5809,72 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "ALLCMD",
+			pos:  position{line: 2034, col: 1, offset: 58356},
+			expr: &choiceExpr{
+				pos: position{line: 2034, col: 12, offset: 58367},
+				alternatives: []any{
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 12, offset: 58367},
+						name: "CMD_REGEX",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 24, offset: 58379},
+						name: "CMD_STATS",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 36, offset: 58391},
+						name: "CMD_FIELDS",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 49, offset: 58404},
+						name: "CMD_WHERE",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 61, offset: 58416},
+						name: "CMD_HEAD_NO_SPACE",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 81, offset: 58436},
+						name: "CMD_EVAL",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 92, offset: 58447},
+						name: "CMD_REX",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 102, offset: 58457},
+						name: "CMD_TOP",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 112, offset: 58467},
+						name: "CMD_RARE",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 123, offset: 58478},
+						name: "CMD_RENAME",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 2034, col: 136, offset: 58491},
+						name: "CMD_TIMECHART",
+					},
+				},
+			},
+		},
+		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 2033, col: 1, offset: 58316},
+			pos:  position{line: 2035, col: 1, offset: 58506},
 			expr: &seqExpr{
-				pos: position{line: 2033, col: 15, offset: 58330},
+				pos: position{line: 2035, col: 15, offset: 58520},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2033, col: 15, offset: 58330},
+						pos:        position{line: 2035, col: 15, offset: 58520},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2033, col: 24, offset: 58339},
+						pos:  position{line: 2035, col: 24, offset: 58529},
 						name: "SPACE",
 					},
 				},
@@ -5819,18 +5882,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 2034, col: 1, offset: 58345},
+			pos:  position{line: 2036, col: 1, offset: 58535},
 			expr: &seqExpr{
-				pos: position{line: 2034, col: 14, offset: 58358},
+				pos: position{line: 2036, col: 14, offset: 58548},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2034, col: 14, offset: 58358},
+						pos:        position{line: 2036, col: 14, offset: 58548},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2034, col: 22, offset: 58366},
+						pos:  position{line: 2036, col: 22, offset: 58556},
 						name: "SPACE",
 					},
 				},
@@ -5838,18 +5901,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 2035, col: 1, offset: 58372},
+			pos:  position{line: 2037, col: 1, offset: 58562},
 			expr: &seqExpr{
-				pos: position{line: 2035, col: 14, offset: 58385},
+				pos: position{line: 2037, col: 14, offset: 58575},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2035, col: 14, offset: 58385},
+						pos:        position{line: 2037, col: 14, offset: 58575},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2035, col: 22, offset: 58393},
+						pos:  position{line: 2037, col: 22, offset: 58583},
 						name: "SPACE",
 					},
 				},
@@ -5857,18 +5920,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 2036, col: 1, offset: 58399},
+			pos:  position{line: 2038, col: 1, offset: 58589},
 			expr: &seqExpr{
-				pos: position{line: 2036, col: 15, offset: 58413},
+				pos: position{line: 2038, col: 15, offset: 58603},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2036, col: 15, offset: 58413},
+						pos:        position{line: 2038, col: 15, offset: 58603},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2036, col: 24, offset: 58422},
+						pos:  position{line: 2038, col: 24, offset: 58612},
 						name: "SPACE",
 					},
 				},
@@ -5876,18 +5939,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 2037, col: 1, offset: 58428},
+			pos:  position{line: 2039, col: 1, offset: 58618},
 			expr: &seqExpr{
-				pos: position{line: 2037, col: 14, offset: 58441},
+				pos: position{line: 2039, col: 14, offset: 58631},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2037, col: 14, offset: 58441},
+						pos:        position{line: 2039, col: 14, offset: 58631},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2037, col: 22, offset: 58449},
+						pos:  position{line: 2039, col: 22, offset: 58639},
 						name: "SPACE",
 					},
 				},
@@ -5895,9 +5958,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 2038, col: 1, offset: 58455},
+			pos:  position{line: 2040, col: 1, offset: 58645},
 			expr: &litMatcher{
-				pos:        position{line: 2038, col: 22, offset: 58476},
+				pos:        position{line: 2040, col: 22, offset: 58666},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -5905,16 +5968,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 2039, col: 1, offset: 58483},
+			pos:  position{line: 2041, col: 1, offset: 58673},
 			expr: &seqExpr{
-				pos: position{line: 2039, col: 13, offset: 58495},
+				pos: position{line: 2041, col: 13, offset: 58685},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2039, col: 13, offset: 58495},
+						pos:  position{line: 2041, col: 13, offset: 58685},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2039, col: 31, offset: 58513},
+						pos:  position{line: 2041, col: 31, offset: 58703},
 						name: "SPACE",
 					},
 				},
@@ -5922,18 +5985,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 2040, col: 1, offset: 58519},
+			pos:  position{line: 2042, col: 1, offset: 58709},
 			expr: &seqExpr{
-				pos: position{line: 2040, col: 13, offset: 58531},
+				pos: position{line: 2042, col: 13, offset: 58721},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2040, col: 13, offset: 58531},
+						pos:        position{line: 2042, col: 13, offset: 58721},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2040, col: 20, offset: 58538},
+						pos:  position{line: 2042, col: 20, offset: 58728},
 						name: "SPACE",
 					},
 				},
@@ -5941,18 +6004,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 2041, col: 1, offset: 58544},
+			pos:  position{line: 2043, col: 1, offset: 58734},
 			expr: &seqExpr{
-				pos: position{line: 2041, col: 12, offset: 58555},
+				pos: position{line: 2043, col: 12, offset: 58745},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2041, col: 12, offset: 58555},
+						pos:        position{line: 2043, col: 12, offset: 58745},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2041, col: 18, offset: 58561},
+						pos:  position{line: 2043, col: 18, offset: 58751},
 						name: "SPACE",
 					},
 				},
@@ -5960,9 +6023,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 2042, col: 1, offset: 58567},
+			pos:  position{line: 2044, col: 1, offset: 58757},
 			expr: &litMatcher{
-				pos:        position{line: 2042, col: 12, offset: 58578},
+				pos:        position{line: 2044, col: 12, offset: 58768},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -5970,9 +6033,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 2043, col: 1, offset: 58584},
+			pos:  position{line: 2045, col: 1, offset: 58774},
 			expr: &litMatcher{
-				pos:        position{line: 2043, col: 13, offset: 58596},
+				pos:        position{line: 2045, col: 13, offset: 58786},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -5980,18 +6043,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 2044, col: 1, offset: 58603},
+			pos:  position{line: 2046, col: 1, offset: 58793},
 			expr: &seqExpr{
-				pos: position{line: 2044, col: 15, offset: 58617},
+				pos: position{line: 2046, col: 15, offset: 58807},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2044, col: 15, offset: 58617},
+						pos:        position{line: 2046, col: 15, offset: 58807},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2044, col: 24, offset: 58626},
+						pos:  position{line: 2046, col: 24, offset: 58816},
 						name: "SPACE",
 					},
 				},
@@ -5999,18 +6062,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 2045, col: 1, offset: 58632},
+			pos:  position{line: 2047, col: 1, offset: 58822},
 			expr: &seqExpr{
-				pos: position{line: 2045, col: 18, offset: 58649},
+				pos: position{line: 2047, col: 18, offset: 58839},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2045, col: 18, offset: 58649},
+						pos:        position{line: 2047, col: 18, offset: 58839},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2045, col: 30, offset: 58661},
+						pos:  position{line: 2047, col: 30, offset: 58851},
 						name: "SPACE",
 					},
 				},
@@ -6018,9 +6081,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 2046, col: 1, offset: 58667},
+			pos:  position{line: 2048, col: 1, offset: 58857},
 			expr: &litMatcher{
-				pos:        position{line: 2046, col: 13, offset: 58679},
+				pos:        position{line: 2048, col: 13, offset: 58869},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -6028,27 +6091,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 2047, col: 1, offset: 58686},
+			pos:  position{line: 2049, col: 1, offset: 58876},
 			expr: &seqExpr{
-				pos: position{line: 2047, col: 16, offset: 58701},
+				pos: position{line: 2049, col: 16, offset: 58891},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 2047, col: 16, offset: 58701},
+						pos: position{line: 2049, col: 16, offset: 58891},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2047, col: 16, offset: 58701},
+							pos:  position{line: 2049, col: 16, offset: 58891},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2047, col: 23, offset: 58708},
+						pos:        position{line: 2049, col: 23, offset: 58898},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 2047, col: 27, offset: 58712},
+						pos: position{line: 2049, col: 27, offset: 58902},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2047, col: 27, offset: 58712},
+							pos:  position{line: 2049, col: 27, offset: 58902},
 							name: "SPACE",
 						},
 					},
@@ -6057,115 +6120,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 2050, col: 1, offset: 58823},
+			pos:  position{line: 2052, col: 1, offset: 59013},
 			expr: &choiceExpr{
-				pos: position{line: 2050, col: 16, offset: 58838},
+				pos: position{line: 2052, col: 16, offset: 59028},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 2050, col: 16, offset: 58838},
+						pos:        position{line: 2052, col: 16, offset: 59028},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 2050, col: 47, offset: 58869},
+						pos:        position{line: 2052, col: 47, offset: 59059},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2050, col: 55, offset: 58877},
+						pos:        position{line: 2052, col: 55, offset: 59067},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 16, offset: 58900},
+						pos:        position{line: 2053, col: 16, offset: 59090},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 26, offset: 58910},
+						pos:        position{line: 2053, col: 26, offset: 59100},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 34, offset: 58918},
+						pos:        position{line: 2053, col: 34, offset: 59108},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 42, offset: 58926},
+						pos:        position{line: 2053, col: 42, offset: 59116},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 50, offset: 58934},
+						pos:        position{line: 2053, col: 50, offset: 59124},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 58, offset: 58942},
+						pos:        position{line: 2053, col: 58, offset: 59132},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2051, col: 66, offset: 58950},
+						pos:        position{line: 2053, col: 66, offset: 59140},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 16, offset: 58972},
+						pos:        position{line: 2054, col: 16, offset: 59162},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 26, offset: 58982},
+						pos:        position{line: 2054, col: 26, offset: 59172},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 34, offset: 58990},
+						pos:        position{line: 2054, col: 34, offset: 59180},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 42, offset: 58998},
+						pos:        position{line: 2054, col: 42, offset: 59188},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 50, offset: 59006},
+						pos:        position{line: 2054, col: 50, offset: 59196},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 58, offset: 59014},
+						pos:        position{line: 2054, col: 58, offset: 59204},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 66, offset: 59022},
+						pos:        position{line: 2054, col: 66, offset: 59212},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2052, col: 74, offset: 59030},
+						pos:        position{line: 2054, col: 74, offset: 59220},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -6175,25 +6238,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 2053, col: 1, offset: 59036},
+			pos:  position{line: 2055, col: 1, offset: 59226},
 			expr: &choiceExpr{
-				pos: position{line: 2053, col: 16, offset: 59051},
+				pos: position{line: 2055, col: 16, offset: 59241},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 2053, col: 16, offset: 59051},
+						pos:        position{line: 2055, col: 16, offset: 59241},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 2053, col: 30, offset: 59065},
+						pos:        position{line: 2055, col: 30, offset: 59255},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2053, col: 36, offset: 59071},
+						pos:        position{line: 2055, col: 36, offset: 59261},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -6203,18 +6266,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2057, col: 1, offset: 59227},
+			pos:  position{line: 2059, col: 1, offset: 59417},
 			expr: &seqExpr{
-				pos: position{line: 2057, col: 8, offset: 59234},
+				pos: position{line: 2059, col: 8, offset: 59424},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2057, col: 8, offset: 59234},
+						pos:        position{line: 2059, col: 8, offset: 59424},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2057, col: 14, offset: 59240},
+						pos:  position{line: 2059, col: 14, offset: 59430},
 						name: "SPACE",
 					},
 				},
@@ -6222,22 +6285,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2058, col: 1, offset: 59246},
+			pos:  position{line: 2060, col: 1, offset: 59436},
 			expr: &seqExpr{
-				pos: position{line: 2058, col: 7, offset: 59252},
+				pos: position{line: 2060, col: 7, offset: 59442},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2058, col: 7, offset: 59252},
+						pos:  position{line: 2060, col: 7, offset: 59442},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2058, col: 13, offset: 59258},
+						pos:        position{line: 2060, col: 13, offset: 59448},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2058, col: 18, offset: 59263},
+						pos:  position{line: 2060, col: 18, offset: 59453},
 						name: "SPACE",
 					},
 				},
@@ -6245,22 +6308,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2059, col: 1, offset: 59269},
+			pos:  position{line: 2061, col: 1, offset: 59459},
 			expr: &seqExpr{
-				pos: position{line: 2059, col: 8, offset: 59276},
+				pos: position{line: 2061, col: 8, offset: 59466},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2059, col: 8, offset: 59276},
+						pos:  position{line: 2061, col: 8, offset: 59466},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2059, col: 14, offset: 59282},
+						pos:        position{line: 2061, col: 14, offset: 59472},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2059, col: 20, offset: 59288},
+						pos:  position{line: 2061, col: 20, offset: 59478},
 						name: "SPACE",
 					},
 				},
@@ -6268,22 +6331,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 2060, col: 1, offset: 59294},
+			pos:  position{line: 2062, col: 1, offset: 59484},
 			expr: &seqExpr{
-				pos: position{line: 2060, col: 9, offset: 59302},
+				pos: position{line: 2062, col: 9, offset: 59492},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2060, col: 9, offset: 59302},
+						pos:  position{line: 2062, col: 9, offset: 59492},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2060, col: 15, offset: 59308},
+						pos:        position{line: 2062, col: 15, offset: 59498},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2060, col: 19, offset: 59312},
+						pos:  position{line: 2062, col: 19, offset: 59502},
 						name: "SPACE",
 					},
 				},
@@ -6291,22 +6354,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2061, col: 1, offset: 59318},
+			pos:  position{line: 2063, col: 1, offset: 59508},
 			expr: &seqExpr{
-				pos: position{line: 2061, col: 7, offset: 59324},
+				pos: position{line: 2063, col: 7, offset: 59514},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2061, col: 7, offset: 59324},
+						pos:  position{line: 2063, col: 7, offset: 59514},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2061, col: 13, offset: 59330},
+						pos:        position{line: 2063, col: 13, offset: 59520},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2061, col: 19, offset: 59336},
+						pos:  position{line: 2063, col: 19, offset: 59526},
 						name: "SPACE",
 					},
 				},
@@ -6314,22 +6377,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2062, col: 1, offset: 59362},
+			pos:  position{line: 2064, col: 1, offset: 59552},
 			expr: &seqExpr{
-				pos: position{line: 2062, col: 7, offset: 59368},
+				pos: position{line: 2064, col: 7, offset: 59558},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2062, col: 7, offset: 59368},
+						pos:  position{line: 2064, col: 7, offset: 59558},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2062, col: 13, offset: 59374},
+						pos:        position{line: 2064, col: 13, offset: 59564},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2062, col: 19, offset: 59380},
+						pos:  position{line: 2064, col: 19, offset: 59570},
 						name: "SPACE",
 					},
 				},
@@ -6337,22 +6400,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 2064, col: 1, offset: 59407},
+			pos:  position{line: 2066, col: 1, offset: 59597},
 			expr: &seqExpr{
-				pos: position{line: 2064, col: 10, offset: 59416},
+				pos: position{line: 2066, col: 10, offset: 59606},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2064, col: 10, offset: 59416},
+						pos:  position{line: 2066, col: 10, offset: 59606},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2064, col: 25, offset: 59431},
+						pos:        position{line: 2066, col: 25, offset: 59621},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2064, col: 29, offset: 59435},
+						pos:  position{line: 2066, col: 29, offset: 59625},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -6360,22 +6423,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 2065, col: 1, offset: 59450},
+			pos:  position{line: 2067, col: 1, offset: 59640},
 			expr: &seqExpr{
-				pos: position{line: 2065, col: 10, offset: 59459},
+				pos: position{line: 2067, col: 10, offset: 59649},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2065, col: 10, offset: 59459},
+						pos:  position{line: 2067, col: 10, offset: 59649},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2065, col: 25, offset: 59474},
+						pos:        position{line: 2067, col: 25, offset: 59664},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2065, col: 29, offset: 59478},
+						pos:  position{line: 2067, col: 29, offset: 59668},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -6383,18 +6446,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 2066, col: 1, offset: 59493},
+			pos:  position{line: 2068, col: 1, offset: 59683},
 			expr: &seqExpr{
-				pos: position{line: 2066, col: 12, offset: 59504},
+				pos: position{line: 2068, col: 12, offset: 59694},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2066, col: 12, offset: 59504},
+						pos:        position{line: 2068, col: 12, offset: 59694},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2066, col: 16, offset: 59508},
+						pos:  position{line: 2068, col: 16, offset: 59698},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -6402,16 +6465,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 2067, col: 1, offset: 59523},
+			pos:  position{line: 2069, col: 1, offset: 59713},
 			expr: &seqExpr{
-				pos: position{line: 2067, col: 12, offset: 59534},
+				pos: position{line: 2069, col: 12, offset: 59724},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2067, col: 12, offset: 59534},
+						pos:  position{line: 2069, col: 12, offset: 59724},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2067, col: 27, offset: 59549},
+						pos:        position{line: 2069, col: 27, offset: 59739},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -6421,40 +6484,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 2069, col: 1, offset: 59554},
+			pos:  position{line: 2071, col: 1, offset: 59744},
 			expr: &notExpr{
-				pos: position{line: 2069, col: 8, offset: 59561},
+				pos: position{line: 2071, col: 8, offset: 59751},
 				expr: &anyMatcher{
-					line: 2069, col: 9, offset: 59562,
+					line: 2071, col: 9, offset: 59752,
 				},
 			},
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 2070, col: 1, offset: 59564},
+			pos:  position{line: 2072, col: 1, offset: 59754},
 			expr: &choiceExpr{
-				pos: position{line: 2070, col: 10, offset: 59573},
+				pos: position{line: 2072, col: 10, offset: 59763},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2070, col: 11, offset: 59574},
+						pos: position{line: 2072, col: 11, offset: 59764},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 2070, col: 11, offset: 59574},
+								pos: position{line: 2072, col: 11, offset: 59764},
 								expr: &litMatcher{
-									pos:        position{line: 2070, col: 11, offset: 59574},
+									pos:        position{line: 2072, col: 11, offset: 59764},
 									val:        " ",
 									ignoreCase: false,
 									want:       "\" \"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2070, col: 16, offset: 59579},
+								pos:  position{line: 2072, col: 16, offset: 59769},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 2070, col: 24, offset: 59587},
+								pos: position{line: 2072, col: 24, offset: 59777},
 								expr: &litMatcher{
-									pos:        position{line: 2070, col: 24, offset: 59587},
+									pos:        position{line: 2072, col: 24, offset: 59777},
 									val:        " ",
 									ignoreCase: false,
 									want:       "\" \"",
@@ -6463,9 +6526,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 2070, col: 32, offset: 59595},
+						pos: position{line: 2072, col: 32, offset: 59785},
 						expr: &litMatcher{
-							pos:        position{line: 2070, col: 32, offset: 59595},
+							pos:        position{line: 2072, col: 32, offset: 59785},
 							val:        " ",
 							ignoreCase: false,
 							want:       "\" \"",
@@ -6476,38 +6539,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 2071, col: 1, offset: 59600},
+			pos:  position{line: 2073, col: 1, offset: 59790},
 			expr: &seqExpr{
-				pos: position{line: 2071, col: 12, offset: 59611},
+				pos: position{line: 2073, col: 12, offset: 59801},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2071, col: 12, offset: 59611},
+						pos:        position{line: 2073, col: 12, offset: 59801},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 2071, col: 18, offset: 59617},
+						pos: position{line: 2073, col: 18, offset: 59807},
 						expr: &seqExpr{
-							pos: position{line: 2071, col: 19, offset: 59618},
+							pos: position{line: 2073, col: 19, offset: 59808},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 2071, col: 19, offset: 59618},
+									pos: position{line: 2073, col: 19, offset: 59808},
 									expr: &litMatcher{
-										pos:        position{line: 2071, col: 21, offset: 59620},
+										pos:        position{line: 2073, col: 21, offset: 59810},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 2071, col: 28, offset: 59627,
+									line: 2073, col: 28, offset: 59817,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2071, col: 32, offset: 59631},
+						pos:        position{line: 2073, col: 32, offset: 59821},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -6517,16 +6580,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 2072, col: 1, offset: 59637},
+			pos:  position{line: 2074, col: 1, offset: 59827},
 			expr: &choiceExpr{
-				pos: position{line: 2072, col: 20, offset: 59656},
+				pos: position{line: 2074, col: 20, offset: 59846},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2072, col: 20, offset: 59656},
+						pos:  position{line: 2074, col: 20, offset: 59846},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2072, col: 28, offset: 59664},
+						pos:        position{line: 2074, col: 28, offset: 59854},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -218,7 +218,7 @@ InitialSearchBlock <- CMD_SEARCH? clause:ClauseLevel4 {
     return clause, nil
 }
 
-SearchBlock <- CMD_SEARCH clause:ClauseLevel4 {
+SearchBlock <- !(ALLCMD) CMD_SEARCH? clause:ClauseLevel4 {
     return clause, nil
 }
 
@@ -2030,6 +2030,8 @@ Subseconds <- ("us" / "ms" / "cs" / "ds") {
     return timeUnit, nil
 }
 
+// All cmd expect CMD_SEARCH
+ALLCMD <- (CMD_REGEX / CMD_STATS / CMD_FIELDS / CMD_WHERE / CMD_HEAD_NO_SPACE / CMD_HEAD / CMD_EVAL / CMD_REX / CMD_TOP / CMD_RARE / CMD_RENAME / CMD_TIMECHART)
 CMD_SEARCH <- "search" SPACE
 CMD_REGEX <- "regex" SPACE
 CMD_STATS <- "stats" SPACE


### PR DESCRIPTION
# Description
In the past, only the first search block can execute without using keywrod `search`
E.g.:
`"Santa Ana" | search latency > 500000`

After this change, allow this type of query:
E.g.:
`"Santa Ana" | latency > 500000`

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
