### PR TITLE
Feat: Add abs func support for Promql query

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -697,7 +697,14 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}
-
+			case *pql.VectorSelector:
+				function := extractFuncFromPath(path)
+				switch function {
+				case "abs":
+					mquery.Function = structs.Function{MathFunction: segutils.Abs}
+				default:
+					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
+				}
 			}
 			return nil
 		})

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -116,6 +116,11 @@ func ApplyMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTimeR
 		mRes.AddError(err)
 	}
 
+	err = mRes.ApplyFunctionsToResults(mQuery.Function)
+	if err != nil {
+		mRes.AddError(err)
+	}
+
 	return mRes
 }
 

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -264,10 +264,10 @@ func (r *MetricsResult) ApplyFunctionsToResults(function structs.Function) error
 
 type float64Func func(float64) float64
 
-func evaluate(res map[string]map[uint32]float64, mathFuc float64Func) {
+func evaluate(res map[string]map[uint32]float64, mathFunc float64Func) {
 	for _, timeSeries := range res {
 		for key, val := range timeSeries {
-			timeSeries[key] = mathFuc(val)
+			timeSeries[key] = mathFunc(val)
 		}
 	}
 }

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -20,6 +20,7 @@ package mresults
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -247,6 +248,28 @@ func (r *MetricsResult) ApplyRangeFunctionsToResults(parallelism int, function s
 	r.DsResults = nil
 
 	return nil
+}
+
+func (r *MetricsResult) ApplyFunctionsToResults(function structs.Function) error {
+
+	switch function.MathFunction {
+	case segutils.Abs:
+		evaluate(r.Results, math.Abs)
+	default:
+		return fmt.Errorf("ApplyFunctionsToResults: unsupported function type %v", function)
+	}
+
+	return nil
+}
+
+type float64Func func(float64) float64
+
+func evaluate(res map[string]map[uint32]float64, mathFuc float64Func) {
+	for _, timeSeries := range res {
+		for key, val := range timeSeries {
+			timeSeries[key] = mathFuc(val)
+		}
+	}
 }
 
 func (r *MetricsResult) AddError(err error) {

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -209,4 +210,29 @@ func Test_reduceRunningEntries(t *testing.T) {
 	// Cardinality is not implemented yet, so this should error.
 	_, err = reduceRunningEntries(entries, segutils.Cardinality, functionConstant)
 	assert.NotNil(t, err)
+}
+
+func Test_applyMathFunctionsToResults(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1714880880] = -3
+	ts[1714880881] = 2
+	ts[1714880891] = -1
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	function := structs.Function{MathFunction: segutils.Abs}
+
+	err := metricsResults.ApplyFunctionsToResults(function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for _, val := range timeSeries {
+			if val < 0 {
+				t.Errorf("Expected value to be >= 0, got %v", val)
+			}
+		}
+	}
+
 }

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -18,6 +18,7 @@
 package mresults
 
 import (
+	"math"
 	"testing"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
@@ -228,9 +229,14 @@ func Test_applyMathFunctionsToResults(t *testing.T) {
 	err := metricsResults.ApplyFunctionsToResults(function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
-		for _, val := range timeSeries {
-			if val < 0 {
-				t.Errorf("Expected value to be >= 0, got %v", val)
+		for key, val := range timeSeries {
+			preVal, exists := ts[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != math.Abs(preVal) {
+				t.Errorf("Expected value should be %v, but got %v", math.Abs(preVal), val)
 			}
 		}
 	}

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -38,6 +38,7 @@ type MetricsQuery struct {
 	MetricName      string // metric name to query for.
 	HashedMName     uint64
 	Aggregator      Aggreation
+	Function        Function
 	Downsampler     Downsampler
 	TagsFilters     []*TagsFilter // all tags filters to apply
 	SelectAllSeries bool          //flag to select all series - for promQl
@@ -55,6 +56,10 @@ type Aggreation struct {
 	AggregatorFunction utils.AggregateFunctions //aggregator function
 	RangeFunction      utils.RangeFunctions     //range function to apply, only one of these will be non nil
 	FuncConstant       float64
+}
+
+type Function struct {
+	MathFunction utils.MathFunctions
 }
 
 type Downsampler struct {

--- a/tools/sigclient/pkg/utils/metricsreader.go
+++ b/tools/sigclient/pkg/utils/metricsreader.go
@@ -58,7 +58,7 @@ func (mg *MetricsGenerator) GetRawLog() (map[string]interface{}, error) {
 	retVal["metric"] = mName
 	retVal["timestamp"] = time.Now().Unix()
 	if fastrand.Uint32n(1_000)%2 == 0 {
-		mg.val = float64(fastrand.Uint32n(1_000))
+		mg.val = float64(fastrand.Uint32n(1_000)) - 1000
 	}
 	retVal["value"] = mg.val
 


### PR DESCRIPTION
# Description
Summarize the change.

# Testing
```
api: http://localhost:5122/metrics-explorer/api/v1/timeseries

{
    "start": "now-30m",
    "end": "now",
    "queries": [
        {
            "name": "a",
            "query": "abs(testmetric3)",
            "qlType": "promql"
        }
    ],
    "formulas": [
        {
            "formula": "a"
        }
    ]
}
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
