### PR TITLE
Feat: Add Clear Button to Reset Query Builder (#549)

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -686,3 +686,29 @@ div.show-record-popup {
     border-radius: 10px;
     background: var(--black1-to-white0)
 }
+
+/* Position-relative container for query-input bar */
+.position-relative {
+    position: relative;
+    width: 100%;
+}
+
+/* Clear query button styles */
+#clear-query-btn {
+    /* Position the button */
+    position: absolute;
+    top: 45%; /* Adjust vertically */
+    right: 10px; /* Adjust horizontally */
+    transform: translateY(-50%);
+
+    /* Button appearance */
+    background-color: transparent;
+    color: rgba(0, 0, 0, 0.6); /* Lighter font color */
+    font-family: "DINpro", Arial, sans-serif;
+    font-weight: lighter;
+    font-size: 20px;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -40,6 +40,7 @@
     <script src="./js/lib/popper.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script src="./js/log-search.js"></script>
 
     {{ .RunCheck1 | safeHTML }}
 </head>
@@ -60,7 +61,10 @@
                 </ul>
                 <div id = "tabs-1">
                     <div class="query-box">
-                        <input class="form-control query-text" id="query-input" type="text" disabled="disabled">
+                        <div class="position-relative"> <!-- Position relative -->
+                            <input class="form-control query-text" id="query-input" type="text" disabled="disabled">
+                            <button id="clear-query-btn" class="clear-query-btn">x</button> <!-- Added clear button -->
+                        </div>
                         <div class="search-img" id="query-builder-btn"> </div>
                     </div>
                     <div class="filter-info">

--- a/static/js/log-search.js
+++ b/static/js/log-search.js
@@ -169,3 +169,32 @@ $("#clearInput").click(function() {
     $("#filter-input").val("").focus();
     $(this).hide();
 });
+
+/*
+Function to clear the query input field, search filter tags, and related elements
+*/
+function clearQueryInput() {
+    // Clear the query input field
+    $("#query-input").val("*").focus();
+
+    // Hide the clear button for the query input field if it's empty
+    if ($("#query-input").val().trim() !== "") {
+        $("#clear-query-btn").show();
+    } else {
+        $("#clear-query-btn").hide();
+    }
+
+    // Clear all search filter tags and related elements
+    $("#tags, #tags-second, #tags-third").empty();
+    firstBoxSet.clear();
+    secondBoxSet.clear();
+    thirdBoxSet.clear();
+
+    // Show the default text for search filters, aggregation attribute, and aggregations
+    $("#search-filter-text, #aggregate-attribute-text, #aggregations").show();
+}
+
+// Event handler for the clear button associated with the query input field
+$("#clear-query-btn").click(function() {
+    clearQueryInput();
+});


### PR DESCRIPTION
# Description
Added a small "X" at the end of the search box in the query builder. This X works similarly to what we already have in the Free Text tab, allowing users to quickly clear their query and start over.

Fixes #549  (UI : Add Clear Button to Reset Query Builder)

# Testing
1. Go to Logs, Query Builder. 
2. If you don't already have data loaded, go to Ingestion and Send Test Data.
3. Try to add Search Filters, Aggregate Attributes and/or Search Criteria.
4. Click the 'X' button on the upper right corner, next to the search icon.
5. This should clear out the query successfully.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
