### PR TITLE
Feat: Add promql comparison operators

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -50,7 +50,6 @@ day_of_year(testmetric0),now-90d,now,"367,367,367",lt
 day_of_year(testmetric0),now-90d,now,"0,0,0",gt
 days_in_month(testmetric0),now-90d,now,"32,32,32",lt
 days_in_month(testmetric0),now-90d,now,"27,27,27",gt
-"predict_linear(testmetric0[48h], 1000000)",now-7d,now,"76.28998388512214,322.0191498768958",approx
 "predict_linear(testmetric0[48h], 100)",now-7d,now,"127.06355282392336,159.54968553618554",approx
 "(testmetric0) > 132",now-90d,now,"159.53343696489338",approx
 "(testmetric0) >= 131",now-90d,now,"131.45590577322224,159.53343696489338",approx

--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -41,5 +41,4 @@ changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
 "(testmetric0) >= 131",now-90d,now,"131.45590577322224,159.53343696489338",approx
 "(testmetric0) < 131",now-90d,now,"127.06863068860355",approx
 "(testmetric0) <= 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
-"(testmetric0) == 1000",now-90d,now,"",approx
 "(testmetric0) != 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx

--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -37,3 +37,9 @@ avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.262268230913
 max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx
 changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
 "predict_linear(testmetric0[48h], 1000000)",now-7d,now,"76.28998388512214,322.0191498768958",approx
+"(testmetric0) > 132",now-90d,now,"159.53343696489338",approx
+"(testmetric0) >= 131",now-90d,now,"131.45590577322224,159.53343696489338",approx
+"(testmetric0) < 131",now-90d,now,"127.06863068860355",approx
+"(testmetric0) <= 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
+"(testmetric0) == 1000",now-90d,now,"",approx
+"(testmetric0) != 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -929,6 +929,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 
 		mquery.Aggregator = structs.Aggreation{}
 		parser.Inspect(es.Expr, func(node parser.Node, path []parser.Node) error {
+			// If there is no child node, just return nil
 			if node == nil {
 				return nil
 			}
@@ -998,6 +999,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 		// Since we currently handle evaluation logic only in sub-elements like MatrixSelector or VectorSelector, if we add a default case in the switch statement,
 		// traversal would stop prematurely due to an error being returned before reaching sub-nodes such as MatrixSelector
 		parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+			// If there is no child node, just return nil
 			if node == nil {
 				return nil
 			}
@@ -1184,7 +1186,7 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 			arithmeticOperation.RHS = rhsRequest[0].MetricsQuery.HashedMName
 
 		}
-		arithmeticOperation.Operation = getArithmeticOperation(expr.Op)
+		arithmeticOperation.Operation = getLogicalAndArithmeticOperation(expr.Op)
 		if rhsValType == parser.ValueTypeVector {
 			lhsValType = parser.ValueTypeVector
 		}
@@ -1236,16 +1238,28 @@ func convertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 	return []structs.MetricsQueryRequest{*metricQueryRequest}, pqlQuerytype, []structs.QueryArithmetic{}, nil
 }
 
