### PR TITLE
Add util to log and return an error

### DIFF
--- a/pkg/utils/logutils.go
+++ b/pkg/utils/logutils.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TeeErrorf(format string, args ...interface{}) error {
+	err := fmt.Errorf(format, args...)
+	log.Error(err.Error())
+
+	return err
+}


### PR DESCRIPTION
# Description
We often want to log and return an error, so we have error handling like this:
```
if someCondition {
    err := fmt.Errorf("myFunc: failed to do foo using bar; err=%v", err)
    log.Errorf(err.Error())
    return err
}
```
With the new util we can just do:
```
if someCondition {
    return utils.TeeErrorf("myFunc: failed to do foo using bar; err=%v", err)
}
```

We could potentially rename this util to something more verbose like `LogAndReturnErrorf`. I went with `TeeErrorf` (like the unix `tee` command) because it's shorter and if we frequently use this util throughout the codebase, everyone should be able to remember what it does. But I'm open to name change suggestions

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
