### PR TITLE
feat: exiting edit panel screen with unsaved changes shows alert

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2733,7 +2733,7 @@ input[type="date"]::-webkit-calendar-picker-indicator , input[type="time"]::-web
     border-radius: 5px;
 }
 
-.launch-dashboard .popupContent button, #buttons-ret-prompt button,#panel-del-prompt button {
+.launch-dashboard .popupContent button, #buttons-ret-prompt button,#panel-del-prompt button, #panel-edit-prompt button {
     width: 195px !important;
     height: 32px !important;
     border-radius: 5px;

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -576,6 +576,18 @@
                 </ul>
             </div>
         </div>
+        <div class="popupOverlay">
+        </div>
+        <div id="panel-edit-prompt" class="popupContent">
+            <h3 class="header">Confirmation</h3>
+            <div class="prompt-text-container">
+                <div class="edit-db-text">You have unsaved changes. Are you sure you want to exit?</div>
+            </div>
+            <div id="buttons-db-prompt">
+                <button type="button" id="cancel-btn-panel">Cancel</button>
+                <button type="button" id="exit-btn-panel">Discard and Exit</button>
+            </div>
+        </div>
     </div>
     <div class="dbSet-container">
         <div class="dbSet-navBar">

--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -440,7 +440,7 @@ function editPanelInit(redirectedFromViewScreen) {
 	$(".panEdit-apply").unbind("click");
 	$('.panEdit-apply').on('click', () => applyChangesToPanel(redirectedFromViewScreen))
 	$(".panEdit-goToDB").unbind("click");
-	$('.panEdit-goToDB').on("click", () => goToDashboard(redirectedFromViewScreen))
+	$('.panEdit-goToDB').on("click", () => handleGoToDBArrowClick(redirectedFromViewScreen))
 	setTimePicker();
 	pauseRefreshInterval();
 }
@@ -1098,6 +1098,47 @@ function applyChangesToPanel(redirectedFromViewScreen) {
 	else {
 		updateTimeRangeForPanels();
 		goToDashboard();
+	}
+}
+
+function handleGoToDBArrowClick(redirectedFromViewScreen) {
+	if (!checkUnsavedChages()) {
+		if (showPrompt(redirectedFromViewScreen)) {
+			goToDashboard(redirectedFromViewScreen);
+		}
+	} else {
+		goToDashboard(redirectedFromViewScreen);
+	}
+	
+	function checkUnsavedChages() {
+		let serverPanel = JSON.parse(JSON.stringify(localPanels[panelIndex]));
+		return (currentPanel.chartType === serverPanel.chartType
+			&& currentPanel.dataType === serverPanel.dataType
+			&& currentPanel.description === serverPanel.description
+			&& currentPanel.name === serverPanel.name
+			&& currentPanel.queryType === serverPanel.queryType
+			&& currentPanel.unit === serverPanel.unit
+			&& currentPanel.panelIndex === serverPanel.panelIndex
+			
+			&& currentPanel.queryData.endEpoch === serverPanel.queryData.endEpoch
+			&& currentPanel.queryData.indexName === serverPanel.queryData.indexName
+			&& currentPanel.queryData.queryLanguage === serverPanel.queryData.queryLanguage
+			&& currentPanel.queryData.searchText === serverPanel.queryData.searchText
+			&& currentPanel.queryData.startEpoch === serverPanel.queryData.startEpoch
+			&& currentPanel.queryData.state === serverPanel.queryData.state);
+	}
+	
+	function showPrompt(redirectedFromViewScreen) {
+		$('.popupOverlay, .popupContent').addClass('active');
+		$('#exit-btn-panel').on("click", function () {
+			$('.popupOverlay, .popupContent').removeClass('active');
+			goToDashboard(redirectedFromViewScreen);
+			return true;
+		});
+		$('#cancel-btn-panel, .popupOverlay').on("click", function () {
+			$('.popupOverlay, .popupContent').removeClass('active');
+			return false;
+		});
 	}
 }
 

--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -1103,9 +1103,7 @@ function applyChangesToPanel(redirectedFromViewScreen) {
 
 function handleGoToDBArrowClick(redirectedFromViewScreen) {
 	if (!checkUnsavedChages()) {
-		if (showPrompt(redirectedFromViewScreen)) {
-			goToDashboard(redirectedFromViewScreen);
-		}
+		showPrompt(redirectedFromViewScreen)
 	} else {
 		goToDashboard(redirectedFromViewScreen);
 	}
@@ -1133,11 +1131,9 @@ function handleGoToDBArrowClick(redirectedFromViewScreen) {
 		$('#exit-btn-panel').on("click", function () {
 			$('.popupOverlay, .popupContent').removeClass('active');
 			goToDashboard(redirectedFromViewScreen);
-			return true;
 		});
 		$('#cancel-btn-panel, .popupOverlay').on("click", function () {
 			$('.popupOverlay, .popupContent').removeClass('active');
-			return false;
 		});
 	}
 }


### PR DESCRIPTION
# Description
exiting edit panel screen with unsaved changes shows alert

Fixes #444  (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
1. Make a dashboard and add a panel
2. Make some changes to the panel (select a Data Source, enter a query, etc.) but don't click the Save or Apply buttons.
3. In the top left, click the back arrow next to <MyDashboard> / <MyPanel> (not the browser's back button)

If you made changes in panel name, panel description, chart type, query type, query message, and so on (essentially deep compare of currentPanel object with original panel), shows popup. If there is no change, popup doesn't show up. If you clicked save button and exited without further change, popup doesn't show up.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [*] I have self-reviewed this PR.
- [*] I have removed all print-debugging and commented-out code that should not be merged.
- [*] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [*] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
