### PR TITLE
Alert notifications on Slack computes color based on the alert state

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -245,7 +245,7 @@ func ProcessTestContactPointRequest(ctx *fasthttp.RequestCtx) {
 			ChannelId: channelID,
 			SlToken:   slackToken,
 		}
-		err := sendSlack("Test Alert", "This is a test message to verify the Slack integration.", channel, "")
+		err := sendSlack("Test Alert", "This is a test message to verify the Slack integration.", channel, alertutils.Normal, "")
 		if err != nil {
 			utils.SendError(ctx, err.Error(), "Error sending test message to slack. Request Body:"+string(ctx.PostBody()), err)
 			return

--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -75,7 +75,7 @@ func NotifyAlertHandlerRequest(alertID string, alertState alertutils.AlertState,
 	}
 	if len(channelIDs) > 0 {
 		for _, channelID := range channelIDs {
-			err = sendSlack(subject, message, channelID, alertDataMessage)
+			err = sendSlack(subject, message, channelID, alertState, alertDataMessage)
 			if err != nil {
 				log.Errorf("NotifyAlertHandlerRequest: Error sending Slack message to channelID- %v for alert id- %v, err=%v", channelID, alertID, err)
 			} else {
@@ -220,17 +220,25 @@ func isCooldownOver(cooldownMinutes uint64, lastSendTime time.Time) bool {
 	return currentTimeUTC.Sub(lastSendTimeUTC) >= cooldownDuration
 }
 
-func sendSlack(alertName string, message string, channel alertutils.SlackTokenConfig, alertDataMessage string) error {
+func getSlackMessageColor(alertState alertutils.AlertState) string {
+	if alertState == alertutils.Normal {
+		return "#00FF00"
+	}
+	return "#FF0000"
+}
+
+func sendSlack(alertName string, message string, channel alertutils.SlackTokenConfig, alertState alertutils.AlertState, alertDataMessage string) error {
 
 	channelID := channel.ChannelId
 	token := channel.SlToken
 	alert := fmt.Sprintf("Alert Name : '%s'", alertName)
 	client := slack.New(token, slack.OptionDebug(false))
+	color := getSlackMessageColor(alertState)
 
 	attachment := slack.Attachment{
 		Pretext: alert,
 		Text:    message,
-		Color:   "#FF0000",
+		Color:   color,
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Date",


### PR DESCRIPTION
# Description
Summarize the change.

Fixes #1194 

# Testing
I ran the server locally and tried with the "Test" button on the "Contact Points" page, and verified that the color of the notification changed depending on the state.

Alert with a Firing state:
<img width="436" alt="image" src="https://github.com/siglens/siglens/assets/2202231/4f4da89f-6fa4-401d-8a97-7cea45ed0def">

Alert with a Normal state:
<img width="400" alt="image" src="https://github.com/siglens/siglens/assets/2202231/1c772198-dccc-4c93-bb01-77ae8d490061">


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
