### PR TITLE
fix: panic while framing promql response

### DIFF
--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -365,7 +365,9 @@ func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQueryt
 				} else {
 					keyValue = strings.Split(val, ":")
 				}
-				result.Metric[keyValue[0]] = keyValue[1]
+				if len(keyValue) > 1 {
+					result.Metric[keyValue[0]] = keyValue[1]
+				}
 			}
 			for k, v := range results {
 				result.Value = []interface{}{int64(k), fmt.Sprintf("%v", v)}


### PR DESCRIPTION
# Description
panic in accessing keyValue while framing promql response while querying only for metricName without label filters

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
