### PR TITLE
refac: Refactored smrLock to use `RWMutex`

### DIFF
--- a/pkg/segment/query/metadata/segmentmicroindex.go
+++ b/pkg/segment/query/metadata/segmentmicroindex.go
@@ -104,7 +104,7 @@ func (smi *SegmentMicroIndices) GetCMIsForBlock(blkNum uint16) (map[string]*stru
 		return nil, fmt.Errorf("no cmis are loaded")
 	}
 
-	if int(blkNum) >= len(smi.blockCmis)-1 {
+	if int(blkNum) >= len(smi.blockCmis) {
 		return nil, fmt.Errorf("blkNum %+v does not exist", blkNum)
 	}
 	cmis := smi.blockCmis[blkNum]

--- a/pkg/segment/query/metadata/segmentmicroindex.go
+++ b/pkg/segment/query/metadata/segmentmicroindex.go
@@ -99,6 +99,11 @@ func (smi *SegmentMicroIndices) clearMicroIndices() {
 
 // Returns all columnar cmis for a given block or any errors encountered
 func (smi *SegmentMicroIndices) GetCMIsForBlock(blkNum uint16) (map[string]*structs.CmiContainer, error) {
+	if len(smi.blockCmis) == 0 {
+		log.Errorf("GetCMIsForBlock: No block cmis are loaded. loadedMicroIndices: %+v", smi.loadedMicroIndices)
+		return nil, fmt.Errorf("no cmis are loaded")
+	}
+
 	if int(blkNum) >= len(smi.blockCmis) {
 		return nil, fmt.Errorf("blkNum %+v does not exist", blkNum)
 	}
@@ -114,7 +119,7 @@ func (smi *SegmentMicroIndices) GetCMIForBlockAndColumn(blkNum uint16, cname str
 	}
 	retVal, ok := allCmis[cname]
 	if !ok {
-		return nil, fmt.Errorf("Failed to find column %+v in cmis for block %+v", cname, blkNum)
+		return nil, fmt.Errorf("failed to find column %+v in cmis for block %+v", cname, blkNum)
 	}
 	return retVal, nil
 }

--- a/pkg/segment/query/metadata/segmentmicroindex.go
+++ b/pkg/segment/query/metadata/segmentmicroindex.go
@@ -104,7 +104,7 @@ func (smi *SegmentMicroIndices) GetCMIsForBlock(blkNum uint16) (map[string]*stru
 		return nil, fmt.Errorf("no cmis are loaded")
 	}
 
-	if int(blkNum) >= len(smi.blockCmis) {
+	if int(blkNum) >= len(smi.blockCmis)-1 {
 		return nil, fmt.Errorf("blkNum %+v does not exist", blkNum)
 	}
 	cmis := smi.blockCmis[blkNum]

--- a/pkg/segment/writer/segmetareader.go
+++ b/pkg/segment/writer/segmetareader.go
@@ -46,8 +46,8 @@ func ReadLocalSegmeta() []*structs.SegMeta {
 
 // returns all segmetas downloaded, including the current nodes segmeta and all global segmetas
 func ReadAllSegmetas() []*structs.SegMeta {
-	smrLock.Lock()
-	defer smrLock.Unlock()
+	smrLock.RLock()
+	defer smrLock.RUnlock()
 
 	ingestDir := config.GetIngestNodeBaseDir()
 	files, err := os.ReadDir(ingestDir)

--- a/pkg/segment/writer/segmetareader.go
+++ b/pkg/segment/writer/segmetareader.go
@@ -33,8 +33,8 @@ var SegmetaSuffix = "segmeta.json"
 
 // read only the current nodes segmeta
 func ReadLocalSegmeta() []*structs.SegMeta {
-	smrLock.Lock()
-	defer smrLock.Unlock()
+	smrLock.RLock()
+	defer smrLock.RUnlock()
 
 	segMetaFilename := GetLocalSegmetaFName()
 	retVal, err := getAllSegmetas(segMetaFilename)
@@ -92,8 +92,8 @@ func ReadAllSegmetas() []*structs.SegMeta {
 }
 
 func ReadSegmeta(smFname string) ([]*structs.SegMeta, error) {
-	smrLock.Lock()
-	defer smrLock.Unlock()
+	smrLock.RLock()
+	defer smrLock.RUnlock()
 	retVal, err := getAllSegmetas(smFname)
 	if err != nil {
 		log.Errorf("ReadSegmeta: getsegmetas err=%v ", err)

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -60,7 +60,7 @@ var maxSegFileSize uint64
 
 var KibanaInternalBaseDir string
 
-var smrLock sync.Mutex = sync.Mutex{}
+var smrLock sync.RWMutex = sync.RWMutex{}
 var localSegmetaFname string
 
 // Create a writer that caches compressors.

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -761,8 +761,8 @@ func getActiveBaseDirVTable(virtualTableName string) string {
 }
 
 func GetSegMetas(segmentKeys []string) (map[string]*structs.SegMeta, error) {
-	smrLock.Lock()
-	defer smrLock.Unlock()
+	smrLock.RLock()
+	defer smrLock.RUnlock()
 
 	segKeySet := make(map[string]struct{})
 	for _, segKey := range segmentKeys {

--- a/tools/sigclient/pkg/alerts/alerts.go
+++ b/tools/sigclient/pkg/alerts/alerts.go
@@ -51,7 +51,7 @@ const (
 	AlertMessagePrefix       = "Test Alert - "
 	LogsString               = "Logs"
 	MetricsString            = "Metrics"
-	MetricsQueryParamsString = "{\"start\": \"now-24h\", \"end\": \"now\", \"queries\": [{\"name\": \"a\", \"query\": \"avg by (car_type) (testmetric0{car_type=\\\"Passenger car heavy\\\"})\", \"qlType\": \"promql\"}, {\"name\": \"b\", \"query\": \"avg by (car_type) (testmetric1{car_type=\\\"Passenger car heavy\\\"})\", \"qlType\": \"promql\"}], \"formulas\": [{\"formula\": \"a+b\"}]}"
+	MetricsQueryParamsString = "{\"start\": \"now-1h\", \"end\": \"now\", \"queries\": [{\"name\": \"a\", \"query\": \"avg by (car_type) (testmetric0{car_type=\\\"Passenger car heavy\\\"})\", \"qlType\": \"promql\"}, {\"name\": \"b\", \"query\": \"avg by (car_type) (testmetric1{car_type=\\\"Passenger car heavy\\\"})\", \"qlType\": \"promql\"}], \"formulas\": [{\"formula\": \"a+b\"}]}"
 	LogsQueryText            = `app_name=Wheat* AND gender=male | stats count(app_name) by gender`
 	LogsQueryLanguage        = "Splunk QL"
 	LogsStartTime            = "now-1h"


### PR DESCRIPTION
# Description
- Refactored `smrLock` to use `RWMutex` instead of `Mutex`. 
- Changed all the read functions to use `RLock()` instead of `Lock()`.
- This also made the `clusterStats` endpoint to load the data faster.
- Fixed an issue with `nil pointer` error in `segmentmicroindex` while getting the `CMIsForBlock`.  

# Testing
- All the tests passed.
- Verified that the cluster stats is showing correctly and the queries are working.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
