### PR TITLE
fix: timechart bucket index out of range

### DIFF
--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -37,6 +37,9 @@ func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) []uint64 {
 // Find correct time range bucket for timestamp
 func FindTimeRangeBucket(timePoints []uint64, timestamp uint64, intervalMillis uint64) uint64 {
 	index := ((timestamp - timePoints[0]) / intervalMillis)
+	if index >= uint64(len(timePoints)) {
+		index = uint64(len(timePoints) - 1)
+	}
 	return timePoints[index]
 }
 


### PR DESCRIPTION
# Description
Fixes the time chart panic error: index out of range. The time chart index is returning the index to be the same length as the time chart time points, which is causing the panic. I have made a condition to check to assign it to the last time bucket.

# Testing
- I have tested the query against the Localhost UI.
- Need to run this on Playground.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
