### PR TITLE
Cluster stats page UI changes

### DIFF
--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -72,41 +72,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <div class="cstats-data-container myOrg-container">
                 <div class="org-nav-tab">
                     {{ .Button1 | safeHTML }}
+                <div class="dropdown" id="cstats-time-picker">
+                    <button class="btn dropdown-toggle" type="button" id="date-picker-btn"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                        data-bs-toggle="dropdown" title="Pick the time window">
+                        <span>Time Picker</span>
+                        <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
+                        <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
+                    </button>
+                    <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn"
+                        id="daterangepicker ">
+                        <p class="dt-header">Ingestion Stats for the last</p>
+                        <div class="ranges">
+                            <div class="inner-range">
+                                <div id="now-24h" class="range-item">24 Hrs</div>
+                                <div id="now-90d" class="range-item">90 Days</div>
+                            </div>
+                            <div class="inner-range">
+                                <div id="now-7d" class="range-item active">7 Days</div>
+                                <div id="now-180d" class="range-item">180 Days</div>
+                            </div>
+                            <div class="inner-range">
+                                <div id="now-30d" class="range-item">30 Days</div>
+                                <div id="now-365d" class="range-item">1 Year</div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
+            </div>
                 <div class="myOrg-inner-container">
                     <div class="usage-stats-header">
                         <p class="caption">Track progress and performance </p>
                     </div>
+                    <p class="index-stats-header">Logs Stats</p>
                     <div class="chart-container">
-                        <div id="filter-container">
-                            <div class="dropdown" id="cstats-time-picker">
-                                <button class="btn dropdown-toggle" type="button" id="date-picker-btn"
-                                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-                                    data-bs-toggle="dropdown" title="Pick the time window">
-                                    <span>Time Picker</span>
-                                    <img class="dropdown-arrow orange" src="assets/arrow-btn.svg">
-                                    <img class="dropdown-arrow blue" src="assets/up-arrow-btn-light-theme.svg">
-                                </button>
-                                <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn"
-                                    id="daterangepicker ">
-                                    <p class="dt-header">Ingestion Stats for the last</p>
-                                    <div class="ranges">
-                                        <div class="inner-range">
-                                            <div id="now-24h" class="range-item">24 Hrs</div>
-                                            <div id="now-90d" class="range-item">90 Days</div>
-                                        </div>
-                                        <div class="inner-range">
-                                            <div id="now-7d" class="range-item active">7 Days</div>
-                                            <div id="now-180d" class="range-item">180 Days</div>
-                                        </div>
-                                        <div class="inner-range">
-                                            <div id="now-30d" class="range-item">30 Days</div>
-                                            <div id="now-365d" class="range-item">1 Year</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                         <div class="graph-container mt-2">
                             <div class="chart_container">
                                 <div class="ingestion-stats-header">Incoming Logs Event Count</div>
@@ -117,6 +116,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <canvas id="GBCountChart-logs"></canvas>
                             </div>
                         </div>
+                    </div>
+                    <div class="query-index-container">
+                        <div class="index-stats">
+                            <table id="index-data-table" class="index-data-table"></table>
+                        </div>
+                    </div>
+                    <p class="index-stats-header">Metrics Stats</p>
+                    <div class="chart-container">
                         <div class="graph-container mt-2">
                             <div class="chart_container">
                                 <div class="ingestion-stats-header">Incoming Metrics Datapoints Count</div>
@@ -128,15 +135,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             </div>
                         </div>
                     </div>
+
                     <div class="query-index-container">
                         <div class="index-stats">
-                            <p class="index-stats-header" id="logs-stats-header">Logs Stats</p>
-                            <table id="index-data-table" class="index-data-table"></table>
-                        </div>
-                    </div>
-                    <div class="query-index-container">
-                        <div class="index-stats">
-                            <p class="index-stats-header">Metrics Stats</p>
                             <table id="metrics-data-table" class="index-data-table"></table>
                         </div>
                     </div>

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1617,9 +1617,11 @@ div.dts div.dataTables_scrollBody table {
     align-items: center;
     width: 100%;
     margin-top: 40px;
+    margin-bottom: 40px;
 }
 
 .chart-container{
+    position: relative;
     flex-direction: column;
     border: 1px solid var(--search-input-border);
     box-shadow: var(--box-shadow);

--- a/static/js/cluster-stats.js
+++ b/static/js/cluster-stats.js
@@ -513,7 +513,20 @@ function processClusterStats(res) {
         ''
     ];
 
-    let indexdataTableColumns = columnOrder.map((columnName, index) => {
+    let indexColumnOrder = ['Index Name', 'Incoming Volume', 'Event Count', ''];
+    let metricsColumnOrder = ['Index Name', 'Incoming Volume', 'Datapoint Count'];
+
+    let indexdataTableColumns = indexColumnOrder.map((columnName, index) => {
+        let title = `<div class="grid"><div>${columnName}&nbsp;</div><div><i data-index="${index}"></i></div></div>`;
+        return {
+            title: title,
+            name: columnName,
+            visible: true,
+            defaultContent: ``,
+        };
+    });
+
+    let metricsdataTableColumns = metricsColumnOrder.map((columnName, index) => {
         let title = `<div class="grid"><div>${columnName}&nbsp;</div><div><i data-index="${index}"></i></div></div>`;
         return {
             title: title,
@@ -525,7 +538,6 @@ function processClusterStats(res) {
 
     const commonDataTablesConfig = {
         bPaginate: true,
-        columns: indexdataTableColumns,
         autoWidth: false,
         colReorder: false,
         scrollX: false,
@@ -539,10 +551,16 @@ function processClusterStats(res) {
         columnDefs: [],
         data: []
     };
-    
-    let indexDataTable = $('#index-data-table').DataTable(commonDataTablesConfig);
-    let metricsDataTable = $('#metrics-data-table').DataTable(commonDataTablesConfig);
-    
+
+    let indexDataTable = $('#index-data-table').DataTable({
+        ...commonDataTablesConfig,
+        columns: indexdataTableColumns
+    });
+
+    let metricsDataTable = $('#metrics-data-table').DataTable({
+        ...commonDataTablesConfig,
+        columns: metricsdataTableColumns
+    });
     function displayIndexDataRows(res) {
         let totalIngestVolume = 0;
         let totalEventCount = 0;


### PR DESCRIPTION
# Description
UI changes for cluster stats page - display separate containers for logs and metrics and display respective stats table after each container. 
- Have a global time picker for all graphs  on the cluster stats page
- Time picker is only applied for the graphs and the table shows details from beginning of time.

# Testing
- Tested time picker with different windows.
- No errors on console.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
