### PR TITLE
Fix: Increase tolerance for approximate equality in metrics test

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -36,4 +36,4 @@ count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq
 avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
 max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx
 changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
-"predict_linear(testmetric0[48h], 1000000)",now-7d,now,"76.28998388512214,322.0191498768958",approx
+"predict_linear(testmetric0[48h], 100)",now-7d,now,"127.06355282392336,159.54968553618554",approx

--- a/pkg/common/dtypeutils/dtypeutils.go
+++ b/pkg/common/dtypeutils/dtypeutils.go
@@ -613,7 +613,7 @@ func ReplaceWildcardStarWithRegex(input string) string {
 }
 
 func AlmostEquals(left, right float64) bool {
-	tolerance := 0.000001
+	tolerance := 0.0001
 	if difference := math.Abs(left - right); difference < tolerance {
 		return true
 	} else {


### PR DESCRIPTION
# Description
Floating-point operations can sometimes lead to precision loss, so the tolerance value has been increased.
<img width="1071" alt="image" src="https://github.com/siglens/siglens/assets/67371917/ab24bba4-fc00-4a60-8569-d56198763b8c">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