-func getArithmeticOperation(op parser.ItemType) segutils.ArithmeticOperator {
+func getLogicalAndArithmeticOperation(op parser.ItemType) segutils.LogicalAndArithmeticOperator {
 	switch op {
 	case parser.ADD:
-		return segutils.Add
+		return segutils.LetAdd
 	case parser.SUB:
-		return segutils.Subtract
+		return segutils.LetSubtract
 	case parser.MUL:
-		return segutils.Multiply
+		return segutils.LetMultiply
 	case parser.DIV:
-		return segutils.Divide
+		return segutils.LetDivide
+	case parser.GTR:
+		return segutils.LetGreaterThan
+	case parser.GTE:
+		return segutils.LetGreaterThanOrEqualTo
+	case parser.LSS:
+		return segutils.LetLessThan
+	case parser.LTE:
+		return segutils.LetLessThanOrEqualTo
+	case parser.EQL:
+		return segutils.LetEquals
+	case parser.NEQ:
+		return segutils.LetNotEquals
 	default:
 		log.Errorf("getArithmeticOperation: unexpected op: %v", op)
 		return 0

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -1256,7 +1256,7 @@ func getLogicalAndArithmeticOperation(op parser.ItemType) segutils.LogicalAndAri
 		return segutils.LetLessThan
 	case parser.LTE:
 		return segutils.LetLessThanOrEqualTo
-	case parser.EQL:
+	case parser.EQLC:
 		return segutils.LetEquals
 	case parser.NEQ:
 		return segutils.LetNotEquals

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -562,11 +562,11 @@ func ProcessUiMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	metricQueriesList := make([]*structs.MetricsQuery, 0)
 	var timeRange *dtu.MetricsTimeRange
 	hashList := make([]uint64, 0)
-	for _, metricQuery := range metricQueryRequest {
-		hashList = append(hashList, metricQuery.MetricsQuery.HashedMName)
-		metricQueriesList = append(metricQueriesList, &metricQuery.MetricsQuery)
-		segment.LogMetricsQuery("PromQL metrics query parser", &metricQuery, qid)
-		timeRange = &metricQuery.TimeRange
+	for i := range metricQueryRequest {
+		hashList = append(hashList, metricQueryRequest[i].MetricsQuery.HashedMName)
+		metricQueriesList = append(metricQueriesList, &metricQueryRequest[i].MetricsQuery)
+		segment.LogMetricsQuery("PromQL metrics query parser", &metricQueryRequest[i], qid)
+		timeRange = &metricQueryRequest[i].TimeRange
 	}
 	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryArithmetic, timeRange, qid)
 	mQResponse, err := res.GetResultsPromQlForUi(metricQueriesList[0], pqlQuerytype, startTime, endTime)

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -735,11 +735,11 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	metricQueriesList := make([]*structs.MetricsQuery, 0)
 	var timeRange *dtu.MetricsTimeRange
 	hashList := make([]uint64, 0)
-	for _, metricQuery := range metricQueryRequest {
-		hashList = append(hashList, metricQuery.MetricsQuery.HashedMName)
-		metricQueriesList = append(metricQueriesList, &metricQuery.MetricsQuery)
-		segment.LogMetricsQuery("PromQL metrics query parser", &metricQuery, qid)
-		timeRange = &metricQuery.TimeRange
+	for i := range metricQueryRequest {
+		hashList = append(hashList, metricQueryRequest[i].MetricsQuery.HashedMName)
+		metricQueriesList = append(metricQueriesList, &metricQueryRequest[i].MetricsQuery)
+		segment.LogMetricsQuery("PromQL metrics query parser", &metricQueryRequest[i], qid)
+		timeRange = &metricQueryRequest[i].TimeRange
 	}
 	segment.LogMetricsQueryOps("PromQL metrics query parser: Ops: ", queryArithmetic, qid)
 	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryArithmetic, timeRange, qid)

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
+	"github.com/siglens/siglens/pkg/segment"
 	mresults "github.com/siglens/siglens/pkg/segment/results/mresults"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -402,6 +403,157 @@ func TestCalculateInterval(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, expectedInterval, actualInterval)
+		}
+	}
+}
+
+func Test_GetResults_GTR(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetGreaterThan,
+				Constant:   1045,
+			},
+		})
+}
+
+func Test_GetResults_GTE(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			10800: 1045,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetGreaterThanOrEqualTo,
+				Constant:   100,
+			},
+		})
+}
+
+func Test_GetResults_LSS(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0: 45,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetLessThan,
+				Constant:   1045,
+			},
+		})
+}
+
+func Test_GetResults_LTE(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:     45,
+			10800: 1045,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetLessThanOrEqualTo,
+				Constant:   1045,
+			},
+		})
+}
+
+func Test_GetResults_EQLC(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0: 45,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetEquals,
+				Constant:   45,
+			},
+		})
+}
+
+func Test_GetResults_NEQ(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			10800: 1045,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetNotEquals,
+				Constant:   45,
+			},
+		})
+}
+
+func test_GetResults_Ops(t *testing.T, ansMap map[uint32]float64, queryOps []structs.QueryArithmetic) {
+	mQuery := &structs.MetricsQuery{
+		MetricName:  "test.metric.0",
+		HashedMName: 1,
+		Downsampler: structs.Downsampler{
+			Interval:   3,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Sum},
+		},
+	}
+	qid := uint64(0)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
+	assert.NotNil(t, metricsResults)
+
+	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
+	defer bytebufferpool.Put(tsGroupId)
+	_, err := tsGroupId.Write([]byte("color:yellow"))
+	assert.NoError(t, err)
+	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
+
+	// they should all downsample to 0
+	for i := 0; i < 10; i++ {
+		series.AddEntry(uint32(i), float64(i))
+	}
+
+	assert.Equal(t, series.GetIdx(), 10)
+	metricsResults.AddSeries(series, uint64(100), tsGroupId)
+
+	series2 := mresults.InitSeriesHolder(mQuery, tsGroupId)
+
+	// they should all downsample to 3 * 3600
+	for i := 100; i < 110; i++ {
+		series2.AddEntry(uint32(i)+4*3600, float64(i)) // Timestamp is larger than ds interval (3h), so that it can become a separated key,value pair
+	}
+
+	metricsResults.AddSeries(series2, uint64(101), tsGroupId)
+
+	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
+
+	errors := metricsResults.AggregateResults(1)
+	assert.Nil(t, errors)
+
+	res := segment.HelperQueryArithmeticAndLogical(queryOps, map[uint64]*mresults.MetricsResult{
+		1: metricsResults,
+	})
+	assert.Len(t, res.Results, 1)
+	for _, resMap := range res.Results {
+		assert.Equal(t, len(ansMap), len(resMap))
+		for timestamp, val := range resMap {
+			expectedVal, exists := ansMap[timestamp]
+			if !exists {
+				t.Errorf("Should not have this key: %v", timestamp)
+			}
+
+			if expectedVal != val {
+				t.Errorf("Expected value should be %v, but got %v", expectedVal, val)
+			}
 		}
 	}
 }

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -15,12 +15,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package mresults
+package tests
 
 import (
 	"testing"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
+	mresults "github.com/siglens/siglens/pkg/segment/results/mresults"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
@@ -45,14 +46,14 @@ func Test_GetResults_AggFn_Sum(t *testing.T) {
 		},
 	}
 	qid := uint64(0)
