### PR TITLE
fix: SPL Transaction Startswith bug fixed

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/segment/structs"
@@ -1651,7 +1650,7 @@ func getInputValueFromExpression(expr *structs.ExpressionInput, record map[strin
 
 func isTransactionMatchedWithTheFliterStringCondition(with *structs.FilterStringExpr, recordMapStr string, record map[string]interface{}) bool {
 	if with.StringValue != "" {
-		return strings.Contains(recordMapStr, with.StringValue)
+		return evaluateMatchPhrase(with.StringValue, recordMapStr)
 	} else if with.EvalBoolExpr != nil {
 		return evaluateBoolExpr(with.EvalBoolExpr, record)
 	} else if with.SearchNode != nil {
@@ -1786,8 +1785,10 @@ func processTransactionsOnRecords(records map[string]map[string]interface{}, all
 		}
 	}
 
-	// Only group By fields. In this case, the groupRecords will not be appended to the groupedRecords. So we need to append them here.
-	if transactionStartsWith == nil && transactionEndsWith == nil {
+	// Transaction EndsWith is not given In this case, most or all of the groupRecords will not be appended to the groupedRecords.
+	// Even if we are appending the groupRecords at StartsWith, not all the groupRecords will be appended to the groupedRecords.
+	// So we need to append them here.
+	if transactionEndsWith == nil {
 		for key := range groupRecords {
 			appendGroupedRecords(groupState[key], key)
 		}


### PR DESCRIPTION
# Description
- SPL Transaction command was not showing results when only the StartsWith command was given.
- So the issue was that the code was not appending the results until it found another StartsWith condition.
- I changed the code to append the code when EndsWith is not given and append any leftover grouped records.

# Testing
- Tested the command with commands on UI.
- Tested with the automated tests written in `segaggs_test.go`

# Checklist:

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
