### PR TITLE
Fix - Panel Overview and Time-picker of Metrics Panels

### DIFF
--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -1112,6 +1112,7 @@ function goToDashboard() {
     $('.popupOverlay').removeClass('active');
     $('#app-container').show();
     $('#viewPanel-container').hide();
+    $('#overview-button').removeClass('active');
     setTimePickerValue();
     displayPanels();
     if (dbRefresh) {

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1653,6 +1653,10 @@ function mergeGraphs(chartType, panelId = -1) {
     var mergedCtx;
     if (isDashboardScreen) {
         // For dashboard page
+        if(currentPanel){
+            const data = getMetricsQData();
+            currentPanel.queryData = data;
+        }
         var panelChartEl;
         if (panelId === -1) {
             panelChartEl = $(`.panelDisplay .panEdit-panel`);

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1807,7 +1807,11 @@ function mergeGraphs(chartType, panelId = -1) {
 }
 
 const shouldShowLegend = (panelId, datasets) => {
-    return panelId === -1 || datasets.length < 5;
+    if ($('#overview-button').hasClass('active')) {
+        return true; // Show legends for panel overview
+    } else {
+        return panelId === -1 || datasets.length < 5; // Hide legends for panel with more than 5 legends
+    }
 };
 
 // Converting the response in form to use to create graphs

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1653,7 +1653,7 @@ function mergeGraphs(chartType, panelId = -1) {
     var mergedCtx;
     if (isDashboardScreen) {
         // For dashboard page
-        if(currentPanel){
+        if (currentPanel) {
             const data = getMetricsQData();
             currentPanel.queryData = data;
         }


### PR DESCRIPTION
# Description
Fix for issue - When editing metrics queries or formulas, on the panel overview the changes were not reflected correctly. Switching back to edit mode or using the time picker reverted the panel to its previously saved state, removing all recent edits.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
