### PR TITLE
fix: Updating of Alerting Labels

### DIFF
--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -373,6 +373,13 @@ func (p Sqlite) UpdateAlert(editedAlert *alertutils.AlertDetails) error {
 		editedAlert.ContactName = contactData.ContactName
 	}
 
+	// Clear existing labels
+	if err := p.db.Model(&currentAlertData).Association("Labels").Clear(); err != nil {
+		err := fmt.Errorf("UpdateAlert: unable to clear labels for alert: %v, Error=%v", editedAlert.AlertName, err)
+		log.Error(err.Error())
+		return err
+	}
+
 	result := p.db.Set("gorm:association_autoupdate", true).Save(&editedAlert)
 	if result.Error != nil && result.RowsAffected != 1 {
 		err := fmt.Errorf("UpdateAlert: unable to update details for alert: %v, Error=%v", editedAlert.AlertName, result.Error)

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -249,7 +249,13 @@ func (p Sqlite) GetAlert(alert_id string) (*alertutils.AlertDetails, error) {
 	if err != nil {
 		err = fmt.Errorf("GetAlert: unable to decode query params for Alert: %v, Error=%v", alert.AlertName, err)
 		log.Error(err.Error())
-		return nil, err
+
+		// This would mean that the Alert Query is not in Base64 Format. Update the document in db to Base64
+		err = p.UpdateAlert(&alert)
+		if err != nil {
+			log.Errorf("GetAlert: unable to update alert: %v, Error=%v", alert.AlertName, err)
+			return nil, err
+		}
 	}
 
 	return &alert, nil
@@ -267,7 +273,13 @@ func (p Sqlite) GetAllAlerts(orgId uint64) ([]*alertutils.AlertDetails, error) {
 		if err != nil {
 			err = fmt.Errorf("GetAllAlerts: unable to decode query params for Alert: %v, Error=%v", alert.AlertName, err)
 			log.Error(err.Error())
-			continue
+
+			// This would mean that the Alert Query is not in Base64 Format. Update the document in db to Base64
+			err = p.UpdateAlert(alert)
+			if err != nil {
+				log.Errorf("GetAllAlerts: unable to update alert: %v, Error=%v", alert.AlertName, err)
+				continue
+			}
 		}
 		finalAlerts = append(finalAlerts, alert)
 	}


### PR DESCRIPTION
# Description
- Fixes the issue with the update or deletion of Labels in an Alert.
- Refactored the `GetAllAlerts` and `GetAlert` method to update the Alert so that the `QueryParams` will be encode to `base64` and stored in the db, if it is already not in `base64` format.

# Testing
- Tested by updating the Labels in an Alert.
- Tested by verifying that the Alerts are being displayed in the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
