### PR TITLE
feat: Reject if Alert Logs Query is not a Stats Query + Update Notification Logic to send an alert based on AlertState

### DIFF
--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -191,7 +191,7 @@ func handleAlertCondition(alertToEvaluate *alertutils.AlertDetails, isAlertCondi
 		// If the Alert State is updated to Firing, then we should send the Alert Notification.
 		// If the previous state was Firing, then the cooldown period on the Notification Handler will decide if the notification should be sent.
 		if newAlertState == alertutils.Firing {
-			err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, alertDataMessage)
+			err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, newAlertState, alertDataMessage)
 			if err != nil {
 				return fmt.Errorf("handleAlertCondition: Could not send Alert Notification. found error = %v", err)
 			}
@@ -205,7 +205,7 @@ func handleAlertCondition(alertToEvaluate *alertutils.AlertDetails, isAlertCondi
 		// The Alert state is Normal, then we should send the Alert Notification.
 		// The cooldown period on the Notification Handler will decide if the notification should be sent. So that false positives are avoided.
 		// The Notification handler is expected to send the Normal State Notification, only if the previous Notification sent was Firing.
-		err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, "The Alert State has been updated to Normal.")
+		err = NotifyAlertHandlerRequest(alertToEvaluate.AlertId, alertutils.Normal, "The Alert State has been updated to Normal.")
 		if err != nil {
 			return fmt.Errorf("handleAlertCondition: Could not send Alert Notification. found error = %v", err)
 		}
@@ -369,7 +369,7 @@ func evaluateMinionSearch(msToEvaluate *alertutils.MinionSearch, job gocron.Job)
 			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Firing, msToEvaluate.AlertName, err)
 		}
 
