### PR TITLE
Fix: Prevent Overriding of boolNode.TimeRange when not nil

### DIFF
--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -54,12 +54,14 @@ func ParseRequest(searchText string, startEpoch, endEpoch uint64, qid uint64, qu
 		return nil, nil, err
 	}
 
-	tRange, err := ast.ParseTimeRange(startEpoch, endEpoch, queryAggs, qid)
-	if err != nil {
-		log.Errorf("qid=%d, ParseRequest: parseTimeRange error: %v", qid, err)
-		return nil, nil, err
+	if boolNode.TimeRange == nil {
+		tRange, err := ast.ParseTimeRange(startEpoch, endEpoch, queryAggs, qid)
+		if err != nil {
+			log.Errorf("qid=%d, ParseRequest: parseTimeRange error: %v", qid, err)
+			return nil, nil, err
+		}
+		boolNode.TimeRange = tRange
 	}
-	boolNode.TimeRange = tRange
 
 	//aggs
 	if queryAggs != nil {


### PR DESCRIPTION
# Description
Summarize the change.
TimeRange would come from parser we do not need to set it using timepicker if its present.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
```
Inserted data at Jun 19th, 2024 @ 18:55:35
Inserted data at Jun 19th, 2024 @ 19:19:19

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | earliest=04/19/2022:00:00:00 latest=04/27/2022:00:00:00

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | earliest=06/19/2024:18:55:00 latest=06/19/2024:18:56:00

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | earliest=06/19/2024:18:55:36 latest=06/19/2024:18:56:00

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | earliest=06/19/2024:19:19:18

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | earliest=06/19/2024:19:19:18 latest=06/19/2024:19:19:20

address = "4852 Lake Ridge port, Santa Ana, Nebraska 13548" | latest=06/19/2024:19:19:20

* | earliest=06/19/2024:00:00:20

* | earliest=06/19/2024:19:00:20
```


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
