### PR TITLE
Fix: Metrics Ingestion And Flushing of Metrics Blocks

### DIFF
--- a/pkg/influx/writer/putmetrics_test.go
+++ b/pkg/influx/writer/putmetrics_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var rawCSV = []byte("measurement,tag1=val1,tag2=val2 value=100 0000000000000000000\nmeasurement,tag1=val1,tag2=val2 value=300 0000000000000000000\n")
+var rawCSV = []byte("measurement,tag1=val1,tag2=val2 value=100 1714511214000000000\nmeasurement,tag1=val1,tag2=val2 value=300 1714511215000000000\n")
 
 func Test_InsertCsv(t *testing.T) {
 
@@ -38,7 +38,7 @@ func Test_InsertCsv(t *testing.T) {
 
 	sTime := time.Now()
 	totalSuccess := uint64(0)
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1; i++ {
 		success, fail, err := HandlePutMetrics([]byte(rawCSV), 0)
 		assert.NoError(t, err)
 		assert.Equal(t, success, uint64(2))

--- a/pkg/integrations/prometheus/ingest/putmetrics_test.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics_test.go
@@ -34,10 +34,10 @@ import (
 )
 
 // FixtureSamplePayload returns a Snappy-compressed TimeSeries
-func FixtureSamplePayload() []byte {
+func FixtureSamplePayload(inc int) []byte {
 	nameLabelPair := prompb.Label{Name: model.MetricNameLabel, Value: "mah-test-metric"}
 	stubLabelPair := prompb.Label{Name: "environment", Value: "production"}
-	stubSample := prompb.Sample{Value: 123.45, Timestamp: time.Now().UTC().Unix()}
+	stubSample := prompb.Sample{Value: 123.45, Timestamp: time.Now().UTC().Unix() + int64(inc)}
 	stubTimeSeries := prompb.TimeSeries{
 		Labels:  []prompb.Label{stubLabelPair, nameLabelPair},
 		Samples: []prompb.Sample{stubSample},
@@ -53,11 +53,11 @@ func FixtureSamplePayload() []byte {
 func Test_PutMetrics(t *testing.T) {
 	config.InitializeTestingConfig()
 	writer.InitWriterNode()
-	postData := FixtureSamplePayload()
 
 	sTime := time.Now()
 	totalSuccess := uint64(0)
 	for i := 0; i < 100; i++ {
+		postData := FixtureSamplePayload(i)
 		success, fail, err := HandlePutMetrics(postData)
 		assert.NoError(t, err)
 		assert.Equal(t, success, uint64(1))

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -628,6 +628,7 @@ func ExtractInfluxPayload(rawCSV []byte, tags *TagsHolder) ([]byte, float64, uin
 
 	var mName []byte
 	var dpVal float64
+	var ts uint32 = uint32(time.Now().Unix())
 	var err error
 
 	reader := csv.NewReader(bytes.NewBuffer(rawCSV))
@@ -647,6 +648,14 @@ func ExtractInfluxPayload(rawCSV []byte, tags *TagsHolder) ([]byte, float64, uin
 			whitespace_split := strings.Fields(line)
 			tag_set := strings.Split(whitespace_split[0], ",")
 			field_set := strings.Split(whitespace_split[1], ",")
+			if len(whitespace_split) > 2 {
+				tsNano, err := strconv.ParseInt(whitespace_split[2], 10, 64)
+				if err != nil {
+					log.Errorf("ExtractInfluxPayload: failed to parse timestamp! %+v", err)
+				} else {
+					ts = uint32(tsNano / 1_000_000_000)
+				}
+			}
 			for index, value := range tag_set {
 				if index == 0 {
 					mName = []byte(value)
@@ -677,7 +686,7 @@ func ExtractInfluxPayload(rawCSV []byte, tags *TagsHolder) ([]byte, float64, uin
 
 	}
 
-	return mName, dpVal, 0, err
+	return mName, dpVal, ts, err
 
 }
 

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -270,7 +270,7 @@ func timeBasedMetricsFlush() {
 				ms.rwLock.Lock()
 				err := ms.mBlock.rotateBlock(ms.metricsKeyBase, ms.Suffix, ms.currBlockNum)
 				if err != nil {
-					log.Errorf("timeBasedMetricsFlush: failed to rotate block %v", err)
+					log.Errorf("timeBasedMetricsFlush: failed to rotate block number: %v due to the error: %v", ms.currBlockNum, err)
 				} else {
 					ms.currBlockNum++
 				}
@@ -651,7 +651,7 @@ func ExtractInfluxPayload(rawCSV []byte, tags *TagsHolder) ([]byte, float64, uin
 			if len(whitespace_split) > 2 {
 				tsNano, err := strconv.ParseInt(whitespace_split[2], 10, 64)
 				if err != nil {
-					log.Errorf("ExtractInfluxPayload: failed to parse timestamp! %+v", err)
+					log.Errorf("ExtractInfluxPayload: failed to parse the timestamp: %+v, error: %+v", whitespace_split[2], err)
 				} else {
 					ts = uint32(tsNano / 1_000_000_000)
 				}

--- a/pkg/segment/writer/metrics/tagsholder.go
+++ b/pkg/segment/writer/metrics/tagsholder.go
@@ -154,3 +154,16 @@ func (th *TagsHolder) GetTSID(mName []byte) (uint64, error) {
 func (th *TagsHolder) getEntries() []tagEntry {
 	return th.entries[:th.idx]
 }
+
+func (th *TagsHolder) String() string {
+	buf := bytebufferpool.Get()
+	buf.WriteString("{")
+	for _, val := range th.entries {
+		buf.WriteString(val.tagKey)
+		buf.WriteString(":")
+		buf.Write(val.tagValue)
+		buf.WriteString(",")
+	}
+	buf.WriteString("}")
+	return buf.String()
+}

--- a/pkg/segment/writer/metrics/tagsholder.go
+++ b/pkg/segment/writer/metrics/tagsholder.go
@@ -157,13 +157,13 @@ func (th *TagsHolder) getEntries() []tagEntry {
 
 func (th *TagsHolder) String() string {
 	buf := bytebufferpool.Get()
-	buf.WriteString("{")
+	_, _ = buf.WriteString("{")
 	for _, val := range th.entries {
-		buf.WriteString(val.tagKey)
-		buf.WriteString(":")
-		buf.Write(val.tagValue)
-		buf.WriteString(",")
+		_, _ = buf.WriteString(val.tagKey)
+		_, _ = buf.WriteString(":")
+		_, _ = buf.Write(val.tagValue)
+		_, _ = buf.WriteString(",")
 	}
-	buf.WriteString("}")
+	_, _ = buf.WriteString("}")
 	return buf.String()
 }

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -283,7 +283,7 @@ func AddTimeSeriesEntryToInMemBuf(rawJson []byte, signalType SIGNAL_TYPE, orgid 
 		err = metrics.EncodeDatapoint(mName, tagsHolder, dp, ts, uint64(len(rawJson)), orgid)
 		if err != nil {
 			metrics.ReturnTagsHolder(tagsHolder)
-			return err
+			return fmt.Errorf("entry rejected for metric %s %v because of error: %v", mName, tagsHolder, err)
 		}
 		metrics.ReturnTagsHolder(tagsHolder)
 	case SIGNAL_METRICS_INFLUX:


### PR DESCRIPTION
# Description
- Fixed Metrics Ingestion to reject the old/duplicate timestamps per `TimeSeries`.
- Fixed overriding the first value in a `TimeSeries` block while ingesting metrics.
- Fixed flushing of Metrics Blocks that was not incrementing the `BlockNum`.
- Fixed the tests of Metrics Ingestion that is being rejected because of duplicate Timestamps.
- Extracting the timestamp from the Influx Db case while ingesting metrics in csv format.
- Fixed the tests related to Influx DB Put Metrics: Ingestion through csv.

# Testing
- Tested by running the ingestion through SigClient and queries through UI. 

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
