### PR TITLE
Clear colWips if it's too large

### DIFF
--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -105,13 +105,19 @@ func (segstore *SegStore) initWipBlock() {
 func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 
 	segstore.wipBlock.maxIdx = 0
-	for _, cwip := range segstore.wipBlock.colWips {
-		cwip.cbufidx = 0
-		cwip.cstartidx = 0
 
-		cwip.deCount = 0
-		for dword := range cwip.deMap {
-			delete(cwip.deMap, dword)
+	if len(segstore.wipBlock.colWips) > 2000 {
+		log.Errorf("resetWipBlock: colWips size is too large: %v", len(segstore.wipBlock.colWips))
+		segstore.wipBlock.colWips = make(map[string]*ColWip)
+	} else {
+		for _, cwip := range segstore.wipBlock.colWips {
+			cwip.cbufidx = 0
+			cwip.cstartidx = 0
+
+			cwip.deCount = 0
+			for dword := range cwip.deMap {
+				delete(cwip.deMap, dword)
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description
When new columns are added, they're included in `colWips`. However, old columns aren't removed, so the size could grow. If it gets larger than it should, we'll reset it.

# Testing
I've not tested this

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
