### PR TITLE
Hide Available Fields Dropdown and Table View for `aggs` and `segstats` query

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -687,6 +687,7 @@ div.show-record-popup {
     position: relative;
     height: 100%;
     background: none;
+    display: none;
 }
 .tab-chart-list{
     height: 30px;
@@ -836,6 +837,7 @@ div.show-record-popup {
     padding: 40px;
     border-radius: 5px;
     color: var(--empty-response-text-color);
+    display: none;
 }
 #empty-response{
     display: none;

--- a/static/js/log-search.js
+++ b/static/js/log-search.js
@@ -65,6 +65,7 @@ $(document).ready(async () => {
         $('#run-filter-btn').html(' ');
         $("#query-builder-btn").html(" ");
         $("#custom-chart-tab").hide();
+        $('#initial-response').show();
     }
 
     $('body').css('cursor', 'default');

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -766,6 +766,7 @@
          if (res && res.hits && res.hits.totalMatched) {
              totalHits = res.hits.totalMatched
          }
+         $('#views-container').show();
     } else if (res.measure && (res.qtype === "aggs-query" || res.qtype === "segstats-query")) {
       let columnOrder =[]
         if (res.columnsOrder !=undefined && res.columnsOrder.length > 0) {
@@ -783,6 +784,7 @@
  
          aggsColumnDefs=[];
          segStatsRowData=[]; 
+         $('#views-container').hide();
          renderMeasuresGrid(columnOrder, res);
  
      }
@@ -902,6 +904,7 @@
          renderMeasuresGrid(columnOrder, res);
          if ((res.qtype ==="aggs-query" || res.qtype === "segstats-query") && res.bucketCount){
              totalHits = res.bucketCount;
+           $('#views-container').hide();
          }
      }else{
       measureInfo = [];


### PR DESCRIPTION
# Description
Since for Aggs and SegStats queries we do not show any available fields options or allow changing the view, I removed the dropdown and the table view option for these types of queries.
### Previously - 

<img width="1270" alt="image" src="https://github.com/siglens/siglens/assets/71771131/106d77db-d4be-41bb-b6bc-65520e0f3df7">

<img width="1429" alt="image" src="https://github.com/siglens/siglens/assets/71771131/961fe81f-8e57-4c25-95b4-00a61320ce9c">

### Now - 
<img width="1296" alt="image" src="https://github.com/siglens/siglens/assets/71771131/3829e6e3-3d06-46db-a218-2768a6f0fa48">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
