### PR TITLE
fix: metric name in tags and empty metric names

### DIFF
--- a/pkg/integrations/prometheus/ingest/putmetrics.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics.go
@@ -143,6 +143,7 @@ func HandlePutMetrics(compressed []byte) (uint64, uint64, error) {
 								if ok {
 									metricName = valString
 								}
+								continue // skip metric __name__ as tag
 							}
 							valString, ok := v.(string)
 							if ok {
@@ -152,11 +153,16 @@ func HandlePutMetrics(compressed []byte) (uint64, uint64, error) {
 					}
 				}
 			}
-			tags += `"metric"` + `:"` + metricName + `",`
 			if tags[len(tags)-1] == ',' {
 				tags = tags[:len(tags)-1]
 			}
 			tags += "}"
+
+			if metricName == "" {
+				failedCount++
+				log.Errorf("HandlePutMetrics: the Metric name is empty. json data payload: %+v", dataJson)
+				continue
+			}
 
 			modifiedData := `{"metric":"` + metricName + `","tags":` + tags + `,"timestamp":` + strconv.FormatInt(s.Timestamp, 10) + `,"value":` + strconv.FormatFloat(s.Value, 'f', -1, 64) + `}`
 

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -212,6 +212,9 @@ func GetAllMetricNamesOverTheTimeRange(timeRange *dtu.MetricsTimeRange, orgid ui
 	}
 
 	for mName := range unrotatedResultContainer {
+		if mName == "" {
+			continue
+		}
 		_, ok := resultContainer[mName]
 		if !ok {
 			resultContainer[mName] = true

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -408,6 +408,9 @@ If it cannot find the series or no space exists in the metrics segment, it will 
 Return number of bytes written and any error encountered
 */
 func EncodeDatapoint(mName []byte, tags *TagsHolder, dp float64, timestamp uint32, nBytes uint64, orgid uint64) error {
+	if len(mName) == 0 {
+		return fmt.Errorf("metric name is empty")
+	}
 	tsid, err := tags.GetTSID(mName)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description
Summarize the change.

Fixes #887 
Fixes #886 

# Testing
- Tested by executing the API endpoints.
- And ingesting with empty metric name.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
