### PR TITLE
Fix oom

### DIFF
--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -86,14 +86,7 @@ func buildSegMap(allrrc []*utils.RecordResultContainer, segEncToKey map[uint16]s
 	return segmap, recordIndexInFinal
 }
 
-// Gets all raw json records from RRCs. If esResponse is false, _id and _type will not be added to any record
-func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, qid uint64,
-	segEncToKey map[uint16]string, aggs *structs.QueryAggregators) ([]map[string]interface{}, []string, error) {
-
-	sTime := time.Now()
-	nodeRes := GetOrCreateNodeRes(qid)
-	segmap, recordIndexInFinal := buildSegMap(allrrc, segEncToKey)
-
+func prepareOutputTransforms(aggs *structs.QueryAggregators) (map[string]int, map[string]string, bool, bool, []string, map[string]string) {
 	rawIncludeValuesIndicies := make(map[string]int)
 	valuesToLabels := make(map[string]string)
 	logfmtRequest := false
@@ -119,6 +112,18 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 		}
 
 	}
+
+	return rawIncludeValuesIndicies, valuesToLabels, logfmtRequest, tableColumnsExist, hardcodedArray, renameHardcodedColumns
+}
+
+// Gets all raw json records from RRCs. If esResponse is false, _id and _type will not be added to any record
+func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, qid uint64,
+	segEncToKey map[uint16]string, aggs *structs.QueryAggregators) ([]map[string]interface{}, []string, error) {
+
+	sTime := time.Now()
+	nodeRes := GetOrCreateNodeRes(qid)
+	segmap, recordIndexInFinal := buildSegMap(allrrc, segEncToKey)
+	rawIncludeValuesIndicies, valuesToLabels, logfmtRequest, tableColumnsExist, hardcodedArray, renameHardcodedColumns := prepareOutputTransforms(aggs)
 
 	allRecords := make([]map[string]interface{}, len(allrrc))
 	finalCols := make(map[string]bool)

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -188,145 +188,149 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 	recsAggRecords := make([]map[string]interface{}, 0)
 	var numTotalSegments uint64
 
+	processSingleSegment := func(currSeg string, virtualTableName string, blkRecIndexes map[uint16]map[uint16]uint64) {
+		recs, cols, err := GetRecordsFromSegment(currSeg, virtualTableName, blkRecIndexes,
+			config.GetTimeStampKey(), esResponse, qid, aggs)
+		if err != nil {
+			log.Errorf("GetJsonFromAllRrc: failed to read recs from segfile=%v, err=%v", currSeg, err)
+			return
+		}
+		for cName := range cols {
+			finalCols[cName] = true
+		}
+
+		for key := range renameHardcodedColumns {
+			finalCols[key] = true
+		}
+
+		if hasQueryAggergatorBlock || transactionArgsExist {
+
+			numTotalSegments, err = query.GetTotalSegmentsToSearch(qid)
+			if err != nil {
+				// For synchronous queries, the query is deleted by this
+				// point, but segmap has all the segments that the query
+				// searched.
+				// For async queries, the segmap has just one segment
+				// because we process them as the search completes, but the
+				// query isn't deleted until all segments get processed, so
+				// we shouldn't get to this block for async queries.
+				numTotalSegments = uint64(len(segmap))
+			}
+
+			/**
+			* Overview of Aggregation Processing:
+			* 1. Initiate the process by executing PostQueryBucketCleaning to prepare records for aggregation.
+			* 2. Evaluate the PerformAggsOnRecs flag post-cleanup:
+			*    - True: Indicates not all aggregations were processed. In this case:
+			*       a. Perform aggregations on records using performAggsOnRecs. This function requires all the segments to be processed before proceeding to the next step.
+			*       b. Evaluate the CheckNextAgg flag from the result:
+			*          i. If true, reset PerformAggsOnRecs to false, update aggs with NextQueryAgg, and loop for additional cleaning.
+			*          ii. If false or if resultRecMap is empty, it implies additional segments may require processing; exit the loop for further segment evaluation.
+			*    - False: All aggregations for the current segment have been processed; exit the loop to either process the next segment or return the final results.
+			* 3. The loop facilitates sequential data processing, ensuring each or all the segments are thoroughly processed before proceeding to the next,
+			*    adapting dynamically based on the flags set by the PostQueryBucketCleaning and PerformAggsOnRecs functions.
+			 */
+			for {
+				agg.PostQueryBucketCleaning(nodeRes, aggs, recs, recordIndexInFinal, finalCols, numTotalSegments)
+				if nodeRes.PerformAggsOnRecs {
+					resultRecMap = search.PerformAggsOnRecs(nodeRes, aggs, recs, finalCols, numTotalSegments, qid)
+					if len(resultRecMap) > 0 {
+						boolVal, exists := resultRecMap["CHECK_NEXT_AGG"]
+						if exists && boolVal {
+							// Reset the flag to false and update aggs with NextQueryAgg to loop for additional cleaning.
+							nodeRes.PerformAggsOnRecs = false
+							aggs = nodeRes.NextQueryAgg
+						} else {
+							break
+						}
+					} else {
+						// Not checking or processing Next Agg. This implies that there might be more segments to process.
+						// Break out of the loop and continue processing the next segment.
+						break
+					}
+				} else {
+					// No need to perform aggs on recs. All the Aggs are Processed.
+					break
+				}
+			}
+			// For other cmds, if we cannot map recInden to an index, we simply append the record to allRecords
+			// However, for the sort cmd, we should assign the length of the result set to be the same as recordIndexInFinal
+			// This way, when mapping the results to allRecords, we can preserve the order of the results rather than just appending them to the end of allRecords
+			if len(recordIndexInFinal) > len(allRecords) {
+				allRecords = make([]map[string]interface{}, len(recordIndexInFinal))
+			}
+		}
+
+		numProcessedRecords += len(recs)
+		for recInden, record := range recs {
+			for key, val := range renameHardcodedColumns {
+				record[key] = val
+			}
+
+			unknownIndex := false
+			idx, ok := recordIndexInFinal[recInden]
+			if !ok {
+				// For async queries where we need all records before we
+				// can return any (like dedup with a sortby), once we can
+				// get to this block because processing the dedup may
+				// return some records from previous segments and since
+				// it's an async query we're running this function with
+				// len(segmap)=1 because we try to process the data as the
+				// searched complete.
+				log.Infof("qid=%d, GetJsonFromAllRrc: Did not find index for record indentifier %s.", qid, recInden)
+				unknownIndex = true
+			}
+			if logfmtRequest {
+				record = addKeyValuePairs(record)
+			}
+			includeValues := make(map[string]interface{})
+			for cname, val := range record {
+				if len(valuesToLabels[cname]) > 0 {
+					actualIndex := rawIncludeValuesIndicies[cname]
+					switch valType := val.(type) {
+					case []interface{}:
+						if actualIndex > len(valType)-1 || actualIndex < 0 {
+							log.Errorf("GetJsonFromAllRrc: index=%v out of bounds for column=%v of length %v", actualIndex, cname, len(valType))
+							continue
+						}
+						includeValues[valuesToLabels[cname]] = valType[actualIndex]
+					case interface{}:
+						log.Errorf("GetJsonFromAllRrc: accessing object in %v as array!", cname)
+						continue
+					default:
+						log.Errorf("GetJsonFromAllRrc: unsupported value type")
+						continue
+					}
+				}
+
+			}
+			for label, val := range includeValues {
+				if record[label] != nil {
+					log.Errorf("GetJsonFromAllRrc: accessing object in %v as array!", label) //case where label == original column
+					continue
+				}
+				record[label] = val
+			}
+
+			delete(recordIndexInFinal, recInden)
+
+			if unknownIndex {
+				allRecords = append(allRecords, record)
+			} else {
+				allRecords[idx] = record
+			}
+
+			if transactionArgsExist {
+				recsAggRecords = append(recsAggRecords, record)
+			}
+		}
+	}
+
 	if !(tableColumnsExist || aggs.OutputTransforms == nil || hasQueryAggergatorBlock || transactionArgsExist) {
 		allRecords, finalCols = applyHardcodedColumns(hardcodedArray, renameHardcodedColumns, allRecords, finalCols)
 	} else {
 		for currSeg, blkIds := range segmap {
-			recs, cols, err := GetRecordsFromSegment(currSeg, blkIds.VirtualTableName, blkIds.BlkRecIndexes,
-				config.GetTimeStampKey(), esResponse, qid, aggs)
-			if err != nil {
-				log.Errorf("GetJsonFromAllRrc: failed to read recs from segfile=%v, err=%v", currSeg, err)
-				continue
-			}
-			for cName := range cols {
-				finalCols[cName] = true
-			}
-
-			for key := range renameHardcodedColumns {
-				finalCols[key] = true
-			}
-
-			if hasQueryAggergatorBlock || transactionArgsExist {
-
-				numTotalSegments, err = query.GetTotalSegmentsToSearch(qid)
-				if err != nil {
-					// For synchronous queries, the query is deleted by this
-					// point, but segmap has all the segments that the query
-					// searched.
-					// For async queries, the segmap has just one segment
-					// because we process them as the search completes, but the
-					// query isn't deleted until all segments get processed, so
-					// we shouldn't get to this block for async queries.
-					numTotalSegments = uint64(len(segmap))
-				}
-
-				/**
-				* Overview of Aggregation Processing:
-				* 1. Initiate the process by executing PostQueryBucketCleaning to prepare records for aggregation.
-				* 2. Evaluate the PerformAggsOnRecs flag post-cleanup:
-				*    - True: Indicates not all aggregations were processed. In this case:
-				*       a. Perform aggregations on records using performAggsOnRecs. This function requires all the segments to be processed before proceeding to the next step.
-				*       b. Evaluate the CheckNextAgg flag from the result:
-				*          i. If true, reset PerformAggsOnRecs to false, update aggs with NextQueryAgg, and loop for additional cleaning.
-				*          ii. If false or if resultRecMap is empty, it implies additional segments may require processing; exit the loop for further segment evaluation.
-				*    - False: All aggregations for the current segment have been processed; exit the loop to either process the next segment or return the final results.
-				* 3. The loop facilitates sequential data processing, ensuring each or all the segments are thoroughly processed before proceeding to the next,
-				*    adapting dynamically based on the flags set by the PostQueryBucketCleaning and PerformAggsOnRecs functions.
-				 */
-				for {
-					agg.PostQueryBucketCleaning(nodeRes, aggs, recs, recordIndexInFinal, finalCols, numTotalSegments)
-					if nodeRes.PerformAggsOnRecs {
-						resultRecMap = search.PerformAggsOnRecs(nodeRes, aggs, recs, finalCols, numTotalSegments, qid)
-						if len(resultRecMap) > 0 {
-							boolVal, exists := resultRecMap["CHECK_NEXT_AGG"]
-							if exists && boolVal {
-								// Reset the flag to false and update aggs with NextQueryAgg to loop for additional cleaning.
-								nodeRes.PerformAggsOnRecs = false
-								aggs = nodeRes.NextQueryAgg
-							} else {
-								break
-							}
-						} else {
-							// Not checking or processing Next Agg. This implies that there might be more segments to process.
-							// Break out of the loop and continue processing the next segment.
-							break
-						}
-					} else {
-						// No need to perform aggs on recs. All the Aggs are Processed.
-						break
-					}
-				}
-				// For other cmds, if we cannot map recInden to an index, we simply append the record to allRecords
-				// However, for the sort cmd, we should assign the length of the result set to be the same as recordIndexInFinal
-				// This way, when mapping the results to allRecords, we can preserve the order of the results rather than just appending them to the end of allRecords
-				if len(recordIndexInFinal) > len(allRecords) {
-					allRecords = make([]map[string]interface{}, len(recordIndexInFinal))
-				}
-			}
-
-			numProcessedRecords += len(recs)
-			for recInden, record := range recs {
-				for key, val := range renameHardcodedColumns {
-					record[key] = val
-				}
-
-				unknownIndex := false
-				idx, ok := recordIndexInFinal[recInden]
-				if !ok {
-					// For async queries where we need all records before we
-					// can return any (like dedup with a sortby), once we can
-					// get to this block because processing the dedup may
-					// return some records from previous segments and since
-					// it's an async query we're running this function with
-					// len(segmap)=1 because we try to process the data as the
-					// searched complete.
-					log.Infof("qid=%d, GetJsonFromAllRrc: Did not find index for record indentifier %s.", qid, recInden)
-					unknownIndex = true
-				}
-				if logfmtRequest {
-					record = addKeyValuePairs(record)
-				}
-				includeValues := make(map[string]interface{})
-				for cname, val := range record {
-					if len(valuesToLabels[cname]) > 0 {
-						actualIndex := rawIncludeValuesIndicies[cname]
-						switch valType := val.(type) {
-						case []interface{}:
-							if actualIndex > len(valType)-1 || actualIndex < 0 {
-								log.Errorf("GetJsonFromAllRrc: index=%v out of bounds for column=%v of length %v", actualIndex, cname, len(valType))
-								continue
-							}
-							includeValues[valuesToLabels[cname]] = valType[actualIndex]
-						case interface{}:
-							log.Errorf("GetJsonFromAllRrc: accessing object in %v as array!", cname)
-							continue
-						default:
-							log.Errorf("GetJsonFromAllRrc: unsupported value type")
-							continue
-						}
-					}
-
-				}
-				for label, val := range includeValues {
-					if record[label] != nil {
-						log.Errorf("GetJsonFromAllRrc: accessing object in %v as array!", label) //case where label == original column
-						continue
-					}
-					record[label] = val
-				}
-
-				delete(recordIndexInFinal, recInden)
-
-				if unknownIndex {
-					allRecords = append(allRecords, record)
-				} else {
-					allRecords[idx] = record
-				}
-
-				if transactionArgsExist {
-					recsAggRecords = append(recsAggRecords, record)
-				}
-			}
+			processSingleSegment(currSeg, blkIds.VirtualTableName, blkIds.BlkRecIndexes)
 		}
 	}
 

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -266,13 +266,15 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 }
 
 func PerformAggsOnRecs(nodeResult *structs.NodeResult, aggs *structs.QueryAggregators, recs map[string]map[string]interface{},
-	finalCols map[string]bool, numTotalSegments uint64, qid uint64) map[string]bool {
+	finalCols map[string]bool, numTotalSegments uint64, finishesSegment bool, qid uint64) map[string]bool {
 
 	if !nodeResult.PerformAggsOnRecs {
 		return nil
 	}
 
-	nodeResult.RecsAggsProcessedSegments++
+	if finishesSegment {
+		nodeResult.RecsAggsProcessedSegments++
+	}
 
 	if nodeResult.RecsAggsType == structs.GroupByType {
 		return PerformGroupByRequestAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments)
@@ -366,7 +368,7 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 		blockRes.AddMeasureResultsToKey(currKey, measureResults, "", false, qid)
 	}
 
