### PR TITLE
Feat: Add promql funcs <aggregation>_over_time()

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -1025,6 +1025,16 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 					mquery.Function = structs.Function{RangeFunction: segutils.IRate, TimeWindow: timeWindow}
 				case "increase":
 					mquery.Function = structs.Function{RangeFunction: segutils.Increase, TimeWindow: timeWindow}
+				case "avg_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Avg_Over_time, TimeWindow: timeWindow}
+				case "min_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Min_Over_time, TimeWindow: timeWindow}
+				case "max_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Max_Over_time, TimeWindow: timeWindow}
+				case "sum_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Sum_Over_time, TimeWindow: timeWindow}
+				case "count_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Count_Over_time, TimeWindow: timeWindow}
 				default:
 					return fmt.Errorf("parser.Inspect: unsupported function type %v", function)
 				}

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -152,6 +152,41 @@ const metricFunctions = `[
 		"desc": "Calculates the per-second derivative of the time series in a range vector v, using simple linear regression", 
 		"eg": "deriv(avg (system.disk.used[5m]))",
 		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "avg_over_time", 
+		"name": "Average Over Time", 
+		"desc": "The average value of all points in the specified interval.", 
+		"eg": "avg_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "min_over_time", 
+		"name": "Minimum Over Time", 
+		"desc": "The minimum value of all points in the specified interval.", 
+		"eg": "min_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "max_over_time", 
+		"name": "Maximum Over Time", 
+		"desc": "The maximum value of all points in the specified interval.", 
+		"eg": "max_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "sum_over_time", 
+		"name": "Sum Over Time", 
+		"desc": "The sum of all values in the specified interval.", 
+		"eg": "sum_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "count_over_time", 
+		"name": "Count Over Time", 
+		"desc": "The count of all values in the specified interval.", 
+		"eg": "count_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
 	}
 ]`
 

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -37,37 +37,37 @@ func Test_applyRangeFunctionRate(t *testing.T) {
 		1025: 6.5,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Rate, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Rate, TimeWindow: 10})
 	assert.Nil(t, err)
 
 	// There's six timestamps in the series, but we need two points to calculate
 	// the rate, so we can't calculate it on the first point. So we should have
 	// 5 elements in the result.
-	assert.Len(t, rate, 5)
+	assert.Len(t, res, 5)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1003]
+	val, ok = res[1003]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (3.0-2.0)/(3-0)))
 
-	val, ok = rate[1008]
+	val, ok = res[1008]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (4.0-2.0)/(8-0)))
 
-	val, ok = rate[1012]
+	val, ok = res[1012]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (18.0-3.0)/(12-3)))
 
-	val, ok = rate[1020]
+	val, ok = res[1020]
 	assert.True(t, ok)
 	// Since the value here is smaller than at the last timestamp, the value was
 	// reset since the last timestamp. So the increase is just this value, not
 	// this value minus the previous value.
 	assert.True(t, dtypeutils.AlmostEquals(val, (2.5)/(20-12)))
 
-	val, ok = rate[1025]
+	val, ok = res[1025]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (6.5-2.5)/(25-20)))
 }
@@ -82,37 +82,37 @@ func Test_applyRangeFunctionIRate(t *testing.T) {
 		1009: 1.0,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.IRate, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.IRate, TimeWindow: 10})
 	assert.Nil(t, err)
 
 	// There's six timestamps in the series, but we need two points to calculate
 	// the rate, so we can't calculate it on the first point. So we should have
 	// 5 elements in the result.
-	assert.Len(t, rate, 5)
+	assert.Len(t, res, 5)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1001]
+	val, ok = res[1001]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (3.0-2.0)/(1-0)))
 
-	val, ok = rate[1002]
+	val, ok = res[1002]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, (4.0-3.0)/(2-1)))
 
-	val, ok = rate[1003]
+	val, ok = res[1003]
 	assert.True(t, ok)
 	// Since the value here is smaller than at the last timestamp, the value was
 	// reset since the last timestamp. So the increase is just this value, not
 	// this value minus the previous value.
 	assert.True(t, dtypeutils.AlmostEquals(val, 0.0))
 
-	val, ok = rate[1008]
+	val, ok = res[1008]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 2.5/(8-3)))
 
