### PR TITLE
fix: building of PromQL Metrics query from formulas

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -788,16 +788,20 @@ func ProcessGetMetricTimeSeriesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 func buildMetricQueryFromFormulaAndQueries(formula string, queries map[string]string) (string, error) {
 
-	pattern := ""
-	for key := range queries {
-		pattern = fmt.Sprintf("%s|%s", pattern, key)
-	}
-
-	if pattern == "" {
+	if len(queries) == 0 {
 		return "", errors.New("no queries found")
 	}
 
-	pattern = fmt.Sprintf("(%s)", pattern[1:])
+	pattern := ""
+	for key := range queries {
+		if pattern == "" {
+			pattern = fmt.Sprintf(`\b%s\b`, key)
+		} else {
+			pattern = fmt.Sprintf(`%s|\b%s\b`, pattern, key)
+		}
+	}
+
+	pattern = fmt.Sprintf("(%s)", pattern)
 
 	regEx, err := regexp.Compile(pattern)
 	if err != nil {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -278,6 +278,15 @@ func Test_buildMetricQueryFromFormulaAndQueries(t *testing.T) {
 			},
 			expected: `avg(rate(metric1[5m])) + sum by (type) (metric2{type="test"})`,
 		},
+		{
+			formula: "atan(abs(ceil(123 * a + b))) + abs(ceil(c))",
+			queries: map[string]string{
+				"a": `ceil(avg by (type) (metric1))`,
+				"b": `max by (type) (metric2)`,
+				"c": `min by (type) (metric3)`,
+			},
+			expected: `atan(abs(ceil(123 * ceil(avg by (type) (metric1)) + max by (type) (metric2)))) + abs(ceil(min by (type) (metric3)))`,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
# Description
- Fixes the issue of building queries through formulas, for fomula's like this: `atan(abs(ceil(123 * a)))`

# Testing
- Tested by executing queries through postman.
- Tested by updating the unit test case.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
