### PR TITLE
Fix: Unrotated segment range checking logic

### DIFF
--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -255,7 +255,7 @@ func GetTotalSegmentsToSearch(qid uint64) (uint64, error) {
 	rQuery, ok := allRunningQueries[qid]
 	arqMapLock.RUnlock()
 	if !ok {
-		return 0, fmt.Errorf("qid does not exist")
+		return 0, fmt.Errorf("qid: %v does not exist", qid)
 	}
 
 	rQuery.rqsLock.Lock()

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -206,7 +206,7 @@ func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators,
 	if aggs != nil {
 		numTotalSegments, err := query.GetTotalSegmentsToSearch(qid)
 		if err != nil {
-			log.Errorf("executeQueryInternal: failed to get number of total segments for qid! Error: %v", err)
+			log.Errorf("executeQueryInternal: failed to get number of total segments for qid: %v! Error: %v", qid, err)
 		}
 		nodeRes = agg.PostQueryBucketCleaning(nodeRes, aggs, nil, nil, nil, numTotalSegments, false)
 	}

--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -352,6 +352,7 @@ func (usi *UnrotatedSegmentInfo) doRangeCheckForCols(timeFilteredBlocks map[uint
 			continue
 		}
 		currInfo := usi.unrotatedBlockCmis[blkNum]
+		// As long as there is one column within the range, the value is equal to true
 		var matchedBlockRange bool
 		for col := range colsToCheck {
 			var cmi *structs.CmiContainer
@@ -362,10 +363,11 @@ func (usi *UnrotatedSegmentInfo) doRangeCheckForCols(timeFilteredBlocks map[uint
 			if cmi.Ranges == nil {
 				continue
 			}
-			matchedBlockRange = metautils.CheckRangeIndex(rangeFilter, cmi.Ranges, rangeOp, qid)
-			if matchedBlockRange {
+			isMatched := metautils.CheckRangeIndex(rangeFilter, cmi.Ranges, rangeOp, qid)
+			if isMatched {
 				timeFilteredBlocks[blkNum][col] = true
 			}
+			matchedBlockRange = matchedBlockRange || isMatched
 		}
 		if !matchedBlockRange {
 			delete(timeFilteredBlocks, blkNum)


### PR DESCRIPTION
# Description
Fix the issue where running a range query like `search 200` sometimes does not return results correctly. I believe this can also solve some CI/CD test issues at the same time.
# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
