### PR TITLE
Fix: Rate/Deriv processing logic

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -552,6 +552,18 @@ func ProcessGetMetricFunctionsRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 			"desc": "Calculates the decimal logarithm for all elements in v.", 
 			"eg": "log10(avg (system.disk.used))"
 		},
+		{
+			"fn": "rate", 
+			"name": "Rate", 
+			"desc": "Calculates the per-second average rate of increase of the time series in the range vector.", 
+			"eg": "rate(avg (system.disk.used[5m]))"
+		},
+		{
+			"fn": "deriv", 
+			"name": "Derivative", 
+			"desc": "Calculates the per-second derivative of the time series in a range vector v, using simple linear regression", 
+			"eg": "deriv(avg (system.disk.used[5m]))"
+		}
 	]`
 	ctx.SetContentType("application/json")
 	_, err := ctx.Write([]byte(metricFunctions))

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -22,11 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/cespare/xxhash"
 	pql "github.com/influxdata/promql/v2"
@@ -267,7 +265,6 @@ func ProcessUiMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	log.Infof("qid=%v, ProcessMetricsSearchRequest:  searchString=[%v] startEpochMs=[%v] endEpochMs=[%v] step=[%v]", qid, searchText, startTime, endTime, step)
 
-	startTime, endTime = parseSearchTextForRangeSelection(searchText, startTime, endTime)
 	metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(searchText, startTime, endTime, myid)
 
 	if err != nil {
@@ -448,12 +445,6 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 		return
 	}
 
-	start, end = parseSearchTextForRangeSelection(finalSearchText, start, end)
-	// If timerangeSeconds is greater than 10 years reject the request
-	if end-start > TEN_YEARS_IN_SECS {
-		utils.SendError(ctx, "Time range is greater than 10 years", fmt.Sprintf("qid: %v, Time range: %v", qid, end-start), errors.New("Time range is greater than 10 years"))
-		return
-	}
 	metricQueryRequest, pqlQuerytype, queryArithmetic, err := convertPqlToMetricsQuery(finalSearchText, start, end, myid)
 	if err != nil {
 		utils.SendError(ctx, "Error parsing metrics query", fmt.Sprintf("qid: %v, Metrics Query: %+v", qid, finalSearchText), err)
@@ -721,11 +712,18 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				if mquery.TagsFilters != nil {
 					groupby = true
 				}
+
+				timeWindow, err := extractTimeWindow(expr.Args)
+				if err != nil {
+					return fmt.Errorf("pql.Inspect: can not extract time window from a range vector: %v", err)
+				}
 				switch function {
 				case "deriv":
-					mquery.Function = structs.Function{RangeFunction: segutils.Derivative}
+					mquery.Function = structs.Function{RangeFunction: segutils.Derivative, TimeWindow: timeWindow}
 				case "rate":
-					mquery.Function = structs.Function{RangeFunction: segutils.Rate}
+					mquery.Function = structs.Function{RangeFunction: segutils.Rate, TimeWindow: timeWindow}
+				case "irate":
+					mquery.Function = structs.Function{RangeFunction: segutils.IRate, TimeWindow: timeWindow}
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}
@@ -1038,58 +1036,6 @@ func parseAlphaNumTime(nowTs uint64, inp string, defValue uint64) (uint64, usage
 	return retVal, granularity
 }
 
-func parseSearchTextForRangeSelection(searchText string, startTime uint32, endTime uint32) (uint32, uint32) {
-
-	pattern := `\[(.*?)\]`
-
-	regex := regexp.MustCompile(pattern)
-
-	matches := regex.FindAllStringSubmatch(searchText, -1)
-
-	var timeRange string
-
-	for _, match := range matches {
-		timeRange = match[1]
-	}
-
-	var totalVal uint32 = 0
-	var curVal uint32 = 0
-	var curDimension string = ""
-	var dimensionVal uint32 = 0
-
-	for _, ch := range timeRange {
-		if unicode.IsDigit(ch) {
-			if curDimension == "" {
-				curVal = curVal*10 + uint32(ch-'0')
-			} else {
-				totalVal += curVal * dimensionVal
-				curDimension = ""
-				curVal = uint32(ch - '0')
-			}
-		} else {
-			curDimension += curDimension + string(ch)
-			if curDimension == "s" || curDimension == "S" {
-				dimensionVal = 1
-			} else if curDimension == "m" || curDimension == "M" {
-				dimensionVal = 60
-			} else if curDimension == "h" || curDimension == "H" {
-				dimensionVal = 3600
-			} else if curDimension == "d" || curDimension == "D" {
-				dimensionVal = 24 * 3600
-			} else if curDimension == "w" || curDimension == "W" {
-				dimensionVal = 7 * 24 * 3600
-			}
-		}
-	}
-	totalVal += curVal * dimensionVal
-
-	if totalVal > 0 {
-		startTime = endTime - totalVal
-	}
-
-	return startTime, endTime
-}
-
 func parseTimeStringToUint32(s interface{}) (uint32, error) {
 	var startTimeStr string
 	var timeVal uint32
@@ -1116,4 +1062,16 @@ func parseTimeStringToUint32(s interface{}) (uint32, error) {
 		return timeVal, err
 	}
 	return timeVal, nil
+}
+
+func extractTimeWindow(args pql.Expressions) (float64, error) {
+	if len(args) > 0 {
+		if ms, ok := args[0].(*pql.MatrixSelector); ok {
+			return ms.Range.Seconds(), nil
+		} else {
+			return 0, fmt.Errorf("extractTimeWindow: can not extract time window from args: %v", args)
+		}
+	} else {
+		return 0, fmt.Errorf("extractTimeWindow: can not extract time window")
+	}
 }

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -771,9 +771,9 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				}
 				switch function {
 				case "deriv":
-					mquery.Aggregator = structs.Aggreation{RangeFunction: segutils.Derivative}
+					mquery.Function = structs.Function{RangeFunction: segutils.Derivative}
 				case "rate":
-					mquery.Aggregator = structs.Aggreation{RangeFunction: segutils.Rate}
+					mquery.Function = structs.Function{RangeFunction: segutils.Rate}
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -150,10 +150,19 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 
 func Test_metricsFuncPromptJson(t *testing.T) {
 	type Function struct {
-		Fn   string `json:"fn"`
-		Name string `json:"name"`
-		Desc string `json:"desc"`
-		Eg   string `json:"eg"`
+		Fn              string `json:"fn"`
+		Name            string `json:"name"`
+		Desc            string `json:"desc"`
+		Eg              string `json:"eg"`
+		IsTimeRangeFunc bool   `json:"isTimeRangeFunc"`
+	}
+
+	attrMap := map[string]string{
+		"Fn":              "string",
+		"Name":            "string",
+		"Desc":            "string",
+		"Eg":              "string",
+		"IsTimeRangeFunc": "bool",
 	}
 
 	var functions []Function
@@ -165,8 +174,10 @@ func Test_metricsFuncPromptJson(t *testing.T) {
 		val := reflect.ValueOf(function)
 		for i := 0; i < val.NumField(); i++ {
 			field := val.Type().Field(i)
-			valueField := val.Field(i)
-			assert.False(t, valueField.IsZero(), "Missing Field: %s", field.Name)
+
+			fieldType, exists := attrMap[field.Name]
+			assert.True(t, exists, "Missing Field: %s", field.Name)
+			assert.Equal(t, fieldType, field.Type.Kind().String())
 		}
 	}
 }

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -10,54 +10,63 @@ const metricFunctions = `[
 		"fn": "abs",
 		"name": "Absolute",
 		"desc": "Returns the input vector with all datapoint values converted to their absolute value.",
-		"eg": "abs(avg (system.disk.used{*}))"
+		"eg": "abs(avg (system.disk.used{*}))",
+		"isTimeRangeFunc": false
 	}, 
 	{
 		"fn": "ceil",
 		"name": "Ceil",
 		"desc": "Rounds the datapoint values of all elements in v up to the nearest integer.",
-		"eg": "ceil(avg (system.disk.used))"
+		"eg": "ceil(avg (system.disk.used))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "floor",
 		"name": "Floor",
 		"desc": "Rounds the datapoint values of all elements in v down to the nearest integer.",
-		"eg": "floor(avg (system.disk.used))"
+		"eg": "floor(avg (system.disk.used))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "round",
 		"name": "Round",
 		"desc": "Rounds the datapoint values of all elements in v to the nearest integer.",
-		"eg": "round(avg (system.disk.used)), round(avg (system.disk.used, 1/2))"
+		"eg": "round(avg (system.disk.used)), round(avg (system.disk.used, 1/2))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "ln",
 		"name": "Natural logarithm",
 		"desc": "Calculates the natural logarithm for all elements in v.",
-		"eg": "ln(avg (system.disk.used))"
+		"eg": "ln(avg (system.disk.used))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "log2",
 		"name": "Binary logarithm",
 		"desc": "Calculates the binary logarithm for all elements in v.",
-		"eg": "log2(avg (system.disk.used))"
+		"eg": "log2(avg (system.disk.used))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "log10",
 		"name": "Decimal logarithm",
 		"desc": "Calculates the decimal logarithm for all elements in v.",
-		"eg": "log10(avg (system.disk.used))"
+		"eg": "log10(avg (system.disk.used))",
+		"isTimeRangeFunc": false
 	},
 	{
 		"fn": "rate", 
 		"name": "Rate", 
 		"desc": "Calculates the per-second average rate of increase of the time series in the range vector.", 
-		"eg": "rate(avg (system.disk.used[5m]))"
+		"eg": "rate(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
 	},
 	{
 		"fn": "deriv", 
 		"name": "Derivative", 
 		"desc": "Calculates the per-second derivative of the time series in a range vector v, using simple linear regression", 
-		"eg": "deriv(avg (system.disk.used[5m]))"
+		"eg": "deriv(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
 	}
 ]`

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -111,9 +111,13 @@ func ApplyMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTimeR
 		return mRes
 	}
 
-	err = mRes.ApplyFunctionsToResults(parallelism, mQuery.Function)
-	if err != nil {
-		mRes.AddError(err)
+	errors = mRes.ApplyFunctionsToResults(parallelism, mQuery.Function)
+	if errors != nil {
+		for _, err := range errors {
+			mRes.AddError(err)
+		}
+
+		return mRes
 	}
 
 	return mRes

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -111,12 +111,7 @@ func ApplyMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTimeR
 		return mRes
 	}
 
-	err = mRes.ApplyRangeFunctionsToResults(parallelism, mQuery.Aggregator.RangeFunction)
-	if err != nil {
-		mRes.AddError(err)
-	}
-
-	err = mRes.ApplyFunctionsToResults(mQuery.Function)
+	err = mRes.ApplyFunctionsToResults(parallelism, mQuery.Function)
 	if err != nil {
 		mRes.AddError(err)
 	}

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -220,7 +220,7 @@ func (r *MetricsResult) AggregateResults(parallelism int) []error {
 /*
 Apply function to results for series sharing a groupid.
 */
-func (r *MetricsResult) ApplyFunctionsToResults(parallelism int, function structs.Function) error {
+func (r *MetricsResult) ApplyFunctionsToResults(parallelism int, function structs.Function) []error {
 
 	lock := &sync.Mutex{}
 	wg := &sync.WaitGroup{}
@@ -249,7 +249,13 @@ func (r *MetricsResult) ApplyFunctionsToResults(parallelism int, function struct
 	}
 
 	wg.Wait()
+
+	if len(errList) > 0 {
+		return errList
+	}
+
 	r.DsResults = nil
+
 	return nil
 }
 

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -29,15 +29,15 @@ import (
 
 func Test_applyRangeFunctionRate(t *testing.T) {
 	timeSeries := map[uint32]float64{
-		0: 2.0,
-		1: 3.0,
-		2: 4.0,
-		3: 0.0,
-		8: 2.5,
-		9: 1.0,
+		1000: 2.0,
+		1003: 3.0,
+		1008: 4.0,
+		1012: 18.0,
+		1020: 2.5,
+		1025: 6.5,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, segutils.Rate)
+	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Rate, TimeWindow: 10})
 	assert.Nil(t, err)
 
 	// There's six timestamps in the series, but we need two points to calculate
@@ -48,26 +48,71 @@ func Test_applyRangeFunctionRate(t *testing.T) {
 	var val float64
 	var ok bool
 
-	val, ok = rate[1]
+	val, ok = rate[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (3.0-2.0)/(3-0)))
+
+	val, ok = rate[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (4.0-2.0)/(8-0)))
+
+	val, ok = rate[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (18.0-3.0)/(12-3)))
+
+	val, ok = rate[1020]
+	assert.True(t, ok)
+	// Since the value here is smaller than at the last timestamp, the value was
+	// reset since the last timestamp. So the increase is just this value, not
+	// this value minus the previous value.
+	assert.True(t, dtypeutils.AlmostEquals(val, (2.5)/(20-12)))
+
+	val, ok = rate[1025]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (6.5-2.5)/(25-20)))
+}
+
+func Test_applyRangeFunctionIRate(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1001: 3.0,
+		1002: 4.0,
+		1003: 0.0,
+		1008: 2.5,
+		1009: 1.0,
+	}
+
+	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.IRate, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	// There's six timestamps in the series, but we need two points to calculate
+	// the rate, so we can't calculate it on the first point. So we should have
+	// 5 elements in the result.
+	assert.Len(t, rate, 5)
+
+	var val float64
+	var ok bool
+
+	val, ok = rate[1001]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (3.0-2.0)/(1-0)))
 
-	val, ok = rate[2]
+	val, ok = rate[1002]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (4.0-3.0)/(2-1)))
 
-	val, ok = rate[3]
+	val, ok = rate[1003]
 	assert.True(t, ok)
 	// Since the value here is smaller than at the last timestamp, the value was
 	// reset since the last timestamp. So the increase is just this value, not
 	// this value minus the previous value.
 	assert.True(t, dtypeutils.AlmostEquals(val, 0.0))
 
-	val, ok = rate[8]
+	val, ok = rate[1008]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 2.5/(8-3)))
 
-	val, ok = rate[9]
+	val, ok = rate[1009]
 	assert.True(t, ok)
 	// Since the value here is smaller than at the last timestamp, the value was
 	// reset since the last timestamp. So the increase is just this value, not

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -228,7 +228,7 @@ func Test_applyMathFunctionAbs(t *testing.T) {
 
 	function := structs.Function{MathFunction: segutils.Abs}
 
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -263,7 +263,7 @@ func Test_applyMathFunctionFloor(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Floor, Value: ""}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -298,7 +298,7 @@ func Test_applyMathFunctionCeil(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Ceil, Value: ""}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -334,7 +334,7 @@ func Test_applyMathFunctionRoundWithoutPrecision(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Round, Value: ""}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -369,7 +369,7 @@ func Test_applyMathFunctionRoundWithPrecision1(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Round, Value: "0.3"}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -401,7 +401,7 @@ func Test_applyMathFunctionRoundWithPrecision2(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Round, Value: "1 / 2"}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -433,7 +433,7 @@ func Test_applyMathFunctionLog2(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Log2}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -451,7 +451,7 @@ func Test_applyMathFunctionLog2(t *testing.T) {
 	ts[3] = -1
 	result["metric"] = ts
 	metricsResults.Results = result
-	err = metricsResults.ApplyFunctionsToResults(function)
+	err = metricsResults.ApplyFunctionsToResults(8, function)
 	assert.NotNil(t, err)
 }
 
@@ -471,7 +471,7 @@ func Test_applyMathFunctionLog10(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Log10}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -489,7 +489,7 @@ func Test_applyMathFunctionLog10(t *testing.T) {
 	ts[3] = -1
 	result["metric"] = ts
 	metricsResults.Results = result
-	err = metricsResults.ApplyFunctionsToResults(function)
+	err = metricsResults.ApplyFunctionsToResults(8, function)
 	assert.NotNil(t, err)
 }
 
@@ -509,7 +509,7 @@ func Test_applyMathFunctionLn(t *testing.T) {
 	}
 
 	function := structs.Function{MathFunction: segutils.Ln}
-	err := metricsResults.ApplyFunctionsToResults(function)
+	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
 		for key, val := range timeSeries {
@@ -527,6 +527,6 @@ func Test_applyMathFunctionLn(t *testing.T) {
 	ts[3] = -1
 	result["metric"] = ts
 	metricsResults.Results = result
-	err = metricsResults.ApplyFunctionsToResults(function)
+	err = metricsResults.ApplyFunctionsToResults(8, function)
 	assert.NotNil(t, err)
 }

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -52,13 +52,13 @@ type MetricsQuery struct {
 
 type Aggreation struct {
 	AggregatorFunction utils.AggregateFunctions //aggregator function
-	RangeFunction      utils.RangeFunctions     //range function to apply, only one of these will be non nil
 	FuncConstant       float64
 }
 
 type Function struct {
-	MathFunction utils.MathFunctions
-	Value        string
+	MathFunction  utils.MathFunctions
+	RangeFunction utils.RangeFunctions //range function to apply, only one of these will be non nil
+	Value         string
 }
 
 type Downsampler struct {

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -60,6 +60,7 @@ type Function struct {
 	MathFunction  utils.MathFunctions
 	RangeFunction utils.RangeFunctions //range function to apply, only one of these will be non nil
 	Value         string
+	TimeWindow    float64 //E.g: rate(metrics[1m]), extract 1m and convert to seconds
 }
 
 type Downsampler struct {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -308,6 +308,7 @@ type RangeFunctions int
 const (
 	Derivative RangeFunctions = iota + 1
 	Rate
+	IRate
 )
 
 // For columns used by aggs with eval statements, we should keep their raw values because we need to evaluate them


### PR DESCRIPTION
# Description
- Consolidate range funcs with math funcs.
- Fix Metrics Range funcs
- Verify [Rate](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate)/[Deriv](https://prometheus.io/docs/prometheus/latest/querying/functions/#deriv) processing logic
- Add irate()

# Testing
- "deriv(testmetric0[10m])"
- "rate(testmetric0[5m])"
- "irate(testmetric0[5m])"

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
