### PR TITLE
feat: close icon on column header

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -248,11 +248,11 @@ function resetCustomDateRange(){
         Cookies.remove('customStartTime');
         Cookies.remove('customEndTime');
 }
-function hideColumnHandler(evt) {
+function hideColumnHandler(evt, isCloseIcon = false) {
     evt.preventDefault();
     evt.stopPropagation();
 
-    availableFieldsSelectHandler(evt);
+    availableFieldsSelectHandler(evt, isCloseIcon);
 }
 
 function setQueryLangHandler(e) {
@@ -394,9 +394,18 @@ function availableFieldsClickHandler(evt) {
     evt.stopPropagation();
 }
 
-function availableFieldsSelectHandler(evt) {
+function availableFieldsSelectHandler(evt, isCloseIcon = false) {
+    let colName
 
-    let colName = evt.currentTarget.dataset.index;
+    if(isCloseIcon){
+        const outerDiv = evt.currentTarget.closest('.ag-header-cell');
+        const colId = outerDiv.getAttribute('col-id');
+        colName = colId
+    }
+    else{
+        colName = evt.currentTarget.dataset.index
+    }
+
     let encColName = string2Hex(colName);
     // don't toggle the timestamp column
     if (colName !== "timestamp") {

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -143,11 +143,32 @@ const gridOptions = {
             sortAscending: '<i class="fa fa-sort-alpha-down"/>',
             sortDescending: '<i class="fa fa-sort-alpha-desc"/>',
           },
+          headerComponentParams: {
+            template:
+                `<div class="ag-cell-label-container" role="presentation">
+                  <span ref="eMenu" class="ag-header-icon ag-header-cell-menu-button"></span>
+                  <span ref="eFilterButton" class="ag-header-icon ag-header-cell-filter-button"></span>
+                  <div ref="eLabel" class="ag-header-cell-label" role="presentation">
+                    <div style="display: flex; align-items: center; justify-content: space-between; gap: 3px; width: 100%;">
+                        <div style="display: flex; align-items: center; gap: 3px;">
+                            <span ref="eText" class="ag-header-cell-text" role="columnheader"></span>
+                            <span ref="eSortOrder" class="ag-header-icon ag-sort-order"></span>
+                            <span ref="eSortAsc" class="ag-header-icon ag-sort-ascending-icon"></span>
+                            <span ref="eSortDesc" class="ag-header-icon ag-sort-descending-icon"></span>
+                            <span ref="eSortNone" class="ag-header-icon ag-sort-none-icon"></span>
+                            <span ref="eFilter" class="ag-header-icon ag-filter-icon"></span>
+                        </div>
+                        <i onclick="hideColumnHandler(event, true)" class="fa fa-close close-icon"></i>
+                    </div>
+                  </div>
+                </div>`
+        }
     },
     icons: {
         sortAscending: '<i class="fa fa-sort-alpha-down"/>',
         sortDescending: '<i class="fa fa-sort-alpha-desc"/>',
       },
+      close: true,
     enableCellTextSelection: true,
     suppressScrollOnNewData: true,
     suppressAnimationFrame: true,
@@ -185,6 +206,24 @@ const gridOptions = {
         }
     },
     overlayLoadingTemplate: '<div class="ag-overlay-loading-center"><div class="loading-icon"></div><div class="loading-text">Loading...</div></div>',
+    onGridReady: function (params) {
+        const eGridDiv = document.querySelector('#LogResultsGrid');
+        const style = document.createElement('style');
+        style.textContent = `
+            .close-icon {
+                cursor: pointer;
+                color: #888;
+                margin-left: 5px;
+                display: none;
+            }
+              
+            .ag-header-cell:not([col-id="timestamp"]):hover .close-icon {
+                display: inline-block;
+            }
+            
+        `;
+        eGridDiv.appendChild(style);
+    }
 };
 
 function showLoadingIndicator() {
@@ -300,6 +339,7 @@ function renderLogsGrid(columnOrder, hits){
     });
     gridOptions.columnApi.autoSizeColumns(allColumnIds, false);
     gridOptions.api.setRowData(logsRowData);
+
     
     switch (logview){
         case 'single-line':


### PR DESCRIPTION
# Description
This PR includes the change in which there will be a close icon on the column header through which user can hide that particular column.

# Testing
![image](https://github.com/siglens/siglens/assets/108896805/81e8dabb-7eb5-4b32-b874-c8827229b611)
I tested by clicking on the close icon and checking in the `available fields` dropdown.
![image](https://github.com/siglens/siglens/assets/108896805/43323a7a-4333-4c0f-89fd-61c028f05f0c)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
