### PR TITLE
Release 0.1.33 

### DIFF
--- a/.github/workflows/develop-e2e-install.yml
+++ b/.github/workflows/develop-e2e-install.yml
@@ -22,10 +22,10 @@ jobs:
         load: true
         tags: siglens-develop:latest
 
-    - name: Run install_with_docker.sh script
+    - name: Run install.sh script
       run: |
-        chmod +x ./install_with_docker.sh
-        ./install_with_docker.sh
+        chmod +x ./install.sh
+        ./install.sh
       env:
         DOCKER_IMAGE_NAME: "siglens-develop:latest"
         DOCKER_COMPOSE_YAML: "./docker-compose.yml"

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 package config
 
-const SigLensVersion = "0.1.33d"
+const SigLensVersion = "0.1.33"

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 package config
 
-const SigLensVersion = "0.1.32"
+const SigLensVersion = "0.1.33d"

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -18,6 +18,7 @@ package aggregations
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -1545,4 +1546,557 @@ func Test_getColumnsToKeepAndRemove(t *testing.T) {
 			assert.Equal(t, tt.wantColsToRemove, gotColsToRemove)
 		})
 	}
+}
+
+func Test_performArithmeticOperation_Addition(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "Addition of numbers",
+			left:  5,
+			right: 3,
+			want:  float64(8),
+		},
+		{
+			name:  "Add a string and a number",
+			left:  2,
+			right: "3",
+			want:  float64(5),
+		},
+		{
+			name:  "Concatenation of strings",
+			left:  "Hello, ",
+			right: "World!",
+			want:  "Hello, World!",
+		},
+		{
+			name:    "Adding a string and a number",
+			left:    "Hello, ",
+			right:   3,
+			wantErr: true,
+			errMsg:  "rightValue is not a string",
+		},
+		{
+			name:    "Adding a number and a string",
+			left:    3,
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.Add)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_Subtraction(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    float64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "10-5",
+			left:  10,
+			right: 5,
+			want:  5,
+		},
+		{
+			name:  "-5-(-2)",
+			left:  -5,
+			right: -2,
+			want:  -3,
+		},
+		{
+			name:  "5.5-2.2",
+			left:  5.5,
+			right: 2.2,
+			want:  3.3,
+		},
+		{
+			name:  "0-5",
+			left:  0,
+			right: 5,
+			want:  -5,
+		},
+		{
+			name:  "Subtracting a string(number) from a string(number)",
+			left:  "2",
+			right: "5",
+			want:  -3,
+		},
+		{
+			name:  "Subtracting a number from a string(number)",
+			left:  "2",
+			right: 5,
+			want:  -3,
+		},
+		{
+			name:  "Subtracting a string from a number",
+			left:  5,
+			right: "2",
+			want:  3,
+		},
+		{
+			name:    "Subtracting a number from a string",
+			left:    "Hello,",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Subtracting a string from a number",
+			left:    5,
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Subtracting a string from a string",
+			left:    "Hello,",
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.Subtract)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_Multiplication(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    float64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "3*4",
+			left:  3,
+			right: 4,
+			want:  12,
+		},
+		{
+			name:  "-2*3",
+			left:  -2,
+			right: 3,
+			want:  -6,
+		},
+		{
+			name:  "5.5*2",
+			left:  5.5,
+			right: 2,
+			want:  11,
+		},
+		{
+			name:  "2*(-5)",
+			left:  2,
+			right: -5,
+			want:  -10,
+		},
+		{
+			name:    "Multiplying a string with a number",
+			left:    "Hello,",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Multiplying a number with a string",
+			left:    5,
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Multiplying a string with a string",
+			left:    "Hello,",
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.Multiply)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_Division(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    float64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "10/2",
+			left:  10,
+			right: 2,
+			want:  5,
+		},
+		{
+			name:  "5/(-1)",
+			left:  5,
+			right: -1,
+			want:  -5,
+		},
+		{
+			name:  "(-6)/(-3)",
+			left:  -6,
+			right: -3,
+			want:  2,
+		},
+		{
+			name:  "7.5/2.5",
+			left:  7.5,
+			right: 2.5,
+			want:  3,
+		},
+		{
+			name:    "Dividing by zero",
+			left:    5,
+			right:   0,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: cannot divide by zero",
+		},
+		{
+			name:    "Dividing a string by a number",
+			left:    "Hello,",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Dividing a number by a string",
+			left:    5,
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Dividing a string by a string",
+			left:    "Hello,",
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.Divide)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_Modulo(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    int64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "10%3",
+			left:  10,
+			right: 3,
+			want:  1,
+		},
+		{
+			name:  "18%7",
+			left:  18,
+			right: -7,
+			want:  4,
+		},
+		{
+			name:  "(-4)%3",
+			left:  -4,
+			right: 3,
+			want:  -1,
+		},
+		{
+			name:  "(-4)%(-3)",
+			left:  -4,
+			right: -3,
+			want:  -1,
+		},
+		{
+			name:    "Modulo a string by a number",
+			left:    "Hello,",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Modulo a number by a string",
+			left:    5,
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "Modulo a string by a string",
+			left:    "Hello,",
+			right:   "World!",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.Modulo)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_BitwiseAnd(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    int64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "6 & 3, expect 2",
+			left:  6,
+			right: 3,
+			want:  2,
+		},
+		{
+			name:  "10 & 8, expect 8",
+			left:  10,
+			right: 8,
+			want:  8,
+		},
+		{
+			name:    "bitwise a string by a number",
+			left:    "a",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise a number by a string",
+			left:    5,
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise a string by a string",
+			left:    "a",
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.BitwiseAnd)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_BitwiseOr(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    int64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "10|2",
+			left:  10,
+			right: 2,
+			want:  10,
+		},
+		{
+			name:  "1|4",
+			left:  1,
+			right: 4,
+			want:  5,
+		},
+		{
+			name:  "1|2",
+			left:  1,
+			right: 2,
+			want:  3,
+		},
+		{
+			name:    "bitwise or a string by a number",
+			left:    "a",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise or a number by a string",
+			left:    5,
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise or a string by a string",
+			left:    "a",
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.BitwiseOr)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_BitwiseExclusiveOr(t *testing.T) {
+	tests := []struct {
+		name    string
+		left    interface{}
+		right   interface{}
+		want    int64
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "10^5",
+			left:  10,
+			right: 5,
+			want:  15,
+		},
+		{
+			name:  "3^4",
+			left:  3,
+			right: 4,
+			want:  7,
+		},
+		{
+			name:  "2^3",
+			left:  2,
+			right: 3,
+			want:  1,
+		},
+		{
+			name:    "bitwise exclusive or a string by a number",
+			left:    "a",
+			right:   5,
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise exclusive or a number by a string",
+			left:    5,
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+		{
+			name:    "bitwise exclusive or a string by a string",
+			left:    "a",
+			right:   "b",
+			wantErr: true,
+			errMsg:  "performArithmeticOperation: leftValue or rightValue is not a number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := performArithmeticOperation(tt.left, tt.right, utils.BitwiseExclusiveOr)
+			if !tt.wantErr {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			if tt.wantErr {
+				assert.Equal(t, tt.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func Test_performArithmeticOperation_WrongOp(t *testing.T) {
+	_, err := performArithmeticOperation(5, 3, 100)
+	assert.Equal(t, errors.New("performArithmeticOperation: invalid arithmetic operator"), err)
 }

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -277,15 +277,15 @@ func PerformAggsOnRecs(nodeResult *structs.NodeResult, aggs *structs.QueryAggreg
 	}
 
 	if nodeResult.RecsAggsType == structs.GroupByType {
-		return PerformGroupByRequestAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments)
+		return PerformGroupByRequestAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments, uint64(aggs.Limit))
 	} else if nodeResult.RecsAggsType == structs.MeasureAggsType {
-		return PerformMeasureAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments)
+		return PerformMeasureAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments, uint64(aggs.Limit))
 	}
 
 	return nil
 }
 
-func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64) map[string]bool {
+func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64, sizeLimit uint64) map[string]bool {
 
 	nodeResult.GroupByRequest.BucketCount = 3000
 
@@ -307,9 +307,9 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 
 	measureResults := make([]utils.CValueEnclosure, len(internalMops))
 
-	columnKeys := make(map[string][]interface{})
-
-	finalRecInden := make(map[string]string)
+	if nodeResult.RecsAggsColumnKeysMap == nil {
+		nodeResult.RecsAggsColumnKeysMap = make(map[string][]interface{})
+	}
 
 	for recInden, record := range recs {
 		colKeyValues := make([]interface{}, 0)
@@ -331,9 +331,8 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 
 		keyStr := toputils.UnsafeByteSliceToString(currKey.Bytes())
 
-		if _, exists := columnKeys[keyStr]; !exists {
-			columnKeys[keyStr] = colKeyValues
-			finalRecInden[keyStr] = recInden
+		if _, exists := nodeResult.RecsAggsColumnKeysMap[keyStr]; !exists {
+			nodeResult.RecsAggsColumnKeysMap[keyStr] = append(colKeyValues, recInden)
 		}
 
 		for cname, indices := range measureInfo {
@@ -375,13 +374,19 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 		recAggsBlockresults.MergeBuckets(blockRes)
 	}
 
-	if nodeResult.RecsAggsProcessedSegments < numTotalSegments {
+	nodeResult.TotalRRCCount += uint64(len(recs))
+
+	if (nodeResult.RecsAggsProcessedSegments < numTotalSegments) && (sizeLimit == 0 || nodeResult.TotalRRCCount < sizeLimit) {
 		for k := range recs {
 			delete(recs, k)
 		}
 		return nil
 	} else {
 		blockRes = nodeResult.RecsAggsBlockResults.(*blockresults.BlockResults)
+		if sizeLimit > 0 && nodeResult.TotalRRCCount >= sizeLimit {
+			log.Info("PerformGroupByRequestAggsOnRecs: Reached size limit, Returning the Bucket Results.")
+			nodeResult.RecsAggsProcessedSegments = numTotalSegments
+		}
 	}
 
 	for k := range finalCols {
@@ -389,12 +394,10 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 	}
 
 	validRecIndens := make(map[string]bool)
+	columnKeys := nodeResult.RecsAggsColumnKeysMap
 
 	for bKey, index := range blockRes.GroupByAggregation.StringBucketIdx {
-		recInden, exists := finalRecInden[bKey]
-		if !exists {
-			continue
-		}
+		recInden := columnKeys[bKey][len(columnKeys[bKey])-1].(string)
 		validRecIndens[recInden] = true
 		bucketValues, bucketCount := blockRes.GroupByAggregation.AllRunningBuckets[index].GetRunningStatsBucketValues()
 
@@ -402,6 +405,11 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 			if index == 0 {
 				finalCols[colName] = true
 			}
+
+			if _, exists := recs[recInden]; !exists {
+				recs[recInden] = make(map[string]interface{})
+			}
+
 			recs[recInden][colName] = columnKeys[bKey][idx]
 		}
 
@@ -440,7 +448,7 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 	return map[string]bool{"CHECK_NEXT_AGG": true}
 }
 
-func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64) map[string]bool {
+func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64, sizeLimit uint64) map[string]bool {
 
 	searchResults, err := segresults.InitSearchResults(uint64(len(recs)), &structs.QueryAggregators{MeasureOperations: nodeResult.MeasureOperations}, structs.SegmentStatsCmd, qid)
 	if err != nil {
@@ -528,13 +536,9 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 		nodeResult.RecsRunningSegStats = searchResults.GetSegmentRunningStats()
 	}
 
-	if anyCountStat > -1 {
-		nodeResult.TotalRRCCount += uint64(lenRecords)
-	}
+	nodeResult.TotalRRCCount += uint64(lenRecords)
 
-	if nodeResult.RecsAggsProcessedSegments < numTotalSegments {
-		return nil
-	} else {
+	processFinalSegement := func() {
 		for k := range finalCols {
 			delete(finalCols, k)
 		}
@@ -557,6 +561,16 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 		}
 
 		recs[firstRecInden] = finalSegment
+	}
+
+	if sizeLimit > 0 && nodeResult.TotalRRCCount >= sizeLimit {
+		log.Info("PerformMeasureAggsOnRecs: Reached size limit, processing final segment.")
+		nodeResult.RecsAggsProcessedSegments = numTotalSegments
+		processFinalSegement()
+	} else if nodeResult.RecsAggsProcessedSegments < numTotalSegments {
+		return nil
+	} else {
+		processFinalSegement()
 	}
 
 	return map[string]bool{"CHECK_NEXT_AGG": true}

--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -1,0 +1,363 @@
+package search
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func getMockRecsAndFinalCols(numRecs uint64) (map[string]map[string]interface{}, map[string]bool) {
+	rand.Seed(time.Now().UnixNano()) // Ensure random behavior is not repetitive.
+
+	recs := make(map[string]map[string]interface{}, numRecs)
+	finalCols := make(map[string]bool)
+
+	// Generate records
+	for i := uint64(1); i <= numRecs; i++ {
+		recID := fmt.Sprintf("rec%d", i)
+		recData := map[string]interface{}{
+			"measure1": rand.Float64() * 100,     // Random float value
+			"measure2": rand.Intn(100),           // Random integer value
+			"measure3": fmt.Sprintf("info%d", i), // Incremental info string
+		}
+		recs[recID] = recData
+	}
+
+	// Generate final columns
+	finalCols["measure1"] = true
+	finalCols["measure2"] = true
+	finalCols["measure3"] = true
+
+	return recs, finalCols
+}
+
+// Tests the case where the size limit is zero and the number of segments is 2.
+// Normal case where sizelimit should not be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
+	numSegments := 2
+	sizeLimit := 0
+	recsSize := 100
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(recsSize*numSegments), record["count(*)"], "The count(*) value should be Equal to count of all records of all the Segments.")
+			}
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is less than the records of all the segments.
+// The size limit should be considered instead of the number of segments.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.T) {
+	numSegments := 2
+	sizeLimit := 99
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	recs, finalCols := getMockRecsAndFinalCols(uint64(sizeLimit))
+
+	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
+
+	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
+	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
+	assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation")
+	for _, record := range recs {
+		assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "The count should be equal to the size limit")
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is equal to the records of all the segments. Or It requires all the segments to be processed.
+// Number of Segments should be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T) {
+	numSegments := 2
+	recsSize := 100
+	sizeLimit := 180
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		if i == numSegments-1 {
+			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegments - 1))))
+		}
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(sizeLimit), record["count(*)"], "The count(*) value should be Equal to the size limit.")
+			}
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is greater than the records of all the segments.
+// Number of Segments should be considered.
+func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testing.T) {
+	numSegments := 2
+	recsSize := 100
+	sizeLimit := 250
+	nodeResult := &structs.NodeResult{PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType, MeasureOperations: []*structs.MeasureAggregator{
+		{
+			MeasureCol:  "*",
+			MeasureFunc: utils.Count,
+			StrEnc:      "count(*)",
+		},
+	}}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, 1, len(recs), "MeasureAggs: Should return only a single record containing result of the aggregation.")
+			for _, record := range recs {
+				assert.Equal(t, fmt.Sprint(recsSize*numSegments), record["count(*)"], "The count(*) value should be Equal to count of all records of all the Segments.")
+			}
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}
+
+// Tests the case where the size limit is zero and the number of segments is 2.
+// Normal case where sizelimit should not be considered.
+func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.T) {
+	numSegments := 2
+	sizeLimit := 0
+	recsSize := 100
+	nodeResult := &structs.NodeResult{
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
+				},
+			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
+		},
+	}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
+			for _, record := range recs {
+				assert.Equal(t, uint64(2), record["count(*)"], "The count(*) value should be Equal to 2 as each record in a segment is unique and is repeated across segments.")
+			}
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is less than the records of all the segments.
+// The size limit should be considered instead of the number of segments.
+func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.T) {
+	numSegments := 2
+	sizeLimit := 99
+	nodeResult := &structs.NodeResult{
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
+				},
+			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
+		},
+	}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	recs, finalCols := getMockRecsAndFinalCols(uint64(sizeLimit))
+
+	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
+
+	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
+	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
+	assert.Equal(t, sizeLimit, len(recs), "The records size should be equal to the size limit as each record is unique in a segment and only one segment is required/processed.")
+	for _, record := range recs {
+		assert.Equal(t, uint64(1), record["count(*)"], "The count(*) value should be Equal to 1 as each record is unique in a segment and only one segment is required/processed.")
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is equal to the records of all the segments. Or It requires all the segments to be processed.
+// Number of Segments should be considered.
+func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T) {
+	numSegments := 2
+	recsSize := 100
+	sizeLimit := 180
+	nodeResult := &structs.NodeResult{
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
+				},
+			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
+		},
+	}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		if i == numSegments-1 {
+			recs, finalCols = getMockRecsAndFinalCols(uint64(sizeLimit - (recsSize * (numSegments - 1))))
+		}
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
+			twoCountRecs := 0
+			oneCountRecs := 0
+			for _, record := range recs {
+				assert.True(t, (uint64(2) == record["count(*)"] || uint64(1) == record["count(*)"]), "The count should either 2 or 1 as there are two segments and the second segment has less records (resulting to 1).")
+				if uint64(2) == record["count(*)"] {
+					twoCountRecs++
+				} else {
+					oneCountRecs++
+				}
+			}
+			assert.Equal(t, 80, twoCountRecs, "The count(*) value should be Equal to number of Segments for 80 records as the last segment there has 80 records.")
+			assert.Equal(t, 20, oneCountRecs, "The count(*) value should be (num of Segments - 1) for 20 records as the each segment has 100 records and the last segment has 80 records.")
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}
+
+// Tests the case where the size limit is non-zero and the number of segments is 2.
+// A case where the size limit is greater than the records of all the segments.
+// Number of Segments should be considered.
+func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testing.T) {
+	numSegments := 2
+	recsSize := 100
+	sizeLimit := 250
+	nodeResult := &structs.NodeResult{
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
+				},
+			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
+		},
+	}
+	aggs := &structs.QueryAggregators{Limit: sizeLimit}
+
+	for i := 0; i < numSegments; i++ {
+		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
+
+		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
+
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+
+		if i == numSegments-1 {
+			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
+			assert.True(t, resultMap["CHECK_NEXT_AGG"], "The Last Segment should return a resultMap with a key CHECK_NEXT_AGG set to true.")
+			assert.Equal(t, recsSize, len(recs), "The records size should be equal to the recsSize as each record in a segment is unique and is repeated across segments.")
+			for _, record := range recs {
+				assert.Equal(t, uint64(2), record["count(*)"], "The count should be equal to number of Segments as each record in a segment is unique and is repeated across segments.")
+			}
+		} else {
+			assert.Nil(t, resultMap, "The resultMap should be nil until the last segment is processed")
+		}
+	}
+}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -490,9 +490,9 @@ func (qa *QueryAggregators) hasLetColumnsRequest() bool {
 			qa.OutputTransforms.LetColumns.ValueColRequest != nil || qa.OutputTransforms.LetColumns.SortColRequest != nil)
 }
 
