### PR TITLE
fix: Rendering of Metric Query from the URL

### DIFF
--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -2250,7 +2250,7 @@ async function populateMetricsQueryElement(metricsQueryParams){
     
     for (const query of queries) {
         const parsedQueryObject = parsePromQL(query.query);
-        await addQueryElementOnAlertEdit(query.name, parsedQueryObject);
+        await addQueryElementForAlertAndPanel(query.name, parsedQueryObject);
     }
     
     if (queries.length >= 1) {


### PR DESCRIPTION
# Description
- Changed the function that would actually render the metrics query from the url in the `populateMetricsQueryElement` function.


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
