### PR TITLE
solved 'Download Results' Does Not Save City Name and metric cardinality sort icon

### DIFF
--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -294,7 +294,11 @@ function setDownloadLogsDialog() {
                                 if (key != 'key' && key != 'doc_count') newPerInfo[key] = perInfo[key].value;
                                 else if (key == 'key') {
                                     for (let j = 0; j < textArr.length; j++) {
-                                        newPerInfo[textArr[j]] = perInfo.key[j];
+                                        if (Array.isArray(perInfo.key)) {
+                                            newPerInfo[textArr[j]] = perInfo.key[j];
+                                        } else {
+                                            newPerInfo[textArr[j]] = perInfo.key;
+                                        }
                                     }
                                 }
                             }

--- a/static/js/metrics-cardinality.js
+++ b/static/js/metrics-cardinality.js
@@ -27,16 +27,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var tagKeysGridOptions = {
         columnDefs: [
-            { headerName: 'Key', field: 'key', filter: true, resizable: true },
-            { headerName: 'Number of Series', field: 'numSeries', filter: true, resizable: true },
+            { headerName: 'Key', field: 'key', filter: true, resizable: true,sort: 'asc' },
+            { headerName: 'Number of Series', field: 'numSeries', filter: true, resizable: true ,sort: 'asc'},
         ],
         rowData: [],
         rowHeight: 44,
         headerHeight: 32,
         defaultColDef: {
             cellClass: 'align-center-grid',
-
-            resizable: true,
+            icons: {
+                sortAscending: '<i class="fa fa-sort-alpha-down"/>',
+                sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+            },
+           sortable: true,
+           filter: false,
+           resizable: false,
+           cellStyle: { 'text-align': 'left' },
+           minWidth: 120,
+           animateRows: true,
+           readOnlyEdit: true,
+           autoHeight: true,
+           resizable: true,
         },
         enableCellTextSelection: true,
         suppressScrollOnNewData: true,
@@ -48,17 +59,28 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var tagPairsGridOptions = {
         columnDefs: [
-            { headerName: 'Key', field: 'key', filter: true, resizable: true },
-            { headerName: 'Value', field: 'value', filter: true, resizable: true },
-            { headerName: 'Number of Series', field: 'numSeries', filter: true, resizable: true },
+            { headerName: 'Key', field: 'key', filter: true, resizable: true,sort: 'asc' },
+            { headerName: 'Value', field: 'value', filter: true, resizable: true,sort: 'asc' },
+            { headerName: 'Number of Series', field: 'numSeries', filter: true, resizable: true,sort: 'asc' },
         ],
         rowData: [],
         rowHeight: 44,
         headerHeight: 32,
         defaultColDef: {
             cellClass: 'align-center-grid',
-
-            resizable: true,
+            icons: {
+                sortAscending: '<i class="fa fa-sort-alpha-down"/>',
+                sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+            },
+            sortable: true,
+           filter: false,
+           resizable: false,
+           cellStyle: { 'text-align': 'left' },
+           minWidth: 120,
+           animateRows: true,
+           readOnlyEdit: true,
+           autoHeight: true,
+           resizable: true,
         },
         enableCellTextSelection: true,
         suppressScrollOnNewData: true,
@@ -70,16 +92,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var tagKeysValuesGridOptions = {
         columnDefs: [
-            { headerName: 'Key', field: 'key', filter: true, resizable: true },
-            { headerName: 'Number of Unique Values', field: 'numValues', filter: true, resizable: true },
+            { headerName: 'Key', field: 'key', filter: true, resizable: true,sort: 'asc' },
+            { headerName: 'Number of Unique Values', field: 'numValues', filter: true, resizable: true ,sort: 'asc'},
         ],
         rowData: [],
         rowHeight: 44,
         headerHeight: 32,
         defaultColDef: {
             cellClass: 'align-center-grid',
-
-            resizable: true,
+            icons: {
+                sortAscending: '<i class="fa fa-sort-alpha-down"/>',
+                sortDescending: '<i class="fa fa-sort-alpha-up"/>',
+            },
+            sortable: true,
+           filter: false,
+           resizable: false,
+           cellStyle: { 'text-align': 'left' },
+           minWidth: 120,
+           animateRows: true,
+           readOnlyEdit: true,
+           autoHeight: true,
+           resizable: true,
         },
         enableCellTextSelection: true,
         suppressScrollOnNewData: true,

--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -168,6 +168,8 @@ $(document).ready(function () {
         }, 500);
     } else if (currentUrl.includes('metric-summary.html')) {
         $('.nav-metrics').addClass('active');
+    } else if (currentUrl.includes('metric-cardinality.html')) {
+        $('.nav-metrics').addClass('active');
     } else if (currentUrl.includes('dashboards-home.html') || currentUrl.includes('dashboard.html')) {
         $('.nav-ldb').addClass('active');
     } else if (currentUrl.includes('saved-queries.html')) {


### PR DESCRIPTION
1.Metrics Cardinality - Add sorting icons to all columns in all metrics cardinality table
![Screenshot 2024-07-22 174744](https://github.com/user-attachments/assets/ed1cf4c8-77b9-44d6-b11f-61337ce52966)

2.the city name is not saved correctly. when performing a query such as * | stats count(city) BY city, the downloaded results do not include the city name.
![Screenshot 2024-07-22 174901](https://github.com/user-attachments/assets/addf4298-f1ae-4e5a-aa3a-21b86a177d40)


# Description
Summarize the change.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
