### PR TITLE
fix: issue of rendering button for a text message in Alerting Notifications through Slack

### DIFF
--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -255,29 +255,31 @@ func sendSlack(alertName string, message string, channel alertutils.SlackTokenCo
 		}
 	}
 
-	// If the Message that a user has set while creating is a URL,
-	// then we will add a button to view the message
-	encodedURL, err := utils.EncodeURL(message)
-	if err != nil {
-		log.Errorf("sendSlack: Error encoding URL. Error=%v", err)
-	} else {
-		messageAttachment := slack.AttachmentAction{
-			Name:  "view_message_link",
-			Text:  "View Message",
-			Type:  "button",
-			URL:   encodedURL,
-			Style: "default",
-		}
-		if len(attachment.Actions) > 0 {
-			attachment.Actions = append(attachment.Actions, messageAttachment)
+	if utils.IsValidURL(message) {
+		// If the Message that a user has set while creating is a URL,
+		// then we will add a button to view the message
+		encodedURL, err := utils.EncodeURL(message)
+		if err != nil {
+			log.Errorf("sendSlack: Error encoding URL. Error=%v", err)
 		} else {
-			attachment.Actions = []slack.AttachmentAction{messageAttachment}
-		}
+			messageAttachment := slack.AttachmentAction{
+				Name:  "view_message_link",
+				Text:  "View Message",
+				Type:  "button",
+				URL:   encodedURL,
+				Style: "default",
+			}
+			if len(attachment.Actions) > 0 {
+				attachment.Actions = append(attachment.Actions, messageAttachment)
+			} else {
+				attachment.Actions = []slack.AttachmentAction{messageAttachment}
+			}
 
-		attachment.Text = ""
+			attachment.Text = ""
+		}
 	}
 
-	_, _, err = client.PostMessage(
+	_, _, err := client.PostMessage(
 		channelID,
 		slack.MsgOptionAttachments(attachment),
 	)


### PR DESCRIPTION
# Description
- Corrects the rendering of the button for a text.
- However, even when a notification is sent as the alert state is updated to `Normal`, the button will still be rendered if a `URL` is provided in the alert message.

Fixes #1358 

# Testing
- Tested by triggering Alert Notifications with URL and with sample text as Alert Messages.
- Verified that the button is not rendering for text messages.

![image](https://github.com/user-attachments/assets/0529575f-4628-40f8-8910-b7f91ef8dba2)


# Checklist:
- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
