### PR TITLE
Cluster stats time picker granularity

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -219,6 +219,12 @@ func parseIngestionStatsRequest(jsonSource map[string]interface{}) (uint64, usag
 			pastXhours = uint64(7 * 24)
 		}
 	}
+
+	// If pastXhours is less than 24, set granularity to ByMinute
+	if pastXhours < 24 {
+		granularity = usageStats.ByMinute
+	}
+
 	return pastXhours, granularity
 }
 func isIndexExcluded(indexName string) bool {

--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -426,9 +426,9 @@ func GetUsageStats(pastXhours uint64, granularity UsageStatsGranularity, orgid u
 	allStatsMap := make([]ReadStats, 0)
 	resultMap := make(map[string]ReadStats)
 	var bucketInterval string
-	runningTs := startEpoch
 	var intervalMinutes uint32
 	var err error
+	runningTs := startEpoch
 	if granularity == ByMinute {
 		intervalMinutes, err = CalculateIntervalForStatsByMinute(uint32(pastXhours * 60))
 		if err != nil {

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -85,6 +85,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <p class="dt-header">Ingestion Stats for the last</p>
                         <div class="ranges">
                             <div class="inner-range">
+                                <div id="now-1h" class="range-item">1 Hr</div>
+                                <div id="now-3h" class="range-item">3 Hrs</div>
+                            </div>
+                            <div class="inner-range">
+                                <div id="now-6h" class="range-item">6 Hrs</div>
+                                <div id="now-12h" class="range-item">12 Hrs</div>
+                            </div>
+                            <div class="inner-range">
                                 <div id="now-24h" class="range-item">24 Hrs</div>
                                 <div id="now-90d" class="range-item">90 Days</div>
                             </div>

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -86,22 +86,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <div class="ranges">
                             <div class="inner-range">
                                 <div id="now-1h" class="range-item">1 Hr</div>
+                                <div id="now-7d" class="range-item active">7 Days</div>
+                            </div>
+                            <div class="inner-range">
                                 <div id="now-3h" class="range-item">3 Hrs</div>
+                                <div id="now-30d" class="range-item">30 Days</div>
                             </div>
                             <div class="inner-range">
                                 <div id="now-6h" class="range-item">6 Hrs</div>
-                                <div id="now-12h" class="range-item">12 Hrs</div>
-                            </div>
-                            <div class="inner-range">
-                                <div id="now-24h" class="range-item">24 Hrs</div>
                                 <div id="now-90d" class="range-item">90 Days</div>
                             </div>
                             <div class="inner-range">
-                                <div id="now-7d" class="range-item active">7 Days</div>
+                                <div id="now-12h" class="range-item">12 Hrs</div>
                                 <div id="now-180d" class="range-item">180 Days</div>
                             </div>
                             <div class="inner-range">
-                                <div id="now-30d" class="range-item">30 Days</div>
+                                <div id="now-24h" class="range-item">24 Hrs</div>
                                 <div id="now-365d" class="range-item">1 Year</div>
                             </div>
                         </div>


### PR DESCRIPTION
# Description
Get stats by minute intervals if requested time window is less than 24 hours.

# Testing
- Tested by calling the API with various time intervals like past1h,2h,4h etc.. 
- Verified that the aggregated results of each window matches the one that is sent for hourly granularity and daily granularity.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
