### PR TITLE
bug #524 [install_with_docker.sh failed due to github api rate limit] fixed.

### DIFF
--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -4,9 +4,12 @@
 # inside the quotes. Use -n to supress printing each line, and p to print the
 # modified line.
 SIGLENS_VERSION=`\
-    curl  --silent "https://api.github.com/repos/siglens/siglens/releases/latest" |
-    grep '"tag_name":' |
-    sed -E 's/.*"([^"]+)".*/\1/'`
+    git ls-remote --tags "https://github.com/siglens/siglens.git" |
+    grep -E 'refs/tags/v?[0-9]+\.[0-9]+\.[0-9]+$' |
+    awk '{print $2}' |
+    awk -F"/" '{print $3}' |
+    sort -V |
+    tail -n1`
 
 sudo_cmd=""
 


### PR DESCRIPTION
# Description
Summarize the change.

Use git to fetch the latest siglens version instead of relying on the GitHub API, which is subject to rate limits.

Fixes #524  (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
```sh 
./install_with_docker.sh
===> Running installer with non-sudo permissions.
     In case of any failure or prompt, run the script with sudo privileges.


===> Starting Docker ...

Docker started successfully.

----------Pulling the latest docker image for SigLens----------
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   921  100   921    0     0   1398      0 --:--:-- --:--:-- --:--:--  1398
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1047  100  1047    0     0    905      0  0:00:01  0:00:01 --:--:--  1581
Pulling the latest docker image for SigLens from upstream
0.1.23: Pulling from siglens/siglens
Digest: sha256:616afb381f39264088ba43537d117a468ffc926ec162a94b319ffc54be9ad549
Status: Image is up to date for siglens/siglens:0.1.23
docker.io/siglens/siglens:0.1.23

What's Next?
  1. Sign in to your Docker account → docker login
  2. View a summary of image vulnerabilities and recommendations → docker scout quickview siglens/siglens:0.1.23

===> SigLens installation complete with version: 0.1.23
Port 5122 is available
Port 8081 is available

 Starting Siglens with image: siglens/siglens:0.1.23
[+] Running 3/4
 ⠼ Network siglens_default                             Created                                                                                                    0.4s 
 ✔ Container siglens-siglens-1                         Started                                                                                                    0.3s 
 ✔ Container siglens-siglens-metrics-otel-collector-1  Started                                                                                                    0.3s 
 ✔ Container siglens-hotrod-1                          Started                                                                                                    0.3s 
Failed to check sample log dataset status
x 2kevents.json

 Sample log dataset sent successfully
{
  "success": true
}
===> Frontend can be accessed on http://localhost:5122


*** Thank you! ***


```
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
