### PR TITLE
Make access logs more robust

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -321,6 +321,7 @@ func ProcessPipeSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		ctx.Request.URI().String(),
 		string(ctx.PostBody()),
 		func() int { return ctx.Response.StatusCode() },
+		false,
 		"access.log",
 	)
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -43,6 +43,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthtt
 		ctx.Request.URI().String(),
 		fmt.Sprintf("%+v", event),
 		func() int { return ctx.Response.StatusCode() },
+		true, // Log this even though it's a websocket connection
 		"access.log",
 	)
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -18,6 +18,7 @@ package pipesearch
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/fasthttp/websocket"
@@ -28,11 +29,23 @@ import (
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"github.com/valyala/fasthttp"
 )
 
-func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64) {
+func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthttp.RequestCtx) {
+
 	qid := rutils.GetNextQid()
 	event, err := readInitialEvent(qid, conn)
+	defer utils.DeferableAddAccessLogEntry(
+		time.Now(),
+		func() time.Time { return time.Now() },
+		"No-user", // TODO : Add logged in user when user auth is implemented
+		ctx.Request.URI().String(),
+		fmt.Sprintf("%+v", event),
+		func() int { return ctx.Response.StatusCode() },
+		"access.log",
+	)
+
 	if err != nil {
 		log.Errorf("qid=%d, ProcessPipeSearchWebsocket: Failed to read initial event %+v!", qid, err)
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -19,7 +19,6 @@ package queryserver
 import (
 	"time"
 
-	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/utils"
 
 	"github.com/fasthttp/websocket"
@@ -209,9 +208,18 @@ var upgrader = websocket.FastHTTPUpgrader{
 }
 
 func pipeSearchWebsocketHandler(myid uint64) func(ctx *fasthttp.RequestCtx) {
-
 	return func(ctx *fasthttp.RequestCtx) {
-		startTime := time.Now()
+		log.Errorf("andrew doing defer")
+		defer utils.DeferableAddAccessLogEntry(
+			time.Now(),
+			func() time.Time { return time.Now() },
+			"No-user", // TODO : Add logged in user when user auth is implemented
+			ctx.Request.URI().String(),
+			string(ctx.PostBody()),
+			func() int { return ctx.Response.StatusCode() },
+			"access.log",
+		)
+
 		err := upgrader.Upgrade(ctx, func(conn *websocket.Conn) {
 			defer func() {
 				deadline := time.Now().Add(time.Second * 5)
@@ -230,24 +238,12 @@ func pipeSearchWebsocketHandler(myid uint64) func(ctx *fasthttp.RequestCtx) {
 					return
 				}
 			}()
-			pipesearch.ProcessPipeSearchWebsocket(conn, myid)
+			pipesearch.ProcessPipeSearchWebsocket(conn, myid, ctx)
 		})
 		if err != nil {
 			log.Errorf("PipeSearchWebsocketHandler: Error upgrading websocket connection %+v", err)
 			return
 		}
-
-		// Logging data to access.log
-		// timeStamp <logged-in user> <request URI> <request body> <response status code> <elapsed time in ms>
-		duration := time.Since(startTime).Milliseconds()
-		utils.AddAccessLogEntry(dtypeutils.AccessLogData{
-			TimeStamp:   time.Now().Format("2006-01-02 15:04:05"),
-			UserName:    "No-User", // TODO : Add logged in user when user auth is implemented
-			URI:         ctx.Request.URI().String(),
-			RequestBody: string(ctx.PostBody()),
-			StatusCode:  ctx.Response.StatusCode(),
-			Duration:    duration,
-		}, "access.log")
 	}
 }
 
@@ -501,7 +497,7 @@ func liveTailHandler(myid uint64) func(ctx *fasthttp.RequestCtx) {
 					return
 				}
 			}()
-			pipesearch.ProcessPipeSearchWebsocket(conn, myid)
+			pipesearch.ProcessPipeSearchWebsocket(conn, myid, ctx)
 		})
 		if err != nil {
 			log.Errorf("liveTailHandler: Error upgrading websocket connection %+v", err)

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -19,8 +19,6 @@ package queryserver
 import (
 	"time"
 
-	"github.com/siglens/siglens/pkg/utils"
-
 	"github.com/fasthttp/websocket"
 
 	"github.com/siglens/siglens/pkg/alerts/alertsHandler"
@@ -209,17 +207,6 @@ var upgrader = websocket.FastHTTPUpgrader{
 
 func pipeSearchWebsocketHandler(myid uint64) func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
-		log.Errorf("andrew doing defer")
-		defer utils.DeferableAddAccessLogEntry(
-			time.Now(),
-			func() time.Time { return time.Now() },
-			"No-user", // TODO : Add logged in user when user auth is implemented
-			ctx.Request.URI().String(),
-			string(ctx.PostBody()),
-			func() int { return ctx.Response.StatusCode() },
-			"access.log",
-		)
-
 		err := upgrader.Upgrade(ctx, func(conn *websocket.Conn) {
 			defer func() {
 				deadline := time.Now().Add(time.Second * 5)

--- a/pkg/utils/accessLogUtils.go
+++ b/pkg/utils/accessLogUtils.go
@@ -4,11 +4,28 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	log "github.com/sirupsen/logrus"
 )
 
+func DeferableAddAccessLogEntry(startTime time.Time, endTimeFunc func() time.Time, user string,
+	uri string, requestBody string, statusCodeFunc func() int, fileName string) {
+
+	data := dtypeutils.AccessLogData{
+		TimeStamp:   startTime.Format("2006-01-02 15:04:05"),
+		UserName:    user,
+		URI:         uri,
+		RequestBody: requestBody,
+		StatusCode:  statusCodeFunc(),
+		Duration:    endTimeFunc().Sub(startTime).Milliseconds(),
+	}
+	AddAccessLogEntry(data, fileName)
+}
+
+// Write to access.log in the following format
+// timeStamp <logged-in user> <request URI> <request body> <response status code> <elapsed time in ms>
 func AddAccessLogEntry(data dtypeutils.AccessLogData, fileName string) {
 	logFile, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {

--- a/pkg/utils/accessLogUtils.go
+++ b/pkg/utils/accessLogUtils.go
@@ -32,10 +32,7 @@ func AddAccessLogEntry(data dtypeutils.AccessLogData, fileName string) {
 		log.Errorf("Unable to write to access.log file, err=%v", err)
 	}
 	defer logFile.Close()
-	// Do not log websocket connections
-	if data.StatusCode == 101 {
-		return
-	}
+
 	// Do not log internal search requests for trace data
 	if (strings.TrimSpace(data.URI) == "http:///" || strings.TrimSpace(data.URI) == "https:///") && strings.Contains(data.RequestBody, "\"indexName\":\"traces\"") {
 		return

--- a/pkg/utils/accesslogutils_test.go
+++ b/pkg/utils/accesslogutils_test.go
@@ -30,8 +30,9 @@ func TestAddAccessLogEntry(t *testing.T) {
 	}
 
 	// Call the function with the temporary logFile
+	allowWebsocket := false
 	fileName := tempLogFile.Name()
-	AddAccessLogEntry(data, fileName)
+	AddAccessLogEntry(data, allowWebsocket, fileName)
 
 	// Read the content of the temporary file
 	content, err := ioutil.ReadFile(fileName)
@@ -83,8 +84,9 @@ func Test_AddLogEntryValidations(t *testing.T) {
 		defer os.Remove(tempLogFile.Name())
 
 		// Call the function with the temporary logFile
+		allowWebsocket := false
 		fileName := tempLogFile.Name()
-		AddAccessLogEntry(test.input, fileName)
+		AddAccessLogEntry(test.input, allowWebsocket, fileName)
 
 		// Read the content of the temporary file
 		content, err := ioutil.ReadFile(fileName)


### PR DESCRIPTION
# Description
This makes it so access.log logs both UI and API queries, even when the queries are invalid so they exit due to error handling.

# Testing
I tested some valid and invalid queries via the API:
```
curl -X POST -d '{
    "searchText": "* | stats max(latency)",
    "index": "*",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search | python3 -m json.tool

curl -X POST -d '{
    "searchText": "* | stats max(latenc",
    "index": "*",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search | python3 -m json.tool
```

I also tested valid and invalid queries on the UI
```
city=helloworld
city=helloworld | stats lskdjf
```

I got this in my access.log
```
2024-01-08 17:40:45 No-user http://localhost:5122/api/search {
    "searchText": "* | stats max(latency)",
    "index": "*",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
} 200 16
2024-01-08 17:40:56 No-user http://localhost:5122/api/search {
    "searchText": "* | stats max(latenc",
    "index": "*",
    "startEpoch": "now-240h",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
} 400 0
2024-01-08 17:41:07 No-user http://localhost:5122/api/search/ws map[endEpoch:now from:0 indexName:* queryLanguage:Splunk QL searchText:city=helloworld startEpoch:now-7d state:query] 101 27
2024-01-08 17:41:24 No-user http://localhost:5122/api/search/ws map[endEpoch:now from:0 indexName:* queryLanguage:Splunk QL searchText:city=helloworld | stats lskdjf startEpoch:now-7d state:query] 101 0
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
