### PR TITLE
Self managed pool for reading metrics files

### DIFF
--- a/pkg/segment/query/metadata/tsmeta.go
+++ b/pkg/segment/query/metadata/tsmeta.go
@@ -79,7 +79,7 @@ func GetMetricsSegmentRequests(mName string, tRange *dtu.MetricsTimeRange, query
 			finalReq := &structs.MetricsSearchRequest{
 				MetricsKeyBaseDir:    msm.MSegmentDir,
 				BlocksToSearch:       retBlocks,
-				BlkWorkerParallelism: uint(1),
+				BlkWorkerParallelism: uint(2),
 				QueryType:            structs.METRICS_SEARCH,
 				AllTagKeys:           allTagKeys,
 			}

--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -91,7 +91,7 @@ type poolItem struct {
 
 var globalPool = customPool{}
 
-const numPoolItems = 20
+const numPoolItems = 2
 
 func init() {
 	globalPool.items = make([]poolItem, 0)
@@ -339,6 +339,7 @@ func (tssr *TimeSeriesSegmentReader) loadTSOFile(fileName string) ([]byte, uint1
 	rbuf := tssr.tsoBuf[:cap(tssr.tsoBuf)]
 	sizeToAdd := fileSize - int64(len(rbuf))
 	if sizeToAdd > 0 {
+		panic("should not get here")
 		newArr := *seriesBufferPool.Get().(*[]byte)
 		if diff := sizeToAdd - int64(len(newArr)); diff <= 0 {
 			newArr = newArr[:sizeToAdd]
@@ -383,6 +384,7 @@ func (tssr *TimeSeriesSegmentReader) loadTSGFile(fileName string) ([]byte, error
 	rbuf := tssr.tsgBuf[:cap(tssr.tsgBuf)]
 	sizeToAdd := fileSize - int64(len(rbuf))
 	if sizeToAdd > 0 {
+		panic("should not get here")
 		newArr := *seriesBufferPool.Get().(*[]byte)
 		if diff := sizeToAdd - int64(len(newArr)); diff <= 0 {
 			newArr = newArr[:sizeToAdd]

--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -333,7 +333,12 @@ func getOffsetFromTsoFile(low uint32, high uint32, nTsids uint32, tsid uint64, t
 
 func (tssr *TimeSeriesSegmentReader) expandTSOBufferToMinSize(minSize uint64) error {
 	if cap(tssr.tsoBuf) < int(minSize) {
-		globalPool.Put(tssr.tsoBuf)
+		err := globalPool.Put(tssr.tsoBuf)
+		if err != nil {
+			log.Errorf("expandTSOBufferToMinSize: Error putting buffer back to the pool: %v", err)
+			return err
+		}
+
 		buf, err := globalPool.Get(minSize)
 		if err != nil {
 			log.Errorf("expandTSOBufferToMinSize: Error getting buffer from the pool: %v", err)
@@ -350,7 +355,12 @@ func (tssr *TimeSeriesSegmentReader) expandTSOBufferToMinSize(minSize uint64) er
 
 func (tssr *TimeSeriesSegmentReader) expandTSGBufferToMinSize(minSize uint64) error {
 	if cap(tssr.tsgBuf) < int(minSize) {
-		globalPool.Put(tssr.tsgBuf)
+		err := globalPool.Put(tssr.tsgBuf)
+		if err != nil {
+			log.Errorf("expandTSGBufferToMinSize: Error putting buffer back to the pool: %v", err)
+			return err
+		}
+
 		buf, err := globalPool.Get(minSize)
 		if err != nil {
 			log.Errorf("expandTSGBufferToMinSize: Error getting buffer from the pool: %v", err)
@@ -381,7 +391,6 @@ func (tssr *TimeSeriesSegmentReader) loadTSOFile(fileName string) ([]byte, uint1
 	}
 
 	fileSize := finfo.Size()
-	tssr.expandTSOBufferToMinSize(uint64(fileSize))
 	err = tssr.expandTSOBufferToMinSize(uint64(fileSize))
 	if err != nil {
 		log.Errorf("loadTSOFile: Error expanding TSO buffer: %v", err)

--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -87,7 +87,7 @@ func init() {
 	defer globalPool.mutex.Unlock()
 
 	for i := 0; i < numPoolItems; i++ {
-		buf := make([]byte, 180_000_000)
+		buf := make([]byte, segutils.METRICS_SEARCH_ALLOCATE_BLOCK)
 		item := poolItem{
 			// buf:   make([]byte, 0, segutils.METRICS_SEARCH_ALLOCATE_BLOCK),
 			buf:   buf[:0],
@@ -101,8 +101,9 @@ func init() {
 
 func (cp *customPool) expandItemToMinSize(i int, minSize uint64) {
 	if cap(cp.items[i].buf) < int(minSize) {
-		cp.items[i].buf = make([]byte, 0, minSize)
+		cp.items[i].buf = make([]byte, 1, minSize)
 		cp.items[i].ptr = unsafe.Pointer(&cp.items[i].buf[0])
+		cp.items[i].buf = cp.items[i].buf[:0]
 	}
 }
 

--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -89,7 +89,6 @@ func init() {
 	for i := 0; i < numPoolItems; i++ {
 		buf := make([]byte, segutils.METRICS_SEARCH_ALLOCATE_BLOCK)
 		item := poolItem{
-			// buf:   make([]byte, 0, segutils.METRICS_SEARCH_ALLOCATE_BLOCK),
 			buf:   buf[:0],
 			inUse: false,
 			ptr:   unsafe.Pointer(&buf[0]),
@@ -130,7 +129,6 @@ func (cp *customPool) Put(buf []byte) error {
 	if len(buf) == 0 {
 		buf = buf[:1]
 	}
-	// log.Printf("andrew putting buffer %p", unsafe.Pointer(&buf[0]))
 
 	bufPtr := unsafe.Pointer(&buf[0])
 	for i := range cp.items {

--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -77,7 +77,7 @@ type poolItem struct {
 
 var globalPool = customPool{}
 
-const numPoolItems = 2
+const numPoolItems = 4
 
 func init() {
 	globalPool.items = make([]poolItem, 0)

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1346,7 +1346,7 @@ func GetUnrotatedMetricsSegmentRequests(metricName string, tRange *dtu.MetricsTi
 			finalReq := &structs.MetricsSearchRequest{
 				MetricsKeyBaseDir:    mSeg.metricsKeyBase + fmt.Sprintf("%d", mSeg.Suffix),
 				BlocksToSearch:       retBlocks,
-				BlkWorkerParallelism: uint(1),
+				BlkWorkerParallelism: uint(2),
 				QueryType:            structs.UNROTATED_METRICS_SEARCH,
 				AllTagKeys:           tKeys,
 			}


### PR DESCRIPTION
# Description
Replaces sync.Pool with our own pool, since we're using large buffers and sync.Pool doesn't give guarantees about when it will free items, or that it will use an existing item if available rather than create a new item.

# Testing
Ingested 800 million metric datapoints
```
go run main.go ingest metrics -d http://localhost:8081/otsdb -t 800_000_000 -m 8 -p 10
```
And then ran metric benchmarks:
```
go run main.go metricsbench -d http://localhost:5122 -n 50
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
