### PR TITLE
Include previous columns when loading more results

### DIFF
--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -265,7 +265,7 @@ function renderLogsGrid(columnOrder, hits){
         }
             
     }
-    logsColumnDefs = cols
+    logsColumnDefs = _.chain(logsColumnDefs).concat(cols).uniqBy('field').value();
     gridOptions.api.setColumnDefs(logsColumnDefs);
 
     const allColumnIds = [];


### PR DESCRIPTION
# Description
This reverts this change: https://github.com/siglens/siglens/pull/880/files#diff-36df0a4a5334aafc44f81bc2dee3c144edfac7d80466c9cbd31fd3c44eb8b2e0L259-R268

Now when you scroll for more logs on the UI and the next batch comes in but the columns of this batch and the previous records do not match, all the columns are combined (and you get blank values for columns that don't exist for a certain record).

# Testing
1. Start siglens with no data
2. Use sigclient to ingest some data, but modify it so it only sends some fields. Ingest at least 100 records, since that's how many the UI fetches per batch
3. Restart siglens so the segment gets flushed
4. Update sigsclient again so it sends some (but not all) of the old columns and some new columns
5. Go to the UI and do a `*` search. In the first batch, you should just see the columns you sent with sigclient the first time; scroll down and get siglens to refresh until it gets records from your second sigclient request. Now the UI shows the union of all the columns you sent

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
