### PR TITLE
Fix Search traces with min/max duration with timeunits

### DIFF
--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -26,10 +26,10 @@ import (
 	"github.com/siglens/siglens/pkg/ast/spl"
 	"github.com/siglens/siglens/pkg/ast/sql"
 	"github.com/siglens/siglens/pkg/config"
-	"github.com/siglens/siglens/pkg/segment/aggregations"
 	"github.com/siglens/siglens/pkg/segment/query/metadata"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	. "github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/utils"
 
 	segment "github.com/siglens/siglens/pkg/segment"
 	. "github.com/siglens/siglens/pkg/segment/utils"
@@ -78,7 +78,7 @@ func ParseRequest(searchText string, startEpoch, endEpoch uint64, qid uint64, qu
 						return nil, nil, err
 					}
 					queryAggs.TimeHistogram.Timechart.BinOptions.SpanOptions = spanOptions
-					queryAggs.TimeHistogram.IntervalMillis = aggregations.GetIntervalInMillis(spanOptions.SpanLength.Num, spanOptions.SpanLength.TimeScalr)
+					queryAggs.TimeHistogram.IntervalMillis = utils.GetIntervalInMillis(spanOptions.SpanLength.Num, spanOptions.SpanLength.TimeScalr)
 				}
 				queryAggs.TimeHistogram.StartTime = startEpoch
 				queryAggs.TimeHistogram.EndTime = endEpoch

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -99,7 +99,7 @@ func deMorgansLaw(node *ast.Node) {
 	}
 }
 
-//Generate NumericExpr struct for eval functions
+// Generate NumericExpr struct for eval functions
 func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNumericExpr *structs.NumericExpr, numericExprMode structs.NumericExprMode) (*structs.NumericExpr, error) {
 	if leftNumericExpr == nil {
 		return nil, fmt.Errorf("expr cannot be nil")
@@ -5493,10 +5493,14 @@ var g = &grammar{
 						alternatives: []any{
 							&ruleRefExpr{
 								pos:  position{line: 2187, col: 39, offset: 63251},
+								name: "NamedFieldWithTimeDurationValue",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 2187, col: 73, offset: 63285},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2187, col: 67, offset: 63279},
+								pos:  position{line: 2187, col: 101, offset: 63313},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -5506,34 +5510,34 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 2191, col: 1, offset: 63342},
+			pos:  position{line: 2191, col: 1, offset: 63376},
 			expr: &actionExpr{
-				pos: position{line: 2191, col: 30, offset: 63371},
+				pos: position{line: 2191, col: 30, offset: 63405},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 2191, col: 30, offset: 63371},
+					pos: position{line: 2191, col: 30, offset: 63405},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2191, col: 30, offset: 63371},
+							pos:   position{line: 2191, col: 30, offset: 63405},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2191, col: 34, offset: 63375},
+								pos:  position{line: 2191, col: 34, offset: 63409},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2191, col: 44, offset: 63385},
+							pos:   position{line: 2191, col: 44, offset: 63419},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2191, col: 47, offset: 63388},
+								pos:  position{line: 2191, col: 47, offset: 63422},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2191, col: 64, offset: 63405},
+							pos:   position{line: 2191, col: 64, offset: 63439},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2191, col: 70, offset: 63411},
+								pos:  position{line: 2191, col: 70, offset: 63445},
 								name: "String",
 							},
 						},
@@ -5542,16 +5546,62 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 2203, col: 1, offset: 63644},
+			name: "NamedFieldWithTimeDurationValue",
+			pos:  position{line: 2203, col: 1, offset: 63678},
 			expr: &actionExpr{
-				pos: position{line: 2203, col: 32, offset: 63675},
+				pos: position{line: 2203, col: 36, offset: 63713},
+				run: (*parser).callonNamedFieldWithTimeDurationValue1,
+				expr: &seqExpr{
+					pos: position{line: 2203, col: 36, offset: 63713},
+					exprs: []any{
+						&labeledExpr{
+							pos:   position{line: 2203, col: 36, offset: 63713},
+							label: "key",
+							expr: &ruleRefExpr{
+								pos:  position{line: 2203, col: 40, offset: 63717},
+								name: "FieldName",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 2203, col: 50, offset: 63727},
+							label: "op",
+							expr: &choiceExpr{
+								pos: position{line: 2203, col: 54, offset: 63731},
+								alternatives: []any{
+									&ruleRefExpr{
+										pos:  position{line: 2203, col: 54, offset: 63731},
+										name: "EqualityOperator",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 2203, col: 73, offset: 63750},
+										name: "InequalityOperator",
+									},
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 2203, col: 93, offset: 63770},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 2203, col: 99, offset: 63776},
+								name: "TimeDuration",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UnnamedFieldWithStringValue",
+			pos:  position{line: 2215, col: 1, offset: 64145},
+			expr: &actionExpr{
+				pos: position{line: 2215, col: 32, offset: 64176},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2203, col: 32, offset: 63675},
+					pos:   position{line: 2215, col: 32, offset: 64176},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2203, col: 38, offset: 63681},
+						pos:  position{line: 2215, col: 38, offset: 64182},
 						name: "String",
 					},
 				},
@@ -5559,35 +5609,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 2217, col: 1, offset: 64012},
+			pos:  position{line: 2229, col: 1, offset: 64513},
 			expr: &actionExpr{
-				pos: position{line: 2217, col: 18, offset: 64029},
+				pos: position{line: 2229, col: 18, offset: 64530},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2217, col: 18, offset: 64029},
+					pos: position{line: 2229, col: 18, offset: 64530},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2217, col: 18, offset: 64029},
+							pos:   position{line: 2229, col: 18, offset: 64530},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2217, col: 24, offset: 64035},
+								pos:  position{line: 2229, col: 24, offset: 64536},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2217, col: 34, offset: 64045},
+							pos:   position{line: 2229, col: 34, offset: 64546},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2217, col: 39, offset: 64050},
+								pos: position{line: 2229, col: 39, offset: 64551},
 								expr: &seqExpr{
-									pos: position{line: 2217, col: 40, offset: 64051},
+									pos: position{line: 2229, col: 40, offset: 64552},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2217, col: 40, offset: 64051},
+											pos:  position{line: 2229, col: 40, offset: 64552},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2217, col: 46, offset: 64057},
+											pos:  position{line: 2229, col: 46, offset: 64558},
 											name: "FieldName",
 										},
 									},
@@ -5600,15 +5650,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 2237, col: 1, offset: 64820},
+			pos:  position{line: 2249, col: 1, offset: 65321},
 			expr: &actionExpr{
-				pos: position{line: 2237, col: 14, offset: 64833},
+				pos: position{line: 2249, col: 14, offset: 65334},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2237, col: 14, offset: 64833},
+					pos: position{line: 2249, col: 14, offset: 65334},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 2237, col: 14, offset: 64833},
+							pos:        position{line: 2249, col: 14, offset: 65334},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -5616,9 +5666,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2237, col: 27, offset: 64846},
+							pos: position{line: 2249, col: 27, offset: 65347},
 							expr: &charClassMatcher{
-								pos:        position{line: 2237, col: 27, offset: 64846},
+								pos:        position{line: 2249, col: 27, offset: 65347},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -5632,22 +5682,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 2241, col: 1, offset: 64899},
+			pos:  position{line: 2253, col: 1, offset: 65400},
 			expr: &actionExpr{
-				pos: position{line: 2241, col: 11, offset: 64909},
+				pos: position{line: 2253, col: 11, offset: 65410},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2241, col: 11, offset: 64909},
+					pos:   position{line: 2253, col: 11, offset: 65410},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 2241, col: 16, offset: 64914},
+						pos: position{line: 2253, col: 16, offset: 65415},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2241, col: 16, offset: 64914},
+								pos:  position{line: 2253, col: 16, offset: 65415},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2241, col: 31, offset: 64929},
+								pos:  position{line: 2253, col: 31, offset: 65430},
 								name: "UnquotedString",
 							},
 						},
@@ -5657,23 +5707,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 2245, col: 1, offset: 64970},
+			pos:  position{line: 2257, col: 1, offset: 65471},
 			expr: &actionExpr{
-				pos: position{line: 2245, col: 17, offset: 64986},
+				pos: position{line: 2257, col: 17, offset: 65487},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 2245, col: 17, offset: 64986},
+					pos: position{line: 2257, col: 17, offset: 65487},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2245, col: 17, offset: 64986},
+							pos:        position{line: 2257, col: 17, offset: 65487},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2245, col: 21, offset: 64990},
+							pos: position{line: 2257, col: 21, offset: 65491},
 							expr: &charClassMatcher{
-								pos:        position{line: 2245, col: 21, offset: 64990},
+								pos:        position{line: 2257, col: 21, offset: 65491},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -5681,7 +5731,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2245, col: 27, offset: 64996},
+							pos:        position{line: 2257, col: 27, offset: 65497},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -5692,21 +5742,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 2250, col: 1, offset: 65107},
+			pos:  position{line: 2262, col: 1, offset: 65608},
 			expr: &actionExpr{
-				pos: position{line: 2250, col: 12, offset: 65118},
+				pos: position{line: 2262, col: 12, offset: 65619},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 2250, col: 13, offset: 65119},
+					pos: position{line: 2262, col: 13, offset: 65620},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2250, col: 13, offset: 65119},
+							pos:        position{line: 2262, col: 13, offset: 65620},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2250, col: 22, offset: 65128},
+							pos:        position{line: 2262, col: 22, offset: 65629},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -5717,42 +5767,42 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 2255, col: 1, offset: 65222},
+			pos:  position{line: 2267, col: 1, offset: 65723},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 19, offset: 65240},
+				pos: position{line: 2267, col: 19, offset: 65741},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2255, col: 19, offset: 65240},
+					pos: position{line: 2267, col: 19, offset: 65741},
 					expr: &choiceExpr{
-						pos: position{line: 2255, col: 20, offset: 65241},
+						pos: position{line: 2267, col: 20, offset: 65742},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2255, col: 20, offset: 65241},
+								pos:        position{line: 2267, col: 20, offset: 65742},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 2255, col: 27, offset: 65248},
+								pos: position{line: 2267, col: 27, offset: 65749},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 2255, col: 27, offset: 65248},
+										pos: position{line: 2267, col: 27, offset: 65749},
 										expr: &choiceExpr{
-											pos: position{line: 2255, col: 29, offset: 65250},
+											pos: position{line: 2267, col: 29, offset: 65751},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2255, col: 29, offset: 65250},
+													pos:  position{line: 2267, col: 29, offset: 65751},
 													name: "MAJOR_BREAK",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2255, col: 43, offset: 65264},
