### PR TITLE
feat: Updated the logic for Alert State Transition during Alert Evaluation based on Alert Eval Window

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -353,6 +353,33 @@
             "message": "Alert deleted successfully"
         }
 
+### Get Alert History For An Alert by AlertID
+    endpoint: /api/alerts/{alert_id}/history
+    method: GET
+
+    Query Params:
+        - sort_order: "DESC" / "ASC" (optional)
+        - limit: uint (optional)  // limit the number of results
+        - offset: uint (optional) // skip these number of results
+
+    Example:
+    request: http://localhost:5122/api/alerts/3a4a7c72-5195-4ab0-bf2f-0b8cac7a5bee/history?sort_order=DESC&limit=10&offset=5
+    response: 
+        {
+            "alertHistory": [
+                {
+                    "ID": 256,
+                    "alert_id": "3a4a7c72-5195-4ab0-bf2f-0b8cac7a5bee",
+                    "alert_type": 2,
+                    "alert_state": 2,
+                    "event_description": "Alert Pending",
+                    "user_name": "System Generated",
+                    "event_triggered_at": "2024-06-21T23:28:04.933045Z"
+                }
+            ],
+            "count": 1
+        }
+
 ### Get All Contacts
     endpoint: api/alerts/allContacts
     method: GET

--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -139,6 +139,11 @@ func ProcessCreateAlertRequest(ctx *fasthttp.RequestCtx, org_id uint64) {
 		return
 	}
 
+	if alertToBeCreated.EvalWindow < alertToBeCreated.EvalInterval {
+		utils.SendError(ctx, "EvalWindow should be greater than or equal to EvalInterval", fmt.Sprintf("EvalWindow: %v, EvalInterval:%v", alertToBeCreated.EvalWindow, alertToBeCreated.EvalInterval), nil)
+		return
+	}
+
 	// Validate Alert Type and Query
 	extraMsgToLog, err := validateAlertTypeAndQuery(&alertToBeCreated)
 	if err != nil {
@@ -340,6 +345,11 @@ func ProcessUpdateAlertRequest(ctx *fasthttp.RequestCtx) {
 	err := json.Unmarshal(rawJSON, &alertToBeUpdated)
 	if err != nil {
 		utils.SendError(ctx, "Failed to unmarshal json", "", err)
+		return
+	}
+
+	if alertToBeUpdated.EvalWindow < alertToBeUpdated.EvalInterval {
+		utils.SendError(ctx, "EvalWindow should be greater than or equal to EvalInterval", fmt.Sprintf("EvalWindow: %v, EvalInterval:%v", alertToBeUpdated.EvalWindow, alertToBeUpdated.EvalInterval), nil)
 		return
 	}
 

--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -223,7 +223,7 @@ func evaluateLogAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.Job) 
 
 	if isResultsEmpty {
 		// Should not return here, as this can mean, there are no valid logs that satisfies the Alert Query.
-		// This should be considered as a normal state. And we should update the alert state to Inactive.
+		// This should be considered as a normal state. And we should update the alert state to Normal.
 		log.Warnf("ALERTSERVICE: evaluateLogAlert: Empty response returned by server.")
 
 		// We should call the update here instead of letting the execution go to the evaluation of the conditions.
@@ -350,15 +350,15 @@ func evaluateMinionSearch(msToEvaluate *alertutils.MinionSearch, job gocron.Job)
 
 	if isResultsEmpty {
 		// Should not return here, as this can mean, there are no valid logs that satisfies the Alert Query.
-		// This should be considered as a normal state. And we should update the alert state to Inactive.
+		// This should be considered as a normal state. And we should update the alert state to Normal.
 		log.Warnf("MinionSearch: evaluate: Empty response returned by server.")
 
 		// We should call the update here instead of letting the execution go to the evaluation of the conditions.
 		// This is because, we return -1 as the result, when there are no logs that satisfies the query.
 		// And the condition in the evaluation can be looking for a value that is (>, <, =, !=) -1.
-		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Inactive, alertutils.AlertNormal)
+		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Normal, alertutils.AlertNormal)
 		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Inactive, msToEvaluate.AlertName, err)
+			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Normal, msToEvaluate.AlertName, err)
 		}
 		return
 	}
@@ -375,9 +375,9 @@ func evaluateMinionSearch(msToEvaluate *alertutils.MinionSearch, job gocron.Job)
 			return
 		}
 	} else {
-		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Inactive, alertutils.AlertNormal)
+		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Normal, alertutils.AlertNormal)
 		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Inactive, msToEvaluate.AlertName, err)
