### PR TITLE
fix: descending icon of table sorting option

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2801,6 +2801,10 @@ input[type="date"]::-webkit-calendar-picker-indicator , input[type="time"]::-web
     margin-left: 5px !important;
 }
 
+.fa-sort-alpha-desc:before{
+    margin-left: 5px !important;
+}
+
 /*launch dashboard*/
 .launch-dashboard .popupContent{
     width: 464px !important;

--- a/static/js/all-alerts.js
+++ b/static/js/all-alerts.js
@@ -156,7 +156,7 @@ const alertGridOptions = {
     headerHeight:32,
 	defaultColDef: {
 		icons: {
-			sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+			sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
 			sortDescending: '<i class="fa fa-sort-alpha-down"/>',
 		},
         cellClass: 'align-center-grid',

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -77,13 +77,13 @@ let aggGridOptions = {
         resizable: true,
         sortable: true,
         icons: {
-            sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+            sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
             sortDescending: '<i class="fa fa-sort-alpha-down"/>',
         },
         cellRenderer: params => params.value ? params.value : 'null',
     },
     icons: {
-        sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+        sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
         sortDescending: '<i class="fa fa-sort-alpha-down"/>',
     }
 };

--- a/static/js/contacts.js
+++ b/static/js/contacts.js
@@ -450,7 +450,7 @@ const contactGridOptions = {
     headerHeight:32,
 	defaultColDef: {
 		icons: {
-			sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+			sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
 			sortDescending: '<i class="fa fa-sort-alpha-down"/>',
 		},
         cellClass: 'align-center-grid',

--- a/static/js/dashboard-logs-results-grid.js
+++ b/static/js/dashboard-logs-results-grid.js
@@ -79,12 +79,12 @@ function getPanelGridOptions() {
             resizable: true,
             minWidth: 200,
             icons: {
-                sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+                sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
                 sortDescending: '<i class="fa fa-sort-alpha-down"/>',
             },
         },
         icons: {
-            sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+            sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
             sortDescending: '<i class="fa fa-sort-alpha-down"/>',
         },
         enableCellTextSelection: true,
@@ -239,13 +239,13 @@ function renderPanelAggsGrid(columnOrder, hits,panelId) {
             resizable: true,
             sortable: true,
             icons: {
-                sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+                sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
                 sortDescending: '<i class="fa fa-sort-alpha-down"/>',
             },
             cellRenderer: params => params.value ? params.value : 'null',
         },
         icons: {
-            sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+            sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
             sortDescending: '<i class="fa fa-sort-alpha-down"/>',
         }
     };

--- a/static/js/dashboards-home.js
+++ b/static/js/dashboards-home.js
@@ -438,7 +438,7 @@ const dbgridOptions = {
 	rowHeight: 54,
 	defaultColDef: {
 		icons: {
-			sortAscending: '<i class="fa fa-sort-alpha-up"/>',
+			sortAscending: '<i class="fa fa-sort-alpha-desc"/>',
 			sortDescending: '<i class="fa fa-sort-alpha-down"/>',
 		},
 	},

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -141,12 +141,12 @@ const gridOptions = {
         minWidth: 200,
         icons: {
             sortAscending: '<i class="fa fa-sort-alpha-down"/>',
-            sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+            sortDescending: '<i class="fa fa-sort-alpha-desc"/>',
           },
     },
     icons: {
         sortAscending: '<i class="fa fa-sort-alpha-down"/>',
-        sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+        sortDescending: '<i class="fa fa-sort-alpha-desc"/>',
       },
     enableCellTextSelection: true,
     suppressScrollOnNewData: true,

--- a/static/js/service-health.js
+++ b/static/js/service-health.js
@@ -78,7 +78,7 @@ const gridOptions = {
       autoHeight: true,
       icons: {
           sortAscending: '<i class="fa fa-sort-alpha-down"/>',
-          sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+          sortDescending: '<i class="fa fa-sort-alpha-desc"/>',
         },
     },
     columnDefs:columnDefs,


### PR DESCRIPTION
# Description
In the PR, the descending is changed as it will reflect as `Z to A down arrow`

# Testing
I have verified by going through every table which has this sorting option.
![image](https://github.com/siglens/siglens/assets/108896805/afc6bf6b-0609-45dc-adc5-fb03592626c2)


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
