### PR TITLE
Selecting default logs option for dataSource

### DIFF
--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -371,9 +371,13 @@ function editPanelInit(redirectedFromViewScreen) {
 		$('.dropDown-data-rate-options span').html('Data Rate');
 		prevSelectedDataTypeIndex = -2;
 	}
-			
+	if (selectedDataSourceTypeIndex === -1 || selectedDataSourceTypeIndex === undefined) {
+		selectedDataSourceTypeIndex = mapDataSourceTypeToIndex.get("logs");
+	}
+	refreshDataSourceMenuOptions();
+		
 	if (selectedDataSourceTypeIndex != -1 && selectedDataSourceTypeIndex !== undefined) {
-		refreshDataSourceMenuOptions();
+		
 		if(selectedDataSourceTypeIndex == 1) {
 			$("#index-btn").css('display', 'inline-block');
 			$("#query-language-btn").css('display', 'inline-block');
@@ -388,6 +392,8 @@ function editPanelInit(redirectedFromViewScreen) {
 			$("#query-language-btn").css('display', 'none');
 			$("#metrics-query-language-btn").css('display', 'none');
 		}
+		displayQueryToolTip(selectedDataSourceTypeIndex);
+		$(".editPanelMenu-dataSource .editPanelMenu-options[data-index='" + selectedDataSourceTypeIndex + "']").click();
 	}
 	if (selectedChartTypeIndex != -1 && selectedChartTypeIndex !== undefined)
 		refreshChartMenuOptions();


### PR DESCRIPTION
# Description
If the user doesn't select the data source choice, the logs option will be chosen as the default option.
The Data Source dropdown have Logs selected by default for new panels. So when you make a new panel and edit it, the dropdown will show Logs instead of Data Source

Fixes #467 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