+			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Normal, msToEvaluate.AlertName, err)
 		}
 	}
 }

--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -104,6 +104,7 @@ func updateAlertStateAndCreateAlertHistory(alertDetails *alertutils.AlertDetails
 	alertEvent := alertutils.AlertHistoryDetails{
 		AlertId:          alertDetails.AlertId,
 		AlertType:        alertDetails.AlertType,
+		AlertState:       alertState,
 		EventDescription: eventDesc,
 		UserName:         alertutils.SystemGeneratedAlert,
 		EventTriggeredAt: time.Now().UTC(),
@@ -113,6 +114,109 @@ func updateAlertStateAndCreateAlertHistory(alertDetails *alertutils.AlertDetails
 		log.Errorf("ALERTSERVICE: updateAlertStateAndCreateAlertHistory: could not create alert event in alert history. found error = %v", err)
 		return err
 	}
+	return nil
+}
+
+// An Alert State can be updated to Firing, when the previous (IntervalCount - 1) Evaluations + Current Evaluation satisfies the conditions.
+// Meaning, the (IntervalCount - 1) evaluations and the current Evaluations State should be in either Pending or Firing.
+// The (IntervalCount - 1) evaluations will be Fetched from the AlertHistory Table.
+func shouldUpdateAlertStateToFiring(alertDetails *alertutils.AlertDetails, currentState alertutils.AlertState) bool {
+	if !alertutils.IsAlertStatePendingOrFiring(currentState) {
+		return false
+	}
+
+	intervalCount := alertDetails.EvalWindow / alertDetails.EvalInterval
+	if intervalCount == 0 {
+		log.Errorf("ALERTSERVICE: shouldUpdateAlertStateToFiring: EvalWindow=%v is less than EvalInterval=%v. Alert=%+v", alertDetails.EvalWindow, alertDetails.EvalInterval, alertDetails.AlertName)
+		return false
+	}
+
+	alertHistoryList, err := databaseObj.GetAlertHistoryByAlertID(&alertutils.AlertHistoryQueryParams{
+		AlertId:   alertDetails.AlertId,
+		Limit:     intervalCount - 1,
+		SortOrder: alertutils.DESC,
+	})
+	if err != nil {
+		log.Errorf("ALERTSERVICE: shouldUpdateAlertStateToFiring: Error getting AlertHistory. Alert=%+v & err=%+v.", alertDetails.AlertName, err)
+		return false
+	}
+
+	if len(alertHistoryList) < int(intervalCount-1) {
+		return false
+	}
+
+	for _, alertHistory := range alertHistoryList {
+		if !alertutils.IsAlertStatePendingOrFiring(alertHistory.AlertState) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func GetLatestAlertHistory(alertId string) (*alertutils.AlertHistoryDetails, error) {
+	alertHistoryList, err := databaseObj.GetAlertHistoryByAlertID(&alertutils.AlertHistoryQueryParams{
+		AlertId:   alertId,
+		Limit:     1,
+		SortOrder: alertutils.DESC,
+	})
+	if err != nil {
+		log.Errorf("ALERTSERVICE: GetLatestAlertHistory: Error getting AlertHistory. AlertId=%v & err=%+v.", alertId, err)
+		return nil, err
+	}
+
+	if len(alertHistoryList) == 0 {
+		return nil, nil
+	}
+
+	return alertHistoryList[0], nil
+}
+
+func handleAlertCondition(alertToEvaluate *alertutils.AlertDetails, isAlertConditionMatched bool, alertDataMessage string) error {
+	if isAlertConditionMatched {
+
+		newAlertState := alertutils.Pending
+		eventDesc := alertutils.AlertPending
+
+		if shouldUpdateAlertStateToFiring(alertToEvaluate, newAlertState) {
+			newAlertState = alertutils.Firing
+			eventDesc = alertutils.AlertFiring
+		}
+
+		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, newAlertState, eventDesc)
+		if err != nil {
+			log.Errorf("ALERTSERVICE: handleAlertCondition: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v", newAlertState, alertToEvaluate.AlertName, err)
+		}
+
+		// If the Alert State is updated to Firing, then we should send the Alert Notification.
+		// If the previous state was Firing, then the cooldown period on the Notification Handler will decide if the notification should be sent.
+		if newAlertState == alertutils.Firing {
+			err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, alertDataMessage)
+			if err != nil {
+				return fmt.Errorf("handleAlertCondition: Could not send Alert Notification. found error = %v", err)
+			}
+		}
+	} else {
+		lastAlertHistory, err := GetLatestAlertHistory(alertToEvaluate.AlertId)
+		if err != nil {
+			log.Errorf("handleAlertCondition: Error getting latest alert history. Alert=%+v & err=%+v", alertToEvaluate.AlertName, err)
+		}
+
+		err = updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Normal, alertutils.AlertNormal)
+		if err != nil {
+			log.Errorf("ALERTSERVICE: handleAlertCondition: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v", alertutils.Normal, alertToEvaluate.AlertName, err)
+		}
+
+		// If the previous state was Firing, then we should send the Alert Notification.
+		// The cooldown period on the Notification Handler will decide if the notification should be sent. So that false positives are avoided.
+		if lastAlertHistory != nil && lastAlertHistory.AlertState == alertutils.Firing {
+			err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, "The Alert State has been updated to Normal.")
+			if err != nil {
+				return fmt.Errorf("handleAlertCondition: Could not send Alert Notification. found error = %v", err)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -131,31 +235,18 @@ func evaluateLogAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.Job) 
 		// We should call the update here instead of letting the execution go to the evaluation of the conditions.
 		// This is because, we return -1 as the result, when there are no logs that satisfies the query.
 		// And the condition in the evaluation can be looking for a value that is (>, <, =, !=) -1.
-		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Inactive, alertutils.AlertNormal)
+		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Normal, alertutils.AlertNormal)
 		if err != nil {
 			log.Errorf("ALERTSERVICE: evaluateLogAlert: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Inactive, alertToEvaluate.AlertName, err)
 		}
 		return
 	}
 
