### PR TITLE
feat: Added new DtypeVal []string for MultiValue functions

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -145,6 +145,7 @@ const (
 	SS_DT_UNSIGNED_NUM
 	SS_DT_FLOAT
 	SS_DT_STRING
+	SS_DT_STRING_SLICE
 	SS_DT_STRING_SET
 	SS_DT_BACKFILL
 	SS_DT_SIGNED_32_NUM
@@ -512,6 +513,7 @@ type DtypeEnclosure struct {
 	FloatVal       float64
 	StringVal      string
 	StringValBytes []byte         // byte slice representation of StringVal
+	StringSliceVal []string       // used for array dict
 	rexpCompiled   *regexp.Regexp //  should be unexported to allow for gob encoding
 }
 

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -81,6 +81,10 @@ func CreateDtypeEnclosure(inVal interface{}, qid uint64) (*DtypeEnclosure, error
 			}
 			dte.SetRegexp(compiledRegex)
 		}
+	case []string:
+		dte.Dtype = SS_DT_STRING_SLICE
+		dte.StringSliceVal = inVal
+		dte.StringVal = fmt.Sprintf("%v", inVal)
 	case *regexp.Regexp:
 		if inVal == nil {
 			return nil, errors.New("CreateDtypeEnclosure: inVal is nil Regexp")


### PR DESCRIPTION
# Description
- This Adds a new type for `DtypeEnclosure` that can be used for Multi value functions.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
