### PR TITLE
Fix: SPL Head command followed by Stats When querying less than total Segments

### DIFF
--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -39,7 +39,7 @@ func getMockRecsAndFinalCols(numRecs uint64) (map[string]map[string]interface{},
 // Tests the case where the size limit is zero and the number of segments is 2.
 // Normal case where sizelimit should not be considered.
 func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	sizeLimit := 0
 	recsSize := 100
 	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
@@ -51,23 +51,23 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
 	}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", i+1, nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
 			for _, record := range recs {
-				assert.Equal(t, fmt.Sprint(recsSize*numSegements), record["count(*)"], "expected=%v, actual=%v", recsSize*numSegements, record["count(*)"])
+				assert.Equal(t, fmt.Sprint(recsSize*numSegments), record["count(*)"], "The count(*) value should be Equal to count of all records of all the Segments.")
 			}
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }
@@ -76,7 +76,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
 // A case where the size limit is less than the records of all the segments.
 // The size limit should be considered instead of the number of segments.
 func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	sizeLimit := 99
 	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
 		{
@@ -89,15 +89,15 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.
 
 	recs, finalCols := getMockRecsAndFinalCols(uint64(sizeLimit))
 
-	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-	assert.Equal(t, uint64(numSegements), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
 
-	assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-	assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-	assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
+	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
+	assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation")
 	for _, record := range recs {
-		assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "expected=%v, actual=%v", sizeLimit, record["count(*)"])
+		assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "The count should be equal to the size limit")
 	}
 }
 
@@ -105,7 +105,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.
 // A case where the size limit is equal to the records of all the segments. Or It requires all the segments to be processed.
 // Number of Segments should be considered.
 func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	recsSize := 100
 	sizeLimit := 180
 	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
@@ -117,26 +117,26 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T
 	}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		if i == numSegements-1 {
-			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegements - 1))))
+		if i == numSegments-1 {
+			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegments - 1))))
 		}
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
 			for _, record := range recs {
-				assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "expected=%v, actual=%v", sizeLimit, record["count(*)"])
+				assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "The count(*) value should be Equal to the size limit.")
 			}
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }
@@ -145,7 +145,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T
 // A case where the size limit is greater than the records of all the segments.
 // Number of Segments should be considered.
 func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	recsSize := 100
 	sizeLimit := 250
 	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
@@ -157,22 +157,22 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testi
 	}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
 			for _, record := range recs {
-				assert.Equal(t, fmt.Sprint(recsSize*numSegements), record["count(*)"], "expected=%v, actual=%v", recsSize*numSegements, record["count(*)"])
+				assert.Equal(t, fmt.Sprint(recsSize*numSegments), record["count(*)"], "The count(*) value should be Equal to count of all records of all the Segments.")
 			}
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }
@@ -180,7 +180,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testi
 // Tests the case where the size limit is zero and the number of segments is 2.
 // Normal case where sizelimit should not be considered.
 func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	sizeLimit := 0
 	recsSize := 100
 	nodeResult := &structs.NodeResult{
@@ -201,22 +201,22 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", i+1, nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, recsSize, len(recs), "expected=%v, actual=%v", recsSize, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
 			for _, record := range recs {
-				assert.Equal(t, uint64(2), record["count(*)"], "expected=%v, actual=%v", recsSize*numSegements, record["count(*)"])
+				assert.Equal(t, uint64(2), record["count(*)"], "The count(*) value should be Equal to 2 as each record in a segment is unique and is repeated across segments.")
 			}
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }
@@ -225,7 +225,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.
 // A case where the size limit is less than the records of all the segments.
 // The size limit should be considered instead of the number of segments.
 func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	sizeLimit := 99
 	nodeResult := &structs.NodeResult{
 		PerformAggsOnRecs: true,
@@ -247,15 +247,15 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *t
 
 	recs, finalCols := getMockRecsAndFinalCols(uint64(sizeLimit))
 
-	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-	assert.Equal(t, uint64(numSegements), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
 
-	assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-	assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-	assert.Equal(t, sizeLimit, len(recs), "expected=%v, actual=%v", sizeLimit, len(recs))
+	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
+	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
+	assert.Equal(t, sizeLimit, len(recs), "The records size should be equal to the size limit as each record is unique in a segment and only one segment is required/processed.")
 	for _, record := range recs {
-		assert.Equal(t, uint64(1), record["count(*)"], "expected=%v, actual=%v", sizeLimit, record["count(*)"])
+		assert.Equal(t, uint64(1), record["count(*)"], "The count(*) value should be Equal to 1 as each record is unique in a segment and only one segment is required/processed.")
 	}
 }
 
@@ -263,7 +263,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *t
 // A case where the size limit is equal to the records of all the segments. Or It requires all the segments to be processed.
 // Number of Segments should be considered.
 func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	recsSize := 100
 	sizeLimit := 180
 	nodeResult := &structs.NodeResult{
@@ -284,35 +284,35 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *te
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		if i == numSegements-1 {
-			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegements - 1))))
+		if i == numSegments-1 {
+			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegments - 1))))
 		}
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, recsSize, len(recs), "expected=%v, actual=%v", recsSize, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
 			twoCountRecs := 0
 			oneCountRecs := 0
 			for _, record := range recs {
-				assert.True(t, (uint64(2) == record["count(*)"] || uint64(1) == record["count(*)"]), "expected=%v, actual=%v", "2 or 1", record["count(*)"])
+				assert.True(t, (uint64(2) == record["count(*)"] || uint64(1) == record["count(*)"]), "The count should either 2 or 1 as there are two segments and the second segment has less records (resulting to 1).")
 				if uint64(2) == record["count(*)"] {
 					twoCountRecs++
 				} else {
 					oneCountRecs++
 				}
 			}
