### PR TITLE
Fix AgileAggs panic during encoding

### DIFF
--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -390,17 +390,3 @@ func (stb *StarTreeBuilder) writeLevsInfo(strMFd *os.File, levsOffsets []int64,
 	}
 	return nil
 }
-
-func (stb *StarTreeBuilder) estimateMetaSize() int {
-
-	// 55: estimate for width of colNames
-	colsMeta := (int(stb.numGroupByCols) + len(stb.mColNames)) * 55
-
-	deSize := int(0)
-	for colNum := range stb.groupByKeys {
-		// 60 : estimate for colnamelen, columnname, 55: for enc len
-		deSize += 60 + int(stb.segDictLastNum[colNum])*55
-	}
-
-	return colsMeta + deSize + 1000
-}

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -137,7 +137,6 @@ func (stb *StarTreeBuilder) encodeMetadata(strMFd *os.File) (uint32, error) {
 
 	// each aggFunc
 	for _, mCname := range stb.mColNames {
-
 		// Mcol len
 		l1 := uint16(len(mCname))
 		_, err = writer.Write(utils.Uint16ToBytesLittleEndian(l1))
@@ -168,7 +167,7 @@ func (stb *StarTreeBuilder) encodeMetadata(strMFd *os.File) (uint32, error) {
 	writer.Flush()
 
 	// Now we know the size of the metadata, so we can write it. The value we
-	// write doesn't include the 4 bytes we use to store the length.
+	// write doesn't include the 4 bytes we use to store the value.
 	_, err = strMFd.WriteAt(utils.Uint32ToBytesLittleEndian(metadataSize-4), 0)
 	if err != nil {
 		log.Errorf("StarTreeBuilder.encodeMetadata: failed to write metadata length; err=%v", err)


### PR DESCRIPTION
# Description
This fixes a panic that sometimes occurs when encoding the AgileAggs tree.
The issue was that we were estimating (not calculating) how large of a buffer we needed, and then assuming that it was sufficient; sometimes we underestimated, and then got a panic when we tried to write too far.

This changes that so we just use bufio to handle all the details of buffering writing to the file for us, and allows us to not have to estimate the buffer size.

# Testing
I was able to reproduce the bug by running with `pqsEnabled: true` in the config, forcing the estimator function to return a low value like 50, and then starting siglens and running the following
```
curl -X POST -d '{
    "tableName": "ind-0",
    "groupByColumns": ["http_method", "weekday"],
    "measureColumns": ["http_status"]
}' http://localhost:5122/api/pqs/aggs
echo ""
go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 10_000
```
Once the data was rotated (e.g., shutdown siglens), siglens would panic.

With this PR, I can run those same steps and siglens does not panic.
Also, the AgileAggs unit tests continue to pass.


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
