### PR TITLE
Fix: P50, P90 and P99 numbers on service health page

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -420,6 +420,9 @@ func ProcessRedTracesIngest() {
 		}
 
 		durations, exists := serviceToSpanDuration[service]
+		for i, duration := range durations {
+			durations[i] = duration / 1000000
+		}
 		if exists {
 			redMetrics.P50 = utils.FindPercentileData(durations, 50)
 			redMetrics.P90 = utils.FindPercentileData(durations, 90)

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -421,7 +421,7 @@ func ProcessRedTracesIngest() {
 
 		durations, exists := serviceToSpanDuration[service]
 		for i, duration := range durations {
-			durations[i] = duration / 1000000
+			durations[i] = duration / 1000000 // convert duration from nanoseconds to milliseconds
 		}
 		if exists {
 			redMetrics.P50 = utils.FindPercentileData(durations, 50)


### PR DESCRIPTION
# Description
The percentile numbers on the service-health page was initially shown in nano seconds instead of milliseconds. This change converts the durations to ms.
Fixes #419

# Testing
- Tested it by sending a small number of traces and verifying the accuracy of the percentile values manually.
![image](https://github.com/siglens/siglens/assets/113487319/5bba15d8-51ef-4efe-98ba-af92f5a2879d)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
