### PR TITLE
Fix: Multiple segment/index Head issue

### DIFF
--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -662,16 +662,8 @@ func (qa *QueryAggregators) hasHeadBlock() bool {
 	if qa.OutputTransforms == nil {
 		return false
 	}
-	if qa.OutputTransforms.HeadRequest == nil {
-		return false
-	}
-	if qa.OutputTransforms.HeadRequest.BoolExpr != nil {
-		return true
-	}
-	if qa.OutputTransforms.HeadRequest.MaxRows > qa.OutputTransforms.HeadRequest.RowsAdded {
-		return true
-	}
-	return false
+
+	return qa.OutputTransforms.HeadRequest != nil
 }
 
 type queryAggregatorsBoolFunc func(_ *QueryAggregators) bool

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -117,21 +117,6 @@ func Test_HasQueryAggergatorBlock_MaxRowsGreaterThanRowAdded(t *testing.T) {
 	assert.True(t, qa.HasQueryAggergatorBlock())
 }
 
-func Test_HasQueryAggergatorBlock_MaxRowsLessThanRowAdded(t *testing.T) {
-	ot := &OutputTransforms{
-		HeadRequest: &HeadExpr{
-			MaxRows:   1,
-			RowsAdded: 9,
-		},
-	}
-
-	qa := &QueryAggregators{
-		OutputTransforms: ot,
-	}
-
-	assert.False(t, qa.HasQueryAggergatorBlock())
-}
-
 func Test_HasQueryAggergatorBlock(t *testing.T) {
 	lcr := &LetColumnsRequest{
 		RexColRequest: &RexExpr{},
@@ -235,19 +220,6 @@ func Test_HasQueryAggergatorBlockInChain_SingleNodeWithBlock(t *testing.T) {
 	}
 
 	assert.True(t, qa.HasQueryAggergatorBlockInChain(), "Expected true when single node has a query aggregator block, got false")
-}
-
-func Test_HasQueryAggergatorBlockInChain_SingleNodeWithoutBlock(t *testing.T) {
-	qa := &QueryAggregators{
-		OutputTransforms: &OutputTransforms{
-			HeadRequest: &HeadExpr{
-				MaxRows:   1,
-				RowsAdded: 10,
-			},
-		},
-	}
-
-	assert.False(t, qa.HasQueryAggergatorBlockInChain(), "Expected false when single node does not have a query aggregator block, got true")
 }
 
 func Test_HasQueryAggergatorBlockInChain_MultipleNodesWithBlockAtEnd(t *testing.T) {


### PR DESCRIPTION
# Description
Summarize the change.
Cleanup for multiple segments was not happening properly cause postQueryBucketCleaning was not being called as hasQueryAggregatorBlock was returning false for second or later segments if the rows were added. Due, to this, the left-out rows were just getting added to the result.
This condition was added from the earlier hasQueryAggregator block method.

Fixes #<issue-number> (link all the GitHub issues this addresses)
HasQueryAggregatorBlock now returns true in all cases when there is a headRequest, so that either performMaxRows or performConditionalHead is always called.

The issue is only present for performMaxRows, performConditionalHead is working fine as expected.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
For multiple segments/index this query seems to be working now.
```
* | search app_name="W*" | fields app_name, batch | head 2
* | search app_name="W*" | fields app_name, batch | head like(app_name, "%") limit=3
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
