### PR TITLE
Promql query support for sigclient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
             go run main.go query esbulk -d http://localhost:5122 -f ../../cicd/ingest.csv
             go run main.go query otsdb -d http://localhost:5122/otsdb -n 5 -y
             go run main.go query otsdb -d http://localhost:5122/metrics-explorer/api/v1/timeseries -f ../../cicd/metrics_test.csv
+            go run main.go query promql -d http://localhost:5122/promql/api/v1/query_range -v -f ../../cicd/promql_test.csv
       - run:
           name: Kill Siglens
           command: |

--- a/cicd/promql_test.csv
+++ b/cicd/promql_test.csv
@@ -1,0 +1,46 @@
+# This file is a test set of metrics data. The fields below represent: query, start time, end time,step,expected result
+"testmetric0",now-1d,now,15,true
+"testmetric1{car_type=""Passenger car compact""}",now-1d,now,15,true
+"round(testmetric0, 1/2)",now-1d,now,15,true
+"avg_over_time(testmetric0[24h])",now-1d,now,15,true
+"max_over_time(testmetric0[48h])",now-1d,now,15,true
+"changes(testmetric0[48h])",now-1d,now,15,true
+"abs(testmetric1)",now-1d,now,15,true
+"sqrt(testmetric1)",now-1d,now,15,true
+"ceil(testmetric1)",now-1d,now,15,true
+"floor(testmetric1)",now-1d,now,15,true
+"round(testmetric0)",now-1d,now,15,true
+"round(testmetric0, 1/2)",now-1d,now,15,true
+"ln(testmetric1)",now-1d,now,15,true
+"log2(testmetric1)",now-1d,now,15,true
+"log10(testmetric1)",now-1d,now,15,true
+"sgn(testmetric2)",now-1d,now,15,true
+"deg(testmetric2)",now-1d,now,15,true
+"rad(testmetric2)",now-1d,now,15,true
+"clamp(testmetric3, -10, 100)",now-1d,now,15,true
+"clamp_max(testmetric3, 99)",now-1d,now,15,true
+"clamp_min(testmetric3, 0)",now-1d,now,15,true
+"rate(abs(testmetric3[48h]))",now-1d,now,15,false
+"irate(testmetric3[48h])",now-1d,now,15,true
+"increase(testmetric3[48h])",now-1d,now,15,true
+"delta(testmetric3[48h])",now-1d,now,15,true
+"idelta(testmetric3[48h])",now-1d,now,15,true
+"changes(testmetric4[24h])",now-1d,now,15,true
+"resets(testmetric4[24h])",now-1d,now,15,true
+"avg_over_time(testmetric4[24h])",now-1d,now,15,true
+"min_over_time(testmetric4[24h])",now-1d,now,15,true
+"max_over_time(testmetric4[24h])",now-1d,now,15,true
+"sum_over_time(testmetric4[24h])",now-1d,now,15,true
+"count_over_time(testmetric4[24h])",now-1d,now,15,true
+"avg_over_time(testmetric0[24h])",now-1d,now,15,true
+"max_over_time(testmetric0[48h])",now-1d,now,15,true
+"changes(testmetric0[48h])",now-1d,now,15,true
+"testmetric0[24h]",now-1d,now,15,false
+"testmetric1{car_type=""Passenger car compact""}[48h]",now-1d,now,15,false
+"abs(testmetric1[24h])",now-1d,now,15,false
+"sqrt(testmetric1[48h])",now-1d,now,15,false
+"ceil(testmetric1[24h])",now-1d,now,15,false
+"floor(testmetric1[48h])",now-1d,now,15,false
+"round(testmetric0[24h])",now-1d,now,15,false
+"round(testmetric0, 1/2)[48h]",now-1d,now,15,false
+"ln(testmetric1[24h])",now-1m,now,15,false

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -178,18 +178,20 @@ var promQLQueryCmd = &cobra.Command{
 		promQLQueryWithStartEnd, _ := cmd.Flags().GetString("query")
 		var promQLQuery, startEpoch, endEpoch string
 		if promQLQueryWithStartEnd != "" {
-			// Split the string into parts
-			parts := strings.Split(promQLQueryWithStartEnd, " ")
-
-			// Check that the length of parts is exactly 3
-			if len(parts) != 3 {
+			parts := strings.SplitN(promQLQueryWithStartEnd, "start:", 2)
+			if len(parts) != 2 {
 				log.Fatalf("Invalid query format: %v. Expected format: <query> start:<startEpoch> end:<endEpoch>", promQLQueryWithStartEnd)
 			}
 
-			// Extract the individual arguments
-			promQLQuery = parts[0]
-			startEpoch = strings.TrimPrefix(parts[1], "start:")
-			endEpoch = strings.TrimPrefix(parts[2], "end:")
+			promQLQuery = strings.TrimSpace(parts[0])
+			parts = strings.SplitN(parts[1], "end:", 2)
+
+			if len(parts) != 2 {
+				log.Fatalf("Invalid query format: %v. Expected format: <query> start:<startEpoch> end:<endEpoch>", promQLQueryWithStartEnd)
+			}
+
+			startEpoch = strings.TrimSpace(parts[0])
+			endEpoch = strings.TrimSpace(parts[1])
 		}
 		log.Infof("dest : %+v\n", dest)
 		log.Infof("filePath : %+v\n", filepath)

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -258,7 +258,7 @@ func init() {
 	queryCmd.PersistentFlags().BoolP("validateMetricsOutput", "y", false, "check if metric querries return any results")
 	queryCmd.PersistentFlags().StringP("filePath", "f", "", "filepath to csv file to use to run queries from")
 	queryCmd.PersistentFlags().BoolP("randomQueries", "", false, "generate random queries")
-	queryCmd.PersistentFlags().StringP("query", "q", "", "query to run")
+	queryCmd.PersistentFlags().StringP("query", "q", "", "promql query to run")
 	queryCmd.AddCommand(esQueryCmd)
 	queryCmd.AddCommand(metricsQueryCmd)
 	queryCmd.AddCommand(promQLQueryCmd)

--- a/tools/sigclient/pkg/query/promqlquery.go
+++ b/tools/sigclient/pkg/query/promqlquery.go
@@ -50,10 +50,9 @@ func RunPromQLQueryFromFile(apiURL string, filepath string) {
 		query, step := rec[0], rec[3]
 
 		nowTs := uint64(time.Now().Unix())
-		defValue := nowTs - 60*60 // default value is current time - 1 hour
 
-		start := utils.ConvertStringToEpochSec(nowTs, rec[1], defValue)
-		end := utils.ConvertStringToEpochSec(nowTs, rec[2], defValue)
+		start := utils.ConvertStringToEpochSec(nowTs, rec[1], nowTs-3600)
+		end := utils.ConvertStringToEpochSec(nowTs, rec[2], nowTs)
 		expectedResult, err := strconv.ParseBool(rec[4])
 		if err != nil {
 			log.Fatalf("RunPromQLQueryFromFile: Invalid value for expected result: %v", rec[4])
@@ -65,6 +64,7 @@ func RunPromQLQueryFromFile(apiURL string, filepath string) {
 			log.Fatalf("Query: %v, expected result: %v, actual result: %v", query, expectedResult, success)
 		}
 	}
+	log.Info("RunPromQLQueryFromFile: All queries executed successfully")
 }
 
 func RunPromQLQuery(apiURL string, query string, start string, end string, step string, expectedResult bool) (success bool) {
@@ -101,9 +101,9 @@ func RunPromQLQuery(apiURL string, query string, start string, end string, step 
 		log.Printf("Query: %v was successful.", query)
 		return true
 	} else if expectedResult {
-		log.Errorf("Non-200 HTTP status code: %v, query: %v response body: %v", resp.StatusCode, u.RawQuery, string(body))
+		log.Errorf("Query: %v, Expected: %v, Actual: %v, status code: %v, response body: %v", query, expectedResult, success, resp.StatusCode, string(body))
 	} else {
-		log.Printf("Query: %v failed as expected.", query)
+		log.Printf("Query: %v, Expected: Fail, Actual: Fail", query)
 	}
 	return false
 }

--- a/tools/sigclient/pkg/query/promqlquery.go
+++ b/tools/sigclient/pkg/query/promqlquery.go
@@ -1,0 +1,109 @@
+package query
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+	"verifier/pkg/utils"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func RunPromQLQueryFromFile(apiURL string, filepath string) {
+	log.Infof("RunPromQLQueryFromFile: Reading queries from file: %v", filepath)
+	f, err := os.Open(filepath)
+	if err != nil {
+		log.Fatalf("RunPromQLQueryFromFile: Error opening file: %v, err: %v", filepath, err)
+		return
+	}
+	defer f.Close()
+
+	csvReader := csv.NewReader(f)
+	// Skip the first line comment
+	_, err = csvReader.Read()
+	if err != nil {
+		log.Fatalf("RunPromQLQueryFromFile: Error reading file header: %v, err: %v", filepath, err)
+		return
+	}
+
+	for {
+		rec, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("RunPromQLQueryFromFile: Error reading file: %v, err: %v", filepath, err)
+			return
+		}
+
+		if len(rec) != 5 {
+			log.Fatalf("RunPromQLQueryFromFile: Invalid number of columns in query file: [%v]. Expected 5", rec)
+			return
+		}
+
+		query, step := rec[0], rec[3]
+
+		nowTs := uint64(time.Now().Unix())
+		defValue := nowTs - 60*60 // default value is current time - 1 hour
+
+		start := utils.ConvertStringToEpochSec(nowTs, rec[1], defValue)
+		end := utils.ConvertStringToEpochSec(nowTs, rec[2], defValue)
+		expectedResult, err := strconv.ParseBool(rec[4])
+		if err != nil {
+			log.Fatalf("RunPromQLQueryFromFile: Invalid value for expected result: %v", rec[4])
+			return
+		}
+
+		success := RunPromQLQuery(apiURL, query, fmt.Sprintf("%v", start), fmt.Sprintf("%v", end), step, expectedResult)
+		if success != expectedResult {
+			log.Fatalf("Query: %v, expected result: %v, actual result: %v", query, expectedResult, success)
+		}
+	}
+}
+
+func RunPromQLQuery(apiURL string, query string, start string, end string, step string, expectedResult bool) (success bool) {
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		log.Fatalf("Error parsing URL: %v, err: %v", apiURL, err)
+		return false
+	}
+
+	params := url.Values{}
+	params.Add("query", query)
+	params.Add("start", start)
+	params.Add("end", end)
+	params.Add("step", step)
+	u.RawQuery = params.Encode()
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		log.Fatalf("Error sending GET request: %v, err: %v", u.String(), err)
+		return false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response body: %v, err: %v", u.String(), err)
+		return false
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal(body, &result)
+
+	if result["status"] == "success" {
+		log.Printf("Query: %v was successful.", query)
+		return true
+	} else if expectedResult {
+		log.Errorf("Non-200 HTTP status code: %v, query: %v response body: %v", resp.StatusCode, u.RawQuery, string(body))
+	} else {
+		log.Printf("Query: %v failed as expected.", query)
+	}
+	return false
+}


### PR DESCRIPTION
# Description
This PR adds code to run queries against the promQL API and lets you verify the result against the expected result if a particular query should fail or succeed.

To test using queries from a file using sigclient run the below command:

`go run main.go query promql -d http://localhost:5122/promql/api/v1/query_range -f ../../cicd/promql_test.csv`

To test a single query run the below command:

`go run main.go query promql -d http://localhost:5122/promql/api/v1/query_range -q "testmetric0 start:1716239444 end:1716239544"`

the `-q` flag accepts the query along with the start and end epoch in seconds in this format - `"<query> start:<startEpoch> end:<endEpoch>"`

# Testing
- Tested the above commands with different queries
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
