### PR TITLE
feat: fixed Alert queries for all types of Logs queries

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -119,7 +119,7 @@ func validateAlertTypeAndQuery(alertToBeCreated *alertutils.AlertDetails) (strin
 		}
 
 	} else if alertToBeCreated.AlertType == alertutils.AlertTypeMetrics {
-		_, _, _, _, errorLog, err := promql.ParseMetricTimeSeriesRequest([]byte(alertToBeCreated.MetricsQueryParamsString))
+		_, _, _, _, errorLog, _, err := promql.ParseMetricTimeSeriesRequest([]byte(alertToBeCreated.MetricsQueryParamsString))
 		if err != nil {
 			return errorLog, err
 		}

--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -697,7 +697,7 @@ func convertToSiglensAlert(lmDetails alertutils.LogLinesFile) []*alertutils.Mini
 			LogTextHash:     entry.LogTextHash,
 			LogLevel:        entry.LogLevel,
 			Condition:       alertutils.IsAbove,
-			Value:           float32(entry.Value),
+			Value:           float64(entry.Value),
 			EvalFor:         0,
 			EvalInterval:    1,
 			Message:         "Minion search " + alert_name,

--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -31,6 +31,7 @@ import (
 	"github.com/siglens/siglens/pkg/integrations/prometheus/promql"
 	rutils "github.com/siglens/siglens/pkg/readerUtils"
 	"github.com/siglens/siglens/pkg/segment/results/mresults"
+	"github.com/siglens/siglens/pkg/segment/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -249,28 +250,17 @@ func getLogsQueryLinkForTheAlert(alertDetails *alertutils.AlertDetails, timeRang
 }
 
 func evaluateLogAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.Job) {
-	serResVal, isResultsEmpty, timeRange, err := pipesearch.ProcessAlertsPipeSearchRequest(alertToEvaluate.QueryParams)
+	searchResponse, timeRange, err := pipesearch.ProcessAlertsPipeSearchRequest(alertToEvaluate.QueryParams)
 	if err != nil {
 		log.Errorf("ALERTSERVICE: evaluateLogAlert: Error processing logs query. Alert=%+v, err=%+v", alertToEvaluate.AlertName, err)
 		return
 	}
 
-	if isResultsEmpty {
-		// Should not return here, as this can mean, there are no valid logs that satisfies the Alert Query.
-		// This should be considered as a normal state. And we should update the alert state to Normal.
-		log.Warnf("ALERTSERVICE: evaluateLogAlert: Empty response returned by server.")
-
-		// We should call the update here instead of letting the execution go to the evaluation of the conditions.
-		// This is because, we return -1 as the result, when there are no logs that satisfies the query.
-		// And the condition in the evaluation can be looking for a value that is (>, <, =, !=) -1.
-		err := handleAlertCondition(alertToEvaluate, false, "")
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateLogAlert: Error in handleAlertCondition. Alert=%+v & err=%+v.", alertToEvaluate.AlertName, err)
-		}
+	isAlertConditionMatched, err := evaluateLogsQueryConditions(searchResponse, &alertToEvaluate.Condition, alertToEvaluate.Value)
+	if err != nil {
+		log.Errorf("ALERTSERVICE: evaluateLogAlert: Error evaluating logs query conditions. Alert=%+v, err=%+v", alertToEvaluate.AlertName, err)
 		return
 	}
-
-	isAlertConditionMatched := evaluateConditions(serResVal, &alertToEvaluate.Condition, alertToEvaluate.Value)
 
 	alertDataMessage := fmt.Sprintf("View the Query Results: %v", getLogsQueryLinkForTheAlert(alertToEvaluate, timeRange))
 
@@ -316,16 +306,16 @@ func updateAlertState(alertId string, alertState alertutils.AlertState) error {
 	return err
 }
 
-func evaluateConditions(serResVal int, queryCond *alertutils.AlertQueryCondition, val float32) bool {
+func evaluateConditions(serResVal float64, queryCond *alertutils.AlertQueryCondition, val float64) bool {
 	switch *queryCond {
 	case alertutils.IsAbove:
-		return serResVal > int(val)
+		return serResVal > val
 	case alertutils.IsBelow:
-		return serResVal < int(val)
+		return serResVal < val
 	case alertutils.IsEqualTo:
-		return serResVal == int(val)
+		return serResVal == val
 	case alertutils.IsNotEqualTo:
-		return serResVal != int(val)
+		return serResVal != val
 	case alertutils.HasNoValue:
 		return serResVal == 0
 	default:
@@ -333,13 +323,13 @@ func evaluateConditions(serResVal int, queryCond *alertutils.AlertQueryCondition
 	}
 }
 
-func evaluateMetricsQueryConditions(queryRes *mresults.MetricsResult, queryCond *alertutils.AlertQueryCondition, alertValue float32) []alertutils.MetricAlertData {
+func evaluateMetricsQueryConditions(queryRes *mresults.MetricsResult, queryCond *alertutils.AlertQueryCondition, alertValue float64) []alertutils.MetricAlertData {
 
 	alertsDataList := make([]alertutils.MetricAlertData, 0)
 
 	for seriesId, tsMap := range queryRes.Results {
 		for ts, val := range tsMap {
-			toBeAlerted := evaluateConditions(int(val), queryCond, alertValue)
+			toBeAlerted := evaluateConditions(val, queryCond, alertValue)
 			if toBeAlerted {
 				alertData := alertutils.MetricAlertData{
 					SeriesId:  seriesId,
@@ -352,6 +342,95 @@ func evaluateMetricsQueryConditions(queryRes *mresults.MetricsResult, queryCond 
 	}
 
 	return alertsDataList
+}
+
+func evaluateLogsQueryConditions(searchResponse *pipesearch.PipeSearchResponseOuter, queryCond *alertutils.AlertQueryCondition, alertValue float64) (bool, error) {
+
+	if searchResponse == nil {
+		err := fmt.Errorf("ALERTSERVICE: evaluateLogsQueryConditions: searchResponse is nil")
+		log.Error(err.Error())
+		return false, err
+	}
+
+	if len(searchResponse.MeasureAggregationCols) > 0 {
+		return evaluateRecordsMeasureAggsAlertCondition(searchResponse, queryCond, alertValue)
+	} else if searchResponse.MeasureResults != nil && len(searchResponse.MeasureResults) > 0 {
+		return evaluateMeasureResultsAlertCondition(searchResponse, queryCond, alertValue)
+	}
+
+	return false, nil
+}
+
+func evaluateMeasureResultsAlertCondition(searchResponse *pipesearch.PipeSearchResponseOuter, queryCond *alertutils.AlertQueryCondition, alertValue float64) (bool, error) {
+	if searchResponse == nil {
+		err := fmt.Errorf("ALERTSERVICE: evaluateMeasureResultsAlertCondition: searchResponse is nil")
+		log.Error(err.Error())
+		return false, err
+	}
+
+	firstBucket := searchResponse.MeasureResults[0]
+	if len(firstBucket.MeasureVal) > 1 {
+		err := fmt.Errorf("ALERTSERVICE: evaluateMeasureResultsAlertCondition: The Query has more than 1 Measure Column")
+		log.Error(err.Error())
+		return false, err
+	}
+
+	for _, bucket := range searchResponse.MeasureResults {
+		for _, measureVal := range bucket.MeasureVal {
+			floatVal, err := utils.ParseHumanizedValueToFloat(measureVal)
+			if err != nil {
+				log.Errorf("ALERTSERVICE: evaluateMeasureResultsAlertCondition: Error converting value to float. Value=%v, err=%v", measureVal, err)
+				continue
+			}
+			toBeAlerted := evaluateConditions(floatVal, queryCond, alertValue)
+			if toBeAlerted {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func evaluateRecordsMeasureAggsAlertCondition(searchResponse *pipesearch.PipeSearchResponseOuter, queryCond *alertutils.AlertQueryCondition, alertValue float64) (bool, error) {
+	if searchResponse == nil {
+		err := fmt.Errorf("ALERTSERVICE: evaluateRecordsMeasureAggsCondition: searchResponse is nil")
+		log.Error(err.Error())
+		return false, err
+	}
+
+	if len(searchResponse.MeasureAggregationCols) > 1 {
+		err := fmt.Errorf("ALERTSERVICE: evaluateRecordsMeasureAggsCondition: The Query has more than 1 Measure Column")
+		log.Error(err.Error())
+		return false, err
+	}
+
+	if len(searchResponse.RenameColumns) > 0 {
+		for i, measureCol := range searchResponse.MeasureAggregationCols {
+			if newColName, ok := searchResponse.RenameColumns[measureCol]; ok {
+				searchResponse.MeasureAggregationCols[i] = newColName
+			}
+		}
+	}
+
+	for _, record := range searchResponse.Hits.Hits {
+		for _, col := range searchResponse.MeasureAggregationCols {
+			if value, ok := record[col]; ok {
+				floatVal, err := utils.ParseHumanizedValueToFloat(value)
+				if err != nil {
+					log.Errorf("ALERTSERVICE: evaluateRecordsMeasureAggsCondition: Error converting value to float. Value=%v, err=%v", value, err)
+					continue
+				}
+				toBeAlerted := evaluateConditions(floatVal, queryCond, alertValue)
+				if toBeAlerted {
+					return true, nil
+				}
+			}
+
+		}
+	}
+
+	return false, nil
 }
 
 func updateMinionSearchStateAndCreateAlertHistory(msToEvaluate *alertutils.MinionSearch, alertState alertutils.AlertState, eventDesc string) error {
@@ -378,27 +457,18 @@ func updateMinionSearchStateAndCreateAlertHistory(msToEvaluate *alertutils.Minio
 }
 
 func evaluateMinionSearch(msToEvaluate *alertutils.MinionSearch, job gocron.Job) {
-	serResVal, isResultsEmpty, _, err := pipesearch.ProcessAlertsPipeSearchRequest(msToEvaluate.QueryParams)
+	searchResponse, _, err := pipesearch.ProcessAlertsPipeSearchRequest(msToEvaluate.QueryParams)
 	if err != nil {
 		log.Errorf("MinionSearch: evaluate: Error processing logs query. Alert=%+v, err=%+v", msToEvaluate.AlertName, err)
 		return
 	}
 
-	if isResultsEmpty {
-		// Should not return here, as this can mean, there are no valid logs that satisfies the Alert Query.
-		// This should be considered as a normal state. And we should update the alert state to Normal.
-		log.Warnf("MinionSearch: evaluate: Empty response returned by server.")
-
-		// We should call the update here instead of letting the execution go to the evaluation of the conditions.
-		// This is because, we return -1 as the result, when there are no logs that satisfies the query.
-		// And the condition in the evaluation can be looking for a value that is (>, <, =, !=) -1.
-		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Normal, alertutils.AlertNormal)
-		if err != nil {
-			log.Errorf("ALERTSERVICE: evaluateMinionSearch: Error in updateMinionSearchStateAndCreateAlertHistory. AlertState=%v, Alert=%+v & err=%+v.", alertutils.Normal, msToEvaluate.AlertName, err)
-		}
+	isFiring, err := evaluateLogsQueryConditions(searchResponse, &msToEvaluate.Condition, msToEvaluate.Value)
+	if err != nil {
+		log.Errorf("MinionSearch: evaluate: Error evaluating logs query conditions. Alert=%+v, err=%+v", msToEvaluate.AlertName, err)
 		return
 	}
-	isFiring := evaluateConditions(serResVal, &msToEvaluate.Condition, msToEvaluate.Value)
+
 	if isFiring {
 		err := updateMinionSearchStateAndCreateAlertHistory(msToEvaluate, alertutils.Firing, alertutils.AlertFiring)
 		if err != nil {

--- a/pkg/alerts/alertutils/alertutils.go
+++ b/pkg/alerts/alertutils/alertutils.go
@@ -47,7 +47,7 @@ type AlertDetails struct {
 	QueryParams              QueryParams         `json:"queryParams" gorm:"embedded"`
 	MetricsQueryParamsString string              `json:"metricsQueryParams"`
 	Condition                AlertQueryCondition `json:"condition"`
-	Value                    float32             `json:"value"`
+	Value                    float64             `json:"value"`
 	EvalWindow               uint64              `json:"eval_for"`      // in minutes; TODO: Rename json field to eval_window
 	EvalInterval             uint64              `json:"eval_interval"` // in minutes
 	Message                  string              `json:"message"`
@@ -219,7 +219,7 @@ type MinionSearch struct {
 	SilenceMinutes  uint64              `json:"silence_minutes"`
 	QueryParams     QueryParams         `json:"queryParams" gorm:"embedded"`
 	Condition       AlertQueryCondition `json:"condition"`
-	Value           float32             `json:"value"`
+	Value           float64             `json:"value"`
 	EvalFor         uint64              `json:"eval_for"`
 	EvalInterval    uint64              `json:"eval_interval"`
 	Message         string              `json:"message"`

--- a/pkg/ast/pipesearch/resultStructs.go
+++ b/pkg/ast/pipesearch/resultStructs.go
@@ -20,20 +20,22 @@ package pipesearch
 import "github.com/siglens/siglens/pkg/segment/structs"
 
 type PipeSearchResponseOuter struct {
-	Hits               PipeSearchResponse            `json:"hits"`
-	Aggs               map[string]AggregationResults `json:"aggregations"`
-	ElapedTimeMS       int64                         `json:"elapedTimeMS"`
-	AllPossibleColumns []string                      `json:"allColumns"`
-	Errors             []string                      `json:"errors,omitempty"`
-	MeasureFunctions   []string                      `json:"measureFunctions,omitempty"`
-	MeasureResults     []*structs.BucketHolder       `json:"measure,omitempty"`
-	GroupByCols        []string                      `json:"groupByCols,omitempty"`
-	Qtype              string                        `json:"qtype,omitempty"`
-	CanScrollMore      bool                          `json:"can_scroll_more"`
-	TotalRRCCount      interface{}                   `json:"total_rrc_count,omitempty"`
-	BucketCount        int                           `json:"bucketCount,omitempty"`
-	DashboardPanelId   string                        `json:"dashboardPanelId"`
-	ColumnsOrder       []string                      `json:"columnsOrder"`
+	Hits                   PipeSearchResponse            `json:"hits"`
+	Aggs                   map[string]AggregationResults `json:"aggregations"`
+	ElapedTimeMS           int64                         `json:"elapedTimeMS"`
+	AllPossibleColumns     []string                      `json:"allColumns"`
+	Errors                 []string                      `json:"errors,omitempty"`
+	MeasureFunctions       []string                      `json:"measureFunctions,omitempty"`
+	MeasureResults         []*structs.BucketHolder       `json:"measure,omitempty"`
+	GroupByCols            []string                      `json:"groupByCols,omitempty"`
+	Qtype                  string                        `json:"qtype,omitempty"`
+	CanScrollMore          bool                          `json:"can_scroll_more"`
+	TotalRRCCount          interface{}                   `json:"total_rrc_count,omitempty"`
+	BucketCount            int                           `json:"bucketCount,omitempty"`
+	DashboardPanelId       string                        `json:"dashboardPanelId"`
+	ColumnsOrder           []string                      `json:"columnsOrder"`
+	MeasureAggregationCols []string                      `json:"measureAggregationCols,omitempty"`
+	RenameColumns          map[string]string             `json:"renameColumns,omitempty"`
 }
 
 type PipeSearchResponse struct {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -28,7 +28,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 		]
 	}`
 
-	start, end, queries, formulas, _, err := ParseMetricTimeSeriesRequest([]byte(validJSON))
+	start, end, queries, formulas, _, _, err := ParseMetricTimeSeriesRequest([]byte(validJSON))
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(1625248200), start)
 	assert.Equal(t, uint32(1625248300), end)
@@ -54,7 +54,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"formula": "formula2"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)
@@ -73,7 +73,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"formula": "formula2"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)
@@ -89,7 +89,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"formula": "formula2"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)
@@ -105,7 +105,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"name": "query2", "query": "SELECT * FROM table", "qlType": "SQL"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)
@@ -125,7 +125,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"formula": "formula2"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)
@@ -145,7 +145,7 @@ func Test_parseMetricTimeSeriesRequest(t *testing.T) {
 			{"formula2": "formula2"}
 		]
 	}`
-	start, end, queries, formulas, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
+	start, end, queries, formulas, _, _, err = ParseMetricTimeSeriesRequest([]byte(invalidJSON))
 	assert.Error(t, err)
 	assert.NotNil(t, start)
 	assert.NotNil(t, end)

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -461,6 +461,14 @@ func (ma *MeasureAggregator) String() string {
 	return ma.StrEnc
 }
 
+func GetMeasureAggregatorStrEncColumns(measureAggs []*MeasureAggregator) []string {
+	var columns []string
+	for _, ma := range measureAggs {
+		columns = append(columns, ma.String())
+	}
+	return columns
+}
+
 func (ss *SegStats) Merge(other *SegStats) {
 	ss.Count += other.Count
 	ss.Records = append(ss.Records, other.Records...)

--- a/pkg/segment/utils/numberutils.go
+++ b/pkg/segment/utils/numberutils.go
@@ -17,7 +17,11 @@
 
 package utils
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 func GetNumberTypeAndVal(numstr string) (SS_IntUintFloatTypes, int64, uint64, float64) {
 	firstchar := numstr[0]
@@ -97,4 +101,21 @@ func getIntTypeAndVal(strnum string) (SS_IntUintFloatTypes, int64, bool) {
 		}
 	}
 	return -1, 0, false
+}
+
+func ParseHumanizedValueToFloat(humanizedValue interface{}) (float64, error) {
+	humanizedValueStr := fmt.Sprintf("%v", humanizedValue)
+
+	if humanizedValueStr == "" {
+		return 0, fmt.Errorf("ParseHumanizedValueToFloat: humanizedValue is empty")
+	}
+
+	cleanedStr := strings.ReplaceAll(humanizedValueStr, ",", "")
+
+	floatVal, err := strconv.ParseFloat(cleanedStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("ParseHumanizedValueToFloat: error parsing float value. Error: %v", err)
+	}
+
+	return floatVal, nil
 }


### PR DESCRIPTION
# Description
- Fixed the Alert logs Query so that:
   - It checks for all of the series in a `Group By` request.
   -  And now it will also work for queries with nested Group By.

**NOTE:** As of now I am rejecting the query with Multiple Measure Columns even with `Eval` or `where` condition set. But the queries like this with Multiple Columns will still work, if the they are followed by a stats query at the end like below.
```
* | rex field=app_version "(?<major>\d+)\.(?<minor>\d).*" 
| stats count(*) as count, sum(major) as sum_major by minor 
| where minor < sum_major 
| stats count(*) as count
```

- This PR also includes the building and sending the Metrics Query Link while sending an Alert Notification.

# Testing
- Tested by executing different types of Logs Queries and verified that the Alert Notification is being sent.
- Tested the metrics query link by creating an Alert for Metric Queries and verified that the URL received in the Notification by decoding the url using online URL-decoders.

# Checklist:
- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
