### PR TITLE
Save Indexes in Cookies

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -54,6 +54,10 @@ function renderIndexDropdown(listIndices) {
                        </div>`);
         });
     }
-    selectedSearchIndex = sortedListIndices[0].index;
-    $("#index-btn span").html(sortedListIndices[0].index);
+    if (Cookies.get('IndexList')) {
+        selectedSearchIndex = Cookies.get('IndexList');
+    }else {
+        selectedSearchIndex = sortedListIndices[0].index;
+        $("#index-btn span").html(sortedListIndices[0].index);
+    }
 }

--- a/static/js/log-search.js
+++ b/static/js/log-search.js
@@ -91,11 +91,6 @@ $(document).ready(() => {
         $('#time-end').addClass('active');
     }
 
-    if (!Cookies.get('IndexList')) {
-        Cookies.set('IndexList', "*");
-    }
-
-
 	$("#info-icon-sql").tooltip({
 		delay: { show: 0, hide: 300 },
 		trigger: 'click'


### PR DESCRIPTION
# Description

1. Storing indexes in cookies so that if a user reloads the page, the selected indexes are not refreshed.
2. If cookies contain indexes - use them, otherwise, select the first sorted index.
3. Removed some code related to the '*' index.