### PR TITLE
fix: anchor wildcard search

### DIFF
--- a/pkg/common/dtypeutils/dtypeutils.go
+++ b/pkg/common/dtypeutils/dtypeutils.go
@@ -598,6 +598,7 @@ func BitwiseXOr(left interface{}, right interface{}) (interface{}, error) {
 // todo: better wildcard comparison
 func ReplaceWildcardStarWithRegex(input string) string {
 	var result strings.Builder
+	result.WriteString("^") // Start of string
 	for i, literal := range strings.Split(input, "*") {
 
 		// Replace * with .*
@@ -609,6 +610,8 @@ func ReplaceWildcardStarWithRegex(input string) string {
 		// literal text.
 		result.WriteString(regexp.QuoteMeta(literal))
 	}
+	result.WriteString("$") // End of string
+
 	return result.String()
 }
 


### PR DESCRIPTION
# Description
- Fixes the issue with Wildcard Search. 
- Currently a search like `app_name=Be*` is converted to `*Be*`.
- Now the search is anchored at both ends, making above search as `^Be.*$`

# Testing
- Tested by executing similar regex queries through the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
