### PR TITLE
Search stats fix

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -863,8 +863,8 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 				case string:
 					stats.AddSegStatsStr(lStats, colName, val, bb, aggColUsage, hasValuesFunc)
 				default:
-					// This should never occur as dict encoding is only supported for string fields.
-					log.Errorf("qid=%d, segmentStatsWorker found a non string in a dict encoded segment. CName %+s", qid, colName)
+					retVal[colName] = true
+					log.Errorf("qid=%d, segmentStatsWorker found a non string or non-numeric in a dict encoded segment. CName %+s", qid, colName)
 				}
 			}
 		}

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -863,6 +863,7 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 				case string:
 					stats.AddSegStatsStr(lStats, colName, val, bb, aggColUsage, hasValuesFunc)
 				default:
+					// This means the column is not dict encoded. So add it to the return value
 					retVal[colName] = true
 					log.Errorf("qid=%d, segmentStatsWorker found a non string or non-numeric in a dict encoded segment. CName %+s", qid, colName)
 				}


### PR DESCRIPTION
# Description
- Fixed the issue with search with Stats.

Now the below queries will work:

```SPL
1. * | app_name=Stadiumshake | stats count(http_status)
2. * | app_name=Stadium* | stats sum(http_status), count(http_status)
3. * | app_name=Stadium* | stats avg(http_status)
```

# Testing
Tested against the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
