### PR TITLE
Fix selecting segments

### DIFF
--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -382,7 +382,7 @@ func GetRemoteRawLogInfo(remoteID string, inrrcs []*utils.RecordResultContainer,
 	arqMapLock.RLock()
 	rQuery, ok := allRunningQueries[qid]
 	if !ok {
-		log.Errorf("GetQueryType: qid %+v does not exist!", qid)
+		log.Errorf("GetRemoteRawLogInfo: qid %+v does not exist!", qid)
 		arqMapLock.RUnlock()
 		return nil, nil, fmt.Errorf("qid does not exist")
 	}

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -249,7 +249,6 @@ func GetNodeResultsForSegmentStatsCmd(queryInfo *QueryInformation, sTime time.Ti
 	qsrs []*QuerySegmentRequest, querySummary *summary.QuerySummary, getUnrotated bool, getRotated bool, orgid uint64) *structs.NodeResult {
 	sortedQSRSlice, numRawSearch, numDistributed := getAllSegmentsInAggs(queryInfo, qsrs, queryInfo.aggs, queryInfo.queryRange, queryInfo.indexInfo.GetQueryTables(),
 		queryInfo.qid, getUnrotated, getRotated, sTime, orgid)
-	log.Errorf("andrew inside GetNodeResultsForSegmentStatsCmd with qsrs: %+v, sortedQSRSlice: %+v", qsrs, sortedQSRSlice)
 	err := setTotalSegmentsToSearch(queryInfo.qid, numRawSearch+numDistributed)
 	if err != nil {
 		log.Errorf("qid=%d Failed to set total segments to search! Error: %+v", queryInfo.qid, err)
@@ -366,7 +365,6 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 		reverseSortedQSRSlice(sortedQSRSlice)
 	}
 
-	log.Errorf("andrew inside applyFopAllRequests; looping over %v sqrs", len(sortedQSRSlice))
 	for idx, segReq := range sortedQSRSlice {
 
 		isCancelled, err := checkForCancelledQuery(queryInfo.qid)
@@ -558,7 +556,6 @@ func getAllSegmentsInAggs(queryInfo *QueryInformation, qsrs []*QuerySegmentReque
 	qid uint64, getUnrotated bool, getRotated bool, sTime time.Time, orgid uint64) ([]*QuerySegmentRequest, uint64, uint64) {
 
 	if len(qsrs) != 0 {
-		log.Errorf("andrew getAllSegmentsInAggs: early return 1 with qsrs: %+v", qsrs)
 		return qsrs, uint64(len(qsrs)), 0
 	}
 
@@ -581,14 +578,6 @@ func getAllSegmentsInAggs(queryInfo *QueryInformation, qsrs []*QuerySegmentReque
 	}
 
 	return finalQsrs, numRawSearch, numDistributed
-
-	//// Do rotated time & index name filtering
-	//rotatedQSR, rotatedRawCount, rotatedDistQueries := getAllRotatedSegmentsInAggs(queryInfo, aggs, timeRange, indexNames, qid, sTime, orgid)
-	//unrotatedQSR, unrotatedRawCount, unrotatedDistQueries := getAllUnrotatedSegmentsInAggs(queryInfo, aggs, timeRange, indexNames, qid, sTime, orgid, getUnrotated)
-	//allSegRequests := append(rotatedQSR, unrotatedQSR...)
-	//log.Errorf("andrew getAllSegmentsInAggs: returning with unrotatedQSR: %+v, rotatedQSR: %+v", unrotatedQSR, rotatedQSR)
-	////get seg stats for allPossibleKeys
-	//return allSegRequests, rotatedRawCount + unrotatedRawCount, rotatedDistQueries + unrotatedDistQueries
 }
 
 func getAllUnrotatedSegmentsInAggs(queryInfo *QueryInformation, aggs *structs.QueryAggregators, timeRange *dtu.TimeRange, indexNames []string,
@@ -630,7 +619,6 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 	// Use a global variable to store data that meets the conditions during the process of traversing segments
 	runningEvalStats := make(map[string]interface{}, 0)
 	//assuming we will allow 100 measure Operations
-	log.Errorf("andrew inside applyAggOpOnSegments; looping over %v sqrs", len(sortedQSRSlice))
 	for _, segReq := range sortedQSRSlice {
 		isCancelled, err := checkForCancelledQuery(qid)
 		if err != nil {

--- a/pkg/segment/query/segquery_test.go
+++ b/pkg/segment/query/segquery_test.go
@@ -97,7 +97,7 @@ func bloomMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err := InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 0, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err := getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err := getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -134,7 +134,7 @@ func bloomMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err = InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 1, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -163,7 +163,7 @@ func bloomMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err = InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 2, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -207,7 +207,7 @@ func rangeMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err := InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 2, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err := getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err := getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -244,7 +244,7 @@ func rangeMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err = InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 2, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -282,7 +282,7 @@ func rangeMetadataFilter(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	queryInfo, err = InitQueryInformation(searchNode, nil, timeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 2, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	allQuerySegKeys, rawCount, _, pqsCount, err = getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, allQuerySegKeys, fileCount)
 	assert.Equal(t, rawCount, uint64(fileCount))
@@ -356,7 +356,7 @@ func pqsSegQuery(t *testing.T, numBuffers int, numEntriesForBuffer int, fileCoun
 	queryInfo, err := InitQueryInformation(searchNode, nil, fullTimeRange, ti, uint64(numEntriesForBuffer*numBuffers*fileCount),
 		4, 2, &DistributedQueryService{}, 0)
 	assert.NoError(t, err)
-	querySegmentRequests, numRawSearchKeys, _, numPQSKeys, err := getAllSegmentsInQuery(queryInfo, false, time.Now(), 0)
+	querySegmentRequests, numRawSearchKeys, _, numPQSKeys, err := getAllSegmentsInQuery(queryInfo, true, true, time.Now(), 0)
 	assert.NoError(t, err)
 	assert.Len(t, querySegmentRequests, fileCount, "each file has a query segment request")
 	assert.Equal(t, uint64(0), numRawSearchKeys)


### PR DESCRIPTION
# Description
1. Lets you correctly specify whether unrotated segments should be queried, and whether rotated segments should be queried.
2. Updates the `scrollFrom` in the wsHandler each `UPDATE`, so previous logs already sent to the UI are not resent

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
