### PR TITLE
Fix ingestion stats bug for unrotated-only index

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dustin/go-humanize"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/siglens/siglens/pkg/hooks"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	segwriter "github.com/siglens/siglens/pkg/segment/writer"
 	"github.com/siglens/siglens/pkg/segment/writer/metrics"
 	mmeta "github.com/siglens/siglens/pkg/segment/writer/metrics/meta"
@@ -292,7 +293,9 @@ func getStats(myid uint64, filterFunc func(string) bool, volumeField, countField
 
 		counts, ok := allVTableCounts[indexName]
 		if !ok {
-			continue
+			// We still want to check for unrotated data, so don't skip this
+			// loop iteration.
+			counts = &structs.VtableCounts{}
 		}
 
 		unrotatedByteCount, unrotatedEventCount, unrotatedOnDiskBytesCount := segwriter.GetUnrotatedVTableCounts(indexName, myid)


### PR DESCRIPTION
# Description
Fixes a bug where if an index only has unrotated data, the stats on MyOrg doesn't show any data for that index (and the unrotated data is not included in the total amount of ingested data).

# Testing
Manual testing:
1. Ingest 100k records into 10 indexes
2. Go to MyOrg and verify the correct stats are there
3. Restart siglens to force rotation
4. Check MyOrg again (nothing should change)
5. Ingest another 100k records
6. Check MyOrg again (now there's twice the data)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
