### PR TITLE
Add prompt messages for metrics-explorer page

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsconsts.go
+++ b/pkg/integrations/prometheus/promql/metricsconsts.go
@@ -385,6 +385,62 @@ const metricFunctions = `[
 		"desc": "The value 1 for any series in the specified interval.", 
 		"eg": "present_over_time(avg (system.disk.used[5m]))",
 		"isTimeRangeFunc": true
+	},
+	{
+		"fn": "sum", 
+		"name": "Sum", 
+		"desc": "Calculate sum over dimensions.", 
+		"eg": "sum(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "min", 
+		"name": "Minimum", 
+		"desc": "Select minimum over dimensions.", 
+		"eg": "min(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "max", 
+		"name": "Maximum", 
+		"desc": "Select maximum over dimensions.", 
+		"eg": "max(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "avg", 
+		"name": "Average", 
+		"desc": "Calculate the average over dimensions.", 
+		"eg": "avg(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "group", 
+		"name": "Group", 
+		"desc": "All values in the resulting vector are 1.", 
+		"eg": "group(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "stddev", 
+		"name": "Standard deviation", 
+		"desc": "Calculate population standard deviation over dimensions.", 
+		"eg": "stddev(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "stdvar", 
+		"name": "Standard variance", 
+		"desc": "Calculate population standard variance over dimensions.", 
+		"eg": "stdvar(system.disk.used)",
+		"isTimeRangeFunc": false
+	},
+	{
+		"fn": "count", 
+		"name": "Count", 
+		"desc": "Count number of elements in the vector.", 
+		"eg": "count(system.disk.used)",
+		"isTimeRangeFunc": false
 	}
 ]`
 

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -374,7 +374,7 @@ async function initializeAutocomplete(queryElement, previousQuery = {}) {
         queryDetails.functions = previousQuery.functions.slice(); 
     }
 
-    var availableOptions = ["max by", "min by", "avg by", "sum by"];
+    var availableOptions = ["max by", "min by", "avg by", "sum by", "count by", "stddev by", "stdvar by", "group by"];
 
     var currentMetricsValue = queryElement.find('.metrics').val();
 


### PR DESCRIPTION
# Description
Add prompt messages for metrics-explorer page

However, we still do not support using queries that need extra parameters.
E.g: 
- topk(1, metric0)
- present_over_time(avg (system.disk.used[5m]))

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