-	metricsResults := InitMetricResults(mQuery, qid)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
 	assert.NotNil(t, metricsResults)
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
 	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
-	series := InitSeriesHolder(mQuery, tsGroupId)
+	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
 	// they should all downsample to 0
 	sum := float64(0)
@@ -67,10 +68,10 @@ func Test_GetResults_AggFn_Sum(t *testing.T) {
 	assert.Len(t, metricsResults.AllSeries, 1)
 	assert.Len(t, metricsResults.DsResults, 0)
 	assert.Len(t, metricsResults.Results, 0)
-	assert.Equal(t, metricsResults.State, SERIES_READING)
+	assert.Equal(t, metricsResults.State, mresults.SERIES_READING)
 
 	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
-	assert.Equal(t, metricsResults.State, DOWNSAMPLING)
+	assert.Equal(t, metricsResults.State, mresults.DOWNSAMPLING)
 	assert.Len(t, metricsResults.AllSeries, 0)
 	assert.Len(t, metricsResults.DsResults, 1)
 	assert.Len(t, metricsResults.Results, 0)
@@ -114,14 +115,14 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 		},
 	}
 	qid := uint64(0)
-	metricsResults := InitMetricResults(mQuery, qid)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
 	assert.NotNil(t, metricsResults)
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
 	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
-	series := InitSeriesHolder(mQuery, tsGroupId)
+	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
 	// they should all downsample to i
 	avg := float64(0)
@@ -137,10 +138,10 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 	assert.Len(t, metricsResults.AllSeries, 1)
 	assert.Len(t, metricsResults.DsResults, 0)
 	assert.Len(t, metricsResults.Results, 0)
