### PR TITLE
Split retention hours for logs, traces and metrics

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -80,7 +80,9 @@ type Configuration struct {
 	IngestNode                 string   `yaml:"ingestNode"`           //Node to enable/disable all ingest endpoints
 	SegFlushIntervalSecs       int      `yaml:"segFlushIntervalSecs"` // Time Interval after which to write to segfile
 	DataPath                   string   `yaml:"dataPath"`
-	RetentionHours             int      `yaml:"retentionHours"`
+	LogRetentionHours          int      `yaml:"logRetentionHours"`
+	TraceRetentionHours        int      `yaml:"traceRetentionHours"`
+	MetricRetentionHours       int      `yaml:"metricRetentionHours"`
 	TimeStampKey               string   `yaml:"timestampKey"`
 	MaxSegFileSize             uint64   `yaml:"maxSegFileSize"` // segment file size (in bytes)
 	LicenseKeyPath             string   `yaml:"licenseKeyPath"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,8 +102,16 @@ func GetEventTypeKeywords() *[]string {
 	return &runningConfig.EventTypeKeywords
 }
 
-func GetRetentionHours() int {
-	return runningConfig.RetentionHours
+func GetLogRetentionHours() int {
+	return runningConfig.LogRetentionHours
+}
+
+func GetTraceRetentionHours() int {
+	return runningConfig.TraceRetentionHours
+}
+
+func GetMetricRetentionHours() int {
+	return runningConfig.MetricRetentionHours
 }
 
 func IsS3Enabled() bool {
@@ -344,8 +352,16 @@ func SetSegFlushIntervalSecs(val int) {
 	runningConfig.SegFlushIntervalSecs = val
 }
 
-func SetRetention(val int) {
-	runningConfig.RetentionHours = val
+func SetLogRetentionHours(val int) {
+	runningConfig.LogRetentionHours = val
+}
+
+func SetTraceRetentionHours(val int) {
+	runningConfig.TraceRetentionHours = val
+}
+
+func SetMetricRetentionHours(val int) {
+	runningConfig.MetricRetentionHours = val
 }
 
 func SetTimeStampKey(val string) {
@@ -470,7 +486,9 @@ func GetTestConfig() common.Configuration {
 		SegFlushIntervalSecs:       5,
 		DataPath:                   "data/",
 		S3:                         common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-		RetentionHours:             24 * 90,
+		LogRetentionHours:          24 * 30,
+		TraceRetentionHours:        24 * 60,
+		MetricRetentionHours:       24 * 90,
 		TimeStampKey:               "timestamp",
 		MaxSegFileSize:             1_073_741_824,
 		LicenseKeyPath:             "./",
@@ -650,9 +668,17 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 
 	}
 
-	if config.RetentionHours == 0 {
+	if config.LogRetentionHours == 0 {
 		log.Infof("Defaulting to 2160hrs (90 days) of retention...")
-		config.RetentionHours = 90 * 24
+		config.LogRetentionHours = 2160
+	}
+	if config.TraceRetentionHours == 0 {
+		log.Infof("Defaulting to 2160hrs (90 days) of retention...")
+		config.TraceRetentionHours = 2160
+	}
+	if config.MetricRetentionHours == 0 {
+		log.Infof("Defaulting to 2160hrs (90 days) of retention...")
+		config.MetricRetentionHours = 2160
 	}
 	if len(config.TimeStampKey) <= 0 {
 		config.TimeStampKey = "timestamp"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,7 +49,9 @@ func Test_ExtractConfigData(t *testing.T) {
   bucketName: "test-1"
   bucketPrefix: ""
   regionName: "us-east-1"
- retentionHours: 90
+ logRetentionHours: 30
+ traceRetentionHours: 60
+ metricRetentionHours: 90
  TimeStampKey: "timestamp"
  maxSegFileSize: 10
  licensekeyPath: "./"
@@ -91,7 +93,9 @@ func Test_ExtractConfigData(t *testing.T) {
 				SegFlushIntervalSecs:       5,
 				DataPath:                   "data/",
 				S3:                         common.S3Config{Enabled: true, BucketName: "test-1", BucketPrefix: "", RegionName: "us-east-1"},
-				RetentionHours:             90,
+				LogRetentionHours:          30,
+				TraceRetentionHours:        60,
+				MetricRetentionHours:       90,
 				TimeStampKey:               "timestamp",
 				MaxSegFileSize:             10,
 				LicenseKeyPath:             "./",
@@ -128,7 +132,9 @@ func Test_ExtractConfigData(t *testing.T) {
  metareaderNode: true
  segFlushIntervalSecs: 1200
  DataPath: "data/"
- retentionHours: 123
+ logRetentionHours: 30
+ traceRetentionHours: 60
+ metricRetentionHours: 90
  TimeStampKey: "timestamp"
  maxSegFileSize: 12345
  licensekeyPath: "./"
@@ -167,7 +173,9 @@ func Test_ExtractConfigData(t *testing.T) {
 				SegFlushIntervalSecs:       1200,
 				DataPath:                   "data/",
 				S3:                         common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-				RetentionHours:             123,
+				LogRetentionHours:          30,
+				TraceRetentionHours:        60,
+				MetricRetentionHours:       90,
 				TimeStampKey:               "timestamp",
 				MaxSegFileSize:             12345,
 				LicenseKeyPath:             "./",
@@ -207,7 +215,9 @@ invalid input, we should error out
 				SegFlushIntervalSecs:     30,
 				DataPath:                 "data/",
 				S3:                       common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-				RetentionHours:           90,
+				LogRetentionHours:        30,
+				TraceRetentionHours:      60,
+				MetricRetentionHours:     90,
 				TimeStampKey:             "timestamp",
 				MaxSegFileSize:           1_073_741_824,
 				LicenseKeyPath:           "./",
@@ -244,7 +254,9 @@ a: b
 				SegFlushIntervalSecs:       5,
 				DataPath:                   "data/",
 				S3:                         common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-				RetentionHours:             90 * 24,
+				LogRetentionHours:          30 * 24,
+				TraceRetentionHours:        60 * 24,
+				MetricRetentionHours:       90 * 24,
 				TimeStampKey:               "timestamp",
 				MaxSegFileSize:             1_073_741_824,
 				LicenseKeyPath:             "./",

--- a/pkg/ssa/ssa.go
+++ b/pkg/ssa/ssa.go
@@ -321,7 +321,9 @@ func getBaseInfo() map[string]interface{} {
 
 func populateDeploymentSsa(m map[string]interface{}) {
 	m["uptime_minutes"] = math.Round(time.Since(utils.GetServerStartTime()).Minutes())
-	m["retention_hours"] = config.GetRetentionHours()
+	m["log_retention_hours"] = config.GetLogRetentionHours()
+	m["trace_retention_hours"] = config.GetTraceRetentionHours()
+	m["metric_retention_hours"] = config.GetMetricRetentionHours()
 	m["company_name"] = "OSS"
 	m["version"] = config.SigLensVersion
 	m["deployment_type"] = getDeploymentType()

--- a/playground.yaml
+++ b/playground.yaml
@@ -19,7 +19,9 @@ pqsEnabled: false
 esVersion: "7.9.3"
 
 ## Number of hours data will be stored/retained on persistent storage.
-retentionHours: 48
+logRetentionHours: 48
+traceRetentionHours: 48
+metricRetentionHours: 48
 
 ## Percent of available RAM that siglens will occupy
 # memoryThresholdPercent: 80

--- a/server.yaml
+++ b/server.yaml
@@ -19,7 +19,9 @@ pqsEnabled: false
 esVersion: "7.9.3"
 
 ## Number of hours data will be stored/retained on persistent storage.
-# retentionHours: 2160
+logRetentionHours: 2160
+traceRetentionHours: 2160
+metricRetentionHours: 2160
 
 ## Percent of available RAM that siglens will occupy
 # memoryThresholdPercent: 80


### PR DESCRIPTION
# Description
Split retention hours for logs, traces and metrics

# Testing
- Tested by ingesting logs and traces with different retention hours and verified that retention kicks in as per the hours mentioned. 
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [] I have self-reviewed this PR.
- [] I have removed all print-debugging and commented-out code that should not be merged.
- [] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
