### PR TITLE
Added flag to prevent multiple simultaneous fetches

### DIFF
--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -20,6 +20,7 @@
 'use strict';
 
 let cellEditingClass = '';
+let isFetching = false; 
 
 class ReadOnlyCellEditor {
     // gets called once before the renderer is used
@@ -161,23 +162,34 @@ const gridOptions = {
     suppressAnimationFrame: true,
     suppressFieldDotNotation: true,
     onBodyScroll(evt){
-        if(evt.direction === 'vertical' && canScrollMore == true){
+        if(evt.direction === 'vertical' && canScrollMore && !isFetching) {
             let diff = logsRowData.length - evt.api.getLastDisplayedRow();
-            // if we're less than 1 items from the end...fetch more data
+            // if we're less than 5 items from the end...fetch more data
             if(diff <= 5) {
-                // Show loading indicator
+                isFetching = true;
                 showLoadingIndicator();
-                
+
                 let scrollingTrigger = true;
                 data = getSearchFilter(false, scrollingTrigger);
                 if (data && data.searchText == "error") {
                   alert("Error");
                   hideLoadingIndicator(); // Hide loading indicator on error
+                  isFetching = false;
                   return;
                 }
-                doSearch(data).then(() => {
-                    hideLoadingIndicator(); // Hide loading indicator once data is fetched
-                });
+
+                doSearch(data)
+                    .then(() => {
+                        isFetching = false;
+                    })
+                    .catch((error) => {
+                        console.warn("Error fetching data", error);
+                        isFetching = false;
+                    })
+                    .finally(() => {
+                        hideLoadingIndicator(); // Hide loading indicator once data is fetched
+                        isFetching = false;
+                    });
             }
         }
     },


### PR DESCRIPTION
# Description

After Andrew's [PR](https://github.com/siglens/siglens/pull/938) the error is fixed , but we sometimes see the warning.
Added `isFetching` flag to prevent multiple concurrent requests so that only one request is being processed at a time.

<img width="1322" alt="image" src="https://github.com/siglens/siglens/assets/71771131/3c9b58cc-72de-4567-aa0e-f0139c141696">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
