### PR TITLE
fix issue with colOrder on logs page

### DIFF
--- a/static/js/ag-grid-seg-stats.js
+++ b/static/js/ag-grid-seg-stats.js
@@ -19,60 +19,55 @@
 
  'use strict';
 
- let eGridDiv = null;
- 
- function renderMeasuresGrid(columnOrder, hits, groupByCols) {
-     if (eGridDiv === null) {
-         eGridDiv = document.querySelector('#measureAggGrid');
-         new agGrid.Grid(eGridDiv, aggGridOptions);
-     }
-     // set the column headers from the data
-     let colDefs = aggGridOptions.api.getColumnDefs();
-     colDefs.length = 0;
-     colDefs = columnOrder.map((colName, index) => {
-         let title =  colName;
-         let resize = index + 1 == columnOrder.length ? false : true;
-         let maxWidth = Math.max(displayTextWidth(colName, "italic 19pt  DINpro "), 200)         //200 is approx width of 1trillion number
-         return {
-             field: title,
-             headerName: title,
-             resizable: resize,
-             minWidth: maxWidth,
-         };
-     });
-     aggsColumnDefs = _.chain(aggsColumnDefs).concat(colDefs).uniqBy('field').value();
-     aggGridOptions.api.setColumnDefs(aggsColumnDefs);
-     let newRow = new Map()
-     $.each(hits, function (key, resMap) {
+let eGridDiv = null;
+
+function renderMeasuresGrid(columnOrder, hits) {
+    if (eGridDiv === null) {
+        eGridDiv = document.querySelector('#measureAggGrid');
+        new agGrid.Grid(eGridDiv, aggGridOptions);
+    }
+    // set the column headers from the data
+    let colDefs = aggGridOptions.api.getColumnDefs();
+    colDefs.length = 0;
+    colDefs = columnOrder.map((colName, index) => {
+        let title = colName;
+        let resize = index + 1 == columnOrder.length ? false : true;
+        let maxWidth = Math.max(displayTextWidth(colName, "italic 19pt  DINpro "), 200)         //200 is approx width of 1trillion number
+        return {
+            field: title,
+            headerName: title,
+            resizable: resize,
+            minWidth: maxWidth,
+        };
+    });
+    aggsColumnDefs = _.chain(aggsColumnDefs).concat(colDefs).uniqBy('field').value();
+    aggGridOptions.api.setColumnDefs(aggsColumnDefs);
+    let newRow = new Map()
+    $.each(hits, function (key, resMap) {
         newRow.set("id", 0)
         columnOrder.map((colName, index) => {
-            let ind = -1;
-            if (groupByCols != undefined && groupByCols.length > 0)
-                ind = findColumnIndex(groupByCols, colName)
-            if (resMap.GroupByValues!=null && resMap.GroupByValues[ind]!="*" &&  ind< (resMap.GroupByValues).length && ind != -1){
-                newRow.set(colName, resMap.GroupByValues[ind])
-            }else{
+            if (resMap.GroupByValues != null && resMap.GroupByValues[index] != "*" && index < (resMap.GroupByValues).length) {
+                newRow.set(colName, resMap.GroupByValues[index])
+            } else {
                 // Check if MeasureVal is undefined or null and set it to 0
                 if (resMap.MeasureVal[colName] === undefined || resMap.MeasureVal[colName] === null) {
                     newRow.set(colName, "0");
                 } else {
                     newRow.set(colName, resMap.MeasureVal[colName]);
                 }
-            }            
+            }
         })
-         segStatsRowData = _.concat(segStatsRowData, Object.fromEntries(newRow));
-     })
-     aggGridOptions.api.setRowData(segStatsRowData);
- 
- 
- }
- 
- function displayTextWidth(text, font) {
+        segStatsRowData = _.concat(segStatsRowData, Object.fromEntries(newRow));
+    })
+    aggGridOptions.api.setRowData(segStatsRowData);
+
+
+}
+
+function displayTextWidth(text, font) {
     let canvas = displayTextWidth.canvas || (displayTextWidth.canvas = document.createElement("canvas"));
     let context = canvas.getContext("2d");
     context.font = font;
     let metrics = context.measureText(text);
     return metrics.width;
-  }
-
-  
+}