+													pos:  position{line: 2267, col: 43, offset: 65765},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 2255, col: 48, offset: 65269,
+										line: 2267, col: 48, offset: 65770,
 									},
 								},
 							},
@@ -5763,14 +5813,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 2262, col: 1, offset: 65443},
+			pos:  position{line: 2274, col: 1, offset: 65944},
 			expr: &actionExpr{
-				pos: position{line: 2262, col: 18, offset: 65460},
+				pos: position{line: 2274, col: 18, offset: 65961},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 2262, col: 18, offset: 65460},
+					pos: position{line: 2274, col: 18, offset: 65961},
 					expr: &charClassMatcher{
-						pos:        position{line: 2262, col: 18, offset: 65460},
+						pos:        position{line: 2274, col: 18, offset: 65961},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -5782,15 +5832,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 2266, col: 1, offset: 65511},
+			pos:  position{line: 2278, col: 1, offset: 66012},
 			expr: &actionExpr{
-				pos: position{line: 2266, col: 11, offset: 65521},
+				pos: position{line: 2278, col: 11, offset: 66022},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 2266, col: 11, offset: 65521},
+					pos:   position{line: 2278, col: 11, offset: 66022},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2266, col: 18, offset: 65528},
+						pos:  position{line: 2278, col: 18, offset: 66029},
 						name: "NumberAsString",
 					},
 				},
@@ -5798,53 +5848,53 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 2272, col: 1, offset: 65717},
+			pos:  position{line: 2284, col: 1, offset: 66218},
 			expr: &actionExpr{
-				pos: position{line: 2272, col: 19, offset: 65735},
+				pos: position{line: 2284, col: 19, offset: 66236},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 2272, col: 19, offset: 65735},
+					pos: position{line: 2284, col: 19, offset: 66236},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2272, col: 19, offset: 65735},
+							pos:   position{line: 2284, col: 19, offset: 66236},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 2272, col: 27, offset: 65743},
+								pos: position{line: 2284, col: 27, offset: 66244},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2272, col: 27, offset: 65743},
+										pos:  position{line: 2284, col: 27, offset: 66244},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2272, col: 43, offset: 65759},
+										pos:  position{line: 2284, col: 43, offset: 66260},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 2272, col: 60, offset: 65776},
+							pos: position{line: 2284, col: 60, offset: 66277},
 							expr: &choiceExpr{
-								pos: position{line: 2272, col: 62, offset: 65778},
+								pos: position{line: 2284, col: 62, offset: 66279},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2272, col: 62, offset: 65778},
+										pos:  position{line: 2284, col: 62, offset: 66279},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 2272, col: 70, offset: 65786},
+										pos:        position{line: 2284, col: 70, offset: 66287},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2272, col: 76, offset: 65792},
+										pos:        position{line: 2284, col: 76, offset: 66293},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2272, col: 82, offset: 65798},
+										pos:  position{line: 2284, col: 82, offset: 66299},
 										name: "EOF",
 									},
 								},
@@ -5856,17 +5906,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 2278, col: 1, offset: 65927},
+			pos:  position{line: 2290, col: 1, offset: 66428},
 			expr: &actionExpr{
-				pos: position{line: 2278, col: 18, offset: 65944},
+				pos: position{line: 2290, col: 18, offset: 66445},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 2278, col: 18, offset: 65944},
+					pos: position{line: 2290, col: 18, offset: 66445},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2278, col: 18, offset: 65944},
+							pos: position{line: 2290, col: 18, offset: 66445},
 							expr: &charClassMatcher{
-								pos:        position{line: 2278, col: 18, offset: 65944},
+								pos:        position{line: 2290, col: 18, offset: 66445},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -5874,9 +5924,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2278, col: 24, offset: 65950},
+							pos: position{line: 2290, col: 24, offset: 66451},
 							expr: &charClassMatcher{
-								pos:        position{line: 2278, col: 24, offset: 65950},
+								pos:        position{line: 2290, col: 24, offset: 66451},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5884,15 +5934,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2278, col: 31, offset: 65957},
+							pos:        position{line: 2290, col: 31, offset: 66458},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 2278, col: 35, offset: 65961},
+							pos: position{line: 2290, col: 35, offset: 66462},
 							expr: &charClassMatcher{
-								pos:        position{line: 2278, col: 35, offset: 65961},
+								pos:        position{line: 2290, col: 35, offset: 66462},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5905,17 +5955,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 2283, col: 1, offset: 66056},
+			pos:  position{line: 2295, col: 1, offset: 66557},
 			expr: &actionExpr{
-				pos: position{line: 2283, col: 20, offset: 66075},
+				pos: position{line: 2295, col: 20, offset: 66576},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 2283, col: 20, offset: 66075},
+					pos: position{line: 2295, col: 20, offset: 66576},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2283, col: 20, offset: 66075},
+							pos: position{line: 2295, col: 20, offset: 66576},
 							expr: &charClassMatcher{
-								pos:        position{line: 2283, col: 20, offset: 66075},
+								pos:        position{line: 2295, col: 20, offset: 66576},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -5923,9 +5973,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 2283, col: 26, offset: 66081},
+							pos: position{line: 2295, col: 26, offset: 66582},
 							expr: &charClassMatcher{
-								pos:        position{line: 2283, col: 26, offset: 66081},
+								pos:        position{line: 2295, col: 26, offset: 66582},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -5937,32 +5987,100 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "EqualityOperator",
-			pos:  position{line: 2287, col: 1, offset: 66124},
+			name: "TimeDuration",
+			pos:  position{line: 2299, col: 1, offset: 66625},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 21, offset: 66144},
+				pos: position{line: 2299, col: 17, offset: 66641},
+				run: (*parser).callonTimeDuration1,
+				expr: &seqExpr{
+					pos: position{line: 2299, col: 17, offset: 66641},
+					exprs: []any{
+						&labeledExpr{
+							pos:   position{line: 2299, col: 17, offset: 66641},
+							label: "value",
+							expr: &oneOrMoreExpr{
+								pos: position{line: 2299, col: 23, offset: 66647},
+								expr: &choiceExpr{
+									pos: position{line: 2299, col: 24, offset: 66648},
+									alternatives: []any{
+										&ruleRefExpr{
+											pos:  position{line: 2299, col: 24, offset: 66648},
+											name: "FloatAsString",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 2299, col: 40, offset: 66664},
+											name: "IntegerAsString",
+										},
+									},
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 2299, col: 58, offset: 66682},
+							label: "timeUnit",
+							expr: &choiceExpr{
+								pos: position{line: 2299, col: 68, offset: 66692},
+								alternatives: []any{
+									&ruleRefExpr{
+										pos:  position{line: 2299, col: 68, offset: 66692},
+										name: "Subseconds",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 2299, col: 81, offset: 66705},
+										name: "Second",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 2299, col: 89, offset: 66713},
+										name: "Minute",
+									},
+								},
+							},
+						},
+						&notExpr{
+							pos: position{line: 2299, col: 97, offset: 66721},
+							expr: &ruleRefExpr{
+								pos:  position{line: 2299, col: 98, offset: 66722},
+								name: "String",
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 2299, col: 105, offset: 66729},
+							expr: &ruleRefExpr{
+								pos:  position{line: 2299, col: 105, offset: 66729},
+								name: "EOF",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "EqualityOperator",
+			pos:  position{line: 2317, col: 1, offset: 67270},
+			expr: &actionExpr{
+				pos: position{line: 2317, col: 21, offset: 67290},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 21, offset: 66144},
+					pos: position{line: 2317, col: 21, offset: 67290},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2287, col: 21, offset: 66144},
+							pos:  position{line: 2317, col: 21, offset: 67290},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2287, col: 36, offset: 66159},
+							pos:   position{line: 2317, col: 36, offset: 67305},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2287, col: 40, offset: 66163},
+								pos: position{line: 2317, col: 40, offset: 67309},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2287, col: 40, offset: 66163},
+										pos:        position{line: 2317, col: 40, offset: 67309},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2287, col: 46, offset: 66169},
+										pos:        position{line: 2317, col: 46, offset: 67315},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -5971,7 +6089,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2287, col: 52, offset: 66175},
+							pos:  position{line: 2317, col: 52, offset: 67321},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -5980,43 +6098,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 2295, col: 1, offset: 66356},
+			pos:  position{line: 2325, col: 1, offset: 67502},
 			expr: &actionExpr{
-				pos: position{line: 2295, col: 23, offset: 66378},
+				pos: position{line: 2325, col: 23, offset: 67524},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 2295, col: 23, offset: 66378},
+					pos: position{line: 2325, col: 23, offset: 67524},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2295, col: 23, offset: 66378},
+							pos:  position{line: 2325, col: 23, offset: 67524},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2295, col: 38, offset: 66393},
+							pos:   position{line: 2325, col: 38, offset: 67539},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2295, col: 42, offset: 66397},
+								pos: position{line: 2325, col: 42, offset: 67543},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2295, col: 42, offset: 66397},
+										pos:        position{line: 2325, col: 42, offset: 67543},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2295, col: 49, offset: 66404},
+										pos:        position{line: 2325, col: 49, offset: 67550},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2295, col: 55, offset: 66410},
+										pos:        position{line: 2325, col: 55, offset: 67556},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2295, col: 62, offset: 66417},
+										pos:        position{line: 2325, col: 62, offset: 67563},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -6025,7 +6143,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2295, col: 67, offset: 66422},
+							pos:  position{line: 2325, col: 67, offset: 67568},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -6034,30 +6152,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 2303, col: 1, offset: 66605},
+			pos:  position{line: 2333, col: 1, offset: 67751},
 			expr: &choiceExpr{
-				pos: position{line: 2303, col: 25, offset: 66629},
+				pos: position{line: 2333, col: 25, offset: 67775},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2303, col: 25, offset: 66629},
+						pos: position{line: 2333, col: 25, offset: 67775},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 2303, col: 25, offset: 66629},
+							pos:   position{line: 2333, col: 25, offset: 67775},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2303, col: 28, offset: 66632},
+								pos:  position{line: 2333, col: 28, offset: 67778},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2306, col: 3, offset: 66674},
+						pos: position{line: 2336, col: 3, offset: 67820},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 2306, col: 3, offset: 66674},
+							pos:   position{line: 2336, col: 3, offset: 67820},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2306, col: 6, offset: 66677},
+								pos:  position{line: 2336, col: 6, offset: 67823},
 								name: "InequalityOperator",
 							},
 						},
