### PR TITLE
fix NaN error while ingesting siglens metrics

### DIFF
--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -546,7 +546,7 @@ func ExtractOTSDBPayload(rawJson []byte, tags *TagsHolder) ([]byte, float64, uin
 	if len(mName) > 0 && ts > 0 {
 		return mName, dpVal, ts, nil
 	} else if len(mName) == 0 && err == nil {
-		//comes here when mName = targe_info
+		//comes here when mName = target_info
 		return nil, dpVal, 0, nil
 	} else {
 		return nil, dpVal, 0, fmt.Errorf("failed to find all expected keys")

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -536,6 +536,7 @@ func ExtractOTSDBPayload(rawJson []byte, tags *TagsHolder) ([]byte, float64, uin
 		}
 		return nil
 	}
+	rawJson = bytes.Replace(rawJson, []byte("NaN"), []byte("0"), -1)
 	err = jp.ObjectEach(rawJson, handler)
 
 	if err != nil {
@@ -544,6 +545,9 @@ func ExtractOTSDBPayload(rawJson []byte, tags *TagsHolder) ([]byte, float64, uin
 	}
 	if len(mName) > 0 && ts > 0 {
 		return mName, dpVal, ts, nil
+	} else if len(mName) == 0 && err == nil {
+		//comes here when mName = targe_info
+		return nil, dpVal, 0, nil
 	} else {
 		return nil, dpVal, 0, fmt.Errorf("failed to find all expected keys")
 	}


### PR DESCRIPTION
# Description
Summarize the change.
Fixed following error while ingesting siglens metrics with NaN value:
```ExtractOTSDBPayload payload {\\\"metric\\\":\\\"ss_segment_latency_avg_ms\\\",\\\"tags\\\":{\\\"__name__\\\":\\\"ss_segment_latency_avg_ms\\\",\\\"instance\\\":\\\"siglens:2222\\\",\\\"job\\\":\\\"siglens-metrics\\\",\\\"otel_scope_name\\\":\\\"siglens\\\",\\\"pqid\\\":\\\"18251664056736810150\\\",\\\"metric\\\":\\\"ss_segment_latency_avg_ms\\\"},\\\"timestamp\\\":1712909069675,\\\"value\\\":NaN} failed to extract payload! Unknown value type ",```

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
