### PR TITLE
Feat: Add Promql Clamp funcs

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -928,7 +928,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 				case "round":
 					mquery.Function = structs.Function{MathFunction: segutils.Round}
 					if len(expr.Args) > 1 {
-						mquery.Function.Value = expr.Args[1].String()
+						mquery.Function.ValueList = []string{expr.Args[1].String()}
 					}
 				case "floor":
 					mquery.Function = structs.Function{MathFunction: segutils.Floor}
@@ -938,6 +938,21 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 					mquery.Function = structs.Function{MathFunction: segutils.Log2}
 				case "log10":
 					mquery.Function = structs.Function{MathFunction: segutils.Log10}
+				case "clamp":
+					if len(expr.Args) != 3 {
+						return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the clamp function", expr.Args.String())
+					}
+					mquery.Function = structs.Function{MathFunction: segutils.Clamp, ValueList: []string{expr.Args[1].String(), expr.Args[2].String()}}
+				case "clamp_max":
+					if len(expr.Args) != 2 {
+						return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the clamp_max function", expr.Args.String())
+					}
+					mquery.Function = structs.Function{MathFunction: segutils.Clamp_Max, ValueList: []string{expr.Args[1].String()}}
+				case "clamp_min":
+					if len(expr.Args) != 2 {
+						return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the clamp_min function", expr.Args.String())
+					}
+					mquery.Function = structs.Function{MathFunction: segutils.Clamp_Min, ValueList: []string{expr.Args[1].String()}}
 				default:
 					return fmt.Errorf("parser.Inspect: unsupported function type %v", function)
 				}

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -56,6 +56,27 @@ const metricFunctions = `[
 		"isTimeRangeFunc": false
 	},
 	{
+		"fn": "clamp",
+		"name": "Clamp",
+		"desc": "Clamps the sample values of all elements in v to have a lower limit of min and an upper limit of max.",
+		"eg": "clamp(avg (system.disk.used), 0, 99)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "clamp_max",
+		"name": "Clamp Max",
+		"desc": "Clamps the sample values of all elements in v to have an upper limit of max.",
+		"eg": "clamp_max(avg (system.disk.used), 99)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "clamp_min",
+		"name": "Clamp Min",
+		"desc": "Clamps the sample values of all elements in v to have a lower limit of min.",
+		"eg": "clamp_min(avg (system.disk.used), 0)",
+		"isTimeRangeFunc": false
+	},
+	{
 		"fn": "rate", 
 		"name": "Rate", 
 		"desc": "Calculates the per-second average rate of increase of the time series in the range vector.", 

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -677,3 +677,117 @@ func Test_applyMathFunctionLn(t *testing.T) {
 	err = metricsResults.ApplyFunctionsToResults(8, function)
 	assert.NotNil(t, err)
 }
+
+func Test_applyMathFunctionClamp(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1714880880] = -30.2
+	ts[1714880881] = 22
+	ts[1714880891] = -10
+	ts[1714880892] = 5.5
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := make(map[uint32]float64)
+	ans[1714880880] = 1
+	ans[1714880881] = 10
+	ans[1714880891] = 1
+	ans[1714880892] = 5.5
+
+	function := structs.Function{MathFunction: segutils.Clamp, ValueList: []string{"1", "10"}}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+}
+
+func Test_applyMathFunctionClampMin(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1714880880] = -30.2
+	ts[1714880881] = 22
+	ts[1714880891] = -10
+	ts[1714880892] = 5.5
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := make(map[uint32]float64)
+	ans[1714880880] = 1
+	ans[1714880881] = 22
+	ans[1714880891] = 1
+	ans[1714880892] = 5.5
+
+	function := structs.Function{MathFunction: segutils.Clamp_Min, ValueList: []string{"1"}}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+}
+
+func Test_applyMathFunctionClampMax(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := make(map[uint32]float64)
+	ts[1714880880] = -30.2
+	ts[1714880881] = 22
+	ts[1714880891] = -10
+	ts[1714880892] = 5.5
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := make(map[uint32]float64)
+	ans[1714880880] = -30.2
+	ans[1714880881] = 4
+	ans[1714880891] = -10
+	ans[1714880892] = 4
+
+	function := structs.Function{MathFunction: segutils.Clamp_Max, ValueList: []string{"4"}}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if val != expectedVal {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+}

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -409,7 +409,7 @@ func Test_applyMathFunctionFloor(t *testing.T) {
 		Results: result,
 	}
 
-	function := structs.Function{MathFunction: segutils.Floor, Value: ""}
+	function := structs.Function{MathFunction: segutils.Floor, ValueList: []string{""}}
 	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
@@ -444,7 +444,7 @@ func Test_applyMathFunctionCeil(t *testing.T) {
 		Results: result,
 	}
 
-	function := structs.Function{MathFunction: segutils.Ceil, Value: ""}
+	function := structs.Function{MathFunction: segutils.Ceil, ValueList: []string{""}}
 	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
@@ -480,7 +480,7 @@ func Test_applyMathFunctionRoundWithoutPrecision(t *testing.T) {
 		Results: result,
 	}
 
-	function := structs.Function{MathFunction: segutils.Round, Value: ""}
+	function := structs.Function{MathFunction: segutils.Round, ValueList: []string{""}}
 	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
@@ -515,7 +515,7 @@ func Test_applyMathFunctionRoundWithPrecision1(t *testing.T) {
 		Results: result,
 	}
 
-	function := structs.Function{MathFunction: segutils.Round, Value: "0.3"}
+	function := structs.Function{MathFunction: segutils.Round, ValueList: []string{"0.3"}}
 	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {
@@ -547,7 +547,7 @@ func Test_applyMathFunctionRoundWithPrecision2(t *testing.T) {
 		Results: result,
 	}
 
-	function := structs.Function{MathFunction: segutils.Round, Value: "1 / 2"}
+	function := structs.Function{MathFunction: segutils.Round, ValueList: []string{"1 /2"}}
 	err := metricsResults.ApplyFunctionsToResults(8, function)
 	assert.Nil(t, err)
 	for _, timeSeries := range metricsResults.Results {

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -61,7 +61,7 @@ type Aggreation struct {
 type Function struct {
 	MathFunction  utils.MathFunctions
 	RangeFunction utils.RangeFunctions //range function to apply, only one of these will be non nil
-	Value         string
+	ValueList     []string
 	TimeWindow    float64 //E.g: rate(metrics[1m]), extract 1m and convert to seconds
 }
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -301,6 +301,9 @@ const (
 	Ln
 	Log2
 	Log10
+	Clamp
+	Clamp_Max
+	Clamp_Min
 )
 
 type RangeFunctions int


### PR DESCRIPTION
# Description
Add promql clamp functions as mentioned in [doc](https://prometheus.io/docs/prometheus/latest/querying/functions/#clamp): clamp, clamp_max, clamp_min

# Testing
- clamp(testmetric0, 1, 50)
- clamp_max(testmetric0, 10)
- clamp_min(testmetric0, 1)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
