### PR TITLE
refac: Allow update of Alert type for an Alert

### DIFF
--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -289,11 +289,6 @@ func (p Sqlite) UpdateAlert(editedAlert *alertutils.AlertDetails) error {
 		}
 	}
 
-	if currentAlertData.AlertType > 0 && editedAlert.AlertType != currentAlertData.AlertType {
-		log.Errorf("UpdateAlert: alert type cannot be updated for alert: %v. Given AlertType=%v, Expected AlertType=%v", editedAlert.AlertName, editedAlert.AlertType, currentAlertData.AlertType)
-		return fmt.Errorf("UpdateAlert: alert type cannot be updated for alert: %v. Given AlertType=%v, Expected AlertType=%v", editedAlert.AlertName, editedAlert.AlertType, currentAlertData.AlertType)
-	}
-
 	if editedAlert.AlertType == alertutils.AlertTypeLogs {
 		if !isValid(editedAlert.QueryParams.QueryText) {
 			log.Errorf("UpdateAlert: data validation check failed for alert: %v. Alert Query is not Valid: %v", editedAlert.AlertName, editedAlert.QueryParams.QueryText)


### PR DESCRIPTION
# Description
- Removes the restriction to update the `AlertType` for an Alert.


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
