### PR TITLE
Regex search support for Tag filters

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pbnjay/memory"
 	"github.com/siglens/siglens/pkg/config/common"
+	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -275,7 +277,12 @@ a: b
 			assert.Error(t, err)
 			continue
 		}
-
+		if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
+			assert.Equal(t, uint64(50), actualConfig.MemoryThresholdPercent)
+			// If memory is less than 8GB, config by default returns 50% as the threshold
+			// For testing purpose resetting it to 80%
+			actualConfig.MemoryThresholdPercent = 80
+		}
 		assert.NoError(t, err, fmt.Sprintf("Comparison failed, test=%v", i+1))
 		assert.EqualValues(t, test.expected, actualConfig, fmt.Sprintf("Comparison failed, test=%v", i+1))
 	}

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -174,7 +174,7 @@ func acceptRegexVal(pattern string, tagRawValue []byte, tagOperator segutils.Tag
 		return false, err
 	}
 	acceptVal := (matched && tagOperator == segutils.Regex) || (!matched && tagOperator == segutils.NegRegex)
-	
+
 	return acceptVal, nil
 }
 

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 
 	"github.com/cespare/xxhash"
 	tsidtracker "github.com/siglens/siglens/pkg/segment/results/mresults/tsid"
@@ -28,7 +29,6 @@ import (
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
-	"regexp"
 )
 
 const STAR = "*"

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -28,6 +28,7 @@ import (
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"regexp"
 )
 
 const STAR = "*"
@@ -166,6 +167,17 @@ func (attr *AllTagTreeReaders) CloseAllTagTreeReaders() {
 	}
 }
 