@@ -6067,25 +6185,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 2310, col: 1, offset: 66720},
+			pos:  position{line: 2340, col: 1, offset: 67866},
 			expr: &actionExpr{
-				pos: position{line: 2310, col: 11, offset: 66730},
+				pos: position{line: 2340, col: 11, offset: 67876},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 2310, col: 11, offset: 66730},
+					pos: position{line: 2340, col: 11, offset: 67876},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2310, col: 11, offset: 66730},
+							pos:  position{line: 2340, col: 11, offset: 67876},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2310, col: 26, offset: 66745},
+							pos:        position{line: 2340, col: 26, offset: 67891},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2310, col: 30, offset: 66749},
+							pos:  position{line: 2340, col: 30, offset: 67895},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -6094,25 +6212,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 2314, col: 1, offset: 66789},
+			pos:  position{line: 2344, col: 1, offset: 67935},
 			expr: &actionExpr{
-				pos: position{line: 2314, col: 12, offset: 66800},
+				pos: position{line: 2344, col: 12, offset: 67946},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 2314, col: 12, offset: 66800},
+					pos: position{line: 2344, col: 12, offset: 67946},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 12, offset: 66800},
+							pos:  position{line: 2344, col: 12, offset: 67946},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2314, col: 27, offset: 66815},
+							pos:        position{line: 2344, col: 27, offset: 67961},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 31, offset: 66819},
+							pos:  position{line: 2344, col: 31, offset: 67965},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -6121,25 +6239,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 2318, col: 1, offset: 66859},
+			pos:  position{line: 2348, col: 1, offset: 68005},
 			expr: &actionExpr{
-				pos: position{line: 2318, col: 10, offset: 66868},
+				pos: position{line: 2348, col: 10, offset: 68014},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 2318, col: 10, offset: 66868},
+					pos: position{line: 2348, col: 10, offset: 68014},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2318, col: 10, offset: 66868},
+							pos:  position{line: 2348, col: 10, offset: 68014},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2318, col: 25, offset: 66883},
+							pos:        position{line: 2348, col: 25, offset: 68029},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2318, col: 29, offset: 66887},
+							pos:  position{line: 2348, col: 29, offset: 68033},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -6148,25 +6266,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 2322, col: 1, offset: 66927},
+			pos:  position{line: 2352, col: 1, offset: 68073},
 			expr: &actionExpr{
-				pos: position{line: 2322, col: 10, offset: 66936},
+				pos: position{line: 2352, col: 10, offset: 68082},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 2322, col: 10, offset: 66936},
+					pos: position{line: 2352, col: 10, offset: 68082},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2322, col: 10, offset: 66936},
+							pos:  position{line: 2352, col: 10, offset: 68082},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2322, col: 25, offset: 66951},
+							pos:        position{line: 2352, col: 25, offset: 68097},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2322, col: 29, offset: 66955},
+							pos:  position{line: 2352, col: 29, offset: 68101},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -6175,39 +6293,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 2327, col: 1, offset: 67019},
+			pos:  position{line: 2357, col: 1, offset: 68165},
 			expr: &actionExpr{
-				pos: position{line: 2327, col: 11, offset: 67029},
+				pos: position{line: 2357, col: 11, offset: 68175},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 2327, col: 12, offset: 67030},
+					pos: position{line: 2357, col: 12, offset: 68176},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2327, col: 12, offset: 67030},
+							pos:        position{line: 2357, col: 12, offset: 68176},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2327, col: 24, offset: 67042},
+							pos:        position{line: 2357, col: 24, offset: 68188},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2327, col: 35, offset: 67053},
+							pos:        position{line: 2357, col: 35, offset: 68199},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2327, col: 44, offset: 67062},
+							pos:        position{line: 2357, col: 44, offset: 68208},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2327, col: 52, offset: 67070},
+							pos:        position{line: 2357, col: 52, offset: 68216},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -6218,39 +6336,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 2331, col: 1, offset: 67111},
+			pos:  position{line: 2361, col: 1, offset: 68257},
 			expr: &actionExpr{
-				pos: position{line: 2331, col: 11, offset: 67121},
+				pos: position{line: 2361, col: 11, offset: 68267},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 2331, col: 12, offset: 67122},
+					pos: position{line: 2361, col: 12, offset: 68268},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2331, col: 12, offset: 67122},
+							pos:        position{line: 2361, col: 12, offset: 68268},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2331, col: 24, offset: 67134},
+							pos:        position{line: 2361, col: 24, offset: 68280},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2331, col: 35, offset: 67145},
+							pos:        position{line: 2361, col: 35, offset: 68291},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2331, col: 44, offset: 67154},
+							pos:        position{line: 2361, col: 44, offset: 68300},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2331, col: 52, offset: 67162},
+							pos:        position{line: 2361, col: 52, offset: 68308},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -6261,39 +6379,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 2335, col: 1, offset: 67203},
+			pos:  position{line: 2365, col: 1, offset: 68349},
 			expr: &actionExpr{
-				pos: position{line: 2335, col: 9, offset: 67211},
+				pos: position{line: 2365, col: 9, offset: 68357},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 2335, col: 10, offset: 67212},
+					pos: position{line: 2365, col: 10, offset: 68358},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2335, col: 10, offset: 67212},
+							pos:        position{line: 2365, col: 10, offset: 68358},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2335, col: 20, offset: 67222},
+							pos:        position{line: 2365, col: 20, offset: 68368},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2335, col: 29, offset: 67231},
+							pos:        position{line: 2365, col: 29, offset: 68377},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2335, col: 37, offset: 67239},
+							pos:        position{line: 2365, col: 37, offset: 68385},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2335, col: 44, offset: 67246},
+							pos:        position{line: 2365, col: 44, offset: 68392},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -6304,27 +6422,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 2339, col: 1, offset: 67285},
+			pos:  position{line: 2369, col: 1, offset: 68431},
 			expr: &actionExpr{
-				pos: position{line: 2339, col: 8, offset: 67292},
+				pos: position{line: 2369, col: 8, offset: 68438},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 2339, col: 9, offset: 67293},
+					pos: position{line: 2369, col: 9, offset: 68439},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2339, col: 9, offset: 67293},
+							pos:        position{line: 2369, col: 9, offset: 68439},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2339, col: 18, offset: 67302},
+							pos:        position{line: 2369, col: 18, offset: 68448},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2339, col: 26, offset: 67310},
+							pos:        position{line: 2369, col: 26, offset: 68456},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -6335,27 +6453,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 2343, col: 1, offset: 67348},
+			pos:  position{line: 2373, col: 1, offset: 68494},
 			expr: &actionExpr{
-				pos: position{line: 2343, col: 9, offset: 67356},
+				pos: position{line: 2373, col: 9, offset: 68502},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 2343, col: 10, offset: 67357},
+					pos: position{line: 2373, col: 10, offset: 68503},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2343, col: 10, offset: 67357},
+							pos:        position{line: 2373, col: 10, offset: 68503},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2343, col: 20, offset: 67367},
+							pos:        position{line: 2373, col: 20, offset: 68513},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2343, col: 29, offset: 67376},
+							pos:        position{line: 2373, col: 29, offset: 68522},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -6366,27 +6484,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 2347, col: 1, offset: 67415},
+			pos:  position{line: 2377, col: 1, offset: 68561},
 			expr: &actionExpr{
-				pos: position{line: 2347, col: 10, offset: 67424},
+				pos: position{line: 2377, col: 10, offset: 68570},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 2347, col: 11, offset: 67425},
+					pos: position{line: 2377, col: 11, offset: 68571},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2347, col: 11, offset: 67425},
+							pos:        position{line: 2377, col: 11, offset: 68571},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2347, col: 22, offset: 67436},
+							pos:        position{line: 2377, col: 22, offset: 68582},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2347, col: 32, offset: 67446},
+							pos:        position{line: 2377, col: 32, offset: 68592},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -6397,39 +6515,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 2351, col: 1, offset: 67488},
+			pos:  position{line: 2381, col: 1, offset: 68634},
 			expr: &actionExpr{
-				pos: position{line: 2351, col: 12, offset: 67499},
+				pos: position{line: 2381, col: 12, offset: 68645},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 2351, col: 13, offset: 67500},
+					pos: position{line: 2381, col: 13, offset: 68646},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2351, col: 13, offset: 67500},
+							pos:        position{line: 2381, col: 13, offset: 68646},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2351, col: 26, offset: 67513},
+							pos:        position{line: 2381, col: 26, offset: 68659},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2351, col: 38, offset: 67525},
+							pos:        position{line: 2381, col: 38, offset: 68671},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2351, col: 47, offset: 67534},
+							pos:        position{line: 2381, col: 47, offset: 68680},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2351, col: 55, offset: 67542},
+							pos:        position{line: 2381, col: 55, offset: 68688},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -6440,33 +6558,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 2356, col: 1, offset: 67676},
+			pos:  position{line: 2386, col: 1, offset: 68822},
 			expr: &actionExpr{
-				pos: position{line: 2356, col: 15, offset: 67690},
+				pos: position{line: 2386, col: 15, offset: 68836},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 2356, col: 16, offset: 67691},
+					pos: position{line: 2386, col: 16, offset: 68837},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 2356, col: 16, offset: 67691},
+							pos:        position{line: 2386, col: 16, offset: 68837},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2356, col: 23, offset: 67698},
+							pos:        position{line: 2386, col: 23, offset: 68844},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2356, col: 30, offset: 67705},
+							pos:        position{line: 2386, col: 30, offset: 68851},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 2356, col: 37, offset: 67712},
+							pos:        position{line: 2386, col: 37, offset: 68858},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -6477,26 +6595,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 2365, col: 1, offset: 67935},
+			pos:  position{line: 2395, col: 1, offset: 69081},
 			expr: &actionExpr{
-				pos: position{line: 2365, col: 21, offset: 67955},
+				pos: position{line: 2395, col: 21, offset: 69101},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2365, col: 21, offset: 67955},
+					pos: position{line: 2395, col: 21, offset: 69101},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2365, col: 21, offset: 67955},
+							pos:  position{line: 2395, col: 21, offset: 69101},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2365, col: 26, offset: 67960},
+							pos:  position{line: 2395, col: 26, offset: 69106},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 2365, col: 42, offset: 67976},
+							pos:   position{line: 2395, col: 42, offset: 69122},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2365, col: 53, offset: 67987},
+								pos:  position{line: 2395, col: 53, offset: 69133},
 								name: "TransactionOptions",
 							},
 						},
