### PR TITLE
PR: Add Podman Install scripts as release assets

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -177,6 +177,16 @@ jobs:
             asset_path: install_with_docker.sh
             asset_name: install_with_docker.sh
             asset_content_type: application/octet-stream
+        - name: Upload Release Asset - Install using Docker/Podman script
+          id: upload-release-asset-InstallDockerPodmanScripts
+          uses: actions/upload-release-asset@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.SL_GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} 
+            asset_path: install.sh
+            asset_name: install.sh
+            asset_content_type: application/octet-stream
         - name: Upload Release Asset - docker-compose.yml
           id: upload-release-asset-DockerCompose
           uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -197,4 +197,24 @@ jobs:
             asset_path: ssmetrics-otel-collector-config.yaml
             asset_name: ssmetrics-otel-collector-config.yaml
             asset_content_type: application/octet-stream
+        - name: Upload Release Asset - podman-compose.yaml
+          id: upload-release-asset-PodmanCompose
+          uses: actions/upload-release-asset@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.SL_GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} 
+            asset_path: podman-compose.yaml
+            asset_name: podman-compose.yaml
+            asset_content_type: application/octet-stream
+        - name: Upload Release Asset - podman-network_siglens.conflist
+          id: upload-release-asset-Podman-Network_SigLens
+          uses: actions/upload-release-asset@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.SL_GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }} 
+            asset_path: podman-network_siglens.conflist
+            asset_name: podman-network_siglens.conflist
+            asset_content_type: application/octet-stream
     

--- a/install.sh
+++ b/install.sh
@@ -519,7 +519,7 @@ install_podman_compose() {
 # Fetch and set up the custom network configuration file
 get_podman_custom_network_configuration() {
     echo "Setting up custom Podman network configuration..."
-    curl -O -L "https://raw.githubusercontent.com/Macbeth98/siglens/install-with-podman/podman-network_siglens.conflist" || {
+    curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/podman-network_siglens.conflist" || {
         print_error_and_exit "Failed to download custom network configuration file."
     }
 
@@ -571,7 +571,7 @@ pull_siglens_podman_image() {
         fi
         
         # Download podman-compose.yml
-        if ! curl -O -L "https://raw.githubusercontent.com/Macbeth98/siglens/install-with-podman/podman-compose.yml"; then
+        if ! curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/podman-compose.yml"; then
             print_error_and_exit "Failed to download podman-compose.yml."
         fi
         

--- a/install.sh
+++ b/install.sh
@@ -519,7 +519,7 @@ install_podman_compose() {
 # Fetch and set up the custom network configuration file
 get_podman_custom_network_configuration() {
     echo "Setting up custom Podman network configuration..."
-    curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/podman-network_siglens.conflist" || {
+    curl -O -L "https://raw.githubusercontent.com/Macbeth98/siglens/install-with-podman/podman-network_siglens.conflist" || {
         print_error_and_exit "Failed to download custom network configuration file."
     }
 
@@ -571,7 +571,7 @@ pull_siglens_podman_image() {
         fi
         
         # Download podman-compose.yml
-        if ! curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/podman-compose.yml"; then
+        if ! curl -O -L "https://raw.githubusercontent.com/Macbeth98/siglens/install-with-podman/podman-compose.yml"; then
             print_error_and_exit "Failed to download podman-compose.yml."
         fi
         


### PR DESCRIPTION
# Description
- Added the `install.sh` script as a release asset.
- Added `podman-compose.yaml` && `podman-network_siglens.conflist` as release assets.
- Changed the Curl URLs of the above two files to GitHub release versions.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
