### PR TITLE
Fix: Dual index bug

### DIFF
--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -83,7 +83,8 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case RegexExpression:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
 		if err != nil {
-			return false, err
+			log.Errorf("ApplyColumnarSearchQuery: %v", err)
+			return false, nil
 		}
 		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte)
 	case RegexExpressionAllColumns:
@@ -251,11 +252,8 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 	case SimpleExpression, RegexExpression:
 
 		isDict, err := mcr.IsBlkDictEncoded(sq.QueryInfo.ColName, blockNum)
-		if err != nil {
-			return true, dictEncColNames, err
-		}
-
-		if !isDict {
+		// Like other switch cases, we do not return the error. When an error occurs, stop executing the subsequent logic.
+		if err != nil || !isDict {
 			return true, dictEncColNames, nil
 		}
 

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -83,7 +83,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case RegexExpression:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
 		if err != nil {
-			log.Errorf("ApplyColumnarSearchQuery: %v", err)
+			log.Debugf("ApplyColumnarSearchQuery: %v", err)
 			return false, nil
 		}
 		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte)

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -83,7 +83,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case RegexExpression:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
 		if err != nil {
-			log.Debugf("ApplyColumnarSearchQuery: %v", err)
+			log.Debugf("ApplyColumnarSearchQuery: failed to read column %v rec from column file. qid: %v, err: %v", query.QueryInfo.ColName, qid, err)
 			return false, nil
 		}
 		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte)

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -200,7 +200,7 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 	case SS_DT_STRING:
 		if len(rec) == 0 || rec[0] != VALTYPE_ENC_SMALL_STRING[0] {
 			// if we are doing a regex search on a number, we need to convert the number to string
-			if isRegexSearch && isValTypeEncANumber(rec[0]) {
+			if len(rec) > 0 && isRegexSearch && isValTypeEncANumber(rec[0]) {
 				return filterOpOnRecNumberEncType(rec, qValDte, fop, isRegexSearch, recDte)
 			}
 			return false, nil


### PR DESCRIPTION
# Description
If we have two indices, `ind-0` and `ind-1`, `ind-0` index contains `http_status` while `ind-1` index contains `http_method`

In the past, If the filter query uses regex(E.g. http_status=2*), it will give us an error as shown below, since `ind-1` does not contain field `http_status`
![image](https://github.com/siglens/siglens/assets/67371917/af7b733c-a47f-4bc4-bc6f-50c634df2612)

After this pr, query should just return rows meet the condition without giving error

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
