### PR TITLE
Exclude '_index' from columnsOrder when 'fields' command is entered

### DIFF
--- a/pkg/segment/reader/record/rrcreader_test.go
+++ b/pkg/segment/reader/record/rrcreader_test.go
@@ -153,15 +153,15 @@ func Test_GetJsonFromAllRrc_withAggs_IncludeCols(t *testing.T) {
 	assert.Equal(t, 2, len(allRecords))
 
 	// 11 columns + timestamp + index
-	assert.Equal(t, 3, len(allRecords[0]))
+	assert.Equal(t, 2, len(allRecords[0]))
 
 	// checking decoding non random column values
 
-	indexName := "evts"
+	// indexName := "evts"
 	key0Val := "match words 123 abc"
 
 	for i := 0; i < numRecords; i++ {
-		assert.Equal(t, indexName, allRecords[i]["_index"])
+		// assert.Equal(t, indexName, allRecords[i]["_index"])
 		assert.Equal(t, key0Val, allRecords[i]["key0"])
 		assert.Equal(t, uint64(i), allRecords[i][config.GetTimeStampKey()])
 	}
@@ -217,11 +217,11 @@ func Test_GetJsonFromAllRrc_withAggs_ExcludeCols(t *testing.T) {
 	assert.Equal(t, 2, len(allRecords))
 
 	// 11 columns + timestamp + index
-	assert.Equal(t, 13, len(allRecords[0]))
+	assert.Equal(t, 12, len(allRecords[0]))
 
 	// checking decoding non random column values
 
-	indexName := "evts"
+	// indexName := "evts"
 	// key0Val := "match words 123 abc"
 	key1Val := "value1"
 	key2Vals := []int64{0, 1}
@@ -231,7 +231,7 @@ func Test_GetJsonFromAllRrc_withAggs_ExcludeCols(t *testing.T) {
 	key8Val := int64(0)
 	key10Val := segkey
 	for i := 0; i < numRecords; i++ {
-		assert.Equal(t, indexName, allRecords[i]["_index"])
+		// assert.Equal(t, indexName, allRecords[i]["_index"])
 		// assert.Equal(t, key0Val, allRecords[i]["key0"])
 		assert.Equal(t, key1Val, allRecords[i]["key1"])
 		assert.Equal(t, key2Vals[i], allRecords[i]["key2"]) // we only encode floats

--- a/pkg/segment/reader/record/rrcreader_test.go
+++ b/pkg/segment/reader/record/rrcreader_test.go
@@ -157,7 +157,6 @@ func Test_GetJsonFromAllRrc_withAggs_IncludeCols(t *testing.T) {
 
 	// checking decoding non random column values
 
-	// indexName := "evts"
 	key0Val := "match words 123 abc"
 
 	for i := 0; i < numRecords; i++ {
@@ -221,7 +220,6 @@ func Test_GetJsonFromAllRrc_withAggs_ExcludeCols(t *testing.T) {
 
 	// checking decoding non random column values
 
-	// indexName := "evts"
 	// key0Val := "match words 123 abc"
 	key1Val := "value1"
 	key2Vals := []int64{0, 1}
@@ -231,7 +229,6 @@ func Test_GetJsonFromAllRrc_withAggs_ExcludeCols(t *testing.T) {
 	key8Val := int64(0)
 	key10Val := segkey
 	for i := 0; i < numRecords; i++ {
-		// assert.Equal(t, indexName, allRecords[i]["_index"])
 		// assert.Equal(t, key0Val, allRecords[i]["key0"])
 		assert.Equal(t, key1Val, allRecords[i]["key1"])
 		assert.Equal(t, key2Vals[i], allRecords[i]["key2"]) // we only encode floats


### PR DESCRIPTION
# Description
Summarize the change.
- Adding logic to exclude **_index** based on the length of allMatchedColumns.
- Changes unit test to handle exclusion of index.

Fixes #965  (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Running query on frontend for different combination of fields.
- Running all unit tests using command  ``` make all ```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
