### PR TITLE
fixed "Add to Alert" on Logs Does Not Populate Query on Alerts Page

### DIFF
--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -96,7 +96,7 @@ $(document).ready(async function () {
     $('#alert-rule-name').val(urlParams.get('alertRule_name'));
     data = getInitialSearchFilter(false, false);
     initialSearchData = data;
-    doSearch(data); 
+    doSearch(data);
     $('.alert-condition-options li').on('click', setAlertConditionHandler);
     $('#contact-points-dropdown').on('click', contactPointsDropdownHandler);
     $('#logs-language-options li').on('click', setLogsLangHandler);

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -94,6 +94,9 @@ $(document).ready(async function () {
     setupEventHandlers();
     const urlParams = new URLSearchParams(window.location.search);
     $('#alert-rule-name').val(urlParams.get('alertRule_name'));
+    data = getInitialSearchFilter(false, false);
+    initialSearchData = data;
+    doSearch(data); 
     $('.alert-condition-options li').on('click', setAlertConditionHandler);
     $('#contact-points-dropdown').on('click', contactPointsDropdownHandler);
     $('#logs-language-options li').on('click', setLogsLangHandler);

--- a/static/js/dashboard-from-logs-metrics.js
+++ b/static/js/dashboard-from-logs-metrics.js
@@ -68,7 +68,7 @@ $(document).ready(function () {
         };
 
         var queryString = $.param(queryParams);
-        window.open('../alert.html' + queryString, '_blank');
+        window.open('../alert.html?' + queryString, '_blank');
     });
     var currentPage = window.location.pathname;
     if (currentPage === '/metrics-explorer.html') {


### PR DESCRIPTION
# Description
Populates Alert Page with the query of logs screen when add to alert is pressed

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