-			assert.Equal(t, 80, twoCountRecs, "expected=%v, actual=%v", 1, twoCountRecs)
-			assert.Equal(t, 20, oneCountRecs, "expected=%v, actual=%v", 1, oneCountRecs)
+			assert.Equal(t, 80, twoCountRecs, "The count(*) value should be Equal to number of Segments for 80 records as the last segment there has 80 records.")
+			assert.Equal(t, 20, oneCountRecs, "The count(*) value should be (num of Segments - 1) for 20 records as the each segment has 100 records and the last segment has 80 records.")
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }
@@ -321,7 +321,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *te
 // A case where the size limit is greater than the records of all the segments.
 // Number of Segments should be considered.
 func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testing.T) {
-	numSegements := 2
+	numSegments := 2
 	recsSize := 100
 	sizeLimit := 250
 	nodeResult := &structs.NodeResult{
@@ -342,22 +342,22 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
-	for i := 0; i < numSegements; i++ {
+	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 
-		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
-		if i == numSegements-1 {
-			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
-			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
-			assert.Equal(t, recsSize, len(recs), "expected=%v, actual=%v", recsSize, len(recs))
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
 			for _, record := range recs {
-				assert.Equal(t, uint64(2), record["count(*)"], "expected=%v, actual=%v", uint64(2), record["count(*)"])
+				assert.Equal(t, uint64(2), record["count(*)"], "The count should be equal to number of Segments as each record in a segment is unique and is repeated across segments.")
 			}
 		} else {
-			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
 		}
 	}
 }

--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -1,0 +1,203 @@
+package search
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func getMockRecsAndFinalCols(numRecs uint64) (map[string]map[string]interface{}, map[string]bool) {
+	rand.Seed(time.Now().UnixNano()) // Ensure random behavior is not repetitive.
+
+	recs := make(map[string]map[string]interface{}, numRecs)
+	finalCols := make(map[string]bool)
+
+	// Generate records
+	for i := uint64(1); i <= numRecs; i++ {
+		recID := fmt.Sprintf("rec%d", i)
+		recData := map[string]interface{}{
+			"measure1": rand.Float64() * 100,     // Random float value
+			"measure2": rand.Intn(100),           // Random integer value
+			"measure3": fmt.Sprintf("info%d", i), // Incremental info string
+		}
+		recs[recID] = recData
+	}
+
+	// Generate final columns
+	finalCols["measure1"] = true
+	finalCols["measure2"] = true
+	finalCols["measure3"] = true
+
+	return recs, finalCols
+}
+
+// Tests the case where the size limit is zero and the number of segments is 2.
+// Normal case where sizelimit should not be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
+	numSegements := 2
+	sizeLimit := 0
+	recsSize := 100
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegements; i++ {
+
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", i+1, nodeResult.RecsAggsProcessedSegments)
+
+		if i == numSegements-1 {
+			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
+			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(recsSize*numSegements), record["count(*)"], "expected=%v, actual=%v", recsSize*numSegements, recs["count(*)"])
+			}
+		} else {
+			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is less than the records of all the segments.
+// The size limit should be considered instead of the number of segments.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.T) {
+	numSegements := 2
+	sizeLimit := 99
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	recs, finalCols := getMockRecsAndFinalCols(uint64(sizeLimit))
+
+	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+
+	assert.Equal(t, uint64(numSegements), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+
+	assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
+	assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
+	assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+	for _, record := range recs {
+		assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "expected=%v, actual=%v", sizeLimit, recs["count(*)"])
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is equal to the records of all the segments. Or It requires all the segments to be processed.
+// Number of Segments should be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T) {
+	numSegements := 2
+	recsSize := 100
+	sizeLimit := 180
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegements; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		if i == numSegements-1 {
+			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegements - 1))))
+		}
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+
+		if i == numSegements-1 {
+			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
+			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "expected=%v, actual=%v", sizeLimit, recs["count(*)"])
+			}
+		} else {
+			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is greater than the records of all the segments.
+// Number of Segments should be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testing.T) {
+	numSegements := 2
+	recsSize := 100
+	sizeLimit := 250
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegements; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegements), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "expected=%v, actual=%v", uint64(numSegements), nodeResult.RecsAggsProcessedSegments)
+
+		if i == numSegements-1 {
+			assert.Equal(t, 1, len(resultMap), "expected=%v, actual=%v", 1, len(resultMap))
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "expected=%v, actual=%v", true, resultMap["CHECK_NEXT_AGG"])
+			assert.Equal(t, 1, len(recs), "expected=%v, actual=%v", 1, len(recs))
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(recsSize*numSegements), record["count(*)"], "expected=%v, actual=%v", recsSize*numSegements, recs["count(*)"])
+			}
+		} else {
+			assert.Nil(t, resultMap, "expected=%v, actual=%v", nil, resultMap)
+		}
+	}
+}
+
+// Tests the case where the size limit is zero and the number of segments is 2.
+// Normal case where sizelimit should not be considered.
+// func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.T) {
+// 	numSegements := 2
+// 	sizeLimit := 0
+// 	recsSize := 100
+// 	nodeResult := &structs.NodeResult{
+// 		PerformAggsOnRecs: true,
+// 		RecsAggsType: structs.GroupByType,
+// 		GroupByRequest: &structs.GroupByRequest{
+// 			MeasureOperations: []*structs.MeasureAggregator{
+// 				{
+// 					MeasureCol:  "*",
+// 					MeasureFunc: utils.Count,
+// 					StrEnc:      "count(*)",
+// 				},
+// 			},
+// 			GroupByColumns: []string{"measure3"},
+// 			AggName: "agg1",
+
+// 		},
+// 	}
+// 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+// }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -282,7 +282,8 @@ type NodeResult struct {
 	GroupByRequest            *GroupByRequest
 	MeasureOperations         []*MeasureAggregator
 	NextQueryAgg              *QueryAggregators