@@ -6506,17 +6624,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 2374, col: 1, offset: 68293},
+			pos:  position{line: 2404, col: 1, offset: 69439},
 			expr: &actionExpr{
-				pos: position{line: 2374, col: 23, offset: 68315},
+				pos: position{line: 2404, col: 23, offset: 69461},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2374, col: 23, offset: 68315},
+					pos:   position{line: 2404, col: 23, offset: 69461},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 2374, col: 34, offset: 68326},
+						pos: position{line: 2404, col: 34, offset: 69472},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2374, col: 34, offset: 68326},
+							pos:  position{line: 2404, col: 34, offset: 69472},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -6525,35 +6643,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 2389, col: 1, offset: 68717},
+			pos:  position{line: 2419, col: 1, offset: 69863},
 			expr: &actionExpr{
-				pos: position{line: 2389, col: 37, offset: 68753},
+				pos: position{line: 2419, col: 37, offset: 69899},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 2389, col: 37, offset: 68753},
+					pos: position{line: 2419, col: 37, offset: 69899},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2389, col: 37, offset: 68753},
+							pos:   position{line: 2419, col: 37, offset: 69899},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2389, col: 43, offset: 68759},
+								pos:  position{line: 2419, col: 43, offset: 69905},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2389, col: 71, offset: 68787},
+							pos:   position{line: 2419, col: 71, offset: 69933},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2389, col: 76, offset: 68792},
+								pos: position{line: 2419, col: 76, offset: 69938},
 								expr: &seqExpr{
-									pos: position{line: 2389, col: 77, offset: 68793},
+									pos: position{line: 2419, col: 77, offset: 69939},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2389, col: 77, offset: 68793},
+											pos:  position{line: 2419, col: 77, offset: 69939},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2389, col: 83, offset: 68799},
+											pos:  position{line: 2419, col: 83, offset: 69945},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -6566,26 +6684,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 2424, col: 1, offset: 69788},
+			pos:  position{line: 2454, col: 1, offset: 70934},
 			expr: &actionExpr{
-				pos: position{line: 2424, col: 32, offset: 69819},
+				pos: position{line: 2454, col: 32, offset: 70965},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 2424, col: 32, offset: 69819},
+					pos:   position{line: 2454, col: 32, offset: 70965},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2424, col: 40, offset: 69827},
+						pos: position{line: 2454, col: 40, offset: 70973},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2424, col: 40, offset: 69827},
+								pos:  position{line: 2454, col: 40, offset: 70973},
 								name: "SpaceSeparatedFieldNameList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2424, col: 70, offset: 69857},
+								pos:  position{line: 2454, col: 70, offset: 71003},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2424, col: 89, offset: 69876},
+								pos:  position{line: 2454, col: 89, offset: 71022},
 								name: "EndsWithOption",
 							},
 						},
@@ -6595,48 +6713,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2430, col: 1, offset: 70022},
+			pos:  position{line: 2460, col: 1, offset: 71168},
 			expr: &actionExpr{
-				pos: position{line: 2430, col: 32, offset: 70053},
+				pos: position{line: 2460, col: 32, offset: 71199},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2430, col: 32, offset: 70053},
+					pos: position{line: 2460, col: 32, offset: 71199},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2430, col: 32, offset: 70053},
+							pos:   position{line: 2460, col: 32, offset: 71199},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2430, col: 38, offset: 70059},
+								pos:  position{line: 2460, col: 38, offset: 71205},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2430, col: 48, offset: 70069},
+							pos: position{line: 2460, col: 48, offset: 71215},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2430, col: 50, offset: 70071},
+								pos:  position{line: 2460, col: 50, offset: 71217},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2430, col: 57, offset: 70078},
+							pos:   position{line: 2460, col: 57, offset: 71224},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2430, col: 62, offset: 70083},
+								pos: position{line: 2460, col: 62, offset: 71229},
 								expr: &seqExpr{
-									pos: position{line: 2430, col: 63, offset: 70084},
+									pos: position{line: 2460, col: 63, offset: 71230},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2430, col: 63, offset: 70084},
+											pos:  position{line: 2460, col: 63, offset: 71230},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2430, col: 69, offset: 70090},
+											pos:  position{line: 2460, col: 69, offset: 71236},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2430, col: 79, offset: 70100},
+											pos: position{line: 2460, col: 79, offset: 71246},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2430, col: 81, offset: 70102},
+												pos:  position{line: 2460, col: 81, offset: 71248},
 												name: "EQUAL",
 											},
 										},
@@ -6650,28 +6768,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 2448, col: 1, offset: 70526},
+			pos:  position{line: 2478, col: 1, offset: 71672},
 			expr: &actionExpr{
-				pos: position{line: 2448, col: 21, offset: 70546},
+				pos: position{line: 2478, col: 21, offset: 71692},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 2448, col: 21, offset: 70546},
+					pos: position{line: 2478, col: 21, offset: 71692},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2448, col: 21, offset: 70546},
+							pos:        position{line: 2478, col: 21, offset: 71692},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2448, col: 34, offset: 70559},
+							pos:  position{line: 2478, col: 34, offset: 71705},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2448, col: 40, offset: 70565},
+							pos:   position{line: 2478, col: 40, offset: 71711},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2448, col: 48, offset: 70573},
+								pos:  position{line: 2478, col: 48, offset: 71719},
 								name: "TransactionFilterString",
 							},
 						},
@@ -6681,28 +6799,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 2458, col: 1, offset: 70811},
+			pos:  position{line: 2488, col: 1, offset: 71957},
 			expr: &actionExpr{
-				pos: position{line: 2458, col: 19, offset: 70829},
+				pos: position{line: 2488, col: 19, offset: 71975},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 2458, col: 19, offset: 70829},
+					pos: position{line: 2488, col: 19, offset: 71975},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2458, col: 19, offset: 70829},
+							pos:        position{line: 2488, col: 19, offset: 71975},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2458, col: 30, offset: 70840},
+							pos:  position{line: 2488, col: 30, offset: 71986},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2458, col: 36, offset: 70846},
+							pos:   position{line: 2488, col: 36, offset: 71992},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2458, col: 44, offset: 70854},
+								pos:  position{line: 2488, col: 44, offset: 72000},
 								name: "TransactionFilterString",
 							},
 						},
@@ -6712,26 +6830,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 2469, col: 1, offset: 71123},
+			pos:  position{line: 2499, col: 1, offset: 72269},
 			expr: &actionExpr{
-				pos: position{line: 2469, col: 28, offset: 71150},
+				pos: position{line: 2499, col: 28, offset: 72296},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2469, col: 28, offset: 71150},
+					pos:   position{line: 2499, col: 28, offset: 72296},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2469, col: 37, offset: 71159},
+						pos: position{line: 2499, col: 37, offset: 72305},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2469, col: 37, offset: 71159},
+								pos:  position{line: 2499, col: 37, offset: 72305},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2469, col: 63, offset: 71185},
+								pos:  position{line: 2499, col: 63, offset: 72331},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2469, col: 81, offset: 71203},
+								pos:  position{line: 2499, col: 81, offset: 72349},
 								name: "TransactionSearch",
 							},
 						},
