### PR TITLE
Variable Tag Keys Per Metric + Formulas.

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -455,14 +455,7 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	start, end, interval := parseSearchTextForRangeSelection(finalSearchText, start, end)
 	metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(finalSearchText, start, end, myid)
 	if err != nil {
-		ctx.SetContentType(ContentJson)
-		ctx.SetStatusCode(fasthttp.StatusBadRequest)
-		WriteJsonResponse(ctx, nil)
-		log.Errorf("qid=%v, ProcessMetricsSearchRequest: Error parsing query err=%+v", qid, err)
-		_, err = ctx.WriteString(err.Error())
-		if err != nil {
-			log.Errorf("qid=%v, ProcessMetricsSearchRequest: could not write error message err=%v", qid, err)
-		}
+		utils.SendError(ctx, "Error parsing metrics query", fmt.Sprintf("qid: %v, Metrics Query: %+v", qid, finalSearchText), err)
 		return
 	}
 

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -446,7 +446,7 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		queryFormulaMap[fmt.Sprintf("%v", query["name"])] = fmt.Sprintf("%v", query["query"])
 	}
 
-	finalSearchText, err := buildMetricQueryFromFormulAndQueries(fmt.Sprintf("%v", formulas[0]["formula"]), queryFormulaMap)
+	finalSearchText, err := buildMetricQueryFromFormulaAndQueries(fmt.Sprintf("%v", formulas[0]["formula"]), queryFormulaMap)
 	if err != nil {
 		utils.SendError(ctx, "Error building metrics query", fmt.Sprintf("qid: %v, Error: %+v", qid, err), err)
 		return
@@ -480,7 +480,7 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }
 
