### PR TITLE
showing bgcolor for longer fieldName

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -543,9 +543,9 @@ a:visited.ui-button,
     width: 30px;
     border: 1px solid var(--border-btn-color);
 }
-.available-fields-dropdown-item{
-    width: 180px !important;
-}
+/*.available-fields-dropdown-item{
+   width: 180px !important;
+}*/
 .fields{
     margin-left: 10px;
 }

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2005,16 +2005,20 @@ progress.hidden {
     scrollbar-width: none;
     -ms-overflow-style: none;
     border: 1px solid var(--timepicker-border-color);
+    width: max-content;
 }
 #available-fields::-webkit-scrollbar {
     width: 0;
 }
 .available-fields-dropdown-item {
     height: 32px;
+    display: flex; 
+    align-items: center;
     background: var(--index-drop-down-item-inactive-bg-color);
     color: var(--index-drop-down-item-inactive-text-color);
     margin-bottom: 10px;
     margin-top: 6px;
+    margin-right: 10px;
     cursor: pointer;
     padding-left: 12px;
     font-size: 14px;
@@ -2032,16 +2036,24 @@ progress.hidden {
 .available-fields-dropdown-item.active {
     background: var(--available-fields-drop-down-item-active-bg-color);
     color: var(--available-fields-drop-down-item-active-text-color);
+    width: max-content;
 }
 
 .available-fields-dropdown-item img {
     display: none;
     float: right;
     position: relative;
-    top: 9px;
+    top: 15%; 
+    transform: translateY(-50%); 
     right: 5px;
+    vertical-align: middle;
+    margin-left: 10px;
 }
-
+.fieldname-text {
+    flex-grow: 1; 
+    white-space: nowrap;
+    overflow: visible;
+}
 .available-fields-dropdown-item.active img {
     display: inline;
 }
@@ -2051,44 +2063,37 @@ progress.hidden {
     font-size: 14px;
     font-weight: var(--fw-500);
     font-family: "DINpro", Arial, sans-serif;
-    left: 11px !important;
     position: relative;
-    margin-top: 5px 0 0 10px;
+    margin-top: 5px;
+    margin-left: 11px;
+    display: flex;
+    align-items: center;
 }
 
 .select-unselect-checkbox {
-    float: right;
-    position: relative;
-    right: 26px;
+    margin-left: 10px; 
     height: 20px;
     width: 20px;
+    border: 1px solid transparent; 
     border-radius: 4px;
+    cursor: pointer;
+    position: relative;
+    z-index: 1; 
 }
-.select-unselect-checkbox:hover {
-    float: right;
-    position: relative;
-    right: 26px;
-    height: 20px;
-    width: 20px;
-    border: 1px solid var(--select-unselect-box-border-color-hover);
-    border-radius: 4px;
+.select-unselect-checkbox:hover {   
+    border: 1px solid var(--select-unselect-box-border-color-hover); 
 }
 
-.select-unselect-checkbox.active {
-    float: right;
-    position: relative;
-    right: 26px;
-    height: 20px;
-    width: 20px;
+.select-unselect-checkbox.active {  
     border: 0px solid var(--select-unselect-box-border-color-clicked);
-    border-radius: 4px;
 }
 
 .select-unselect-checkmark {
-    float: right;
     position: relative;
-    right: 9px;
-    top: 5px;
+    z-index: 2; 
+    float: right;
+    right: 16px;
+    top: 0px;
 }
 
 

--- a/static/js/available-fields.js
+++ b/static/js/available-fields.js
@@ -37,24 +37,13 @@ function renderAvailableFields(columnOrder) {
                         </div>`);
     });
 
-    // Adjust the width of the availablefields drop down items
-    var longestColName = availColNames.sort(
-        function (a, b) {
-            return b.length - a.length;
-        })[0];
+let afieldDropDownItem = $(".fields .available-fields-dropdown-item");
+afieldDropDownItem.each(function (idx, li) {
+    li.style.width = "auto"; 
+});
 
-    let selUnselHeader = $(".select-unselect-header")
-    let minWidth = Math.min(displayTextWidth(selUnselHeader.text(), "italic 19pt  DINpro "), 200)
-    let maxWidth = Math.max(displayTextWidth(longestColName, "italic 19pt  DINpro "), 200)
-
-    let afieldDropDownItem = $(".fields .available-fields-dropdown-item");
-    afieldDropDownItem.each(function(idx, li){
-        li.style.width = maxWidth + "px";
-    });
-
-    let afieldDropDown = document.getElementById("available-fields");
-    afieldDropDown.style.width= maxWidth + "px";
-    afieldDropDown.style.minWidth= minWidth + "px";
+let afieldDropDown = document.getElementById("available-fields");
+afieldDropDown.style.width = "auto"; 
 
     if (updatedSelFieldList){
         selectedFieldsList = _.intersection(selectedFieldsList, availColNames);


### PR DESCRIPTION
# Description
When selecting Available Fields in the UI the background color for each field  extends to the end of the column name for longer column names.

Fixes #274 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
