### PR TITLE
Add HotROD to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,12 @@ services:
       - UI_PORT=${UI_PORT}
       - WORK_DIR=${WORK_DIR}
       - SIGLENS_VERSION=${SIGLENS_VERSION}
+
+  hotrod:
+    image: jaegertracing/example-hotrod:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://siglens:8081/otlp/v1/traces
+    depends_on:
+      - siglens


### PR DESCRIPTION
# Description
Now when you use docker-compose to bring up siglens, it will also bring up HotROD so you can easily send example trace data.

# Testing
1. From the `siglens/` directory, run
```
UI_PORT=5122 WORK_DIR=. SIGLENS_VERSION=0.1.16 docker-compose up
```
2. Open the HotROD UI at localhost:8080 and send a few traces (click the blue buttons to send traces)
3. Open the siglens UI and go to Tracing -> Search Traces. After a few seconds, you should see some new traces from HotROD

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
