### PR TITLE
Query Builder Fix

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -285,11 +285,16 @@ function hideColumnHandler(evt) {
 function setQueryLangHandler(e) {
     $('.query-language-option').removeClass('active');
     let currentTab = $("#custom-code-tab").tabs("option", "active");
-    if ($(this).attr("id").split("-")[1] != "3" && currentTab == 0) {
+    let selectedQueryLanguageId = $(this).attr("id").split("-")[1];
+    if (selectedQueryLanguageId !== "3" && currentTab === 0) {
         $("#custom-code-tab").tabs("option", "active", 1);
+    } else if (selectedQueryLanguageId !== "3" && currentTab === 1) {
+        $("#custom-code-tab").tabs("option", "disabled", [0]);
+    } else if (selectedQueryLanguageId === "3" && currentTab === 1) {
+        $("#custom-code-tab").tabs("option", "disabled", []);
     }
     $('#query-language-btn span').html($(this).html());
-    displayQueryLangToolTip($(this).attr('id').split('-')[1]);
+    displayQueryLangToolTip(selectedQueryLanguageId);
     $(this).addClass('active');
 }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -62,38 +62,6 @@ limitations under the License.
      }
  }
  
-function getColumns() {
-  let currentTab = $("#custom-code-tab").tabs("option", "active");
-  if (availColNames.length == 0 && currentTab == 0) {
-    data = {
-      state: "query",
-      searchText: "*",
-      startEpoch: "now-24h",
-      endEpoch: "now",
-      indexName: "*",
-      from: 0,
-      size: 1,
-      queryLanguage: "Splunk QL",
-    };
-    $.ajax({
-      method: "post",
-      url: "api/search/",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        Accept: "*/*",
-      },
-      crossDomain: true,
-      dataType: "json",
-      data: JSON.stringify(data),
-      success: function (res) {
-        if (res) {
-          availColNames = res.allColumns;
-        }
-      },
-    });
-  }
-}
-
  function doSearch(data) {
      startQueryTime = (new Date()).getTime();
      newUri = wsURL("/api/search/ws");
@@ -159,14 +127,12 @@ function getColumns() {
                  console.log(`[message] Timeout state received from server: ${jsonEvent}`);
                  processTimeoutUpdate(jsonEvent);
                  console.timeEnd("TIMEOUT");
-                 if (availColNames.length == 0) getColumns();
                  break;
              case "ERROR":
                  console.time("ERROR");
                  console.log(`[message] Error state received from server: ${jsonEvent}`);
                  processErrorUpdate(jsonEvent);
                  console.timeEnd("ERROR");
-                 if (availColNames.length == 0) getColumns();
                  break;
              default:
                  console.log(`[message] Unknown state received from server: `+ JSON.stringify(jsonEvent));
@@ -175,7 +141,6 @@ function getColumns() {
                  } else if (jsonEvent.message.includes("not present")){
                     jsonEvent['no_data_err'] = "No data found for the query"
                  }
-                 if (availColNames.length == 0) getColumns();
                  processSearchErrorLog(jsonEvent);
          }
      };
@@ -187,7 +152,6 @@ function getColumns() {
              console.log(`Connection close not clean=${event} code=${event.code} reason=${event.reason} `);
          }
          console.timeEnd("socket timing");
-         if (availColNames.length == 0) getColumns();
      };
  
      socket.addEventListener('error', (event) => {


### PR DESCRIPTION
# Description
This PR addresses several issues in the query builder:

1. Fix the issue where the column name does not come based on the chosen index and time window
2. Fixed the issue where the query builder didn't display the right query when switching between free text and query builder.
3. The query builder dynamically shows numerical columns for aggregation instead of using hardcoded options.
4. Resolves the issue where column names did not populate until the second click when performing an aggregation query.
5. Column names won't show when there's no data in the selected time window in the query builder.
6. Disable Query Builder if the selected Query Language is SQL and LogQL

Fixes #408  (link all the GitHub issues this addresses)
# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
