### PR TITLE
Fix: Dashboard API's groupByCols were not updated after using the rename cmd

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -617,6 +617,9 @@ func performRenameColRequest(nodeResult *structs.NodeResult, aggs *structs.Query
 		return fmt.Errorf("performRenameColRequest: %v", err)
 	}
 
+	// Modify the nodeResults.groupByCols
+	nodeResult.GroupByCols = structs.GetRenameGroupByCols(nodeResult.GroupByCols, aggs)
+
 	return nil
 }
 

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -356,7 +356,7 @@ func GetMeasureResultsForQid(qid uint64, pullGrpBucks bool, skenc uint16, limit 
 			}
 
 			// Remove unused columns for Rename block
-			aggGroupByCols = rQuery.searchRes.RemoveUnusedGroupByCols(aggGroupByCols)
+			aggGroupByCols = structs.RemoveUnusedGroupByCols(rQuery.searchRes.GetAggs(), aggGroupByCols)
 
 			return bucketHolderArr, retMFuns, aggGroupByCols, GetFinalColsOrder(columnsOrder), added
 		} else {

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -356,12 +356,7 @@ func GetMeasureResultsForQid(qid uint64, pullGrpBucks bool, skenc uint16, limit 
 			}
 
 			// Remove unused columns for Rename block
-			aggs, err := rQuery.searchRes.GetAggs()
-			if err != nil {
-				log.Errorf("GetMeasureResultsForQid: %v", err)
-			} else {
-				aggGroupByCols = structs.RemoveUnusedGroupByCols(aggs, aggGroupByCols)
-			}
+			aggGroupByCols = structs.RemoveUnusedGroupByCols(rQuery.searchRes.GetAggs(), aggGroupByCols)
 
 			return bucketHolderArr, retMFuns, aggGroupByCols, GetFinalColsOrder(columnsOrder), added
 		} else {

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -356,7 +356,12 @@ func GetMeasureResultsForQid(qid uint64, pullGrpBucks bool, skenc uint16, limit 
 			}
 
 			// Remove unused columns for Rename block
-			aggGroupByCols = structs.RemoveUnusedGroupByCols(rQuery.searchRes.GetAggs(), aggGroupByCols)
+			aggs, err := rQuery.searchRes.GetAggs()
+			if err != nil {
+				log.Errorf("GetMeasureResultsForQid: %v", err)
+			} else {
+				aggGroupByCols = structs.RemoveUnusedGroupByCols(aggs, aggGroupByCols)
+			}
 
 			return bucketHolderArr, retMFuns, aggGroupByCols, GetFinalColsOrder(columnsOrder), added
 		} else {

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -416,6 +416,12 @@ func (sr *SearchResults) GetTotalCount() uint64 {
 	return sr.resultCount
 }
 
+func (sr *SearchResults) GetAggs() *structs.QueryAggregators {
+	sr.updateLock.Lock()
+	defer sr.updateLock.Unlock()
+	return sr.sAggs
+}
+
 // Adds remote rrc results to the search results
 func (sr *SearchResults) MergeRemoteRRCResults(rrcs []*utils.RecordResultContainer, grpByBuckets *blockresults.GroupByBucketsJSON,
 	timeBuckets *blockresults.TimeBucketsJSON, allCols map[string]struct{}, rawLogs []map[string]interface{},
@@ -568,62 +574,6 @@ func (sr *SearchResults) GetStatisticGroupByCols() []string {
 		}
 	}
 	return groupByCols
-}
-
-// For Rename or top/rare block, we may need to delete some groupby columns while processing them
-func (sr *SearchResults) RemoveUnusedGroupByCols(aggGroupByCols []string) []string {
-	for agg := sr.sAggs; agg != nil; agg = agg.Next {
-		// Rename block
-		aggGroupByCols = sr.GetRenameGroupByCols(aggGroupByCols, agg)
-		// Statistic block: to be finished
-	}
-	return aggGroupByCols
-}
-
-// Rename field A to field B. If A and B are groupby columns, field B should be removed from groupby columns, and rename A to B
-func (sr *SearchResults) GetRenameGroupByCols(aggGroupByCols []string, agg *structs.QueryAggregators) []string {
-	if agg.OutputTransforms != nil && agg.OutputTransforms.LetColumns != nil && agg.OutputTransforms.LetColumns.RenameColRequest != nil {
-
-		// Except for regex, other RenameExprModes will only rename one column
-		renameIndex := -1
-		indexToRemove := make([]int, 0)
-
-		for index, groupByCol := range aggGroupByCols {
-			switch agg.OutputTransforms.LetColumns.RenameColRequest.RenameExprMode {
-			case structs.REMPhrase:
-				fallthrough
-			case structs.REMOverride:
-
-				if groupByCol == agg.OutputTransforms.LetColumns.RenameColRequest.OriginalPattern {
-					renameIndex = index
-				}
-				if groupByCol == agg.OutputTransforms.LetColumns.RenameColRequest.NewPattern {
-					indexToRemove = append(indexToRemove, index)
-				}
-
-			case structs.REMRegex:
-				newColName, err := agg.OutputTransforms.LetColumns.RenameColRequest.ProcessRenameRegexExpression(groupByCol)
-				if err != nil {
-					return []string{}
-				}
-				if len(newColName) == 0 {
-					continue
-				}
-				for i, colName := range aggGroupByCols {
-					if colName == newColName {
-						indexToRemove = append(indexToRemove, i)
-						break
-					}
-				}
-				aggGroupByCols[index] = newColName
-			}
-		}
-		if renameIndex != -1 {
-			aggGroupByCols[renameIndex] = agg.OutputTransforms.LetColumns.RenameColRequest.NewPattern
-		}
-		aggGroupByCols = agg.OutputTransforms.LetColumns.RenameColRequest.RemoveColsByIndex(aggGroupByCols, indexToRemove)
-	}
-	return aggGroupByCols
 }
 
 // Subsequent calls may not return the same result as the previous may clean up the underlying heap used. Use GetResultsCopy to prevent this

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -416,19 +416,10 @@ func (sr *SearchResults) GetTotalCount() uint64 {
 	return sr.resultCount
 }
 
