### PR TITLE
Fix : Double rendering of metrics graph and Alerting UI

### DIFF
--- a/static/alert.html
+++ b/static/alert.html
@@ -88,21 +88,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
 
         <div id="alerting">
-            <div class="alerts-nav-tab">
-            </div>
-            <div class="upper-header">
-                <p class="caption">Rules that determine whether an alert will fire
-                </p>
+            <div class="dashboard-names mb-2">
+                <h4 class="all-dashboards" id="all-alerts-text">All Alerts</h4>
+                <span class="dashboard-arrow"></span>
+                <h3 class="name-dashboard" id="alert-name">New Alert</h3>
             </div>
             <!-- create alert form -->
-            <div class="form-container">
+            <div class="form-container" id="alerting-form-container">
                 <form id="alert-form">
                     <div class="d-flex btn-container">
                         <button class="btn" id="cancel-alert-btn" type="button" tabindex="9">Cancel</button>
                         <button class="btn" id="save-alert-btn" type="submit" tabindex="10">Save</button>
                     </div>
                     <div class="add-alert-form">
-                        <div class="rulename" style="display:none"></div>
                         <div id="metrics-graphs" class="metrics-graph-container">
     
                         </div>
@@ -195,7 +193,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <div class="d-flex">
                                             <div id = "tabs-1">
                                                 <div class="filter-info">
-                                                    <div id="filter-container">
+                                                    <div id="filter-container" class="position-relative">
                                                         <div class="filter-con">
                                                             <div class="filter-box" id="filter-box-1">
                                                                 <span class = "aggregations" id="search-filter-text">Search filter</span>
@@ -236,6 +234,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                                 <button id="cancel-enter-third" class="cancel-enter btn">×</button>
                                                             </div>
                                                         </div>
+                                                        <div class="require-field-tooltip" id="logs-error">Please fill a query</div>
                                                     </div>
                                                     <button class="search-img" id="query-builder-btn" type="button"></button>
                                                 </div>
@@ -265,8 +264,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div id="metrics-explorer">
                                 <div id="metrics-queries"></div>
                                 <div id="metrics-formula"></div>
-                                <div class="error-message" id="metric-error">Please select a metric.</div>
-                        
                                  <div class="mt-3 d-flex ">
                                      <button id="add-query" class="btn" type="button"><span class="plus-icon">+</span> Add Query</button>
                                      <button id="add-formula" class="btn" type="button"><span class="plus-icon">+</span> Add Formula</button>
@@ -349,9 +346,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         aria-labelledby="index-btn">
                                         <li id="option-0" class="contact-points-option">Add New</li>
                                     </div>
+                                    <div class="require-field-tooltip" id="contact-point-error">Please choose a contact point option!</div>
                                 </div>
                             </div>
-                            <div class="error-message" id="contact-point-error">Please choose a contact point option!</div>
                             <div class="message-info" id="message-info">
                                 Message<textarea name="message" id="notification-msg" rows="4" class="message" tabindex="6"
                                     required></textarea>

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -40,7 +40,6 @@
   --top-save-btn-bg-img: url("../assets/save-icon.svg");
   --arrow-dashboard-img: url("../assets/arrow-dashboard-light.svg");
   --panel-container: var(--white-5);
-  --front-arrow :  url('../assets/front-arrow-icon-dark.svg');
 }
 
 [data-theme='light']{
@@ -62,7 +61,6 @@
   --top-save-btn-bg-img: url("../assets/save-btn.svg");
   --arrow-dashboard-img: url("../assets/arrow-dashboard-black.svg");
   --panel-container: var(--white-9);
-  --front-arrow:  url('../assets/front-arrow-icon-light.svg');
 }
 
 
