### PR TITLE
bump develop version to 0.1.31d

### DIFF
--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 package config
 
-const SigLensVersion = "0.1.30"
+const SigLensVersion = "0.1.31d"


### PR DESCRIPTION
# Description
- Incremented the SigLens version to 0.1.31 and added the suffix `d`.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
