### PR TITLE
fix: tagsholder panic

### DIFF
--- a/pkg/segment/writer/metrics/tagsholder.go
+++ b/pkg/segment/writer/metrics/tagsholder.go
@@ -18,8 +18,8 @@
 package metrics
 
 import (
+	"bytes"
 	"sort"
-	"sync"
 
 	jp "github.com/buger/jsonparser"
 	"github.com/cespare/xxhash"
@@ -37,28 +37,10 @@ type TagsHolder struct {
 	len     int
 	done    bool
 	entries []tagEntry
-	buf     *bytebufferpool.ByteBuffer
+	buf     *bytes.Buffer
 }
 
 var initialTagCapacity int = 10
-
-var tagsEntryPool = sync.Pool{
-	New: func() interface{} {
-		// returning &slice causes race conditions, so we return []tagEntry and pay the price of allocating on returning
-		// this price is much lower than the cost of creating a new []tagEntry each time
-		slice := make([]tagEntry, initialTagCapacity)
-		return slice
-	},
-}
-
-var tagsHolderPool = sync.Pool{
-	New: func() interface{} {
-		// The Pool's New function should generally only return pointer
-		// types, since a pointer can be put into the return interface
-		// value without an allocation:
-		return &TagsHolder{}
-	},
-}
 
 /*
 Allocates and returns a TagsHolder
@@ -66,25 +48,15 @@ Allocates and returns a TagsHolder
 Caller is responsible for calling ReturnTagsHolder
 */
 func GetTagsHolder() *TagsHolder {
-	holder := tagsHolderPool.Get().(*TagsHolder)
-	holder.buf = bytebufferpool.Get()
-	tagsBuf := tagsEntryPool.Get().([]tagEntry)
+	holder := &TagsHolder{}
+	holder.buf = &bytes.Buffer{}
 
 	holder.len = initialTagCapacity
 	holder.idx = 0
-	holder.entries = tagsBuf
+	holder.entries = make([]tagEntry, initialTagCapacity)
 	holder.done = false
 
 	return holder
-}
-
-/*
-Returns allocated tags holder memory back to the pool
-*/
-func ReturnTagsHolder(th *TagsHolder) {
-	bytebufferpool.Put(th.buf)
-	tagsEntryPool.Put(th.entries)
-	tagsHolderPool.Put(th)
 }
 
 func (th *TagsHolder) Insert(key string, value []byte, vType jp.ValueType) {

--- a/pkg/segment/writer/metrics/tagsholder_test.go
+++ b/pkg/segment/writer/metrics/tagsholder_test.go
@@ -1,0 +1,38 @@
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	jp "github.com/buger/jsonparser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsHolderConcurrency(t *testing.T) {
+	var wg sync.WaitGroup
+	numGoroutines := 100
+	numInsertsPerGoroutine := 1000
+
+	insertTags := func(holder *TagsHolder, wg *sync.WaitGroup) {
+		defer wg.Done()
+		for i := 0; i < numInsertsPerGoroutine; i++ {
+			key := "key" + fmt.Sprint(i)
+			value := []byte("value" + fmt.Sprint(i))
+			vType := jp.String
+			holder.Insert(key, value, vType)
+		}
+
+		holder.finish()
+
+		assert.Equal(t, numInsertsPerGoroutine, holder.idx, "The number of inserted tags should match the expected count")
+	}
+
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		holder := GetTagsHolder()
+		go insertTags(holder, &wg)
+	}
+
+	wg.Wait()
+}

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -277,28 +277,22 @@ func AddTimeSeriesEntryToInMemBuf(rawJson []byte, signalType SIGNAL_TYPE, orgid 
 		tagsHolder := metrics.GetTagsHolder()
 		mName, dp, ts, err := metrics.ExtractOTSDBPayload(rawJson, tagsHolder)
 		if err != nil {
-			metrics.ReturnTagsHolder(tagsHolder)
 			return err
 		}
 		err = metrics.EncodeDatapoint(mName, tagsHolder, dp, ts, uint64(len(rawJson)), orgid)
 		if err != nil {
-			metrics.ReturnTagsHolder(tagsHolder)
 			return fmt.Errorf("entry rejected for metric %s %v because of error: %v", mName, tagsHolder, err)
 		}
-		metrics.ReturnTagsHolder(tagsHolder)
 	case SIGNAL_METRICS_INFLUX:
 		tagsHolder := metrics.GetTagsHolder()
 		mName, dp, ts, err := metrics.ExtractInfluxPayload(rawJson, tagsHolder)
 		if err != nil {
-			metrics.ReturnTagsHolder(tagsHolder)
 			return err
 		}
 		err = metrics.EncodeDatapoint(mName, tagsHolder, dp, ts, uint64(len(rawJson)), orgid)
 		if err != nil {
-			metrics.ReturnTagsHolder(tagsHolder)
 			return err
 		}
-		metrics.ReturnTagsHolder(tagsHolder)
 	default:
 		return fmt.Errorf("unknown signal type %+v", signalType)
 	}


### PR DESCRIPTION
# Description
- Fixes the issue of TagsHolder concurrent access.
- Removed the use of pools.

# Testing
- Tested by running the script that simultaneous try to ingest 1000 metrics.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
