### PR TITLE
Fix : Available Fields

### DIFF
--- a/static/js/available-fields.js
+++ b/static/js/available-fields.js
@@ -61,12 +61,6 @@ afieldDropDown.style.width = "auto";
                 $(`.toggle-${string2Hex(colName)}`).removeClass('active');
             }
         });
-    } else {
-        selectedFieldsList = [];
-        availColNames.forEach((colName, index) => {
-            $(`.toggle-${string2Hex(colName)}`).addClass('active');
-            selectedFieldsList.push(colName);
-        });
     }
 }
 

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -108,23 +108,14 @@ let logsColumnDefs = [
                         $(`.toggle-${string2Hex(colName)}`).removeClass('active');
                     }
                 });
-            } else {
-                selectedFieldsList = [];
-                availColNames.forEach((colName, index) => {
-                    $(`.toggle-${string2Hex(colName)}`).addClass('active');
-                    selectedFieldsList.push(colName);
-                });
             }
             _.forEach(params.data, (value, key) => {
                 let colSep = counter > 0 ? '<span class="col-sep"> | </span>' : '';
                 if (key != 'logs' && selectedFieldsList.includes(key)) {
                     logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=`+ JSON.stringify(JSON.unflatten(value), null, 2)+`</span>`;                    
+                    counter++;
 
                 }
-                if (key === 'timestamp'){
-                    logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=${value}</span>`;
-                }
-                counter++;
             });
             return logString;
         },


### PR DESCRIPTION
# Description

- This PR fixes an issue where user selections to unselect all available fields were not being respected in subsequent searches. Now, when all fields are unselected, only the timestamps column will be shown in the search results.
- Removed the timestamps from the logs columns, as it is already shown separately.

<img width="1296" alt="image" src="https://github.com/siglens/siglens/assets/71771131/44aa82c2-6368-4de4-86d1-13f1fe158961">
<img width="1282" alt="image" src="https://github.com/siglens/siglens/assets/71771131/47ccac93-8369-42af-b5d9-720a2afde23b">
<img width="1293" alt="image" src="https://github.com/siglens/siglens/assets/71771131/fc314566-5baf-4b13-a678-25d2726c87f0">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
