### PR TITLE
feat: remove automatic cleanup and added it as a command option

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -169,7 +169,14 @@ var alertsLoadTestCmd = &cobra.Command{
 		destHost, _ := cmd.Flags().GetString("dest")
 		numAlerts, _ := cmd.Flags().GetUint64("numAlerts")
 		runVector, _ := cmd.Flags().GetInt8("runVector")
+		cleanup, _ := cmd.Flags().GetBool("cleanup")
 		log.Infof("destHost : %+v\n", destHost)
+
+		if cleanup {
+			alerts.RunAlertsCleanup(destHost)
+			return
+		}
+
 		log.Infof("numAlerts : %+v\n", numAlerts)
 		if destHost == "" {
 			log.Fatalf("Destination Host is required")
@@ -334,6 +341,7 @@ func init() {
 
 	alertsLoadTestCmd.PersistentFlags().Uint64P("numAlerts", "n", 1, "Number of alerts to create")
 	alertsLoadTestCmd.PersistentFlags().Int8P("runVector", "v", 0, "Run vector: -1 - Explicitly Disable running of Vector, 0 - Optional State: Will try to run vector, but will not stop the test if encountered and issue with Vector, 1 - Explictly Enable running of Vector")
+	alertsLoadTestCmd.PersistentFlags().BoolP("cleanup", "c", false, "Cleanup alerts. If this is set true, it will only cleanup alerts and not run the load test")
 
 	queryCmd.AddCommand(esQueryCmd)
 	queryCmd.AddCommand(metricsQueryCmd)

--- a/tools/sigclient/pkg/alerts/alerts_loadtest.go
+++ b/tools/sigclient/pkg/alerts/alerts_loadtest.go
@@ -62,6 +62,7 @@ const (
 	VectorModeDisabled VectorMode = -1
 	VectorModeEnabled  VectorMode = 1
 	VectorModeOptional VectorMode = 0
+	LOG_MSG_DELIM      string     = "___"
 )
 
 func setUpLoggingToFileAndStdOut() string {
@@ -232,7 +233,7 @@ func trackNotifications(webhookChan chan alertutils.WebhookBody, numAlerts int, 
 		case webhookBody := <-webhookChan:
 			alertReceivedTime := time.Now()
 			timeout.Stop() // Stop the timeout as we received an alert
-			log.Infof("CurrentMinute=%v,ReceivedAlert=%v,NumEvaluations=%v", currentMinute, webhookBody.Title, webhookBody.NumEvaluationsCount)
+			log.Infof("%vCurrentMinute=%v,ReceivedAlert=%v,NumEvaluations=%v", LOG_MSG_DELIM, currentMinute, webhookBody.Title, webhookBody.NumEvaluationsCount)
 
 			alertEvalMinute := int(webhookBody.NumEvaluationsCount) - 1
 
@@ -269,9 +270,7 @@ func trackNotifications(webhookChan chan alertutils.WebhookBody, numAlerts int, 
 				}
 			}
 		case <-timeout.C:
-			log.Errorf("Timed out waiting for alerts")
-			successChan <- false
-			return
+			log.Errorf("%vCurrentMinute=%v,Timeout=%v,ErrorMessage=Timed out waiting for alerts", LOG_MSG_DELIM, currentMinute, true)
 		case <-exitChan:
 			log.Warnf("Received Exit Signal. Exiting the test!")
 
@@ -283,7 +282,7 @@ func trackNotifications(webhookChan chan alertutils.WebhookBody, numAlerts int, 
 				summary.AverageAlertsPerMinute = 0
 			}
 
-			log.Infof("CurrentMinute=%v,FinalSummary=%v,TotalTime=%v,TotalAlertsReceived=%d,TotalDelay=%v,AverageDelay=%v,AverageAlertsPerMinute=%v", currentMinute, true, time.Since(startTime), summary.TotalAlertsReceived, summary.TotalDelay, summary.AverageDelay, summary.AverageAlertsPerMinute)
+			log.Infof("%vCurrentMinute=%v,FinalSummary=%v,TotalTime=%v,TotalAlertsReceived=%d,TotalDelay=%v,AverageDelay=%v,AverageAlertsPerMinute=%v", LOG_MSG_DELIM, currentMinute, true, time.Since(startTime), summary.TotalAlertsReceived, summary.TotalDelay, summary.AverageDelay, summary.AverageAlertsPerMinute)
 			successChan <- true
 			return
 		}
@@ -292,14 +291,14 @@ func trackNotifications(webhookChan chan alertutils.WebhookBody, numAlerts int, 
 
 func logMinuteSummary(minute int, minuteData MinuteSummaryData, numAlerts int) {
 	alertsCount := len(minuteData.Alerts)
-	log.Infof("Minute=%d,IsSummary=%v,UniqueAlertsCount=%d,Pass=%v,TotalAlertsCount=%v,AverageDelay=%v", minute, true, alertsCount, alertsCount >= numAlerts, minuteData.TotalAlertsReceived, minuteData.AverageDelay)
+	log.Infof("%vMinute=%d,IsSummary=%v,UniqueAlertsCount=%d,Pass=%v,TotalAlertsCount=%v,AverageDelay=%v", LOG_MSG_DELIM, minute, true, alertsCount, alertsCount >= numAlerts, minuteData.TotalAlertsReceived, minuteData.AverageDelay)
 	for title, data := range minuteData.Alerts {
 		averageDelay := data.TotalDelay / time.Duration(data.ReceivedCount)
-		log.Infof("Minute=%d,Alert=%s,ReceivedCount=%d,AverageDelay=%v", minute, title, data.ReceivedCount, averageDelay)
+		log.Infof("%vMinute=%d,Alert=%s,ReceivedCount=%d,AverageDelay=%v", LOG_MSG_DELIM, minute, title, data.ReceivedCount, averageDelay)
 	}
 }
 
-func doCleanup(host string, contactId string) error {
+func doCleanup(host string) error {
 	log.Infof("Cleaning up...")
 	alerts, err := getAllAlerts(host)
 	if err != nil {
@@ -313,9 +312,16 @@ func doCleanup(host string, contactId string) error {
 		}
 	}
 
-	err = deleteContactPoint(host, contactId)
+	contacts, err := getAllContactPoints(host)
 	if err != nil {
-		return fmt.Errorf("error deleting contact %s: %v", contactId, err)
+		return fmt.Errorf("error getting all contacts: %v", err)
+	}
+
+	for _, contact := range contacts {
+		err = deleteContactPoint(host, contact.ContactId)
+		if err != nil {
+			return fmt.Errorf("error deleting contact %s: %v", contact.ContactId, err)
+		}
 	}
 
 	return nil
@@ -415,7 +421,6 @@ func RunAlertsLoadTest(host string, numAlerts uint64, runVector int8) {
 	err = createMultipleAlerts(host, contact.ContactId, int(numAlerts))
 	if err != nil {
 		log.Fatalf("Error creating multiple alerts: %v", err)
-		doCleanup(host, contact.ContactId)
 		return
 	}
 	log.Infof("Created %d Alerts", numAlerts)
@@ -429,18 +434,18 @@ func RunAlertsLoadTest(host string, numAlerts uint64, runVector int8) {
 		log.Errorf("Failed to receive all alerts in time")
 	}
 
-	// Cleanup
-	err = doCleanup(host, contact.ContactId)
-	if err != nil {
-		log.Errorf("Error cleaning up: %v", err)
-		return
-	}
-
 	if success {
 		log.Infof("Test completed successfully")
 	}
 
 	if runVector >= 0 {
 		stopVector(vectorCmd)
+	}
+}
+
+func RunAlertsCleanup(host string) {
+	err := doCleanup(host)
+	if err != nil {
+		log.Errorf("Error cleaning up: %v", err)
 	}
 }

--- a/tools/sigclient/pkg/alerts/alerts_loadtest.go
+++ b/tools/sigclient/pkg/alerts/alerts_loadtest.go
@@ -266,7 +266,7 @@ func trackNotifications(webhookChan chan alertutils.WebhookBody, numAlerts int, 
 				if minuteData, exists := summary.MinuteData[minute]; exists {
 					minuteData.AverageDelay = minuteData.TotalDelay / time.Duration(minuteData.TotalAlertsReceived)
 					logMinuteSummary(minute, minuteData, numAlerts)
-					summary.MinuteData[minute] = minuteData
+					delete(summary.MinuteData, minute)
 				}
 			}
 		case <-timeout.C:

--- a/tools/sigclient/pkg/alerts/alerts_loadtest_vector.yaml
+++ b/tools/sigclient/pkg/alerts/alerts_loadtest_vector.yaml
@@ -13,12 +13,15 @@ transforms:
       - read_from_file
     source: |
       messageVal = .message
-      values = split!(.message, r'^\x1b\[\d{2}m[A-Z]+\x1b\[0m\[\d{4}\]\s')
-      message = values[1]
-      containsMinute = contains!(message, "Minute", case_sensitive: false)
-      if containsMinute {
-          . = parse_key_value!(message, field_delimiter: ",", key_value_delimiter: "=")
-          .message = messageVal
+      values = split!(.message, "___")
+      valuesLength = length(values)
+      if valuesLength > 1 {
+        message = values[1]
+        containsMinute = contains!(message, "Minute", case_sensitive: false)
+        if containsMinute {
+            . = parse_key_value!(message, field_delimiter: ",", key_value_delimiter: "=")
+            .message = messageVal
+        }
       }
       ._index = "alerts-loadtest"
 


### PR DESCRIPTION
# Description
- Removed Auto Cleanup after a LoadTest when succeeded or failed due to an error.
- Added it as a optional command argument
- The test also will not exit when timeout occurs.

# Testing
- Tested it by running the command with 10 Alerts.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
