### PR TITLE
Enable SSL/TLS for Query and Ingest Service. 

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -219,8 +219,9 @@ func StartSiglensServer(nodeType commonconfig.DeploymentType, nodeID string) err
 	ingestServer := fmt.Sprint(config.GetIngestListenIP()) + ":" + fmt.Sprintf("%d", config.GetIngestPort())
 	queryServer := fmt.Sprint(config.GetQueryListenIP()) + ":" + fmt.Sprintf("%d", config.GetQueryPort())
 
-	if config.IsTlsEnabled() && config.GetQueryPort() != 443 {
-		log.Warnf("TLS requires using 443; you will have issues if nothing in your setup configures port 443 to route to the Query/UI port (%d)", config.GetQueryPort())
+	if config.IsTlsEnabled() && (config.GetTLSCertificatePath() == "" || config.GetTLSPrivateKeyPath() == "") {
+		fmt.Println("TLS is enabled but certificate or private key path is not provided")
+		log.Fatalf("TLS is enabled but certificate or private key path is not provided")
 	}
 
 	err = vtable.InitVTable()

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -33,8 +33,7 @@ type LogConfig struct {
 }
 
 type TLSConfig struct {
-	Enabled         bool   `yaml:"enabled"`
-	ACMEFolder      string `yaml:"acmeFolder"`      // folder to store acme certificates
+	Enabled         bool   `yaml:"enabled"`         // folder to store acme certificates
 	CertificatePath string `yaml:"certificatePath"` // path to certificate file
 	PrivateKeyPath  string `yaml:"privateKeyPath"`  // path to private key file
 }

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -33,8 +33,10 @@ type LogConfig struct {
 }
 
 type TLSConfig struct {
-	Enabled    bool   `yaml:"enabled"`
-	ACMEFolder string `yaml:"acmeFolder"` // folder to store acme certificates
+	Enabled         bool   `yaml:"enabled"`
+	ACMEFolder      string `yaml:"acmeFolder"`      // folder to store acme certificates
+	CertificatePath string `yaml:"certificatePath"` // path to certificate file
+	PrivateKeyPath  string `yaml:"privateKeyPath"`  // path to private key file
 }
 
 type AlertConfig struct {

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -33,7 +33,7 @@ type LogConfig struct {
 }
 
 type TLSConfig struct {
-	Enabled         bool   `yaml:"enabled"`         // folder to store acme certificates
+	Enabled         bool   `yaml:"enabled"`         // enable/disable tls
 	CertificatePath string `yaml:"certificatePath"` // path to certificate file
 	PrivateKeyPath  string `yaml:"privateKeyPath"`  // path to private key file
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,11 +168,6 @@ func GetDataPath() string {
 	return runningConfig.DataPath
 }
 
-// returns the configured acme path
-func GetTLSACMEDir() string {
-	return runningConfig.TLS.ACMEFolder
-}
-
 // returns if tls is enabled
 func IsTlsEnabled() bool {
 	return runningConfig.TLS.Enabled
@@ -359,10 +354,6 @@ func SetDataPath(path string) {
 	runningConfig.DataPath = path
 }
 
-func SetCertsPath(path string) {
-	runningConfig.TLS.ACMEFolder = path
-}
-
 func SetDataDiskThresholdPercent(percent uint64) {
 	runningConfig.DataDiskThresholdPercent = percent
 }
@@ -479,7 +470,7 @@ func GetTestConfig() common.Configuration {
 		AgileAggsEnabledConverted:  true,
 		QueryHostname:              "",
 		Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
-		TLS:                        common.TLSConfig{Enabled: false, ACMEFolder: "certs/", CertificatePath: "", PrivateKeyPath: ""},
+		TLS:                        common.TLSConfig{Enabled: false, CertificatePath: "", PrivateKeyPath: ""},
 		DatabaseConfig:             common.DatabaseConfig{Enabled: true, Provider: "sqlite"},
 		EmailConfig:                common.EmailConfig{SmtpHost: "smtp.gmail.com", SmtpPort: 587, SenderEmail: "doe1024john@gmail.com", GmailAppPassword: " "},
 	}
@@ -681,9 +672,6 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 
 	if config.S3IngestBufferSize == 0 {
 		config.S3IngestBufferSize = 1000
-	}
-	if len(config.TLS.ACMEFolder) >= 0 && strings.HasPrefix(config.TLS.ACMEFolder, "./") {
-		config.TLS.ACMEFolder = strings.Trim(config.TLS.ACMEFolder, "./")
 	}
 
 	if len(config.TLS.CertificatePath) >= 0 && strings.HasPrefix(config.TLS.CertificatePath, "./") {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,16 @@ func IsTlsEnabled() bool {
 	return runningConfig.TLS.Enabled
 }
 
+// returns the configured certificate path
+func GetTLSCertificatePath() string {
+	return runningConfig.TLS.CertificatePath
+}
+
+// returns the configured private key path
+func GetTLSPrivateKeyPath() string {
+	return runningConfig.TLS.PrivateKeyPath
+}
+
 // used by
 func GetQueryHostname() string {
 	return runningConfig.QueryHostname
@@ -469,7 +479,7 @@ func GetTestConfig() common.Configuration {
 		AgileAggsEnabledConverted:  true,
 		QueryHostname:              "",
 		Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
-		TLS:                        common.TLSConfig{Enabled: false, ACMEFolder: "certs/"},
+		TLS:                        common.TLSConfig{Enabled: false, ACMEFolder: "certs/", CertificatePath: "", PrivateKeyPath: ""},
 		DatabaseConfig:             common.DatabaseConfig{Enabled: true, Provider: "sqlite"},
 		EmailConfig:                common.EmailConfig{SmtpHost: "smtp.gmail.com", SmtpPort: 587, SenderEmail: "doe1024john@gmail.com", GmailAppPassword: " "},
 	}
@@ -674,6 +684,14 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	}
 	if len(config.TLS.ACMEFolder) >= 0 && strings.HasPrefix(config.TLS.ACMEFolder, "./") {
 		config.TLS.ACMEFolder = strings.Trim(config.TLS.ACMEFolder, "./")
+	}
+
+	if len(config.TLS.CertificatePath) >= 0 && strings.HasPrefix(config.TLS.CertificatePath, "./") {
+		config.TLS.CertificatePath = strings.Trim(config.TLS.CertificatePath, "./")
+	}
+
+	if len(config.TLS.PrivateKeyPath) >= 0 && strings.HasPrefix(config.TLS.PrivateKeyPath, "./") {
+		config.TLS.PrivateKeyPath = strings.Trim(config.TLS.PrivateKeyPath, "./")
 	}
 
 	return config, nil

--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -151,11 +151,20 @@ func (hs *ingestionServerCfg) Run() (err error) {
 
 	// run fasthttp server
 	var g run.Group
-	g.Add(func() error {
-		return s.Serve(hs.ln)
-	}, func(e error) {
-		_ = hs.ln.Close()
-	})
+
+	if config.IsTlsEnabled() && config.GetTLSCertificatePath() != "" && config.GetTLSPrivateKeyPath() != "" {
+		g.Add(func() error {
+			return s.ServeTLS(hs.ln, config.GetTLSCertificatePath(), config.GetTLSPrivateKeyPath())
+		}, func(e error) {
+			_ = hs.ln.Close()
+		})
+	} else {
+		g.Add(func() error {
+			return s.Serve(hs.ln)
+		}, func(e error) {
+			_ = hs.ln.Close()
+		})
+	}
 	return g.Run()
 }
 

--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -152,7 +152,7 @@ func (hs *ingestionServerCfg) Run() (err error) {
 	// run fasthttp server
 	var g run.Group
 
-	if config.IsTlsEnabled() && config.GetTLSCertificatePath() != "" && config.GetTLSPrivateKeyPath() != "" {
+	if config.IsTlsEnabled() {
 		g.Add(func() error {
 			return s.ServeTLS(hs.ln, config.GetTLSCertificatePath(), config.GetTLSPrivateKeyPath())
 		}, func(e error) {

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -18,6 +18,7 @@ package queryserver
 
 import (
 	"crypto/tls"
+	"fmt"
 	htmltemplate "html/template"
 	"net"
 	texttemplate "text/template"
@@ -295,6 +296,7 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 		cfg.Certificates[0], err = tls.LoadX509KeyPair(config.GetTLSCertificatePath(), config.GetTLSPrivateKeyPath())
 
 		if err != nil {
+			fmt.Println("Run: error in loading TLS certificate: ", err)
 			log.Fatalf("Run: error in loading TLS certificate: %v", err)
 		}
 

--- a/server.yaml
+++ b/server.yaml
@@ -39,9 +39,9 @@ log:
 
 # TLS configuration
 tls:
-  enabled: false   # Set to true to enable TLS
-  acmeFolder: ""    # Folder for ACME challenge Certificates; Optional. Set this if the port is 443 and you do not have a certificate
+  enabled: true   # Set to true to enable TLS
   certificatePath: ""  # Path to the certificate file
   privateKeyPath: ""   # Path to the private key file
 
+# SigLens server hostname
 queryHostname: ""

--- a/server.yaml
+++ b/server.yaml
@@ -36,3 +36,12 @@ log:
 
   ## Compress log file
   # compressLogFile: false
+
+# TLS configuration
+tls:
+  enabled: false   # Set to true to enable TLS
+  acmeFolder: ""    # Folder for ACME challenge Certificates; Optional. Set this if the port is 443 and you do not have a certificate
+  certificatePath: ""  # Path to the certificate file
+  privateKeyPath: ""   # Path to the private key file
+
+queryHostname: ""

--- a/server.yaml
+++ b/server.yaml
@@ -39,7 +39,7 @@ log:
 
 # TLS configuration
 tls:
-  enabled: true   # Set to true to enable TLS
+  enabled: false   # Set to true to enable TLS
   certificatePath: ""  # Path to the certificate file
   privateKeyPath: ""   # Path to the private key file
 


### PR DESCRIPTION
# Description
- SSL/TLS for the query and ingest service can be enabled.
- Added two more variables under TLS config to take the Certificate and PrivateKey.

# Testing
- Tested by setting up a domain, generating a Certificate and private key, and Enabling the TLS.
- Ingested data from my local to hosted URL ingestion `https` endpoint.
- Ran queries against the UI and sent sample test data from UI against the `https` query endpoint.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
