### PR TITLE
Fix: #553 Add alt text for images in dashboard.html

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -61,8 +61,8 @@
                         <button class="btn dropdown-toggle btn-top index-btn-show" type="button" id="date-picker-btn" data-toggle="dropdown"
                             aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" title="Pick the time window">
                             <span>Time Picker</span>
-                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                         </button>
                         <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn" id="daterangepicker ">
                             <p class="dt-header">Search the last</p>
@@ -116,8 +116,8 @@
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                                 data-bs-toggle="dropdown">
                                 <span></span>
-                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                             </button>
                             <div class="dropdown-menu refresh-picker" aria-labelledby="index-btn" id="refresh-picker ">
                                 <div class="ranges">
@@ -133,7 +133,7 @@
                     </div>
                     <button class="btn" id="add-panel-btn" title="Add panel">
                         <span>
-                            <img src="./assets/add-icon.svg" class="add-icon" /> </span>Add Panel
+                            <img src="./assets/add-icon.svg" class="add-icon" alt="add icon"/> </span>Add Panel
                     </button>
                 </div>
             </div>
@@ -174,8 +174,8 @@
                             aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown"
                             title="Index Name to search on" style="display: none;">
                             <span>Index</span>
-                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                         </button>
                         <div class="dropdown-menu box-shadow" aria-labelledby="index-btn" id="available-indexes">
                             <div id="index-listing"></div>
@@ -184,8 +184,8 @@
                             aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown"
                             title="Pick the time window">
                             <span>Time Picker</span>
-                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                            <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                            <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                         </button>
                         <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn" id="daterangepicker ">
                             <p class="dt-header">Search the last</p>
@@ -311,8 +311,8 @@
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                                 data-bs-toggle="dropdown" title="Select Query Type" style="display: none;">
                                 <span>Splunk QL</span>
-                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                             </button>
                             <div class="dropdown-menu box-shadow" aria-labelledby="index-btn"
                                 id="query-language-options">
@@ -326,8 +326,8 @@
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                                 data-bs-toggle="dropdown" title="Select Query Type" style="display: none;">
                                 <span>PromQL</span>
-                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                                <img class="dropdown-arrow orange" src="assets/arrow-btn.svg" alt="expand">
+                                <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg" alt="retract">
                             </button>
                             <div class="dropdown-menu box-shadow" aria-labelledby="index-btn"
                                 id="metrics-query-language-options">
@@ -364,27 +364,27 @@
                 </div>
                 <ul class="editPanelMenu editPanelMenu-chart">
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="0">
-                        <img src="./assets/line-chart.svg" alt="" class="chart-display"/>
+                        <img src="./assets/line-chart.svg" alt="line chart icon" class="chart-display" />
                         <li>Line Chart</li>
                     </div>
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="1">
-                        <img src="./assets/bar-chart.svg" alt="" class="chart-display"/>
+                        <img src="./assets/bar-chart.svg" alt="bar chart icon" class="chart-display"/>
                         <li>Bar Chart</li>
                     </div>
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="2">
-                        <img src="./assets/pie-chart.svg" alt="" class="chart-display"/>
+                        <img src="./assets/pie-chart.svg" alt="pie chart icon" class="chart-display"/>
                         <li>Pie Chart</li>
                     </div>
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="3">
-                        <img src="./assets/data-table.svg" alt="" class="chart-display"/>
+                        <img src="./assets/data-table.svg" alt="data table icon" class="chart-display"/>
                         <li>Data Table</li>
                     </div>
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="4">
-                        <img src="./assets/number-chart.svg" alt="" class="chart-display" />
+                        <img src="./assets/number-chart.svg" alt="number chart icon" class="chart-display" />
                         <li>Number</li>
                     </div>
                     <div class="editPanelMenu-options chart-options" id="chart-type-options" data-index="5">
-                        <img src="./assets/log-lines.svg" alt="" class="chart-display" />
+                        <img src="./assets/log-lines.svg" alt="log lines icon" class="chart-display" />
                         <li>Log Lines</li>
                     </div>
                 </ul>


### PR DESCRIPTION
# Description
Added descriptive `alt` texts for all the images in the file `dashboard.html`.
Made sure if the images are not visible, the alt text provides concise description about the element while not cluttering the view.

Fixes #553 

# Testing
Since the changes were made in HTML files, built the project and tested it locally.
### Tests conducted
- Tested dashboard in the happy path
- Tested the dashboard on desktop view after removing source images (.svg files)
- Tested the dashboard on Mobile view similarly. _(*optional)_

#### Screenshot for the made changes:
_screenshots were taken after the assets were unloaded, simulating scenarios for resource not found_
<img width="1440" alt="Screenshot 2024-02-23 at 10 13 23 PM" src="https://github.com/siglens/siglens/assets/45676471/033a1d0d-2fb0-40af-9a0f-b16b98fe9a08">
<img width="1440" alt="Screenshot 2024-02-23 at 10 13 27 PM" src="https://github.com/siglens/siglens/assets/45676471/5e5bc6c8-4c49-4ad1-a72d-ba20ccbf6d55">
<img width="1440" alt="Screenshot 2024-02-23 at 10 13 30 PM" src="https://github.com/siglens/siglens/assets/45676471/d9df04b1-4b2d-4a75-a32a-10f93f93e2b5">


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .` no changes made to `.go` files.
