### PR TITLE
Fix for same metric name in promql range query result

### DIFF
--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -507,7 +507,7 @@ func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQueryt
 			var result structs.Result
 			var keyValue []string
 			result.Metric = make(map[string]string)
-			result.Metric["__name__"] = mQuery.MetricName
+			result.Metric["__name__"] = ExtractMetricNameFromGroupID(grpId)
 			for idx, val := range tagValues {
 				if idx == 0 {
 					keyValue = strings.Split(removeMetricNameFromGroupID(val), ":")


### PR DESCRIPTION
# Description
Summarize the change.
Setting default metric name of mQuery does not work with multiple metric based queries. Need to set the metric name according to the grpId received in result, extract the proper metric name and set it for the PromQL response.

Fixes #<issue-number> (link all the GitHub issues this addresses)
Found this bug during query verification.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Sample query for testing
`avg({__name__=~'(usage_user|usage_system|usage_idle|usage_nice|usage_iowait|usage_irq|usage_softirq|usage_steal|usage_guest|usage_guest_nice)'}) by (__name__, hostname)`

Sample API:
`http://localhost:5122/promql/api/v1/query_range?query=avg({__name__=~'(usage_user|usage_system|usage_idle|usage_nice|usage_iowait|usage_irq|usage_softirq|usage_steal|usage_guest|usage_guest_nice)'}) by (__name__, hostname)&start=2024-06-08T00:00:00.000Z&end=2024-06-09T23:59:59.000Z&step=0`

Earlier it used to return a specific metric name picked up by the mQuery for all the results. Now, one should see proper combination of each metric name and hostname.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
