### PR TITLE
Improve slack alert notification

### DIFF
--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/smtp"
 	"strconv"
@@ -226,32 +225,27 @@ func sendSlack(alertName string, message string, channel alertutils.SlackTokenCo
 
 	channelID := channel.ChannelId
 	token := channel.SlToken
-	alert := fmt.Sprintf("Alert Name : '%s'", alertName)
 	client := slack.New(token, slack.OptionDebug(false))
 	color := getSlackMessageColor(alertState)
 
 	attachment := slack.Attachment{
-		Pretext: alert,
-		Text:    message,
-		Color:   color,
-		Fields: []slack.AttachmentField{
-			{
-				Title: "Date",
-				Value: time.Now().String(),
-			},
-		},
+		AuthorName: alertName,
+		Text:       message,
+		Color:      color,
+		Ts:         json.Number(strconv.FormatInt(time.Now().Unix(), 10)),
 	}
 
 	if alertDataMessage != "" {
-		attachment.Fields = append(attachment.Fields, slack.AttachmentField{
-			Title: "Alert Data",
-			Value: alertDataMessage,
-		})
+		attachment.Fields = []slack.AttachmentField{
+			{
+				Title: "Alert Data",
+				Value: alertDataMessage,
+			},
+		}
 	}
 
 	_, _, err := client.PostMessage(
 		channelID,
-		slack.MsgOptionText("New message from Alert System", false),
 		slack.MsgOptionAttachments(attachment),
 	)
 	return err


### PR DESCRIPTION
# Description
Improve slack alert notification:
- Reduce text
- Move alert name to the top with strong text
- Make the date more readable and move it to the bottom

**Old alert notification:**
![image](https://github.com/siglens/siglens/assets/2202231/e995adb1-bacd-4665-b615-ba64307e685c)

**New alert notification:**
![image](https://github.com/siglens/siglens/assets/2202231/283b4eb0-c1a5-4625-b60b-19d5454af4e8)

**Old alert recovery notification:**
![image](https://github.com/siglens/siglens/assets/2202231/3ef5df06-34f8-4322-8dfc-6568820c7000)

**New alert recovery notification:**
![image](https://github.com/siglens/siglens/assets/2202231/7d4f4fa5-491e-4e1b-b81c-912133b748bd)

**Old test notification:**
![image](https://github.com/siglens/siglens/assets/2202231/ab08c6a2-e723-489a-804c-feb33f75206b)

**New test notification:**
![image](https://github.com/siglens/siglens/assets/2202231/d507c7b6-29e5-4d47-b6ae-53914faf2fd6)

# Testing
Tested the notification locally.

# Checklist:
- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
