### PR TITLE
feat: Added support constant value in metrics PromQL Parser

### DIFF
--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cespare/xxhash"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	putils "github.com/siglens/siglens/pkg/integrations/prometheus/utils"
 	"github.com/siglens/siglens/pkg/segment/results/mresults"
@@ -59,6 +60,12 @@ func extractTimeWindow(args parser.Expressions) (float64, float64, error) {
 }
 
 func ConvertPromQLToMetricsQuery(query string, startTime, endTime uint32, myid uint64) ([]structs.MetricsQueryRequest, parser.ValueType, []structs.QueryArithmetic, error) {
+	// Check if the query is just a number
+	_, err := dtypeutils.ConvertToFloat(query, 64)
+	if err == nil {
+		// If yes, then add 0 + to the query, to convert it as a Binary Expr
+		query = fmt.Sprintf("0 + %s", query)
+	}
 	mQueryReqs, pqlQuerytype, queryArithmetic, err := parsePromQLQuery(query, startTime, endTime, myid)
 	if err != nil {
 		return []structs.MetricsQueryRequest{}, "", []structs.QueryArithmetic{}, err

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -1152,6 +1152,26 @@ func Test_parsePromQLQuery_Scalar_Op_v1(t *testing.T) {
 	assert.Equal(t, float64(4), queryOp.RHSExpr.RHSExpr.Constant)
 }
 
+func Test_parsePromQLQuery_Scalar_SingleValue(t *testing.T) {
+	endTime := uint32(time.Now().Unix())
+	startTime := endTime - 86400 // 1 day
+
+	myId := uint64(0)
+
+	query := "99"
+
+	mQueryReqs, pqlQuerytype, queryArithmetic, err := ConvertPromQLToMetricsQuery(query, startTime, endTime, myId)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mQueryReqs))
+	assert.Equal(t, 1, len(queryArithmetic))
+	assert.Equal(t, parser.ValueTypeScalar, pqlQuerytype)
+	assert.Equal(t, segutils.LetAdd, queryArithmetic[0].Operation)
+	assert.True(t, queryArithmetic[0].ConstantOp)
+	assert.NotNil(t, queryArithmetic[0].RHSExpr)
+	assert.True(t, queryArithmetic[0].RHSExpr.ConstantOp)
+	assert.Equal(t, float64(99), queryArithmetic[0].RHSExpr.Constant)
+}
+
 func Test_parsePromQLQuery_Parse_Metrics_Test_CSV(t *testing.T) {
 	endTime := uint32(time.Now().Unix())
 	startTime := endTime - 86400 // 1 day


### PR DESCRIPTION
# Description
- Now the PromQL Parser will handle constant scalar values as Queries. Example queries like: `1`, `1000`, etc.

# Testing
- Added a new unit test case for the parser.
- Tested by executing the TimeSeries API through Postman.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
