### PR TITLE
Visualization tab update fix

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -395,7 +395,6 @@ function runFilterBtnHandler(evt) {
       doCancel(data);
     }
     $('#daterangepicker').hide();
-    
 }
 
 function filterInputHandler(evt) {

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -380,7 +380,9 @@ function runFilterBtnHandler(evt) {
       $("#run-filter-btn").text() === " " ||
       $("#query-builder-btn").text() === " "
     ) {
-
+      if (chart != null && chart != "" && chart != undefined) {
+        echarts.dispose(chart);
+      }
       resetDashboard();
       logsRowData = [];
       wsState = "query";
@@ -393,6 +395,7 @@ function runFilterBtnHandler(evt) {
       doCancel(data);
     }
     $('#daterangepicker').hide();
+    
 }
 
 function filterInputHandler(evt) {


### PR DESCRIPTION
# Description
Added code to reset chart on query update.

<img width="1680" alt="Screenshot 2024-03-26 at 11 43 49 AM" src="https://github.com/siglens/siglens/assets/38106598/8c807f1b-2ea4-466b-ba7d-3cb341a9ec61">
<img width="1673" alt="Screenshot 2024-03-26 at 11 45 54 AM" src="https://github.com/siglens/siglens/assets/38106598/534e7ef1-6bdf-416e-94e0-c8ae905f4be8">


Fixes #646

# Testing

1. Ingest some test data
2. Run this query on the UI: * | timechart avg(latency) by http_method span=1h
3. Beneath the query, there's two tabs: Table, and Visualization. Select the Visualization tab and you should see a bar graph with 6 bars.
4. Stay on Visualization and run * | timechart avg(latency) span=1h
5. The chart data should update on query change


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