-// To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block, MaxRows...
+// To determine whether it contains certain specific AggregatorBlocks, such as: Rename Block, Rex Block, FilterRows, MaxRows...
 func (qa *QueryAggregators) HasQueryAggergatorBlock() bool {
-	return qa != nil && qa.OutputTransforms != nil && (qa.hasLetColumnsRequest() || qa.OutputTransforms.MaxRows > qa.OutputTransforms.RowsAdded)
+	return qa != nil && qa.OutputTransforms != nil && (qa.hasLetColumnsRequest() || qa.OutputTransforms.FilterRows != nil || qa.OutputTransforms.MaxRows > qa.OutputTransforms.RowsAdded)
 }
 
 func (qa *QueryAggregators) HasQueryAggergatorBlockInChain() bool {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -282,7 +282,8 @@ type NodeResult struct {
 	GroupByRequest            *GroupByRequest
 	MeasureOperations         []*MeasureAggregator
 	NextQueryAgg              *QueryAggregators
-	RecsAggsBlockResults      interface{} // Evaluates to *blockresults.BlockResults
+	RecsAggsBlockResults      interface{}              // Evaluates to *blockresults.BlockResults
+	RecsAggsColumnKeysMap     map[string][]interface{} // map of column name to column keys for GroupBy Recs
 	RecsAggsProcessedSegments uint64
 	RecsRunningSegStats       []*SegStats
 	TransactionEventRecords   map[string]map[string]interface{}

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -37,3 +37,92 @@ func Test_HasTransactionArguments_NonNilTransactionArguments(t *testing.T) {
 	}
 	assert.Equal(t, true, qa.HasTransactionArguments(), "Expected true when TransactionArguments is not nil, got false")
 }
+
+func Test_HasQueryAggergatorBlock_NilQueryAggregators(t *testing.T) {
+	var qa *QueryAggregators
+
+	assert.Equal(t, false, qa.HasQueryAggergatorBlock(), "Expected false when QueryAggregators is nil, got true")
+}
+func Test_HasQueryAggergatorBlock_NilOutputTransforms(t *testing.T) {
+	var ot *OutputTransforms
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, false, qa.HasQueryAggergatorBlock(), "Expected false when OutputTransforms is nil, got true")
+}
+
+func Test_HasQueryAggergatorBlock_HasLetColumnsRequest(t *testing.T) {
+	lcr := &LetColumnsRequest{
+		RexColRequest: &RexExpr{},
+	}
+
+	ot := &OutputTransforms{
+		LetColumns: lcr,
+	}
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, true, qa.HasQueryAggergatorBlock(), "Expected true when hasLetColumnsRequest is true, got false")
+}
+
+func Test_HasQueryAggergatorBlock_HasNoLetColumnsRequest(t *testing.T) {
+	lcr := &LetColumnsRequest{}
+
+	ot := &OutputTransforms{
+		LetColumns: lcr,
+	}
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, false, qa.HasQueryAggergatorBlock(), "Expected false when hasLetColumnsRequest is false, got true")
+}
+
+func Test_HasQueryAggergatorBlock_MaxRowsGreaterThanRowAdded(t *testing.T) {
+	ot := &OutputTransforms{
+		MaxRows:   12,
+		RowsAdded: 1,
+	}
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, true, qa.HasQueryAggergatorBlock(), "Expected true when MaxRows is greater than RowsAdded, got false")
+}
+
+func Test_HasQueryAggergatorBlock_MaxRowsLessThanRowAdded(t *testing.T) {
+	ot := &OutputTransforms{
+		MaxRows:   1,
+		RowsAdded: 9,
+	}
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, false, qa.HasQueryAggergatorBlock(), "Expected false when MaxRows is less than RowsAdded, got true")
+}
+
+func Test_HasQueryAggergatorBlock(t *testing.T) {
+	lcr := &LetColumnsRequest{
+		RexColRequest: &RexExpr{},
+	}
+
+	ot := &OutputTransforms{
+		LetColumns: lcr,
+		MaxRows:    5,
+		RowsAdded:  1,
+	}
+
+	qa := &QueryAggregators{
+		OutputTransforms: ot,
+	}
+
+	assert.Equal(t, true, qa.HasQueryAggergatorBlock(), "Expected true when HasQueryAggergatorBlock is true, got false")
+}