@@ -1523,13 +1521,6 @@ input:checked + .slider:before {
   font-size: 23px;
   padding-bottom: 3px;
   cursor: pointer;
-}
-
-.dashboard-arrow{
-  background-image: var(--front-arrow);
-  height: 10px;
-  width: 6px;
-  background-size: contain;
 }
 
 .avail-fields-btn{

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -72,9 +72,6 @@ input:checked + .slider:before {
     align-items: center;
     border: 1px solid var(--border-color-regular);
 }
-.graph-view-container {
-    margin-right: 10px;
-}
 
 .alert-from-metrics-btn {
     background-image: var(--alerting-btn-img);
@@ -91,7 +88,8 @@ input:checked + .slider:before {
     width: 30px;
     border: 1px solid var(--border-btn-color);
 }
-.metrics-query .query-box .options-container {
+.metrics-query .query-box .options-container , 
+.formula-box .options-container-formula{
     display: none;
 }
 
@@ -181,7 +179,7 @@ input:checked + .slider:before {
     transform: rotate(270deg);
 }
 
-.metrics-query input:focus{
+.metrics-query input:focus, .formula-box input:focus{
     background: var(--ui-widget-bg-color);
     outline: none;
     border-radius: 0px;
@@ -518,7 +516,7 @@ input:checked + .slider:before {
     position: absolute;
     top: 100%;
     left: 0;
-    min-width: 257px;
+    min-width: 270px;
     padding: 0 !important;
     border:none !important;
     z-index: 999;

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1717,14 +1717,11 @@ div.dts div.dataTables_scrollBody table {
     overflow: scroll;
     border: 1px solid var(--timepicker-border-color);
 }
-#save-query-options,
-#query-language-options,
-#query-mode-options,
-#source-options {
+#save-query-options{
     width: 130px;
     background: var(--index-drop-down-box-bg-color);
     overflow: hidden;
-    padding: 0px 10px 10px 10px;
+    padding: 0px 5px 5px 5px;
     border: 1px solid var(--timepicker-border-color);
 }
 

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -5702,17 +5702,15 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
 }
 
 .metric-summary {
-    padding-bottom: 1%;
+   padding-bottom: 1%;
   display:flex;
   flex-direction: column;
   justify-content: left;
-  overflow-y: scroll;
+  overflow: hidden;
   scrollbar-width: none; 
   -ms-overflow-style: none; 
 }
-.metric-summary-head{
-  margin-top: 0.5%;
-}
+
 .icon {
   visibility: hidden;
 }
@@ -5731,10 +5729,11 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
     left: 25%; 
     transform: translateX(-50%);
     white-space: nowrap;
-    box-shadow: 0px 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     font-family: Arial, sans-serif;
     font-size: 14px;
-    border: 1px solid black;  
+    border: 1px solid #d9d9d9;
+    margin-top: 8px;
 }
 
 .error-message::before, #metric-error::before {
@@ -5757,12 +5756,15 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
 .error-message::after, #metric-error::after {
     content: '';
     position: absolute;
-    left: 25%; 
-    border-width: 8px;
-    border-style: solid;
-    bottom: 100%;
-    border-color: transparent transparent white transparent;
-    transform: translateX(-25%);  
+    left: 15px; 
+    top: -9px;
+    width: 16px;
+    height: 16px;
+    background-color: white;
+    border-left: 1px solid #d9d9d9;
+    border-top: 1px solid #d9d9d9;
+    transform: rotate(45deg);
+    z-index: -1;
 }
   
 

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -268,6 +268,7 @@
     --selected-filter-blue: rgb(10, 42, 105);
     --selected-filter-red: rgb(102, 0, 61);
     --number-and-unit-color:var(--orange-1);
+    --front-arrow :  url('../assets/front-arrow-icon-dark.svg');
 }
 
 /* end aliases */
@@ -415,6 +416,7 @@
     --selected-filter-yellow: #FFFFCC;
     --selected-filter-red: #FBE7F4;
     --number-and-unit-color:var(--purple-1);
+    --front-arrow:  url('../assets/front-arrow-icon-light.svg');
 }
 
 
@@ -950,12 +952,6 @@ input.form-control:focus {
 }
 
 /* end - bootstrap overrides*/
-.rulename {
-    font-size: 18px;
-    font-weight: 700;
-    margin-bottom: 20px;
-    margin-left: 5px;
-}
 #progress-div {
     display: grid;
     grid-template-columns: 3fr auto;
@@ -3020,20 +3016,27 @@ float: right;
     background-color: var(--db-bg-color);
 }
 
-#new-dashboard .dashboard-names{
+.dashboard-names{
     display: flex;
     gap: 8px;
     align-items: center;
 }
 