@@ -6741,22 +6859,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 2473, col: 1, offset: 71251},
+			pos:  position{line: 2503, col: 1, offset: 72397},
 			expr: &actionExpr{
-				pos: position{line: 2473, col: 28, offset: 71278},
+				pos: position{line: 2503, col: 28, offset: 72424},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2473, col: 28, offset: 71278},
+					pos:   position{line: 2503, col: 28, offset: 72424},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 2473, col: 33, offset: 71283},
+						pos: position{line: 2503, col: 33, offset: 72429},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2473, col: 33, offset: 71283},
+								pos:  position{line: 2503, col: 33, offset: 72429},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2473, col: 64, offset: 71314},
+								pos:  position{line: 2503, col: 64, offset: 72460},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -6766,29 +6884,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 2477, col: 1, offset: 71374},
+			pos:  position{line: 2507, col: 1, offset: 72520},
 			expr: &actionExpr{
-				pos: position{line: 2477, col: 38, offset: 71411},
+				pos: position{line: 2507, col: 38, offset: 72557},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2477, col: 38, offset: 71411},
+					pos: position{line: 2507, col: 38, offset: 72557},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2477, col: 38, offset: 71411},
+							pos:        position{line: 2507, col: 38, offset: 72557},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2477, col: 42, offset: 71415},
+							pos:   position{line: 2507, col: 42, offset: 72561},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2477, col: 55, offset: 71428},
+								pos:  position{line: 2507, col: 55, offset: 72574},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2477, col: 68, offset: 71441},
+							pos:        position{line: 2507, col: 68, offset: 72587},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -6799,23 +6917,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 2485, col: 1, offset: 71580},
+			pos:  position{line: 2515, col: 1, offset: 72726},
 			expr: &actionExpr{
-				pos: position{line: 2485, col: 21, offset: 71600},
+				pos: position{line: 2515, col: 21, offset: 72746},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 2485, col: 21, offset: 71600},
+					pos: position{line: 2515, col: 21, offset: 72746},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2485, col: 21, offset: 71600},
+							pos:        position{line: 2515, col: 21, offset: 72746},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 2485, col: 25, offset: 71604},
+							pos: position{line: 2515, col: 25, offset: 72750},
 							expr: &charClassMatcher{
-								pos:        position{line: 2485, col: 25, offset: 71604},
+								pos:        position{line: 2515, col: 25, offset: 72750},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -6823,7 +6941,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2485, col: 44, offset: 71623},
+							pos:        position{line: 2515, col: 44, offset: 72769},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -6834,15 +6952,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 2490, col: 1, offset: 71734},
+			pos:  position{line: 2520, col: 1, offset: 72880},
 			expr: &actionExpr{
-				pos: position{line: 2490, col: 33, offset: 71766},
+				pos: position{line: 2520, col: 33, offset: 72912},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2490, col: 33, offset: 71766},
+					pos:   position{line: 2520, col: 33, offset: 72912},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2490, col: 37, offset: 71770},
+						pos:  position{line: 2520, col: 37, offset: 72916},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -6850,15 +6968,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 2498, col: 1, offset: 71925},
+			pos:  position{line: 2528, col: 1, offset: 73071},
 			expr: &actionExpr{
-				pos: position{line: 2498, col: 22, offset: 71946},
+				pos: position{line: 2528, col: 22, offset: 73092},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 2498, col: 22, offset: 71946},
+					pos:   position{line: 2528, col: 22, offset: 73092},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2498, col: 27, offset: 71951},
+						pos:  position{line: 2528, col: 27, offset: 73097},
 						name: "ClauseLevel1",
 					},
 				},
@@ -6866,37 +6984,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 2508, col: 1, offset: 72123},
+			pos:  position{line: 2538, col: 1, offset: 73269},
 			expr: &actionExpr{
-				pos: position{line: 2508, col: 20, offset: 72142},
+				pos: position{line: 2538, col: 20, offset: 73288},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 2508, col: 20, offset: 72142},
+					pos: position{line: 2538, col: 20, offset: 73288},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 2508, col: 20, offset: 72142},
+							pos:        position{line: 2538, col: 20, offset: 73288},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2508, col: 27, offset: 72149},
+							pos:  position{line: 2538, col: 27, offset: 73295},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2508, col: 42, offset: 72164},
+							pos:  position{line: 2538, col: 42, offset: 73310},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2508, col: 50, offset: 72172},
+							pos:   position{line: 2538, col: 50, offset: 73318},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2508, col: 60, offset: 72182},
+								pos:  position{line: 2538, col: 60, offset: 73328},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2508, col: 69, offset: 72191},
+							pos:  position{line: 2538, col: 69, offset: 73337},
 							name: "R_PAREN",
 						},
 					},
@@ -6905,68 +7023,68 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 2518, col: 1, offset: 72372},
+			pos:  position{line: 2548, col: 1, offset: 73518},
 			expr: &choiceExpr{
-				pos: position{line: 2518, col: 12, offset: 72383},
+				pos: position{line: 2548, col: 12, offset: 73529},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 12, offset: 72383},
+						pos:  position{line: 2548, col: 12, offset: 73529},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 24, offset: 72395},
+						pos:  position{line: 2548, col: 24, offset: 73541},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 36, offset: 72407},
+						pos:  position{line: 2548, col: 36, offset: 73553},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 49, offset: 72420},
+						pos:  position{line: 2548, col: 49, offset: 73566},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 61, offset: 72432},
+						pos:  position{line: 2548, col: 61, offset: 73578},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 81, offset: 72452},
+						pos:  position{line: 2548, col: 81, offset: 73598},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 92, offset: 72463},
+						pos:  position{line: 2548, col: 92, offset: 73609},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 103, offset: 72474},
+						pos:  position{line: 2548, col: 103, offset: 73620},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 113, offset: 72484},
+						pos:  position{line: 2548, col: 113, offset: 73630},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 123, offset: 72494},
+						pos:  position{line: 2548, col: 123, offset: 73640},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 134, offset: 72505},
+						pos:  position{line: 2548, col: 134, offset: 73651},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 147, offset: 72518},
+						pos:  position{line: 2548, col: 147, offset: 73664},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 163, offset: 72534},
+						pos:  position{line: 2548, col: 163, offset: 73680},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 181, offset: 72552},
+						pos:  position{line: 2548, col: 181, offset: 73698},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2518, col: 193, offset: 72564},
+						pos:  position{line: 2548, col: 193, offset: 73710},
 						name: "CMD_SORT",
 					},
 				},
@@ -6974,18 +7092,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 2519, col: 1, offset: 72574},
+			pos:  position{line: 2549, col: 1, offset: 73720},
 			expr: &seqExpr{
-				pos: position{line: 2519, col: 15, offset: 72588},
+				pos: position{line: 2549, col: 15, offset: 73734},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2519, col: 15, offset: 72588},
+						pos:        position{line: 2549, col: 15, offset: 73734},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2519, col: 24, offset: 72597},
+						pos:  position{line: 2549, col: 24, offset: 73743},
 						name: "SPACE",
 					},
 				},
@@ -6993,18 +7111,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 2520, col: 1, offset: 72603},
+			pos:  position{line: 2550, col: 1, offset: 73749},
 			expr: &seqExpr{
-				pos: position{line: 2520, col: 14, offset: 72616},
+				pos: position{line: 2550, col: 14, offset: 73762},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2520, col: 14, offset: 72616},
+						pos:        position{line: 2550, col: 14, offset: 73762},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2520, col: 22, offset: 72624},
+						pos:  position{line: 2550, col: 22, offset: 73770},
 						name: "SPACE",
 					},
 				},
@@ -7012,18 +7130,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 2521, col: 1, offset: 72630},
+			pos:  position{line: 2551, col: 1, offset: 73776},
 			expr: &seqExpr{
-				pos: position{line: 2521, col: 14, offset: 72643},
+				pos: position{line: 2551, col: 14, offset: 73789},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2521, col: 14, offset: 72643},
+						pos:        position{line: 2551, col: 14, offset: 73789},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2521, col: 22, offset: 72651},
+						pos:  position{line: 2551, col: 22, offset: 73797},
 						name: "SPACE",
 					},
 				},
@@ -7031,18 +7149,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 2522, col: 1, offset: 72657},
+			pos:  position{line: 2552, col: 1, offset: 73803},
 			expr: &seqExpr{
-				pos: position{line: 2522, col: 15, offset: 72671},
+				pos: position{line: 2552, col: 15, offset: 73817},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2522, col: 15, offset: 72671},
+						pos:        position{line: 2552, col: 15, offset: 73817},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2522, col: 24, offset: 72680},
+						pos:  position{line: 2552, col: 24, offset: 73826},
 						name: "SPACE",
 					},
 				},
@@ -7050,18 +7168,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 2523, col: 1, offset: 72686},
+			pos:  position{line: 2553, col: 1, offset: 73832},
 			expr: &seqExpr{
-				pos: position{line: 2523, col: 14, offset: 72699},
+				pos: position{line: 2553, col: 14, offset: 73845},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2523, col: 14, offset: 72699},
+						pos:        position{line: 2553, col: 14, offset: 73845},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2523, col: 22, offset: 72707},
+						pos:  position{line: 2553, col: 22, offset: 73853},
 						name: "SPACE",
 					},
 				},
@@ -7069,9 +7187,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 2524, col: 1, offset: 72713},
+			pos:  position{line: 2554, col: 1, offset: 73859},
 			expr: &litMatcher{
-				pos:        position{line: 2524, col: 22, offset: 72734},
+				pos:        position{line: 2554, col: 22, offset: 73880},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -7079,16 +7197,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 2525, col: 1, offset: 72741},
+			pos:  position{line: 2555, col: 1, offset: 73887},
 			expr: &seqExpr{
-				pos: position{line: 2525, col: 13, offset: 72753},
+				pos: position{line: 2555, col: 13, offset: 73899},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2525, col: 13, offset: 72753},
+						pos:  position{line: 2555, col: 13, offset: 73899},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2525, col: 31, offset: 72771},
+						pos:  position{line: 2555, col: 31, offset: 73917},
 						name: "SPACE",
 					},
 				},
