### PR TITLE
bug-fix #987 Fix time picker alignment on MyOrg cluster status page

### DIFF
--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -70,7 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div id="empty-response"></div>
         <div id="app-content-area">
             <div class="cstats-data-container myOrg-container">
-                <div class="org-nav-tab">
+                <div class="org-nav-tab subsection-navbar align-items-end justify-content-between">
                     {{ .Button1 | safeHTML }}
                 <div class="dropdown" id="cstats-time-picker">
                     <button class="btn dropdown-toggle" type="button" id="date-picker-btn"


### PR DESCRIPTION
# Description
This is a simple fix to correct the vertical alignment of the time picker on the cluster-stats.html page
Fixes #987  (link all the GitHub issues this addresses)

# Testing
Changes are cosmetic, i.e. only a single html file is changed.
I have verified the expected behavior: 
![image](https://github.com/siglens/siglens/assets/31703946/12bb93ff-834d-4939-8dcb-37223b835014)

Additionally, I also ran `make all` and `make pr`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
