### PR TITLE
Add implementation for mvexpand

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -247,3 +247,7 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "city=Boston | stats count AS Count BY http_status | eval res=relative_time(1721738260,""-1w"")",now-1d,now,*,group:res:400,eq,1721133460000,Splunk QL
 "city=Boston | stats count AS Count BY http_status | eval res=relative_time(1721738260,""-1s"")",now-1d,now,*,group:res:400,eq,1721738259000,Splunk QL
 "city=Boston | stats count AS Count BY http_status | eval nowResult=relative_time(now(),""-1h"") | eval timeResult=relative_time(time()/1000,""-1h"") | eval finalResult=if(nowResult=timeResult, ""Pass"", ""Fail"")",now-1d,now,*,group:finalResult:400,eq,"Pass",Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 1| mvexpand names | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 2| mvexpand names | stats count",now-1d,now,*,countRecord:count(*):*,eq,8,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 1| mvexpand names limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 3| mvexpand names limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,6,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -228,3 +228,7 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "| gentimes start=04/04/2021 end=04/07/2021 | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
 "| gentimes start=-30 end=-20 increment=7s | stats count",now-1d,now,*,countRecord:count(*):*,eq,"123,429",Splunk QL
 "| gentimes start=12/01/2021:16:11:56 end=12/05/2021:12:00:01 increment=3m | stats count",now-1d,now,*,countRecord:count(*):*,eq,"1,837",Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 1| mvexpand names | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 2| mvexpand names | stats count",now-1d,now,*,countRecord:count(*):*,eq,8,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 1| mvexpand names limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
+"city=Boston | eval names=""Frank,Grace,Heidi,Ivan""| makemv delim="","" names | head 3| mvexpand names limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,6,Splunk QL

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -1970,15 +1970,13 @@ func performMultiValueColRequestWithoutGroupby(letColReq *structs.LetColumnsRequ
 func performMVExpand(fieldValue interface{}) []interface{} {
 	var values []interface{}
 
-	switch v := fieldValue.(type) {
-	case []string:
-		for _, val := range v {
-			values = append(values, val)
-		}
-	case []interface{}:
-		values = v
-	default:
+	isArrayOrSlice, v, _ := utils.IsArrayOrSlice(fieldValue)
+	if !isArrayOrSlice {
 		return nil
+	}
+
+	for i := 0; i < v.Len(); i++ {
+		values = append(values, v.Index(i).Interface())
 	}
 
 	return values

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -1981,11 +1981,6 @@ func performMVExpand(fieldValue interface{}) []interface{} {
 		}
 	case []interface{}:
 		values = v
-	case string:
-		splitValues := strings.Split(v, ",")
-		for _, val := range splitValues {
-			values = append(values, val)
-		}
 	default:
 		return nil
 	}

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -1948,15 +1948,11 @@ func performMultiValueColRequestWithoutGroupby(letColReq *structs.LetColumnsRequ
 			}
 			delete(recs, key)
 			for i, expandedValue := range expandedRecs {
-				expandedValueStr, ok := expandedValue.(string)
-				if !ok {
-					expandedValueStr = fmt.Sprintf("%v", expandedValue)
-				}
 				newRec := make(map[string]interface{})
 				for k, v := range rec {
 					newRec[k] = v
 				}
-				newRec[mvColReq.ColName] = expandedValueStr
+				newRec[mvColReq.ColName] = expandedValue
 				newRecs[fmt.Sprintf("%s_%d", key, i)] = newRec
 			}
 		default:

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -2901,6 +2901,7 @@ func Test_PerformMVExpand(t *testing.T) {
 		"3": {"numbers": []int{1, 2, 3, 4}},
 		"4": {"prices": []float64{10.5, 20.75, 30.0}},
 		"5": {"flags": []bool{true, false, true}},
+		"6": {"invalid": "not a slice"}, // Non-slice input.
 	}
 
 	expectedResults := map[string]map[string][]interface{}{
@@ -2909,12 +2910,13 @@ func Test_PerformMVExpand(t *testing.T) {
 		"3": {"numbers": {1, 2, 3, 4}},
 		"4": {"prices": {10.5, 20.75, 30.0}},
 		"5": {"flags": {true, false, true}},
+		"6": {"invalid": nil}, // Expect nil as this input should fail.
 	}
 
 	for recNum, rec := range recs {
 		for colName, values := range rec {
 			expandedValues := performMVExpand(values)
-			assert.Equal(t, expectedResults[recNum][colName], expandedValues)
+			assert.Equal(t, expectedResults[recNum][colName], expandedValues, fmt.Sprintf("Test failed for record %s, column %s", recNum, colName))
 		}
 	}
 }

--- a/pkg/segment/aggregations/segaggs_test.go
+++ b/pkg/segment/aggregations/segaggs_test.go
@@ -2893,3 +2893,28 @@ func Test_Values(t *testing.T) {
 	}
 
 }
+
+func Test_PerformMVExpand(t *testing.T) {
+	recs := map[string]map[string]interface{}{
+		"1": {"senders": []string{"john@example.com", "jane@example.com", "doe@example.com"}},
+		"2": {"senders": []string{"foo@example.com", "", "bar@example.com"}},
+		"3": {"numbers": []int{1, 2, 3, 4}},
+		"4": {"prices": []float64{10.5, 20.75, 30.0}},
+		"5": {"flags": []bool{true, false, true}},
+	}
+
+	expectedResults := map[string]map[string][]interface{}{
+		"1": {"senders": {"john@example.com", "jane@example.com", "doe@example.com"}},
+		"2": {"senders": {"foo@example.com", "", "bar@example.com"}},
+		"3": {"numbers": {1, 2, 3, 4}},
+		"4": {"prices": {10.5, 20.75, 30.0}},
+		"5": {"flags": {true, false, true}},
+	}
+
+	for recNum, rec := range recs {
+		for colName, values := range rec {
+			expandedValues := performMVExpand(values)
+			assert.Equal(t, expectedResults[recNum][colName], expandedValues)
+		}
+	}
+}


### PR DESCRIPTION
# Description
https://docs.splunk.com/Documentation/Splunk/9.2.2/SearchReference/Mvexpand

# Testing
- `city=Boston 
| eval names="Frank,Grace,Heidi,Ivan"
| makemv delim="," names 
| mvexpand names
`
- `city=Boston 
| eval names="Frank,Grace,Heidi,Ivan"
| makemv delim="," names 
| mvexpand names limit=2
`
- `city=Boston 
| eval names="Frank,Grace,Heidi,Ivan"
| eval cities="Boston, Chicago, Miami"
| makemv delim="," cities | mvexpand cities
`
- `city=Boston 
| eval names="Frank,Grace,Heidi,Ivan"
| eval cities="Boston, Chicago, Miami"
| makemv delim="," cities | mvexpand cities limit=2`
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
