### PR TITLE
Bug Fix fields command after generating commands.

### DIFF
--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -224,6 +224,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 		} else {
 			recs = make(map[string]map[string]interface{})
 			finalCols = nodeRes.FinalColumns
+			nodeRes.ColumnsOrder = colsIndexMap
 		}
 
 		if hasQueryAggergatorBlock || transactionArgsExist {

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -213,7 +213,6 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 				return
 			}
 			recs = _recs
-			nodeRes.ColumnsOrder = colsIndexMap
 			for cName := range cols {
 				finalCols[cName] = true
 			}
@@ -224,8 +223,9 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 		} else {
 			recs = make(map[string]map[string]interface{})
 			finalCols = nodeRes.FinalColumns
-			nodeRes.ColumnsOrder = colsIndexMap
 		}
+
+		nodeRes.ColumnsOrder = colsIndexMap
 
 		if hasQueryAggergatorBlock || transactionArgsExist {
 


### PR DESCRIPTION
# Description
Summarize the change.
Earlier for non-search events like gentimes, etc. fields command was erroring out due to nil map for nodeResult.ColumnsOrder at this [line](https://github.com/siglens/siglens/blob/a5bda9c262fe5e30552d62355eee5fb0f0c2ebf2/pkg/segment/aggregations/segaggs.go#L834).

Fixes #<issue-number> (link all the GitHub issues this addresses)
nodeResult.ColumnsOrder must be initialized like over [here](https://github.com/siglens/siglens/blob/a5bda9c262fe5e30552d62355eee5fb0f0c2ebf2/pkg/segment/reader/record/rrcreader.go#L216).

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

```
| gentimes start=-2 increment=5m | fields starttime
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
