### PR TITLE
Feat: Add log2, log10, ln funcs for promql 

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -511,6 +511,24 @@ func ProcessGetMetricFunctionsRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 			"eg": "abs(avg (system.disk.used{*}))"
 		}, 
 		{
+			"fn": "ln", 
+			"name": "Natural logarithm", 
+			"desc": "Calculates the natural logarithm for all elements in v.", 
+			"eg": "ln(avg (system.disk.used))"
+		},
+		{
+			"fn": "log2", 
+			"name": "Binary logarithm", 
+			"desc": "Calculates the binary logarithm for all elements in v.", 
+			"eg": "log2(avg (system.disk.used))"
+		},
+		{
+			"fn": "log10", 
+			"name": "Decimal logarithm", 
+			"desc": "Calculates the decimal logarithm for all elements in v.", 
+			"eg": "log10(avg (system.disk.used))"
+		},
+		{
 			"fn": "rate", 
 			"name": "Rate", 
 			"desc": "Calculates the per-second average rate of increase of the time series in the range vector.", 

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -746,6 +746,12 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				switch function {
 				case "abs":
 					mquery.Function = structs.Function{MathFunction: segutils.Abs}
+				case "ln":
+					mquery.Function = structs.Function{MathFunction: segutils.Ln}
+				case "log2":
+					mquery.Function = structs.Function{MathFunction: segutils.Log2}
+				case "log10":
+					mquery.Function = structs.Function{MathFunction: segutils.Log10}
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -252,25 +252,30 @@ func (r *MetricsResult) ApplyRangeFunctionsToResults(parallelism int, function s
 }
 
 func (r *MetricsResult) ApplyFunctionsToResults(function structs.Function) error {
+	// Not using any math functions
+	if function.MathFunction == 0 {
+		return nil
+	}
 
+	var err error
 	switch function.MathFunction {
 	case segutils.Abs:
 		evaluate(r.Results, math.Abs)
+	case segutils.Ln:
+		err = evaluateLogFunc(r.Results, math.Log)
+	case segutils.Log2:
+		err = evaluateLogFunc(r.Results, math.Log2)
+	case segutils.Log10:
+		err = evaluateLogFunc(r.Results, math.Log10)
 	default:
 		return fmt.Errorf("ApplyFunctionsToResults: unsupported function type %v", function)
 	}
 
-	return nil
-}
-
-type float64Func func(float64) float64
-
-func evaluate(res map[string]map[uint32]float64, mathFunc float64Func) {
-	for _, timeSeries := range res {
-		for key, val := range timeSeries {
-			timeSeries[key] = mathFunc(val)
-		}
+	if err != nil {
+		return fmt.Errorf("ApplyFunctionsToResults: %v", err)
 	}
+
+	return nil
 }
 
 func (r *MetricsResult) AddError(err error) {

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -452,3 +452,25 @@ func reduceRunningEntries(entries []RunningEntry, fn utils.AggregateFunctions, f
 
 	return ret, nil
 }
+
+type float64Func func(float64) float64
+
+func evaluate(res map[string]map[uint32]float64, mathFunc float64Func) {
+	for _, timeSeries := range res {
+		for key, val := range timeSeries {
+			timeSeries[key] = mathFunc(val)
+		}
+	}
+}
+
+func evaluateLogFunc(res map[string]map[uint32]float64, mathFunc float64Func) error {
+	for _, timeSeries := range res {
+		for key, val := range timeSeries {
+			if val <= 0 {
+				return fmt.Errorf("evaluateLogFunc: log function cannot evaluate non-positive numbers: %v", val)
+			}
+			timeSeries[key] = mathFunc(val)
+		}
+	}
+	return nil
+}

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -242,3 +242,41 @@ func Test_applyMathFunctionsToResults(t *testing.T) {
 	}
 
 }
+
+func Test_applyMathFunctionLog(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1] = 2
+	ts[2] = 8
+
+	result["metric"] = ts
+	ans := make(map[uint32]float64)
+	ans[1] = 1
+	ans[2] = 3
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	function := structs.Function{MathFunction: segutils.Log2}
+	err := metricsResults.ApplyFunctionsToResults(function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+
+	ts[3] = -1
+	result["metric"] = ts
+	metricsResults.Results = result
+	err = metricsResults.ApplyFunctionsToResults(function)
+	assert.NotNil(t, err)
+}

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -243,7 +243,7 @@ func Test_applyMathFunctionsToResults(t *testing.T) {
 
 }
 
-func Test_applyMathFunctionLog(t *testing.T) {
+func Test_applyMathFunctionLog2(t *testing.T) {
 	result := make(map[string]map[uint32]float64)
 	ts := make(map[uint32]float64)
 	ts[1] = 2
@@ -259,6 +259,82 @@ func Test_applyMathFunctionLog(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Log2}
+	err := metricsResults.ApplyFunctionsToResults(function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+
+	ts[3] = -1
+	result["metric"] = ts
+	metricsResults.Results = result
+	err = metricsResults.ApplyFunctionsToResults(function)
+	assert.NotNil(t, err)
+}
+
+func Test_applyMathFunctionLog10(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1] = 10
+	ts[2] = 10000
+
+	result["metric"] = ts
+	ans := make(map[uint32]float64)
+	ans[1] = 1
+	ans[2] = 4
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	function := structs.Function{MathFunction: segutils.Log10}
+	err := metricsResults.ApplyFunctionsToResults(function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+
+	ts[3] = -1
+	result["metric"] = ts
+	metricsResults.Results = result
+	err = metricsResults.ApplyFunctionsToResults(function)
+	assert.NotNil(t, err)
+}
+
+func Test_applyMathFunctionLn(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1] = math.E
+	ts[2] = 7.38905609893065
+
+	result["metric"] = ts
+	ans := make(map[uint32]float64)
+	ans[1] = 1
+	ans[2] = 2
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	function := structs.Function{MathFunction: segutils.Ln}
 	err := metricsResults.ApplyFunctionsToResults(function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -297,6 +297,9 @@ const (
 	Abs
 	Sqrt
 	Exp
+	Ln
+	Log2
+	Log10
 )
 
 type RangeFunctions int

--- a/tools/sigclient/pkg/utils/metricsreader.go
+++ b/tools/sigclient/pkg/utils/metricsreader.go
@@ -58,7 +58,7 @@ func (mg *MetricsGenerator) GetRawLog() (map[string]interface{}, error) {
 	retVal["metric"] = mName
 	retVal["timestamp"] = time.Now().Unix()
 	if fastrand.Uint32n(1_000)%2 == 0 {
-		mg.val = float64(fastrand.Uint32n(1_000)) - 1000
+		mg.val = float64(fastrand.Uint32n(1_000)) - 500
 	}
 	retVal["value"] = mg.val
 


### PR DESCRIPTION
# Description
Add log2, log10, ln funcs for promql [Promql docs](https://prometheus.io/docs/prometheus/latest/querying/functions)

# Testing
Test with queries like:
- "log2(testmetric3)",
- "log10(testmetric3)"
- "ln(testmetric3)"

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
