### PR TITLE
Set the memory threshold to 50% by default for Memory < 8GB

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,8 @@ import (
 const MINUTES_REREAD_CONFIG = 15
 const RunModFilePath = "data/common/runmod.cfg"
 
+const SIZE_8GB_IN_MB = uint64(8192)
+
 var configFileLastModified uint64
 
 var runningConfig common.Configuration
@@ -680,7 +682,11 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 		config.DataDiskThresholdPercent = 85
 	}
 	if config.MemoryThresholdPercent == 0 {
-		config.MemoryThresholdPercent = 80
+		if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
+			config.MemoryThresholdPercent = 50
+		} else {
+			config.MemoryThresholdPercent = 80
+		}
 	}
 
 	if len(config.S3IngestQueueName) <= 0 {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -678,15 +678,22 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	if config.Log.LogFileRotationSizeMB == 0 {
 		config.Log.LogFileRotationSizeMB = 100
 	}
+
 	if config.DataDiskThresholdPercent == 0 {
 		config.DataDiskThresholdPercent = 85
 	}
-	if config.MemoryThresholdPercent == 0 {
-		if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
+
+	if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
+		if config.MemoryThresholdPercent > 50 {
+			log.Infof("MemoryThresholdPercent is set to %v%% but bringing it down to 50%%", config.MemoryThresholdPercent)
 			config.MemoryThresholdPercent = 50
-		} else {
-			config.MemoryThresholdPercent = 80
+		} else if config.MemoryThresholdPercent == 0 {
+			config.MemoryThresholdPercent = 50
 		}
+	}
+
+	if config.MemoryThresholdPercent == 0 {
+		config.MemoryThresholdPercent = 80
 	}
 
 	if len(config.S3IngestQueueName) <= 0 {

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -524,15 +524,12 @@ func ExtractOTSDBPayload(rawJson []byte, tags *TagsHolder) ([]byte, float64, uin
 		case bytes.Equal(key, otsdb_mname), bytes.Equal(key, metric_name_key):
 			switch valueType {
 			case jp.String:
-				temp, err := jp.ParseString(value)
+				_, err := jp.ParseString(value)
 				if err != nil {
 					log.Errorf("failed to extract tags %+v", err)
+					return err
 				}
-				if temp != "target_info" {
-					mName = value
-				} else {
-					return nil
-				}
+				mName = value
 			}
 		case bytes.Equal(key, otsdb_tags):
 			if valueType != jp.Object {
@@ -633,7 +630,6 @@ func ExtractOTSDBPayload(rawJson []byte, tags *TagsHolder) ([]byte, float64, uin
 	if len(mName) > 0 && ts > 0 {
 		return mName, dpVal, ts, nil
 	} else if len(mName) == 0 && err == nil {
-		//comes here when mName = target_info
 		return nil, dpVal, 0, nil
 	} else {
 		return nil, dpVal, 0, fmt.Errorf("failed to find all expected keys")


### PR DESCRIPTION
# Description
- Updated the `config.go` to set the default Memory Threshold to 50% for memory < 8GB.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
