### PR TITLE
fix: deletion of siglens.db during recreation of the docker container 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "${UI_PORT}:5122"
     volumes:
       - "${WORK_DIR}/data:/siglens/data"
+      - "${WORK_DIR}/siglens.db:/siglens/siglens.db"
       - "${WORK_DIR}/logs:/siglens/logs"
       - "${WORK_DIR}/${CONFIG_FILE}:/siglens/${CONFIG_FILE}"
     command: ["./siglens", "--config", "${CONFIG_FILE}"]

--- a/install.sh
+++ b/install.sh
@@ -718,6 +718,15 @@ chmod a+rwx data || {
     print_error_and_exit "Failed to change permissions for directory 'data'. Please check your file permissions."
 }
 
+touch siglens.db || {
+    post_event "install_failed" "Failed to create file 'siglens.db'."
+    print_error_and_exit "Failed to create file 'siglens.db'. Please check your permissions."
+}
+chmod a+rwx siglens.db || {
+    post_event "install_failed" "Failed to change permissions for file 'siglens.db'."
+    print_error_and_exit "Failed to change permissions for file 'siglens.db'. Please check your file permissions."
+}
+
 mkdir -p logs || {
     post_event "install_failed" "Failed to create directory 'logs'"
     print_error_and_exit "Failed to create directory 'logs'. Please check your permissions."
@@ -806,11 +815,11 @@ CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=
 if [[ $CONTAINER_TOOL == "docker" ]]; then
 request_sudo
 sudo cat << EOF > .env
-    IMAGE_NAME=${IMAGE_NAME}
-    UI_PORT=${UI_PORT}
-    CONFIG_FILE=${CFILE}
-    WORK_DIR="$(pwd)"
-    CSI=${csi}
+IMAGE_NAME=${IMAGE_NAME}
+UI_PORT=${UI_PORT}
+CONFIG_FILE=${CFILE}
+WORK_DIR=$(pwd)
+CSI=${csi}
 EOF
 fi
 


### PR DESCRIPTION
# Description
- Fixes the removal of `siglens.db` when docker container is removed.
- This also fixes for upgrading to a new version by running the `install.sh` script.

# Testing
- Tested by running the install script and running the commands: `docker-compose down` and `docker-compose up -d`.
- Verified that the Alerts data is being persisted.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