-	isFiring := evaluateConditions(serResVal, &alertToEvaluate.Condition, alertToEvaluate.Value)
-	if isFiring {
+	isAlertConditionMatched := evaluateConditions(serResVal, &alertToEvaluate.Condition, alertToEvaluate.Value)
 
-		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Firing, alertutils.AlertFiring)
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateLogAlert: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Firing, alertToEvaluate.AlertName, err)
-		}
-
-		err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, "")
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateLogAlert: could not setup the notification handler. found error = %v", err)
-			return
-		}
-	} else {
-		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Inactive, alertutils.AlertNormal)
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateLogAlert: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Inactive, alertToEvaluate.AlertName, err)
-		}
+	err = handleAlertCondition(alertToEvaluate, isAlertConditionMatched, "")
+	if err != nil {
+		log.Errorf("ALERTSERVICE: evaluateLogAlert: Error in handleAlertCondition. Alert=%+v & err=%+v.", alertToEvaluate.AlertName, err)
 	}
 }
 
@@ -181,24 +272,12 @@ func evaluateMetricsAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.J
 
 	alertsDataList := evaluateMetricsQueryConditions(queryRes, &alertToEvaluate.Condition, alertToEvaluate.Value)
 
-	if len(alertsDataList) > 0 {
+	isAlertConditionMatched := len(alertsDataList) > 0
 
-		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Firing, alertutils.AlertFiring)
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMetricsAlert: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Firing, alertToEvaluate.AlertName, err)
-		}
+	err = handleAlertCondition(alertToEvaluate, isAlertConditionMatched, fmt.Sprintf("%v", alertsDataList))
 
-		err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, fmt.Sprintf("%v", alertsDataList))
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMetricsAlert: could not setup the notification handler. found error = %v", err)
-			return
-		}
-
-	} else {
-		err := updateAlertStateAndCreateAlertHistory(alertToEvaluate, alertutils.Inactive, alertutils.AlertNormal)
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMetricsAlert: Error in updateAlertStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Inactive, alertToEvaluate.AlertName, err)
-		}
+	if err != nil {
+		log.Errorf("ALERTSERVICE: evaluateMetricsAlert: Error in handleAlertCondition. Alert=%+v & err=%+v.", alertToEvaluate.AlertName, err)
 	}
 }
 
