### PR TITLE
Fix : Add Chart Type Popup (Dashboard)

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1293,6 +1293,9 @@ input:checked + .slider:before {
 .graph-customization{
   width: 320px;
 }
+#add-widget-options{
+  display: none;
+}
 #add-widget-options .editPanelMenu{
     width: 20%;
     padding: 10px 10px;
@@ -1439,7 +1442,6 @@ input:checked + .slider:before {
 .add-panel-div .plus-icon{
   font-size: 40px;
   color: var(--lavender-2);
-  display: none;
 }
 .add-panel-div .text{
   font-size: 15px;

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -154,9 +154,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             </div>
                         </div>
                     </div>
-                    <button class="btn active" id="add-panel-btn" title="Add panel">
+                    <button class="btn" id="add-panel-btn" title="Add panel">
                         <span>
-                            <img src="./assets/add-icon.svg" class="add-icon rotate-icon" alt="add icon "/> </span>Add Panel
+                            <img src="./assets/add-icon.svg" class="add-icon" alt="add icon "/> </span>Add Panel
                     </button>
                 </div>
             </div>

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -46,7 +46,7 @@ $(document).ready(async function () {
     dbId = getDashboardId();
     if (defaultDashboardIds.includes(dbId)) {
         isDefaultDashboard = true;
-        $('#save-db-btn, #add-panel-btn, #add-widget-options .editPanelMenu').hide();
+        $('#save-db-btn, #add-panel-btn').hide();
     }
 
     $("#add-panel-btn, .close-widget-popup").click(() => {
@@ -410,6 +410,15 @@ async function getDashboardData() {
         setFavoriteValue(dbData.isFavorite);
         updateTimeRangeForPanels();
         setRefreshItemHandler();
+
+        if (!(localPanels.length > 0)) {
+            $('.default-item').addClass('active');
+            $('#add-widget-options').toggle();
+            $('.add-icon').toggleClass('rotate-icon');
+            $('#add-panel-btn').toggleClass('active'); 
+            $('.default-item').find('.text').text('Select the panel type');
+            $('.plus-icon').hide();
+        }
     }
 }
 
@@ -922,16 +931,15 @@ function addDuplicatePanel(panelToDuplicate) {
 }
 
 function addDefaultPanel(){
-    var defaultItem = grid.addWidget(`<div class="grid-stack-item default-item active"><div class="add-panel-div">
+    var defaultItem = grid.addWidget(`<div class="grid-stack-item default-item"><div class="add-panel-div">
     <div class="plus-icon">+</div>
-    <div class="text">Select the Panel Type</div>
+    <div class="text">Add Panel</div>
     </div></div>`, 
     {   width: 4, 
         height:2,  
         noResize: true,
         noMove: true,
     });
-    $('#add-widget-options').show();
 }
 
 


### PR DESCRIPTION
# Description
If no panels the popup shows up -
<img width="1275" alt="image" src="https://github.com/siglens/siglens/assets/71771131/d88c47bb-7952-4b07-9194-3ba11c6fae9a">

If panels are present then the popup does not shows up -
<img width="1275" alt="image" src="https://github.com/siglens/siglens/assets/71771131/031eab41-e8ec-483b-a572-9415315f6e11">


Fixes #977

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
