### PR TITLE
Fix: Check if incoming bytes is greater than 0 for cluster stats API

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -77,11 +77,18 @@ func ProcessClusterStatsHandler(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	httpResp.IngestionStats["Log Storage Used"] = convertBytesToGB(logsOnDiskBytes)
 	httpResp.IngestionStats["Metrics Storage Used"] = convertBytesToGB(float64(metricsOnDiskBytes + metricsImMemBytes))
-	logsStorageSaved := (1 - (logsOnDiskBytes / logsIncomingBytes)) * 100
-	httpResp.IngestionStats["Logs Storage Saved"] = logsStorageSaved
-
-	metricsStorageSaved := (1 - ((float64(metricsOnDiskBytes + metricsImMemBytes)) / float64(metricsIncomingBytes))) * 100
-	httpResp.IngestionStats["Metrics Storage Saved"] = metricsStorageSaved
+	if logsIncomingBytes > 0 {
+		logsStorageSaved := (1 - (float64(logsOnDiskBytes) / float64(logsIncomingBytes))) * 100
+		httpResp.IngestionStats["Logs Storage Saved"] = logsStorageSaved
+	} else {
+		httpResp.IngestionStats["Logs Storage Saved"] = 0.0
+	}
+	if metricsIncomingBytes > 0 {
+		metricsStorageSaved := (1 - ((float64(metricsOnDiskBytes + metricsImMemBytes)) / float64(metricsIncomingBytes))) * 100
+		httpResp.IngestionStats["Metrics Storage Saved"] = metricsStorageSaved
+	} else {
+		httpResp.IngestionStats["Metrics Storage Saved"] = 0.0
+	}
 
 	if hook := hooks.GlobalHooks.SetExtraIngestionStatsHook; hook != nil {
 		hook(httpResp.IngestionStats)


### PR DESCRIPTION
# Description
This PR fixes a bug where the cluster stats API would fail to respond if the incoming bytes were 0 for logs or metrics and replace the storage saved with NaN and hence fail marshaling of json

# Testing
- Tested by ingesting just metrics and both metrics and logs.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
