### PR TITLE
fix: SPL Head Command Fix

### DIFF
--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -446,6 +446,10 @@ func parseColumnsCmd(node *structs.OutputTransforms, qid uint64) (*QueryAggregat
 
 	aggNode.OutputTransforms.MaxRows = node.MaxRows
 
+	if node.MaxRows > 0 {
+		aggNode.Limit = int(node.MaxRows)
+	}
+
 	return aggNode, nil
 }
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -377,6 +377,8 @@ func createRecsWsResp(qid uint64, sizeLimit uint64, searchPercent float64, scrol
 				break
 			}
 
+			sizeLimit = uint64(aggs.OutputTransforms.MaxRows)
+
 			useAnySegKey = true
 		}
 

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -248,11 +248,13 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 					}
 				} else if nodeRes.PerformAggsOnRecs {
 					resultRecMap = search.PerformAggsOnRecs(nodeRes, aggs, recs, finalCols, numTotalSegments, finishesSegment, qid)
+					// By default set PerformAggsOnRecs, otherwise the execution will immediately return here from PostQueryBucketCleaning;
+					// Without performing the aggs from the start for the next segment or next bulk.
+					nodeRes.PerformAggsOnRecs = false
 					if len(resultRecMap) > 0 {
 						boolVal, exists := resultRecMap["CHECK_NEXT_AGG"]
 						if exists && boolVal {
-							// Reset the flag to false and update aggs with NextQueryAgg to loop for additional cleaning.
-							nodeRes.PerformAggsOnRecs = false
+							// Update aggs with NextQueryAgg to loop for additional cleaning.
 							aggs = nodeRes.NextQueryAgg
 						} else {
 							break

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -248,7 +248,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 					}
 				} else if nodeRes.PerformAggsOnRecs {
 					resultRecMap = search.PerformAggsOnRecs(nodeRes, aggs, recs, finalCols, numTotalSegments, finishesSegment, qid)
-					// By default set PerformAggsOnRecs, otherwise the execution will immediately return here from PostQueryBucketCleaning;
+					// By default reset PerformAggsOnRecs flag, otherwise the execution will immediately return here from PostQueryBucketCleaning;
 					// Without performing the aggs from the start for the next segment or next bulk.
 					nodeRes.PerformAggsOnRecs = false
 					if len(resultRecMap) > 0 {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -174,6 +174,7 @@ type OutputTransforms struct {
 	LetColumns             *LetColumnsRequest // let columns processing on output columns
 	FilterRows             *BoolExpr          // discard rows failing some condition
 	MaxRows                uint64             // if 0, get all results; else, get at most this many
+	RowsAdded              uint64             // number of rows added to the result. This is used in conjunction with MaxRows.
 }
 
 type GroupByRequest struct {
@@ -483,10 +484,15 @@ func (qa *QueryAggregators) IsStatisticBlockEmpty() bool {
 }
 
 // To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block...
-func (qa *QueryAggregators) HasQueryAggergatorBlock() bool {
+func (qa *QueryAggregators) hasLetColumnsRequest() bool {
 	return qa != nil && qa.OutputTransforms != nil && qa.OutputTransforms.LetColumns != nil &&
 		(qa.OutputTransforms.LetColumns.RexColRequest != nil || qa.OutputTransforms.LetColumns.RenameColRequest != nil || qa.OutputTransforms.LetColumns.DedupColRequest != nil ||
 			qa.OutputTransforms.LetColumns.ValueColRequest != nil || qa.OutputTransforms.LetColumns.SortColRequest != nil)
+}
+
+// To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block, MaxRows...
+func (qa *QueryAggregators) HasQueryAggergatorBlock() bool {
+	return qa != nil && qa.OutputTransforms != nil && (qa.hasLetColumnsRequest() || qa.OutputTransforms.MaxRows > qa.OutputTransforms.RowsAdded)
 }
 
 func (qa *QueryAggregators) HasQueryAggergatorBlockInChain() bool {


### PR DESCRIPTION
# Description
### Fixed the SPL Head Command.

Now the following queries will work:

```SPL
1. * | head limit=10
2. * | head 10
3. * | search app_name="Waspsing"  | head 10
4. * | search app_name=Stadium* | stats count(*) by app_name | head 15
5. * | search app_name=* | stats count(*) by app_name, http_method | head 5
6. * | rex field=app_version "(?<major>\d+)\.(?<minor>\d).*" | stats count(*) by minor | head 2
7. * | head 132000
8. * | head 100000 | stats count(*)
9. * | search app_name="W*"  | fields app_name, batch | head 2
10. search app_name=Hyena* | fields gender, http_method, http_status | transaction gender http_method startswith=http_status=301  endswith=(http_status=404 OR http_status=500) | head 2
```
- Also resolved a bug regarding the `for loop` at processing of aggs at `rrcreader.go`.

# Testing
- Tested against the UI With the above queries.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