-	if nodeResult.RecsAggsProcessedSegments == 1 {
+	if nodeResult.RecsAggsBlockResults == nil {
 		nodeResult.RecsAggsBlockResults = blockRes
 	} else {
 		recAggsBlockresults := nodeResult.RecsAggsBlockResults.(*blockresults.BlockResults)

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -193,7 +193,7 @@ func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators,
 		}
 	}
 	if qc.SizeLimit == math.MaxUint64 {
-		qc.SizeLimit = 1500000 // temp Fix: Will debug and remove it.
+		qc.SizeLimit = math.MaxInt64 // temp Fix: Will debug and remove it.
 	}
 	// if query aggregations exist, get all results then truncate after
 	nodeRes := query.ApplyFilterOperator(root, root.TimeRange, aggs, qid, qc)


### PR DESCRIPTION
# Description
This fixes an out-of-memory issue with some SPL queries, for example:
```
* | rex field=app_version "(?<major>\d+)\.(?<minor>\d).*" | stats count by major
```
Since we have to go through all the records for this type of query, we were using a lot of memory storing the records for each segment before we did the aggregation. With this PR, we now do the aggregation computation for each block within the segment, and merge the block aggregations into the segment aggregation, so we're able to significantly reduce memory usage because we don't need to store as many records at once.

The first 4-5 commits are just refactoring and shouldn't change any behavior. 
The main change is lines 334-341 in rrcreader.go, where instead of passing all the block indexes, we iterate over them and pass them one at a time, so that we do the aggregations on a per-block basis. Then the existing logic for merging aggregations across segments (220-256) handles the merging of aggregations across blocks.

# Testing
I tested manually with this query:
```
* | rex field=app_version "(?<major>\d+)\.(?<minor>\d).*" | stats count by major
```
I tested this in docker and ingested data into two segments. I also ran docker so that it was limited to 2GB of memory. Without these changes, the container was consuming too much memory so the docker daemon killed it. But with this PR it was able to release records soon enough that it could complete the query without causing an OOM crash. 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
