### PR TITLE
Fix: Return all values with timestamps for promql query APIs

### DIFF
--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -378,7 +378,7 @@ func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQueryt
 				}
 			}
 			for k, v := range results {
-				result.Value = []interface{}{int64(k), fmt.Sprintf("%v", v)}
+				result.Value = append(result.Value, []interface{}{int64(k), fmt.Sprintf("%v", v)})
 			}
 			pqldata.Result = append(pqldata.Result, result)
 		}

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -95,7 +95,7 @@ type Label struct {
 
 type Result struct {
 	Metric map[string]string `json:"metric"`
-	Value  []interface{}     `json:"value"`
+	Value  []interface{}     `json:"values"`
 }
 
 type Data struct {


### PR DESCRIPTION
# Description
There was a bug in the code while framing the promql response that was returning only the last timestamp in case of range queries. This fix will return all the timestamps with its values within that range. Also updated the json response to have `values` instead of `value` as `values` is working fine for both instant and range queries.

# Testing
- Tested against both instant and range queries on grafana

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