--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -327,6 +327,7 @@ input.form-control {
     background-position: center;
     border-radius: 0 5px 5px 0;
     cursor: pointer;
+    border: none;
 }
 .run-filter-btn {
     background-image: url("../assets/search-img.svg");

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2749,10 +2749,25 @@ input[type="date"]::-webkit-calendar-picker-indicator , input[type="time"]::-web
 .odd-popup-textarea{
     background: var(--datatable-odd-row-bg-color) !important;
     color: var(--text-color) !important;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+    box-sizing: border-box;
+    overflow: auto;
+    font-size: 12px;
 }
+
 .even-popup-textarea{
     background: var(--datatable-even-row-bg-color) !important;
     color: var(--text-color) !important;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+    box-sizing: border-box;
+    overflow: auto;
+    font-size: 12px;
 }
 
 .fa-sort-alpha-up:before{

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2358,7 +2358,7 @@ input[type="submit" i] {
     color: var(--text-color);
 
     width: 330px !important;
-    height: 486px !important;
+    height: 440px !important;
     background: var(--timepicker-bg-color);
     border: 1px solid var(--timepicker-border-color);
     border-radius: 5px;
@@ -2451,7 +2451,7 @@ input[type="submit" i] {
 }
 
 hr {
-    margin: 1rem 0;
+    margin: .5rem 0;
     color: var(--timepicker-hr-color) !important;
     border: 0;
 }
@@ -2487,14 +2487,14 @@ hr {
 }
 
 #daterange-from {
-    margin-top: 20px;
+    margin-top: 12px;
 }
 #dt-from-text {
     margin-left: 12px;
 }
 
 #daterange-to {
-    margin-top: 19px;
+    margin-top: 12px;
 }
 #dt-to-text {
     margin-left: 12px;
