### PR TITLE
fix: database is locked issue in Alerting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.data
-siglens.db
+siglens.db*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -61,8 +61,7 @@ type database interface {
 	GetAlertNotification(alert_id string) (*alertutils.Notification, error)
 	GetContactDetails(alert_id string) (string, string, string, error)
 	GetEmailAndChannelID(contact_id string) ([]string, []alertutils.SlackTokenConfig, []alertutils.WebHookConfig, error)
-	UpdateLastSentTimeAndAlertState(alert_id string, alertState alertutils.AlertState) error
-	UpdateAlertStateAndIncrementNumEvaluations(alertId string, alertState alertutils.AlertState) error
+	UpdateAlertStateAndNotificationDetails(alertId string, alertState alertutils.AlertState, updateNotificationState bool) error
 	DeleteContactPoint(contact_id string) error
 }
 

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -656,10 +656,10 @@ func (p Sqlite) DeleteContactPoint(contact_id string) error {
 }
 
 // update last_sent_time and last_alert_state in notification_details table
-func updateLastSentTimeAndAlertState(tx *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
+func updateLastSentTimeAndAlertState(db *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
 	currentTime := time.Now().UTC()
 
-	err := tx.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).
+	err := db.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).
 		Updates(map[string]interface{}{
 			"last_sent_time":   currentTime,
 			"last_alert_state": alertState,
@@ -673,8 +673,8 @@ func updateLastSentTimeAndAlertState(tx *gorm.DB, alert_id string, alertState al
 	return nil
 }
 
-func updateAlertStateAndIncrementNumEvaluations(tx *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
-	err := tx.Model(&alertutils.AlertDetails{}).Where("alert_id = ?", alert_id).
+func updateAlertStateAndIncrementNumEvaluations(db *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
+	err := db.Model(&alertutils.AlertDetails{}).Where("alert_id = ?", alert_id).
 		Updates(map[string]interface{}{
 			"state":                 alertState,
 			"num_evaluations_count": gorm.Expr("num_evaluations_count + ?", 1),

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -37,6 +38,8 @@ type Sqlite struct {
 	db  *gorm.DB
 	ctx context.Context
 }
+
+const maxRetries = 5
 
 func (p *Sqlite) SetDB(dbConnection *gorm.DB) {
 	p.db = dbConnection
@@ -58,6 +61,16 @@ func (p *Sqlite) Connect() error {
 	})
 	if err != nil {
 		log.Errorf("Connect: error in opening sqlite connection, Error=%+v", err)
+		return err
+	}
+
+	if err := dbConnection.Exec("PRAGMA journal_mode=WAL;").Error; err != nil {
+		log.Errorf("Connect: error in setting journal mode, Error=%+v", err)
+		return err
+	}
+
+	if err := dbConnection.Exec("PRAGMA busy_timeout=5000;").Error; err != nil {
+		log.Errorf("Connect: error in setting busy timeout, Error=%+v", err)
 		return err
 	}
 
@@ -101,6 +114,23 @@ func (p *Sqlite) Connect() error {
 
 func isValid(str string) bool {
 	return str != "" && str != "*"
+}
+
+func retry(operation func(attemptCount int) error) error {
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = operation(i + 1)
+		if err == nil {
+			return nil
+		}
+		if strings.Contains(err.Error(), "database is locked") {
+			log.Warnf("retry: database is locked, retrying attempt %d. Error=%v", i+1, err)
+			time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Millisecond * 50)
+			continue
+		}
+		return err
+	}
+	return err
 }
 
 // checks whether the alert name exists
@@ -625,49 +655,73 @@ func (p Sqlite) DeleteContactPoint(contact_id string) error {
 }
 
 // update last_sent_time and last_alert_state in notification_details table
-func (p Sqlite) UpdateLastSentTimeAndAlertState(alert_id string, alertState alertutils.AlertState) error {
+func updateLastSentTimeAndAlertState(tx *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
 	currentTime := time.Now().UTC()
 
-	if err := p.db.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).
+	if err := tx.Model(&alertutils.Notification{}).Where("alert_id = ?", alert_id).
 		Updates(map[string]interface{}{
 			"last_sent_time":   currentTime,
 			"last_alert_state": alertState,
 		}).Error; err != nil {
 		err = fmt.Errorf("UpdateLastSentTimeAndAlertState: unable to update, AlertId=%v, Error=%+v", alert_id, err)
-		log.Errorf(err.Error())
 		return err
 	}
 
 	return nil
 }
 
-func (p Sqlite) UpdateAlertStateAndIncrementNumEvaluations(alert_id string, alertState alertutils.AlertState) error {
+func updateAlertStateAndIncrementNumEvaluations(tx *gorm.DB, alert_id string, alertState alertutils.AlertState) error {
+	if err := tx.Model(&alertutils.AlertDetails{}).Where("alert_id = ?", alert_id).
+		Updates(map[string]interface{}{
+			"state":                 alertState,
+			"num_evaluations_count": gorm.Expr("num_evaluations_count + ?", 1),
+		}).Error; err != nil {
+		err = fmt.Errorf("UpdateAlertStateAndIncrementNumEvaluations: unable to update alert state and increment evaluations count with AlertId=%v, Error=%+v", alert_id, err)
+		return err
+	}
+	return nil
+}
+
+func (p Sqlite) UpdateAlertStateAndNotificationDetails(alert_id string, alertState alertutils.AlertState, updateNotificationState bool) error {
 	if !isValid(alert_id) {
-		err := fmt.Errorf("UpdateAlertStateAndIncrementNumEvaluations: Data Validation Check Failed: AlertId=%v is not valid", alert_id)
+		err := fmt.Errorf("UpdateAlertStateAndNotificationDetails: Data Validation Check Failed: AlertId=%v is not valid", alert_id)
 		log.Error(err.Error())
 		return err
 	}
 	alertExists, _, err := p.verifyAlertExists(alert_id)
 	if err != nil {
-		err = fmt.Errorf("UpdateAlertStateAndIncrementNumEvaluations: unable to verify if alert name exists, AlertId=%v, Error=%+v", alert_id, err)
+		err = fmt.Errorf("UpdateAlertStateAndNotificationDetails: unable to verify if alert name exists, AlertId=%v, Error=%+v", alert_id, err)
 		log.Error(err.Error())
 		return err
 	}
 	if !alertExists {
-		err := fmt.Errorf("UpdateAlertStateAndIncrementNumEvaluations: alert does not exist, AlertId=%v", alert_id)
+		err := fmt.Errorf("UpdateAlertStateAndNotificationDetails: alert does not exist, AlertId=%v", alert_id)
 		log.Error(err.Error())
 		return err
 	}
 
-	if err := p.db.Model(&alertutils.AlertDetails{}).Where("alert_id = ?", alert_id).
-		Updates(map[string]interface{}{
-			"state":                 alertState,
-			"num_evaluations_count": gorm.Expr("num_evaluations_count + ?", 1),
-		}).Error; err != nil {
-		err = fmt.Errorf("UpdateAlertStateAndIncrementNumEvaluations: unable to update alert state and increment evaluations count, with AlertId=%v, Error=%+v", alert_id, err)
+	err = retry(func(attemptCount int) error {
+		return p.db.Transaction(func(tx *gorm.DB) error {
+			if err := updateAlertStateAndIncrementNumEvaluations(tx, alert_id, alertState); err != nil {
+				return err
+			}
+
+			if updateNotificationState {
+				if err := updateLastSentTimeAndAlertState(tx, alert_id, alertState); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	})
+
+	if err != nil {
+		err = fmt.Errorf("UpdateAlertStateAndNotificationDetails: unable to update alert state and notification details, with AlertId=%v, Error=%+v", alert_id, err)
 		log.Error(err.Error())
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Description
- Fixes the database is locked issue when updating the Alert state and last sent notification time.
- This fix includes: 
    - Enabling `WAL` for SQLite and setting a busy timeout wait of `5000` ms. The busy timeout is for the scenarios where the database is locked for a relatively small time. The DB operation will wait for the set time before throwing a database is locked error.
    - Setting retry for 5 times with increasing delays before a retry.
- This fix seems to work perfectly fine after testing on my local device with 2000 Alerts.
- In future, we may need to do the updates in batches if this not work for more work loads. At that time we can use `chan` to collect the Alerts data and call update every set interval ms.

# Testing
- Tested by running alerts load-test up to 2000 Alerts per Minute.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
