### PR TITLE
Use existing FD limit

### DIFF
--- a/pkg/common/fileutils/fileutils.go
+++ b/pkg/common/fileutils/fileutils.go
@@ -32,7 +32,7 @@ import (
 */
 
 var GLOBAL_FD_LIMITER *semaphore.WeightedSemaphore
-var DEFAULT_MAX_OPEN_FDs uint64 = 1024
+var DEFAULT_MAX_OPEN_FDs uint64 = 8192
 
 /*
 what percent of max open FDs should we actually use?
@@ -54,8 +54,8 @@ func init() {
 		numFiles = rLimit.Cur
 	}
 	var newLimit syscall.Rlimit
-	newLimit.Max = 8192
-	newLimit.Cur = 8192
+	newLimit.Max = numFiles
+	newLimit.Cur = numFiles
 
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &newLimit)
 	if err != nil {
@@ -65,7 +65,7 @@ func init() {
 		numFiles = newLimit.Cur
 	}
 	maxPossibleOpenFds := int64(numFiles*OPEN_FD_THRESHOLD_PERCENT) / 100
-	log.Debugf("Initialized FD limiter with %+v as max number of open files", maxPossibleOpenFds)
+	log.Infof("Initialized FD limiter with %+v as max number of open files", maxPossibleOpenFds)
 	GLOBAL_FD_LIMITER = semaphore.NewDefaultWeightedSemaphore(maxPossibleOpenFds, "GlobalFileLimiter")
 }
 


### PR DESCRIPTION
# Description
Previously we always used 8192 as the max number of open files. Now we use the result of a system call to get the current max, and use that.

# Testing
I ran siglens on my machine and through docker. On my machine, the limit was 122880 (but we use 70% of the max, so 86016). On docker I got 1048576 (so 70% is 734,003). 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
