### PR TITLE
Fix: promql node traversal issue

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -707,6 +707,10 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 			return nil
 		})
 	case *pql.Call:
+		// E.g: rate(http_requests_total[5m]), So, the process of the Inspect method calling node is as follows:
+		// promql.Call:"rate(http_requests_total[5m])" -> promql.Expressions[0] -> promql.MatrixSelector:"http_requests_total[5m]"
+		// Since we currently handle evaluation logic only in sub-elements like MatrixSelector or VectorSelector, if we add a default case in the switch statement,
+		// traversal would stop prematurely due to an error being returned before reaching sub-nodes such as MatrixSelector
 		pql.Inspect(expr, func(node pql.Node, path []pql.Node) error {
 			if node == nil {
 				return nil
@@ -756,10 +760,6 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}
-			default:
-				err := fmt.Errorf("pql.Inspect: Unsupported node type %T", node)
-				log.Errorf("%v", err)
-				return err
 			}
 			return nil
 		})

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -643,6 +643,9 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 
 		mquery.Aggregator = structs.Aggreation{}
 		pql.Inspect(es.Expr, func(node pql.Node, path []pql.Node) error {
+			if node == nil {
+				return nil
+			}
 			switch expr := node.(type) {
 			case *pql.AggregateExpr:
 				aggFunc := extractFuncFromPath(path)
@@ -705,6 +708,9 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 		})
 	case *pql.Call:
 		pql.Inspect(expr, func(node pql.Node, path []pql.Node) error {
+			if node == nil {
+				return nil
+			}
 			switch node.(type) {
 			case *pql.MatrixSelector:
 				function := extractFuncFromPath(path)
@@ -750,6 +756,10 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				default:
 					return fmt.Errorf("pql.Inspect: unsupported function type %v", function)
 				}
+			default:
+				err := fmt.Errorf("pql.Inspect: Unsupported node type %T", node)
+				log.Errorf("%v", err)
+				return err
 			}
 			return nil
 		})

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -63,6 +63,13 @@ const metricFunctions = `[
 		"isTimeRangeFunc": true
 	},
 	{
+		"fn": "irate", 
+		"name": "Instant Rate", 
+		"desc": "Calculates the per-second instant rate of increase of the time series in the range vector", 
+		"eg": "irate(http_requests_total[5m])",
+		"isTimeRangeFunc": true
+	},
+	{
 		"fn": "deriv", 
 		"name": "Derivative", 
 		"desc": "Calculates the per-second derivative of the time series in a range vector v, using simple linear regression", 


### PR DESCRIPTION
# Description
<img width="966" alt="image-20240509210403104" src="https://github.com/siglens/siglens/assets/67371917/6daaf15f-627c-43c8-83a0-66387094066e">

&nbsp;
Fixes Unsupported node type issue, when using metrics queries with aggregate func such as: max(metric1), sum(metric1)

As I was debugging this, I checked this [document](https://pkg.go.dev/github.com/influxdata/promql/v2#Inspect) and the PromQL source code. I found that it will walk into a nil point at the end. I think the reason PromQL adds this step is because it allows us to do some post-processing after we finish traversing all the nodes. Currently, we do not need to do that, so I just return nil when it finishes traversing and walks into a nil point. But please correct me if I am wrong.

<img width="647" alt="image-20240509205604740" src="https://github.com/siglens/siglens/assets/67371917/5c5c56b0-f01e-48ec-8b40-87b5c0e2f768">
<img width="647" alt="image-20240509205618371" src="https://github.com/siglens/siglens/assets/67371917/a1359dd1-f456-47b2-a206-ee51ffdfced9">

# Testing
Try the queries again:
- max(metric1)
- sum(metric1)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
