### PR TITLE
Add error utils

### DIFF
--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -867,6 +867,7 @@ func ExtractSeriesOfJsonObjects(body []byte) ([]map[string]interface{}, error) {
 }
 
 func sendErrorWithStatus(ctx *fasthttp.RequestCtx, messageToUser string, extraMessageToLog string, err error, statusCode int) {
+	// Get the caller function name, file name, and line number.
 	pc, _, _, _ := runtime.Caller(2) // Get the caller two levels up.
 	caller := runtime.FuncForPC(pc)
 	callerName := "unknown"
@@ -884,12 +885,14 @@ func sendErrorWithStatus(ctx *fasthttp.RequestCtx, messageToUser string, extraMe
 		callerFile = callerFile[strings.LastIndex(callerFile, "/pkg/")+1:]
 	}
 
+	// Log the error message.
 	if extraMessageToLog == "" {
 		log.Errorf("%s at %s:%d: %v, err=%v", callerName, callerFile, callerLine, messageToUser, err)
 	} else {
 		log.Errorf("%s at %s:%d: %v. %v, err=%v", callerName, callerFile, callerLine, messageToUser, extraMessageToLog, err)
 	}
 
+	// Send the error message to the client.
 	responsebody := make(map[string]interface{})
 	responsebody["error"] = messageToUser
 	ctx.SetStatusCode(statusCode)

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/cespare/xxhash"
@@ -863,4 +864,42 @@ func ExtractSeriesOfJsonObjects(body []byte) ([]map[string]interface{}, error) {
 	}
 
 	return objects, nil
+}
+
+func sendErrorWithStatus(ctx *fasthttp.RequestCtx, messageToUser string, extraMessageToLog string, err error, statusCode int) {
+	pc, _, _, _ := runtime.Caller(2) // Get the caller two levels up.
+	caller := runtime.FuncForPC(pc)
+	callerName := "unknown"
+	callerFile := "unknown"
+	callerLine := 0
+
+	if caller != nil {
+		callerName = caller.Name()
+		callerFile, callerLine = caller.FileLine(pc)
+
+		// Only take the function name after the last dot.
+		callerName = callerName[strings.LastIndex(callerName, ".")+1:]
+
+		// Only take the /pkg/... part of the file path.
+		callerFile = callerFile[strings.LastIndex(callerFile, "/pkg/")+1:]
+	}
+
+	if extraMessageToLog == "" {
+		log.Errorf("%s at %s:%d: %v, err=%v", callerName, callerFile, callerLine, messageToUser, err)
+	} else {
+		log.Errorf("%s at %s:%d: %v. %v, err=%v", callerName, callerFile, callerLine, messageToUser, extraMessageToLog, err)
+	}
+
+	responsebody := make(map[string]interface{})
+	responsebody["error"] = messageToUser
+	ctx.SetStatusCode(statusCode)
+	WriteJsonResponse(ctx, responsebody)
+}
+
+func SendError(ctx *fasthttp.RequestCtx, messageToUser string, extraMessageToLog string, err error) {
+	sendErrorWithStatus(ctx, messageToUser, extraMessageToLog, err, fasthttp.StatusBadRequest)
+}
+
+func SendInternalError(ctx *fasthttp.RequestCtx, messageToUser string, extraMessageToLog string, err error) {
+	sendErrorWithStatus(ctx, messageToUser, extraMessageToLog, err, fasthttp.StatusInternalServerError)
 }


### PR DESCRIPTION
# Description
This adds some convenience functions for more succinctly blocks of error handling like
```
if err != nil {
	log.Errorf("ProcessCreateLogMinionSearchRequest: could not unmarshal json body, err=%v", err)
	ctx.SetStatusCode(fasthttp.StatusBadRequest)
	responseBody["error"] = err.Error()
	utils.WriteJsonResponse(ctx, responseBody)
	return
}
```
No you can do simply
```
if err != nil {
	utils.SendError(ctx, "could not unmarshal json body", "", err)
	return
}
```
These functions also automatically get the name of the function (in this case `ProcessCreateLogMinionSearchRequest`) that called `SendError()` and prepend that to the emitted log message. The second string (empty in this example) is to provide more information in our internal log message that we don't want to show to the user.

# Testing
Called the functions and verified I got the expected results logged. I also tested it in docker, and the correct filename and line number was still shown.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
