### PR TITLE
Add utils for debugging

### DIFF
--- a/pkg/utils/debugutils.go
+++ b/pkg/utils/debugutils.go
@@ -27,14 +27,14 @@ import (
 )
 
 // Use this at the start of a function like this:
-// TraceEnter(fmt.Sprintf("parameter foo=%v", foo))
+// SigDebugEnter(fmt.Sprintf("parameter foo=%v", foo))
 // OR
-// TraceEnter("")
-func TraceEnter(extraMessage string) {
+// SigDebugEnter("")
+func SigDebugEnter(extraMessage string) {
 	// Get information about the function we're entering.
 	programCounter, file, line, ok := runtime.Caller(1)
 	if !ok {
-		log.Warnf("TraceEnter: Unable to get caller information")
+		log.Warnf("SigDebugEnter: Unable to get caller information")
 		return
 	}
 	funcName := extractFuncName(runtime.FuncForPC(programCounter).Name())
@@ -60,13 +60,17 @@ func TraceEnter(extraMessage string) {
 }
 
 // Use this at the start of a function like this:
-// defer TraceExit(func() string { return fmt.Sprintf("final foo=%v", foo) })
+// defer SigDebugExit(func() string { return fmt.Sprintf("final foo=%v", foo) })
 // OR
-// defer TraceExit(nil)
-func TraceExit(computeExtraMessage func() string) {
+// defer SigDebugExit(nil)
+//
+// Note: this uses a function to compute the extra message so that when it's
+// used with defer, the values captured are the values when the defer is
+// executed, not when the defer is declared.
+func SigDebugExit(computeExtraMessage func() string) {
 	programCounter, file, line, ok := runtime.Caller(1)
 	if !ok {
-		log.Warnf("TraceExit: Unable to get caller information")
+		log.Warnf("SigDebugExit: Unable to get caller information")
 		return
 	}
 	funcName := extractFuncName(runtime.FuncForPC(programCounter).Name())

--- a/pkg/utils/debugutils.go
+++ b/pkg/utils/debugutils.go
@@ -32,24 +32,24 @@ import (
 // TraceEnter("")
 func TraceEnter(extraMessage string) {
 	// Get information about the function we're entering.
-	pc, file, line, ok := runtime.Caller(1)
+	programCounter, file, line, ok := runtime.Caller(1)
 	if !ok {
 		log.Warnf("TraceEnter: Unable to get caller information")
 		return
 	}
-	funcName := extractFuncName(runtime.FuncForPC(pc).Name())
+	funcName := extractFuncName(runtime.FuncForPC(programCounter).Name())
 	fileName := filepath.Base(file)
 
 	// Get information about the caller.
 	var message string
-	callerPc, callerFile, callerLine, callerOk := runtime.Caller(2)
+	callerProgramCounter, callerFile, callerLine, callerOk := runtime.Caller(2)
 	if callerOk {
-		callerFuncName := extractFuncName(runtime.FuncForPC(callerPc).Name())
+		callerFuncName := extractFuncName(runtime.FuncForPC(callerProgramCounter).Name())
 		callerFileName := filepath.Base(callerFile)
-		message = fmt.Sprintf("Entering %s at %s:%d from %s at %s:%d",
+		message = fmt.Sprintf("Entering %s (%s:%d) from %s at %s:%d",
 			funcName, fileName, line, callerFuncName, callerFileName, callerLine)
 	} else {
-		message = fmt.Sprintf("Entering %s at %s:%d (cannot determine caller)", funcName, fileName, line)
+		message = fmt.Sprintf("Entering %s (%s:%d) (cannot determine caller)", funcName, fileName, line)
 	}
 
 	if extraMessage != "" {
@@ -64,12 +64,12 @@ func TraceEnter(extraMessage string) {
 // OR
 // defer TraceExit(nil)
 func TraceExit(computeExtraMessage func() string) {
-	pc, file, line, ok := runtime.Caller(1)
+	programCounter, file, line, ok := runtime.Caller(1)
 	if !ok {
 		log.Warnf("TraceExit: Unable to get caller information")
 		return
 	}
-	funcName := extractFuncName(runtime.FuncForPC(pc).Name())
+	funcName := extractFuncName(runtime.FuncForPC(programCounter).Name())
 	fileName := filepath.Base(file)
 
 	message := fmt.Sprintf("Exiting %s at %s:%d", funcName, fileName, line)

--- a/pkg/utils/debugutils.go
+++ b/pkg/utils/debugutils.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Use this at the start of a function like this:
+// TraceEnter(fmt.Sprintf("parameter foo=%v", foo))
+// OR
+// TraceEnter("")
+func TraceEnter(extraMessage string) {
+	// Get information about the function we're entering.
+	pc, file, line, ok := runtime.Caller(1)
+	if !ok {
+		log.Warnf("TraceEnter: Unable to get caller information")
+		return
+	}
+	funcName := extractFuncName(runtime.FuncForPC(pc).Name())
+	fileName := filepath.Base(file)
+
+	// Get information about the caller.
+	var message string
+	callerPc, callerFile, callerLine, callerOk := runtime.Caller(2)
+	if callerOk {
+		callerFuncName := extractFuncName(runtime.FuncForPC(callerPc).Name())
+		callerFileName := filepath.Base(callerFile)
+		message = fmt.Sprintf("Entering %s at %s:%d from %s at %s:%d",
+			funcName, fileName, line, callerFuncName, callerFileName, callerLine)
+	} else {
+		message = fmt.Sprintf("Entering %s at %s:%d (cannot determine caller)", funcName, fileName, line)
+	}
+
+	if extraMessage != "" {
+		message += "; " + extraMessage
+	}
+
+	log.Infof(message)
+}
+
+// Use this at the start of a function like this:
+// defer TraceExit(func() string { return fmt.Sprintf("final foo=%v", foo) })
+// OR
+// defer TraceExit(nil)
+func TraceExit(computeExtraMessage func() string) {
+	pc, file, line, ok := runtime.Caller(1)
+	if !ok {
+		log.Warnf("TraceExit: Unable to get caller information")
+		return
+	}
+	funcName := extractFuncName(runtime.FuncForPC(pc).Name())
+	fileName := filepath.Base(file)
+
+	message := fmt.Sprintf("Exiting %s at %s:%d", funcName, fileName, line)
+
+	if computeExtraMessage != nil {
+		message += "; " + computeExtraMessage()
+	}
+
+	log.Infof(message)
+}
+
+// Takes a full function name like:
+// github.com/siglens/siglens/pkg/segment/aggregations.PostQueryBucketCleaning
+// and returns just the function name: PostQueryBucketCleaning
+func extractFuncName(funcName string) string {
+	funcNameSplit := strings.Split(funcName, ".")
+	return funcNameSplit[len(funcNameSplit)-1]
+}


### PR DESCRIPTION
# Description
Add some utils for debugging the flow of functions, and allows you to log extra relevant info. These functions are intended to be used just while debugging.

For example, at the top of the function you can add:
```
utils.TraceEnter(fmt.Sprintf("len recs: %v", len(recs)))
defer utils.TraceExit(func() string { return fmt.Sprintf("len recs: %v", len(recs)) })
```
Then when that function is called, you'll get something like:
```
Entering performAggOnResult (segaggs.go:183) from PostQueryBucketCleaning at segaggs.go:146; len recs: 1000
```
And when the function exits you'll see:
```
Exiting PostQueryBucketCleaning at segaggs.go:162; len recs: 2000
```
Also the the line number it mentions here (segaggs.go:162), is the exact line number of the `return` that got triggered, so if the function has multiple returns, you can see exactly which one got triggered.


# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
