### PR TITLE
fix: Loki/LogQL Instant Query time range

### DIFF
--- a/pkg/integrations/loki/loki.go
+++ b/pkg/integrations/loki/loki.go
@@ -107,8 +107,8 @@ func parseTimeRangeInMS(ctx *fasthttp.RequestCtx, defaultDelta uint64) (uint64, 
 			if err != nil {
 				return 0, 0, err
 			}
-			endTimeMs = timeInMS
-			startTimeMs = endTimeMs - 90*DAY_IN_MS
+			startTimeMs = timeInMS - 1*1000 // subtract 1 second
+			endTimeMs = timeInMS + 1*1000   // add 1  second
 
 			return startTimeMs, endTimeMs, nil
 		}


### PR DESCRIPTION
# Description
- Fixes the Loki instant Query Time range.


# Testing
- Tested by executing the queries against.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
