### PR TITLE
Fix GetQueryServerBaseUrl

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1024,19 +1024,22 @@ func getQueryServerPort() (uint64, error) {
 
 func GetQueryServerBaseUrl() string {
 	hostname := GetQueryHostname()
+	port, err := getQueryServerPort()
+	if err != nil {
+		log.Errorf("GetQueryServerBaseUrl: failed to get query port; err: %v", err)
+		return "http://localhost:5122"
+	}
+
 	if hostname == "" {
-		port, err := getQueryServerPort()
-		if err != nil {
-			return "http://localhost:5122"
-		}
 		return "http://localhost:" + fmt.Sprintf("%d", port)
 	} else {
-		if IsTlsEnabled() {
-			hostname = "https://" + hostname
-		} else {
-			hostname = "http://" + hostname
+		isTlsEnabled := IsTlsEnabled()
+		protocol := "http"
+		if isTlsEnabled {
+			protocol = "https"
 		}
-		return hostname
+
+		return fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1033,9 +1033,8 @@ func GetQueryServerBaseUrl() string {
 	if hostname == "" {
 		return "http://localhost:" + fmt.Sprintf("%d", port)
 	} else {
-		isTlsEnabled := IsTlsEnabled()
 		protocol := "http"
-		if isTlsEnabled {
+		if IsTlsEnabled() {
 			protocol = "https"
 		}
 


### PR DESCRIPTION
# Description
The behavior of `GetQueryServerBaseUrl()` was inconsistent. If the provided hostname was empty, it would return the url with the port, but if the hostname was not empty, it would exclude the port.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
