### PR TITLE
Flush the histogram after finishing all segments

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -572,7 +572,8 @@ func applyFopAllRequests(sortedQSRSlice []*querySegmentRequest, queryInfo *query
 	}
 
 	if segsNotSent > 0 {
-		incrementNumFinishedSegments(segsNotSent, queryInfo.qid, recsSearchedSinceLastUpdate, 0, false, nil)
+		doBucketPull := true // This is the last update, so flush the buckets.
+		incrementNumFinishedSegments(segsNotSent, queryInfo.qid, recsSearchedSinceLastUpdate, 0, doBucketPull, nil)
 	}
 
 	if !rrcsCompleted {


### PR DESCRIPTION
# Description
There was an issue that caused the `MeasureFunctions` to not be populated for groupby queries where the max number of buckets were created. In this case the buckets that were created weren't properly being flushed and so the `MeasureFunctions` were not being set. So then for queries like that that also rename or create some `MeasureFunctions`, those weren't being properly handled.

# Testing
Now this query correctly has `avg_lat` and `r_avg_lat` columns. Previously it had `avg(latency)` (so it wasn't renamed to `avg_lat`) and the `r_avg_lat` column never got created.
```
* | stats avg(latency) as avg_lat by app_name | eval r_avg_lat=round(avg_lat)
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
