### PR TITLE
Make Ingest and Query Listen IP Addresses configurable

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -183,8 +183,8 @@ func StartSiglensServer(nodeType config.DeploymentType, nodeID string) error {
 	usageStats.StartUsageStats()
 	ingestNode := config.IsIngestNode()
 	queryNode := config.IsQueryNode()
-	ingestServer := "0.0.0.0:" + fmt.Sprintf("%d", config.GetIngestPort())
-	queryServer := "0.0.0.0:" + fmt.Sprintf("%d", config.GetQueryPort())
+	ingestServer := fmt.Sprint(config.GetIngestListenIP()) + ":" + fmt.Sprintf("%d", config.GetIngestPort())
+	queryServer := fmt.Sprint(config.GetQueryListenIP()) + ":" + fmt.Sprintf("%d", config.GetQueryPort())
 
 	if config.IsTlsEnabled() && config.GetQueryPort() != 443 {
 		fmt.Printf("Error starting Query/UI server with TLS, QueryPort should be set to 443 ")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,6 +110,8 @@ assignment in the following functions
 
 // If you add a new config parameters to the Configuration struct below, make sure to add a descriptive info in server.yaml
 type Configuration struct {
+	IngestListenIP             string   `yaml:"ingestListenIP"`       // Listen IP used for ingestion server
+	QueryListenIP              string   `yaml:"queryListenIP"`        // Listen IP used for query server
 	IngestPort                 uint64   `yaml:"ingestPort"`           // Port for ingestion server
 	QueryPort                  uint64   `yaml:"queryPort"`            // Port used for query server
 	PsqlPort                   uint64   `yaml:"psqlPort"`             // Port used for sql server
@@ -253,6 +255,18 @@ func GetMaxSegFileSize() *uint64 {
 
 func GetESVersion() *string {
 	return &runningConfig.ESVersion
+}
+
+// returns the configured ingest listen IP Addr
+// if the node is not an ingest node, this will not be set
+func GetIngestListenIP() string {
+	return runningConfig.IngestListenIP
+}
+
+// returns the configured query listen IP Addr
+// if the node is not a query node, this will not be set
+func GetQueryListenIP() string {
+	return runningConfig.QueryListenIP
 }
 
 // returns the configured ingest port
@@ -552,6 +566,8 @@ func InitializeDefaultConfig() {
 	// ************************************
 
 	runningConfig = Configuration{
+		IngestListenIP:             "0.0.0.0",
+		QueryListenIP:              "0.0.0.0",
 		IngestPort:                 8081,
 		QueryPort:                  5122,
 		IngestUrl:                  "",
@@ -641,6 +657,14 @@ func ExtractConfigData(yamlData []byte) (Configuration, error) {
 		log.Errorf("Error parsing yaml err=%v", err)
 		return config, err
 	}
+
+	if len(config.IngestListenIP) <= 0 {
+		config.IngestListenIP = "0.0.0.0"
+	}
+	if len(config.QueryListenIP) <= 0 {
+		config.QueryListenIP = "0.0.0.0"
+	}
+
 	if config.IngestPort <= 0 {
 		config.IngestPort = 8081
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,8 @@ func Test_ExtractConfigData(t *testing.T) {
 	}{
 		{ // case 1 - For correct input parameters and values
 			[]byte(`
+ ingestListenIP: "0.0.0.0"
+ queryListenIP: "0.0.0.0"
  ingestPort: 9090
  eventTypeKeywords: ["utm_content"]
  baseLogDir: "./pkg/ingestor/httpserver/"
@@ -74,6 +76,8 @@ func Test_ExtractConfigData(t *testing.T) {
  `),
 
 			Configuration{
+				IngestListenIP:             "0.0.0.0",
+				QueryListenIP:              "0.0.0.0",
 				IngestPort:                 9090,
 				IngestUrl:                  "http://localhost:9090",
 				QueryPort:                  5122,
@@ -108,6 +112,8 @@ func Test_ExtractConfigData(t *testing.T) {
 		},
 		{ // case 2 - For wrong input type, show error message
 			[]byte(`
+ ingestListenIP: "0.0.0.0"
+ queryListenIP: "0.0.0.0"
  ingestPort: 9090
  queryPort: 9000
  eventTypeKeywords: ["utm_content"]
@@ -143,6 +149,8 @@ func Test_ExtractConfigData(t *testing.T) {
  `),
 
 			Configuration{
+				IngestListenIP:             "0.0.0.0",
+				QueryListenIP:              "0.0.0.0",
 				IngestPort:                 9090,
 				QueryPort:                  9000,
 				IngestUrl:                  "http://localhost:9090",
@@ -181,6 +189,8 @@ invalid input, we should error out
 `),
 
 			Configuration{
+				IngestListenIP:           "0.0.0.0",
+				QueryListenIP:            "0.0.0.0",
 				IngestPort:               8081,
 				QueryPort:                0,
 				IngestUrl:                "http://localhost:8081",
@@ -216,6 +226,8 @@ invalid input, we should error out
 a: b
 `),
 			Configuration{
+				IngestListenIP:             "0.0.0.0",
+				QueryListenIP:              "0.0.0.0",
 				IngestPort:                 8081,
 				QueryPort:                  5122,
 				IngestUrl:                  "http://localhost:8081",

--- a/playground.yaml
+++ b/playground.yaml
@@ -1,8 +1,10 @@
 ---
-## Address port for SigLens ingestion server
+## IP and port for SigLens ingestion server
+ingestListenIP: 0.0.0.0
 ingestPort: 8081
 
-## Address port for SigLens query server, including UI
+## IP and port for SigLens query server, including UI
+queryListenIP: 0.0.0.0
 queryPort: 5122
 
 ## Location for storing local node data

--- a/server.yaml
+++ b/server.yaml
@@ -1,8 +1,10 @@
 ---
-## Address port for SigLens ingestion server
+## IP and port for SigLens ingestion server
+ingestListenIP: 0.0.0.0
 ingestPort: 8081
 
-## Address port for SigLens query server, including UI
+## IP and port for SigLens query server, including UI
+queryListenIP: 0.0.0.0
 queryPort: 5122
 
 ## Location for storing local node data


### PR DESCRIPTION
# Description
This PR makes Ingest and Query Listen IP addresses configurable in server.yaml. This is the list of changes:

-     Add ingestListenIP and queryListenIP to server.yaml
-     Add IngestListenIP and QueryListenIP to Configuration
-     Implement GetIngestListenIP and GetQueryListenIP functions and call them in place of hard coded strings in startup.go.
-     Set the defaults in ExtractConfigData, InitializeDefaultConfig and server.yaml, update playground, tests and examples.

Fixes #507 

# Testing
- Define 0.0.0.0 for ingestListenIP and queryListenIP 
- Define 127.0.0.1 for ingestListenIP and queryListenIP 
- Define different IPs ingestListenIP and queryListenIP 
in server.yaml and run siglens. Both services should start listening on the corresponding specified IP Addresses. 

# Checklist:
- [x] I have self-reviewed this PR.
- [x ] I have removed all print-debugging and commented-out code that should not be merged.
- [x ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have run 'make all'.
- [x] I have run 'make pr'. 