--- a/static/js/dashboard-logs-results-grid.js
+++ b/static/js/dashboard-logs-results-grid.js
@@ -227,7 +227,6 @@ function panelLogOptionTableHandler(panelGridOptions,panelLogsColumnDefs) {
 
 
 function renderPanelAggsGrid(columnOrder, hits,panelId, groupByCols) {
-    console.log(columnOrder, hits, panelId, groupByCols)
     let aggsColumnDefs = [];
     let segStatsRowData=[];
     const aggGridOptions = {

--- a/static/js/dashboard-logs-results-grid.js
+++ b/static/js/dashboard-logs-results-grid.js
@@ -227,6 +227,7 @@ function panelLogOptionTableHandler(panelGridOptions,panelLogsColumnDefs) {
 
 
 function renderPanelAggsGrid(columnOrder, hits,panelId, groupByCols) {
+    console.log(columnOrder, hits, panelId, groupByCols)
     let aggsColumnDefs = [];
     let segStatsRowData=[];
     const aggGridOptions = {
@@ -276,11 +277,10 @@ function renderPanelAggsGrid(columnOrder, hits,panelId, groupByCols) {
     $.each(hits, function (key, resMap) {
        newRow.set("id", 0)
        columnOrder.map((colName, index) => {
-            let ind = -1;
-            if (groupByCols != undefined && groupByCols.length > 0)
-                ind = findColumnIndex(groupByCols, colName)
-            if (resMap.GroupByValues!=null && resMap.GroupByValues[ind]!="*" &&  ind< (resMap.GroupByValues).length && ind != -1){
-                newRow.set(colName, resMap.GroupByValues[ind])
+            if (groupByCols != undefined && groupByCols.length > 0 && resMap.GroupByValues.length >1)
+                index = findColumnIndex(groupByCols, colName)
+            if (resMap.GroupByValues!=null && resMap.GroupByValues[index]!="*" &&  index< (resMap.GroupByValues).length && index != -1 ){
+                newRow.set(colName, resMap.GroupByValues[index])
             }else{
                 // Check if MeasureVal is undefined or null and set it to 0
                 if (resMap.MeasureVal[colName] === undefined || resMap.MeasureVal[colName] === null) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -671,7 +671,7 @@
 
       aggsColumnDefs = [];
       segStatsRowData = [];
-      renderMeasuresGrid(columnOrder, res.measure,res.groupByCols);
+      renderMeasuresGrid(columnOrder, res.measure);
     }
     let totalTime = new Date().getTime() - startQueryTime;
     let percentComplete = res.percent_complete;
@@ -736,7 +736,7 @@
  
          aggsColumnDefs=[];
          segStatsRowData=[]; 
-         renderMeasuresGrid(columnOrder, res.measure, res.groupByCols);
+         renderMeasuresGrid(columnOrder, res.measure);
  
      }
      let totalTime = (new Date()).getTime() - startQueryTime;
@@ -791,7 +791,7 @@
       $("#agg-result-container").show();
       aggsColumnDefs = [];
       segStatsRowData = [];
-      renderMeasuresGrid(columnOrder, res.measure,res.groupByCols);
+      renderMeasuresGrid(columnOrder, res.measure);
       if (
         (res.qtype === "aggs-query" || res.qtype === "segstats-query") &&
         res.bucketCount
@@ -855,7 +855,7 @@
          $("#agg-result-container").show();
          aggsColumnDefs=[];
          segStatsRowData=[];
-         renderMeasuresGrid(columnOrder, res.measure, res.groupByCols);
+         renderMeasuresGrid(columnOrder, res.measure);
          if ((res.qtype ==="aggs-query" || res.qtype === "segstats-query") && res.bucketCount){
              totalHits = res.bucketCount;
          }


### PR DESCRIPTION
# Description
Summarize the change.

websocket results do not have groupByCols , instead it returns results with colNames. I removed the check for colName index in groupByCols


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
