### PR TITLE
Allow gzipped splunk ingestion of multiple records

### DIFF
--- a/pkg/integrations/splunk/splunk.go
+++ b/pkg/integrations/splunk/splunk.go
@@ -17,7 +17,6 @@ limitations under the License.
 package splunk
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -39,22 +38,9 @@ func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		return
 	}
 
-	for _, line := range bytes.Split(body, []byte("\n")) {
-		if len(line) == 0 {
-			continue
-		}
-
-		jsonLine := make(map[string]interface{})
-		err = json.Unmarshal(line, &jsonLine)
-		if err != nil {
-			log.Errorf("ProcessSplunkHecIngestRequest: Unable to parse JSON request body, err=%v", err)
-			ctx.SetStatusCode(fasthttp.StatusBadRequest)
-			responseBody["error"] = "Unable to parse JSON request body"
-			utils.WriteJsonResponse(ctx, responseBody)
-			return
-		}
-
-		err, statusCode := handleSingleRecord(jsonLine, myid)
+	jsonObjects, err := utils.ExtractSeriesOfJsonObjects(body)
+	for _, record := range jsonObjects {
+		err, statusCode := handleSingleRecord(record, myid)
 		if err != nil {
 			log.Errorf("ProcessSplunkHecIngestRequest: Failed to handle record, err=%v", err)
 			ctx.SetStatusCode(statusCode)
@@ -63,7 +49,6 @@ func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 			return
 		}
 	}
-
 
 	responseBody["status"] = "Success"
 	utils.WriteJsonResponse(ctx, responseBody)

--- a/pkg/integrations/splunk/splunk.go
+++ b/pkg/integrations/splunk/splunk.go
@@ -28,9 +28,18 @@ import (
 )
 
 func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
-	postBody := make([]map[string]interface{}, 0)
-	err := json.Unmarshal(ctx.PostBody(), &postBody)
 	responseBody := make(map[string]interface{})
+	body, err := utils.GetDecodedBody(ctx)
+	if err != nil {
+		log.Errorf("ProcessSplunkHecIngestRequest: Unable to decode request body, err=%v", err)
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		responseBody["error"] = "Unable to decode request body"
+		utils.WriteJsonResponse(ctx, responseBody)
+		return
+	}
+
+	postBody := make([]map[string]interface{}, 0)
+	err = json.Unmarshal(body, &postBody)
 	if err != nil {
 		log.Errorf("ProcessSplunkHecIngestRequest: Unable to parse JSON request body, err=%v", err)
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)

--- a/pkg/integrations/splunk/splunk.go
+++ b/pkg/integrations/splunk/splunk.go
@@ -39,6 +39,14 @@ func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	}
 
 	jsonObjects, err := utils.ExtractSeriesOfJsonObjects(body)
+	if err != nil {
+		log.Errorf("ProcessSplunkHecIngestRequest: Unable to extract json objects from request body, err=%v", err)
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		responseBody["error"] = "Unable to extract json objects from request body"
+		utils.WriteJsonResponse(ctx, responseBody)
+		return
+	}
+
 	for _, record := range jsonObjects {
 		err, statusCode := handleSingleRecord(record, myid)
 		if err != nil {

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -823,3 +823,19 @@ func GetSpecificIdentifier() (string, error) {
 
 	return hostname, nil
 }
+
+func GetDecodedBody(ctx *fasthttp.RequestCtx) ([]byte, error) {
+	contentEncoding := string(ctx.Request.Header.Peek("Content-Encoding"))
+	switch contentEncoding {
+	case "":
+		return ctx.Request.Body(), nil
+	case "gzip":
+		return gunzip(ctx.Request.Body())
+	default:
+		return nil, fmt.Errorf("GetDecodedBody: unsupported content encoding: %s", contentEncoding)
+	}
+}
+
+func gunzip(data []byte) ([]byte, error) {
+	return fasthttp.AppendGunzipBytes(nil, data)
+}


### PR DESCRIPTION
# Description
This allows the splunk ingestion endpoint to handle data that is gzipped. It also makes it handle multiple records that are sent as a series of JSON objects (not inside a JSON list)

https://github.com/siglens/siglens/pull/673 had allowed multiple records to be ingested but it required them to be in a JSON list, which doesn't follow the Splunk documentation; see https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_data

# Testing
Manually tested with
```
curl -XPOST -d '{
    "index": "example",
    "field1": "apples",
    "field2": "oranges"
    }{"field1": "thing1", "field2": "thing2"}' http://localhost:8081/services/collector/event
```
I also tested sending gzipped records

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
