### PR TITLE
feat: added support rendering buttons for URLs in Slack Alert Notifications

### DIFF
--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -286,7 +286,7 @@ func evaluateLogAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.Job) 
 		return
 	}
 
-	alertDataMessage := fmt.Sprintf("View the Query Results: %v", getLogsQueryLinkForTheAlert(alertToEvaluate, timeRange))
+	alertDataMessage := getLogsQueryLinkForTheAlert(alertToEvaluate, timeRange)
 
 	err = handleAlertCondition(alertToEvaluate, isAlertConditionMatched, alertDataMessage)
 	if err != nil {
@@ -324,7 +324,7 @@ func evaluateMetricsAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.J
 		parsedJsonMap["start"] = start
 		parsedJsonMap["end"] = end
 
-		alertDataMessage = fmt.Sprintf("View the Query Results: %v", getMetricsQueryLinkForTheAlert(alertToEvaluate, parsedJsonMap))
+		alertDataMessage = getMetricsQueryLinkForTheAlert(alertToEvaluate, parsedJsonMap)
 	}
 
 	err = handleAlertCondition(alertToEvaluate, isAlertConditionMatched, alertDataMessage)

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	"runtime"
 	"strings"
@@ -933,4 +934,18 @@ func SendInternalError(ctx *fasthttp.RequestCtx, messageToUser string, extraMess
 
 func SendUnauthorizedError(ctx *fasthttp.RequestCtx, messageToUser string, extraMessageToLog string, err error) {
 	sendErrorWithStatus(log.StandardLogger(), ctx, messageToUser, extraMessageToLog, err, fasthttp.StatusUnauthorized)
+}
+
+func IsValidURL(str string) bool {
+	u, err := url.Parse(str)
+	return err == nil && u.Scheme != "" && u.Host != ""
+}
+
+func EncodeURL(str string) (string, error) {
+	u, err := url.Parse(str)
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = url.QueryEscape(u.RawQuery)
+	return u.String(), nil
 }


### PR DESCRIPTION
# Description
- Now the Query results Link or a URL that is in the Message set by the user will render as Buttons in the Slack Notification message.

# Testing
- Tested by creating alert with a link in the message and verified that both Query Results Link and the Message are rendered as buttons.

This is how the Message looks:
![image](https://github.com/user-attachments/assets/aed7f01d-5b9a-4b35-a903-9bdee98bc5c3)


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
