### PR TITLE
fix: Error log line msg for Suffix Files

### DIFF
--- a/pkg/segment/writer/suffix/suffix.go
+++ b/pkg/segment/writer/suffix/suffix.go
@@ -20,6 +20,7 @@ package suffix
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -71,10 +72,14 @@ func getSuffixFromFile(fileName string) (uint64, error) {
 	scanner := bufio.NewScanner(f)
 	scanner.Scan()
 	rawbytes := scanner.Bytes()
+	if len(rawbytes) == 0 {
+		log.Errorf("getSuffixFromFile: Empty suffix file %v", fileName)
+		return 0, fmt.Errorf("empty suffix file %v", fileName)
+	}
 	var suffxE SuffixEntry
 	err = json.Unmarshal(rawbytes, &suffxE)
 	if err != nil {
-		log.Errorf("GetSuffix: Cannot unmarshal data = %v, err= %v", string(rawbytes), err)
+		log.Errorf("getSuffixFromFile: Cannot unmarshal file = %v with data = %v, err= %v", fileName, string(rawbytes), err)
 		return 0, err
 	}
 	retVal := suffxE.Suffix

--- a/pkg/segment/writer/suffix/suffix.go
+++ b/pkg/segment/writer/suffix/suffix.go
@@ -69,6 +69,10 @@ func getSuffixFromFile(fileName string) (uint64, error) {
 		}
 		return 0, err
 	}
+	if err != nil {
+		log.Errorf("getSuffixFromFile: Cannot open file %v, err= %v", fileName, err)
+		return 0, err
+	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	scanner.Scan()

--- a/pkg/segment/writer/suffix/suffix.go
+++ b/pkg/segment/writer/suffix/suffix.go
@@ -69,6 +69,7 @@ func getSuffixFromFile(fileName string) (uint64, error) {
 		}
 		return 0, err
 	}
+	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	scanner.Scan()
 	rawbytes := scanner.Bytes()


### PR DESCRIPTION
# Description
- Fixes the Error log line for Suffix Functions.


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
