### PR TITLE
Fix: Add ColumnsOrder attr for ProcessPipeSearchRequest (Dashboard Api)

### DIFF
--- a/pkg/ast/pipesearch/resultStructs.go
+++ b/pkg/ast/pipesearch/resultStructs.go
@@ -33,6 +33,7 @@ type PipeSearchResponseOuter struct {
 	TotalRRCCount      interface{}                   `json:"total_rrc_count,omitempty"`
 	BucketCount        int                           `json:"bucketCount,omitempty"`
 	DashboardPanelId   string                        `json:"dashboardPanelId"`
+	ColumnsOrder       []string                      `json:"columnsOrder"`
 }
 
 type PipeSearchResponse struct {

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -463,6 +463,12 @@ func getQueryResponseJson(nodeResult *structs.NodeResult, indexName string, quer
 	httpRespOuter.BucketCount = nodeResult.BucketCount
 	httpRespOuter.DashboardPanelId = dbPanelId
 
+	httpRespOuter.ColumnsOrder = allCols
+	// The length of AllCols is 0, which means it is not a async query
+	if len(allCols) == 0 {
+		httpRespOuter.ColumnsOrder = query.GetFinalColsOrder(nodeResult.ColumnsOrder)
+	}
+
 	log.Infof("qid=%d, Query Took %+v ms", qid, httpRespOuter.ElapedTimeMS)
 
 	return httpRespOuter


### PR DESCRIPTION
# Description
Now Resp for Dashboard Api should contain an attr called `ColumnsOrder`

> - For the non agg query, attr allColumns is the fields order
> - For the agg query, attr columnsOrder is the fields order. (Please notice that: Agg queries without groupby cols: to be finished)

I put some sample queries below. Will test throughly in the future


# Testing
1. Non agg query:
city=Boston | fields weekday, state, app_version
* | fields weekday, city, address | rename weekday AS "test_rename"

2. Agg query:
2.1 Has group by cols
city=Boston | stats count, avg(latency) BY weekday, http_method | fields weekday, http_method
city=Boston | stats count, avg(latency) BY weekday, app_version, http_method | fields http_method, weekday, app_version

with rename expr:
city=Boston | stats count, avg(latency) BY weekday, http_method | fields weekday, http_method | rename weekday AS "w"
city=Boston | stats count, avg(latency) AS b BY weekday, app_version, http_method | fields http_method, b, weekday, app_version | rename app_version AS "a"
city=Boston | stats count, avg(latency) AS b BY weekday, app_version, http_method | fields http_method, b, weekday, app_version | rename a*n AS sig*scalr

2.2 Without groupby cols: to be finished

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
