### PR TITLE
UI changes to display segment count on cluster stats screen

### DIFF
--- a/static/js/cluster-stats.js
+++ b/static/js/cluster-stats.js
@@ -488,9 +488,9 @@ function processClusterStats(res) {
         }
     });
 
-    let indexColumnOrder = ['Index Name', 'Incoming Volume', 'Event Count', ''];
+    let indexColumnOrder = ['Index Name', 'Incoming Volume', 'Event Count', 'Segment Count', ''];
     let metricsColumnOrder = ['Index Name', 'Incoming Volume', 'Datapoint Count'];
-    let traceColumnOrder = ['Index Name', 'Incoming Volume', 'Span Count'];
+    let traceColumnOrder = ['Index Name', 'Incoming Volume', 'Span Count', 'Segment Count'];
 
     let indexDataTableColumns = indexColumnOrder.map((columnName, index) => {
         let title = `<div class="grid"><div>${columnName}&nbsp;</div><div><i data-index="${index}"></i></div></div>`;
@@ -556,6 +556,8 @@ function processClusterStats(res) {
     function displayIndexDataRows(res) {
         let totalIngestVolume = 0;
         let totalEventCount = 0;
+        let totalLogSegmentCount = 0;
+        let totalTraceSegmentCount = 0;
         let totalValRow = [];
         totalValRow[0] = `Total`;
         totalValRow[1] = `${Number(`${totalIngestVolume >= 10 ? totalIngestVolume.toFixed().toLocaleString('en-US') : totalIngestVolume}`)} GB`;
@@ -569,10 +571,12 @@ function processClusterStats(res) {
                     let l = parseFloat(v.ingestVolume);
                     currRow[1] = Number(`${l >= 10 ? l.toFixed().toLocaleString('en-US') : l}`) + '  GB';
                     currRow[2] = `${v.eventCount}`;
-                    currRow[3] = `<button class="btn-simple index-del-btn" id="index-del-btn-${k}"></button>`;
+                    currRow[3] = `${v.segmentCount}`;
+                    currRow[4] = `<button class="btn-simple index-del-btn" id="index-del-btn-${k}"></button>`;
 
                     totalIngestVolume += parseFloat(`${v.ingestVolume}`);
                     totalEventCount += parseInt(`${v.eventCount}`.replaceAll(',', ''));
+                    totalLogSegmentCount += parseInt(`${v.segmentCount}`.replaceAll(',', ''));
 
                     indexDataTable.row.add(currRow);
                 });
@@ -601,14 +605,17 @@ function processClusterStats(res) {
                     let l = parseFloat(v.traceVolume);
                     currRow[1] = Number(`${l >= 10 ? l.toFixed().toLocaleString('en-US') : l}`) + '  GB';
                     currRow[2] = `${v.traceSpanCount}`;
+                    currRow[3] = `${v.segmentCount}`;
+                    totalTraceSegmentCount += parseInt(v.segmentCount);
                     traceDataTable.row.add(currRow);
                 });
             });
         }
-
+        totalValRowTrace[3] = totalTraceSegmentCount.toLocaleString(); 
         totalIngestVolume = Math.round(parseFloat(`${res.ingestionStats['Log Incoming Volume']}`) * 1000) / 1000;
         totalValRow[1] = `${Number(`${totalIngestVolume >= 10 ? totalIngestVolume.toFixed().toLocaleString('en-US') : totalIngestVolume}`)} GB`;
         totalValRow[2] = `${totalEventCount.toLocaleString()}`;
+        totalValRow[3] = `${totalLogSegmentCount.toLocaleString()}`;
         indexDataTable.draw();
         metricsDataTable.draw();
         traceDataTable.draw();


### PR DESCRIPTION
# Description
Display segment count along with other stats for logs and traces


# Testing
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/67bc91e9-fd25-4462-9b00-fffe83d1a898">

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/4144f7b8-848a-43e9-bfb9-97bb51f853b0">
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
