### PR TITLE
 Address dropdown should be large enough#569

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -285,6 +285,10 @@ input.form-control {
     color: var(--text-color);
 }
 
+.ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front{
+    width: max-content!important;
+}
+
 .ui-tabs-tab {
     border-radius: 10px;
 }

--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -287,6 +287,7 @@ input.form-control {
 
 .ui-menu.ui-widget.ui-widget-content.ui-autocomplete.ui-front{
     width: max-content!important;
+    min-width: 120px;
 }
 
 .ui-tabs-tab {


### PR DESCRIPTION
# Description
Added css property,"width" for the dynamically created dropdown.

Fixes #569  (link all the GitHub issues this addresses)

# Testing
Populated the logs data for address info and then filtered to check if the width property added works.

# Checklist:

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