@@ -2504,7 +2504,7 @@ hr {
     margin-top: 8px;
     margin-left: 12px;
     width: 147.41px;
-    height: 35px;
+    height: 32px;
 
     border: 1px solid var(--timepicker-border-color);
     border-radius: 4px;
@@ -2527,7 +2527,7 @@ hr {
     margin-top: 8px;
     margin-left: 11px;
     width: 147.41px;
-    height: 35px;
+    height: 32px;
 
     border: 1px solid var(--timepicker-border-color);
     border-radius: 4px;
@@ -2572,11 +2572,11 @@ input[type="date"]::-webkit-calendar-picker-indicator , input[type="time"]::-web
 
 .daterangepicker .drp-buttons .btn{
     width: 306px !important;
-    height: 35px !important;
+    height: 32px !important;
     background: var(--btn-regular-bg-color) !important;
     border-radius: 4px;
     font-weight: var(--fw-400);
-    font-size: 18px;
+    font-size: 16px;
     line-height: 23px;
     font-family: "DINpro", Arial, sans-serif !important;
     opacity: 100 !important;

--- a/static/css/tracing.css
+++ b/static/css/tracing.css
@@ -369,6 +369,11 @@ input.form-control {
     height: 124px;
     margin-top: 20px;
     cursor: pointer;
+    color: var(--text-color);
+}
+
+a.warn-box-anchor {
+    text-decoration: none;
 }
 
 .error-span,
@@ -527,16 +532,9 @@ input.form-control {
     padding: 5px !important;
     border-radius: 5px !important;
     font-size: 13px !important;
+    margin-top: -20px;
 }
 
 circle:hover{
     cursor: pointer;
-}
-
-.subsection-navbar .dropdown-menu.daterangepicker.show{
-    height: 162px !important;
-    padding: 8px !important;
-}
-.subsection-navbar .inner-range{
-    grid-template-columns: repeat(2, 1fr) !important;
 }

--- a/static/css/tracing.css
+++ b/static/css/tracing.css
@@ -538,3 +538,18 @@ a.warn-box-anchor {
 circle:hover{
     cursor: pointer;
 }
+
+.subsection-navbar .dropdown-menu.daterangepicker.show{
+    height: 162px !important;
+    padding: 8px !important;
+}
+.subsection-navbar .inner-range{
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.dep {
+    height: auto !important;
+}
+.dep{
+    grid-template-columns: repeat(3, 1fr) !important;
+}

--- a/static/dependency-graph.html
+++ b/static/dependency-graph.html
@@ -51,7 +51,36 @@
         </div>
 
         <div id="dashboard" class="p-20">
-            <div class="subsection-navbar">
+            <div class="subsection-navbar align-items-end justify-content-between">
+                <div class="dropdown">
+                    <button class="btn dropdown-toggle" type="button" id="date-picker-btn" data-toggle="dropdown"
+                        aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown"
+                        title="Pick the time window">
+                        <span>Time Picker</span>
+                        <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
+                        <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                    </button>
+                    <div class="dropdown-menu daterangepicker dep" aria-labelledby="index-btn" id="daterangepicker ">
+                        <p class="dt-header">Search the last</p>
+                        <div class="ranges">
+                            <div class="inner-range dep">
+                                <div id="now-1h" class="range-item active">1 Hr</div>
+                                <div id="now-6h" class="range-item">6 Hrs</div>
+                                <div id="now-2d" class="range-item">2 Days</div>
+                            </div>
+                            <div class="inner-range dep">
+                                <div id="now-2h" class="range-item">2 Hrs</div>
+                                <div id="now-12h" class="range-item">12 Hrs</div>
+                                <div id="now-7d" class="range-item">7 Days</div>
+                            </div>
+                            <div class="inner-range dep">
+                                <div id="now-3h" class="range-item">3 Hrs</div>
+                                <div id="now-24h" class="range-item">24 Hrs</div>
+                                <div id="now-30d" class="range-item">30 Days</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div id="dependency-graph-container" class="position-relative "> 
                 <div class="position-absolute" style="bottom:11px; right:40px;">
@@ -76,6 +105,7 @@
     <script src="./js/navbar.js?cb=1_1_10"></script>
     <script src="./js/common.js?cb=1_1_10"></script>
     <script src="./js/event-handlers.js?cb=1_1_10"></script>
+    <script src="./js/date-picker.js?cb=1_1_10"></script>
     <script src="./component/upper-navbar/upper-navbar.js"></script>
     <script src="./js/dependency-graph.js?cb=1_1_10"></script>
 

--- a/static/js/date-picker.js
+++ b/static/js/date-picker.js
@@ -47,6 +47,11 @@ function datePickerHandler(startDate, endDate, label) {
             displayStart = moment().subtract(1, 'hours').valueOf();
             displayLabel = 'Last 1 Hr';
             break;
+        case 'Last 2 Hrs':
+        case 'now-2h':
+            displayStart = moment().subtract(2, 'hours').valueOf();
+            displayLabel = 'Last 2 Hrs';
+            break;
         case 'Last 3 Hrs':
         case 'now-3h':
             displayStart = moment().subtract(3, 'hours').valueOf();

--- a/static/js/dependency-graph.js
+++ b/static/js/dependency-graph.js
@@ -38,6 +38,11 @@ let svgWidth;
 let svgHeight;
 
 $(document).ready(() => {
+  let stDate = "now-1h";
+    let endDate = "now";
+    datePickerHandler(stDate, endDate, stDate);
+    setupDependencyEventHandlers()
+
     if (Cookies.get("theme")) {
         theme = Cookies.get("theme");
         $("body").attr("data-theme", theme);
@@ -48,7 +53,7 @@ $(document).ready(() => {
     svgHeight = $("#dependency-graph-container").height();
 
     $("#error-msg-container, #dependency-info").hide();
-    getServiceDependencyData();
+    getServiceDependencyData(stDate, endDate);
 
     $("#dependency-info").tooltip({
       delay: { show: 0, hide: 300 },
@@ -66,7 +71,53 @@ $(document).ready(() => {
     });
 });
 
-function getServiceDependencyData() {
+function rangeItemHandler(evt) {
+  resetCustomDateRange();
+  $.each($(".range-item.active"), function () {
+      $(this).removeClass('active');
+  });
+  $(evt.currentTarget).addClass('active');
+  const start = $(this).attr('id')
+  const end = "now"
+  const label = $(this).attr('id')
+  datePickerHandler(start, end, label)
+  getServiceDependencyData(start, end)
+}
+
+function resetDatePickerHandler(evt) {
+  evt.stopPropagation();
+  resetCustomDateRange();
+  $.each($(".range-item.active"), function () {
+      $(this).removeClass('active');
+  });
+
+}
+
+function showDatePickerHandler(evt) {
+  evt.stopPropagation();
+  $('#daterangepicker').toggle();
+  $(evt.currentTarget).toggleClass('active');
+}
+
+function hideDatePickerHandler() {
+  $('#daterangepicker').removeClass('active');
+}
+
+function setupDependencyEventHandlers(){
+    $('#date-picker-btn').on('show.bs.dropdown', showDatePickerHandler);
+    $('#date-picker-btn').on('hide.bs.dropdown', hideDatePickerHandler);
+    $('#reset-timepicker').on('click', resetDatePickerHandler);
+
+    $('#time-start').on('change', getStartTimeHandler);
+    $('#time-end').on('change', getEndTimeHandler);
+    $('#customrange-btn').on('click', customRangeHandler);
+
+    $('.range-item').on('click', rangeItemHandler)
+}
+
+function getServiceDependencyData(start, end) {
+    d3.select("#dependency-graph-container").selectAll("svg").remove();
+
     $.ajax({
         method: "POST",
         url: "api/traces/dependencies",
@@ -75,11 +126,11 @@ function getServiceDependencyData() {
             Accept: "*/*",
         },
         dataType: "json",
-        crossDomain: true,
         data: JSON.stringify({
-          startEpoch: "now-3h",
-          endEpoch: "now"
+          startEpoch: start || "now-1h",
+          endEpoch: end || "now"
         }),
+        crossDomain: true,
         success: function (res) {
             if ($.isEmptyObject(res)) {
                 $("#dependency-graph-container").hide();

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -26,6 +26,15 @@ class ReadOnlyCellEditor {
         cellEditingClass = params.rowIndex%2===0 ? 'even-popup-textarea' : 'odd-popup-textarea'
         this.eInput.classList.add(cellEditingClass);
         this.eInput.readOnly = true;
+
+        // Set styles to ensure the textarea fits within its container
+        this.eInput.style.width = '100%';
+        this.eInput.style.height = '100%';
+        this.eInput.style.maxWidth = '100%';
+        this.eInput.style.maxHeight = '100%';
+        this.eInput.style.boxSizing = 'border-box';
+        this.eInput.style.overflow = 'auto';
+
         this.eInput.cols = params.cols;
         this.eInput.rows = params.rows;
         this.eInput.maxLength = params.maxLength;

--- a/static/js/service-health-overview.js
+++ b/static/js/service-health-overview.js
@@ -18,11 +18,11 @@ $(document).ready(() => {
 
    
     const serviceName = getParameterFromUrl('service');
+    const stDate = getParameterFromUrl('startEpoch');
+    const endDate = getParameterFromUrl('endEpoch');
     redMetrics['searchText']="service="  + serviceName + "";
     $('.service-name').text(serviceName);
-    
-    let stDate = "now-1h";
-    let endDate = "now";
+	$('.inner-range #' + stDate).addClass('active');
     datePickerHandler(stDate, endDate, stDate);
     $('.range-item').on('click', isGraphsDatePickerHandler);
     let data = getTimeRange();
@@ -55,8 +55,6 @@ let gridLineColor;
 let tickColor;
 
 function getOneServiceOverview(){
-    let endDate = filterEndDate || "now";
-    let stDate = filterStartDate || "now-1h";
     let data = getTimeRange();
     redMetrics = {... redMetrics, ... data}
     $.ajax({

--- a/static/js/service-health.js
+++ b/static/js/service-health.js
@@ -19,15 +19,15 @@ limitations under the License.
 let redMetricsData ={
     "indexName":  "red-traces",
 }
+let stDate = Cookies.get('startEpoch') || "now-3h";
+let endDate = Cookies.get('endEpoch') || "now";
 $(document).ready(() => {
     if (Cookies.get("theme")) {
         theme = Cookies.get("theme");
         $("body").attr("data-theme", theme);
     }
     $(".theme-btn").on("click", themePickerHandler);
-
-    let stDate = "now-15m";
-    let endDate = "now";
+	$('.inner-range #' + stDate).addClass('active');
     datePickerHandler(stDate, endDate, stDate);
     $('.range-item').on('click', isServiceHealthDatePickerHandler);
     let data = getTimeRange();
@@ -109,6 +109,8 @@ function processRedMetricsData(metricsData) {
 
 function getAllServices(){
     data = getTimeRange();
+    stDate = data.startEpoch;
+    endDate = data.endEpoch;
     redMetricsData = {... redMetricsData, ... data}
     $.ajax({
         method: "POST",
@@ -155,7 +157,10 @@ function displayServiceHealthTable(res){
 
 function onRowClicked(event) {
     const serviceName = event.data.service; 
-    window.location.href = 'service-health-overview.html?service=' + encodeURIComponent(serviceName);
+    const url = 'service-health-overview.html?service=' + encodeURIComponent(serviceName) +
+                '&startEpoch=' + encodeURIComponent(stDate) +
+                '&endEpoch=' + encodeURIComponent(endDate);
+    window.location.href = url;
 }
 
 

--- a/static/js/trace.js
+++ b/static/js/trace.js
@@ -47,7 +47,7 @@ function getTraceInformation(traceId) {
         },
         data: JSON.stringify({
             "searchText": `trace_id=${traceId}`,
-            "startEpoch": "now-3h",
+            "startEpoch": "now-365d",
             "endEpoch": "now"
         }),
         dataType: 'json',
@@ -59,7 +59,7 @@ function getTraceInformation(traceId) {
 }
 
 $(".back-to-search-traces").on("click", function(){
-    window.location.href = "search-traces.html";
+   window.history.back();
 });
 
 function traceDetails(res){

--- a/static/service-health-overview.html
+++ b/static/service-health-overview.html
@@ -39,7 +39,7 @@
     <title>SigLens</title>
 </head>
 <body data-theme="light">
-    <div id="cstats-app-container">
+    <div id="app-container">
         <div id="app-side-nav">
         </div>
         <div id="empty-response"></div>
@@ -52,25 +52,50 @@
                             <span>></span>
                             <h3 class="service-name"></h3>
                         </div>
-                        <div class="dropdown" id="cstats-time-picker">
-                            <button class="btn dropdown-toggle" type="button" id="date-picker-btn"
-                                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                                data-bs-toggle="dropdown" title="Pick the time window">
+                        <div class="dropdown">
+                            <button class="btn dropdown-toggle" type="button" id="date-picker-btn" data-toggle="dropdown" aria-haspopup="true"
+                                aria-expanded="false" data-bs-toggle="dropdown" title="Pick the time window">
                                 <span>Time Picker</span>
                                 <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
                                 <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
                             </button>
-                            <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn"
-                                id="daterangepicker ">
-                                <p class="dt-header">Graphs for the last</p>
+                            <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn" id="daterangepicker ">
+                                <p class="dt-header">Search the last</p>
                                 <div class="ranges">
                                     <div class="inner-range">
-                                        <div id="now-24h" class="range-item">24 Hrs</div>
+                                        <div id="now-5m" class="range-item ">5 Mins</div>
+                                        <div id="now-3h" class="range-item">3 Hrs</div>
+                                        <div id="now-2d" class="range-item">2 Days</div>
+                                    </div>
+                                    <div class="inner-range">
+                                        <div id="now-15m" class="range-item">15 Mins</div>
+                                        <div id="now-6h" class="range-item">6 Hrs</div>
                                         <div id="now-7d" class="range-item">7 Days</div>
                                     </div>
                                     <div class="inner-range">
-                                        <div id="now-1h" class="range-item active">1 Hr</div>
-                                        <div id="now-6h" class="range-item">6 Hrs</div>
+                                        <div id="now-30m" class="range-item">30 Mins</div>
+                                        <div id="now-12h" class="range-item">12 Hrs</div>
+                                        <div id="now-30d" class="range-item">30 Days</div>
+                                    </div>
+                                    <div class="inner-range">
+                                        <div id="now-1h" class="range-item">1 Hr</div>
+                                        <div id="now-24h" class="range-item">24 Hrs</div>
+                                        <div id="now-90d" class="range-item">90 Days</div>
+                                    </div>
+                                    <hr>
+                                    </hr>
+                                    <div class="dt-header">Custom Search <span id="reset-timepicker" type="reset">Reset</span>
+                                    </div>
+                                    <div id="daterange-from"> <span id="dt-from-text"> From</span> <br />
+                                        <input type="date" id="date-start" />
+                                        <input type="time" id="time-start" value="00:00" />
+                                    </div>
+                                    <div id="daterange-to"> <span id="dt-to-text"> To </span> <br />
+                                        <input type="date" id="date-end">
+                                        <input type="time" id="time-end" value="00:00">
+                                    </div>
+                                    <div class="drp-buttons">
+                                        <button class="applyBtn btn btn-sm btn-primary" id="customrange-btn" type="button">Apply</button>
                                     </div>
                                 </div>
                             </div>

--- a/static/service-health.html
+++ b/static/service-health.html
@@ -51,36 +51,57 @@
 
         <div id="dashboard" class="p-20">
             <div class="subsection-navbar align-items-end justify-content-between">
-                <div class="dropdown" id="cstats-time-picker">
-                    <button class="btn dropdown-toggle" type="button" id="date-picker-btn"
-                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                        data-bs-toggle="dropdown" title="Pick the time window">
+                <div class="dropdown">
+                    <button class="btn dropdown-toggle" type="button" id="date-picker-btn" data-toggle="dropdown" aria-haspopup="true"
+                        aria-expanded="false" data-bs-toggle="dropdown" title="Pick the time window">
                         <span>Time Picker</span>
                         <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
                         <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
                     </button>
-                    <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn"
-                        id="daterangepicker ">
+                    <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn" id="daterangepicker ">
                         <p class="dt-header">Search the last</p>
                         <div class="ranges">
                             <div class="inner-range">
-                                <div id="now-15m" class="range-item active">15 Mins</div>
-                                <div id="now-24h" class="range-item">24 Hrs</div>
+                                <div id="now-5m" class="range-item ">5 Mins</div>
+                                <div id="now-3h" class="range-item">3 Hrs</div>
+                                <div id="now-2d" class="range-item">2 Days</div>
+                            </div>
+                            <div class="inner-range">
+                                <div id="now-15m" class="range-item">15 Mins</div>
+                                <div id="now-6h" class="range-item">6 Hrs</div>
+                                <div id="now-7d" class="range-item">7 Days</div>
                             </div>
                             <div class="inner-range">
                                 <div id="now-30m" class="range-item">30 Mins</div>
-                                <div id="now-6h" class="range-item">6 Hrs</div>
+                                <div id="now-12h" class="range-item">12 Hrs</div>
+                                <div id="now-30d" class="range-item">30 Days</div>
                             </div>
                             <div class="inner-range">
                                 <div id="now-1h" class="range-item">1 Hr</div>
-                                <div id="now-7d" class="range-item">7 Days</div>
+                                <div id="now-24h" class="range-item">24 Hrs</div>
+                                <div id="now-90d" class="range-item">90 Days</div>
+                            </div>
+                            <hr>
+                            </hr>
+                            <div class="dt-header">Custom Search <span id="reset-timepicker" type="reset">Reset</span>
+                            </div>
+                            <div id="daterange-from"> <span id="dt-from-text"> From</span> <br />
+                                <input type="date" id="date-start" />
+                                <input type="time" id="time-start" value="00:00" />
+                            </div>
+                            <div id="daterange-to"> <span id="dt-to-text"> To </span> <br />
+                                <input type="date" id="date-end">
+                                <input type="time" id="time-end" value="00:00">
+                            </div>
+                            <div class="drp-buttons">
+                                <button class="applyBtn btn btn-sm btn-primary" id="customrange-btn" type="button">Apply</button>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
             <div class="mt-3">
-                <input type="text" class="search-input" placeholder="Search and Filter based on resource attributes">
+                <input type="text" class="search-input" placeholder="Search and Filter based on service name">
             </div>
             <div class="mt-3 h-100 mb-2" id="tracing-container">
                 <div id="ag-grid" class="ag-theme-mycustomtheme">


### PR DESCRIPTION
# Release notes
## Enhancements:
- Introduced a time picker on the dependency graph screen, enabling users to view aggregated dependency graphs for periods up to 30 days in the past.
- Expanded trace search capabilities to include traces up to one year old.

## Bug Fixes:
- Resolved an issue with the SPL `where` command, which now functions correctly with queries that do not include group by operations.
- Addressed a problem with the SPL `head` command, ensuring it works as expected with queries when followed by the stats command, even when querying fewer than total segments.
- Implemented minor UI enhancements on the tracing screen for improved user experience.
