### PR TITLE
feat: Write Metric Names into a file

### DIFF
--- a/pkg/segment/writer/metrics/meta/metricsmeta.go
+++ b/pkg/segment/writer/metrics/meta/metricsmeta.go
@@ -20,7 +20,6 @@ package meta
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 	"sync"
@@ -81,48 +80,6 @@ func AddMetricsMetaEntry(entry *structs.MetricsMeta) error {
 	if err != nil {
 		log.Errorf("AddMetricsMetaEntry: failed to sync filename=%v: err=%v", localMetricsMeta, err)
 		return err
-	}
-
-	return nil
-}
-
-func FlushMetricNames(basePath string, suffix uint64, mNamesMap map[string]bool) error {
-
-	if len(mNamesMap) == 0 {
-		log.Warnf("FlushMetricNames: empty mNamesMap")
-		return nil
-	}
-
-	mMetaLock.Lock()
-	defer mMetaLock.Unlock()
-
-	filePath := fmt.Sprintf("%s%d.mnm", basePath, suffix)
-
-	fd, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		log.Errorf("FlushMetricNames: failed to open filename=%v: err=%v", filePath, err)
-		return err
-	}
-
-	defer fd.Close()
-
-	mNamesJson, err := json.Marshal(mNamesMap)
-	if err != nil {
-		log.Errorf("FlushMetricNames: failed to Marshal: err=%v", err)
-		return err
-	}
-
-	if _, err := fd.Write(mNamesJson); err != nil {
-		log.Errorf("FlushMetricNames: failed to write segmeta filename=%v: err=%v", filePath, err)
-		return err
-	}
-
-	err = fd.Sync()
-	if err != nil {
-		log.Errorf("FlushMetricNames: failed to sync filename=%v: err=%v", filePath, err)
-		return err
-	} else {
-		log.Infof("FlushMetricNames: flushed %d metric names to %s", len(mNamesMap), filePath)
 	}
 
 	return nil

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -310,7 +310,7 @@ func InitMetricsSegment(orgid uint64, mId string) (*MetricsSegment, error) {
 		return nil, err
 	}
 	return &MetricsSegment{
-		mNamesBloom:  bloom.NewWithEstimates(10, 0.001), // TODO: dynamic sizing
+		mNamesBloom:  bloom.NewWithEstimates(1000, 0.001),
 		mNamesMap:    make(map[string]bool, 0),
 		currBlockNum: 0,
 		mBlock: &MetricsBlock{
@@ -1068,7 +1068,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 			log.Errorf("rotateSegment: failed to get next base key for %s: %v", ms.Mid, err)
 			return err
 		}
-
+		mNamesCount := uint(len(ms.mNamesMap))
 		for k := range ms.mNamesMap {
 			delete(ms.mNamesMap, k)
 		}
@@ -1078,7 +1078,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		ms.highTS = 0
 		ms.lowTS = math.MaxUint32
 		ms.currBlockNum = 0
-		ms.mNamesBloom = bloom.NewWithEstimates(uint(len(ms.mNamesMap)), 0.001) // TODO: dynamic sizing
+		ms.mNamesBloom = bloom.NewWithEstimates(mNamesCount, 0.001)
 		ms.totalEncodedSize = 0
 		ms.datapointCount = 0
 		ms.bytesReceived = 0

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1066,7 +1066,6 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 			return err
 		}
 
-		mNamesCount := uint(len(ms.mNamesMap))
 		for k := range ms.mNamesMap {
 			delete(ms.mNamesMap, k)
 		}
@@ -1076,7 +1075,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		ms.highTS = 0
 		ms.lowTS = math.MaxUint32
 		ms.currBlockNum = 0
-		ms.mNamesBloom = bloom.NewWithEstimates(mNamesCount, 0.001) // TODO: dynamic sizing
+		ms.mNamesBloom = bloom.NewWithEstimates(uint(len(ms.mNamesMap)), 0.001) // TODO: dynamic sizing
 		ms.totalEncodedSize = 0
 		ms.datapointCount = 0
 		ms.bytesReceived = 0
@@ -1122,8 +1121,8 @@ func (ms *MetricsSegment) flushMetricNamesBloom() error {
 }
 
 /*
-- Flushes the metrics segment's mNames bloom
-- Todo: Store the Metirc Names in Length and Value format.
+- Flushes the metrics segment's mNamesMap to disk
+- The Metirc Names are stored in the Length and Value format.
 */
 func (ms *MetricsSegment) flushMetricNames() error {
 

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1146,12 +1146,12 @@ func (ms *MetricsSegment) flushMetricNames() error {
 
 	for mName := range ms.mNamesMap {
 		if _, err = fd.Write(toputils.Uint16ToBytesLittleEndian(uint16(len(mName)))); err != nil {
-			log.Errorf("flushMetricNames: failed to write key length filename=%v: err=%v", filePath, err)
+			log.Errorf("flushMetricNames: failed to write metric length for metric=%+v, filename=%v: err=%v", mName, filePath, err)
 			return err
 		}
 
 		if _, err = fd.Write([]byte(mName)); err != nil {
-			log.Errorf("flushMetricNames: failed to write key filename=%v: err=%v", filePath, err)
+			log.Errorf("flushMetricNames: failed to write metric name=%+v, filename=%v: err=%v", mName, filePath, err)
 			return err
 		}
 	}

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -408,7 +408,10 @@ func EncodeDatapoint(mName []byte, tags *TagsHolder, dp float64, timestamp uint3
 	}
 
 	mSeg.mNamesBloom.Add(mName)
+
+	mSeg.rwLock.Lock()
 	mSeg.mNamesMap[string(mName)] = true
+	mSeg.rwLock.Unlock()
 
 	mSeg.Orgid = orgid
 	var ts *TimeSeries


### PR DESCRIPTION
# Description
- The Metric Names will be stored in a file when the Segment is being rotated.
- The Metric Names Bloom will be flushed when the Segment is being rotated.
- Refactored the field `mNames` to `mNamesBloom` in the `MetricsSegment` struct.
- Refactored the  field `Metrics` to `MetricSegments` in the `MetricsAndTagsHolder` struct.

# Testing
- Tested by ingesting multiple metrics across segments.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
