### PR TITLE
feat: ReadMetricsBloom

### DIFF
--- a/pkg/segment/query/metadata/metricsmetadata.go
+++ b/pkg/segment/query/metadata/metricsmetadata.go
@@ -242,6 +242,10 @@ func (mm *MetricsSegmentMetadata) ReadMetricNamesBloom(fileName string) error {
 
 	bufRdr := bytes.NewReader(data[1:])
 
+	if mm.mNamesBloom == nil {
+		log.Warnf("ReadMetricNamesBloom: Bloom filter is nil, creating a new one")
+		mm.mNamesBloom = bloom.NewWithEstimates(1000, 0.001)
+	}
 	_, err = mm.mNamesBloom.ReadFrom(bufRdr)
 	if err != nil {
 		log.Errorf("ReadMetricNamesBloom: Error reading bloom filter from file: %v, err: %v", fileName, err)

--- a/pkg/segment/query/metadata/metricsmetadata.go
+++ b/pkg/segment/query/metadata/metricsmetadata.go
@@ -18,11 +18,15 @@
 package metadata
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
 
+	"github.com/bits-and-blooms/bloom/v3"
+	blob "github.com/siglens/siglens/pkg/blob"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/reader/microreader"
 	"github.com/siglens/siglens/pkg/segment/structs"
@@ -64,6 +68,7 @@ type MetricsSegmentMetadata struct {
 
 type MetricsSegmentSearchMetadata struct {
 	mBlockSummary        []*structs.MBlockSummary
+	mNamesBloom          *bloom.BloomFilter
 	mBlockSize           uint64
 	loadedSearchMetadata bool
 }
@@ -78,6 +83,7 @@ func InitMetricsMicroIndex(mMeta *structs.MetricsMeta) *MetricsSegmentMetadata {
 		MetricsMeta: *mMeta,
 	}
 	mm.loadedSearchMetadata = false
+	mm.mNamesBloom = bloom.NewWithEstimates(1000, 0.001)
 	mm.initMetadataSize()
 	return mm
 }
@@ -195,14 +201,62 @@ func (mm *MetricsSegmentMetadata) LoadSearchMetadata() error {
 		log.Errorf("LoadSearchMetadata: unable to read the metrics block summaries. Error: %v", err)
 		return err
 	}
+	err = mm.ReadMetricNamesBloom(fmt.Sprintf("%s.mbi", mm.MSegmentDir))
+	if err != nil {
+		mm.clearSearchMetadata()
+		log.Errorf("LoadSearchMetadata: unable to read the metric names bloom. Error: %v", err)
+	}
 	mm.loadedSearchMetadata = true
 	mm.mBlockSummary = blockSum
+	return nil
+}
+
+func (mm *MetricsSegmentMetadata) ReadMetricNamesBloom(fileName string) error {
+	err := blob.DownloadSegmentBlob(fileName, false)
+	if err != nil {
+		log.Errorf("ReadMetricNamesBloom: Error downloading metrics block summary file at %s, err: %v", fileName, err)
+		return err
+	}
+
+	finfo, err := os.Stat(fileName)
+	if err != nil {
+		return err
+	}
+
+	fileSize := finfo.Size()
+
+	fd, err := os.OpenFile(fileName, os.O_RDONLY, 0644)
+	if err != nil {
+		log.Infof("ReadMetricNamesBloom: failed to open fileName: %v  Error: %v.", fileName, err)
+		return err
+	}
+
+	defer fd.Close()
+
+	data := make([]byte, fileSize)
+	_, err = fd.Read(data)
+	if err != nil {
+		log.Errorf("ReadMetricNamesBloom: Error reading mbi file: %v, err: %v", fileName, err)
+		return err
+	}
+
+	bufRdr := bytes.NewReader(data[1:])
+
+	_, err = mm.mNamesBloom.ReadFrom(bufRdr)
+	if err != nil {
+		log.Errorf("ReadMetricNamesBloom: Error reading bloom filter from file: %v, err: %v", fileName, err)
+		return err
+	}
+
+	mm.mBlockSize += uint64(fileSize)
+
 	return nil
 }
 
 func (mm *MetricsSegmentMetadata) clearSearchMetadata() {
 	mm.loadedSearchMetadata = false
 	mm.mBlockSummary = nil
+	mm.mNamesBloom = nil
 }
 
 /*

--- a/pkg/segment/query/metadata/metricsmetadata.go
+++ b/pkg/segment/query/metadata/metricsmetadata.go
@@ -220,6 +220,7 @@ func (mm *MetricsSegmentMetadata) ReadMetricNamesBloom(fileName string) error {
 
 	finfo, err := os.Stat(fileName)
 	if err != nil {
+		log.Errorf("ReadMetricNamesBloom: Error getting file info for the Metric Names Bloom file: %s, err: %v", fileName, err)
 		return err
 	}
 
@@ -240,6 +241,7 @@ func (mm *MetricsSegmentMetadata) ReadMetricNamesBloom(fileName string) error {
 		return err
 	}
 
+	// read the version byte
 	bufRdr := bytes.NewReader(data[1:])
 
 	if mm.mNamesBloom == nil {

--- a/pkg/segment/query/metadata/metricsmetadata_test.go
+++ b/pkg/segment/query/metadata/metricsmetadata_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/writer/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReadMetricNamesBloom(t *testing.T) {
+	ms := &metrics.MetricsSegment{}
+
+	filePath := ms.SetMockMetricSegment()
+
+	for i := 0; i < 100_000; i++ {
+		ms.AddMNameToBloom([]byte("test" + fmt.Sprint(i)))
+	}
+
+	err := ms.FlushMetricNamesBloom()
+	assert.Nil(t, err)
+
+	_, err = os.Stat(filePath)
+	assert.Nil(t, err)
+
+	mm := InitMetricsMicroIndex(&structs.MetricsMeta{})
+	err = mm.ReadMetricNamesBloom(filePath)
+	assert.Nil(t, err)
+
+	for i := 0; i < 100000; i++ {
+		assert.True(t, mm.mNamesBloom.Test([]byte("test"+fmt.Sprint(i))))
+	}
+
+	assert.True(t, mm.mBlockSize > 0)
+
+	// cleanup
+	_ = os.RemoveAll(filePath)
+}

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1098,6 +1098,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 	return blob.UploadIngestNodeDir()
 }
 
+// This is a mock function and is only used during tests.
 func (ms *MetricsSegment) SetMockMetricSegment() string {
 	ms.mNamesBloom = bloom.NewWithEstimates(100_000, 0.001)
 	ms.metricsKeyBase = "./testMockMetric"


### PR DESCRIPTION
# Description
- Added `ReadMetricsBloom` method that will read the Metrics Name Bloom File.


# Testing
- Tested by adding a test case that calls the Flush metric names func and then calls the `ReadMetricsBloom` Method.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