@@ -7096,18 +7214,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 2526, col: 1, offset: 72777},
+			pos:  position{line: 2556, col: 1, offset: 73923},
 			expr: &seqExpr{
-				pos: position{line: 2526, col: 13, offset: 72789},
+				pos: position{line: 2556, col: 13, offset: 73935},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2526, col: 13, offset: 72789},
+						pos:        position{line: 2556, col: 13, offset: 73935},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2526, col: 20, offset: 72796},
+						pos:  position{line: 2556, col: 20, offset: 73942},
 						name: "SPACE",
 					},
 				},
@@ -7115,18 +7233,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 2527, col: 1, offset: 72802},
+			pos:  position{line: 2557, col: 1, offset: 73948},
 			expr: &seqExpr{
-				pos: position{line: 2527, col: 12, offset: 72813},
+				pos: position{line: 2557, col: 12, offset: 73959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2527, col: 12, offset: 72813},
+						pos:        position{line: 2557, col: 12, offset: 73959},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2527, col: 18, offset: 72819},
+						pos:  position{line: 2557, col: 18, offset: 73965},
 						name: "SPACE",
 					},
 				},
@@ -7134,18 +7252,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 2528, col: 1, offset: 72825},
+			pos:  position{line: 2558, col: 1, offset: 73971},
 			expr: &seqExpr{
-				pos: position{line: 2528, col: 13, offset: 72837},
+				pos: position{line: 2558, col: 13, offset: 73983},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2528, col: 13, offset: 72837},
+						pos:        position{line: 2558, col: 13, offset: 73983},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2528, col: 20, offset: 72844},
+						pos:  position{line: 2558, col: 20, offset: 73990},
 						name: "SPACE",
 					},
 				},
@@ -7153,9 +7271,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 2529, col: 1, offset: 72850},
+			pos:  position{line: 2559, col: 1, offset: 73996},
 			expr: &litMatcher{
-				pos:        position{line: 2529, col: 12, offset: 72861},
+				pos:        position{line: 2559, col: 12, offset: 74007},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -7163,9 +7281,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 2530, col: 1, offset: 72867},
+			pos:  position{line: 2560, col: 1, offset: 74013},
 			expr: &litMatcher{
-				pos:        position{line: 2530, col: 13, offset: 72879},
+				pos:        position{line: 2560, col: 13, offset: 74025},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -7173,18 +7291,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 2531, col: 1, offset: 72886},
+			pos:  position{line: 2561, col: 1, offset: 74032},
 			expr: &seqExpr{
-				pos: position{line: 2531, col: 15, offset: 72900},
+				pos: position{line: 2561, col: 15, offset: 74046},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2531, col: 15, offset: 72900},
+						pos:        position{line: 2561, col: 15, offset: 74046},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2531, col: 24, offset: 72909},
+						pos:  position{line: 2561, col: 24, offset: 74055},
 						name: "SPACE",
 					},
 				},
@@ -7192,18 +7310,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 2532, col: 1, offset: 72915},
+			pos:  position{line: 2562, col: 1, offset: 74061},
 			expr: &seqExpr{
-				pos: position{line: 2532, col: 18, offset: 72932},
+				pos: position{line: 2562, col: 18, offset: 74078},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2532, col: 18, offset: 72932},
+						pos:        position{line: 2562, col: 18, offset: 74078},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2532, col: 30, offset: 72944},
+						pos:  position{line: 2562, col: 30, offset: 74090},
 						name: "SPACE",
 					},
 				},
@@ -7211,9 +7329,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 2533, col: 1, offset: 72950},
+			pos:  position{line: 2563, col: 1, offset: 74096},
 			expr: &litMatcher{
-				pos:        position{line: 2533, col: 13, offset: 72962},
+				pos:        position{line: 2563, col: 13, offset: 74108},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -7221,18 +7339,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 2534, col: 1, offset: 72969},
+			pos:  position{line: 2564, col: 1, offset: 74115},
 			expr: &seqExpr{
-				pos: position{line: 2534, col: 20, offset: 72988},
+				pos: position{line: 2564, col: 20, offset: 74134},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2534, col: 20, offset: 72988},
+						pos:        position{line: 2564, col: 20, offset: 74134},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2534, col: 34, offset: 73002},
+						pos:  position{line: 2564, col: 34, offset: 74148},
 						name: "SPACE",
 					},
 				},
@@ -7240,9 +7358,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 2535, col: 1, offset: 73008},
+			pos:  position{line: 2565, col: 1, offset: 74154},
 			expr: &litMatcher{
-				pos:        position{line: 2535, col: 14, offset: 73021},
+				pos:        position{line: 2565, col: 14, offset: 74167},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -7250,22 +7368,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 2536, col: 1, offset: 73029},
+			pos:  position{line: 2566, col: 1, offset: 74175},
 			expr: &seqExpr{
-				pos: position{line: 2536, col: 21, offset: 73049},
+				pos: position{line: 2566, col: 21, offset: 74195},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2536, col: 21, offset: 73049},
+						pos:  position{line: 2566, col: 21, offset: 74195},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2536, col: 27, offset: 73055},
+						pos:        position{line: 2566, col: 27, offset: 74201},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2536, col: 36, offset: 73064},
+						pos:  position{line: 2566, col: 36, offset: 74210},
 						name: "SPACE",
 					},
 				},
@@ -7273,27 +7391,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 2537, col: 1, offset: 73070},
+			pos:  position{line: 2567, col: 1, offset: 74216},
 			expr: &seqExpr{
-				pos: position{line: 2537, col: 16, offset: 73085},
+				pos: position{line: 2567, col: 16, offset: 74231},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 2537, col: 16, offset: 73085},
+						pos: position{line: 2567, col: 16, offset: 74231},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2537, col: 16, offset: 73085},
+							pos:  position{line: 2567, col: 16, offset: 74231},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2537, col: 23, offset: 73092},
+						pos:        position{line: 2567, col: 23, offset: 74238},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 2537, col: 27, offset: 73096},
+						pos: position{line: 2567, col: 27, offset: 74242},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2537, col: 27, offset: 73096},
+							pos:  position{line: 2567, col: 27, offset: 74242},
 							name: "SPACE",
 						},
 					},
@@ -7302,115 +7420,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 2540, col: 1, offset: 73207},
+			pos:  position{line: 2570, col: 1, offset: 74353},
 			expr: &choiceExpr{
-				pos: position{line: 2540, col: 16, offset: 73222},
+				pos: position{line: 2570, col: 16, offset: 74368},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 2540, col: 16, offset: 73222},
+						pos:        position{line: 2570, col: 16, offset: 74368},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 2540, col: 47, offset: 73253},
+						pos:        position{line: 2570, col: 47, offset: 74399},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2540, col: 55, offset: 73261},
+						pos:        position{line: 2570, col: 55, offset: 74407},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 16, offset: 73284},
+						pos:        position{line: 2571, col: 16, offset: 74430},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 26, offset: 73294},
+						pos:        position{line: 2571, col: 26, offset: 74440},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 34, offset: 73302},
+						pos:        position{line: 2571, col: 34, offset: 74448},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 42, offset: 73310},
+						pos:        position{line: 2571, col: 42, offset: 74456},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 50, offset: 73318},
+						pos:        position{line: 2571, col: 50, offset: 74464},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 58, offset: 73326},
+						pos:        position{line: 2571, col: 58, offset: 74472},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2541, col: 66, offset: 73334},
+						pos:        position{line: 2571, col: 66, offset: 74480},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 16, offset: 73356},
+						pos:        position{line: 2572, col: 16, offset: 74502},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 26, offset: 73366},
+						pos:        position{line: 2572, col: 26, offset: 74512},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 34, offset: 73374},
+						pos:        position{line: 2572, col: 34, offset: 74520},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 42, offset: 73382},
+						pos:        position{line: 2572, col: 42, offset: 74528},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 50, offset: 73390},
+						pos:        position{line: 2572, col: 50, offset: 74536},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 58, offset: 73398},
+						pos:        position{line: 2572, col: 58, offset: 74544},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 66, offset: 73406},
+						pos:        position{line: 2572, col: 66, offset: 74552},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2542, col: 74, offset: 73414},
+						pos:        position{line: 2572, col: 74, offset: 74560},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -7420,25 +7538,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 2543, col: 1, offset: 73420},
+			pos:  position{line: 2573, col: 1, offset: 74566},
 			expr: &choiceExpr{
-				pos: position{line: 2543, col: 16, offset: 73435},
+				pos: position{line: 2573, col: 16, offset: 74581},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 2543, col: 16, offset: 73435},
+						pos:        position{line: 2573, col: 16, offset: 74581},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 2543, col: 30, offset: 73449},
+						pos:        position{line: 2573, col: 30, offset: 74595},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 2543, col: 36, offset: 73455},
+						pos:        position{line: 2573, col: 36, offset: 74601},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -7448,18 +7566,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 2547, col: 1, offset: 73611},
+			pos:  position{line: 2577, col: 1, offset: 74757},
 			expr: &seqExpr{
-				pos: position{line: 2547, col: 8, offset: 73618},
+				pos: position{line: 2577, col: 8, offset: 74764},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2547, col: 8, offset: 73618},
+						pos:        position{line: 2577, col: 8, offset: 74764},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2547, col: 14, offset: 73624},
+						pos:  position{line: 2577, col: 14, offset: 74770},
 						name: "SPACE",
 					},
 				},
