### PR TITLE
Fix fields command without a groupby

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -266,11 +266,22 @@ RenamingLoop:
 
 		return nil
 	}
+
 	if colReq.ExcludeColumns != nil {
+		currentCols := make([]string, 0)
+		for col := range finalCols {
+			currentCols = append(currentCols, col)
+		}
+
+		// Handle wildcard matching.
+		matchingCols := make([]string, 0)
 		for _, excludeCol := range colReq.ExcludeColumns {
-			if _, exists := finalCols[excludeCol]; exists {
-				finalCols[excludeCol] = false
-			}
+			matchingCols = append(matchingCols, utils.SelectMatchingStringsWithWildcard(excludeCol, currentCols)...)
+		}
+
+		// Remove the matching columns.
+		for _, matchingCol := range matchingCols {
+			delete(finalCols, matchingCol)
 		}
 	}
 
@@ -279,14 +290,25 @@ RenamingLoop:
 			return errors.New("performColumnsRequest: finalCols is nil")
 		}
 
-		// Set everything to false first.
+		currentCols := make([]string, 0)
+		for col := range finalCols {
+			currentCols = append(currentCols, col)
+		}
+
+		// Handle wildcard matching.
+		matchingCols := make([]string, 0)
+		for _, includeCol := range colReq.IncludeColumns {
+			matchingCols = append(matchingCols, utils.SelectMatchingStringsWithWildcard(includeCol, currentCols)...)
+		}
+
+		// First remove everything.
 		for col := range finalCols {
 			delete(finalCols, col)
 		}
 
-		// Set the included columns to true.
-		for _, includeCol := range colReq.IncludeColumns {
-			finalCols[includeCol] = true
+		// Add the matching columns.
+		for _, matchingCol := range matchingCols {
+			finalCols[matchingCol] = true
 		}
 	}
 

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -267,11 +267,29 @@ RenamingLoop:
 		return nil
 	}
 	if colReq.ExcludeColumns != nil {
-		return errors.New("performColumnsRequest: processing ColumnsRequest.ExcludeColumns is not implemented")
+		for _, excludeCol := range colReq.ExcludeColumns {
+			if _, exists := finalCols[excludeCol]; exists {
+				finalCols[excludeCol] = false
+			}
+		}
 	}
+
 	if colReq.IncludeColumns != nil {
-		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeColumns is not implemented")
+		if finalCols == nil {
+			return errors.New("performColumnsRequest: finalCols is nil")
+		}
+
+		// Set everything to false first.
+		for col := range finalCols {
+			delete(finalCols, col)
+		}
+
+		// Set the included columns to true.
+		for _, includeCol := range colReq.IncludeColumns {
+			finalCols[includeCol] = true
+		}
 	}
+
 	if colReq.IncludeValues != nil {
 		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeValues is not implemented")
 	}

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -191,6 +191,33 @@ func performColumnsRequestWithoutGroupby(nodeResult *structs.NodeResult, colReq 
 		}
 	}
 
+	if colReq.ExcludeColumns != nil {
+		// Remove the specified columns, which may have wildcards.
+		matchingCols := getMatchingColumns(colReq.ExcludeColumns, finalCols)
+		for _, matchingCol := range matchingCols {
+			delete(finalCols, matchingCol)
+		}
+	}
+
+	if colReq.IncludeColumns != nil {
+		// Remove all columns except the specified ones, which may have wildcards.
+		if finalCols == nil {
+			return errors.New("performColumnsRequest: finalCols is nil")
+		}
+
+		matchingCols := getMatchingColumns(colReq.IncludeColumns, finalCols)
+
+		// First remove everything.
+		for col := range finalCols {
+			delete(finalCols, col)
+		}
+
+		// Add the matching columns.
+		for _, matchingCol := range matchingCols {
+			finalCols[matchingCol] = true
+		}
+	}
+
 	return nil
 }
 
@@ -268,32 +295,11 @@ RenamingLoop:
 	}
 
 	if colReq.ExcludeColumns != nil {
-		// Remove the specified columns, which may have wildcards.
-		matchingCols := getMatchingColumns(colReq.ExcludeColumns, finalCols)
-		for _, matchingCol := range matchingCols {
-			delete(finalCols, matchingCol)
-		}
+		return errors.New("performColumnsRequest: processing ColumnsRequest.ExcludeColumns is not implemented")
 	}
-
 	if colReq.IncludeColumns != nil {
-		// Remove all columns except the specified ones, which may have wildcards.
-		if finalCols == nil {
-			return errors.New("performColumnsRequest: finalCols is nil")
-		}
-
-		matchingCols := getMatchingColumns(colReq.IncludeColumns, finalCols)
-
-		// First remove everything.
-		for col := range finalCols {
-			delete(finalCols, col)
-		}
-
-		// Add the matching columns.
-		for _, matchingCol := range matchingCols {
-			finalCols[matchingCol] = true
-		}
+		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeColumns is not implemented")
 	}
-
 	if colReq.IncludeValues != nil {
 		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeValues is not implemented")
 	}

--- a/pkg/utils/stringutils.go
+++ b/pkg/utils/stringutils.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package utils
 
+import (
+	"regexp"
+	"strings"
+
+	"github.com/siglens/siglens/pkg/common/dtypeutils"
+	log "github.com/sirupsen/logrus"
+)
+
 // Converts a string like `This has "quotes"` to `This has \"quotes\"`
 func EscapeQuotes(s string) string {
 	result := ""
@@ -28,4 +36,29 @@ func EscapeQuotes(s string) string {
 	}
 
 	return result
+}
+
+// Return all strings in `slice` that match `s`, which may have wildcards.
+func SelectMatchingStringsWithWildcard(s string, slice []string) []string {
+	if strings.Contains(s, "*") {
+		s = dtypeutils.ReplaceWildcardStarWithRegex(s)
+	}
+
+	// We only want exact matches.
+	s = "^" + s + "$"
+
+	compiledRegex, err := regexp.Compile(s)
+	if err != nil {
+		log.Errorf("SelectMatchingStringsWithWildcard: regex compile failed: %v", err)
+		return nil
+	}
+
+	matches := make([]string, 0)
+	for _, potentialMatch := range slice {
+		if compiledRegex.MatchString(potentialMatch) {
+			matches = append(matches, potentialMatch)
+		}
+	}
+
+	return matches
 }


### PR DESCRIPTION
# Description
Implements the `fields` command for more use cases.

Now you should be able to use `fields` in any query except following a groupby clause. Handling it after a groupby clause will be a separate PR.

# Testing
Manually tested with:
```
* | eval rlatitude=round(latitude, 2) | fields rlatitude, latitude
* | eval rlatitude=round(latitude, 2) | fields *lat*
* | eval rlatitude=round(latitude, 2) | fields *lat* | fields - latency
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
