### PR TITLE
fix: Measure val nil for Alerting

### DIFF
--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -131,6 +131,10 @@ func shouldUpdateAlertStateToFiring(alertDetails *alertutils.AlertDetails, curre
 		return false
 	}
 
+	if intervalCount == 1 {
+		return true
+	}
+
 	alertHistoryList, err := databaseObj.GetAlertHistoryByAlertID(&alertutils.AlertHistoryQueryParams{
 		AlertId:   alertDetails.AlertId,
 		Limit:     intervalCount - 1,

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -301,8 +301,10 @@ func ProcessAlertsPipeSearchRequest(queryParams alertutils.QueryParams) (int, bo
 		if httpRespOuter.MeasureResults != nil && len(httpRespOuter.MeasureResults) > 0 && httpRespOuter.MeasureResults[0].MeasureVal != nil {
 			measureValAsAny := httpRespOuter.MeasureResults[0].MeasureVal[httpRespOuter.MeasureFunctions[0]]
 			if measureValAsAny == nil {
-				log.Warnf("ALERTSERVICE: ProcessAlertsPipeSearchRequest: MeasureVal is nil. Measure Results: %v", *httpRespOuter.MeasureResults[0])
-				return -1, true, nil
+				// The Measure results is not empty, but the MeasureVal is nil. This is a valid case.
+				// It means that the measure value is 0.
+				log.Warnf("ALERTSERVICE: ProcessAlertsPipeSearchRequest: MeasureVal is nil. Considering the Measure Value as 0. Measure Results: %v", *httpRespOuter.MeasureResults[0])
+				return 0, false, nil
 			}
 			measureVal := fmt.Sprintf("%v", measureValAsAny) // convert to string. The iMeasureVal can be a string, float64, int, etc.
 			measureVal = strings.ReplaceAll(measureVal, ",", "")

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -54,9 +54,10 @@ let mapIndexToConditionType = new Map([
 ]);
 
 let mapIndexToAlertState = new Map([
-    [0, "Normal"],
-    [1, "Pending"],
-    [2, "Firing"],
+    [0, "Inactive"],
+    [1, "Normal"],
+    [2, "Pending"],
+    [3, "Firing"],
 ]);
 
 const alertForm = $('#alert-form');


### PR DESCRIPTION
# Description
- Fixed the case where Measure Results exists but the value is nil. The value is considered as `0`.

Fixes #1195 #1197 

# Testing
- Tested by creating a similar query that results in Measure Val as Nil. And verified that the alert is being triggered.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