@@ -7467,22 +7585,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 2548, col: 1, offset: 73630},
+			pos:  position{line: 2578, col: 1, offset: 74776},
 			expr: &seqExpr{
-				pos: position{line: 2548, col: 7, offset: 73636},
+				pos: position{line: 2578, col: 7, offset: 74782},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2548, col: 7, offset: 73636},
+						pos:  position{line: 2578, col: 7, offset: 74782},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2548, col: 13, offset: 73642},
+						pos:        position{line: 2578, col: 13, offset: 74788},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2548, col: 18, offset: 73647},
+						pos:  position{line: 2578, col: 18, offset: 74793},
 						name: "SPACE",
 					},
 				},
@@ -7490,22 +7608,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 2549, col: 1, offset: 73653},
+			pos:  position{line: 2579, col: 1, offset: 74799},
 			expr: &seqExpr{
-				pos: position{line: 2549, col: 8, offset: 73660},
+				pos: position{line: 2579, col: 8, offset: 74806},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2549, col: 8, offset: 73660},
+						pos:  position{line: 2579, col: 8, offset: 74806},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2549, col: 14, offset: 73666},
+						pos:        position{line: 2579, col: 14, offset: 74812},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2549, col: 20, offset: 73672},
+						pos:  position{line: 2579, col: 20, offset: 74818},
 						name: "SPACE",
 					},
 				},
@@ -7513,22 +7631,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 2550, col: 1, offset: 73678},
+			pos:  position{line: 2580, col: 1, offset: 74824},
 			expr: &seqExpr{
-				pos: position{line: 2550, col: 9, offset: 73686},
+				pos: position{line: 2580, col: 9, offset: 74832},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2550, col: 9, offset: 73686},
+						pos:  position{line: 2580, col: 9, offset: 74832},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2550, col: 15, offset: 73692},
+						pos:        position{line: 2580, col: 15, offset: 74838},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2550, col: 19, offset: 73696},
+						pos:  position{line: 2580, col: 19, offset: 74842},
 						name: "SPACE",
 					},
 				},
@@ -7536,22 +7654,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 2551, col: 1, offset: 73702},
+			pos:  position{line: 2581, col: 1, offset: 74848},
 			expr: &seqExpr{
-				pos: position{line: 2551, col: 7, offset: 73708},
+				pos: position{line: 2581, col: 7, offset: 74854},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2551, col: 7, offset: 73708},
+						pos:  position{line: 2581, col: 7, offset: 74854},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2551, col: 13, offset: 73714},
+						pos:        position{line: 2581, col: 13, offset: 74860},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2551, col: 19, offset: 73720},
+						pos:  position{line: 2581, col: 19, offset: 74866},
 						name: "SPACE",
 					},
 				},
@@ -7559,22 +7677,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 2552, col: 1, offset: 73746},
+			pos:  position{line: 2582, col: 1, offset: 74892},
 			expr: &seqExpr{
-				pos: position{line: 2552, col: 7, offset: 73752},
+				pos: position{line: 2582, col: 7, offset: 74898},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2552, col: 7, offset: 73752},
+						pos:  position{line: 2582, col: 7, offset: 74898},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2552, col: 13, offset: 73758},
+						pos:        position{line: 2582, col: 13, offset: 74904},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2552, col: 19, offset: 73764},
+						pos:  position{line: 2582, col: 19, offset: 74910},
 						name: "SPACE",
 					},
 				},
@@ -7582,22 +7700,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 2554, col: 1, offset: 73791},
+			pos:  position{line: 2584, col: 1, offset: 74937},
 			expr: &seqExpr{
-				pos: position{line: 2554, col: 10, offset: 73800},
+				pos: position{line: 2584, col: 10, offset: 74946},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2554, col: 10, offset: 73800},
+						pos:  position{line: 2584, col: 10, offset: 74946},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2554, col: 25, offset: 73815},
+						pos:        position{line: 2584, col: 25, offset: 74961},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2554, col: 29, offset: 73819},
+						pos:  position{line: 2584, col: 29, offset: 74965},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -7605,22 +7723,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 2555, col: 1, offset: 73834},
+			pos:  position{line: 2585, col: 1, offset: 74980},
 			expr: &seqExpr{
-				pos: position{line: 2555, col: 10, offset: 73843},
+				pos: position{line: 2585, col: 10, offset: 74989},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2555, col: 10, offset: 73843},
+						pos:  position{line: 2585, col: 10, offset: 74989},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2555, col: 25, offset: 73858},
+						pos:        position{line: 2585, col: 25, offset: 75004},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2555, col: 29, offset: 73862},
+						pos:  position{line: 2585, col: 29, offset: 75008},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -7628,18 +7746,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 2556, col: 1, offset: 73877},
+			pos:  position{line: 2586, col: 1, offset: 75023},
 			expr: &seqExpr{
-				pos: position{line: 2556, col: 12, offset: 73888},
+				pos: position{line: 2586, col: 12, offset: 75034},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2556, col: 12, offset: 73888},
+						pos:        position{line: 2586, col: 12, offset: 75034},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2556, col: 16, offset: 73892},
+						pos:  position{line: 2586, col: 16, offset: 75038},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -7647,16 +7765,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 2557, col: 1, offset: 73907},
+			pos:  position{line: 2587, col: 1, offset: 75053},
 			expr: &seqExpr{
-				pos: position{line: 2557, col: 12, offset: 73918},
+				pos: position{line: 2587, col: 12, offset: 75064},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2557, col: 12, offset: 73918},
+						pos:  position{line: 2587, col: 12, offset: 75064},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2557, col: 27, offset: 73933},
+						pos:        position{line: 2587, col: 27, offset: 75079},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -7666,40 +7784,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 2559, col: 1, offset: 73938},
+			pos:  position{line: 2589, col: 1, offset: 75084},
 			expr: &notExpr{
-				pos: position{line: 2559, col: 8, offset: 73945},
+				pos: position{line: 2589, col: 8, offset: 75091},
 				expr: &anyMatcher{
-					line: 2559, col: 9, offset: 73946,
+					line: 2589, col: 9, offset: 75092,
 				},
 			},
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 2560, col: 1, offset: 73948},
+			pos:  position{line: 2590, col: 1, offset: 75094},
 			expr: &choiceExpr{
-				pos: position{line: 2560, col: 10, offset: 73957},
+				pos: position{line: 2590, col: 10, offset: 75103},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 2560, col: 11, offset: 73958},
+						pos: position{line: 2590, col: 11, offset: 75104},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 2560, col: 11, offset: 73958},
+								pos: position{line: 2590, col: 11, offset: 75104},
 								expr: &litMatcher{
-									pos:        position{line: 2560, col: 11, offset: 73958},
+									pos:        position{line: 2590, col: 11, offset: 75104},
 									val:        " ",
 									ignoreCase: false,
 									want:       "\" \"",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2560, col: 16, offset: 73963},
+								pos:  position{line: 2590, col: 16, offset: 75109},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 2560, col: 24, offset: 73971},
+								pos: position{line: 2590, col: 24, offset: 75117},
 								expr: &litMatcher{
-									pos:        position{line: 2560, col: 24, offset: 73971},
+									pos:        position{line: 2590, col: 24, offset: 75117},
 									val:        " ",
 									ignoreCase: false,
 									want:       "\" \"",
@@ -7708,9 +7826,9 @@ var g = &grammar{
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 2560, col: 32, offset: 73979},
+						pos: position{line: 2590, col: 32, offset: 75125},
 						expr: &litMatcher{
-							pos:        position{line: 2560, col: 32, offset: 73979},
+							pos:        position{line: 2590, col: 32, offset: 75125},
 							val:        " ",
 							ignoreCase: false,
 							want:       "\" \"",
@@ -7721,38 +7839,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 2561, col: 1, offset: 73984},
+			pos:  position{line: 2591, col: 1, offset: 75130},
 			expr: &seqExpr{
-				pos: position{line: 2561, col: 12, offset: 73995},
+				pos: position{line: 2591, col: 12, offset: 75141},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 2561, col: 12, offset: 73995},
+						pos:        position{line: 2591, col: 12, offset: 75141},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 2561, col: 18, offset: 74001},
+						pos: position{line: 2591, col: 18, offset: 75147},
 						expr: &seqExpr{
-							pos: position{line: 2561, col: 19, offset: 74002},
+							pos: position{line: 2591, col: 19, offset: 75148},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 2561, col: 19, offset: 74002},
+									pos: position{line: 2591, col: 19, offset: 75148},
 									expr: &litMatcher{
-										pos:        position{line: 2561, col: 21, offset: 74004},
+										pos:        position{line: 2591, col: 21, offset: 75150},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 2561, col: 28, offset: 74011,
+									line: 2591, col: 28, offset: 75157,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 2561, col: 32, offset: 74015},
+						pos:        position{line: 2591, col: 32, offset: 75161},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -7762,16 +7880,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 2562, col: 1, offset: 74021},
+			pos:  position{line: 2592, col: 1, offset: 75167},
 			expr: &choiceExpr{
-				pos: position{line: 2562, col: 20, offset: 74040},
+				pos: position{line: 2592, col: 20, offset: 75186},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2562, col: 20, offset: 74040},
+						pos:  position{line: 2592, col: 20, offset: 75186},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 2562, col: 28, offset: 74048},
+						pos:        position{line: 2592, col: 28, offset: 75194},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -7781,16 +7899,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_COMMA",
-			pos:  position{line: 2563, col: 1, offset: 74051},
+			pos:  position{line: 2593, col: 1, offset: 75197},
 			expr: &choiceExpr{
-				pos: position{line: 2563, col: 20, offset: 74070},
+				pos: position{line: 2593, col: 20, offset: 75216},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 2563, col: 20, offset: 74070},
+						pos:  position{line: 2593, col: 20, offset: 75216},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 2563, col: 28, offset: 74078},
+						pos:  position{line: 2593, col: 28, offset: 75224},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -10717,6 +10835,24 @@ func (p *parser) callonNamedFieldWithStringValue1() (any, error) {
 	return p.cur.onNamedFieldWithStringValue1(stack["key"], stack["op"], stack["value"])
 }
 
