### PR TITLE
Fix: Update the Metric Ingestion URL in SigClient

### DIFF
--- a/tools/sigclient/pkg/ingest/ingest.go
+++ b/tools/sigclient/pkg/ingest/ingest.go
@@ -70,7 +70,7 @@ func sendRequest(iType IngestType, client *http.Client, lines []byte, url string
 	case ESBulk:
 		requestStr = url + "/_bulk"
 	case OpenTSDB:
-		requestStr = url + "/api/put"
+		requestStr = url + "/otsdb/api/put"
 
 	default:
 		log.Fatalf("unknown ingest type %+v", iType)
@@ -93,10 +93,15 @@ func sendRequest(iType IngestType, client *http.Client, lines []byte, url string
 		return err
 	}
 	defer resp.Body.Close()
-	_, err = io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("sendRequest: client.Do ERROR: %v", err)
 		return err
+	}
+	// Check if the Status code is not 200
+	if resp.StatusCode != http.StatusOK {
+		log.Errorf("sendRequest: client.Do ERROR Response: %v", "StatusCode: "+fmt.Sprint(resp.StatusCode)+": "+string(respBody))
+		return fmt.Errorf("sendRequest: client.Do ERROR Response: %v", "StatusCode: "+fmt.Sprint(resp.StatusCode)+": "+string(respBody))
 	}
 	return nil
 }


### PR DESCRIPTION
# Description
- Updated the metric ingestion URL.
- The error handling of the ingestion response will now also check the status code. 

# Testing
- Tested it by ingesting it into SigLens through SigClient.
- And running the example metric queries.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
