### PR TITLE
Fix for issues 1007 and 1009

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -34,7 +34,6 @@ last_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.30462913556
 present_over_time(testmetric4[24h]),now-90d,now,"1,1,1",eq
 count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq
 avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
-mad_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
 max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx
 changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
 hour(testmetric0),now-90d,now,"24,24,24",lt

--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -34,6 +34,7 @@ last_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.30462913556
 present_over_time(testmetric4[24h]),now-90d,now,"1,1,1",eq
 count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq
 avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
+mad_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
 max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx
 changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
 hour(testmetric0),now-90d,now,"24,24,24",lt
@@ -56,3 +57,4 @@ days_in_month(testmetric0),now-90d,now,"27,27,27",gt
 "(testmetric0) < 131",now-90d,now,"127.06863068860355",approx
 "(testmetric0) <= 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
 "(testmetric0) != 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
+"testmetric1 atan2 2",now-90d,now,"1.567250587846092,1.5614086167437156,-1.5503164884124665",approx

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -1051,6 +1051,8 @@ func ConvertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 					mquery.Function = structs.Function{RangeFunction: segutils.Last_Over_Time, TimeWindow: timeWindow}
 				case "present_over_time":
 					mquery.Function = structs.Function{RangeFunction: segutils.Present_Over_Time, TimeWindow: timeWindow}
