### PR TITLE
Add timeout for install script and use playground.yaml on playground

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             sleep 10
             ls -l
-            tail -f siglens.log
+            tail -f logs/siglens.log
           background: true
       - run:
           name: Run E2E Test test

--- a/install.sh
+++ b/install.sh
@@ -313,7 +313,7 @@ pull_siglens_docker_image() {
     echo -e "\n----------Pulling the latest docker image for SigLens----------"
 
     if [ "$USE_LOCAL_DOCKER_COMPOSE" != true ]; then
-        if [ "$ENVIRONMENT" = "playground" ]; then
+        if [ "$SERVERNAME" = "playground" ]; then
             curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
         fi
         curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/server.yaml"
@@ -569,7 +569,7 @@ pull_siglens_podman_image() {
     # Check if the user wants to use a local compose file
     if [ "$USE_LOCAL_PODMAN_COMPOSE" != true ]; then
         # Download playground.yaml
-        if [ "$ENVIRONMENT" = "playground" ]; then
+        if [ "$SERVERNAME" = "playground" ]; then
             curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
         fi
 
@@ -768,7 +768,7 @@ CFILE="server.yaml"
 if [ -n "${CONFIG_FILE}" ]; then
     CFILE=${CONFIG_FILE}
 # Check if the script is running in playground environment
-elif [ "$ENVIRONMENT" = "playground" ]; then
+elif [ "$SERVERNAME" = "playground" ]; then
     echo "Running in playground environment. Using playground.yaml."
     CFILE="playground.yaml"
 fi

--- a/install.sh
+++ b/install.sh
@@ -313,6 +313,9 @@ pull_siglens_docker_image() {
     echo -e "\n----------Pulling the latest docker image for SigLens----------"
 
     if [ "$USE_LOCAL_DOCKER_COMPOSE" != true ]; then
+        if [ "$ENVIRONMENT" = "playground" ]; then
+            curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
+        fi
         curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/server.yaml"
         curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/docker-compose.yml"
         curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/ssmetrics-otel-collector-config.yaml"
@@ -565,6 +568,11 @@ pull_siglens_podman_image() {
 
     # Check if the user wants to use a local compose file
     if [ "$USE_LOCAL_PODMAN_COMPOSE" != true ]; then
+        # Download playground.yaml
+        if [ "$ENVIRONMENT" = "playground" ]; then
+            curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
+        fi
+
         # Download server.yaml
         if ! curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/server.yaml"; then
             print_error_and_exit "Failed to download server.yaml."
@@ -630,7 +638,34 @@ if [[ $CONTAINER_TOOL == "docker" ]]; then
     IMAGE_NAME="${DOCKER_IMAGE_NAME:-siglens/siglens:${SIGLENS_VERSION}}"
     COMPOSE_FILE="${DOCKER_COMPOSE_FILE:-docker-compose.yml}"
 
-    start_docker
+start_docker_with_timeout() {
+    start_docker &
+    start_docker_pid=$!
+
+    # Wait for up to 180 seconds for start_docker to finish
+    for i in {1..180}; do
+        if ! ps -p $start_docker_pid > /dev/null; then
+            wait $start_docker_pid
+            exit_code=$?
+            if [ $exit_code -ne 0 ]; then
+                print_error_and_exit "Docker failed to start"
+            fi
+            break
+        fi
+        if (( i % 30 == 0 )); then
+            echo "Attempting to start docker... ($((i / 60)) minute(s))"
+        fi
+        sleep 1
+    done
+
+    # If docker is not up after 180 seconds, print an error message and exit
+    docker info > /dev/null 2>&1 || {
+        post_event "install_failed" "start_docker_with_timeout: Failed to retrieve Docker info after 180 seconds"
+        print_error_and_exit "Docker failed to start. Pleas start docker and try again"
+    }
+}
+
+    start_docker_with_timeout
 
     pull_siglens_docker_image
 else
@@ -728,8 +763,14 @@ send_events() {
 UI_PORT=5122
 
 CFILE="server.yaml"
+
+# Check if CONFIG_FILE is set and not empty
 if [ -n "${CONFIG_FILE}" ]; then
     CFILE=${CONFIG_FILE}
+# Check if the script is running in playground environment
+elif [ "$ENVIRONMENT" = "playground" ]; then
+    echo "Running in playground environment. Using playground.yaml."
+    CFILE="playground.yaml"
 fi
 
 print_success_message "\n Starting Siglens with image: ${IMAGE_NAME}"

--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -285,7 +285,7 @@ DOCKER_COMPOSE_FILE="${DOCKER_COMPOSE_FILE:-docker-compose.yml}"
 echo -e "\n----------Pulling the latest docker image for SigLens----------"
 
 if [ "$USE_LOCAL_DOCKER_COMPOSE" != true ]; then
-    if [ "$ENVIRONMENT" = "playground" ]; then
+    if [ "$SERVERNAME" = "playground" ]; then
         curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
     fi
     curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/server.yaml"
@@ -374,7 +374,7 @@ CFILE="server.yaml"
 if [ -n "${CONFIG_FILE}" ]; then
     CFILE=${CONFIG_FILE}
 # Check if the script is running in playground environment
-elif [ "$ENVIRONMENT" = "playground" ]; then
+elif [ "$SERVERNAME" = "playground" ]; then
     echo "Running in playground environment. Using playground.yaml."
     CFILE="playground.yaml"
 fi

--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -252,13 +252,42 @@ if ! is_command_present docker; then
     fi
 fi
 
-start_docker
+start_docker_with_timeout() {
+    start_docker &
+    start_docker_pid=$!
+
+    # Wait for up to 180 seconds for start_docker to finish
+    for i in {1..180}; do
+        if ! ps -p $start_docker_pid > /dev/null; then
+            wait $start_docker_pid
+            exit_code=$?
+            if [ $exit_code -ne 0 ]; then
+                print_error_and_exit "Docker failed to start"
+            fi
+            break
+        fi
+        if (( i % 30 == 0 )); then
+            echo "Attempting to start docker... ($((i / 60)) minute(s))"
+        fi
+        sleep 1
+    done
+
+    # If start_docker is still running after 180 seconds, print an error message and exit
+    if ps -p $start_docker_pid > /dev/null; then
+        print_error_and_exit "Docker failed to start in 3 minutes. Please start docker and try again."
+    fi
+}
+
+start_docker_with_timeout
 DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-siglens/siglens:${SIGLENS_VERSION}}"
 DOCKER_COMPOSE_FILE="${DOCKER_COMPOSE_FILE:-docker-compose.yml}"
 
 echo -e "\n----------Pulling the latest docker image for SigLens----------"
 
 if [ "$USE_LOCAL_DOCKER_COMPOSE" != true ]; then
+    if [ "$ENVIRONMENT" = "playground" ]; then
+        curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/playground.yaml"
+    fi
     curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/server.yaml"
     curl -O -L "https://github.com/siglens/siglens/releases/download/${SIGLENS_VERSION}/docker-compose.yml"
     echo "Pulling the latest docker image for SigLens from upstream"
@@ -339,10 +368,15 @@ send_events() {
 
 UI_PORT=5122
 
-
 CFILE="server.yaml"
+
+# Check if CONFIG_FILE is set and not empty
 if [ -n "${CONFIG_FILE}" ]; then
     CFILE=${CONFIG_FILE}
+# Check if the script is running in playground environment
+elif [ "$ENVIRONMENT" = "playground" ]; then
+    echo "Running in playground environment. Using playground.yaml."
+    CFILE="playground.yaml"
 fi
 
 print_success_message "\n Starting Siglens with image: ${DOCKER_IMAGE_NAME}"

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 package config
 
-const SigLensVersion = "0.1.20"
+const SigLensVersion = "0.1.21"

--- a/playground.yaml
+++ b/playground.yaml
@@ -17,13 +17,13 @@ pqsEnabled: false
 esVersion: "7.9.3"
 
 ## Number of hours data will be stored/retained on persistent storage.
-retentionHours: 168
+retentionHours: 48
 
 ## Percent of available RAM that siglens will occupy
 # memoryThresholdPercent: 80
 
 ## For ephemeral servers (docker, k8s) set this variable to unique container name to persist data across restarts:
-# ssInstanceName: ""
+ssInstanceName: "04c18529eb27"
 
 log:
   logPrefix : ./logs/

--- a/server.yaml
+++ b/server.yaml
@@ -23,7 +23,8 @@ esVersion: "7.9.3"
 # memoryThresholdPercent: 80
 
 ## For ephemeral servers (docker, k8s) set this variable to unique container name to persist data across restarts:
-# ssInstanceName: ""
+# the default ssInstanceName is "sigsingle"
+ssInstanceName: "sigsingle"
 
 log:
   logPrefix : ./logs/


### PR DESCRIPTION
# Description
Add timeout for docker script to check exit if docker does not start in 3 minutes and use playground.yaml instead of server.yaml on playground machine. Playground should be added to   

# Testing
Tested timeout by stopping docker and reducing the wait time to start docker and  test the case where docker wont start in time on local machine.
Tested playground.yaml by setting the environment in my machine and execute the script to use playground.yaml

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
