### PR TITLE
Integrated the Metrics Query flow with new TimeSeries handler

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -403,6 +403,7 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		utils.SendError(ctx, "empty json body received", "", nil)
 		return
 	}
+	qid := rutils.GetNextQid()
 
 	start, end, queries, formulas, errorLog, err := parseMetricTimeSeriesRequest(rawJSON)
 	if err != nil {
@@ -412,26 +413,47 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	log.Debugf("ProcessGetMetricTimeSeriesRequest: start=%v, end=%v, queries=%v, formulas=%v", start, end, queries, formulas)
 	// TODO: Integrate functionality to get metric time series and remove dummy response
-	dummyResponse := `{
-		"aggStats": {
-			"testmetric0": {
-				"2024-05-01T12:59": 0,
-				"2024-05-01T13:00": 0,
-			},
-			"testmetric1": {
-				"2024-05-01T12:59": 0,
-				"2024-05-01T13:00": 0,
-			},
+
+	metricQueriesList := make([]*structs.MetricsQuery, 0)
+	var timeRange *dtu.MetricsTimeRange
+	hashList := make([]uint64, 0)
+
+	// Todo:
+	// The queryFormulas var should contain the parsed formulas.
+	// Modify the below flow to parse the individual queries, execute the queries and then apply the formulas.
+	var queryFormulas []structs.QueryArithmetic
+	for _, query := range queries {
+		searchText, start, end, interval := parseSearchTextForRangeSelection(fmt.Sprintf("%v", query["query"]), start, end)
+		metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(searchText, start, end, myid)
+		if err != nil {
+			utils.SendError(ctx, "Error parsing metrics query", fmt.Sprintf("Metrics Query: %+v", searchText), err)
+			return
 		}
+		// The size of the metricQueryRequest might always be 1.
+		for _, metricQuery := range metricQueryRequest {
+			metricQuery.MetricsQuery.PqlQueryType = pqlQuerytype
+			metricQuery.MetricsQuery.Interval = interval
+			hashList = append(hashList, metricQuery.MetricsQuery.HashedMName)
+			metricQueriesList = append(metricQueriesList, &metricQuery.MetricsQuery)
+			segment.LogMetricsQuery("PromQL metrics query parser", &metricQuery, qid)
+			timeRange = &metricQuery.TimeRange
+		}
+		queryFormulas = queryArithmetic
 	}
-	`
-	ctx.SetBody([]byte(dummyResponse))
+
+	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryFormulas, timeRange, qid)
+	mQResponse, err := res.GetResultsPromQlForUi(metricQueriesList[0], metricQueriesList[0].PqlQueryType, start, end, metricQueriesList[0].Interval)
+	if err != nil {
+		log.Errorf("ExecuteAsyncQuery: Error getting results! %+v", err)
+	}
+	WriteJsonResponse(ctx, &mQResponse)
+	ctx.SetContentType(ContentJson)
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }
 
-func parseMetricTimeSeriesRequest(rawJSON []byte) (int64, int64, []map[string]interface{}, []map[string]interface{}, string, error) {
-	var start = int64(0)
-	var end = int64(0)
+func parseMetricTimeSeriesRequest(rawJSON []byte) (uint32, uint32, []map[string]interface{}, []map[string]interface{}, string, error) {
+	var start = uint32(0)
+	var end = uint32(0)
 	queries := make([]map[string]interface{}, 0)
 	formulas := make([]map[string]interface{}, 0)
 	errorLog := ""
@@ -454,7 +476,7 @@ func parseMetricTimeSeriesRequest(rawJSON []byte) (int64, int64, []map[string]in
 		errorLog = fmt.Sprintf("the start field is either missing or not a float64 in the JSON body: %v", readJSON)
 		return start, end, queries, formulas, errorLog, respBodyErr
 	}
-	start = int64(startFloat)
+	start = uint32(startFloat)
 
 	endFloat, ok := readJSON["end"].(float64)
 	if !ok {
@@ -462,7 +484,7 @@ func parseMetricTimeSeriesRequest(rawJSON []byte) (int64, int64, []map[string]in
 		errorLog = fmt.Sprintf("the end field is either missing or not a float64 in the JSON body: %v", readJSON)
 		return start, end, queries, formulas, errorLog, respBodyErr
 	}
-	end = int64(endFloat)
+	end = uint32(endFloat)
 
 	queryInterfaces, ok := readJSON["queries"].([]interface{})
 	if !ok {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -411,8 +411,7 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		return
 	}
 
-	log.Debugf("ProcessGetMetricTimeSeriesRequest: start=%v, end=%v, queries=%v, formulas=%v", start, end, queries, formulas)
-	// TODO: Integrate functionality to get metric time series and remove dummy response
+	log.Debugf("ProcessGetMetricTimeSeriesRequest: Need to Parse: formulas=%v", formulas)
 
 	metricQueriesList := make([]*structs.MetricsQuery, 0)
 	var timeRange *dtu.MetricsTimeRange

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -23,8 +23,8 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 
 	start, end, queries, formulas, _, err := parseMetricTimeSeriesRequest([]byte(validJSON))
 	assert.NoError(t, err)
-	assert.Equal(t, int64(1625248200), start)
-	assert.Equal(t, int64(1625248300), end)
+	assert.Equal(t, uint32(1625248200), start)
+	assert.Equal(t, uint32(1625248300), end)
 	assert.Len(t, queries, 2)
 	assert.Len(t, formulas, 1)
 	assert.Equal(t, "query1", queries[0]["name"])

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -45,6 +45,9 @@ type MetricsQuery struct {
 	reordered      bool   // if the tags filters have been reordered
 	numStarFilters int    // index such that TagsFilters[:numStarFilters] are all star filters
 	OrgId          uint64 // organization id
+
+	PqlQueryType pql.ValueType // promql query type
+	Interval     uint32        // timeseries interval
 }
 
 type Aggreation struct {


### PR DESCRIPTION
# Description
- Integrates the TimeSeries API with the existing Metrics Query Flow.

# Testing
- Tested by calling the TimeSeries API endpoint through Postman. 

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