-	assert.Equal(t, metricsResults.State, SERIES_READING)
+	assert.Equal(t, metricsResults.State, mresults.SERIES_READING)
 
 	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
-	assert.Equal(t, metricsResults.State, DOWNSAMPLING)
+	assert.Equal(t, metricsResults.State, mresults.DOWNSAMPLING)
 	assert.Len(t, metricsResults.AllSeries, 0)
 	assert.Len(t, metricsResults.DsResults, 1)
 	assert.Len(t, metricsResults.Results, 0)
@@ -187,7 +188,7 @@ func Test_GetResults_AggFn_Multiple(t *testing.T) {
 	}
 
 	qid := uint64(0)
-	metricsResults := InitMetricResults(mQuery, qid)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
 	assert.NotNil(t, metricsResults)
 	dsSec := mQuery.Downsampler.GetIntervalTimeInSeconds()
 
@@ -197,7 +198,7 @@ func Test_GetResults_AggFn_Multiple(t *testing.T) {
 		defer bytebufferpool.Put(tsGroupId)
 		_, err := tsGroupId.Write(grpId)
 		assert.NoError(t, err)
-		series := InitSeriesHolder(mQuery, tsGroupId)
+		series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 		for i := 0; i < 10; i++ {
 			series.AddEntry(uint32(i), float64(i))
 		}
@@ -206,10 +207,10 @@ func Test_GetResults_AggFn_Multiple(t *testing.T) {
 	assert.Len(t, metricsResults.AllSeries, numSeries)
 	assert.Len(t, metricsResults.DsResults, 0)
 	assert.Len(t, metricsResults.Results, 0)
-	assert.Equal(t, metricsResults.State, SERIES_READING)
+	assert.Equal(t, metricsResults.State, mresults.SERIES_READING)
 
 	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
-	assert.Equal(t, metricsResults.State, DOWNSAMPLING)
+	assert.Equal(t, metricsResults.State, mresults.DOWNSAMPLING)
 	assert.Len(t, metricsResults.AllSeries, 0)
 	assert.Len(t, metricsResults.DsResults, 1)
 	assert.Len(t, metricsResults.Results, 0)
@@ -246,14 +247,14 @@ func Test_GetResults_AggFn_Quantile(t *testing.T) {
 		},
 	}
 	qid := uint64(0)
-	metricsResults := InitMetricResults(mQuery, qid)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
 	assert.NotNil(t, metricsResults)
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
 	_, err := tsGroupId.Write([]byte("color:yellow"))
 	assert.NoError(t, err)
-	series := InitSeriesHolder(mQuery, tsGroupId)
+	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
 	// they should all downsample to 0
 	sum := float64(0)
@@ -268,10 +269,10 @@ func Test_GetResults_AggFn_Quantile(t *testing.T) {
 	assert.Len(t, metricsResults.AllSeries, 1)
 	assert.Len(t, metricsResults.DsResults, 0)
 	assert.Len(t, metricsResults.Results, 0)
-	assert.Equal(t, metricsResults.State, SERIES_READING)
+	assert.Equal(t, metricsResults.State, mresults.SERIES_READING)
 
 	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
-	assert.Equal(t, metricsResults.State, DOWNSAMPLING)
+	assert.Equal(t, metricsResults.State, mresults.DOWNSAMPLING)
 	assert.Len(t, metricsResults.AllSeries, 0)
 	assert.Len(t, metricsResults.DsResults, 1)
 	assert.Len(t, metricsResults.Results, 0)
@@ -315,14 +316,14 @@ func Test_GetResults_AggFn_QuantileFloatIndex(t *testing.T) {
 		},
 	}
 	qid := uint64(0)
-	metricsResults := InitMetricResults(mQuery, qid)
+	metricsResults := mresults.InitMetricResults(mQuery, qid)
 	assert.NotNil(t, metricsResults)
 
 	var tsGroupId *bytebufferpool.ByteBuffer = bytebufferpool.Get()
 	defer bytebufferpool.Put(tsGroupId)
 	_, err := tsGroupId.Write([]byte("color:yellow`"))
 	assert.NoError(t, err)
-	series := InitSeriesHolder(mQuery, tsGroupId)
+	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
 	// they should all downsample to 0
 	sum := float64(0)
@@ -337,10 +338,10 @@ func Test_GetResults_AggFn_QuantileFloatIndex(t *testing.T) {
 	assert.Len(t, metricsResults.AllSeries, 1)
 	assert.Len(t, metricsResults.DsResults, 0)
 	assert.Len(t, metricsResults.Results, 0)
-	assert.Equal(t, metricsResults.State, SERIES_READING)
+	assert.Equal(t, metricsResults.State, mresults.SERIES_READING)
 
 	metricsResults.DownsampleResults(mQuery.Downsampler, 1)
-	assert.Equal(t, metricsResults.State, DOWNSAMPLING)
+	assert.Equal(t, metricsResults.State, mresults.DOWNSAMPLING)
 	assert.Len(t, metricsResults.AllSeries, 0)
 	assert.Len(t, metricsResults.DsResults, 1)
 	assert.Len(t, metricsResults.Results, 0)
@@ -395,7 +396,7 @@ func TestCalculateInterval(t *testing.T) {
 		if i < len(steps) {
 			expectedInterval = steps[i]
 		}
-		actualInterval, err := CalculateInterval(tr)
+		actualInterval, err := mresults.CalculateInterval(tr)
 		if timerangeSeconds[i] > 315360000 { // 10 years in seconds
 			assert.Error(t, err)
 		} else {

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -407,13 +407,16 @@ func TestCalculateInterval(t *testing.T) {
 	}
 }
 
-func Test_GetResults_GTR(t *testing.T) {
+func Test_GetResults_GreaterThan(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
 			0:     45,
 			10800: 1045,
+			21600: 1046,
 		},
-		map[uint32]float64{},
+		map[uint32]float64{
+			21600: 1046,
+		},
 		[]structs.QueryArithmetic{
 			{
 				LHS:        1,
@@ -421,17 +424,26 @@ func Test_GetResults_GTR(t *testing.T) {
 				Operation:  utils.LetGreaterThan,
 				Constant:   1045,
 			},
-		})
+		},
+		structs.Downsampler{
+			Interval:   3,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
 }
 
-func Test_GetResults_GTE(t *testing.T) {
+func Test_GetResults_GreaterThanOrEqualTo(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
-			0:     45,
-			10800: 1045,
+			0:    45,
+			3600: 1045,
+			7200: 100,
 		},
 		map[uint32]float64{
-			10800: 1045,
+			3600: 1045,
+			7200: 100,
 		},
 		[]structs.QueryArithmetic{
 			{
@@ -440,17 +452,26 @@ func Test_GetResults_GTE(t *testing.T) {
 				Operation:  utils.LetGreaterThanOrEqualTo,
 				Constant:   100,
 			},
-		})
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
 }
 
-func Test_GetResults_LSS(t *testing.T) {
+func Test_GetResults_LessThan(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
 			0:     45,
-			10800: 1045,
+			3600:  1045,
+			10800: 1044,
 		},
 		map[uint32]float64{
-			0: 45,
+			0:     45,
+			10800: 1044,
 		},
 		[]structs.QueryArithmetic{
 			{
@@ -459,13 +480,21 @@ func Test_GetResults_LSS(t *testing.T) {
 				Operation:  utils.LetLessThan,
 				Constant:   1045,
 			},
-		})
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
 }
 
-func Test_GetResults_LTE(t *testing.T) {
+func Test_GetResults_LessThanOrEqualTo(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
 			0:     45,
+			3600:  1046,
 			10800: 1045,
 		},
 		map[uint32]float64{
@@ -479,14 +508,22 @@ func Test_GetResults_LTE(t *testing.T) {
 				Operation:  utils.LetLessThanOrEqualTo,
 				Constant:   1045,
 			},
-		})
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
 }
 
-func Test_GetResults_EQLC(t *testing.T) {
+func Test_GetResults_Equals(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
 			0:     45,
-			10800: 1045,
+			7200:  1045,
+			14400: 666,
 		},
 		map[uint32]float64{
 			0: 45,
@@ -498,17 +535,26 @@ func Test_GetResults_EQLC(t *testing.T) {
 				Operation:  utils.LetEquals,
 				Constant:   45,
 			},
-		})
+		},
+		structs.Downsampler{
+			Interval:   2,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
 }
 
-func Test_GetResults_NEQ(t *testing.T) {
+func Test_GetResults_NotEquals(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
 			0:     45,
-			10800: 1045,
+			7200:  1045,
+			14400: 666,
 		},
 		map[uint32]float64{
-			10800: 1045,
+			7200:  1045,
+			14400: 666,
 		},
 		[]structs.QueryArithmetic{
 			{
@@ -517,19 +563,21 @@ func Test_GetResults_NEQ(t *testing.T) {
 				Operation:  utils.LetNotEquals,
 				Constant:   45,
 			},
-		})
-}
-
-func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap map[uint32]float64, queryOps []structs.QueryArithmetic) {
-	mQuery := &structs.MetricsQuery{
-		MetricName:  "test.metric.0",
-		HashedMName: 1,
-		Downsampler: structs.Downsampler{
-			Interval:   3,
+		},
+		structs.Downsampler{
+			Interval:   2,
 			Unit:       "h",
 			CFlag:      false,
 			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
 		},
+	)
+}
+
+func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap map[uint32]float64, queryOps []structs.QueryArithmetic, downsampler structs.Downsampler) {
+	mQuery := &structs.MetricsQuery{
+		MetricName:  "test.metric.0",
+		HashedMName: 1,
+		Downsampler: downsampler,
 	}
 	qid := uint64(0)
 	metricsResults := mresults.InitMetricResults(mQuery, qid)
@@ -541,7 +589,6 @@ func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap
 	assert.NoError(t, err)
 	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
-	// The entries' timestamp interval is larger than the data source interval (3 hours), so they can become separate key-value pairs.
 	for timestamp, val := range initialEntries {
 		series.AddEntry(timestamp, val)
 	}

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -73,10 +73,10 @@ func ExecuteMultipleMetricsQuery(hashList []uint64, mQueries []*structs.MetricsQ
 		}
 	}
 
