### PR TITLE
Feat: Promql <aggregation>_over_time funcs Completion

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -27,6 +27,11 @@ avg_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,218.745916705008
 min_over_time(testmetric4[24h]),now-90d,now,"199.18720427445191,199.18720427445191,-112.8784522345932",approx
 max_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.30462913556497,238.30462913556497",approx
 sum_over_time(testmetric4[24h]),now-90d,now,"199.18720427445197,437.49183341001685,125.42617690097171",approx
+"quantile_over_time(0.9, testmetric4[24h])",now-90d,now,"179.26848384700685,234.39288664945366,-77.76014409757737",approx
+stddev_over_time(testmetric4[24h]),now-90d,now,"0,19.55871243055644,175.59154068507908",approx
+stdvar_over_time(testmetric4[24h]),now-90d,now,"0,382.5432319412013,30832.389160159768",approx
+last_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.304629135565,-112.87845223459323",approx
+present_over_time(testmetric4[24h]),now-90d,now,"1,1,1",eq
 count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq
 avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
 max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -1035,6 +1035,19 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 					mquery.Function = structs.Function{RangeFunction: segutils.Sum_Over_time, TimeWindow: timeWindow}
 				case "count_over_time":
 					mquery.Function = structs.Function{RangeFunction: segutils.Count_Over_time, TimeWindow: timeWindow}
+				case "stdvar_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Stdvar_Over_Time, TimeWindow: timeWindow}
+				case "stddev_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Stddev_Over_Time, TimeWindow: timeWindow}
+				case "last_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Last_Over_Time, TimeWindow: timeWindow}
+				case "present_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Present_Over_Time, TimeWindow: timeWindow}
+				case "quantile_over_time":
+					if len(expr.Args) != 2 {
+						return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the quantile_over_time function", expr.Args.String())
+					}
+					mquery.Function = structs.Function{RangeFunction: segutils.Quantile_Over_Time, TimeWindow: timeWindow, ValueList: []string{expr.Args[0].String()}}
 				case "changes":
 					mquery.Function = structs.Function{RangeFunction: segutils.Changes, TimeWindow: timeWindow}
 				case "resets":
