### PR TITLE
fix: Close Webhook Requests After sending an Alert Notification

### DIFF
--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -184,10 +184,11 @@ func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, 
 
 	r.Header.Add("Content-Type", "application/json")
 	client := &http.Client{}
-	_, err1 := client.Do(r)
-	if err1 != nil {
+	resp, err := client.Do(r)
+	if err != nil {
 		log.Errorf("sendWebhooks: Error sending request. WebhookURL=%v, Error=%v", webhookUrl, err)
 	}
+	resp.Body.Close()
 	return err
 }
 

--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -187,9 +187,10 @@ func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, 
 	resp, err := client.Do(r)
 	if err != nil {
 		log.Errorf("sendWebhooks: Error sending request. WebhookURL=%v, Error=%v", webhookUrl, err)
+		return err
 	}
 	resp.Body.Close()
-	return err
+	return nil
 }
 
 func isSilenceMinutesOver(silenceMinutes uint64, lastSendTime time.Time) bool {

--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -180,6 +180,7 @@ func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, 
 	r, err := http.NewRequest("POST", webhookUrl, bytes.NewBuffer(data))
 	if err != nil {
 		log.Errorf("sendWebhooks: Error creating request. WebhookURL=%v, Error=%v", webhookUrl, err)
+		return err
 	}
 
 	r.Header.Add("Content-Type", "application/json")

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -475,6 +475,10 @@ func convertBucketToAggregationResponse(buckets map[string]*structs.AggregationR
 }
 
 func convertQueryCountToTotalResponse(qc *structs.QueryCount) interface{} {
+	if qc == nil {
+		return 0
+	}
+
 	if !qc.EarlyExit {
 		return qc.TotalCount
 	}


### PR DESCRIPTION
# Description
- Added closing of webhook request, once an Alert Notification is sent.
- Without closing the request causes the number of file descriptors to keep increasing and eventually it crosses the `os` limits and will not send the requests.

# Testing
- Tested before making this fix by running the alerts load-test client and the error of sending request would occur approximately around 54th minute for 1000 Alerts and also verified that the number of open files kept increasing over time. 
- Tested after making the fix by running the alerts load-test client and it has been running without any issues for the past 170 minutes for 2000 Alerts. I have verified that the number of open files also stayed consistent with the value that was at the start of SigLens server and before starting the client.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