-	val, ok = rate[1009]
+	val, ok = res[1009]
 	assert.True(t, ok)
 	// Since the value here is smaller than at the last timestamp, the value was
 	// reset since the last timestamp. So the increase is just this value, not
@@ -165,26 +165,26 @@ func Test_applyRangeFunctionDelta(t *testing.T) {
 		1018: 2.5,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Delta, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Delta, TimeWindow: 10})
 	assert.Nil(t, err)
 
-	assert.Len(t, rate, 3)
+	assert.Len(t, res, 3)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1001]
+	val, ok = res[1001]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 3.0-2.0))
 
-	val, ok = rate[1002]
+	val, ok = res[1002]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 5.0-2.0))
 
-	_, ok = rate[1013]
+	_, ok = res[1013]
 	assert.False(t, ok)
 
-	val, ok = rate[1018]
+	val, ok = res[1018]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 2.5-10.0))
 }
@@ -198,26 +198,26 @@ func Test_applyRangeFunctionIDelta(t *testing.T) {
 		1018: 2.5,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.IDelta, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.IDelta, TimeWindow: 10})
 	assert.Nil(t, err)
 
-	assert.Len(t, rate, 3)
+	assert.Len(t, res, 3)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1001]
+	val, ok = res[1001]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 3.0-2.0))
 
-	val, ok = rate[1002]
+	val, ok = res[1002]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 5.0-3.0))
 
-	_, ok = rate[1013]
+	_, ok = res[1013]
 	assert.False(t, ok)
 
-	val, ok = rate[1018]
+	val, ok = res[1018]
 	assert.True(t, ok)
 	assert.True(t, dtypeutils.AlmostEquals(val, 2.5-10.0))
 }
@@ -232,35 +232,35 @@ func Test_applyRangeFunctionChanges(t *testing.T) {
 		1025: 2.5,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Changes, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Changes, TimeWindow: 10})
 	assert.Nil(t, err)
 
-	assert.Len(t, rate, 6)
+	assert.Len(t, res, 6)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1000]
+	val, ok = res[1000]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 
-	val, ok = rate[1001]
+	val, ok = res[1001]
 	assert.True(t, ok)
 	assert.Equal(t, float64(1), val)
 
-	val, ok = rate[1002]
+	val, ok = res[1002]
 	assert.True(t, ok)
 	assert.Equal(t, float64(2), val)
 
-	val, ok = rate[1013]
+	val, ok = res[1013]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 
-	val, ok = rate[1018]
+	val, ok = res[1018]
 	assert.True(t, ok)
 	assert.Equal(t, float64(1), val)
 
-	val, ok = rate[1025]
+	val, ok = res[1025]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 }
@@ -275,35 +275,35 @@ func Test_applyRangeFunctionResets(t *testing.T) {
 		1025: 2.8,
 	}
 
-	rate, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Resets, TimeWindow: 10})
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Resets, TimeWindow: 10})
 	assert.Nil(t, err)
 
-	assert.Len(t, rate, 6)
+	assert.Len(t, res, 6)
 
 	var val float64
 	var ok bool
 
-	val, ok = rate[1000]
+	val, ok = res[1000]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 
-	val, ok = rate[1001]
+	val, ok = res[1001]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 
-	val, ok = rate[1002]
+	val, ok = res[1002]
 	assert.True(t, ok)
 	assert.Equal(t, float64(1), val)
 
-	val, ok = rate[1008]
+	val, ok = res[1008]
 	assert.True(t, ok)
 	assert.Equal(t, float64(2), val)
 
-	val, ok = rate[1019]
+	val, ok = res[1019]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 
-	val, ok = rate[1025]
+	val, ok = res[1025]
 	assert.True(t, ok)
 	assert.Equal(t, float64(0), val)
 }

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -222,6 +222,221 @@ func Test_applyRangeFunctionIDelta(t *testing.T) {
 	assert.True(t, dtypeutils.AlmostEquals(val, 2.5-10.0))
 }
 
