### PR TITLE
bug fix (issue#541) for Dark/Light Mode toggle on saved queries page

### DIFF
--- a/static/js/saved-queries.js
+++ b/static/js/saved-queries.js
@@ -22,7 +22,8 @@ $(document).ready(() => {
         theme = Cookies.get('theme');
         $('body').attr('data-theme', theme);
     }
-    $('.theme-btn').on('click', themePickerHandler);
+    $(document).on('click', '.theme-btn', themePickerHandler);
+
     setupEventHandlers();
     getSavedQueries();
 });


### PR DESCRIPTION
# Description
Saved Queries Page dynamically loads content after the initial page load, the event handler is not attached to the button because it wasn't present in the DOM at the time the script ran. Using event delegation from a static parent element or the document itself to solve

Fixes #<541> (https://github.com/siglens/siglens/issues/541#top)

# Testing
test pass.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
