### PR TITLE
fix: podman install sudo script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -781,13 +781,15 @@ CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=
 CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${IMAGE_NAME} $CONTAINER_TOOL-compose logs -t --tail 20 >> ${CONTAINER_TOOL}_logs.txt
 
 # Create .env file for docker-compose down
+if [[ $CONTAINER_TOOL == "docker" ]]; then
 cat << EOF > .env
-IMAGE_NAME=${IMAGE_NAME}
-UI_PORT=${UI_PORT}
-CONFIG_FILE=${CFILE}
-WORK_DIR="$(pwd)"
-CSI=${csi}
+    IMAGE_NAME=${IMAGE_NAME}
+    UI_PORT=${UI_PORT}
+    CONFIG_FILE=${CFILE}
+    WORK_DIR="$(pwd)"
+    CSI=${csi}
 EOF
+fi
 
 
 # Check if the sample log dataset is available

--- a/install.sh
+++ b/install.sh
@@ -782,7 +782,8 @@ CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=
 
 # Create .env file for docker-compose down
 if [[ $CONTAINER_TOOL == "docker" ]]; then
-cat << EOF > .env
+request_sudo
+sudo cat << EOF > .env
     IMAGE_NAME=${IMAGE_NAME}
     UI_PORT=${UI_PORT}
     CONFIG_FILE=${CFILE}


### PR DESCRIPTION
# Description
- A slight fix for the install script regarding the creation of the `env` file. Creating `.env` file with sudo access.
- The `.env` will only be created for docker installation.

# Testing
- I have tested the script by running it on the Ubuntu Instance.

# Checklist:

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
