### PR TITLE
Avoid using pqs query flow if pqs is disabled even if pqmr file is present

### DIFF
--- a/pkg/segment/query/pqs/pqs.go
+++ b/pkg/segment/query/pqs/pqs.go
@@ -111,6 +111,9 @@ func GetAllPersistentQueryResults(segKey string, pqid string) (*pqmr.SegmentPQMR
 // Returns if segKey, pqid combination exists
 func DoesSegKeyHavePqidResults(segKey string, pqid string) bool {
 
+	if !config.IsPQSEnabled() {
+		return false
+	}
 	_, err := getPQResults(segKey, pqid)
 	return err == nil
 }


### PR DESCRIPTION
# Description
Avoid using pqs query flow if pqs is disabled even if pqmr file is present

# Testing
- Tested by enabling PQS, running a query and then disabling PQS. Verified that the code follows the rawSearch query flow for the same query instead of the PQS query flow, even though the PQMR file was present.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
