### PR TITLE
show chart after resize window

### DIFF
--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -192,6 +192,27 @@ let mapIndexToLogLinesViewType = new Map([
 
 $(document).ready(function () {
 
+	let initialPanelContainerWidth = $('.panelDisplay').width();
+    let initialPanelContainerHeight = $('.panelDisplay').height();
+
+    $(window).resize(function() {
+        var currentPanelContainerWidth = $('.panelDisplay').width();
+        var currentPanelContainerHeight = $('.panelDisplay').height();
+
+        if (initialPanelContainerWidth !== currentPanelContainerWidth || initialPanelContainerHeight !== currentPanelContainerHeight) {
+            runAfterResize();
+        }
+    });
+
+    function runAfterResize() {
+        runQueryBtnHandler();
+        toggleTableView();
+        displayPanelView(panelIndex);
+
+        initialPanelContainerWidth = $('.panelDisplay').width();
+        initialPanelContainerHeight = $('.panelDisplay').height();
+    }
+
 	$("#info-icon-metrics").tooltip({
 		delay: { show: 0, hide: 300 },
 		trigger: 'click'


### PR DESCRIPTION
# Description
When editing a panel , if user resize the browser window the chart disappears, and it get redrawn.



Fixes #446 
# Testing

https://github.com/siglens/siglens/assets/128806421/3f62ff69-79d8-4b31-ad86-4028011fa6d0



# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
