### PR TITLE
Don't do CMI check when there's a NOT expression

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -112,3 +112,5 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "city=Boston | stats max(latitude), range(eval(latitude >= 0)) AS range",now-1d,now,*,group:range:*,eq,89.752,Splunk QL
 "* | stats count(eval(latitude < 0)) AS count, dc(eval(lower(app_name)))",now-1d,now,*,group:count:*,eq,"50,146",Splunk QL
 "* | stats min(eval(latitude < 0)), max(eval(latitude < 0)) AS max, range(eval(latitude < 0)) BY weekday",now-1d,now,*,group:max:Monday,eq,-0.004012,Splunk QL
+"app_name=""Albumis"" (Wednesday OR Tuesday)",now-1d,now,*,total,eq,2,Splunk QL
+"app_name=""Albumis"" (Wednesday OR Tuesday) NOT asdfjklnvwer",now-1d,now,*,total,eq,2,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -112,3 +112,5 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "city=Boston | stats max(latitude), range(eval(latitude >= 0)) AS range",now-1d,now,*,group:range:*,eq,89.752,Splunk QL
 "* | stats count(eval(latitude < 0)) AS count, dc(eval(lower(app_name)))",now-1d,now,*,group:count:*,eq,"50,146",Splunk QL
 "* | stats min(eval(latitude < 0)), max(eval(latitude < 0)) AS max, range(eval(latitude < 0)) BY weekday",now-1d,now,*,group:max:Monday,eq,-0.004012,Splunk QL
+"app_name=""Albumis"" (Wednesday OR Tuesday)",now-1d,now,*,total,eq,2,Splunk QL
+"app_name=""Albumis"" (Wednesday OR Tuesday) NOT asdfjklnvwer",now-1d,now,*,total,eq,2,Splunk QL

--- a/pkg/segment/query/metadata/blockmeta.go
+++ b/pkg/segment/query/metadata/blockmeta.go
@@ -147,7 +147,11 @@ func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
 					doRangeCheckForCol(segMicroIndex, blockToCheck, rangeFilter, rangeOp, timeFilteredBlocks, colsToCheck, qid)
 				}
 			} else {
-				if !wildCardValue {
+				negateMatch := false
+				if currQuery != nil && currQuery.MatchFilter != nil && currQuery.MatchFilter.NegateMatch {
+					negateMatch = true
+				}
+				if !wildCardValue && !negateMatch {
 					if wildcardCol {
 						doBloomCheckAllCol(segMicroIndex, blockToCheck, bloomKeys, bloomOp, timeFilteredBlocks)
 					} else {


### PR DESCRIPTION
# Description
This bypasses the CMI checks when there's a NOT expression. This is because the CMI checks are performed using the bloom indexes, which either say the string is probably in the block or is definitely not in the block; but when negate this we get that the string is probably not in the block or definitely is in the block, so we have to search all the records in all the blocks anyways, making the bloom check useless.

# Testing
1. Start siglens with an empty `data/` directory
2. From sigscalr-client, ingest some data with:
```
go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 1_000_000
```
3. Run the following queries:
```
app_name="Albumis" (Wednesday OR Tuesday)
app_name="Albumis" (Wednesday OR Tuesday) NOT asdfjkliuer
```
Both queries should return the same results (5 rows) because no record contains `asdfjkliuer`. This works with this PR, but not without this PR (tested on commit 9adfc91)

I also tested other queries that we recently fixed bugs for, and did not find any regressions on those queries.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
