### PR TITLE
fix: by default 2 option will be selected in search index dropdown

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -57,7 +57,7 @@ function renderIndexDropdown(listIndices) {
     if (Cookies.get('IndexList')) {
         selectedSearchIndex = Cookies.get('IndexList');
     }else {
-        if(sortedListIndices.length > 1){
+        if(sortedListIndices.length > 0){
             let selected = sortedListIndices[0].index
     
             if(sortedListIndices[0].index === 'default' && sortedListIndices.length >= 2){

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -57,13 +57,15 @@ function renderIndexDropdown(listIndices) {
     if (Cookies.get('IndexList')) {
         selectedSearchIndex = Cookies.get('IndexList');
     }else {
-        let selected = sortedListIndices[0].index
+        if(sortedListIndices.length > 1){
+            let selected = sortedListIndices[0].index
+    
+            if(sortedListIndices[0].index === 'default' && sortedListIndices.length >= 2){
+                selected = sortedListIndices[1].index
+            }
 
-        if(sortedListIndices.length >= 2){
-            selected = sortedListIndices[1].index
+            selectedSearchIndex = selected;
+            $("#index-btn span").html(selected);
         }
-        
-        selectedSearchIndex = selected;
-        $("#index-btn span").html(selected);
     }
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -57,7 +57,13 @@ function renderIndexDropdown(listIndices) {
     if (Cookies.get('IndexList')) {
         selectedSearchIndex = Cookies.get('IndexList');
     }else {
-        selectedSearchIndex = sortedListIndices[0].index;
-        $("#index-btn span").html(sortedListIndices[0].index);
+        let selected = sortedListIndices[0].index
+
+        if(sortedListIndices.length >= 2){
+            selected = sortedListIndices[1].index
+        }
+        
+        selectedSearchIndex = selected;
+        $("#index-btn span").html(selected);
     }
 }


### PR DESCRIPTION
# Description
The default value in the dropdown will be the second option of the list (if available).

# Testing
It can be checked by opening the `Logs` tab in incognito mode, you will see the second option is selected by default (if available)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
