### PR TITLE
feat: Added support for Metrics regex query verification

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -1,77 +1,82 @@
-# This file is a test set of metrics data. The fields below represent: query, start time, end time, response values, equality operator
-testmetric0,now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
-avg(testmetric0),now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
-sum(testmetric0),now-90d,now,"9070.45749835234,8640.666886825056,14358.009326840405",approx
-min(testmetric0),now-90d,now,"-4836.743072493859,-4771.638626812088,-4957.837276049171",approx
-max(testmetric0),now-90d,now,"4962.256115780882,4869.595609262515,4966.760221461016",approx
-count(testmetric0),now-90d,now,"69,68,90",eq
-stddev(testmetric0),now-90d,now,"2956.5686988814973,2887.515395724927,2950.079510470293",approx
-stdvar(testmetric0),now-90d,now,"8741298.471205829,8337745.16054848,8702969.118096648",approx
-group(testmetric0),now-90d,now,"1,1,1",eq
-"quantile(0.99, testmetric0)",now-90d,now,"4910.231230895739,4854.385912657544,4902.289410864303",approx
-"quantile(0.5, testmetric0)",now-90d,now,"236.58630476741217,67.8161282783557,354.39816938476974",approx
-"testmetric1{car_type=""Passenger car compact""}",now-90d,now,"230.60590209835345,-610.0306020928656,-349.9374520340044",approx
-abs(testmetric1),now-90d,now,"564.0549536669834,213.038242129121,97.64336705133965",approx
-sqrt(testmetric1),now-90d,now-1d,"23.749841129299863,14.59582961428096",approx
-ceil(testmetric1),now-90d,now,"565,214,-97",eq
-floor(testmetric1),now-90d,now,"564,213,-98",eq
-round(testmetric0),now-90d,now,"131,127,160",eq
-"round(testmetric0, 1/2)",now-90d,now,"131.5,127,159.5",eq
-ln(testmetric1),now-90d,now-1d,"6.335151682331279,5.361471690106262",approx
-log2(testmetric1),now-90d,now-1d,"9.13969191537871,7.734968619182872",approx
-log10(testmetric1),now-90d,now-1d,"2.7513214176565772,2.3284575698936507",approx
-sgn(testmetric2),now-90d,now,"1,1,-1",eq
-deg(testmetric2),now-90d,now,"4773.30375818451,9009.097446091535,-31225.311733041086",approx
-rad(testmetric2),now-90d,now,"1.4540314746763654,2.744328018635429,-9.511773892154617",approx
-"clamp(testmetric3, -10, 100)",now-90d,now,"-10,-10,100",eq
-"clamp_max(testmetric3, 99)",now-90d,now,"-141.36081542523755,-61.650029946604214,99",approx
-"clamp_min(testmetric3, 0)",now-90d,now,"0,0,436.78052525807817",approx
-rate(testmetric3[48h]),now-90d,now,"0.0009225785356323297,0.003345725351176596",approx
-irate(testmetric3[48h]),now-90d,now,"0.0009225785356323284,0.005768872166720863",approx
-increase(testmetric3[48h]),now-90d,now,"159.42157095726634,578.1413406833158",approx
-delta(testmetric3[48h]),now-90d,now,"79.71078547863307,578.1413406833155",approx
-idelta(testmetric3[48h]),now-90d,now,"79.71078547863327,498.4305552046825",approx
-changes(testmetric4[24h]),now-90d,now,"0,1,1",eq
-resets(testmetric4[24h]),now-90d,now,"0,0,1",eq
-avg_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,218.74591670500848,62.71308845048587",approx
-min_over_time(testmetric4[24h]),now-90d,now,"199.18720427445191,199.18720427445191,-112.8784522345932",approx
-max_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.30462913556497,238.30462913556497",approx
-sum_over_time(testmetric4[24h]),now-90d,now,"199.18720427445197,437.49183341001685,125.42617690097171",approx
-"quantile_over_time(0.9, testmetric4[24h])",now-90d,now,"179.26848384700685,234.39288664945366,-77.76014409757737",approx
-stddev_over_time(testmetric4[24h]),now-90d,now,"0,19.55871243055644,175.59154068507908",approx
-stdvar_over_time(testmetric4[24h]),now-90d,now,"0,382.5432319412013,30832.389160159768",approx
-last_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.304629135565,-112.87845223459323",approx
-present_over_time(testmetric4[24h]),now-90d,now,"1,1,1",eq
-count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq
-avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx
-max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx
-changes(testmetric0[48h]),now-90d,now,"0,1,2",eq
-hour(testmetric0),now-90d,now,"24,24,24",lt
-hour(testmetric0),now-90d,now,"-1,-1,-1",gt
-minute(testmetric0),now-90d,now,"-1,-1,-1",gt
-minute(testmetric0),now-90d,now,"60,60,60",lt
-month(testmetric0),now-90d,now,"13,13,13",lt
-month(testmetric0),now-90d,now,"0,0,0",gt
-day_of_month(testmetric0),now-90d,now,"32,32,32",lt
-day_of_month(testmetric0),now-90d,now,"0,0,0",gt
-day_of_week(testmetric0),now-90d,now,"7,7,7",lt
-day_of_week(testmetric0),now-90d,now,"-1,-1,-1",gt
-day_of_year(testmetric0),now-90d,now,"367,367,367",lt
-day_of_year(testmetric0),now-90d,now,"0,0,0",gt
-days_in_month(testmetric0),now-90d,now,"32,32,32",lt
-days_in_month(testmetric0),now-90d,now,"27,27,27",gt
-"predict_linear(testmetric0[48h], 100)",now-7d,now,"127.06355282392336,159.54968553618554",approx
-"(testmetric0) > 132",now-90d,now,"159.53343696489338",approx
-"(testmetric0) >= 131",now-90d,now,"131.45590577322224,159.53343696489338",approx
-"(testmetric0) < 131",now-90d,now,"127.06863068860355",approx
-"(testmetric0) <= 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
-"(testmetric0) != 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx
-"(testmetric0) == 1000",now-90d,now,"",approx
-"132 < bool (testmetric0)",now-90d,now,"0,0,1",approx
-"(testmetric0) >= bool 131",now-90d,now,"1,0,1",approx
-"(testmetric0) < bool 131",now-90d,now,"0,1,0",approx
-"(testmetric0) <= bool 1000",now-90d,now,"1,1,1",approx
-"1000 != bool (testmetric0)",now-90d,now,"1,1,1",approx
-"(testmetric0) == bool 1000",now-90d,now,"0,0,0",approx
-"(testmetric0) ^ 2",now-90d,now,"17280.6551626583,16146.436905076764,25450.917509831666",approx
-"(testmetric0) % 10",now-90d,now,"1.4559057732223835,7.06863068860379,9.533436964893554",approx
+# This file is a test set of metrics data. The fields below represent: query, start time, end time, response values, equality operator, metricNames, tagFilters
+testmetric0,now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx,"",""
+avg(testmetric0),now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx,"",""
+sum(testmetric0),now-90d,now,"9070.45749835234,8640.666886825056,14358.009326840405",approx,"",""
+min(testmetric0),now-90d,now,"-4836.743072493859,-4771.638626812088,-4957.837276049171",approx,"",""
+max(testmetric0),now-90d,now,"4962.256115780882,4869.595609262515,4966.760221461016",approx,"",""
+count(testmetric0),now-90d,now,"69,68,90",eq,"",""
+stddev(testmetric0),now-90d,now,"2956.5686988814973,2887.515395724927,2950.079510470293",approx,"",""
+stdvar(testmetric0),now-90d,now,"8741298.471205829,8337745.16054848,8702969.118096648",approx,"",""
+group(testmetric0),now-90d,now,"1,1,1",eq,"",""
+"quantile(0.99, testmetric0)",now-90d,now,"4910.231230895739,4854.385912657544,4902.289410864303",approx,"",""
+"quantile(0.5, testmetric0)",now-90d,now,"236.58630476741217,67.8161282783557,354.39816938476974",approx,"",""
+"testmetric1{car_type=""Passenger car compact""}",now-90d,now,"230.60590209835345,-610.0306020928656,-349.9374520340044",approx,"",""
+abs(testmetric1),now-90d,now,"564.0549536669834,213.038242129121,97.64336705133965",approx,"",""
+sqrt(testmetric1),now-90d,now-1d,"23.749841129299863,14.59582961428096",approx,"",""
+ceil(testmetric1),now-90d,now,"565,214,-97",eq,"",""
+floor(testmetric1),now-90d,now,"564,213,-98",eq,"",""
+round(testmetric0),now-90d,now,"131,127,160",eq,"",""
+"round(testmetric0, 1/2)",now-90d,now,"131.5,127,159.5",eq,"",""
+ln(testmetric1),now-90d,now-1d,"6.335151682331279,5.361471690106262",approx,"",""
+log2(testmetric1),now-90d,now-1d,"9.13969191537871,7.734968619182872",approx,"",""
+log10(testmetric1),now-90d,now-1d,"2.7513214176565772,2.3284575698936507",approx,"",""
+sgn(testmetric2),now-90d,now,"1,1,-1",eq,"",""
+deg(testmetric2),now-90d,now,"4773.30375818451,9009.097446091535,-31225.311733041086",approx,"",""
+rad(testmetric2),now-90d,now,"1.4540314746763654,2.744328018635429,-9.511773892154617",approx,"",""
+"clamp(testmetric3, -10, 100)",now-90d,now,"-10,-10,100",eq,"",""
+"clamp_max(testmetric3, 99)",now-90d,now,"-141.36081542523755,-61.650029946604214,99",approx,"",""
+"clamp_min(testmetric3, 0)",now-90d,now,"0,0,436.78052525807817",approx,"",""
+rate(testmetric3[48h]),now-90d,now,"0.0009225785356323297,0.003345725351176596",approx,"",""
+irate(testmetric3[48h]),now-90d,now,"0.0009225785356323284,0.005768872166720863",approx,"",""
+increase(testmetric3[48h]),now-90d,now,"159.42157095726634,578.1413406833158",approx,"",""
+delta(testmetric3[48h]),now-90d,now,"79.71078547863307,578.1413406833155",approx,"",""
+idelta(testmetric3[48h]),now-90d,now,"79.71078547863327,498.4305552046825",approx,"",""
+changes(testmetric4[24h]),now-90d,now,"0,1,1",eq,"",""
+resets(testmetric4[24h]),now-90d,now,"0,0,1",eq,"",""
+avg_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,218.74591670500848,62.71308845048587",approx,"",""
+min_over_time(testmetric4[24h]),now-90d,now,"199.18720427445191,199.18720427445191,-112.8784522345932",approx,"",""
+max_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.30462913556497,238.30462913556497",approx,"",""
+sum_over_time(testmetric4[24h]),now-90d,now,"199.18720427445197,437.49183341001685,125.42617690097171",approx,"",""
+"quantile_over_time(0.9, testmetric4[24h])",now-90d,now,"179.26848384700685,234.39288664945366,-77.76014409757737",approx,"",""
+stddev_over_time(testmetric4[24h]),now-90d,now,"0,19.55871243055644,175.59154068507908",approx,"",""
+stdvar_over_time(testmetric4[24h]),now-90d,now,"0,382.5432319412013,30832.389160159768",approx,"",""
+last_over_time(testmetric4[24h]),now-90d,now,"199.18720427445206,238.304629135565,-112.87845223459323",approx,"",""
+present_over_time(testmetric4[24h]),now-90d,now,"1,1,1",eq,"",""
+count_over_time(testmetric4[24h]),now-90d,now,"1,2,2",eq,"",""
+avg_over_time(testmetric0[24h]),now-90d,now,"131.45590577322233,129.26226823091304,143.30103382674855",approx,"",""
+max_over_time(testmetric0[48h]),now-90d,now,"131.45590577322233,131.45590577322233,159.53343696489338",approx,"",""
+changes(testmetric0[48h]),now-90d,now,"0,1,2",eq,"",""
+hour(testmetric0),now-90d,now,"24,24,24",lt,"",""
+hour(testmetric0),now-90d,now,"-1,-1,-1",gt,"",""
+minute(testmetric0),now-90d,now,"-1,-1,-1",gt,"",""
+minute(testmetric0),now-90d,now,"60,60,60",lt,"",""
+month(testmetric0),now-90d,now,"13,13,13",lt,"",""
+month(testmetric0),now-90d,now,"0,0,0",gt,"",""
+day_of_month(testmetric0),now-90d,now,"32,32,32",lt,"",""
+day_of_month(testmetric0),now-90d,now,"0,0,0",gt,"",""
+day_of_week(testmetric0),now-90d,now,"7,7,7",lt,"",""
+day_of_week(testmetric0),now-90d,now,"-1,-1,-1",gt,"",""
+day_of_year(testmetric0),now-90d,now,"367,367,367",lt,"",""
+day_of_year(testmetric0),now-90d,now,"0,0,0",gt,"",""
+days_in_month(testmetric0),now-90d,now,"32,32,32",lt,"",""
+days_in_month(testmetric0),now-90d,now,"27,27,27",gt,"",""
+"predict_linear(testmetric0[48h], 100)",now-7d,now,"127.06355282392336,159.54968553618554",approx,"",""
+"(testmetric0) > 132",now-90d,now,"159.53343696489338",approx,"",""
+"(testmetric0) >= 131",now-90d,now,"131.45590577322224,159.53343696489338",approx,"",""
+"(testmetric0) < 131",now-90d,now,"127.06863068860355",approx,"",""
+"(testmetric0) <= 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx,"",""
+"(testmetric0) != 1000",now-90d,now,"131.45590577322224,127.06863068860355,159.53343696489338",approx,"",""
+"(testmetric0) == 1000",now-90d,now,"",approx,"",""
+"132 < bool (testmetric0)",now-90d,now,"0,0,1",approx,"",""
+"(testmetric0) >= bool 131",now-90d,now,"1,0,1",approx,"",""
+"(testmetric0) < bool 131",now-90d,now,"0,1,0",approx,"",""
+"(testmetric0) <= bool 1000",now-90d,now,"1,1,1",approx,"",""
+"1000 != bool (testmetric0)",now-90d,now,"1,1,1",approx,"",""
+"(testmetric0) == bool 1000",now-90d,now,"0,0,0",approx,"",""
+"(testmetric0) ^ 2",now-90d,now,"17280.6551626583,16146.436905076764,25450.917509831666",approx,"",""
+"(testmetric0) % 10",now-90d,now,"1.4559057732223835,7.06863068860379,9.533436964893554",approx,"",""
+"({__name__=~'testmetric.*'})",now-90d,now,"163.13171934207875,133.61927559580516,-20.18911392543914",approx,"*",""
+"avg ({__name__!~'testmetric(2)', fuel_type='LPG', color='maroon'}) by (__name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric3","color:maroon,fuel_type:LPG"
+"avg ({__name__=~'testmetric(0|1|2|3|4)', color='maroon'}) by (group, color, __name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric2,testmetric3,testmetric4","color:maroon,group:group 1,__,color:maroon,group:group 0"
+"avg ({__name__=~'testmetric(0|1|2|3|4)', color='maroon'}) by (group, color)",now-90d,now,"",approx,"*","color:maroon,group:group 1,__,color:maroon,group:group 0"
+"avg ({__name__=~'testmetric(2|3)', fuel_type='LPG', color=~'g.*'}) by (__name__)",now-90d,now,"",approx,"testmetric2,testmetric3","color:gray,fuel_type:LPG,__,color:green,fuel_type:LPG"

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -385,16 +385,15 @@ func applyMetricsOperatorOnSegments(mQuery *structs.MetricsQuery, allSearchReqes
 }
 
 func getRegexMatchedMetricNames(mSegSearchReq *structs.MetricsSearchRequest, regexPattern string, operator utils.TagOperator) ([]string, error) {
-	mNamesMap, err := series.GetAllMetricNames(mSegSearchReq.MetricsKeyBaseDir)
-	if err != nil {
-		return nil, err
-	}
+	var mNamesMap map[string]bool
+	var err error
 
 	if len(mSegSearchReq.UnrotatedMetricNames) > 0 {
-		for mName := range mSegSearchReq.UnrotatedMetricNames {
-			if _, ok := mNamesMap[mName]; !ok {
-				mNamesMap[mName] = true
-			}
+		mNamesMap = mSegSearchReq.UnrotatedMetricNames
+	} else {
+		mNamesMap, err = series.GetAllMetricNames(mSegSearchReq.MetricsKeyBaseDir)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/tools/sigclient/pkg/query/otsdbquery.go
+++ b/tools/sigclient/pkg/query/otsdbquery.go
@@ -35,6 +35,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const tagFilterSeparator string = ",__,"
+
 type metricsQueryTypes int
 
 // QueryRequest represents the request structure for the API
@@ -211,8 +213,8 @@ func RunMetricQueryFromFile(apiURL string, filepath string) {
 			return
 		}
 
-		if len(rec) != 5 {
-			log.Fatalf("RunQueryFromFile: Invalid number of columns in query file: [%v]. Expected 5", rec)
+		if len(rec) != 7 {
+			log.Fatalf("RunQueryFromFile: Invalid number of columns in query file: [%v]. Expected 7", rec)
 			return
 		}
 
@@ -221,8 +223,24 @@ func RunMetricQueryFromFile(apiURL string, filepath string) {
 		end := rec[2]
 		expectedValuesStr := rec[3]
 		relation := rec[4]
+		metricNames := rec[5]
+		tagFilters := rec[6]
 
 		expectedValuesStrs := strings.Split(expectedValuesStr, ",")
+
+		metricNamesMap := make(map[string]struct{})
+		if metricNames != "" {
+			for _, metricName := range strings.Split(metricNames, ",") {
+				metricNamesMap[metricName] = struct{}{}
+			}
+		}
+
+		tagFiltersMap := make(map[string]struct{})
+		if tagFilters != "" {
+			for _, tagFilter := range strings.Split(tagFilters, tagFilterSeparator) {
+				tagFiltersMap[tagFilter] = struct{}{}
+			}
+		}
 
 		requestBody := QueryRequest{
 			Start: start,
@@ -275,15 +293,66 @@ func RunMetricQueryFromFile(apiURL string, filepath string) {
 			}
 		}
 
-		for i, actualValue := range queryResponse.Values[0] {
-			isEqual, err := utils.VerifyInequality(actualValue, relation, expectedValuesStrs[i])
-			if !isEqual {
-				log.Fatalf("RunQueryFromFile: For Query=%v, Actual value: %v does not meet condition: [%s %v] at index %d", query, actualValue, relation, expectedValuesStrs[i], i)
-			} else if err != nil {
-				log.Fatalf("RunQueryFromFile: For Query=%v, Error in verifying results: %v", query, err)
+		if len(expectedValuesStr) > 0 {
+			for i, actualValue := range queryResponse.Values[0] {
+				isEqual, err := utils.VerifyInequality(actualValue, relation, expectedValuesStrs[i])
+				if !isEqual {
+					log.Fatalf("RunQueryFromFile: For Query=%v, Actual value: %v does not meet condition: [%s %v] at index %d", query, actualValue, relation, expectedValuesStrs[i], i)
+				} else if err != nil {
+					log.Fatalf("RunQueryFromFile: For Query=%v, Error in verifying results: %v", query, err)
+				}
+			}
+		}
+
+		actualMetricNames := make(map[string]struct{})
+		if len(metricNamesMap) > 0 {
+			for _, seriesId := range queryResponse.Series {
+				mName := ExtractMetricNameFromSeriesID(seriesId)
+				if _, exists := metricNamesMap[mName]; !exists {
+					log.Fatalf("RunQueryFromFile: Query: %v was successful. But the metric name: %v is not expected. Expected Metric Names: %v", query, mName, metricNamesMap)
+				}
+				actualMetricNames[mName] = struct{}{}
+			}
+
+			if len(actualMetricNames) != len(metricNamesMap) {
+				log.Fatalf("RunQueryFromFile: Query: %v was successful. But the query response metric names: %v do not match the expected metric names: %v", query, actualMetricNames, metricNamesMap)
+			}
+		}
+
+		actualTagFilters := make(map[string]struct{})
+		if len(tagFiltersMap) > 0 {
+			for _, seriesId := range queryResponse.Series {
+				tagKeyValue := ExtractTagKeyValuePairsFromSeriesId(seriesId)
+				if _, exists := tagFiltersMap[tagKeyValue]; !exists {
+					log.Fatalf("RunQueryFromFile: Query: %v was successful. But the tag key-value: %v is not expected. Expected Tag Key-Values: %v", query, tagKeyValue, tagFiltersMap)
+				}
+				actualTagFilters[tagKeyValue] = struct{}{}
+			}
+
+			if len(actualTagFilters) != len(tagFiltersMap) {
+				log.Fatalf("RunQueryFromFile: Query: %v was successful. But the query response tag key-values: %v do not match the expected tag key-values: %v", query, actualTagFilters, tagFiltersMap)
 			}
 		}
 
 		log.Printf("RunQueryFromFile: Query: %v was successful. Response matches expected values.", query)
+	}
+}
+
+func ExtractMetricNameFromSeriesID(seriesId string) string {
+	stringVals := strings.Split(seriesId, "{")
+	if len(stringVals) != 2 {
+		return seriesId
+	} else {
+		return stringVals[0]
+	}
+}
+
+func ExtractTagKeyValuePairsFromSeriesId(seriesId string) string {
+	stringVals := strings.Split(seriesId, "{")
+	if len(stringVals) != 2 {
+		return ""
+	} else {
+		// remove the trailing "}"
+		return stringVals[1][:len(stringVals[1])-1]
 	}
 }


### PR DESCRIPTION
# Description
- Updated `otsbdquery.go` with the support to verify regex queries.
- Updated `metrics_test.csv` with some of the regex queries.

# Testing
- Tested by running ingestion command in the circle ci config.
- And run the `metric_test.csv` query command.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
