### PR TITLE
Remove duplicate SetBadMsg func

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -339,7 +339,7 @@ func ProcessPipeSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf(" ProcessPipeSearchRequest: received empty search request body ")
-		SetBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	qid := rutils.GetNextQid()
@@ -526,14 +526,6 @@ func convertQueryCountToTotalResponse(qc *structs.QueryCount) interface{} {
 	}
 
 	return utils.HitsCount{Value: qc.TotalCount, Relation: qc.Op.ToString()}
-}
-
-func SetBadMsg(ctx *fasthttp.RequestCtx) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
 }
 
 /*

--- a/pkg/dashboards/dashboards.go
+++ b/pkg/dashboards/dashboards.go
@@ -532,14 +532,6 @@ func deleteDashboard(id string, orgid uint64) error {
 	return nil
 }
 
-func setBadMsg(ctx *fasthttp.RequestCtx) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
-}
-
 // method to set conflict message and 409 status code
 func setConflictMsg(ctx *fasthttp.RequestCtx) {
 	var httpResp utils.HttpServerResponse
@@ -553,7 +545,7 @@ func ProcessCreateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("ProcessCreateDashboardRequest: received empty user query")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -562,7 +554,7 @@ func ProcessCreateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	err := json.Unmarshal(rawJSON, &dname)
 	if err != nil {
 		log.Errorf("ProcessCreateDashboardRequest: could not unmarshall user query, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	dashboardInfo, err := createDashboard(dname, myid)
@@ -573,7 +565,7 @@ func ProcessCreateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 			return
 		} else {
 			log.Errorf("ProcessCreateDashboardRequest: could not create Dashboard=%v, err=%v", dname, err)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 	}
@@ -586,14 +578,14 @@ func ProcessFavoriteRequest(ctx *fasthttp.RequestCtx) {
 	dId := utils.ExtractParamAsString(ctx.UserValue("dashboard-id"))
 	if dId == "" {
 		log.Errorf("ProcessFavoriteRequest: received empty dashboard id")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
 	isFavorite, err := toggleFavorite(dId)
 	if err != nil {
 		log.Errorf("ProcessFavoriteRequest: could not toggle favorite status for Dashboard=%v, err=%v", dId, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -607,7 +599,7 @@ func ProcessListFavoritesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if err != nil {
 		log.Errorf("ProcessListFavoritesRequest: could not get favorite dashboard ids, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	utils.WriteJsonResponse(ctx, dIds)
@@ -669,7 +661,7 @@ func ProcessListAllRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if err != nil {
 		log.Errorf("ProcessListAllRequest: could not get dashboard ids, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	utils.WriteJsonResponse(ctx, dIds)
@@ -681,7 +673,7 @@ func ProcessListAllDefaultDBRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if err != nil {
 		log.Errorf("ProcessListAllRequest: could not get dashboard ids, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	utils.WriteJsonResponse(ctx, dIds)
@@ -692,7 +684,7 @@ func ProcessUpdateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("ProcessCreateDashboardRequest: received empty user query")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -701,7 +693,7 @@ func ProcessUpdateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	err := json.Unmarshal(rawJSON, &readJSON)
 	if err != nil {
 		log.Errorf("ProcessCreateDashboardRequest: could not unmarshall user query, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -715,7 +707,7 @@ func ProcessUpdateDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 			return
 		} else {
 			log.Errorf("ProcessCreateDashboardRequest: could not create Dashboard=%v, err=%v", dId, err)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 	}
@@ -729,7 +721,7 @@ func ProcessGetDashboardRequest(ctx *fasthttp.RequestCtx) {
 	dashboardDetails, err := getDashboard(dId)
 	if err != nil {
 		log.Errorf("ProcessGetDashboardRequest: could not get Dashboard=%v, err=%v", dId, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	utils.WriteJsonResponse(ctx, dashboardDetails)
@@ -741,7 +733,7 @@ func ProcessDeleteDashboardRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	err := deleteDashboard(dId, myid)
 	if err != nil {
 		log.Errorf("ProcessDeleteDashboardRequest: Failed to delete dashboard=%v, err=%v", dId, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 

--- a/pkg/es/writer/esAliases.go
+++ b/pkg/es/writer/esAliases.go
@@ -100,7 +100,7 @@ func ProcessGetIndexAlias(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if indexName == "" {
 		log.Errorf("ProcessGetIndexAlias: one of nil indexName=%v", indexName)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	log.Infof("ProcessGetIndexAlias: indexName=%v", indexName)
@@ -108,7 +108,7 @@ func ProcessGetIndexAlias(ctx *fasthttp.RequestCtx, myid uint64) {
 	currentAliases, err := vtable.GetAliases(indexName, myid)
 	if err != nil {
 		log.Errorf("ProcessGetIndexAlias: GetAliases returned err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -127,14 +127,14 @@ func ProcessPutAliasesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if indexName == "" || aliasName == "" {
 		log.Errorf("ProcessPutAliasesRequest: one of nil indexName=%v, aliasName=%v", indexName, aliasName)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	log.Infof("ProcessPutAliasesRequest: add alias request, indexName=%v, aliasName=%v", indexName, aliasName)
 	err := vtable.AddAliases(indexName, []string{aliasName}, myid)
 	if err != nil {
 		log.Errorf("ProcessPutAliasesRequest: failed to add alias, indexName=%v, aliasName=%v, err=%v", indexName, aliasName, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -165,7 +165,7 @@ func ProcessPostAliasesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	if err != nil {
 		log.Errorf("ProcessPostAliasesRequest: error un-marshalling JSON: %v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	for key, value := range jsonBody {
@@ -175,12 +175,12 @@ func ProcessPostAliasesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 				processActions(ctx, jsonBody[key], myid)
 			} else {
 				log.Errorf("ProcessPostAliasesRequest: unknown key: %v", key)
-				setBadMsg(ctx)
+				utils.SetBadMsg(ctx, "")
 				return
 			}
 		default:
 			log.Errorf("ProcessPostAliasesRequest: unknown type key: %v, value.Type=%T", key, value)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 	}
@@ -210,19 +210,19 @@ func processActions(ctx *fasthttp.RequestCtx, actions interface{}, myid uint64) 
 						parseRemoveAction(ctx, aValue, myid)
 					} else {
 						log.Errorf("processActions: unhandled action aKey: %v", aKey)
-						setBadMsg(ctx)
+						utils.SetBadMsg(ctx, "")
 						return
 					}
 				}
 			default:
 				log.Errorf("processActions: unknown t1.type=%T, t1=%v", t1, t1)
-				setBadMsg(ctx)
+				utils.SetBadMsg(ctx, "")
 				return
 			}
 		}
 	default:
 		log.Errorf("processActions: unknown actions.(type)  value.type=%T", t)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 }
@@ -238,20 +238,20 @@ func parseAddAction(ctx *fasthttp.RequestCtx, params interface{}, myid uint64) {
 		aliasName := t["alias"]
 		if aliasName == nil {
 			log.Errorf("parseAddAction: aliasName was nil, params=%v", params)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 		indexName := t["index"]
 		indices := t["indices"]
 		if indexName == nil && indices == nil {
 			log.Errorf("parseAddAction: both indexName and indices was nil, params=%v", params)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 		doAddAliases(ctx, indexName, aliasName, indices, myid)
 	default:
 		log.Errorf("parseAddAction: unknown params.(type)=%T  params=%v", params, params)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 }
@@ -270,7 +270,7 @@ func doAddAliases(ctx *fasthttp.RequestCtx, indexName interface{}, aliasName int
 		err := vtable.AddAliases(indexName.(string), []string{aliasName.(string)}, myid)
 		if err != nil {
 			log.Errorf("doAddAliases: failed to add alias, indexName=%v, aliasName=%v err=%v", indexName.(string), aliasName.(string), err)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 		}
 		return
 	}
@@ -285,7 +285,7 @@ func doAddAliases(ctx *fasthttp.RequestCtx, indexName interface{}, aliasName int
 		}
 	default:
 		log.Errorf("doAddAliases: unknown indices.(type)=%T  indices=%v", indices, indices)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 }
@@ -303,24 +303,24 @@ func parseRemoveAction(ctx *fasthttp.RequestCtx, params interface{}, myid uint64
 		aliasName := t["alias"]
 		if aliasName == nil {
 			log.Errorf("parseRemoveAction: aliasName was nil, params=%v", params)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 		indexName := t["index"]
 		if indexName == nil {
 			log.Errorf("parseRemoveAction: both indexName was nil, params=%v", params)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 		err := vtable.RemoveAliases(indexName.(string), []string{aliasName.(string)}, myid)
 		if err != nil {
 			log.Errorf("parseRemoveAction: failed to remove alias, indexName=%v, aliasName=%v err=%v", indexName.(string), aliasName.(string), err)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 		}
 		return
 	default:
 		log.Errorf("parseRemoveAction: unknown params.(type)=%T  params=%v", params, params)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 }

--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -53,8 +53,6 @@ const CREATE_TOP_STR string = "create"
 const UPDATE_TOP_STR string = "update"
 const INDEX_UNDER_STR string = "_index"
 
-var httpResp utils.HttpServerResponse
-
 type kibanaIngHandlerFnDef func(
 	ctx *fasthttp.RequestCtx, request map[string]interface{},
 	indexNameConverted string, updateArg bool, idVal string, tsNow uint64, myid uint64) error
@@ -286,13 +284,6 @@ func ProcessIndexRequest(rawJson []byte, tsNow uint64, indexNameIn string,
 		return err
 	}
 	return nil
-}
-
-func setBadMsg(ctx *fasthttp.RequestCtx) {
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
 }
 
 func ProcessPutIndex(ctx *fasthttp.RequestCtx, myid uint64) {

--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -99,7 +99,7 @@ func ProcessClusterIngestStatsHandler(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf(" ClusterIngestStatsHandler: received empty search request body ")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -248,14 +248,6 @@ func convertBytesToGB(bytes float64) string {
 	convertedGB := bytes / 1_000_000_000
 	finalStr := fmt.Sprintf("%.3f", convertedGB) + " GB"
 	return finalStr
-}
-
-func setBadMsg(ctx *fasthttp.RequestCtx) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
 }
 
 func getMetricsStats(myid uint64) (uint64, uint64, uint64) {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -155,7 +155,7 @@ func ProcessMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf(" ProcessMetricsSearchRequest: received empty search request body ")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	qid := rutils.GetNextQid()
@@ -226,7 +226,7 @@ func ProcessUiMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf(" ProcessMetricsSearchRequest: received empty search request body ")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	qid := rutils.GetNextQid()
@@ -528,15 +528,6 @@ func getArithmeticOperation(op pql.ItemType) segutils.ArithmeticOperator {
 		log.Errorf("getArithmeticOperation: unexpected op: %v", op)
 		return 0
 	}
-}
-
-func setBadMsg(ctx *fasthttp.RequestCtx) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetContentType(ContentJson)
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
 }
 
 func parseTimeFromString(timeStr string) (uint32, error) {

--- a/pkg/querytracker/querytracker.go
+++ b/pkg/querytracker/querytracker.go
@@ -856,7 +856,7 @@ func PostPqsAggCols(ctx *fasthttp.RequestCtx) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("PostPqsAggCols: received empty request")
-		setBadMsg(ctx, "Empty post body")
+		utils.SetBadMsg(ctx, "Empty post body")
 		return
 	}
 
@@ -877,7 +877,7 @@ func PostPqsAggCols(ctx *fasthttp.RequestCtx) {
 	err = parsePostPqsAggBody(readJSON)
 
 	if err != nil {
-		setBadMsg(ctx, err.Error())
+		utils.SetBadMsg(ctx, err.Error())
 	} else {
 		ctx.SetStatusCode(fasthttp.StatusOK)
 		httpResp.Message = "All OK"
@@ -962,12 +962,4 @@ func processPostAggs(inputValueParam interface{}) (map[string]bool, error) {
 		}
 	}
 	return evMap, nil
-}
-
-func setBadMsg(ctx *fasthttp.RequestCtx, msg string) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = msg
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
 }

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -160,7 +160,7 @@ func ParseAndValidateRequestBody(ctx *fasthttp.RequestCtx) (*structs.SearchReque
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("Received empty search request body")
-		pipesearch.SetBadMsg(ctx)
+		putils.SetBadMsg(ctx, "")
 		return nil, nil, errors.New("Received empty search request body")
 	}
 
@@ -629,7 +629,7 @@ func ProcessGanttChartRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("ProcessGanttChartRequest: received empty search request body ")
-		pipesearch.SetBadMsg(ctx)
+		putils.SetBadMsg(ctx, "")
 		return
 	}
 

--- a/pkg/usersavedqueries/usqueries.go
+++ b/pkg/usersavedqueries/usqueries.go
@@ -378,11 +378,11 @@ func DeleteUserSavedQuery(ctx *fasthttp.RequestCtx) {
 	deleted, err := deleteUsq(queryName, 0)
 	if err != nil {
 		log.Errorf("DeleteUserSavedQuery: Failed to delete user saved query %v, err=%v", queryName, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	if !deleted {
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	log.Infof("DeleteUserSavedQuery: Successfully deleted user saved query %v", queryName)
@@ -399,7 +399,7 @@ func GetUserSavedQueriesAll(ctx *fasthttp.RequestCtx) {
 	found, savedQueriesAll, err := getUsqAll(0)
 	if err != nil {
 		log.Errorf("GetUserSavedQueriesAll: Failed to read user saved queries, err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	if !found {
@@ -412,19 +412,11 @@ func GetUserSavedQueriesAll(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }
 
-func setBadMsg(ctx *fasthttp.RequestCtx) {
-	var httpResp utils.HttpServerResponse
-	ctx.SetStatusCode(fasthttp.StatusBadRequest)
-	httpResp.Message = "Bad Request"
-	httpResp.StatusCode = fasthttp.StatusBadRequest
-	utils.WriteResponse(ctx, httpResp)
-}
-
 func SaveUserQueries(ctx *fasthttp.RequestCtx) {
 	rawJSON := ctx.PostBody()
 	if rawJSON == nil {
 		log.Errorf("SaveUserQueries: received empty user query")
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 
@@ -475,14 +467,14 @@ func SaveUserQueries(ctx *fasthttp.RequestCtx) {
 			}
 		default:
 			log.Errorf("SaveUserQueries: Invalid save query key=[%v]", key)
-			setBadMsg(ctx)
+			utils.SetBadMsg(ctx, "")
 			return
 		}
 	}
 	err = writeUsq(qname, usQueryMap, 0)
 	if err != nil {
 		log.Errorf("SaveUserQueries: could not write query to file err=%v", err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	log.Infof("SaveUserQueries: successfully written query %v to file ", qname)
@@ -524,7 +516,7 @@ func SearchUserSavedQuery(ctx *fasthttp.RequestCtx) {
 	log.Infof("SearchUserSavedQuery: Found=%v, usqInfo=%v", found, usqInfo)
 	if err != nil {
 		log.Errorf("SearchUserSavedQuery: Failed to get user saved query %v, err=%v", queryName, err)
-		setBadMsg(ctx)
+		utils.SetBadMsg(ctx, "")
 		return
 	}
 	if !found {

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -417,6 +417,17 @@ func WriteJsonResponse(ctx *fasthttp.RequestCtx, httpResp interface{}) {
 	}
 }
 
+func SetBadMsg(ctx *fasthttp.RequestCtx, msg string) {
+	if len(msg) == 0 {
+		msg = "Bad Request"
+	}
+	var httpResp HttpServerResponse
+	ctx.SetStatusCode(fasthttp.StatusBadRequest)
+	httpResp.Message = msg
+	httpResp.StatusCode = fasthttp.StatusBadRequest
+	WriteResponse(ctx, httpResp)
+}
+
 func ExtractParamAsString(_interface interface{}) string {
 	switch intfc := _interface.(type) {
 	case string:


### PR DESCRIPTION
# Description
Remove duplicate SetBadMsg func. Redefine it at `httpserverutils.go`

Fixes #538 

# Testing
Run the test cases.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
