### PR TITLE
Fix: Display correct disk usage

### DIFF
--- a/pkg/systemConfig/systemconfig.go
+++ b/pkg/systemConfig/systemconfig.go
@@ -27,6 +27,7 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/valyala/fasthttp"
 
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
@@ -74,7 +75,7 @@ func GetSystemInfo(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	diskInfo, err := disk.Usage("/")
+	diskInfo, err := disk.Usage(config.GetDataPath())
 	if err != nil {
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 		log.Errorf("GetSystemInfo: Failed to retrieve disk info: %v", err)


### PR DESCRIPTION
# Description
Summarize the change.
We were using the fixed root path location to find the disk usage. Use config.GetDataPath() to identify where the data directory. disk.Usage will then resolve to the correct disk/partition path and show the usage for that disk and not the default root disk usage.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Created a 60 GB partition on mac and ran siglens from that directory. In the previous case it was showing around 400 GB which is the size of the root partition. After this change its showing around 55 GB which is the size of the newly created disk partition from where siglens is running.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4c56504c-1251-4a76-b753-8e43d47fc3a0">

Previously it was showing this
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a17f5da2-9ae0-4da5-8d13-4e407986c81f">


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
