### PR TITLE
Fix: Proper Rendering of Line Breaks in Wrap View

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -589,6 +589,20 @@ function logOptionSingleHandler() {
         if (colDef.field === "logs"){
             colDef.cellStyle = null;
             colDef.autoHeight = null;
+            colDef.cellRenderer = function(params) {
+                const data = params.data || {};
+                let logString = '';
+                let counter = 0;
+                Object.entries(data)
+                    .filter(([key]) => key !== 'timestamp')
+                    .forEach(([key, value]) => {
+                        let colSep = counter > 0 ? '<span class="col-sep"> | </span>' : '';
+                        logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=${value}</span>`;
+                        counter++;
+                    });
+            
+                return `<div style="white-space: nowrap;">${logString}</div>`;
+            }; 
         }
     });
     gridOptions.api.setColumnDefs(logsColumnDefs);
@@ -614,6 +628,21 @@ function logOptionMultiHandler() {
             
             colDef.cellStyle = {'white-space': 'normal'};
             colDef.autoHeight = true;
+            colDef.cellRenderer = function(params) {
+                const data = params.data || {};
+                let logString = '';
+                let counter = 0;
+                Object.entries(data)
+                    .filter(([key]) => key !== 'timestamp')
+                    .forEach(([key, value]) => {
+                        let colSep = counter > 0 ? '<span class="col-sep"> | </span>' : '';
+                        let formattedValue = formatLogsValue(value);
+                        logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=${formattedValue}</span>`;
+                        counter++;
+                    });
+            
+                return `<div style="white-space: pre-wrap;">${logString}</div>`;
+            }; 
         }
     });
     gridOptions.api.setColumnDefs(logsColumnDefs);
@@ -628,6 +657,15 @@ function logOptionMultiHandler() {
     hideOrShowFieldsInLineViews();
     gridOptions.api.sizeColumnsToFit();
     Cookies.set('log-view', 'multi-line',  {expires: 365});
+}
+
+// Function to format logs value, replacing newlines with <br> tags
+function formatLogsValue(value) {
+    if (typeof value === 'string') {
+        return value.replace(/\n/g, '<br>');
+    } else {
+        return JSON.stringify(JSON.unflatten(value), null, 2);
+    }
 }
 
 function logOptionTableHandler() {

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -592,13 +592,13 @@ function logOptionSingleHandler() {
             colDef.cellRenderer = function(params) {
                 const data = params.data || {};
                 let logString = '';
-                let counter = 0;
+                let addSeparator = false;
                 Object.entries(data)
                     .filter(([key]) => key !== 'timestamp')
                     .forEach(([key, value]) => {
-                        let colSep = counter > 0 ? '<span class="col-sep"> | </span>' : '';
+                        let colSep = addSeparator ? '<span class="col-sep"> | </span>' : '';
                         logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=${value}</span>`;
-                        counter++;
+                        addSeparator = true;
                     });
             
                 return `<div style="white-space: nowrap;">${logString}</div>`;
@@ -631,14 +631,14 @@ function logOptionMultiHandler() {
             colDef.cellRenderer = function(params) {
                 const data = params.data || {};
                 let logString = '';
-                let counter = 0;
+                let addSeparator = false;
                 Object.entries(data)
                     .filter(([key]) => key !== 'timestamp')
                     .forEach(([key, value]) => {
-                        let colSep = counter > 0 ? '<span class="col-sep"> | </span>' : '';
+                        let colSep = addSeparator ? '<span class="col-sep"> | </span>' : '';
                         let formattedValue = formatLogsValue(value);
                         logString += `<span class="cname-hide-${string2Hex(key)}">${colSep}${key}=${formattedValue}</span>`;
-                        counter++;
+                        addSeparator = true;
                     });
             
                 return `<div style="white-space: pre-wrap;">${logString}</div>`;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -436,7 +436,12 @@
             tags.appendChild(tag);
           });
         }
-      $("#search-filter-text, #aggregate-attribute-text, #aggregations").hide();
+        if (thirdBoxSet.size > 0) $("#aggregations").hide();
+        else $("#aggregations").show();
+        if (secondBoxSet.size > 0) $("#aggregate-attribute-text").hide();
+        else $("#aggregate-attribute-text").show();
+        if (firstBoxSet.size > 0) $("#search-filter-text").hide();
+        else $("#search-filter-text").show();
       $("#filter-input").val(filterValue).change();
       isQueryBuilderSearch = true;
       }


### PR DESCRIPTION
# Description

1. In wrap line view, \n now correctly moves to the next line.
2. Fixed an issue where a single row result did not display correctly when switching from wrap to single view.
<img width="1296" alt="image" src="https://github.com/siglens/siglens/assets/71771131/4ea3dcaf-9aa8-49ff-a3c2-ffa26c972f5a">
<img width="1296" alt="image" src="https://github.com/siglens/siglens/assets/71771131/944520dc-797d-41d4-bc0b-278c4bc08458">

Previously - 
<img width="1294" alt="image" src="https://github.com/siglens/siglens/assets/71771131/77e2160b-d0cc-44e5-8030-ea47b72f6ad3">
