### PR TITLE
Fix: Prevent Editing of Default Dashboards

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -783,13 +783,12 @@
   align-items: flex-end;
   width: 80%;
   height: 15%;
-  font-size: 20px;
+  font-size: 18px;
 }
 
 .dbSet-textareaContainer {
   width: 80%;
   height: 70%;
-  margin-top: 1rem;
   position: relative;
 }
 
@@ -907,8 +906,8 @@
 
 .dbSet-name,.dbSet-heading{
   white-space: nowrap;
-  font-weight: 500;
-  font-size: 18px;
+  font-weight: 600;
+  font-size: 16px;
 }
 
 #metrics-query-language-btn{

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -3227,11 +3227,12 @@ float: right;
 .dbSet-textareaContainer .copy{
     background-image: url(../assets/copy-icon.svg);
     background-size: contain;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     position: absolute;
-    right: calc(20% + 20px);
-    top: 20px;
+    right: calc(20% + 10px);
+    top: 12px;
+    cursor: pointer;
 }
 
 [data-theme='dark'] .dbSet-textareaContainer .copy{
@@ -5095,6 +5096,7 @@ input.form-control {
 
 #delbutton.default-dashboard-delete:hover {
     background-image: url(../assets/dark-delete-icon-regular.svg);
+    cursor: not-allowed;
 }
 #data-ingestion .myOrg-heading{
     font-size: 16px;

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -649,7 +649,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </div>
     <div class="dbSet-container">
         <div class="dbSet-navBar">
-            <div>
+            <div class="d-flex align-items-center">
                 <span class="dbSet-goToDB" title="Go back">&#8592</span>
                 <span class="dbSet-name">DBName</span>
             </div>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -65,7 +65,12 @@ let measureInfo = [];
 let isTimechart = false;
 let isQueryBuilderSearch = false;
 let sortByTimestampAtDefault = true;
-
+let defaultDashboardIds = [
+    "10329b95-47a8-48df-8b1d-0a0a01ec6c42",
+    "a28f485c-4747-4024-bb6b-d230f101f852",
+    "bd74f11e-26c8-4827-bf65-c0b464e1f2a4",
+    "53cb3dde-fd78-4253-808c-18e4077ef0f1"
+];
 
 let aggGridOptions = {
     columnDefs: aggsColumnDefs,

--- a/static/js/dashboard-from-logs.js
+++ b/static/js/dashboard-from-logs.js
@@ -149,12 +149,6 @@ function displayExistingDashboards() {
         if (res) {
             let dropdown = $("#dashboard-options");
             // Filtering default dashboards
-            let defaultDashboardIds = [
-                "10329b95-47a8-48df-8b1d-0a0a01ec6c42",
-                "a28f485c-4747-4024-bb6b-d230f101f852",
-                "bd74f11e-26c8-4827-bf65-c0b464e1f2a4",
-                "53cb3dde-fd78-4253-808c-18e4077ef0f1"
-            ];
             let additionalDashboards = Object.keys(res).filter(id => !defaultDashboardIds.includes(id) && !existingDashboards.includes(id));
             if (additionalDashboards.length === 0 && existingDashboards.length === 0) {
                 // Add empty list item when there are no additional dashboards

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -26,6 +26,7 @@ let panelContainer;
 let panelContainerWidthGlobal;
 let originalIndexValues = [];
 let indexValues = [];
+let isDefaultDashboard = false;
 $(document).ready(async function () {
     let indexes = await getListIndices();
     if (indexes){
@@ -43,6 +44,10 @@ $(document).ready(async function () {
     $('.theme-btn').on('click', themePickerHandler);
     setupEventHandlers();
     dbId = getDashboardId();
+    if (defaultDashboardIds.includes(dbId)) {
+        isDefaultDashboard = true;
+        $('#save-db-btn, #add-panel-btn, #add-widget-options .editPanelMenu').hide();
+    }
 
     $("#add-panel-btn, .close-widget-popup").click(() => {
       
@@ -511,16 +516,26 @@ function displayPanels() {
 
     localPanels.forEach((localPanel) => {
         let idpanel = localPanel.panelId;
-        
-        var newItem = grid.addWidget(`<div class="grid-stack-item" id="${idpanel}"><div class="grid-stack-item-content"></div></div>`, {
+        let widgetOptions = {
             width: parseInt(localPanel.gridpos.w),
             height: parseInt(localPanel.gridpos.h),
             x: parseInt(localPanel.gridpos.y),
-            y: parseInt(localPanel.gridpos.x)
-        });
-        
+            y: parseInt(localPanel.gridpos.x),
+        };
+        if(isDefaultDashboard){
+            widgetOptions.noResize = true;
+            widgetOptions.noMove = true;
+        }
+        var newItem = grid.addWidget(`<div class="grid-stack-item" id="${idpanel}"><div class="grid-stack-item-content"></div></div>`,
+            widgetOptions
+        );
+        let panelDiv;
         // Append panel layout to the new grid-stack-item
-        var panelDiv = $("<div>").append(panelLayout).addClass("panel temp").attr("id", `panel${idpanel}`).attr("panel-index", localPanel.panelIndex);
+        if (isDefaultDashboard) {
+            panelDiv = $("<div>").append(defaultPanelLayout).addClass("panel temp").attr("id", `panel${idpanel}`).attr("panel-index", localPanel.panelIndex);
+        }else{
+            panelDiv = $("<div>").append(panelLayout).addClass("panel temp").attr("id", `panel${idpanel}`).attr("panel-index", localPanel.panelIndex);
+        }
         newItem.firstChild.appendChild(panelDiv[0]);
 
         $("#panel" + idpanel).on('mouseenter',function(){
@@ -622,8 +637,10 @@ function displayPanels() {
     if(allResultsDisplayed === 0) {
         $('body').css('cursor', 'default');
     }
-    
-    addDefaultPanel();
+    // Remove the Add Panel Widgets from the default dashboards
+    if (!isDefaultDashboard) {
+        addDefaultPanel();
+    }
 }   
 
 function showToast(msg) {
@@ -664,6 +681,21 @@ var panelLayout =
                 '<li data-value="remove" class="panel-remove-li"><span class="remove"></span>Remove</li>' +
                 '</ul>' +
             '</div>' +
+        '</div>' +
+    '</div>' +
+    `<div class="panel-body">
+    <div class="panEdit-panel"></div>
+    </div>
+    <div class="panel-info-corner"><i class="fa fa-info" aria-hidden="true" id="panel-desc-info"></i></div>
+`;
+
+var defaultPanelLayout =
+    '<div class="panel-header">' +
+        '<div>'+
+            '<p>Panel Title</p>'+
+        '</div>' +
+        '<div class="panel-icons">'+
+            '<div><img src="../assets/resize-icon.svg" alt="" class="panel-view-li" /></div>'+
         '</div>' +
     '</div>' +
     `<div class="panel-body">
@@ -882,8 +914,11 @@ function addDuplicatePanel(panelToDuplicate) {
     handlePanelRemove(idpanel);
     handlePanelDuplicate();
     $(`#panel${idpanel}`).get(0).scrollIntoView({ behavior: 'smooth' });
-
-    addDefaultPanel();
+    
+    // Remove the Add Panel Widgets from the default dashboards
+    if (!isDefaultDashboard) {
+        addDefaultPanel();
+    }
 }
 
 function addDefaultPanel(){
@@ -939,25 +974,12 @@ function handleDbSettings() {
         }), null, 2))
     })
 
-    $.ajax({
-        method: "get",
-        url: "api/dashboards/defaultlistall",
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'Accept': '*/*'
-        },
-        dataType: 'json',
-        crossDomain: true,
-    }).then(function (res) {
-        for (let [key, value] of Object.entries(res)) {
-            if (key == dbId ){
-                $(".dbSet-dbName").prop('readonly', true);
-                $('.dbSet-dbDescr').prop('readonly', true);
-		    
-                break
-            }
-        }
-    })
+    if (isDefaultDashboard) {
+        $(".dbSet-dbName").prop('readonly', true);
+        $('.dbSet-dbDescr').prop('readonly', true);
+
+        $('#dbSet-discard,#dbSet-save').hide();
+    }
 
     //get dashboard data from database
     $.ajax({

--- a/static/js/dashboards-home.js
+++ b/static/js/dashboards-home.js
@@ -228,14 +228,8 @@ class btnRenderer {
         this.starIcon=this.eGui.querySelector('.star-icon');
         this.starIcon.style.backgroundImage = favoriteDBsSet.has(params.data.uniqId) ? starFilledURL : starOutlineURL;
 
-		let defaultDashboardIds = [
-            "10329b95-47a8-48df-8b1d-0a0a01ec6c42",
-            "a28f485c-4747-4024-bb6b-d230f101f852",
-            "bd74f11e-26c8-4827-bf65-c0b464e1f2a4",
-            "53cb3dde-fd78-4253-808c-18e4077ef0f1"
-        ];
-
-        if (defaultDashboardIds.includes(params.data.uniqId)) {
+        //Disable delete for default dashboards
+		if (defaultDashboardIds.includes(params.data.uniqId)) {
             this.dButton.disabled = true;
             this.dButton.title = "Delete disabled";
 			this.dButton.classList.add('default-dashboard-delete'); 

--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -1404,6 +1404,9 @@ function toggleTableView() {
 
 
 function displayPanelView(panelIndex) {
+	if (isDefaultDashboard) { // Hide save and cancel button for default dashboard
+        $('.button-section, #edit-button').hide();
+    }
 	let panelLayout =`<div class="panel-body">
     <div class="panEdit-panel"></div>
     </div>

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -231,7 +231,10 @@ async function dashboardRangeItemHandler(evt){
             })
             
         displayPanels();
-        await updateDashboard();
+        // Don't update if its a default dashboard
+        if (!isDefaultDashboard) {
+            await updateDashboard();
+        }
     }
 }
 function resetCustomDateRange(){


### PR DESCRIPTION
# Description

- Default dashboards cannot be edited. 
- The "Add Panel" button and widget options have been removed, as well as the "Save Dashboard" button from the dashboard screen. 
- From the dashboard settings page, the "Discard" and "Save" buttons have been removed. 
- On the panel, the edit, clone, and delete icons have been removed, leaving only the view option. Also, panels are not resizable or draggable. 
- Changing the time range will not save the dashboards.

These changes apply only to default dashboards.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
