### PR TITLE
fix: Avg Aggregation case for Metrics and Set the default Metrics Aggregation as Avg

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -362,8 +362,8 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				case "quantile":
 					mquery.Aggregator.AggregatorFunction = segutils.Quantile
 				default:
-					log.Infof("convertPqlToMetricsQuery: using sum aggregator by default for AggregateExpr (got %v)", aggFunc)
-					mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Sum}
+					log.Infof("convertPqlToMetricsQuery: using avg aggregator by default for AggregateExpr (got %v)", aggFunc)
+					mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Avg}
 				}
 			case *pql.VectorSelector:
 				_, grouping := extractGroupsFromPath(path)
@@ -393,8 +393,8 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				case "quantile":
 					mquery.Aggregator.AggregatorFunction = segutils.Quantile
 				default:
-					log.Infof("convertPqlToMetricsQuery: using sum aggregator by default for VectorSelector (got %v)", aggFunc)
-					mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Sum}
+					log.Infof("convertPqlToMetricsQuery: using avg aggregator by default for VectorSelector (got %v)", aggFunc)
+					mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Avg}
 				}
 			case *pql.NumberLiteral:
 				mquery.Aggregator.FuncConstant = expr.Val
@@ -430,7 +430,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 		mquery.HashedMName = xxhash.Sum64String(mquery.MetricName)
 		mquery.OrgId = myid
 		mquery.SelectAllSeries = true
-		agg := structs.Aggreation{AggregatorFunction: segutils.Sum}
+		agg := structs.Aggreation{AggregatorFunction: segutils.Avg}
 		mquery.Downsampler = structs.Downsampler{Interval: 1, Unit: "m", Aggregator: agg}
 		metricQueryRequest := &structs.MetricsQueryRequest{
 			MetricsQuery: mquery,
@@ -500,7 +500,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 	mquery.HashedMName = xxhash.Sum64String(metricName)
 
 	if mquery.Aggregator.AggregatorFunction == 0 && !groupby {
-		mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Sum}
+		mquery.Aggregator = structs.Aggreation{AggregatorFunction: segutils.Avg}
 	}
 	mquery.Downsampler = structs.Downsampler{Interval: 1, Unit: "m", Aggregator: mquery.Aggregator}
 	mquery.SelectAllSeries = !groupby // if group by is not present, then we need to select all series

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -390,10 +390,12 @@ func reduceRunningEntries(entries []RunningEntry, fn utils.AggregateFunctions, f
 	var ret float64
 	switch fn {
 	case utils.Avg:
+		count := uint64(0)
 		for i := range entries {
 			ret += entries[i].runningVal
+			count += entries[i].runningCount
 		}
-		ret = ret / float64(len(entries))
+		ret = ret / float64(count)
 	case utils.Sum:
 		for i := range entries {
 			ret += entries[i].runningVal


### PR DESCRIPTION
# Description
- Set the default to `Avg` for Metrics aggregation.
- Fixed the `Avg` Aggregation for Metrics.

# Testing
- Tested by ingesting a set metrics and making queries from the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