-#new-dashboard .all-dashboards{
+.dashboard-arrow{
+    background-image: var(--front-arrow);
+    height: 10px;
+    width: 6px;
+    background-size: contain;
+}
+
+.all-dashboards{
     font-size: 16px;
     color: #6F6B7B;
     cursor: pointer;
     margin-bottom: 0;
 }
 
-#new-dashboard .name-dashboard{
+.name-dashboard{
     font-weight: 600;
     font-size: 16px;
     cursor: pointer;
@@ -4305,9 +4308,13 @@ color: #C8C7CC;
     background-color: var(--black1-to-white0);
     border: 1px solid var(--search-input-border);
     border-radius: 10px;
-    padding: 30px;
+    padding: 20px 30px;
     box-shadow: var(--box-shadow);
     overflow-y: scroll;
+}
+
+#alerting-form-container{
+    margin-top: 10px;
 }
 
 #alerting .section-buttons{
@@ -4329,7 +4336,7 @@ color: #C8C7CC;
 
 .subsection-heading div:nth-child(2){
     color: var(--drop-down-text-color);
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 600;
     margin-left: 20px;
 }
@@ -4356,8 +4363,8 @@ color: #C8C7CC;
     line-height: 14px;
 }
 #alerting .circle{
-    height: 36px;
-    width: 36px;
+    height: 32px;
+    width: 32px;
     border-radius: 50%;
     background-color: var(--purple-1);
     color: var(--white-0);
@@ -4373,8 +4380,8 @@ color: #C8C7CC;
     border: 1px solid var(--search-input-border);
     padding: 20px;
     border-radius: 10px;
-    margin-bottom: 30px;
-    margin-top: 20px;
+    margin-bottom: 20px;
+    margin-top: 10px;
     margin-left: 50px
 }
 
@@ -5007,6 +5014,10 @@ color: #C8C7CC;
     position: absolute;
     right: 20px;
 } 
+
+#alert-form .btn-container{
+    margin-top: -60px;
+}
 
 #alerting #ag-grid, .users-data-table #ag-grid{
     border: 1px solid var(--search-input-border);
@@ -5715,18 +5726,19 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
   visibility: hidden;
 }
 
-.error-message, #metric-error {
+.require-field-tooltip{
+    height: 38px !important;
     display: none;
     width: fit-content;
     text-align: left;
     border-radius: 4px;
-    padding: 8px 12px 8px 40px;
+    padding: 8px 12px 8px 40px !important;
     background-color: white;
     color: #333;
-    position: relative;
+    position: absolute;
     z-index: 1;
-    bottom: 125%;
-    left: 25%; 
+    top: 34px;
+    left: 180px;
     transform: translateX(-50%);
     white-space: nowrap;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -5736,7 +5748,7 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
     margin-top: 8px;
 }
 
-.error-message::before, #metric-error::before {
+.require-field-tooltip::before{
     content: "!";
     display: inline-block;
     width: 20px;
@@ -5753,7 +5765,7 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
     transform: translateY(-50%);
 }
 
-.error-message::after, #metric-error::after {
+.require-field-tooltip::after{
     content: '';
     position: absolute;
     left: 15px; 
@@ -5766,7 +5778,10 @@ ul.metrics-dropdown li, ul.metrics-dropdown li a{
     transform: rotate(45deg);
     z-index: -1;
 }
-  
+
+#alerting #select-metric-input{
+    position: relative;
+}
 
 .metric-summary-searchcontainer{
     display:flex !important;

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -113,6 +113,7 @@ $(document).ready(async function () {
         }
         setDataSourceHandler(alertType);
     });