-func buildMetricQueryFromFormulAndQueries(formula string, queries map[string]string) (string, error) {
+func buildMetricQueryFromFormulaAndQueries(formula string, queries map[string]string) (string, error) {
 
 	finalSearchText := formula
 	for key, value := range queries {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -438,38 +438,46 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		return
 	}
 
-	log.Debugf("ProcessGetMetricTimeSeriesRequest: Need to Parse: formulas=%v", formulas)
+	// Todo:
+	// Some of the Formulas are not being executed properly. Need to fix.
+	queryFormulaMap := make(map[string]string)
+
+	for _, query := range queries {
+		queryFormulaMap[fmt.Sprintf("%v", query["name"])] = fmt.Sprintf("%v", query["query"])
+	}
+
+	finalSearchText, err := buildMetricQueryFromFormulAndQueries(fmt.Sprintf("%v", formulas[0]["formula"]), queryFormulaMap)
+	if err != nil {
+		utils.SendError(ctx, "Error building metrics query", fmt.Sprintf("qid: %v, Error: %+v", qid, err), err)
+		return
+	}
+
+	start, end, interval := parseSearchTextForRangeSelection(finalSearchText, start, end)
+	metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(finalSearchText, start, end, myid)
+	if err != nil {
+		ctx.SetContentType(ContentJson)
+		ctx.SetStatusCode(fasthttp.StatusBadRequest)
+		WriteJsonResponse(ctx, nil)
+		log.Errorf("qid=%v, ProcessMetricsSearchRequest: Error parsing query err=%+v", qid, err)
+		_, err = ctx.WriteString(err.Error())
+		if err != nil {
+			log.Errorf("qid=%v, ProcessMetricsSearchRequest: could not write error message err=%v", qid, err)
+		}
+		return
+	}
 
 	metricQueriesList := make([]*structs.MetricsQuery, 0)
 	var timeRange *dtu.MetricsTimeRange
-	hashedMNamesList := make([]uint64, 0)
-
-	// Todo:
-	// The queryFormulas var should contain the parsed formulas.
-	// Modify the below flow to parse the individual queries, execute the queries and then apply the formulas.
-	var queryFormulas []structs.QueryArithmetic
-	for _, query := range queries {
-		queryStrText := fmt.Sprintf("%v", query["query"])
-		start, end, interval := parseSearchTextForRangeSelection(queryStrText, start, end)
-		metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(queryStrText, start, end, myid)
-		if err != nil {
-			utils.SendError(ctx, "Error parsing metrics query", fmt.Sprintf("qid: %v, Metrics Query: %+v", qid, queryStrText), err)
-			return
-		}
-		// The size of the metricQueryRequest might always be 1.
-		for _, metricQuery := range metricQueryRequest {
-			metricQuery.MetricsQuery.PqlQueryType = pqlQuerytype
-			metricQuery.MetricsQuery.Interval = interval
-			hashedMNamesList = append(hashedMNamesList, metricQuery.MetricsQuery.HashedMName)
-			metricQueriesList = append(metricQueriesList, &metricQuery.MetricsQuery)
-			segment.LogMetricsQuery("PromQL metrics query parser", &metricQuery, qid)
-			timeRange = &metricQuery.TimeRange
-		}
-		queryFormulas = queryArithmetic
+	hashList := make([]uint64, 0)
+	for _, metricQuery := range metricQueryRequest {
+		hashList = append(hashList, metricQuery.MetricsQuery.HashedMName)
+		metricQueriesList = append(metricQueriesList, &metricQuery.MetricsQuery)
+		segment.LogMetricsQuery("PromQL metrics query parser", &metricQuery, qid)
+		timeRange = &metricQuery.TimeRange
 	}
-
-	res := segment.ExecuteMultipleMetricsQuery(hashedMNamesList, metricQueriesList, queryFormulas, timeRange, qid)
-	mQResponse, err := res.GetResultsPromQlForUi(metricQueriesList[0], metricQueriesList[0].PqlQueryType, start, end, metricQueriesList[0].Interval)
+	segment.LogMetricsQueryOps("PromQL metrics query parser: Ops: ", queryArithmetic, qid)
+	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryArithmetic, timeRange, qid)
+	mQResponse, err := res.GetResultsPromQlForUi(metricQueriesList[0], pqlQuerytype, start, end, interval)
 	if err != nil {
 		utils.SendError(ctx, "Failed to get metric time series", fmt.Sprintf("qid: %v", qid), err)
 		return
@@ -477,6 +485,18 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	WriteJsonResponse(ctx, &mQResponse)
 	ctx.SetContentType(ContentJson)
 	ctx.SetStatusCode(fasthttp.StatusOK)
+}
+
+func buildMetricQueryFromFormulAndQueries(formula string, queries map[string]string) (string, error) {
+
+	finalSearchText := formula
+	for key, value := range queries {
+		finalSearchText = strings.ReplaceAll(finalSearchText, key, fmt.Sprintf("%v", value))
+	}
+
+	log.Infof("buildMetricQueryFromFormulAndQueries: finalSearchText=%v", finalSearchText)
+
+	return finalSearchText, nil
 }
 
 func parseMetricTimeSeriesRequest(rawJSON []byte) (uint32, uint32, []map[string]interface{}, []map[string]interface{}, string, error) {

--- a/pkg/segment/reader/metrics/tagstree/tagstree_test.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstree_test.go
@@ -125,7 +125,7 @@ func Test_ReadWriteTagsTree(t *testing.T) {
 	assert.True(t, found)
 	count := 0
 	for {
-		_, filterByteSlice, _, more := itr.Next()
+		_, filterByteSlice, _, _, more := itr.Next()
 		if !more {
 			break
 		}

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -162,6 +162,7 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 		tf := mQuery.TagsFilters[i]
 		if tagVal, ok := tf.RawTagValue.(string); ok && tagVal == "*" {
 			itr, mNameExists, err := attr.GetValueIteratorForMetric(mQuery.HashedMName, tf.TagKey)
+			log.Infof("Mani: FindTSIDS: mNameExists %v, tagKey: %v", mNameExists, tf.TagKey)
 			if err != nil {
 				log.Infof("FindTSIDS: failed to get the value iterator for metric name %v and tag key %v. Error: %v. TagVAlH %+v", mQuery.MetricName, tf.TagKey, err, tf.HashTagValue)
 				tagIndicesToRemove[i] = struct{}{}
@@ -175,17 +176,25 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 
 			rawTagValueToTSIDs := make(map[string]map[uint64]struct{})
 			for {
-				_, grpID, tsids, more := itr.Next()
+				_, tagRawValue, tsids, tagRawValueType, more := itr.Next()
+				log.Infof("Mani: FindTSIDS: tagRawValue %v, tagRawValueType %v, tsids %v", tagRawValue, tagRawValueType, tsids)
 				if !more {
 					break
 				}
-				grpIDStr := string(grpID)
+				var grpIDStr string
+				if tagRawValueType[0] == segutils.VALTYPE_ENC_FLOAT64[0] {
+					grpIDStr = fmt.Sprintf("%f", utils.BytesToFloat64LittleEndian(tagRawValue))
+				} else if tagRawValueType[0] == segutils.VALTYPE_ENC_INT64[0] {
+					grpIDStr = fmt.Sprintf("%d", utils.BytesToInt64LittleEndian(tagRawValue))
+				} else {
+					grpIDStr = string(tagRawValue)
+				}
 				rawTagValueToTSIDs[grpIDStr] = make(map[uint64]struct{})
 				for tsid := range tsids {
 					rawTagValueToTSIDs[grpIDStr][tsid] = struct{}{}
 				}
 			}
-			err = tracker.BulkAddStar(rawTagValueToTSIDs)
+			err = tracker.BulkAddStar(rawTagValueToTSIDs, tf.TagKey)
 			if err != nil {
 				log.Errorf("FindTSIDS: failed to build add tsids to tracker! Error %+v", err)
 				return nil, err
@@ -205,7 +214,7 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 				tagIndicesToRemove[i] = struct{}{}
 				continue
 			}
-			err = tracker.BulkAdd(rawTagValueToTSIDs)
+			err = tracker.BulkAdd(rawTagValueToTSIDs, tf.TagKey)
 			if err != nil {
 				log.Errorf("FindTSIDS: failed to build add tsids to tracker! Error %+v", err)
 				return nil, err
@@ -394,13 +403,13 @@ func (ttr *TagTreeReader) GetValueIteratorForMetric(mName uint64) (*TagValueIter
 Returns next tag value, all matching tsids, and bool indicating if more values exist
 If bool=false, the returned tagvalue/rawvalue/matching tsids will be empty
 */
-func (tvi *TagValueIterator) Next() (uint64, []byte, map[uint64]struct{}, bool) {
+func (tvi *TagValueIterator) Next() (uint64, []byte, map[uint64]struct{}, []byte, bool) {
 	var tagValue []byte
 	var matchingTSIDs map[uint64]struct{} = map[uint64]struct{}{}
 	for tvi.treeOffset < uint32(len(tvi.tagTreeBuf)) {
 		if uint32(len(tvi.tagTreeBuf))-tvi.treeOffset < 10 {
 			// not enough bytes left in tagTreeBuf for a full tag tree entry
-			return 0, nil, nil, false
+			return 0, nil, nil, nil, false
 		}
 		tagHashValue := utils.BytesToUint64LittleEndian(tvi.tagTreeBuf[tvi.treeOffset : tvi.treeOffset+8])
 		tvi.treeOffset += 8
@@ -414,12 +423,17 @@ func (tvi *TagValueIterator) Next() (uint64, []byte, map[uint64]struct{}, bool) 
 		} else if tagRawValueType[0] == segutils.VALTYPE_ENC_FLOAT64[0] {
 			tagValue = tvi.tagTreeBuf[tvi.treeOffset : tvi.treeOffset+8]
 			tvi.treeOffset += 8
+		} else if tagRawValueType[0] == segutils.VALTYPE_ENC_INT64[0] {
+			tagValue = tvi.tagTreeBuf[tvi.treeOffset : tvi.treeOffset+8]
+			tvi.treeOffset += 8
+		} else {
+			log.Errorf("TagValueIterator.Next: unknown value type: %v", tagRawValueType)
 		}
 		tsidCount := utils.BytesToUint16LittleEndian(tvi.tagTreeBuf[tvi.treeOffset : tvi.treeOffset+2])
 		tvi.treeOffset += 2
 		if uint32(len(tvi.tagTreeBuf))-tvi.treeOffset < uint32(tsidCount*8) {
 			// not enough bytes left in tagTreeBuf for all TSIDs
-			return 0, nil, nil, false
+			return 0, nil, nil, nil, false
 		}
 		for i := uint16(0); i < tsidCount; i++ {
 			tsid := utils.BytesToUint64LittleEndian(tvi.tagTreeBuf[tvi.treeOffset : tvi.treeOffset+8])
@@ -428,10 +442,10 @@ func (tvi *TagValueIterator) Next() (uint64, []byte, map[uint64]struct{}, bool) 
 			tvi.matchingTSIDs[tsid] = struct{}{}
 		}
 		if len(matchingTSIDs) > 0 {
-			return tagHashValue, tagValue, matchingTSIDs, true
+			return tagHashValue, tagValue, matchingTSIDs, tagRawValueType, true
 		}
 	}
-	return 0, nil, nil, false
+	return 0, nil, nil, nil, false
 }
 
 // Returns two bools; first is true if it matches this value, second is true if it might match a different value.

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -162,7 +162,6 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 		tf := mQuery.TagsFilters[i]
 		if tagVal, ok := tf.RawTagValue.(string); ok && tagVal == "*" {
 			itr, mNameExists, err := attr.GetValueIteratorForMetric(mQuery.HashedMName, tf.TagKey)
-			log.Infof("Mani: FindTSIDS: mNameExists %v, tagKey: %v", mNameExists, tf.TagKey)
 			if err != nil {
 				log.Infof("FindTSIDS: failed to get the value iterator for metric name %v and tag key %v. Error: %v. TagVAlH %+v", mQuery.MetricName, tf.TagKey, err, tf.HashTagValue)
 				tagIndicesToRemove[i] = struct{}{}
@@ -177,7 +176,6 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 			rawTagValueToTSIDs := make(map[string]map[uint64]struct{})
 			for {
 				_, tagRawValue, tsids, tagRawValueType, more := itr.Next()
-				log.Infof("Mani: FindTSIDS: tagRawValue %v, tagRawValueType %v, tsids %v", tagRawValue, tagRawValueType, tsids)
 				if !more {
 					break
 				}

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -298,13 +298,14 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 	for grpId, results := range r.Results {
 		tags := make(map[string]string)
 		tagValues := strings.Split(grpId, tsidtracker.TAG_VALUE_DELIMITER_STR)
-		if len(tagKeys) != len(tagValues)-1 {
+		if len(tagKeys) != len(tagValues) {
 			err := errors.New("GetResults: the length of tag key and tag value pair must match")
 			return nil, err
 		}
 
-		for index, val := range tagValues[:len(tagValues)-1] {
-			tags[tagKeys[index]] = val
+		for _, val := range tagValues {
+			keyValue := strings.Split(val, ":")
+			tags[keyValue[0]] = keyValue[1]
 		}
 		retVal[idx] = &structs.MetricsQueryResponse{
 			MetricName: mQuery.MetricName,
@@ -389,17 +390,21 @@ func (res *MetricsResult) GetMetricTagsResultSet(mQuery *structs.MetricsQuery) (
 		}
 	}
 
-	tagKeyValueSet := make([]string, 0)
+	uniqueTagKeyValues := make(map[string]bool)
 
 	for _, series := range res.AllSeries {
-		tagValues := strings.Split(series.grpID.String(), tsidtracker.TAG_VALUE_DELIMITER_STR)
-		if len(uniqueTagKeys) != len(tagValues)-1 {
-			err := fmt.Errorf("GetMetricTagsResultSet: the length of tag key and tag value pair must match. UniqueTagKeys length: %v,  TagValues Length: %v", len(uniqueTagKeys), len(tagValues)-1)
-			return nil, nil, err
+		tagKeyValues := strings.Split(series.grpID.String(), tsidtracker.TAG_VALUE_DELIMITER_STR)
+
+		for _, tkVal := range tagKeyValues {
+			if _, ok := uniqueTagKeyValues[tkVal]; !ok {
+				uniqueTagKeyValues[tkVal] = true
+			}
 		}
-		for index, val := range tagValues[:len(tagValues)-1] {
-			tagKeyValueSet = append(tagKeyValueSet, fmt.Sprintf("%s:%s", uniqueTagKeys[index], val))
-		}
+	}
+
+	tagKeyValueSet := make([]string, 0)
+	for tk := range uniqueTagKeyValues {
+		tagKeyValueSet = append(tagKeyValueSet, tk)
 	}
 
 	return uniqueTagKeys, tagKeyValueSet, nil
@@ -411,27 +416,10 @@ func (r *MetricsResult) GetResultsPromQlForUi(mQuery *structs.MetricsQuery, pqlQ
 	if r.State != AGGREGATED {
 		return utils.MetricsStatsResponseInfo{}, errors.New("results is not in aggregated state")
 	}
-	uniqueTagKeys := make(map[string]bool)
-	tagKeys := make([]string, 0)
-	for _, tag := range mQuery.TagsFilters {
-		if _, ok := uniqueTagKeys[tag.TagKey]; !ok {
-			uniqueTagKeys[tag.TagKey] = true
-			tagKeys = append(tagKeys, tag.TagKey)
-		}
-	}
+
 	for grpId, results := range r.Results {
-		tagValues := strings.Split(grpId, tsidtracker.TAG_VALUE_DELIMITER_STR)
-		if len(tagKeys) != len(tagValues)-1 { // Subtract 1 because grpId has a delimiter after the last value
-			err := errors.New("GetResults: the length of tag key and tag value pair must match")
-			return httpResp, err
-		}
 		groupId := mQuery.MetricName + "{"
-		for index, val := range tagValues[:len(tagValues)-1] {
-			groupId += fmt.Sprintf("%v=\"%v\",", tagKeys[index], val)
-		}
-		if last := len(groupId) - 1; last >= 0 && groupId[last] == ',' {
-			groupId = groupId[:last]
-		}
+		groupId += grpId
 		groupId += "}"
 		httpResp.AggStats[groupId] = make(map[string]interface{}, 1)
 		for ts, v := range results {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -406,12 +406,8 @@ func (res *MetricsResult) GetMetricTagsResultSet(mQuery *structs.MetricsQuery) (
 	for tk := range uniqueTagKeyValues {
 		tagKeyValueSet = append(tagKeyValueSet, tk)
 	}
-	uniqueTagKeysSet := make([]string, 0)
-	for key := range tagKeyValueSet {
-		uniqueTagKeysSet = append(uniqueTagKeysSet, key)
-	}
 
-	return uniqueTagKeys, uniqueTagKeysSet, nil
+	return uniqueTagKeys, tagKeyValueSet, nil
 }
 
 func (r *MetricsResult) GetResultsPromQlForUi(mQuery *structs.MetricsQuery, pqlQuerytype pql.ValueType, startTime, endTime, interval uint32) (utils.MetricsStatsResponseInfo, error) {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -391,6 +391,7 @@ func (res *MetricsResult) GetMetricTagsResultSet(mQuery *structs.MetricsQuery) (
 	}
 
 	uniqueTagKeyValues := make(map[string]bool)
+	tagKeyValueSet := make([]string, 0)
 
 	for _, series := range res.AllSeries {
 		tagKeyValues := strings.Split(series.grpID.String(), tsidtracker.TAG_VALUE_DELIMITER_STR)
@@ -398,13 +399,9 @@ func (res *MetricsResult) GetMetricTagsResultSet(mQuery *structs.MetricsQuery) (
 		for _, tkVal := range tagKeyValues {
 			if _, ok := uniqueTagKeyValues[tkVal]; !ok {
 				uniqueTagKeyValues[tkVal] = true
+				tagKeyValueSet = append(tagKeyValueSet, tkVal)
 			}
 		}
-	}
-
-	tagKeyValueSet := make([]string, 0)
-	for tk := range uniqueTagKeyValues {
-		tagKeyValueSet = append(tagKeyValueSet, tk)
 	}
 
 	return uniqueTagKeys, tagKeyValueSet, nil

--- a/pkg/segment/results/mresults/metricsresults_test.go
+++ b/pkg/segment/results/mresults/metricsresults_test.go
@@ -50,7 +50,7 @@ func Test_GetResults_AggFn_Sum(t *testing.T) {
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
-	_, err := tsGroupId.Write([]byte("yellow`"))
+	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
 	series := InitSeriesHolder(mQuery, tsGroupId)
 
@@ -119,7 +119,7 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
-	_, err := tsGroupId.Write([]byte("yellow`"))
+	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
 	series := InitSeriesHolder(mQuery, tsGroupId)
 
@@ -251,7 +251,7 @@ func Test_GetResults_AggFn_Quantile(t *testing.T) {
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
-	_, err := tsGroupId.Write([]byte("yellow`"))
+	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
 	series := InitSeriesHolder(mQuery, tsGroupId)
 
@@ -320,7 +320,7 @@ func Test_GetResults_AggFn_QuantileFloatIndex(t *testing.T) {
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
-	_, err := tsGroupId.Write([]byte("yellow`"))
+	_, err := tsGroupId.Write([]byte("color:yellow`"))
 	assert.NoError(t, err)
 	series := InitSeriesHolder(mQuery, tsGroupId)
 

--- a/pkg/segment/results/mresults/tsid/tsidtracker.go
+++ b/pkg/segment/results/mresults/tsid/tsidtracker.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"sort"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/valyala/bytebufferpool"
 )
 
@@ -99,7 +98,6 @@ func (tr *AllMatchedTSIDs) BulkAdd(rawTagValueToTSIDs map[string]map[uint64]stru
 func (tr *AllMatchedTSIDs) BulkAddStar(rawTagValueToTSIDs map[string]map[uint64]struct{}, tagKey string) error {
 	var err error
 	for tagValue, tsids := range rawTagValueToTSIDs {
-		log.Infof("Mani: BulkAddStar:  tagKey: %+v, tagValue: %+v, tsids: %+v", tagKey, tagValue, tsids)
 		for id := range tsids {
 			buf, ok := tr.allTSIDs[id]
 			if !ok {

--- a/pkg/segment/results/mresults/tsid/tsidtracker.go
+++ b/pkg/segment/results/mresults/tsid/tsidtracker.go
@@ -18,14 +18,16 @@
 package tsidtracker
 
 import (
+	"fmt"
 	"sort"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/valyala/bytebufferpool"
 )
 
-var TAG_VALUE_DELIMITER_BYTE = []byte("`")
+var TAG_VALUE_DELIMITER_BYTE = []byte(",")
 
-var TAG_VALUE_DELIMITER_STR = ("`")
+var TAG_VALUE_DELIMITER_STR = (",")
 
 /*
 Holder struct to track all matched TSIDs
@@ -48,19 +50,16 @@ func InitTSIDTracker(numTagFilters int) (*AllMatchedTSIDs, error) {
 
 // If first time, add all tsids to map
 // Else, intersect with existing tsids
-func (tr *AllMatchedTSIDs) BulkAdd(rawTagValueToTSIDs map[string]map[uint64]struct{}) error {
+func (tr *AllMatchedTSIDs) BulkAdd(rawTagValueToTSIDs map[string]map[uint64]struct{}, tagKey string) error {
 	if tr.first {
 		for tagValue, tsids := range rawTagValueToTSIDs {
 			for id := range tsids {
 				buff := bytebufferpool.Get()
-				_, err := buff.WriteString(tagValue)
+				_, err := buff.WriteString(fmt.Sprintf("%+v:%+v", tagKey, tagValue))
 				if err != nil {
 					return err
 				}
-				_, err = buff.Write(TAG_VALUE_DELIMITER_BYTE)
-				if err != nil {
-					return err
-				}
+
 				tr.allTSIDs[id] = buff
 			}
 		}
@@ -73,11 +72,12 @@ func (tr *AllMatchedTSIDs) BulkAdd(rawTagValueToTSIDs map[string]map[uint64]stru
 					shouldKeep = true
 					valid++
 
-					_, err := tsidInfo.WriteString(tagValue)
+					_, err := tsidInfo.Write(TAG_VALUE_DELIMITER_BYTE)
 					if err != nil {
 						return err
 					}
-					_, err = tsidInfo.Write(TAG_VALUE_DELIMITER_BYTE)
+
+					_, err = tsidInfo.WriteString(fmt.Sprintf("%+v:%+v", tagKey, tagValue))
 					if err != nil {
 						return err
 					}
@@ -96,20 +96,22 @@ func (tr *AllMatchedTSIDs) BulkAdd(rawTagValueToTSIDs map[string]map[uint64]stru
 }
 
 // For all incoming tsids, always add tsid and groupid to stored tsids
-func (tr *AllMatchedTSIDs) BulkAddStar(rawTagValueToTSIDs map[string]map[uint64]struct{}) error {
+func (tr *AllMatchedTSIDs) BulkAddStar(rawTagValueToTSIDs map[string]map[uint64]struct{}, tagKey string) error {
 	var err error
 	for tagValue, tsids := range rawTagValueToTSIDs {
+		log.Infof("Mani: BulkAddStar:  tagKey: %+v, tagValue: %+v, tsids: %+v", tagKey, tagValue, tsids)
 		for id := range tsids {
 			buf, ok := tr.allTSIDs[id]
 			if !ok {
 				buf = bytebufferpool.Get()
 				tr.allTSIDs[id] = buf
+			} else {
+				_, err = buf.Write(TAG_VALUE_DELIMITER_BYTE)
+				if err != nil {
+					return err
+				}
 			}
-			_, err = buf.WriteString(tagValue)
-			if err != nil {
-				return err
-			}
-			_, err = buf.Write(TAG_VALUE_DELIMITER_BYTE)
+			_, err = buf.WriteString(fmt.Sprintf("%+v:%+v", tagKey, tagValue))
 			if err != nil {
 				return err
 			}

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -254,3 +254,8 @@ func LogQueryContext(qc *structs.QueryContext, qid uint64) {
 	fullQueryContextJSON, _ := json.Marshal(qc)
 	log.Infof("qid=%d,Query context: %v", qid, string(fullQueryContextJSON))
 }
+
+func LogMetricsQueryOps(prefix string, queryOps []structs.QueryArithmetic, qid uint64) {
+	queryOpsJSON, _ := json.Marshal(queryOps)
+	log.Infof("qid=%d, QueryOps for %v: %v", qid, prefix, string(queryOpsJSON))
+}

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -46,9 +46,7 @@ type MetricsQuery struct {
 	numStarFilters int    // index such that TagsFilters[:numStarFilters] are all star filters
 	OrgId          uint64 // organization id
 
-	PqlQueryType        pql.ValueType // promql query type
-	Interval            uint32        // timeseries interval
-	ExitAfterTagsSearch bool          // flag to exit after raw tags search
+	ExitAfterTagsSearch bool // flag to exit after raw tags search
 }
 
 type Aggreation struct {

--- a/pkg/segment/writer/metrics/tagstree.go
+++ b/pkg/segment/writer/metrics/tagstree.go
@@ -412,34 +412,34 @@ func (tree *TagTree) encodeTagsTree() ([]byte, error) {
 					id += uint32(len(value))
 				}
 			case jp.Number:
-				if value, err := jp.ParseInt(tInfo.tagValue); err != nil {
-					if value, err := jp.ParseFloat(tInfo.tagValue); err != nil {
-						return nil, fmt.Errorf("encodeTagsTree: Error in raw tag value conversion %T. Error: %v", tInfo.tagValue, err)
-					} else {
-						if _, err := tagBuf.Write(VALTYPE_ENC_FLOAT64[:]); err != nil {
-							log.Errorf("encodeTagsTree: Cannot write to buffer. Error: %v", err)
-							return nil, err
-						}
-						id += 1
-						if _, err := tagBuf.Write(utils.Float64ToBytesLittleEndian(value)); err != nil {
-							log.Errorf("encodeTagsTree: Cannot write to buffer. Error: %v", err)
-							return nil, err
-						}
-						id += 8
+				var valueType []byte
+				var valueInBytes []byte
+				var value interface{}
+
+				value, err := jp.ParseInt(tInfo.tagValue)
+				if err != nil {
+					value, err = jp.ParseFloat(tInfo.tagValue)
+					if err != nil {
+						return nil, fmt.Errorf("encodeTagsTree: Tag Value json number is neither int64 nor float64:  %T. Error: %v", tInfo.tagValue, err)
 					}
+					valueType = VALTYPE_ENC_FLOAT64
+					valueInBytes = utils.Float64ToBytesLittleEndian(value.(float64))
 				} else {
-					if _, err := tagBuf.Write(VALTYPE_ENC_INT64[:]); err != nil {
-						log.Errorf("encodeTagsTree: Cannot write to buffer. Error: %v", err)
-						return nil, err
-					}
-					id += 1
-					if _, err := tagBuf.Write(utils.Int64ToBytesLittleEndian(value)); err != nil {
-						log.Errorf("encodeTagsTree: Cannot write to buffer. Error: %v", err)
-						return nil, err
-					}
-					id += 8
+					valueType = VALTYPE_ENC_INT64
+					valueInBytes = utils.Int64ToBytesLittleEndian(value.(int64))
 				}
 
+				if _, err := tagBuf.Write(valueType[:]); err != nil {
+					log.Errorf("encodeTagsTree: Cannot write tag value type: %+v to buffer. Error: %v", valueType[:], err)
+					return nil, err
+				}
+
+				id += 1
+				if _, err := tagBuf.Write(valueInBytes); err != nil {
+					log.Errorf("encodeTagsTree: Cannot write tag value: %v to buffer. Error: %v", value, err)
+					return nil, err
+				}
+				id += 8
 			default:
 				return nil, fmt.Errorf("encodeTagsTree: Incorrect tag value type %v", tInfo.tagValueType)
 			}

--- a/pkg/segment/writer/metrics/tagstree.go
+++ b/pkg/segment/writer/metrics/tagstree.go
@@ -362,11 +362,11 @@ tag key. Each of these chunks consists of several blocks, with one block per tag
 value that this (key, metric) combination has a time series for. The format of
 each block is:
   - 8 bytes for the hashed tag value
-  - 1 byte for the type of the tag value (currently, either VALTYPE_ENC_SMALL_STRING or VALTYPE_ENC_FLOAT64)
+  - 1 byte for the type of the tag value (currently, either VALTYPE_ENC_SMALL_STRING or VALTYPE_ENC_FLOAT64 or VALTYPE_ENC_INT64)
   - The raw tag value
     -- If the type is VALTYPE_ENC_SMALL_STRING there's 2 bytes for the size of
     the string, and then N more bytes, where N is the size of the string.
-    -- If the type is VALTYPE_ENC_FLOAT64 there's 8 bytes
+    -- If the type is VALTYPE_ENC_FLOAT64 or VALTYPE_ENC_INT64 there's 8 bytes
   - 2 bytes for the number of matching TSIDs; call this numMatchingTSIDs
   - numMatchingTSIDs 8-byte numbers, each representing a TSID satisfying this (metric, key, value) combination
 */


### PR DESCRIPTION
# Description
- Fix for working with variable tag Keys per metric.
- Also included basic formula execution.
- Added the storage and retrieval of `int64` in the tag values for metrics.
- Modified get all tag keys and values per metric api to return only a unique key value pair set.

# Testing
- Tested by executing the existing test cases.
- Ingested data and ran queries by calling the api endpoints.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
