### PR TITLE
Bug: Handle negative value for log span for SPL Bin Command

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -2629,6 +2629,15 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 	}
 
 	if spanOpt.LogSpan != nil {
+		if value == 0.0 {
+			return 0, nil
+		}
+		signMultiplier := 1
+		if value < 0 {
+			// for negative values create bins like positive and apply negative sign
+			signMultiplier = -1
+			value = -value
+		}
 		val := value / spanOpt.LogSpan.Coefficient
 		logVal := math.Log10(val) / math.Log10(spanOpt.LogSpan.Base)
 		floorVal := math.Floor(logVal)
@@ -2636,9 +2645,8 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 		if ceilVal == floorVal {
 			ceilVal += 1
 		}
-
-		lowerBound := math.Pow(spanOpt.LogSpan.Base, floorVal) * spanOpt.LogSpan.Coefficient
-		upperBound := math.Pow(spanOpt.LogSpan.Base, ceilVal) * spanOpt.LogSpan.Coefficient
+		lowerBound := math.Pow(spanOpt.LogSpan.Base, floorVal) * spanOpt.LogSpan.Coefficient * float64(signMultiplier)
+		upperBound := math.Pow(spanOpt.LogSpan.Base, ceilVal) * spanOpt.LogSpan.Coefficient * float64(signMultiplier)
 
 		return fmt.Sprintf("%v-%v", lowerBound, upperBound), nil
 	}

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -2632,10 +2632,10 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 		if value == 0.0 {
 			return 0, nil
 		}
-		signMultiplier := 1
+		isNegative := false
 		if value < 0 {
 			// for negative values create bins like positive and apply negative sign
-			signMultiplier = -1
+			isNegative = true
 			value = -value
 		}
 		val := value / spanOpt.LogSpan.Coefficient
@@ -2645,9 +2645,11 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 		if ceilVal == floorVal {
 			ceilVal += 1
 		}
-		lowerBound := math.Pow(spanOpt.LogSpan.Base, floorVal) * spanOpt.LogSpan.Coefficient * float64(signMultiplier)
-		upperBound := math.Pow(spanOpt.LogSpan.Base, ceilVal) * spanOpt.LogSpan.Coefficient * float64(signMultiplier)
-
+		lowerBound := math.Pow(spanOpt.LogSpan.Base, floorVal) * spanOpt.LogSpan.Coefficient
+		upperBound := math.Pow(spanOpt.LogSpan.Base, ceilVal) * spanOpt.LogSpan.Coefficient
+		if isNegative {
+			return fmt.Sprintf("%v-%v", -upperBound, -lowerBound), nil
+		}
 		return fmt.Sprintf("%v-%v", lowerBound, upperBound), nil
 	}
 

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -2629,15 +2629,10 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 	}
 
 	if spanOpt.LogSpan != nil {
-		if value == 0.0 {
-			return 0, nil
+		if value <= 0 {
+			return value, nil
 		}
-		isNegative := false
-		if value < 0 {
-			// for negative values create bins like positive and apply negative sign
-			isNegative = true
-			value = -value
-		}
+
 		val := value / spanOpt.LogSpan.Coefficient
 		logVal := math.Log10(val) / math.Log10(spanOpt.LogSpan.Base)
 		floorVal := math.Floor(logVal)
@@ -2647,9 +2642,7 @@ func performBinWithSpan(value float64, spanOpt *structs.BinSpanOptions) (interfa
 		}
 		lowerBound := math.Pow(spanOpt.LogSpan.Base, floorVal) * spanOpt.LogSpan.Coefficient
 		upperBound := math.Pow(spanOpt.LogSpan.Base, ceilVal) * spanOpt.LogSpan.Coefficient
-		if isNegative {
-			return fmt.Sprintf("%v-%v", -upperBound, -lowerBound), nil
-		}
+
 		return fmt.Sprintf("%v-%v", lowerBound, upperBound), nil
 	}
 

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -2492,7 +2492,7 @@ func Test_performBinWithSpan(t *testing.T) {
 
 	val, err = performBinWithSpan(-301, spanOpt)
 	assert.Nil(t, err)
-	assert.Equal(t, "-486--162", fmt.Sprintf("%v", val))
+	assert.Equal(t, "-301", fmt.Sprintf("%v", val))
 
 	val, err = performBinWithSpan(1, spanOpt)
 	assert.Nil(t, err)
@@ -2500,11 +2500,19 @@ func Test_performBinWithSpan(t *testing.T) {
 
 	val, err = performBinWithSpan(-1, spanOpt)
 	assert.Nil(t, err)
-	assert.Equal(t, "-2--0.6666666666666666", fmt.Sprintf("%v", val))
+	assert.Equal(t, "-1", fmt.Sprintf("%v", val))
+
+	val, err = performBinWithSpan(-0.01, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "-0.01", fmt.Sprintf("%v", val))
 
 	val, err = performBinWithSpan(0, spanOpt)
 	assert.Nil(t, err)
 	assert.Equal(t, "0", fmt.Sprintf("%v", val))
+
+	val, err = performBinWithSpan(0.1, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "0.07407407407407407-0.2222222222222222", fmt.Sprintf("%v", val))
 
 	spanOpt.LogSpan = &structs.LogSpan{
 		Base:        1.2,

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -2490,6 +2490,22 @@ func Test_performBinWithSpan(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "162-486", fmt.Sprintf("%v", val))
 
+	val, err = performBinWithSpan(-301, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "-162--486", fmt.Sprintf("%v", val))
+
+	val, err = performBinWithSpan(1, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "0.6666666666666666-2", fmt.Sprintf("%v", val))
+
+	val, err = performBinWithSpan(-1, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "-0.6666666666666666--2", fmt.Sprintf("%v", val))
+
+	val, err = performBinWithSpan(0, spanOpt)
+	assert.Nil(t, err)
+	assert.Equal(t, "0", fmt.Sprintf("%v", val))
+
 	spanOpt.LogSpan = &structs.LogSpan{
 		Base:        1.2,
 		Coefficient: 1,

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -2492,7 +2492,7 @@ func Test_performBinWithSpan(t *testing.T) {
 
 	val, err = performBinWithSpan(-301, spanOpt)
 	assert.Nil(t, err)
-	assert.Equal(t, "-162--486", fmt.Sprintf("%v", val))
+	assert.Equal(t, "-486--162", fmt.Sprintf("%v", val))
 
 	val, err = performBinWithSpan(1, spanOpt)
 	assert.Nil(t, err)
@@ -2500,7 +2500,7 @@ func Test_performBinWithSpan(t *testing.T) {
 
 	val, err = performBinWithSpan(-1, spanOpt)
 	assert.Nil(t, err)
-	assert.Equal(t, "-0.6666666666666666--2", fmt.Sprintf("%v", val))
+	assert.Equal(t, "-2--0.6666666666666666", fmt.Sprintf("%v", val))
 
 	val, err = performBinWithSpan(0, spanOpt)
 	assert.Nil(t, err)


### PR DESCRIPTION
# Description
Summarize the change.
Support for negative values for log span in bin command.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
