### PR TITLE
Allow SPL fields command after groupby

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -345,6 +345,11 @@ RenamingLoop:
 			}
 		}
 
+		// Remove the group by columns from MeasureResults.
+		for _, bucketHolder := range nodeResult.MeasureResults {
+			bucketHolder.GroupByValues = utils.SelectIndicesFromSlice(bucketHolder.GroupByValues, groupByColIndicesToKeep)
+		}
+
 		nodeResult.GroupByRequest.GroupByColumns = groupByColNamesToKeep
 	}
 	if colReq.IncludeColumns != nil {

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -302,7 +302,11 @@ RenamingLoop:
 	}
 
 	if colReq.ExcludeColumns != nil {
-		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByCols, colReq.ExcludeColumns, false)
+		if nodeResult.GroupByRequest == nil {
+			return errors.New("performColumnsRequest: expected non-nil GroupByRequest while handling ExcludeColumns")
+		}
+
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByRequest.GroupByColumns, colReq.ExcludeColumns, false)
 		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.ExcludeColumns, false)
 
 		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
@@ -311,7 +315,11 @@ RenamingLoop:
 		}
 	}
 	if colReq.IncludeColumns != nil {
-		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByCols, colReq.IncludeColumns, true)
+		if nodeResult.GroupByRequest == nil {
+			return errors.New("performColumnsRequest: expected non-nil GroupByRequest while handling IncludeColumns")
+		}
+
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByRequest.GroupByColumns, colReq.IncludeColumns, true)
 		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.IncludeColumns, true)
 
 		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
@@ -416,7 +424,6 @@ func removeAggColumns(nodeResult *structs.NodeResult, groupByColIndicesToKeep []
 		}
 	}
 
-	nodeResult.GroupByCols = groupByColNamesToKeep
 	if nodeResult.GroupByRequest == nil {
 		return fmt.Errorf("removeAggColumns: expected non-nil GroupByRequest")
 	} else {

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -416,6 +416,7 @@ func removeAggColumns(nodeResult *structs.NodeResult, groupByColIndicesToKeep []
 		}
 	}
 
+	nodeResult.GroupByCols = groupByColNamesToKeep
 	if nodeResult.GroupByRequest == nil {
 		return fmt.Errorf("removeAggColumns: expected non-nil GroupByRequest")
 	} else {

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -302,16 +302,22 @@ RenamingLoop:
 	}
 
 	if colReq.ExcludeColumns != nil {
-		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumsToKeep(nodeResult.GroupByCols, colReq.ExcludeColumns, false)
-		_, _, measureColNamesToRemove := getColumsToKeep(nodeResult.MeasureFunctions, colReq.ExcludeColumns, false)
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByCols, colReq.ExcludeColumns, false)
+		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.ExcludeColumns, false)
 
 		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
 		if err != nil {
-			return fmt.Errorf("performColumnsRequest: erorr handling ExcludeColumns: %v", err)
+			return fmt.Errorf("performColumnsRequest: error handling ExcludeColumns: %v", err)
 		}
 	}
 	if colReq.IncludeColumns != nil {
-		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeColumns is not implemented")
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByCols, colReq.IncludeColumns, true)
+		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.IncludeColumns, true)
+
+		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
+		if err != nil {
+			return fmt.Errorf("performColumnsRequest: error handling IncludeColumns: %v", err)
+		}
 	}
 	if colReq.IncludeValues != nil {
 		return errors.New("performColumnsRequest: processing ColumnsRequest.IncludeValues is not implemented")
@@ -350,7 +356,7 @@ func getMatchingColumns(wildcardCols []string, finalCols map[string]bool) []stri
 // wildcardCol. When keepMatches is false, a column is kept only if it matches
 // no wildcardCol.
 // The results are returned in the same order as the input `cols`.
-func getColumsToKeep(cols []string, wildcardCols []string, keepMatches bool) ([]int, []string, []string) {
+func getColumnsToKeepAndRemove(cols []string, wildcardCols []string, keepMatches bool) ([]int, []string, []string) {
 	indicesToKeep := make([]int, 0)
 	colsToKeep := make([]string, 0)
 	colsToRemove := make([]string, 0)

--- a/pkg/utils/sliceutils.go
+++ b/pkg/utils/sliceutils.go
@@ -16,12 +16,38 @@ limitations under the License.
 
 package utils
 
+import log "github.com/sirupsen/logrus"
+
 func SliceContainsString(slice []string, s string) bool {
-	for i := range slice {
-		if slice[i] == s {
+	for _, v := range slice {
+		if v == s {
 			return true
 		}
 	}
 
 	return false
+}
+
+func SliceContainsInt(slice []int, x int) bool {
+	for _, v := range slice {
+		if v == x {
+			return true
+		}
+	}
+
+	return false
+}
+
+func SelectIndicesFromSlice(slice []string, indices []int) []string {
+	var result []string
+	for _, v := range indices {
+		if v < 0 || v >= len(slice) {
+			log.Errorf("SelectIndicesFromSlice: index %d out of range for slice of length %v", v, len(slice))
+			continue
+		}
+
+		result = append(result, slice[v])
+	}
+
+	return result
 }

--- a/pkg/utils/stringutils.go
+++ b/pkg/utils/stringutils.go
@@ -60,5 +60,7 @@ func SelectMatchingStringsWithWildcard(s string, slice []string) []string {
 		}
 	}
 
+	log.Errorf("andrew SelectMatchingStringsWithWildcard: matches: %v", matches)
+
 	return matches
 }

--- a/pkg/utils/stringutils.go
+++ b/pkg/utils/stringutils.go
@@ -60,7 +60,5 @@ func SelectMatchingStringsWithWildcard(s string, slice []string) []string {
 		}
 	}
 
-	log.Errorf("andrew SelectMatchingStringsWithWildcard: matches: %v", matches)
-
 	return matches
 }


### PR DESCRIPTION
# Description
Now you can run queries like `... | stats ... | fields ...`

# Testing
Added some unit tests, and also manually tested with these queries:
```
* | stats count as Count by http_status, http_method | eval mine=http_method . " -> " . http_status | fields mine, Count
* | stats count as Count by http_status, http_method | eval mine=http_method . " -> " . http_status | fields *m*
* | stats count as Count by http_status, http_method | eval mine=http_method . " -> " . http_status | fields -*m*
* | stats count as Count by http_status, http_method | eval mine=http_method . " -> " . http_status | fields http*, mine | fields -*status
* | stats count as Count by http_status, http_method | eval mine=http_method . " -> " . http_status | fields -http*
* | stats count as Count by http_status, http_method, weekday | eval mine=http_method . " -> " . http_status | fields -http_method | fields -weekday
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
