### PR TITLE
Pick timestamp from the latest dep graph while aggregating multiple graphs

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -587,12 +587,20 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid uint64) {
 		}
 		return
 	} else {
+		firstHit := true
 		// Loop over all the graphs
 		for _, hit := range dependencyResponseOuter.Hits.Hits {
 			// Process the current graph
 			for key, value := range hit {
-				if key == "_index" || key == "timestamp" {
+				if key == "_index" {
 					processedData[key] = value
+					continue
+				}
+				if key == "timestamp" {
+					if firstHit {
+						processedData[key] = value
+						firstHit = false
+					}
 					continue
 				}
 				keys := strings.Split(key, ".")


### PR DESCRIPTION
# Description
Pick timestamp from the latest dep graph while aggregating multiple dependency graphs.

# Testing
- Tested this using the API endpoint.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
