### PR TITLE
Concurrent searched and block parallelism set to 1

### DIFF
--- a/pkg/segment/query/metadata/tsmeta.go
+++ b/pkg/segment/query/metadata/tsmeta.go
@@ -77,11 +77,11 @@ func GetMetricsSegmentRequests(mName string, tRange *dtu.MetricsTimeRange, query
 				return
 			}
 			finalReq := &structs.MetricsSearchRequest{
-				MetricsKeyBaseDir: msm.MSegmentDir,
-				BlocksToSearch:    retBlocks,
-				Parallelism:       uint(config.GetParallelism()),
-				QueryType:         structs.METRICS_SEARCH,
-				AllTagKeys:        allTagKeys,
+				MetricsKeyBaseDir:    msm.MSegmentDir,
+				BlocksToSearch:       retBlocks,
+				BlkWorkerParallelism: uint(1),
+				QueryType:            structs.METRICS_SEARCH,
+				AllTagKeys:           allTagKeys,
 			}
 
 			retUpdate.Lock()

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -186,11 +186,11 @@ type OTSDBMetricsQueryExpRequest struct {
 }
 
 type MetricsSearchRequest struct {
-	MetricsKeyBaseDir string
-	BlocksToSearch    map[uint16]bool
-	Parallelism       uint
-	QueryType         SegType
-	AllTagKeys        map[string]bool
+	MetricsKeyBaseDir    string
+	BlocksToSearch       map[uint16]bool
+	BlkWorkerParallelism uint
+	QueryType            SegType
+	AllTagKeys           map[string]bool
 }
 
 /*

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1344,11 +1344,11 @@ func GetUnrotatedMetricsSegmentRequests(metricName string, tRange *dtu.MetricsTi
 				return
 			}
 			finalReq := &structs.MetricsSearchRequest{
-				MetricsKeyBaseDir: mSeg.metricsKeyBase + fmt.Sprintf("%d", mSeg.Suffix),
-				BlocksToSearch:    retBlocks,
-				Parallelism:       uint(config.GetParallelism()),
-				QueryType:         structs.UNROTATED_METRICS_SEARCH,
-				AllTagKeys:        tKeys,
+				MetricsKeyBaseDir:    mSeg.metricsKeyBase + fmt.Sprintf("%d", mSeg.Suffix),
+				BlocksToSearch:       retBlocks,
+				BlkWorkerParallelism: uint(1),
+				QueryType:            structs.UNROTATED_METRICS_SEARCH,
+				AllTagKeys:           tKeys,
 			}
 			tt := GetTagsTreeHolder(orgid, mSeg.Mid)
 			if tt == nil {


### PR DESCRIPTION
# Description
- Concurrent Searches managed by Weighted Semaphore is set to 1.
- Block Worked Parallelism for Metrics Search is also set to 1.
- These changes were made to avoid high memory usage after running bench tests.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