-func (sr *SearchResults) GetAggs() (*structs.QueryAggregators, error) {
+func (sr *SearchResults) GetAggs() *structs.QueryAggregators {
 	sr.updateLock.Lock()
 	defer sr.updateLock.Unlock()
-	aggsBytes, err := json.Marshal(sr.sAggs)
-	if err != nil {
-		return nil, fmt.Errorf("GetAggs: unable to get a copy of aggs: %v", err)
-	}
-
-	var aggsCopy structs.QueryAggregators
-	if err := json.Unmarshal(aggsBytes, &aggsCopy); err != nil {
-		return nil, fmt.Errorf("GetAggs: unable to get a copy of aggs: %v", err)
-	}
-	return &aggsCopy, nil
+	return sr.sAggs
 }
 
 // Adds remote rrc results to the search results

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -416,10 +416,19 @@ func (sr *SearchResults) GetTotalCount() uint64 {
 	return sr.resultCount
 }
 
-func (sr *SearchResults) GetAggs() *structs.QueryAggregators {
+func (sr *SearchResults) GetAggs() (*structs.QueryAggregators, error) {
 	sr.updateLock.Lock()
 	defer sr.updateLock.Unlock()
-	return sr.sAggs
+	aggsBytes, err := json.Marshal(sr.sAggs)
+	if err != nil {
+		return nil, fmt.Errorf("GetAggs: unable to get a copy of aggs: %v", err)
+	}
+
+	var aggsCopy structs.QueryAggregators
+	if err := json.Unmarshal(aggsBytes, &aggsCopy); err != nil {
+		return nil, fmt.Errorf("GetAggs: unable to get a copy of aggs: %v", err)
+	}
+	return &aggsCopy, nil
 }
 
 // Adds remote rrc results to the search results


### PR DESCRIPTION
# Description
- Fix the bug where the dashboard API's(http://localhost:5122/api/search/-1) groupByCols were not updated after using the `rename cmd`
- Remove some redundant code

Test with the queries below:
1. Rename to a str:
city=Boston | rename gg AS city
city=Boston | fields city, country | rename city AS "test"
city=Boston | stats count AS Count BY http_status, http_method | rename http_method AS "test"
city=Boston | stats count AS Count BY http_status, http_method | rename Count AS "test"

2. Regex
city=Boston | rename c*y AS sig*scalr
city=Boston | fields app_name, app_version | rename app* AS start*end
city=Boston | stats count AS Count BY http_status, http_method | rename ht* AS A*
city=Boston | stats count AS Count BY http_status, http_method | rename C* AS A*
//Multiple wildcards
city=Boston | stats count AS Count BY http_status, http_method | rename ht*_* AS start*mid*end

3. Rename to a existing field
city=Boston | rename city AS weekday
city=Boston | fields app_name, app_version | rename app_name AS startend
city=Boston | stats count AS Count BY http_status, http_method | eval newField=(http_status - 1000) | rename newField AS http_method

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