+
     $('#cancel-alert-btn').on('click', function () {
         window.location.href = '../all-alerts.html';
         resetAddAlertForm();
@@ -149,7 +150,9 @@ $(document).ready(async function () {
             tooltipIds.forEach((id) => $(`#${id}`).tooltip('hide'));
         }
     });
+
     await getAlertId();
+
     if (window.location.href.includes('alert-details.html')) {
         alertDetailsFunctions();
         fetchAlertProperties();
@@ -163,25 +166,7 @@ $(document).ready(async function () {
         $('#contact-point-error').css('display', 'none'); // Hide error message when a contact point is selected
     });
 
-    $('#save-alert-btn').on('click', function (event) {
-        if ($('#contact-points-dropdown span').text() === 'Choose' || $('#contact-points-dropdown span').text() === 'Add New') {
-            event.preventDefault();
-            $('#contact-point-error').css('display', 'inline-block');
-            document.getElementById('contact-points-dropdown').scrollIntoView({
-                behavior: 'smooth',
-                block: 'center'
-            });
-        } else {
-            $('#contact-point-error').css('display', 'none'); // Hide error message if a valid contact point is selected
-        }
-    });
-
-    // Hide the error message if a contact point is selected again
-    $('#contact-points-dropdown').on('click', function () {
-        if ($('#contact-point-error').css('display') === 'inline-block') {
-            $('#contact-point-error').css('display', 'none');
-        }
-    });
+    handleFormValidationTooltip();
 
     $('#evaluate-for').tooltip({
         title: 'Evaluate For must be greater than or equal to Evaluate Interval',
@@ -215,6 +200,10 @@ $(document).ready(async function () {
 
     $('#evaluate-every').on('input', function () {
         checkEvaluateConditions();
+    });
+
+    $('#all-alerts-text').click(function () {
+        window.location.href = '../all-alerts.html';
     });
 });
 
@@ -356,6 +345,7 @@ if (historyBtn) {
 }
 
 function submitAddAlertForm(e) {
+    console.log('Submit');
     e.preventDefault();
     setAlertRule();
     alertEditFlag && !alertFromMetricsExplorerFlag ? updateAlertRule(alertData) : createNewAlertRule(alertData);
@@ -430,10 +420,6 @@ function createNewAlertRule(alertData) {
             window.location.href = '../all-alerts.html';
         })
         .catch((err) => {
-            $('#metric-error').css('display', 'inline-block');
-            setTimeout(function () {
-                $('#metric-error').css('display', 'none');
-            }, 3000);
             showToast(err.responseJSON.error, 'error');
         });
 }
@@ -530,7 +516,7 @@ async function displayAlert(res) {
 
     if (alertEditFlag && !alertFromMetricsExplorerFlag) {
         alertData.alert_id = res.alert_id;
-        $('.rulename').text(res.alert_name).css('display', 'block');
+        $('#alert-name').empty().text(res.alert_name);
     }
 
     $('#contact-points-dropdown span').html(res.contact_name).attr('id', res.contact_id);
@@ -900,4 +886,66 @@ function alertChart(res) {
             myChart.resize();
         });
     }
+}
+
+function handleFormValidationTooltip() {
+    const metricError = $('<div id="metric-error" class="require-field-tooltip">Please select a metric.</div>');
+    $('.metrics-query .query-box .query-builder').append(metricError);
+
+    $('#save-alert-btn').on('click', function (event) {
+        let dataSource = $('#alert-data-source span').text();
+        let isLogsCodeMode = $('#custom-code-tab').tabs('option', 'active');
+        let isMetricsCodeMode = $('.raw-query-input').is(':visible');
+        if (dataSource === 'Logs' && !isLogsCodeMode) {
+            if (thirdBoxSet.size === 0 && secondBoxSet.size === 0 && firstBoxSet.size === 0) {
+                $('#logs-error').css('display', 'inline-block');
+                $('#metric-error').removeClass('visible');
+                $('#contact-point-error').css('display', 'none');
+                document.getElementById('logs-error').scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                });
+                event.preventDefault();
+                return;
+            }
+        } else if (dataSource === 'Metrics' && !isMetricsCodeMode) {
+            // First, check if the metric input is empty
+            if ($('#select-metric-input').val().trim() === '') {
+                $('#metric-error').css('display', 'inline-block');
+                $('#contact-point-error').css('display', 'none');
+                document.getElementById('select-metric-input').scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                });
+                event.preventDefault();
+                return;
+            }
+        }
+
+        // If metric input is not empty, check the contact point
+        if ($('#contact-points-dropdown span').text() === 'Choose' || $('#contact-points-dropdown span').text() === 'Add New') {
+            event.preventDefault(); // Prevent form submission
+            $('#contact-point-error').css('display', 'inline-block');
+            document.getElementById('contact-points-dropdown').scrollIntoView({
+                behavior: 'smooth',
+                block: 'center',
+            });
+            return;
+        }
+
+        // If both metric input and contact point are valid, form submission will continue
+        // The browser will handle required fields with default tooltips
+    });
+
+    $('#select-metric-input').on('focus', function () {
+        $('#metric-error').css('display', 'none');
+    });
+
+    $(document).on('click', function (event) {
+        if (!$(event.target).closest('#select-metric-input, #save-alert-btn').length) {
+            $('#metric-error').css('display', 'none');
+            $('#logs-error').css('display', 'none');
+            $('#contact-point-error').css('display', 'none');
+        }
+    });
 }

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -167,6 +167,10 @@ $(document).ready(async function () {
         if ($('#contact-points-dropdown span').text() === 'Choose' || $('#contact-points-dropdown span').text() === 'Add New') {
             event.preventDefault();
             $('#contact-point-error').css('display', 'inline-block');
+            document.getElementById('contact-points-dropdown').scrollIntoView({
+                behavior: 'smooth',
+                block: 'center'
+            });
         } else {
             $('#contact-point-error').css('display', 'none'); // Hide error message if a valid contact point is selected
         }

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -345,7 +345,6 @@ if (historyBtn) {
 }
 
 function submitAddAlertForm(e) {
-    console.log('Submit');
     e.preventDefault();
     setAlertRule();
     alertEditFlag && !alertFromMetricsExplorerFlag ? updateAlertRule(alertData) : createNewAlertRule(alertData);

--- a/static/js/dashboard-from-logs-metrics.js
+++ b/static/js/dashboard-from-logs-metrics.js
@@ -68,7 +68,7 @@ $(document).ready(function () {
         };
 
         var queryString = $.param(queryParams);
-        window.location.href = '../alert.html?' + queryString;
+        window.open('../alert.html' + queryString, '_blank');
     });
     var currentPage = window.location.pathname;
     if (currentPage === '/metrics-explorer.html') {
@@ -168,7 +168,7 @@ function createPanelToNewDashboard() {
                 };
                 updateDashboard(dashboard);
                 var queryString = '?id=' + Object.keys(res)[0];
-                window.location.href = '../dashboard.html' + queryString;
+                window.open('../dashboard.html' + queryString, '_blank');
             })
             .catch(function (updateError) {
                 if (updateError.status === 409) {
@@ -255,7 +255,7 @@ function selectDashboardHandler() {
             };
             updateDashboard(dashboard);
             var queryString = '?id=' + dashboardID;
-            window.location.href = '../dashboard.html' + queryString;
+            window.open('../dashboard.html' + queryString, '_blank');
         });
     }
 

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1688,7 +1688,7 @@ function mergeGraphs(chartType, panelId = -1) {
         if (Object.prototype.hasOwnProperty.call(chartDataCollection, queryName)) {
             // Merge datasets for the current query
             var datasets = chartDataCollection[queryName].datasets;
-            graphNames.push(`${datasets[0].label}`);
+            graphNames.push(`${datasets[0]?.label}`);
 
             datasets.forEach(function (dataset, datasetIndex) {
                 // Calculate color for the dataset
@@ -2450,8 +2450,6 @@ $('#alert-from-metrics-btn').click(function () {
             } else {
                 queryString = queryDetails.rawQueryInput;
             }
-            const formula = { formula: queryName };
-            mformulas.push(formula);
             const tquery = { name: queryName, query: `(${queryString})`, qlType: 'promql' };
             mqueries.push(tquery);
         });

--- a/static/metrics-explorer.html
+++ b/static/metrics-explorer.html
@@ -174,7 +174,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </div>
                 </div>
                 <hr>
-                <div class="mt-4" style="display:flex;flex-direction:row;gap:5px">
+                <div class="mt-4" style="display:flex; flex-direction:row; gap:10px">
                     <div class="graph-view-container btn">
                         <label class="switch">
                             <input type="checkbox" id="toggle-switch" checked>


### PR DESCRIPTION
# Description
1. Fix the issue of double rendering of the metrics graph when clicking on the URL sent in the alert message.
2. Add better styling to the tooltip on the Alerts screen if logs, metrics, or contact points are empty, and ensure it scrolls to the point where the tooltip is shown.
3. Remove the upper navbar from the alerting screen.
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/515abeff-5bb9-4928-9acb-7e76470f15a7">
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/a24442b0-3301-4825-8efe-c9d584bdd7c2">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
