### PR TITLE
fix: Get All tag key and values pairs for a metric name

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -572,6 +572,7 @@ func ProcessGetAllMetricTagsRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	}
 
 	metricQueryRequest[0].MetricsQuery.ExitAfterTagsSearch = true
+	metricQueryRequest[0].MetricsQuery.TagIndicesToKeep = make(map[int]struct{})
 
 	segment.LogMetricsQuery("Tags Request PromQL metrics query parser", &metricQueryRequest[0], qid)
 	res := segment.ExecuteMetricsQuery(&metricQueryRequest[0].MetricsQuery, &metricQueryRequest[0].TimeRange, qid)

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -406,11 +406,11 @@ func (res *MetricsResult) GetMetricTagsResultSet(mQuery *structs.MetricsQuery) (
 		return nil, nil, errors.New("results is not in Series Reading state")
 	}
 
-	tagKeysMap := make(map[string]struct{})
+	// The Tag Keys in the TagFilters will be unique,
+	// as they will be cleaned up in the mQuery.ReorderTagFilters()
 	uniqueTagKeys := make([]string, 0)
-	for _, tag := range mQuery.TagsFilters {
-		if _, ok := tagKeysMap[tag.TagKey]; !ok {
-			tagKeysMap[tag.TagKey] = struct{}{}
+	for i, tag := range mQuery.TagsFilters {
+		if _, exists := mQuery.TagIndicesToKeep[i]; exists {
 			uniqueTagKeys = append(uniqueTagKeys, tag.TagKey)
 		}
 	}

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -35,13 +35,14 @@ import (
 Struct to represent a single metrics query request.
 */
 type MetricsQuery struct {
-	MetricName      string // metric name to query for.
-	HashedMName     uint64
-	Aggregator      Aggreation
-	Function        Function
-	Downsampler     Downsampler
-	TagsFilters     []*TagsFilter // all tags filters to apply
-	SelectAllSeries bool          //flag to select all series - for promQl
+	MetricName       string // metric name to query for.
+	HashedMName      uint64
+	Aggregator       Aggreation
+	Function         Function
+	Downsampler      Downsampler
+	TagsFilters      []*TagsFilter    // all tags filters to apply
+	TagIndicesToKeep map[int]struct{} // indices of tags to keep in the result
+	SelectAllSeries  bool             //flag to select all series - for promQl
 
 	reordered       bool   // if the tags filters have been reordered
 	numStarFilters  int    // index such that TagsFilters[:numStarFilters] are all star filters


### PR DESCRIPTION
# Description
- Fix for get All Tag Keys and Values API.
- Also fixes the Metric Query Flow.

# Testing
- Tested by executing the Queries and the API Endpoints.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
