### PR TITLE
Spl functions

### DIFF
--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -1333,7 +1333,7 @@ func (self *NumericExpr) Evaluate(fieldToValue map[string]utils.CValueEnclosure)
 }
 
 func handleTrimFunctions(op string, value string, trim_chars string) string {
-	if (trim_chars == "") {
+	if trim_chars == "" {
 		trim_chars = "\t\n\v\f\r "
 	}
 	switch op {
@@ -1347,7 +1347,6 @@ func handleTrimFunctions(op string, value string, trim_chars string) string {
 		return value
 	}
 }
-
 
 func (self *TextExpr) EvaluateText(fieldToValue map[string]utils.CValueEnclosure) (string, error) {
 	// Todo: implement the processing logic for these functions:

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -357,8 +357,6 @@ func (self *BoolExpr) Evaluate(fieldToValue map[string]utils.CValueEnclosure) (b
 	case "searchmatch":
 		fallthrough
 	case "isnotnull":
-		fallthrough
-	case "isnum":
 		return false, fmt.Errorf("BoolExpr.Evaluate: does support using this operator: %v", self.ValueOp)
 	}
 
@@ -384,6 +382,14 @@ func (self *BoolExpr) Evaluate(fieldToValue map[string]utils.CValueEnclosure) (b
 			}
 
 			_, parseErr := strconv.Atoi(val)
+			return parseErr == nil, nil
+		} else if self.ValueOp == "isnum" {
+			val, err := self.LeftValue.EvaluateToString(fieldToValue)
+			if err != nil {
+				return false, err
+			}
+
+			_, parseErr := strconv.ParseFloat(val, 64)
 			return parseErr == nil, nil
 		} else if self.ValueOp == "isstr" {
 			_, floatErr := self.LeftValue.EvaluateToFloat(fieldToValue)
@@ -1326,6 +1332,23 @@ func (self *NumericExpr) Evaluate(fieldToValue map[string]utils.CValueEnclosure)
 	}
 }
 
+func handleTrimFunctions(op string, value string, trim_chars string) string {
+	if (trim_chars == "") {
+		trim_chars = "\t\n\v\f\r "
+	}
+	switch op {
+	case "ltrim":
+		return strings.TrimLeft(value, trim_chars)
+	case "rtrim":
+		return strings.TrimRight(value, trim_chars)
+	case "trim":
+		return strings.Trim(value, trim_chars)
+	default:
+		return value
+	}
+}
+
+
 func (self *TextExpr) EvaluateText(fieldToValue map[string]utils.CValueEnclosure) (string, error) {
 	// Todo: implement the processing logic for these functions:
 	switch self.Op {
@@ -1441,10 +1464,10 @@ func (self *TextExpr) EvaluateText(fieldToValue map[string]utils.CValueEnclosure
 	switch self.Op {
 	case "lower":
 		return strings.ToLower(cellValueStr), nil
-	case "ltrim":
-		return strings.TrimLeft(cellValueStr, self.StrToRemove), nil
-	case "rtrim":
-		return strings.TrimRight(cellValueStr, self.StrToRemove), nil
+	case "upper":
+		return strings.ToUpper(cellValueStr), nil
+	case "ltrim", "rtrim", "trim":
+		return handleTrimFunctions(self.Op, cellValueStr, self.StrToRemove), nil
 	case "urldecode":
 		decodedStr, decodeErr := url.QueryUnescape(cellValueStr)
 		if decodeErr != nil {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -753,12 +753,9 @@ var unsupportedEvalFuncs = map[string]struct{}{
 	"cluster":          {},
 	"getfields":        {},
 	"isnotnull":        {},
-	"isnum":            {},
 	"typeof":           {},
 	"replace":          {},
 	"spath":            {},
-	"upper":            {},
-	"trim":             {},
 }
 
 type StatsFuncChecker struct{}


### PR DESCRIPTION
# Description
Summarize the change.
Upper, Trim and IsNum SPL

Modified the code for ltrim and rtrim in case of no param as per splunk, leading and trailing spaces needs to be removed respectively. For trim the default case is to remove leading and trailing spaces from both sides.
If param is there use that for removal.
For checking multiple spaces, the evaluate functions is sending the correct data but UI seems to remove extra spaces (need to check with them). Node result has the correct value of string after query execution.

Upper and IsNum is implemented accordingly

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
```

city=Boston | stats count AS Count BY http_status | eval n = upper("abc")
city=Boston | eval up_city = upper("city")
* | eval up_city = upper(city)

city=Boston | stats count AS Count BY http_status | eval n = ltrim("zzzyyyyabczzyy", "zy")
city=Boston | stats count AS Count BY http_status | eval n = ltrim("         abczzyy")
city=Boston | stats count AS Count BY http_status | eval n = ltrim("a         abczzyy")
city=Boston | stats count AS Count BY http_status | eval n = ltrim(http_status, "2")

city=Boston | stats count AS Count BY http_status | eval n = rtrim("zzzyyyabczzyy", "zy")
city=Boston | stats count AS Count BY http_status | eval n = rtrim("zzzyyyabczzyy      ")
city=Boston | stats count AS Count BY http_status | eval n = rtrim("zzzyyyabczzyy      a")
city=Boston | stats count AS Count BY http_status | eval n = rtrim(http_status, "2")

city=Boston | stats count AS Count BY http_status | eval n = trim("zzzyyyabczzyy", "zy")
city=Boston | stats count AS Count BY http_status | eval n = trim("      zzzyyyabczzyy      ")
city=Boston | stats count AS Count BY http_status | eval n = trim("a      zzzyyyabczzyy      a")
city=Boston | stats count AS Count BY http_status | eval n = trim(http_status, "2")

city=Boston | stats count AS Count BY http_status | eval n = if(isnum(123), "yes", "no")
city=Boston | stats count AS Count BY http_status | eval n = if(isnum("123"), "yes", "no")
city=Boston | stats count AS Count BY http_status | eval n = if(isnum("123.12"), "yes", "no")
city=Boston | stats count AS Count BY http_status | eval n = if(isnum("123.12a"), "yes", "no")
city=Boston | eval n = if(isnum(city), "yes", "no")
city=Boston | eval n = if(isnum(ssn), "yes", "no")
city=Boston | eval n = if(isnum(latitude), "yes", "no")
city=Boston | eval n = if(isnum(app_version), "yes", "no")

```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
