### PR TITLE
Fix: Add ColumnsOrder attr in query_update msg for async query

### DIFF
--- a/pkg/ast/pipesearch/resultStructs.go
+++ b/pkg/ast/pipesearch/resultStructs.go
@@ -57,6 +57,7 @@ type PipeSearchWSUpdateResponse struct {
 	Qtype                    string                  `json:"qtype,omitempty"`
 	BucketCount              int                     `json:"bucketCount,omitempty"`
 	SortByTimestampAtDefault bool                    `json:"sortByTimestampAtDefault"`
+	ColumnsOrder             []string                `json:"columnsOrder,omitempty"`
 }
 
 type PipeSearchCompleteResponse struct {
@@ -71,5 +72,5 @@ type PipeSearchCompleteResponse struct {
 	Qtype               string                  `json:"qtype,omitempty"`
 	BucketCount         int                     `json:"bucketCount,omitempty"`
 	IsTimechart         bool                    `json:"isTimechart"`
-	ColumnsOrder        []string                `json:"columnsOrder"`
+	ColumnsOrder        []string                `json:"columnsOrder,omitempty"`
 }

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -345,12 +345,13 @@ func createRecsWsResp(qid uint64, sizeLimit uint64, searchPercent float64, scrol
 			if qUpdate.RemoteID != "" {
 				doPull = true
 			}
-			aggMeasureRes, aggMeasureFunctions, aggGroupByCols, _, bucketCount := query.GetMeasureResultsForQid(qid, doPull, qUpdate.SegKeyEnc, aggs.BucketLimit)
+			aggMeasureRes, aggMeasureFunctions, aggGroupByCols, columnsOrder, bucketCount := query.GetMeasureResultsForQid(qid, doPull, qUpdate.SegKeyEnc, aggs.BucketLimit)
 			wsResponse.MeasureResults = aggMeasureRes
 			wsResponse.MeasureFunctions = aggMeasureFunctions
 			wsResponse.GroupByCols = aggGroupByCols
 			wsResponse.Qtype = qType.String()
 			wsResponse.BucketCount = bucketCount
+			wsResponse.ColumnsOrder = columnsOrder
 		}
 	case structs.RRCCmd:
 		useAnySegKey := false
@@ -405,6 +406,8 @@ func createRecsWsResp(qid uint64, sizeLimit uint64, searchPercent float64, scrol
 		}
 		wsResponse.AllPossibleColumns = allCols
 		wsResponse.Qtype = qType.String()
+
+		wsResponse.ColumnsOrder = allCols
 	}
 	return wsResponse, numRrcsAdded, nil
 }


### PR DESCRIPTION
# Description
Add ColumnsOrder attr in query_update msg for async query

So right now, 
- The resp for all types of queries in dashboard api will contain `ColumnsOrder` attr.
- For `websocket search`, except for agg query without groupby cols. Other queries should contain `ColumnsOrder` attr.

Please notice that:
For `websocket search`, there are 2 types of query.
1. Async query (Non aggregation query):
query_update resp: will contian data we need to append to the UI, including `ColumnsOrder` attr.
query_complete resp: will only contain some statistic data, without `ColumnsOrder` attr.

2. Sync query (Aggregation query):
query_update resp: without `ColumnsOrder` attr.
query_complete resp: will contain all the data, including `ColumnsOrder` attr.



# Testing
1. Non agg query:
city=Boston | fields weekday, state, app_version
* | fields weekday, city, address | rename weekday AS "test_rename"

4. Agg query:
2.1 Has group by cols
city=Boston | stats count, avg(latency) BY weekday, http_method | fields weekday, http_method
city=Boston | stats count, avg(latency) BY weekday, app_version, http_method | fields http_method, weekday, app_version

with rename expr:
city=Boston | stats count, avg(latency) BY weekday, http_method | fields weekday, http_method | rename weekday AS "w"
city=Boston | stats count, avg(latency) AS b BY weekday, app_version, http_method | fields http_method, b, weekday, app_version | rename app_version AS "a"
city=Boston | stats count, avg(latency) AS b BY weekday, app_version, http_method | fields http_method, b, weekday, app_version | rename a*n AS sig*scalr

2.2 Without groupby cols: to be finished

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
