### PR TITLE
Allow Running Stats Query Without GroupBy

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -373,16 +373,7 @@ function runLiveTailBtnHandler(evt) {
   }
   $("#daterangepicker").hide();
 }
-/**
- * 
- * @returns true if the 2nd and 3rd box are all selected or all unselected
- */
-function SecondOrThirdBox(){
-    let num = 0;
-    if(secondBoxSet && secondBoxSet.size > 0) num++;
-    if (thirdBoxSet && thirdBoxSet.size > 0) num++;
-    return num != 1;
-}
+
 function runFilterBtnHandler(evt) {
     $('.popover').hide();
     evt.preventDefault();
@@ -395,10 +386,6 @@ function runFilterBtnHandler(evt) {
       logsRowData = [];
       wsState = "query";
       data = getSearchFilter(false, false);
-      if (!SecondOrThirdBox()) {
-        alert("Error");
-        return;
-      }
       availColNames = [];
       doSearch(data);
     } else {
@@ -419,10 +406,6 @@ function filterInputHandler(evt) {
       resetDashboard();
       logsRowData = [];
       data = getSearchFilter(false, false);
-      if (!SecondOrThirdBox()) {
-        alert("Error");
-        return;
-      }
       availColNames = [];
       doSearch(data);
     }


### PR DESCRIPTION
# Description
Fixed issue with the query builder not allowing the stats query without specifying a groupBy column
<img width="1437" alt="image" src="https://github.com/siglens/siglens/assets/71771131/125444fa-9130-4bd1-8f91-8488b8e821a1">
<img width="1434" alt="image" src="https://github.com/siglens/siglens/assets/71771131/a51a770d-0d18-4c8c-93bd-e201a2ca5e4d">

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
