### PR TITLE
Fix: Where cmd on Recs

### DIFF
--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -490,9 +490,9 @@ func (qa *QueryAggregators) hasLetColumnsRequest() bool {
 			qa.OutputTransforms.LetColumns.ValueColRequest != nil || qa.OutputTransforms.LetColumns.SortColRequest != nil)
 }
 
-// To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block, MaxRows...
+// To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block, FilterRows, MaxRows...
 func (qa *QueryAggregators) HasQueryAggergatorBlock() bool {
-	return qa != nil && qa.OutputTransforms != nil && (qa.hasLetColumnsRequest() || qa.OutputTransforms.MaxRows > qa.OutputTransforms.RowsAdded)
+	return qa != nil && qa.OutputTransforms != nil && (qa.hasLetColumnsRequest() || qa.OutputTransforms.FilterRows != nil || qa.OutputTransforms.MaxRows > qa.OutputTransforms.RowsAdded)
 }
 
 func (qa *QueryAggregators) HasQueryAggergatorBlockInChain() bool {


### PR DESCRIPTION
# Description
- Now `where` cmd will work without stats.
- So Now below commands will work:

```SPL
1. * | search app_name=Was* | fields address, app_name, hobby, http_status | where like(http_status, "%2%")
2. * | search app_name=Wasp* | fields address, app_name, hobby, http_status | where where match(hobby, "ing*")
3. * | search app_name=Was* | where http_status >= 400
4. * | search app_name=Was* | where like(app_name, "%could%")
5. * | search app_name="Wasp*"  | fields address, app_name, hobby, http_status  | where (http_status >= 200 AND http_status < 400) AND like(hobby, "%ing%")
``` 

# Testing
- Tested against the UI by writing the SPL queries similar to the above queries.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