+func Test_applyRangeFunctionAvg(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1003: 3.0,
+		1008: 4.0,
+		1012: 18.0,
+		1020: 2.5,
+		1035: 6.5,
+	}
+
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Avg_Over_time, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	assert.Len(t, res, 6)
+
+	var val float64
+	var ok bool
+
+	val, ok = res[1000]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.0))
+
+	val, ok = res[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (3.0+2.0)/(2)))
+
+	val, ok = res[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (4.0+3.0+2.0)/(3)))
+
+	val, ok = res[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (18.0+4.0+3.0)/(3)))
+
+	val, ok = res[1020]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (2.5+18.0)/(2)))
+
+	val, ok = res[1035]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 6.5))
+}
+
+func Test_applyRangeFunctionMin(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1003: 3.0,
+		1008: 1.0,
+		1012: 18.0,
+		1023: 2.5,
+		1025: 6.5,
+	}
+
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Min_Over_time, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	assert.Len(t, res, 6)
+
+	var val float64
+	var ok bool
+
+	val, ok = res[1000]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.0))
+
+	val, ok = res[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.0))
+
+	val, ok = res[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 1.0))
+
+	val, ok = res[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 1.0))
+
+	val, ok = res[1023]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.5))
+
+	val, ok = res[1025]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.5))
+}
+
+func Test_applyRangeFunctionMax(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1003: 3.0,
+		1008: 1.0,
+		1012: 18.0,
+		1023: 2.5,
+		1025: 6.5,
+	}
+
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Max_Over_time, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	assert.Len(t, res, 6)
+
+	var val float64
+	var ok bool
+
+	val, ok = res[1000]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.0))
+
+	val, ok = res[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 3.0))
+
+	val, ok = res[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 3.0))
+
+	val, ok = res[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 18.0))
+
+	val, ok = res[1023]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.5))
+
+	val, ok = res[1025]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 6.5))
+}
+
+func Test_applyRangeFunctionSum(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1003: 3.0,
+		1008: 4.0,
+		1012: 18.0,
+		1020: 2.5,
+		1025: 6.5,
+	}
+
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Sum_Over_time, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	assert.Len(t, res, 6)
+
+	var val float64
+	var ok bool
+
+	val, ok = res[1000]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2.0))
+
+	val, ok = res[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (3.0+2.0)))
+
+	val, ok = res[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (4.0+3.0+2.0)))
+
+	val, ok = res[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (18.0+4.0+3.0)))
+
+	val, ok = res[1020]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (2.5+18.0)))
+
+	val, ok = res[1025]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, (6.5+2.5)))
+}
+
+func Test_applyRangeFunctionCount(t *testing.T) {
+	timeSeries := map[uint32]float64{
+		1000: 2.0,
+		1003: 3.0,
+		1008: 4.0,
+		1012: 18.0,
+		1020: 2.5,
+		1025: 6.5,
+	}
+
+	res, err := ApplyRangeFunction(timeSeries, structs.Function{RangeFunction: segutils.Count_Over_time, TimeWindow: 10})
+	assert.Nil(t, err)
+
+	assert.Len(t, res, 6)
+
+	var val float64
+	var ok bool
+
+	val, ok = res[1000]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 1))
+
+	val, ok = res[1003]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2))
+
+	val, ok = res[1008]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 3))
+
+	val, ok = res[1012]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 3))
+
+	val, ok = res[1020]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2))
+
+	val, ok = res[1025]
+	assert.True(t, ok)
+	assert.True(t, dtypeutils.AlmostEquals(val, 2))
+}
+
 func Test_reduceEntries(t *testing.T) {
 	entries := []Entry{
 		Entry{downsampledTime: 0, dpVal: 4.3},

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -318,6 +318,11 @@ const (
 	Increase
 	Delta
 	IDelta
+	Avg_Over_time
+	Min_Over_time
+	Max_Over_time
+	Sum_Over_time
+	Count_Over_time
 )
 
 // For columns used by aggs with eval statements, we should keep their raw values because we need to evaluate them


### PR DESCRIPTION
# Description
Add a part of <aggregation>_over_time() functions: https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time

avg_over_time(range-vector): the average value of all points in the specified interval.
min_over_time(range-vector): the minimum value of all points in the specified interval.
max_over_time(range-vector): the maximum value of all points in the specified interval.
sum_over_time(range-vector): the sum of all values in the specified interval.
count_over_time(range-vector): the count of all values in the specified interval.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
