### PR TITLE
feat: add copy icon in the JSON box

### DIFF
--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -76,7 +76,7 @@ class ReadOnlyCellEditor {
       
         // Add copy icon to the textarea
         $('.copyable').each(function() {
-          var copyIcon = $('<span class="copy-icon"></span>');
+          var copyIcon = $('<span style="margin-right: 14px;" class="copy-icon"></span>');
           $(this).after(copyIcon);
         });
       

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -29,6 +29,7 @@ class ReadOnlyCellEditor {
         this.eInput = document.createElement('textarea');
         cellEditingClass = params.rowIndex%2===0 ? 'even-popup-textarea' : 'odd-popup-textarea'
         this.eInput.classList.add(cellEditingClass);
+        this.eInput.classList.add('copyable');
         this.eInput.readOnly = true;
 
         // Set styles to ensure the textarea fits within its container
@@ -43,10 +44,18 @@ class ReadOnlyCellEditor {
         this.eInput.rows = params.rows;
         this.eInput.maxLength = params.maxLength;
         this.eInput.value = params.value;
+
+        this.gridApi = params.api;
     }
     // gets called once when grid ready to insert the element
     getGui() {
-        return this.eInput;
+        this.gridApi.addEventListener('cellEditingStarted', (event) => {
+            if (event.rowIndex === this.gridApi.getDisplayedRowAtIndex(event.rowIndex).rowIndex) {
+              this.addCopyIcon();
+            }
+          });
+        
+          return this.eInput;
     }
     // returns the new value after editing
     getValue() {
@@ -61,6 +70,35 @@ class ReadOnlyCellEditor {
     destroy() {
         this.eInput.classList.remove(cellEditingClass);
     }
+    addCopyIcon() {
+        // Remove any existing copy icons
+        $('.copy-icon').remove();
+      
+        // Add copy icon to the textarea
+        $('.copyable').each(function() {
+          var copyIcon = $('<span class="copy-icon"></span>');
+          $(this).after(copyIcon);
+        });
+      
+        // Attach click event handler to the copy icon
+        $('.copy-icon').on('click', function(event) {
+          var copyIcon = $(this);
+          var inputOrTextarea = copyIcon.prev('.copyable');
+          var inputValue = inputOrTextarea.val();
+      
+          var tempInput = document.createElement("textarea");
+          tempInput.value = inputValue;
+          document.body.appendChild(tempInput);
+          tempInput.select();
+          document.execCommand("copy");
+          document.body.removeChild(tempInput);
+      
+          copyIcon.addClass('success');
+          setTimeout(function() {
+            copyIcon.removeClass('success');
+          }, 1000);
+        });
+      }
   }
 
 const cellEditorParams = (params) => {
@@ -213,6 +251,7 @@ const myCellRenderer= (params) => {
 let gridDiv = null;
 
 function renderLogsGrid(columnOrder, hits){
+    
     if (sortByTimestampAtDefault) {
         logsColumnDefs[0].sort = "desc";
     }else {


### PR DESCRIPTION
# Description
This change adds a copy icon to the `textarea` of the popup of JSON Viewer.

# Testing
![image](https://github.com/siglens/siglens/assets/108896805/fd67c280-d354-4db3-8872-e8ee6124cd64)
The copy icon is copying contents to the clipboard.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