-		err = NotifyAlertHandlerRequest(msToEvaluate.AlertId, "")
+		err = NotifyAlertHandlerRequest(msToEvaluate.AlertId, alertutils.Firing, "")
 		if err != nil {
 			log.Errorf("MinionSearch: evaluate: Could not send Alert Notification. found error = %v", err)
 			return

--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -35,27 +35,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func NotifyAlertHandlerRequest(alertID string, alertDataMessage string) error {
+func NotifyAlertHandlerRequest(alertID string, alertState alertutils.AlertState, alertDataMessage string) error {
 	if alertID == "" {
 		log.Errorf("NotifyAlertHandlerRequest: Missing alert_id")
 		return errors.New("alert ID is empty")
 	}
-	cooldownOver, err := isCooldownOver(alertID)
+
+	shouldSend, err := shouldSendNotification(alertID, alertState)
 	if err != nil {
-		log.Errorf("NotifyAlertHandlerRequest:Error checking cooldown period for alert id- %s, err=%v", alertID, err)
+		log.Errorf("NotifyAlertHandlerRequest:Error checking if notification should be sent for alert id- %s, err=%v", alertID, err)
 		return err
 	}
-	if !cooldownOver {
+	if !shouldSend {
 		return nil
 	}
-	silenceMinutesOver, err := isSilenceMinutesOver(alertID)
-	if err != nil {
-		log.Errorf("NotifyAlertHandlerRequest:Error checking silence period for alert id- %s, err=%v", alertID, err)
-		return err
-	}
-	if !silenceMinutesOver {
-		return nil
-	}
+
 	contact_id, message, subject, err := processGetContactDetails(alertID)
 	if err != nil {
 		log.Errorf("NotifyAlertHandlerRequest:Error retrieving contact and message for alert id- %s, err=%v", alertID, err)
@@ -105,12 +99,42 @@ func NotifyAlertHandlerRequest(alertID string, alertDataMessage string) error {
 
 	}
 
-	err = processUpdateLastSentTime(alertID)
+	err = processUpdateLastSentTimeAndAlertState(alertID, alertState)
 	if err != nil {
 		log.Errorf("NotifyAlertHandlerRequest:Error updating last sent time for alert_id- %s, err=%v", alertID, err)
 		return err
 	}
 	return nil
+}
+
+// shouldSendNotification checks if the notification should be sent based on the cooldown period and silence minutes
+// If the last alert state is normal and the current alert state is also normal, then we should not send the notification
+func shouldSendNotification(alertID string, currentAlertState alertutils.AlertState) (bool, error) {
+	alertNotification, err := processGetAlertNotification(alertID)
+	if err != nil {
+		log.Errorf("shouldSendNotification:Error getting alert notification details for alert id- %s, err=%v", alertID, err)
+		return false, err
+	}
+
+	if alertNotification.LastAlertState == currentAlertState && currentAlertState == alertutils.Normal {
+		// If the current alert state is normal and the last alert notfication state is also normal, then we should not send the notification
+		return false, nil
+	}
+
+	cooldownOver := isCooldownOver(alertNotification.CooldownPeriod, alertNotification.LastSentTime)
+	if !cooldownOver {
+		return false, nil
+	}
+	silenceMinutesOver, err := isSilenceMinutesOver(alertID, alertNotification.LastSentTime)
+	if err != nil {
+		log.Errorf("NotifyAlertHandlerRequest:Error checking silence period for alert id- %s, err=%v", alertID, err)
+		return false, err
+	}
+	if !silenceMinutesOver {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func sendAlertEmail(emailID, subject, message string, alertDataMessage string) error {
@@ -159,8 +183,8 @@ func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string) 
 	return err
 }
 
-func isSilenceMinutesOver(alertID string) (bool, error) {
-	silenceMinutes, lastSendTime, err := processGetSilenceMinutesRequest(alertID)
+func isSilenceMinutesOver(alertID string, lastSendTime time.Time) (bool, error) {
+	silenceMinutes, err := processGetSilenceMinutesRequest(alertID)
 
 	if lastSendTime.IsZero() {
 		return true, nil
@@ -179,24 +203,15 @@ func isSilenceMinutesOver(alertID string) (bool, error) {
 	return false, nil
 }
 
-func isCooldownOver(alertID string) (bool, error) {
-	cooldownMinutes, lastSendTime, err := processGetCooldownRequest(alertID)
-
+func isCooldownOver(cooldownMinutes uint64, lastSendTime time.Time) bool {
 	if lastSendTime.IsZero() {
-		return true, nil
-	}
-
-	if err != nil {
-		return false, err
+		return true
 	}
 
 	currentTimeUTC := time.Now().UTC()
 	lastSendTimeUTC := lastSendTime.UTC()
 	cooldownDuration := time.Duration(cooldownMinutes) * time.Minute
-	if currentTimeUTC.Sub(lastSendTimeUTC) >= cooldownDuration {
-		return true, nil
-	}
-	return false, nil
+	return currentTimeUTC.Sub(lastSendTimeUTC) >= cooldownDuration
 }
 
 func sendSlack(alertName string, message string, channel alertutils.SlackTokenConfig, alertDataMessage string) error {
@@ -233,29 +248,23 @@ func sendSlack(alertName string, message string, channel alertutils.SlackTokenCo
 	return err
 }
 
-func processGetCooldownRequest(alert_id string) (uint64, time.Time, error) {
-	period, last_time, err := databaseObj.GetCoolDownDetails(alert_id)
+func processGetAlertNotification(alert_id string) (*alertutils.Notification, error) {
+	alertNotification, err := databaseObj.GetAlertNotification(alert_id)
 	if err != nil {
-		log.Errorf("ProcessGetCooldownRequest:Error getting cooldown details for alert id- %s err=%v", alert_id, err)
-		return 0, time.Time{}, err
+		log.Errorf("ProcessGetAlertNotification:Error getting alert notification details for alert id- %s err=%v", alert_id, err)
+		return nil, err
 	}
-	return period, last_time, nil
+	return alertNotification, nil
 }
 
-func processGetSilenceMinutesRequest(alert_id string) (uint64, time.Time, error) {
+func processGetSilenceMinutesRequest(alert_id string) (uint64, error) {
 	alertDataObj, err := databaseObj.GetAlert(alert_id)
 	if err != nil {
 		log.Errorf("ProcessGetSilenceMinutesRequest:Error getting alert details for alert id- %s err=%v", alert_id, err)
-		return 0, time.Time{}, err
+		return 0, err
 	}
 
-	_, last_time, err := databaseObj.GetCoolDownDetails(alert_id)
-	if err != nil {
-		log.Errorf("ProcessGetSilenceMinutesRequest:Error getting cooldown details for alert id- %s err=%v", alert_id, err)
-		return 0, time.Time{}, err
-	}
-
-	return alertDataObj.SilenceMinutes, last_time, nil
+	return alertDataObj.SilenceMinutes, nil
 }
 func processGetContactDetails(alert_id string) (string, string, string, error) {
 	id, message, subject, err := databaseObj.GetContactDetails(alert_id)
@@ -276,10 +285,10 @@ func processGetEmailAndChannelID(contact_id string) ([]string, []alertutils.Slac
 	return emails, slacks, webhook, nil
 }
 
-func processUpdateLastSentTime(alert_id string) error {
-	err := databaseObj.UpdateLastSentTime(alert_id)
+func processUpdateLastSentTimeAndAlertState(alert_id string, alertState alertutils.AlertState) error {
+	err := databaseObj.UpdateLastSentTimeAndAlertState(alert_id, alertState)
 	if err != nil {
-		log.Errorf("ProcessUpdateLastSentTime: Unable to update last_sent_time for alert_id- %s, err=%v", alert_id, err)
+		log.Errorf("processUpdateLastSentTimeAndAlertState: Unable to update last_sent_time for alert_id- %s, err=%v", alert_id, err)
 		return err
 	}
 	return nil

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -468,6 +468,14 @@ func (p Sqlite) GetCoolDownDetails(alert_id string) (uint64, time.Time, error) {
 	return cooldown_period, last_sent_time, nil
 }
 
+func (p Sqlite) GetAlertNotification(alert_id string) (*alertutils.Notification, error) {
+	var notification alertutils.Notification
+	if err := p.db.Where("alert_id = ?", alert_id).First(&notification).Error; err != nil {
+		return nil, err
+	}
+	return &notification, nil
+}
+
 func (p Sqlite) DeleteContactPoint(contact_id string) error {
 	if !isValid(contact_id) {
 		log.Errorf("DeleteContactPoint: data validation check failed, contact id: %v", contact_id)
@@ -512,13 +520,21 @@ func (p Sqlite) DeleteContactPoint(contact_id string) error {
 	return nil
 }
 
-// update last_sent_time in notification_details table
-func (p Sqlite) UpdateLastSentTime(alert_id string) error {
+// update last_sent_time and last_alert_state in notification_details table
+func (p Sqlite) UpdateLastSentTimeAndAlertState(alert_id string, alertState alertutils.AlertState) error {
 	currentTime := time.Now().UTC()
-	if err := p.db.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).Update("last_sent_time", currentTime).Error; err != nil {
-		log.Errorf("UpdateLastSentTime: unable to UpdateLastSentTime, alert id: %v, err: %+v", alert_id, err)
-		return fmt.Errorf("UpdateLastSentTime: unable to UpdateLastSentTime, alert id: %v, err: %+v", alert_id, err)
+
+	// Updating both last_sent_time and last_alert_state
+	if err := p.db.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).
+		Updates(map[string]interface{}{
+			"last_sent_time":   currentTime,
+			"last_alert_state": alertState,
+		}).Error; err != nil {
+		err = fmt.Errorf("UpdateLastSentTimeAndAlertState: unable to update, alert id: %v, err: %+v", alert_id, err)
+		log.Errorf(err.Error())
+		return err
 	}
+
 	return nil
 }
 

--- a/pkg/alerts/alertutils/alertutils.go
+++ b/pkg/alerts/alertutils/alertutils.go
@@ -145,10 +145,11 @@ func (WebHookConfig) TableName() string {
 }
 
 type Notification struct {
-	NotificationId string    `json:"notification_id" gorm:"primaryKey"`
-	CooldownPeriod uint64    `json:"cooldown_period"`
-	LastSentTime   time.Time `json:"last_sent_time"`
-	AlertId        string    `json:"-"`
+	NotificationId string     `json:"notification_id" gorm:"primaryKey"`
+	CooldownPeriod uint64     `json:"cooldown_period"`
+	LastSentTime   time.Time  `json:"last_sent_time"`
+	AlertId        string     `json:"-"`
+	LastAlertState AlertState `json:"last_alert_state"`
 }
 
 func (Notification) TableName() string {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -986,3 +986,23 @@ func (br *BucketResult) SetBucketValueForGivenField(fieldName string, value inte
 
 	return nil
 }
+
+func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
+	if qa == nil {
+		return false
+	}
+
+	if qa.GroupByRequest != nil {
+		return true
+	}
+
+	if qa.MeasureOperations != nil {
+		return true
+	}
+
+	if qa.Next != nil {
+		return qa.Next.IsStatsAggPresentInChain()
+	}
+
+	return false
+}

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -257,6 +257,9 @@ function createNewAlertRule(alertData){
 
 // update alert rule
 function updateAlertRule(alertData){
+    if (!alertData.alert_type) {
+        alertData.alert_type = 1;
+    }
         $.ajax({
         method: "post",
         url: "api/alerts/update",


### PR DESCRIPTION
# Description
- Added a check to verify whether the given Logs query is a stats query or not and reject if it is not a stats query.
- Updated the Notification system logic to keep track of Last Alert state when the last notification is sent and based on that along with cooldown and silence minutes, a notification will be sent.
    - The Notification will not be sent if the last notification alert state is `Normal` and the current state is also `Normal`.

# Testing
- Tested by creating two notifications one for logs and other for Metrics.
- Verified that they are sending the notifications when the state is in `Firing` and when the state is transitioned from `Firing` to `Normal`.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
