### PR TITLE
Fix #1030: Linearly interpolate percentile results

### DIFF
--- a/pkg/segment/tracing/structs/tracestruct.go
+++ b/pkg/segment/tracing/structs/tracestruct.go
@@ -62,10 +62,10 @@ type Span struct {
 type RedMetrics struct {
 	Rate      float64 // Number of entry spans divided by 60 seconds
 	ErrorRate float64 // Percentage of entry spans that errored
-	P50       uint64  // p50, p90, p95, p99 latencies are calculated by the list of durations.
-	P90       uint64
-	P95       uint64
-	P99       uint64
+	P50       float64 // p50, p90, p95, p99 latencies are calculated by the list of durations.
+	P90       float64
+	P95       float64
+	P99       float64
 }
 
 // Accept the request body of search traces and act as the request body of the /api/search

--- a/pkg/segment/tracing/utils/lineartimefinding.go
+++ b/pkg/segment/tracing/utils/lineartimefinding.go
@@ -25,7 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func FindPercentileData(arr []uint64, percentile int) uint64 {
+func FindPercentileData(arr []uint64, percentile int) float64 {
 	if len(arr) == 0 {
 		log.Error("FindPercentileData: no duration exists")
 		return 0
@@ -35,8 +35,18 @@ func FindPercentileData(arr []uint64, percentile int) uint64 {
 		return 0
 	}
 
-	k := math.Floor(float64(percentile*(len(arr))) / float64(100))
-	return quickSelect(arr, int(k), &rand.Rand{})
+	k := float64(percentile*(len(arr)-1)) / float64(100)
+	floorK := int(math.Floor(k))
+	ceilK := int(math.Ceil(k))
+
+	if floorK == ceilK {
+		return float64(quickSelect(arr, floorK, &rand.Rand{}))
+	} else {
+		lower := float64(quickSelect(arr, floorK, &rand.Rand{}))
+		upper := float64(quickSelect(arr, ceilK, &rand.Rand{}))
+		weight := k - float64(floorK)
+		return lower + (upper-lower)*weight
+	}
 }
 
 // https://rcoh.me/posts/linear-time-median-finding/

--- a/pkg/segment/tracing/utils/lineartimefinding_test.go
+++ b/pkg/segment/tracing/utils/lineartimefinding_test.go
@@ -25,34 +25,39 @@ func TestFindPercentileData(t *testing.T) {
 	testCases := []struct {
 		arr        []uint64
 		percentile int
-		expected   uint64
+		expected   float64
 	}{
 		{
 			arr:        []uint64{44, 11, 22},
 			percentile: 66,
-			expected:   22,
+			expected:   29.04,
 		},
 		{
 			arr:        []uint64{44, 11, 22},
-			percentile: 67,
-			expected:   44,
+			percentile: 50,
+			expected:   22,
 		},
 		{
 			arr:        []uint64{20, 50, 40, 30, 10},
 			percentile: 35,
-			expected:   20,
+			expected:   24,
 		},
 		{
 			arr:        []uint64{20, 50, 40, 30, 10},
 			percentile: 95,
-			expected:   50,
+			expected:   48,
+		},
+		{
+			arr:        []uint64{25, 75, 0, 50, 100},
+			percentile: 25,
+			expected:   25,
 		},
 	}
 
 	for _, tc := range testCases {
 		result := FindPercentileData(tc.arr, tc.percentile)
 		if result != tc.expected {
-			t.Errorf("Expected %d percentile to be %d, but got %d", tc.percentile, tc.expected, result)
+			t.Errorf("Expected %d percentile to be %f, but got %f", tc.percentile, tc.expected, result)
 		}
 	}
 }


### PR DESCRIPTION
# Description
 - FindPercentileData function no longer returns a uint64, and instead a float64
 - When a non-integer index is found with a given percentile, it now calculates the weight of the index after and before it and returns that, instead of rounding down the index
 - Fixed minor calculation error when calculating index: ``float64(percentile*(len(arr)-1)) / float64(100)`` instead of ``float64(percentile*(len(arr))) / float64(100)``
 - Changed expected test results to match new behavior and added one new test
 - Changed struct RedMetrics' P50, P90, P95 and P99 variable types to match new FindPercentileData return type

Fixes #1030 

# Testing
I compared the results given by the tests with percentile calculation of the arrays with outside tools (such as online calculators).

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