+func acceptRegexVal(pattern string, tagRawValue []byte, tagOperator segutils.TagOperator) (bool, error) {
+	fullAnchorPattern := fmt.Sprintf("^(%v)$", pattern)
+	matched, err := regexp.Match(fullAnchorPattern, tagRawValue)
+	if err != nil {
+		return false, err
+	}
+	acceptVal := (matched && tagOperator == segutils.Regex) || (!matched && tagOperator == segutils.NegRegex)
+	
+	return acceptVal, nil
+}
+
 /*
 Wrapper function that applies all tags filters
 
@@ -204,7 +216,7 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 		if !fileExists {
 			continue
 		}
-		if tagVal, ok := tf.RawTagValue.(string); ok && tagVal == "*" {
+		if tagVal, ok := tf.RawTagValue.(string); ok && (tagVal == "*" || tf.IsRegex()) {
 			itr, mNameExists, err := attr.GetValueIteratorForMetric(mQuery.HashedMName, tf.TagKey, fInfo)
 			if err != nil {
 				log.Infof("FindTSIDS: failed to get the value iterator for metric name %v and tag key %v. Error: %v. TagVAlH %+v", mQuery.MetricName, tf.TagKey, err, tf.HashTagValue)
@@ -218,6 +230,19 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 			rawTagValueToTSIDs := make(map[string]map[uint64]struct{})
 			for {
 				_, tagRawValue, tsids, tagRawValueType, more := itr.Next()
+
+				// if operator is regex check for match and skip on no match
+				if tf.IsRegex() && len(tagRawValue) > 0 {
+					acceptVal, err := acceptRegexVal(tagVal, tagRawValue, tf.TagOperator)
+					if err != nil {
+						log.Errorf("FindTSIDS: failed to match regex %v with tag value %v. Error: %v", tagVal, tagRawValue, err)
+						continue
+					}
+					if !acceptVal {
+						continue
+					}
+				}
+
 				if !more {
 					if mQuery.GetAllLabels {
 						numValueFiltersNonZero := mQuery.GetNumValueFilters() > 0
@@ -242,7 +267,11 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 							} else {
 								initMetricName = fmt.Sprintf("%v{", mQuery.MetricName)
 							}
-							err = tracker.BulkAddStar(rawTagValueToTSIDs, initMetricName, tf.TagKey, numValueFiltersNonZero)
+							if tf.IsRegex() {
+								err = tracker.BulkAdd(rawTagValueToTSIDs, mQuery.MetricName, tf.TagKey)
+							} else {
+								err = tracker.BulkAddStar(rawTagValueToTSIDs, initMetricName, tf.TagKey, numValueFiltersNonZero)
+							}
 						}
 					}
 					if err != nil {

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -319,6 +319,10 @@ func isStarValue(tf *TagsFilter) bool {
 	return ok && tagVal == "*"
 }
 
+func (tf *TagsFilter) IsRegex() bool {
+	return (tf.TagOperator == utils.Regex || tf.TagOperator == utils.NegRegex)
+}
+
 // Handles star tags logic
 func handleStarTag(tf *TagsFilter, queriedTagKeys map[string]TagValueIndex, starTags *[]*TagsFilter) {
 	if _, exists := queriedTagKeys[tf.TagKey]; !exists {


### PR DESCRIPTION
# Description
Summarize the change.
Using the for regex operator shifted the flow to iterate over all the values of the tag similar to what happens in case of *.
Checking the tagRawValue with the tagVal (regex expression parsed correctly by the promql parser and returning the expression as a string). Regex check performed between these two is fully anchored similar to what [promql](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) uses.
Finally calling BulkAdd to add all TSIDs that successfully matched with the regex to tracker.

Fixes #<issue-number> (link all the GitHub issues this addresses)


# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Tested various regex expression to check the correctness below mentioned are the queries and the series results
```

"query": "((testmetric1{model=~\" [0-9]+[a-zA-Z ]*\"}))",

"testmetric1{model: 325xi}",
"testmetric1{model: 750li}",
"testmetric1{model: 325ci Convertible}",
"testmetric1{model: 525xi}",
"testmetric1{model: 530xi Sport Wagon}",
"testmetric1{model: 330ci Convertible}"


"query": "((testmetric1{model=~\"[0-9]+[a-zA-Z ]*\"}))",

"testmetric1{model:350z}"

"query": "((testmetric1{model=~\" [0-9]+[a-zA-Z ]*|[0-9]+[a-zA-Z ]*\"}))",

"testmetric1{model: 530xi Sport Wagon}",
"testmetric1{model: 330ci Convertible}",
"testmetric1{model: 325xi}",
"testmetric1{model: 750li}",
"testmetric1{model: 325ci Convertible}",
"testmetric1{model: 525xi}",
"testmetric1{model:350z}"


"query": "((testmetric1{model=~\"[0-9-]+ [a-zA-Z ]*\"}))"

"testmetric1{model:9-3 Convertible}",
"testmetric1{model:9-3 Sport Sedan}"




"query": "((testmetric1{model=~\"F.*\"}))",

"testmetric1{model:Fx35 Rwd}",
"testmetric1{model:Focus Station Wag}",
"testmetric1{model:F150 Ffv  4wd}",
"testmetric1{model:F150 Ffv  2wd}",
"testmetric1{model:Frontier V6-4wd}",
"testmetric1{model:Freestar Wagon Fwd}",
"testmetric1{model:Frontier 2wd}",
"testmetric1{model:Forester Awd}",
"testmetric1{model:Freestyle Fwd}",
"testmetric1{model:F430}"




"query": "((testmetric1{model=~\"F[a-zA-Z ]+\"}))",

"testmetric1{model:Forester Awd}",
"testmetric1{model:Freestyle Fwd}",
"testmetric1{model:Freestar Wagon Fwd}",
"testmetric1{model:Focus Station Wag}"



"query": "((testmetric1{fuel_type=~\"CNG|G\", color=~\"blue|lime\"}))",

"testmetric1{fuel_type:CNG,color:lime}",
"testmetric1{fuel_type:CNG,color:blue}"



"query": "((testmetric1{fuel_type=~\"CNG|G.*\", color=~\"blue|lime\"}))",

"testmetric1{fuel_type:CNG,color:blue}",
"testmetric1{fuel_type:CNG,color:lime}",
"testmetric1{fuel_type:Gasoline,color:blue}",
"testmetric1{fuel_type:Gasoline,color:lime}"



"query": "((testmetric1{fuel_type=~\"CNG|G.*\", color=~\"b.+|lime\"}))",

"testmetric1{fuel_type:CNG,color:lime}",
"testmetric1{fuel_type:Gasoline,color:lime}",
"testmetric1{fuel_type:Gasoline,color:blue}",
"testmetric1{fuel_type:CNG,color:blue}",
"testmetric1{fuel_type:CNG,color:black}",
"testmetric1{fuel_type:Gasoline,color:black}"



"query": "((testmetric1{fuel_type=~\"CNG|G.*\", color=~\"blue\"}))",

"testmetric1{fuel_type:CNG,color:blue}",
"testmetric1{fuel_type:Gasoline,color:blue}"



"query": "((testmetric1{fuel_type=~\"CNG|G.*\", color=~\"o.*|bl[a-d].*\"}))",

"testmetric1{fuel_type:CNG,color:black}",
"testmetric1{fuel_type:CNG,color:olive}",
"testmetric1{fuel_type:Gasoline,color:olive}",
"testmetric1{fuel_type:Gasoline,color:black}"


"query": "avg(avg_over_time(testmetric1{fuel_type=~\"CNG|G.*\", color=~\"o.*|bl[a-d].*\"}[1h])) by (fuel_type, color)",

"testmetric1{fuel_type:CNG,color:olive}",
"testmetric1{fuel_type:CNG,color:black}",
"testmetric1{fuel_type:Gasoline,color:black}",
"testmetric1{fuel_type:Gasoline,color:olive}"


"query": "max(max_over_time(testmetric1{color=~'black|olive|blue|yellow|red|pink|green|teal'}[1m])) by (color)",

"testmetric1{color:green}",
"testmetric1{color:blue}",
"testmetric1{color:yellow}",
"testmetric1{color:olive}",
"testmetric1{color:teal}",
"testmetric1{color:black}"


"query": "max(max_over_time(testmetric1{fuel_type='LPG'}[1m])) by (fuel_type)",

"testmetric1{fuel_type:LPG}"


"query": "((testmetric1{model!~\"[a-zA-Z][a-zA-Z0-9 ]*\"}))",

"testmetric1{model:S-type 3.0 Litre}",
"testmetric1{model: Z4 3.0si}",
"testmetric1{model: 325ci Convertible}",
"testmetric1{model:9-3 Convertible}",
"testmetric1{model:Lacrosse/allure}",
"testmetric1{model: Z4 M Roadster}",
"testmetric1{model: Mini Cooper Convertible}",
"testmetric1{model:Grand Vitara Xl-7 4wd}",
"testmetric1{model:Clk350 (cabriolet)}",
"testmetric1{model: 325xi}",
"testmetric1{model:E350 4matic (wagon)}",
"testmetric1{model: X5}",
"testmetric1{model: 750li}",
"testmetric1{model:350z}",
"testmetric1{model:Elise/exige}",
"testmetric1{model:300c/srt-8}",
"testmetric1{model:S-type R}",
"testmetric1{model:Mazda Rx-8}",
"testmetric1{model: 530xi Sport Wagon}",
"testmetric1{model:G6 Gt/gtp Convertible}",
"testmetric1{model:Frontier V6-4wd}",
"testmetric1{model:Sebring 4-dr}",
"testmetric1{model: 330ci Convertible}",
"testmetric1{model: 525xi}",
"testmetric1{model: Mini Cooper}",
"testmetric1{model:Town & Country 2wd}",
"testmetric1{model: M3 Convertible}",
"testmetric1{model:4runner 4wd}",
"testmetric1{model:9-3 Sport Sedan}"


"query": "((testmetric1{fuel_type=~\"CNG|G\", color!~\"blue|lime\"}))",

"testmetric1{fuel_type:CNG,color:yellow}",
"testmetric1{fuel_type:CNG,color:silver}",
"testmetric1{fuel_type:CNG,color:teal}",
"testmetric1{fuel_type:CNG,color:gray}",
"testmetric1{fuel_type:CNG,color:fuchsia}",
"testmetric1{fuel_type:CNG,color:maroon}",
"testmetric1{fuel_type:CNG,color:navy}",
"testmetric1{fuel_type:CNG,color:green}",
"testmetric1{fuel_type:CNG,color:black}",
"testmetric1{fuel_type:CNG,color:purple}",
"testmetric1{fuel_type:CNG,color:olive}",
"testmetric1{fuel_type:CNG,color:white}"



"query": "max(max_over_time(testmetric1{color!~'black|olive|blue|yellow|red|pink|green'}[1m])) by (color)",

"testmetric1{color:teal}",
"testmetric1{color:aqua}",
"testmetric1{color:maroon}",
"testmetric1{color:fuchsia}",
"testmetric1{color:white}",
"testmetric1{color:gray}",
"testmetric1{color:purple}",
"testmetric1{color:navy}",
"testmetric1{color:silver}",
"testmetric1{color:lime}"



```






# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
