### PR TITLE
Fixed the SigClient cmd to use events instead of indices

### DIFF
--- a/tools/sigclient/README.md
+++ b/tools/sigclient/README.md
@@ -5,7 +5,7 @@
 ### ES Bulk
 To send ingestion traffic to a server using ES Bulk API:
 ```bash
-$ go run main.go ingest esbulk -n 10_000 -d http://localhost:8081/elastic -p 2
+$ go run main.go ingest esbulk -t 10_000 -d http://localhost:8081/elastic -p 2
 ```
 Options:
 ```


### PR DESCRIPTION
# Description
- The cmd on the SigClient readme sets to use `10_000` indices instead of events.
- I changed it to use events.



# Checklist:

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
