### PR TITLE
Bug: Panicking on certain queries

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -171,8 +171,8 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "* | head 2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "* | head | stats count",now-1d,now,*,countRecord:count(*):*,eq,10,Splunk QL
 "city=Boston | head limit=3 | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
-"app_name = Bracecould | head gender=""female"" | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
-"app_name = Bracecould | head gender=""female"" keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
+"app_name = Bracecould | sort gender | head gender=""female"" | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
+"app_name = Bracecould | sort gender | head gender=""female"" keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
 "app_name = Bracecould | head gender=""female"" OR gender=""male"" limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "app_name = Bracecould | head gender=""female"" OR gender=""male"" limit=2 keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "app_name = Bracecould | sort http_status | head http_status < 400 keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -741,7 +741,7 @@ func (qa *QueryAggregators) GetSortLimit() uint64 {
 	if qa.HasSortBlock() {
 		return qa.OutputTransforms.LetColumns.SortColRequest.Limit
 	}
-	if qa.Next != nil {
+	if qa != nil && qa.Next != nil {
 		return qa.Next.GetSortLimit()
 	}
 	return math.MaxUint64


### PR DESCRIPTION
# Description
Summarize the change.
When specific query is where the GetSortLimit method fails. After the qa.HasSortBlock fails there is no nil check for query aggregator. Added the check to prevent seg fault.
nodeResult.NextQueryAgg will not be set and will come up as [nil](https://github.com/siglens/siglens/blob/239c57ac284c608db219d02a533173c7f412794a/pkg/segment/aggregations/segaggs.go#L144) because len of recs is zero for the case where condition returns 0 records before stats.

Updated the head queries that were giving inconsistent results due to different ingestion order.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Tested the queries manually as well by running the ingest.csv

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