@@ -1420,13 +1433,14 @@ func parseTimeStringToUint32(s interface{}) (uint32, error) {
 }
 
 func extractTimeWindow(args parser.Expressions) (float64, error) {
-	if len(args) > 0 {
-		if ms, ok := args[0].(*parser.MatrixSelector); ok {
-			return ms.Range.Seconds(), nil
-		} else {
-			return 0, fmt.Errorf("extractTimeWindow: can not extract time window from args: %v", args)
-		}
-	} else {
+	if len(args) == 0 {
 		return 0, fmt.Errorf("extractTimeWindow: can not extract time window")
 	}
+
+	for _, arg := range args {
+		if ms, ok := arg.(*parser.MatrixSelector); ok {
+			return ms.Range.Seconds(), nil
+		}
+	}
+	return 0, fmt.Errorf("extractTimeWindow: can not extract time window from args: %v", args)
 }

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -208,6 +208,41 @@ const metricFunctions = `[
 		"desc": "The count of all values in the specified interval.", 
 		"eg": "count_over_time(avg (system.disk.used[5m]))",
 		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "quantile_over_time", 
+		"name": "Quantile Over Time", 
+		"desc": "The φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.", 
+		"eg": "quantile_over_time(0.6, avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "stddev_over_time", 
+		"name": "Standard deviation Over Time", 
+		"desc": "The population standard deviation of the values in the specified interval.", 
+		"eg": "stddev_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "stdvar_over_time", 
+		"name": "Standard variance Over Time", 
+		"desc": "The population standard variance of the values in the specified interval.", 
+		"eg": "stdvar_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "last_over_time", 
+		"name": "Last Over Time", 
+		"desc": " the most recent point value in the specified interval.", 
+		"eg": "last_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "present_over_time", 
+		"name": "Present Over Time", 
+		"desc": "The value 1 for any series in the specified interval.", 
+		"eg": "present_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
 	}
 ]`
 

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -361,15 +361,7 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 	switch function.RangeFunction {
 	case segutils.Derivative:
 		// Use those points which within the time window to calculate the derivative
-		var timestamps []uint32
-		var values []float64
-
-		for timestamp, value := range ts {
-			timestamps = append(timestamps, timestamp)
-			values = append(values, value)
-		}
-
-		for i := 1; i < len(timestamps); i++ {
+		for i := 1; i < len(sortedTimeSeries); i++ {
 			timeWindowStartTime := sortedTimeSeries[i].downsampledTime - timeWindow
 			preIndex := sort.Search(len(sortedTimeSeries), func(j int) bool {
 				return sortedTimeSeries[j].downsampledTime >= timeWindowStartTime
@@ -380,7 +372,7 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 				continue
 			}
 
-			timestamp := timestamps[i]
+			timestamp := sortedTimeSeries[i].downsampledTime
 
 			// Find neighboring data points for linear regression
 			var x []float64
@@ -388,8 +380,8 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 
 			// Collect data points for linear regression
 			for j := preIndex; j <= i; j++ {
-				x = append(x, float64(timestamps[j]))
-				y = append(y, values[j])
+				x = append(x, float64(sortedTimeSeries[j].downsampledTime))
+				y = append(y, sortedTimeSeries[j].dpVal)
 			}
 
 			var sumX, sumY, sumXY, sumX2 float64
@@ -404,7 +396,7 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 			ts[timestamp] = slope
 		}
 		// derivtives at edges do not exist
-		delete(ts, timestamps[0])
+		delete(ts, sortedTimeSeries[0].downsampledTime)
 		return ts, nil
 	case segutils.Rate:
 		return evaluateRate(sortedTimeSeries, ts, timeWindow), nil
@@ -614,6 +606,50 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 			}
 
 			ts[sortedTimeSeries[i].downsampledTime] = float64(i - preIndex + 1)
+		}
+		return ts, nil
+	case segutils.Stdvar_Over_Time:
+		return evaluateStandardVariance(sortedTimeSeries, ts, timeWindow), nil
+	case segutils.Stddev_Over_Time:
+		ts = evaluateStandardVariance(sortedTimeSeries, ts, timeWindow)
+		for key, val := range ts {
+			ts[key] = math.Sqrt(val)
+		}
+		return ts, nil
+	case segutils.Last_Over_Time:
+		// If we take the very last sample from every element of a range vector, the resulting vector will be identical to a regular instant vector query.
+		return ts, nil
+	case segutils.Present_Over_Time:
+		for key := range ts {
+			ts[key] = 1
+		}
+		return ts, nil
+	case segutils.Quantile_Over_Time:
+		if len(function.ValueList) != 1 {
+			return ts, fmt.Errorf("ApplyMathFunction: quantile_over_time has incorrect parameters: %v", function.ValueList)
+		}
+		quantile, err := strconv.ParseFloat(function.ValueList[0], 64)
+		if err != nil {
+			return ts, fmt.Errorf("ApplyMathFunction: quantile_over_time has incorrect parameters: %v", function.ValueList)
+		}
+
+		ts[sortedTimeSeries[0].downsampledTime] = sortedTimeSeries[0].dpVal * quantile
+		for i := 1; i < len(sortedTimeSeries); i++ {
+			timeWindowStartTime := sortedTimeSeries[i].downsampledTime - timeWindow
+			preIndex := sort.Search(len(sortedTimeSeries), func(j int) bool {
+				return sortedTimeSeries[j].downsampledTime >= timeWindowStartTime
+			})
+
+			if i <= preIndex { // Can not find the second point within the time window
+				ts[sortedTimeSeries[i].downsampledTime] = sortedTimeSeries[i].dpVal * quantile
+				continue
+			}
+			// Linear interpolation calculation: P = φ * (N - 1), V = V1 + (P - floor(P)) * (V2 - V1)
+			p := quantile * float64(i-preIndex)
+			index1 := int(math.Floor(float64(preIndex) + p))
+			index2 := int(math.Ceil(float64(preIndex) + p))
+			val := sortedTimeSeries[index1].dpVal + (p-math.Floor(p))*(sortedTimeSeries[index2].dpVal-sortedTimeSeries[index1].dpVal)
+			ts[sortedTimeSeries[i].downsampledTime] = val
 		}
 		return ts, nil
 	default:
@@ -885,4 +921,34 @@ func evaluateClamp(ts map[uint32]float64, minVal float64, maxVal float64) {
 			ts[key] = maxVal
 		}
 	}
+}
+
+func evaluateStandardVariance(sortedTimeSeries []Entry, ts map[uint32]float64, timeWindow uint32) map[uint32]float64 {
+	prefixSum := make([]float64, len(sortedTimeSeries)+1)
+	prefixSum[1] = sortedTimeSeries[0].dpVal
+	for i := 1; i < len(sortedTimeSeries); i++ {
+		prefixSum[i+1] = (prefixSum[i] + sortedTimeSeries[i].dpVal)
+	}
+
+	ts[sortedTimeSeries[0].downsampledTime] = 0
+	for i := 1; i < len(sortedTimeSeries); i++ {
+		timeWindowStartTime := sortedTimeSeries[i].downsampledTime - timeWindow
+		preIndex := sort.Search(len(sortedTimeSeries), func(j int) bool {
+			return sortedTimeSeries[j].downsampledTime >= timeWindowStartTime
+		})
+
+		if i <= preIndex { // Can not find the second point within the time window
+			ts[sortedTimeSeries[i].downsampledTime] = 0
+			continue
+		}
+
+		avgVal := (prefixSum[i+1] - prefixSum[preIndex]) / float64(i-preIndex+1)
+		sumValSquare := 0.0
+		for j := preIndex; j <= i; j++ {
+			sumValSquare += (sortedTimeSeries[j].dpVal - avgVal) * (sortedTimeSeries[j].dpVal - avgVal)
+		}
+
+		ts[sortedTimeSeries[i].downsampledTime] = sumValSquare / float64(i-preIndex+1)
+	}
+	return ts
 }

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -661,6 +661,98 @@ func Test_applyRangeFunctionQuantileOverTime(t *testing.T) {
 	}
 }
 
