### PR TITLE
fix: filename of log and traces export will be 3-254 chars

### DIFF
--- a/static/component/download/download.js
+++ b/static/component/download/download.js
@@ -231,7 +231,7 @@ $("#cancel-loading").on("click", cancelDownload);
       allFields.removeClass("ui-state-error");
       tips.removeClass("ui-state-highlight");
       tips.text("");
-      valid = valid && checkLength(qname, "download name", 3, 16);
+      valid = valid && checkLength(qname, "download name", 3, 254);
       valid =
         valid &&
         checkRegexp(

--- a/static/component/download/download.js
+++ b/static/component/download/download.js
@@ -231,7 +231,7 @@ $("#cancel-loading").on("click", cancelDownload);
       allFields.removeClass("ui-state-error");
       tips.removeClass("ui-state-highlight");
       tips.text("");
-      valid = valid && checkLength(qname, "download name", 3, 254);
+      valid = valid && checkLength(qname, "download name", 1, 254);
       valid =
         valid &&
         checkRegexp(

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -219,7 +219,7 @@ function setDownloadLogsDialog() {
     allFields.removeClass("ui-state-error");
     tips.removeClass("ui-state-highlight");
     tips.text("");
-    valid = valid && checkLength(qname, "download name", 3, 254);
+    valid = valid && checkLength(qname, "download name", 1, 254);
     valid = valid && checkRegexp(
       qname,
       /^[a-zA-Z0-9_.-]+$/i,

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -219,7 +219,7 @@ function setDownloadLogsDialog() {
     allFields.removeClass("ui-state-error");
     tips.removeClass("ui-state-highlight");
     tips.text("");
-    valid = valid && checkLength(qname, "download name", 3, 16);
+    valid = valid && checkLength(qname, "download name", 3, 254);
     valid = valid && checkRegexp(
       qname,
       /^[a-zA-Z0-9_.-]+$/i,


### PR DESCRIPTION
# Description
Earlier, filename of logs and traces export were limited between 3 to 16 characters but now the limit has been extended to 254 characters.

Fixes #851 

# Testing
I have tested by exporting logs and traces with filename of 100 characters and also for 280 characters. Logs and traces exported in the former case while it produced error for the latter one.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
