### PR TITLE
Bump SigLens version to 0.1.30 and add the suffix d

### DIFF
--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 package config
 
-const SigLensVersion = "0.1.29"
+const SigLensVersion = "0.1.30d"


### PR DESCRIPTION
# Description
- Incremented the Siglens version to 0.1.30
- Added the suffix `d`

# Checklist:

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
