### PR TITLE
Log max allowed open files

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -164,7 +164,7 @@ func Main() {
 		hook(baseLogDir)
 	}
 
-	log.Infof("Initialized FD limiter with %+v as max number of open files", fileutils.GetMaxOpenFiles())
+	fileutils.LogMaxOpenFiles()
 
 	err = StartSiglensServer(nodeType, nodeID)
 	if err != nil {

--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -164,6 +164,8 @@ func Main() {
 		hook(baseLogDir)
 	}
 
+	log.Infof("Initialized FD limiter with %+v as max number of open files", fileutils.GetMaxOpenFiles())
+
 	err = StartSiglensServer(nodeType, nodeID)
 	if err != nil {
 		ShutdownSiglensServer()

--- a/pkg/common/fileutils/fileutils.go
+++ b/pkg/common/fileutils/fileutils.go
@@ -70,6 +70,10 @@ func init() {
 	GLOBAL_FD_LIMITER = semaphore.NewDefaultWeightedSemaphore(maxPossibleOpenFds, "GlobalFileLimiter")
 }
 
+func GetMaxOpenFiles() int64 {
+	return GLOBAL_FD_LIMITER.MaxSize
+}
+
 func IsDirEmpty(name string) bool {
 	f, err := os.Open(name)
 	if err != nil {

--- a/pkg/common/fileutils/fileutils.go
+++ b/pkg/common/fileutils/fileutils.go
@@ -66,12 +66,12 @@ func init() {
 		numFiles = newLimit.Cur
 	}
 	maxPossibleOpenFds := int64(numFiles*OPEN_FD_THRESHOLD_PERCENT) / 100
-	log.Infof("Initialized FD limiter with %+v as max number of open files", maxPossibleOpenFds)
 	GLOBAL_FD_LIMITER = semaphore.NewDefaultWeightedSemaphore(maxPossibleOpenFds, "GlobalFileLimiter")
+	LogMaxOpenFiles()
 }
 
-func GetMaxOpenFiles() int64 {
-	return GLOBAL_FD_LIMITER.MaxSize
+func LogMaxOpenFiles() {
+	log.Infof("Initialized FD limiter with %+v as max number of open files", GLOBAL_FD_LIMITER.MaxSize)
 }
 
 func IsDirEmpty(name string) bool {


### PR DESCRIPTION
# Description
This was already printed to stdout. Now it's also included in the log file.

# Testing
The log file contains this:
```
INFO[2024-05-29 09:09:36] Initialized FD limiter with 86016 as max number of open files
```
And this was written to stdout:
```
INFO[0000] Initialized FD limiter with 86016 as max number of open files
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
