### PR TITLE
Return error on bad regex, instead of crashing

### DIFF
--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -69,6 +69,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 					compiledRegex, err := regexp.Compile(t)
 					if err != nil {
 						log.Errorf("qid=%d, ProcessSingleFilter: Failed to compile regex for %s. This may cause search failures. Err: %v", qid, t, err)
+						return nil, fmt.Errorf("Invalid regex: %s", t)
 					}
 					criteria := CreateTermFilterCriteria(colName, compiledRegex, opr, qid)
 					andFilterCondition = append(andFilterCondition, criteria)
@@ -97,6 +98,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 					compiledRegex, err := regexp.Compile(t)
 					if err != nil {
 						log.Errorf("ProcessSingleFilter: Failed to compile regex for %s. This may cause search failures. Err: %v", t, err)
+						return nil, fmt.Errorf("Invalid regex: %s", t)
 					}
 					criteria := CreateTermFilterCriteria(colName, compiledRegex, opr, qid)
 					andFilterCondition = append(andFilterCondition, criteria)

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -76,6 +76,9 @@ func CreateDtypeEnclosure(inVal interface{}, qid uint64) (*DtypeEnclosure, error
 			dte.SetRegexp(compiledRegex)
 		}
 	case *regexp.Regexp:
+		if inVal == nil {
+			return nil, errors.New("CreateDtypeEnclosure: inVal is nil Regexp")
+		}
 		dte.Dtype = SS_DT_STRING
 		dte.StringVal = inVal.String()
 		dte.SetRegexp(inVal)


### PR DESCRIPTION
# Description
Fix an issue where running a query with an invalid regex expression caused the server to crash.

Fixes #641 

# Testing
Ran this invalid regex query (it's invalid because of the `\` before `795`):
```
* | regex address="\795 North Plains view, Pittsburgh, Ohio 94834" | fields address
```
And I got this:
<img width="941" alt="image" src="https://github.com/siglens/siglens/assets/20426590/d8983bd9-3c53-4f15-b8d7-09ea201b4861">

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
