### PR TITLE
Showing info about traces

### DIFF
--- a/static/js/search-traces.js
+++ b/static/js/search-traces.js
@@ -365,8 +365,18 @@ function showScatterPlot() {
       formatter: function (param) {
         var green = param.value[4];
         var red = param.value[5];
+        var duration = param.value[1];
+        var spans = param.value[2];
+        var errors = param.value[3];
+        var traceId = param.dataIndex < returnResTotal.length ? returnResTotal[param.dataIndex].trace_id.substring(0, 7) : '';
+
         return (
-          "<div>" + green + ": " + red + "</div>"
+          "<div>" + green + ": " + red + 
+          "<br>Duration: " + duration + "ms" +
+          "<br>No. of Spans: " + spans +
+          "<br>No. of Error Spans: " + errors +
+          "<br>Trace ID: " + traceId +
+          "</div>"
         );
       },
     },


### PR DESCRIPTION
# Description
On tracing page when the user clicks on the graph and select a trace by clicking it, showing details about the trace like duration, no. of spans, no. of error spans and  the trace id.

Fixes #418 

<img width="718" alt="Screenshot 2024-01-26 at 4 27 58 PM" src="https://github.com/siglens/siglens/assets/128806421/601dcff2-eab0-4890-a1db-07ac87a1e8d9">


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ x ] I have self-reviewed this PR.
- [ x ] I have removed all print-debugging and commented-out code that should not be merged.
- [ x ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