+func Test_applyRangeFunctionLastOverTime(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := map[uint32]float64{
+		1000: 0.1,
+		1001: 0.2,
+		1002: 0.3,
+		1013: 0.4,
+		1018: 0.5,
+		1019: 0.6,
+		1020: 0.7,
+	}
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := map[uint32]float64{
+		1000: 0.1,
+		1001: 0.2,
+		1002: 0.3,
+		1013: 0.4,
+		1018: 0.5,
+		1019: 0.6,
+		1020: 0.7,
+	}
+
+	function := structs.Function{RangeFunction: segutils.Last_Over_Time, TimeWindow: 10}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if !dtypeutils.AlmostEquals(expectedVal, val) {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+}
+
+func Test_applyRangeFunctionPresentOverTime(t *testing.T) {
+	result := make(map[string]map[uint32]float64)
+	ts := map[uint32]float64{
+		1000: 0.1,
+		1001: 0.2,
+		1002: 0.3,
+		1013: 0.4,
+		1018: 0.5,
+		1019: 0.6,
+		1020: 0.7,
+	}
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := map[uint32]float64{
+		1000: 1,
+		1001: 1,
+		1002: 1,
+		1013: 1,
+		1018: 1,
+		1019: 1,
+		1020: 1,
+	}
+
+	function := structs.Function{RangeFunction: segutils.Present_Over_Time, TimeWindow: 10}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if !dtypeutils.AlmostEquals(expectedVal, val) {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
+		}
+	}
+}
+
 func Test_reduceEntries(t *testing.T) {
 	entries := []Entry{
 		Entry{downsampledTime: 0, dpVal: 4.3},

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -328,7 +328,6 @@ const (
 	Stddev_Over_Time
 	Last_Over_Time
 	Present_Over_Time
-	Mad_Over_Time
 	Quantile_Over_Time
 	Changes
 	Resets

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -324,6 +324,12 @@ const (
 	Max_Over_time
 	Sum_Over_time
 	Count_Over_time
+	Stdvar_Over_Time
+	Stddev_Over_Time
+	Last_Over_Time
+	Present_Over_Time
+	Mad_Over_Time
+	Quantile_Over_Time
 	Changes
 	Resets
 )


### PR DESCRIPTION
# Description
Add promql funcs as below:
- quantile_over_time(scalar, range-vector): the φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.
- stddev_over_time(range-vector): the population standard deviation of the values in the specified interval.
- stdvar_over_time(range-vector): the population standard variance of the values in the specified interval.
- last_over_time(range-vector): the most recent point value in the specified interval.
- present_over_time(range-vector): the value 1 for any series in the specified interval.


# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