-	return helperQueryArithmeticAndLogical(queryOps, resMap)
+	return HelperQueryArithmeticAndLogical(queryOps, resMap)
 }
 
-func helperQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult) *mresults.MetricsResult {
+func HelperQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult) *mresults.MetricsResult {
 	finalResult := make(map[string]map[uint32]float64)
 	for _, queryOp := range queryOps {
 		resultLHS := resMap[queryOp.LHS]

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -73,10 +73,10 @@ func ExecuteMultipleMetricsQuery(hashList []uint64, mQueries []*structs.MetricsQ
 		}
 	}
 
-	return helperQueryArithmetic(queryOps, resMap)
+	return helperQueryArithmeticAndLogical(queryOps, resMap)
 }
 
-func helperQueryArithmetic(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult) *mresults.MetricsResult {
+func helperQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult) *mresults.MetricsResult {
 	finalResult := make(map[string]map[uint32]float64)
 	for _, queryOp := range queryOps {
 		resultLHS := resMap[queryOp.LHS]
@@ -94,9 +94,9 @@ func helperQueryArithmetic(queryOps []structs.QueryArithmetic, resMap map[uint64
 				finalResult[groupID] = make(map[uint32]float64)
 				for timestamp, valueLHS := range tsLHS {
 					switch queryOp.Operation {
-					case utils.Add:
+					case utils.LetAdd:
 						finalResult[groupID][timestamp] = valueLHS + valueRHS
-					case utils.Divide:
+					case utils.LetDivide:
 						if valueRHS == 0 {
 							continue
 						}
@@ -104,14 +104,54 @@ func helperQueryArithmetic(queryOps []structs.QueryArithmetic, resMap map[uint64
 							valueRHS = 1 / valueRHS
 						}
 						finalResult[groupID][timestamp] = valueLHS / valueRHS
-					case utils.Multiply:
+					case utils.LetMultiply:
 						finalResult[groupID][timestamp] = valueLHS * valueRHS
-					case utils.Subtract:
+					case utils.LetSubtract:
 						val := valueLHS - valueRHS
 						if swapped {
 							val = val * -1
 						}
 						finalResult[groupID][timestamp] = val
+					case utils.LetGreaterThan:
+						isGtr := valueLHS > valueRHS
+						if swapped {
+							isGtr = valueLHS < valueRHS
+						}
+						if isGtr {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetGreaterThanOrEqualTo:
+						isGte := valueLHS >= valueRHS
+						if swapped {
+							isGte = valueLHS <= valueRHS
+						}
+						if isGte {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetLessThan:
+						isLss := valueLHS < valueRHS
+						if swapped {
+							isLss = valueLHS > valueRHS
+						}
+						if isLss {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetLessThanOrEqualTo:
+						isLte := valueLHS <= valueRHS
+						if swapped {
+							isLte = valueLHS >= valueRHS
+						}
+						if isLte {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetEquals:
+						if valueLHS == valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetNotEquals:
+						if valueLHS != valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
 					}
 				}
 			}
@@ -125,17 +165,41 @@ func helperQueryArithmetic(queryOps []structs.QueryArithmetic, resMap map[uint64
 				for timestamp, valueLHS := range tsLHS {
 					valueRHS := resultRHS.Results[groupID][timestamp]
 					switch queryOp.Operation {
-					case utils.Add:
+					case utils.LetAdd:
 						finalResult[groupID][timestamp] = valueLHS + valueRHS
-					case utils.Divide:
+					case utils.LetDivide:
 						if valueRHS == 0 {
 							continue
 						}
 						finalResult[groupID][timestamp] = valueLHS / valueRHS
-					case utils.Multiply:
+					case utils.LetMultiply:
 						finalResult[groupID][timestamp] = valueLHS * valueRHS
-					case utils.Subtract:
+					case utils.LetSubtract:
 						finalResult[groupID][timestamp] = valueLHS - valueRHS
+					case utils.LetGreaterThan:
+						if valueLHS > valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetGreaterThanOrEqualTo:
+						if valueLHS >= valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetLessThan:
+						if valueLHS < valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetLessThanOrEqualTo:
+						if valueLHS <= valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetEquals:
+						if valueLHS == valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
+					case utils.LetNotEquals:
+						if valueLHS != valueRHS {
+							finalResult[groupID][timestamp] = valueLHS
+						}
 					}
 				}
 			}

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -118,7 +118,7 @@ type QueryArithmetic struct {
 	LHS         uint64
 	RHS         uint64
 	ConstantOp  bool
-	Operation   utils.ArithmeticOperator
+	Operation   utils.LogicalAndArithmeticOperator
 	Constant    float64
 	// maps groupid to a map of ts to value. This aggregates DsResults based on the aggregation function
 	Results       map[string]map[uint32]float64


### PR DESCRIPTION
# Description
Add Comparison binary operators
The following binary comparison operators exist in Prometheus: https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators
```
== (equal)
!= (not-equal)
> (greater-than)
< (less-than)
>= (greater-or-equal)
<= (less-or-equal)
```

Test with these queries:
```
1. >
(testmetric0) > 132
132 > (testmetric0)

2. >=
(testmetric6) >= 666
(testmetric6) >= 667
667 >= (testmetric6)

3. <
131 < (testmetric0)
(testmetric0) < 10
(testmetric0) < 1000

4. <=
667 <= (testmetric6)
(testmetric6) <= 668

5. ==
(testmetric6) === 666

6. !=
(testmetric6) != 66

(testmetric0) + (testmetric0)
(testmetric0) - (testmetric0)
(testmetric0) * (testmetric0)
(testmetric0) / (testmetric0)
(testmetric0) > (testmetric0)
(testmetric0) >= (testmetric0)
(testmetric0) < (testmetric0)
(testmetric0) <= (testmetric0)
(testmetric0) == (testmetric0)
(testmetric0) != (testmetric0)

```

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