+func (c *current) onNamedFieldWithTimeDurationValue1(key, op, value any) (any, error) {
+	node := &ast.Node{
+		NodeType: ast.NodeTerminal,
+		Comparison: ast.Comparison{
+			Op:     op.(string),
+			Field:  key.(string),
+			Values: json.Number(fmt.Sprint(utils.GetIntervalInMillis((value.(*structs.TimeDuration)).Interval, (value.(*structs.TimeDuration)).TimeScalr))),
+		},
+	}
+	return node, nil
+}
+
+func (p *parser) callonNamedFieldWithTimeDurationValue1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNamedFieldWithTimeDurationValue1(stack["key"], stack["op"], stack["value"])
+}
+
 func (c *current) onUnnamedFieldWithStringValue1(value any) (any, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
@@ -10860,6 +10996,30 @@ func (p *parser) callonIntegerAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIntegerAsString1()
+}
+
+func (c *current) onTimeDuration1(value, timeUnit any) (any, error) {
+	if timeIntervalInt, err := strconv.Atoi(value.([]interface{})[0].(string)); err == nil {
+		return &structs.TimeDuration{
+			Interval:  float64(timeIntervalInt),
+			TimeScalr: timeUnit.(utils.TimeUnit),
+		}, nil
+	}
+
+	if timeIntervalFloat, err := strconv.ParseFloat(value.([]interface{})[0].(string), 64); err == nil {
+		return &structs.TimeDuration{
+			Interval:  timeIntervalFloat,
+			TimeScalr: timeUnit.(utils.TimeUnit),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("TimeDuration: Invalid time interval (%v)", value.([]interface{})[0])
+}
+
+func (p *parser) callonTimeDuration1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onTimeDuration1(stack["value"], stack["timeUnit"])
 }
 
 func (c *current) onEqualityOperator1(op any) (any, error) {

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -2184,7 +2184,7 @@ FieldWithBooleanValue <- key:FieldName op:EqualityOperator value:Boolean {
     return node, nil
 }
 
-FieldWithStringValue <- keyValuePair:(NamedFieldWithStringValue / UnnamedFieldWithStringValue) {
+FieldWithStringValue <- keyValuePair:(NamedFieldWithTimeDurationValue / NamedFieldWithStringValue / UnnamedFieldWithStringValue) {
     return keyValuePair, nil
 }
 
@@ -2195,6 +2195,18 @@ NamedFieldWithStringValue <- key:FieldName op:EqualityOperator value:String {
             Op: op.(string),
             Field: key.(string),
             Values: value,
+        },
+    }
+    return node, nil
+}
+
+NamedFieldWithTimeDurationValue <- key:FieldName op:(EqualityOperator / InequalityOperator) value:TimeDuration {
+    node := &ast.Node{
+        NodeType: ast.NodeTerminal,
+        Comparison:ast.Comparison{
+            Op: op.(string),
+            Field: key.(string),
+            Values: json.Number(fmt.Sprint(utils.GetIntervalInMillis((value.(*structs.TimeDuration)).Interval, (value.(*structs.TimeDuration)).TimeScalr))),
         },
     }
     return node, nil
@@ -2282,6 +2294,24 @@ FloatAsString <- [-+]? [0-9]* "." [0-9]+ {
 // Allow leading zeros and a "+" before the number.
 IntegerAsString <- [-+]? [0-9]+ {
     return string(c.text), nil
+}
+
+TimeDuration <- value:(FloatAsString / IntegerAsString)+ timeUnit:(Subseconds / Second/ Minute) !String EOF? {
+	if timeIntervalInt, err := strconv.Atoi(value.([]interface{})[0].(string)); err == nil {
+		return &structs.TimeDuration{
+			Interval:  float64(timeIntervalInt),
+			TimeScalr: timeUnit.(utils.TimeUnit),
+		}, nil
+	}
+
+	if timeIntervalFloat, err := strconv.ParseFloat(value.([]interface{})[0].(string), 64); err == nil {
+		return &structs.TimeDuration{
+			Interval:  timeIntervalFloat,
+			TimeScalr: timeUnit.(utils.TimeUnit),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("TimeDuration: Invalid time interval (%v)", value.([]interface{})[0])
 }
 
 EqualityOperator <- EMPTY_OR_SPACE op:("=" / "!=") EMPTY_OR_SPACE {

--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/axiomhq/hyperloglog"
 	"github.com/siglens/siglens/pkg/segment/structs"
@@ -43,39 +42,9 @@ func FindTimeRangeBucket(timePoints []uint64, timestamp uint64, intervalMillis u
 	return timePoints[index]
 }
 
-func GetIntervalInMillis(num int, timeUnit utils.TimeUnit) uint64 {
-	numD := time.Duration(num)
-
-	switch timeUnit {
-	case utils.TMMicrosecond:
-		// Might not has effect for 'us', because smallest time unit for timestamp in siglens is ms
-	case utils.TMMillisecond:
-		return uint64(numD)
-	case utils.TMCentisecond:
-		return uint64(numD * 10 * time.Millisecond)
-	case utils.TMDecisecond:
-		return uint64(numD * 100 * time.Millisecond)
-	case utils.TMSecond:
-		return uint64((numD * time.Second).Milliseconds())
-	case utils.TMMinute:
-		return uint64((numD * time.Minute).Milliseconds())
-	case utils.TMHour:
-		return uint64((numD * time.Hour).Milliseconds())
-	case utils.TMDay:
-		return uint64((numD * 24 * time.Hour).Milliseconds())
-	case utils.TMWeek:
-		return uint64((numD * 7 * 24 * time.Hour).Milliseconds())
-	case utils.TMMonth:
-		return uint64((numD * 30 * 24 * time.Hour).Milliseconds())
-	case utils.TMQuarter:
-		return uint64((numD * 120 * 24 * time.Hour).Milliseconds())
-	}
-	return uint64((10 * time.Minute).Milliseconds()) // 10 Minutes
-}
-
 func InitTimeBucket(num int, timeUnit utils.TimeUnit, byField string, limitExpr *structs.LimitExpr, measureAggLength int) *structs.TimeBucket {
 
-	intervalMillis := GetIntervalInMillis(num, timeUnit)
+	intervalMillis := utils.GetIntervalInMillis(num, timeUnit)
 
 	timechartExpr := &structs.TimechartExpr{
 		ByField: byField,

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -252,6 +252,11 @@ type TMLimitResult struct {
 	OtherCValArr     []*utils.CValueEnclosure
 }
 
+type TimeDuration struct {
+	Interval  float64
+	TimeScalr utils.TimeUnit
+}
+
 type BoolOperator uint8
 
 const (

--- a/pkg/segment/utils/timeconsts.go
+++ b/pkg/segment/utils/timeconsts.go
@@ -1,6 +1,9 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type TimeUnit uint8
 
@@ -32,4 +35,44 @@ func ConvertSubseconds(subsecond string) (TimeUnit, error) {
 	default:
 		return 0, fmt.Errorf("ConvertSubseconds: can not convert: %v", subsecond)
 	}
+}
+
+func GetIntervalInMillis(num interface{}, timeUnit TimeUnit) uint64 {
+	var numD float64
+
+	switch n := num.(type) {
+	case int:
+		numD = float64(n)
+	case float64:
+		numD = n
+	default:
+		// Handle unsupported type
+		return 0
+	}
+
+	switch timeUnit {
+	case TMMicrosecond:
+		// Might not has effect for 'us', because smallest time unit for timestamp in siglens is ms
+	case TMMillisecond:
+		return uint64(numD)
+	case TMCentisecond:
+		return uint64(numD * 10)
+	case TMDecisecond:
+		return uint64(numD * 100)
+	case TMSecond:
+		return uint64(time.Duration(numD * float64(time.Second)).Milliseconds())
+	case TMMinute:
+		return uint64(time.Duration(numD * float64(time.Minute)).Milliseconds())
+	case TMHour:
+		return uint64(time.Duration(numD * float64(time.Hour)).Milliseconds())
+	case TMDay:
+		return uint64(time.Duration(numD * 24 * float64(time.Hour)).Milliseconds())
+	case TMWeek:
+		return uint64(time.Duration(numD * 7 * 24 * float64(time.Hour)).Milliseconds())
+	case TMMonth:
+		return uint64(time.Duration(numD * 30 * 24 * float64(time.Hour)).Milliseconds())
+	case TMQuarter:
+		return uint64(time.Duration(numD * 120 * 24 * float64(time.Hour)).Milliseconds())
+	}
+	return uint64(time.Duration(10 * time.Minute * time.Millisecond).Milliseconds())
 }


### PR DESCRIPTION
* before this fix, siglens doesn't have support for searching with time duration of different units
* If search example 'search latency>0.5ms' would fail with errors
* the fix  avoids converting time duration with units to string

# Description
* Before convert values like "10s", "10ms", "10ds", "10cs" to string directly, PEG grammer will try to convert as time duration. If that fails only, they will be converted to String
* Added new evaluation struct `TimeDuration` and some additional grammer rules for avoid string conversions for time duration
* Moved and  modified `GetIntervalInMillis` function to different file for reusing

Fixes #574 

# Testing

* added tests 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [X] I have self-reviewed this PR.
- [X] I have removed all print-debugging and commented-out code that should not be merged.
- [X] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [X] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.



