### PR TITLE
fix: count aggregation for metrics

### DIFF
--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -413,7 +413,9 @@ func reduceRunningEntries(entries []RunningEntry, fn utils.AggregateFunctions, f
 			}
 		}
 	case utils.Count:
-		ret += float64(len(entries))
+		for i := range entries {
+			ret += float64(entries[i].runningCount)
+		}
 	case utils.Quantile: //valid range for fnConstant is 0 <= fnConstant <= 1
 		// TODO: calculate the quantile without needing to sort the elements.
 


### PR DESCRIPTION
# Description
- Fixed the count aggregation for Metrics.

# Testing
- Tested by running the queries against the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
