### PR TITLE
Remove the url splunk prefix

### DIFF
--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -109,9 +109,9 @@ func (hs *ingestionServerCfg) Run() (err error) {
 	hs.router.POST(server_utils.LOKI_PREFIX+"/api/v1/push", hs.Recovery(lokiPostBulkHandler()))
 
 	// Splunk Handlers
-	hs.router.POST(server_utils.SPLUNK_PREFIX+"/services/collector/event", hs.Recovery(splunkHecIngestHandler()))
-	hs.router.GET(server_utils.SPLUNK_PREFIX+"/services/collector/health", hs.Recovery(getHealthHandler()))
-	hs.router.GET(server_utils.SPLUNK_PREFIX+"/services/collector/health/1.0", hs.Recovery(getHealthHandler()))
+	hs.router.POST("/services/collector/event", hs.Recovery(splunkHecIngestHandler()))
+	hs.router.GET("/services/collector/health", hs.Recovery(getHealthHandler()))
+	hs.router.GET("/services/collector/health/1.0", hs.Recovery(getHealthHandler()))
 
 	// OpenTSDB Handlers
 	hs.router.PUT(server_utils.OTSDB_PREFIX+"/api/put", hs.Recovery(otsdbPutMetricsHandler()))

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -169,8 +169,8 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.POST(server_utils.LOKI_PREFIX+"/api/v1/series", hs.Recovery(lokiSeriesHandler()))
 
 	//splunk endpoint
-	hs.Router.GET(server_utils.SPLUNK_PREFIX+"/services/collector/health", hs.Recovery(getHealthHandler()))
-	hs.Router.GET(server_utils.SPLUNK_PREFIX+"/services/collector/health/1.0", hs.Recovery(getHealthHandler()))
+	hs.Router.GET("/services/collector/health", hs.Recovery(getHealthHandler()))
+	hs.Router.GET("/services/collector/health/1.0", hs.Recovery(getHealthHandler()))
 
 	//OTSDB query endpoint
 	hs.Router.GET(server_utils.OTSDB_PREFIX+"/api/query", hs.Recovery(otsdbMetricQueryHandler()))

--- a/pkg/server/utils/utils.go
+++ b/pkg/server/utils/utils.go
@@ -29,7 +29,6 @@ const INFLUX_PREFIX string = "/influx"
 const PROMQL_PREFIX string = "/promql"
 const OTLP_PREFIX string = "/otlp"
 const API_PREFIX string = "/api"
-const SPLUNK_PREFIX string = "/splunk"
 const LOKI_PREFIX string = "/loki"
 const HEROKU_ADDON_PREFIX string = "/heroku/resources"
 


### PR DESCRIPTION
# Description
Now instead of having splunk endpoints under `/splunk/` in the URL, it's just under `/`

# Testing
I ingested data with vector using the splunk ingestion methods. This was my vector config:
```
data_dir: deleteme-vector

sources:
  read_from_file:
    type: file
    include:
      - 2kevents.json # Path to the log file

  # The type: "demo_logs" will generate syslog logs
  generate_syslog:
    type: 'demo_logs'
    format: 'syslog'
    count: 2

# Transforms Reference: Transform the data from Sources into desired format
transforms:
  remap_file_log:
    inputs:
      - 'read_from_file'
    type: 'remap'
    # The path to the file containing the remap rules. Parsing the message which is the data read from the file.
    # The parsed json is stored in the structured variable. The structured variable is merged with the other data/fields.
    source: |
      structured = parse_json!(.message)
      ., err = merge(., structured)

sinks:
  siglens:
    type: splunk_hec_logs
    inputs:
      - generate_syslog
      - remap_file_log
    endpoint: http://localhost:8081
    host_key: hostname
    index: 'ind-0'
    indexed_fields:
      - index
    timestamp_key: time
    compression: none
    encoding:
      codec: json
    default_token: 'A94A8FE5CCB19BA61C4C08'
    batch:
      max_events: 1
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