-	RecsAggsBlockResults      interface{} // Evaluates to *blockresults.BlockResults
+	RecsAggsBlockResults      interface{}              // Evaluates to *blockresults.BlockResults
+	RecsAggsColumnKeysMap     map[string][]interface{} // map of column name to column keys for GroupBy Recs
 	RecsAggsProcessedSegments uint64
 	RecsRunningSegStats       []*SegStats
 	TransactionEventRecords   map[string]map[string]interface{}


### PR DESCRIPTION
# Description
- The SPL Head command followed by stats was not working when we query or are given a limit less than the total segments.
- For example, the below queries will not work:
```SPL
* | head 250000 | stats count(*)
* | head 20000 | stats sum(latency)
* | head 30000 | stats sum(latency) by http_method
```
- The above queries won't work assuming that there are more segments than required because of the limit.

#### Fixed a bug in the Group By Recs Aggregation function: `PerformGroupByRequestAggsOnRecs` in `searchaggs.go`. 
- Before, this function only returned the aggregations that were only part of the final segment.
- Now, this is fixed. It now stores the previous aggregations in `NodeResult` in struct and appends data to it for each segment.

# Testing
- Tested the code against the UI.
- Written Tests for Stats and Stats With Group By with Size Limit in `searchaggs_test.go`

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
