### PR TITLE
Fix : SegStats Query with Float Value Does Not Display Correctly

### DIFF
--- a/static/js/ag-grid-seg-stats.js
+++ b/static/js/ag-grid-seg-stats.js
@@ -26,11 +26,10 @@ function renderMeasuresGrid(columnOrder, hits) {
         new agGrid.Grid(eGridDiv, aggGridOptions);
     }
     // set the column headers from the data
-    let colDefs = aggGridOptions.api.getColumnDefs();
-    colDefs.length = 0;
-    colDefs = columnOrder.map((colName, index) => {
+    let colDefs = columnOrder.map((colName, index) => {
         let title = colName;
-        let resize = index + 1 == columnOrder.length ? false : true;
+        let fieldId = colName.replace(/\s+/g, '_').replace(/[^\w\s]/gi, ''); // Replace special characters and spaces
+        let resize = index + 1 !== columnOrder.length;
         let maxWidth = Math.max(displayTextWidth(colName, 'italic 19pt  DINpro '), 200); //200 is approx width of 1trillion number
         //preserving white space for every column
         let cellRenderer = (params) => {
@@ -40,7 +39,7 @@ function renderMeasuresGrid(columnOrder, hits) {
             return span;
         };
         return {
-            field: title,
+            field: fieldId,
             headerName: title,
             resizable: resize,
             minWidth: maxWidth,
@@ -53,21 +52,22 @@ function renderMeasuresGrid(columnOrder, hits) {
     $.each(hits.measure, function (_key, resMap) {
         newRow.set('id', 0);
         columnOrder.map((colName, _index) => {
+            let fieldId = colName.replace(/\s+/g, '_').replace(/[^\w\s]/gi, ''); // Replace special characters and spaces
             let ind = -1;
             if (hits.groupByCols != undefined && hits.groupByCols.length > 0) {
                 ind = findColumnIndex(hits.groupByCols, colName);
             }
             //group by col
             if (ind != -1 && resMap.GroupByValues.length != 1 && resMap.GroupByValues[ind] != '*') {
-                newRow.set(colName, resMap.GroupByValues[ind]);
+                newRow.set(fieldId, resMap.GroupByValues[ind]);
             } else if (ind != -1 && resMap.GroupByValues.length === 1 && resMap.GroupByValues[0] != '*') {
-                newRow.set(colName, resMap.GroupByValues[0]);
+                newRow.set(fieldId, resMap.GroupByValues[0]);
             } else {
                 // Check if MeasureVal is undefined or null and set it to 0
                 if (resMap.MeasureVal[colName] === undefined || resMap.MeasureVal[colName] === null) {
-                    newRow.set(colName, '0');
+                    newRow.set(fieldId, '0');
                 } else {
-                    newRow.set(colName, resMap.MeasureVal[colName]);
+                    newRow.set(fieldId, resMap.MeasureVal[colName]);
                 }
             }
         });

--- a/static/js/dashboard-logs-results-grid.js
+++ b/static/js/dashboard-logs-results-grid.js
@@ -263,10 +263,11 @@ function renderPanelAggsGrid(columnOrder, hits, panelId) {
     colDefs.length = 0;
     colDefs = columnOrder.map((colName, index) => {
         let title = colName;
-        let resize = index + 1 == columnOrder.length ? false : true;
-        let maxWidth = Math.max(displayTextWidth(colName, 'italic 19pt  DINpro '), 200); //200 is approx width of 1trillion number
+        let fieldId = colName.replace(/\s+/g, '_').replace(/[^\w\s]/gi, ''); // Replace special characters and spaces
+        let resize = index + 1 !== columnOrder.length;
+        let maxWidth = Math.max(displayTextWidth(colName, 'italic 19pt DINpro'), 200); //200 is approx width of 1trillion number
         return {
-            field: title,
+            field: fieldId,
             headerName: title,
             resizable: resize,
             minWidth: maxWidth,
@@ -278,21 +279,22 @@ function renderPanelAggsGrid(columnOrder, hits, panelId) {
     $.each(hits.measure, function (key, resMap) {
         newRow.set('id', 0);
         columnOrder.map((colName, _index) => {
+            let fieldId = colName.replace(/\s+/g, '_').replace(/[^\w\s]/gi, ''); // Replace special characters and spaces
             let ind = -1;
             if (hits.groupByCols != undefined && hits.groupByCols.length > 0) {
                 ind = findColumnIndex(hits.groupByCols, colName);
             }
             //group by col
             if (ind != -1 && resMap.GroupByValues.length != 1 && resMap.GroupByValues[ind] != '*') {
-                newRow.set(colName, resMap.GroupByValues[ind]);
+                newRow.set(fieldId, resMap.GroupByValues[ind]);
             } else if (ind != -1 && resMap.GroupByValues.length === 1 && resMap.GroupByValues[0] != '*') {
-                newRow.set(colName, resMap.GroupByValues[0]);
+                newRow.set(fieldId, resMap.GroupByValues[0]);
             } else {
                 // Check if MeasureVal is undefined or null and set it to 0
                 if (resMap.MeasureVal[colName] === undefined || resMap.MeasureVal[colName] === null) {
-                    newRow.set(colName, '0');
+                    newRow.set(fieldId, '0');
                 } else {
-                    newRow.set(colName, resMap.MeasureVal[colName]);
+                    newRow.set(fieldId, resMap.MeasureVal[colName]);
                 }
             }
         });


### PR DESCRIPTION
# Description
Previously, queries like `app_name=Bracecould | stats sum(eval(http_status > 301.1))` or `app_name=Bracecould | stats sum(eval(http_status > 301.1)) as sum_http_status`  were not working. The issue was that special characters like `.` were not being handled properly by the ag-grid. Now, the change will replace any special character with an underscore and then do the comparison so it works correctly.
Fix the issue on both alert and dashboards screen.
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/41eb1ca7-0938-41d8-84db-cb39e83b1aa8">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