+				case "mad_over_time":
+					mquery.Function = structs.Function{RangeFunction: segutils.Mad_Over_Time, TimeWindow: timeWindow}
 				case "quantile_over_time":
 					if len(expr.Args) != 2 {
 						return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the quantile_over_time function", expr.Args.String())
@@ -1256,6 +1258,10 @@ func ConvertPqlToMetricsQuery(searchText string, startTime, endTime uint32, myid
 
 func getLogicalAndArithmeticOperation(op parser.ItemType) segutils.LogicalAndArithmeticOperator {
 	switch op {
+	case parser.MOD:
+		return segutils.LetModulo
+	case parser.POW:
+		return segutils.LetPower
 	case parser.ADD:
 		return segutils.LetAdd
 	case parser.SUB:
@@ -1276,6 +1282,8 @@ func getLogicalAndArithmeticOperation(op parser.ItemType) segutils.LogicalAndAri
 		return segutils.LetEquals
 	case parser.NEQ:
 		return segutils.LetNotEquals
+	case parser.ATAN2:
+		return segutils.LetAtan2
 	default:
 		log.Errorf("getArithmeticOperation: unexpected op: %v", op)
 		return 0

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -119,6 +119,13 @@ const metricFunctions = `[
 		"isTimeRangeFunc": false
 	},
 	{
+		"fn": "atan2",
+		"name": "2-argument arctangent (Atan2)",
+		"desc": "Calculates the arctangent, or inverse tangent, of the specified x and y coordinates as arguments.",
+		"eg": "y atan2 x",
+		"isTimeRangeFunc": false
+	},
+	{
 		"fn": "atan",
 		"name": "Arctangent (atan)",
 		"desc": "Calculates the arctangent of all elements in v.",

--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -390,6 +390,13 @@ const metricFunctions = `[
 		"desc": "The value 1 for any series in the specified interval.", 
 		"eg": "present_over_time(avg (system.disk.used[5m]))",
 		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "mad_over_time", 
+		"name": "Median Absolute deviation Over Time", 
+		"desc": "The median absolute deviation of all points in the specified interval.", 
+		"eg": "mad_over_time(avg (system.disk.used[5m]))",
+		"isTimeRangeFunc": true
 	}
 ]`
 

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -1078,7 +1078,13 @@ func evaluateStandardVariance(sortedTimeSeries []Entry, ts map[uint32]float64, t
 	return ts
 }
 
-// MAD Over Time
+/*
+* Median Absolute Deviation Over Time
+1. Calculate the median absolute deviation of all points in the specified interval
+2. Calculate the absolute difference between each point and obtained median in that interval
+3. Calculate median of these obtained values
+*
+*/
 func evaluateMADOverTime(sortedTimeSeries []Entry, ts map[uint32]float64, timeWindow uint32) map[uint32]float64 {
 	for i := range sortedTimeSeries {
 		// Define the start time of the window for the current entry

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -677,6 +677,8 @@ func ApplyRangeFunction(ts map[uint32]float64, function structs.Function) (map[u
 			ts[key] = math.Sqrt(val)
 		}
 		return ts, nil
+	case segutils.Mad_Over_Time:
+		return evaluateMADOverTime(sortedTimeSeries, ts, timeWindow), nil
 	case segutils.Last_Over_Time:
 		// If we take the very last sample from every element of a range vector, the resulting vector will be identical to a regular instant vector query.
 		return ts, nil
@@ -1074,6 +1076,60 @@ func evaluateStandardVariance(sortedTimeSeries []Entry, ts map[uint32]float64, t
 		ts[sortedTimeSeries[i].downsampledTime] = sumValSquare / float64(i-preIndex+1)
 	}
 	return ts
+}
+
+// MAD Over Time
+func evaluateMADOverTime(sortedTimeSeries []Entry, ts map[uint32]float64, timeWindow uint32) map[uint32]float64 {
+	for i := range sortedTimeSeries {
+		// Define the start time of the window for the current entry
+		timeWindowStartTime := sortedTimeSeries[i].downsampledTime
+		if timeWindow < sortedTimeSeries[i].downsampledTime {
+			timeWindowStartTime -= timeWindow
+		} else {
+			// Case where the window calculation might underflow
+			ts[sortedTimeSeries[i].downsampledTime] = 0
+			continue
+		}
+		// Index of the first entry within the time window
+		preIndex := sort.Search(len(sortedTimeSeries), func(j int) bool {
+			return sortedTimeSeries[j].downsampledTime >= timeWindowStartTime
+		})
+
+		if preIndex >= i { // Check if there is no previous data point within the window
+			ts[sortedTimeSeries[i].downsampledTime] = 0
+			continue
+		}
+
+		// All values within the time window
+		values := make([]float64, 0, i-preIndex+1)
+		for j := preIndex; j <= i; j++ {
+			values = append(values, sortedTimeSeries[j].dpVal)
+		}
+
+		// Median of these values
+		median := computeMedian(values)
+		// Absolute deviations from the median
+		deviations := make([]float64, len(values))
+		for k, v := range values {
+			deviations[k] = math.Abs(v - median)
+		}
+
+		// Median of the absolute deviations
+		mad := computeMedian(deviations)
+		// Store the MAD in the result map
+		ts[sortedTimeSeries[i].downsampledTime] = mad
+	}
+	return ts
+}
+
+// Median Calculation
+func computeMedian(values []float64) float64 {
+	sort.Float64s(values)
+	n := len(values)
+	if n%2 == 0 {
+		return (values[n/2-1] + values[n/2]) / 2
+	}
+	return values[n/2]
 }
 
 func getSlopeByLinearRegression(sortedTimeSeries []Entry, preIndex int, i int) float64 {

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -657,7 +657,6 @@ func Test_applyRangeFunctionStddevOverTime(t *testing.T) {
 	}
 }
 
-// Test For Mad Over Time
 func Test_applyRangeFunctionMADOverTime(t *testing.T) {
 
 	result := make(map[string]map[uint32]float64)

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -657,6 +657,54 @@ func Test_applyRangeFunctionStddevOverTime(t *testing.T) {
 	}
 }
 
+// Test For Mad Over Time
+func Test_applyRangeFunctionMADOverTime(t *testing.T) {
+
+	result := make(map[string]map[uint32]float64)
+	ts := map[uint32]float64{
+		1000: 10,
+		1001: 20.5,
+		1002: 30.25,
+		1013: 40,
+		1018: 50.75,
+		1019: 60,
+		1020: 70.5,
+	}
+
+	result["metric"] = ts
+
+	metricsResults := &MetricsResult{
+		Results: result,
+	}
+
+	ans := map[uint32]float64{
+		1000: 0,
+		1001: 5.25,
+		1002: 9.75,
+		1013: 0,
+		1018: 5.375,
+		1019: 9.25,
+		1020: 9.875,
+	}
+
+	function := structs.Function{RangeFunction: segutils.Mad_Over_Time, TimeWindow: 10}
+
+	err := metricsResults.ApplyFunctionsToResults(8, function)
+	assert.Nil(t, err)
+	for _, timeSeries := range metricsResults.Results {
+		for key, val := range timeSeries {
+			expectedVal, exists := ans[key]
+			if !exists {
+				t.Errorf("Should not have this key: %v", key)
+			}
+
+			if !dtypeutils.AlmostEquals(expectedVal, val) {
+				t.Errorf("Expected value should be %v, but got %v for timestamp %v", expectedVal, val, key)
+			}
+		}
+	}
+}
+
 func Test_applyRangeFunctionQuantileOverTime(t *testing.T) {
 	result := make(map[string]map[uint32]float64)
 	ts := map[uint32]float64{

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -463,7 +463,6 @@ func Test_GetResults_Power(t *testing.T) {
 	)
 }
 
-// Todo: Need to curve values of original answer?
 func Test_GetResults_Atan2_First_And_Fourth_Quadrant(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
@@ -493,7 +492,6 @@ func Test_GetResults_Atan2_First_And_Fourth_Quadrant(t *testing.T) {
 	)
 }
 
-// Todo: Need to curve values of original answer?
 func Test_GetResults_Atan2_Second_And_Third_Quadrant(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{
@@ -523,7 +521,6 @@ func Test_GetResults_Atan2_Second_And_Third_Quadrant(t *testing.T) {
 	)
 }
 
-// Todo: Need to curve values of original answer?
 func Test_GetResults_Atan2_With_Decimal_Values(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -407,6 +407,152 @@ func TestCalculateInterval(t *testing.T) {
 	}
 }
 
+func Test_GetResults_Modulo(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:    52.5,
+			3600: 23,
+			7200: -7.5,
+		},
+		map[uint32]float64{
+			0:    2.5,
+			3600: 3,
+			7200: -2.5,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetModulo,
+				Constant:   5,
+			},
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
+}
+
+func Test_GetResults_Power(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:    2,
+			7200: -10,
+		},
+		map[uint32]float64{
+			0:    4,
+			7200: 100,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetPower,
+				Constant:   2,
+			},
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
+}
+
+// Todo: Need to curve values of original answer?
+func Test_GetResults_Atan2_First_And_Fourth_Quadrant(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:    1,
+			3600: 0,
+			7200: -1,
+		},
+		map[uint32]float64{
+			0:    0.4636476090008061,
+			3600: 0,
+			7200: -0.4636476090008061,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetAtan2,
+				Constant:   2,
+			},
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
+}
+
+// Todo: Need to curve values of original answer?
+func Test_GetResults_Atan2_Second_And_Third_Quadrant(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:    1,
+			3600: 0,
+			7200: -1,
+		},
+		map[uint32]float64{
+			0:    2.677945044588987,
+			3600: 3.141592653589793,
+			7200: -2.677945044588987,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetAtan2,
+				Constant:   -2,
+			},
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
+}
+
+// Todo: Need to curve values of original answer?
+func Test_GetResults_Atan2_With_Decimal_Values(t *testing.T) {
+	test_GetResults_Ops(t,
+		map[uint32]float64{
+			0:    2.46,
+			3600: 1000.4567,
+			7200: -400.12,
+		},
+		map[uint32]float64{
+			0:    2.2534188792121137,
+			3600: 1.5727954111488458,
+			7200: -1.5757947856161965,
+		},
+		[]structs.QueryArithmetic{
+			{
+				LHS:        1,
+				ConstantOp: true,
+				Operation:  utils.LetAtan2,
+				Constant:   -2,
+			},
+		},
+		structs.Downsampler{
+			Interval:   1,
+			Unit:       "h",
+			CFlag:      false,
+			Aggregator: structs.Aggreation{AggregatorFunction: utils.Avg},
+		},
+	)
+}
+
 func Test_GetResults_GreaterThan(t *testing.T) {
 	test_GetResults_Ops(t,
 		map[uint32]float64{

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -152,7 +152,26 @@ func HelperQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap 
 						if valueLHS != valueRHS {
 							finalResult[groupID][timestamp] = valueLHS
 						}
+					case utils.LetModulo:
+						if swapped {
+							finalResult[groupID][timestamp] = math.Mod(valueRHS, valueLHS)
+						} else {
+							finalResult[groupID][timestamp] = math.Mod(valueLHS, valueRHS)
+						}
+					case utils.LetPower:
+						if swapped {
+							finalResult[groupID][timestamp] = math.Pow(valueRHS, valueLHS)
+						} else {
+							finalResult[groupID][timestamp] = math.Pow(valueLHS, valueRHS)
+						}
+					case utils.LetAtan2:
+						if swapped {
+							finalResult[groupID][timestamp] = math.Atan2(valueRHS, valueLHS)
+						} else {
+							finalResult[groupID][timestamp] = math.Atan2(valueLHS, valueRHS)
+						}
 					}
+
 				}
 			}
 
@@ -200,6 +219,12 @@ func HelperQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap 
 						if valueLHS != valueRHS {
 							finalResult[groupID][timestamp] = valueLHS
 						}
+					case utils.LetModulo:
+						finalResult[groupID][timestamp] = math.Mod(valueLHS, valueRHS)
+					case utils.LetPower:
+						finalResult[groupID][timestamp] = math.Pow(valueLHS, valueRHS)
+					case utils.LetAtan2:
+						finalResult[groupID][timestamp] = math.Atan2(valueLHS, valueRHS)
 					}
 				}
 			}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -267,12 +267,14 @@ const (
 	LetDivide
 	LetMultiply
 	LetModulo
+	LetPower
 	LetEquals
 	LetNotEquals
 	LetLessThan
 	LetLessThanOrEqualTo
 	LetGreaterThan
 	LetGreaterThanOrEqualTo
+	LetAtan2
 )
 
 type AggregateFunctions int
@@ -352,6 +354,7 @@ const (
 	Count_Over_Time
 	Stdvar_Over_Time
 	Stddev_Over_Time
+	Mad_Over_Time
 	Last_Over_Time
 	Present_Over_Time
 	Quantile_Over_Time


### PR DESCRIPTION
# Description
Summarize the change.

1. Issue 1007: 
Needed Median Absolute Deviation Over Tine feature for SIgLens.
Made changes to metricsconsts.go, seriesresult_test.go, seriesresult.go, metricssearchhandler.go and segconsts.go files
Made the necessary changes to make this feature work.

1. Issue 1009: 
Needed Atan2, trigonometric binary arithmetic operation, feature for SIgLens.
Made changes to metricsresult_test.go, segexecution.go, metricssearchhandler.go and segconsts.go files
Made the necessary changes to make this feature work.

Fixes 
#1007 
#1009 

# Testing
1. Issue 1007 Mad_over_Time
- It can have positve and decimal inputs so have tested it with those inputs for my changes in seriesresult_test.go file

2. Issue 1009 Atan2
-  It can have vector point in any quadrants and decimal values so have tested it accordingly in metricresult_test.go file
- Got it's actual answer from the math.atan2 function from go playground.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