@@ -255,6 +334,7 @@ func updateMinionSearchStateAndCreateAlertHistory(msToEvaluate *alertutils.Minio
 	alertEvent := alertutils.AlertHistoryDetails{
 		AlertId:          msToEvaluate.AlertId,
 		AlertType:        alertutils.AlertTypeMinion,
+		AlertState:       alertState,
 		EventDescription: eventDesc,
 		UserName:         alertutils.SystemGeneratedAlert,
 		EventTriggeredAt: time.Now().UTC(),
@@ -297,7 +377,7 @@ func evaluateMinionSearch(msToEvaluate *alertutils.MinionSearch, job gocron.Job)
 
 		err = NotifyAlertHandlerRequest(msToEvaluate.AlertId, "")
 		if err != nil {
-			log.Errorf("MinionSearch: evaluate: could not setup the notification handler. found error = %v", err)
+			log.Errorf("MinionSearch: evaluate: Could not send Alert Notification. found error = %v", err)
 			return
 		}
 	} else {

--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -204,6 +204,7 @@ func handleAlertCondition(alertToEvaluate *alertutils.AlertDetails, isAlertCondi
 
 		// The Alert state is Normal, then we should send the Alert Notification.
 		// The cooldown period on the Notification Handler will decide if the notification should be sent. So that false positives are avoided.
+		// The Notification handler is expected to send the Normal State Notification, only if the previous Notification sent was Firing.
 		err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, "The Alert State has been updated to Normal.")
 		if err != nil {
 			return fmt.Errorf("handleAlertCondition: Could not send Alert Notification. found error = %v", err)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -79,14 +79,14 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 
 	query.InitQueryMetrics()
 
-	alertsHandler.InitAlertingService(server_utils.GetMyIds)
-	alertsHandler.InitMinionSearchService(server_utils.GetMyIds)
-
 	err := query.InitQueryNode(server_utils.GetMyIds, server_utils.ExtractKibanaRequests)
 	if err != nil {
 		log.Errorf("Failed to initialize query node: %v", err)
 		return err
 	}
+
+	alertsHandler.InitAlertingService(server_utils.GetMyIds)
+	alertsHandler.InitMinionSearchService(server_utils.GetMyIds)
 
 	hs.Router.GET("/{filename}.html", func(ctx *fasthttp.RequestCtx) {
 		renderHtmlTemplate(ctx, htmlTemplate)

--- a/static/js/all-alerts.js
+++ b/static/js/all-alerts.js
@@ -23,9 +23,10 @@ let alertGridDiv = null;
 let alertRowData = [];
 
 let mapIndexToAlertState=new Map([
-    [0,"Normal"],
-    [1,"Pending"],
-    [2,"Firing"],
+    [0, "Inactive"],
+    [1,"Normal"],
+    [2,"Pending"],
+    [3,"Firing"],
 ]);
 
 $(document).ready(function () {


### PR DESCRIPTION
# Description
- Updated the Alert state transition logic based on the Evaluations across the Eval window.
- State Transition Rules:
   - `Normal` to `Pending`: When an alert condition is matched.
   - `Pending` to `Firing`: When an alert condition is matched for all the last (Interval Count) Evaluations.
   - `Firing` to `Normal` / `Pending` to `Normal`: When an alert condition is not matched.

- `NotificationHandler` will be called to send an alert notification when:
     - The Alert is in `Firing` state or transitioned from `Pending` to `Firing` state.
     - ~~The Alert is Transitioned from `Firing` to `Normal` state (to let user know that the alert state reverted to Normal).~~
     - **UPDATE:** The Alert is in `Normal` state.

**NOTE**: The implementation of cooldown period on the `NotificationHandler` is expected to decide whether to accept or reject a notification request from Alert System. 
**UPDATE:** And the Notification System is expected to send the `Normal` state notification only if the previous Alert notification sent was `Firing`.

### Transition from `Pending` to `Firing`:
- Every time when the alert condition is matched, the Alert system will try to get the last (Interval Count -1) Alert History records from the DB. 
- Interval Count - 1. because, including the current matched one => Interval Count -1 + 1 = Interval Count.
- Once the records are fetched and the size matches (Interval Count - 1), then will check if for all these records, the alert state is in either `Pending` or `Firing`. 
- If `true`, then the state will be transitioned to `Firing`, otherwise, the state will remain in `Pending`.

### Updated the `GetAlertHistory` API
- To fetch the records by sending optional parameters like `offset`, `limit`, and `sort_order`.

### Refactoring:
- Refactored the code after an Alert Condition is evaluated.
- In `server.go` pushed the initiation the Alerting service to last (After `InitQueryMetrics` and `InitQueryNode`). This is because, the alerting service is getting initialized and started to fetch the data before the rotated segments are loaded into the memory buffer.

# Testing
- Tested by creating two test Alerts and verified the transitions from `Pending` to `Firing` and a Firing Alert Notification.
- Verified the Transition from `Firing` to `Normal` and a Normal update Alert Notification.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
