### PR TITLE
Transaction Command fix for Multiple Segments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.opentelemetry.io/proto/otlp v0.19.0
-	golang.org/x/crypto v0.17.0
 	golang.org/x/sync v0.5.0
 	golang.org/x/text v0.14.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1

--- a/go.sum
+++ b/go.sum
@@ -371,8 +371,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
-golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -119,7 +119,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthtt
 
 	if aggs != nil && (aggs.GroupByRequest != nil || aggs.MeasureOperations != nil) {
 		sizeLimit = 0
-	} else if aggs.HasDedupBlockInChain() || aggs.HasSortBlockInChain() || aggs.HasRexBlockInChainWithStats() {
+	} else if aggs.HasDedupBlockInChain() || aggs.HasSortBlockInChain() || aggs.HasRexBlockInChainWithStats() || aggs.HasTransactionArgumentsInChain() {
 		// 1. Dedup needs state information about the previous records, so we can
 		// run into an issue if we show some records, then the user scrolls
 		// down to see more and we run dedup on just the new records and add

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -1160,7 +1160,13 @@ func Test_processTransactionsOnRecords(t *testing.T) {
 		// Process Transactions
 		performTransactionCommandRequest(&structs.NodeResult{}, &structs.QueryAggregators{TransactionArguments: txnArgs}, records, allCols, 1, true)
 
-		assert.Equal(t, allCols, map[string]bool{"timestamp": true, "duration": true, "eventcount": true, "event": true})
+		expectedCols := map[string]bool{"duration": true, "event": true, "eventcount": true, "timestamp": true}
+
+		for _, field := range txnArgs.Fields {
+			expectedCols[field] = true
+		}
+
+		assert.Equal(t, expectedCols, allCols)
 
 		// Check if the number of records is positive or negative
 		assert.Equal(t, matchesSomeRecords[index+1], len(records) > 0)

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -1158,7 +1158,7 @@ func Test_processTransactionsOnRecords(t *testing.T) {
 	for index, txnArgs := range allCasesTxnArgs {
 		records := generateTestRecords(500)
 		// Process Transactions
-		performTransactionCommandRequest(&structs.NodeResult{}, &structs.QueryAggregators{TransactionArguments: txnArgs}, records, allCols)
+		performTransactionCommandRequest(&structs.NodeResult{}, &structs.QueryAggregators{TransactionArguments: txnArgs}, records, allCols, 1, true)
 
 		assert.Equal(t, allCols, map[string]bool{"timestamp": true, "duration": true, "eventcount": true, "event": true})
 

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -241,8 +241,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 					if exists {
 						// Reset the TransactionEventRecords and update aggs with NextQueryAgg to loop for next Aggs processing.
 						delete(nodeRes.TransactionEventRecords, "CHECK_NEXT_AGG")
-						aggs = nodeRes.NextQueryAgg.Next
-						// continue
+						aggs = &structs.QueryAggregators{Next: nodeRes.NextQueryAgg.Next}
 					} else {
 						break // Break out of the loop to process next segment.
 					}
@@ -253,7 +252,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 						if exists && boolVal {
 							// Reset the flag to false and update aggs with NextQueryAgg to loop for additional cleaning.
 							nodeRes.PerformAggsOnRecs = false
-							aggs = nodeRes.NextQueryAgg.Next
+							aggs = nodeRes.NextQueryAgg
 						} else {
 							break
 						}

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -202,7 +202,7 @@ func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators,
 		if err != nil {
 			log.Errorf("executeQueryInternal: failed to get number of total segments for qid! Error: %v", err)
 		}
-		nodeRes = agg.PostQueryBucketCleaning(nodeRes, aggs, nil, nil, nil, numTotalSegments)
+		nodeRes = agg.PostQueryBucketCleaning(nodeRes, aggs, nil, nil, nil, numTotalSegments, false)
 	}
 	// truncate final results after running post aggregations
 	if uint64(len(nodeRes.AllRecords)) > qc.SizeLimit {

--- a/pkg/segment/segexecutionbench_test.go
+++ b/pkg/segment/segexecutionbench_test.go
@@ -132,7 +132,7 @@ func Benchmark_ApplyFilterOpAndAggs(b *testing.B) {
 	for i := 0; i < count; i++ {
 		qItTime := time.Now()
 		nodeRes := query.ApplyFilterOperator(simpleNode, fullTimeRange, agg, 0, &qc)
-		nodeRes = aggregations.PostQueryBucketCleaning(nodeRes, agg, nil, nil, nil, 1)
+		nodeRes = aggregations.PostQueryBucketCleaning(nodeRes, agg, nil, nil, nil, 1, false)
 		if doRespGen {
 			esquery.GetQueryResponseJson(nodeRes, "test", qItTime, sizeLimit, 0, agg)
 		}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -281,6 +281,7 @@ type NodeResult struct {
 	RecsAggsBlockResults      interface{} // Evaluates to *blockresults.BlockResults
 	RecsAggsProcessedSegments uint64
 	RecsRunningSegStats       []*SegStats
+	TransactionEventRecords   map[string]map[string]interface{}
 }
 
 type SegStats struct {


### PR DESCRIPTION
# Description
- The Transaction command now groups events from the entire set of records based on the given time.
- The command can be very slow and resource-intensive if not queried properly.
   - Queries like just raw transaction requests will take too much time and resources. Example: `* | transaction ip session ...`
   - Filter out the search and columns or use limit and many more to get the exact events that you want the grouping of events in the form of transaction. Example: `search productId=pro98766 | fields productId, ip, session, action, email, etc | transaction ip session startswith=view endswith=purchase`

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
