### PR TITLE
Fix: Some queries were not working for multi segment/index data.

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -171,8 +171,8 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "* | head 2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "* | head | stats count",now-1d,now,*,countRecord:count(*):*,eq,10,Splunk QL
 "city=Boston | head limit=3 | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
-"app_name = Bracecould | head gender=""female"" | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
-"app_name = Bracecould | head gender=""female"" keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
+"app_name = Bracecould | sort gender | head gender=""female"" | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
+"app_name = Bracecould | sort gender | head gender=""female"" keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
 "app_name = Bracecould | head gender=""female"" OR gender=""male"" limit=2 | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "app_name = Bracecould | head gender=""female"" OR gender=""male"" limit=2 keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
 "app_name = Bracecould | sort http_status | head http_status < 400 keeplast=true | stats count",now-1d,now,*,countRecord:count(*):*,eq,4,Splunk QL
@@ -259,8 +259,8 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "app_name=Bracecould | stats values(eval(if(http_status > 302, ""Error"", http_status))) as values BY http_method",now-1d,now,*,group:values:POST,eq,"301&nbspError",Splunk QL
 "app_name=Companywill | stats dc(eval(if(http_status > 310, ""Error"", http_status))) as dc by http_method",now-1d,now,*,group:dc:DELETE,eq,2,Splunk QL
 "* | eval newField=nullif(http_status, 200) | fields newField, http_status | fillnull value=FILLING | eval countVal=if(http_status=200 AND newField=""FILLING"", 1, 0) | stats count(http_status) as count, sum(countVal) as sum_count by newField | where count=sum_count",now-1d,now,*,countRecord:newField,eq,"FILLING",Splunk QL
-"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where http_status=200 | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,14,Splunk QL
-"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where nullStatus=null() | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,14,Splunk QL
+"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where http_status=200 | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,167,Splunk QL
+"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where nullStatus=null() | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,167,Splunk QL
 "| gentimes start=08/10/2022 end=08/11/2022 increment=5h | stats count",now-1d,now,*,countRecord:count(*):*,eq,5,Splunk QL
 "| gentimes start=04/04/2021 end=04/07/2021 | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
 "| gentimes start=-30 end=-20 increment=7s | stats count",now-1d,now,*,countRecord:count(*):*,eq,"123,429",Splunk QL

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -638,7 +638,7 @@ func parseANDCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 func GetFinalSizelimit(aggs *QueryAggregators, sizeLimit uint64) uint64 {
 	if aggs != nil && (aggs.GroupByRequest != nil || aggs.MeasureOperations != nil) && aggs.StreamStatsOptions == nil {
 		sizeLimit = 0
-	} else if aggs.HasDedupBlockInChain() || aggs.HasSortBlockInChain() || aggs.HasRexBlockInChainWithStats() || aggs.HasTransactionArgumentsInChain() || aggs.HasTailInChain() || aggs.HasBinInChain() || aggs.HasStreamStatsInChain() || aggs.HasGenerateEvent() {
+	} else if aggs.HasDedupBlockInChain() || aggs.HasSortBlockInChain() || aggs.HasGroupByOrMeasureAggsInChain() || aggs.HasTransactionArgumentsInChain() || aggs.HasTailInChain() || aggs.HasBinInChain() || aggs.HasStreamStatsInChain() || aggs.HasGenerateEvent() {
 		// 1. Dedup needs state information about the previous records, so we can
 		// run into an issue if we show some records, then the user scrolls
 		// down to see more and we run dedup on just the new records and add

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -141,7 +141,7 @@ func PostQueryBucketCleaning(nodeResult *structs.NodeResult, post *structs.Query
 		if len(nodeResult.TransactionEventRecords) > 0 {
 			nodeResult.NextQueryAgg = agg
 			return nodeResult
-		} else if nodeResult.PerformAggsOnRecs && len(recs) > 0 {
+		} else if nodeResult.PerformAggsOnRecs && recs != nil {
 			nodeResult.NextQueryAgg = agg
 			return nodeResult
 		}
@@ -330,7 +330,7 @@ func performInputLookup(nodeResult *structs.NodeResult, agg *structs.QueryAggreg
 
 	// When the first block of the last segment arrives update the records and record index once
 	if !agg.GenerateEvent.InputLookup.UpdatedRecordIndex && agg.GenerateEvent.InputLookup.NumProcessedSegments == numTotalSegments-1 {
-		offset := 0
+		offset := -1
 		for _, recIndex := range recordIndexInFinal {
 			if recIndex > offset {
 				offset = recIndex

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -329,7 +329,7 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 			strSet := make(map[string]struct{}, 0)
 			valuesStrSetVal, exists := sr.runningEvalStats[measureAgg.String()]
 			if !exists {
-				sr.runningEvalStats[measureAgg.String()] = make(map[string]struct{}, 0)
+				sr.runningEvalStats[measureAgg.String()] = strSet
 			} else {
 				strSet, ok = valuesStrSetVal.(map[string]struct{})
 				if !ok {


### PR DESCRIPTION
# Description
Summarize the change.
Setup
Upon ingesting the same amount of data across multiple indexes as given below

```
go run main.go ingest esbulk -n 10 -g benchmark -d http://localhost:8081/elastic -t 100_000
go run main.go query esbulk -d http://localhost:5122/ -f ../../cicd/ingest.csv
```

These 8 queries were failing. The rest of the queries were tested for 50+ runs and worked fine.

```
"app_name=Bracecould | bin span=5s http_status as bin_http | stats count by bin_http | stats count",now-1d,now,*,countRecord:count(*):*,eq,3,Splunk QL
"app_name=Bracecould | bin span=2log3 http_status | stats count by http_status | stats count",now-1d,now,*,countRecord:count(*):*,eq,2,Splunk QL
"app_name=Bracecould | stats values(eval(http_status > 400)) as values",now-1d,now,*,group:values:*,eq,1,Splunk QL
"app_name=Bracecould | stats values(eval(http_status+10)) as values",now-1d,now,*,group:values:*,eq,"311&nbsp312&nbsp410&nbsp510",Splunk QL
"app_name=Bracecould | stats values(eval(if(http_status > 400, 100, ""abc""))) as values",now-1d,now,*,group:values:*,eq,"100&nbspabc",Splunk QL
"app_name=Bracecould | stats values(eval(if(http_method = ""POST"", ""HEAD"", http_method))) as values",now-1d,now,*,group:values:*,eq,"HEAD&nbspPATCH&nbspPUT",Splunk QL
"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where http_status=200 | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,14,Splunk QL
"city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where nullStatus=null() | stats count(*)",now-1d,now,*,countRecord:count(*):*,eq,14,Splunk QL
```

For bin queries, the issue was with the aggregations that is being done at a later stage i.e. from GetJsonFromAllRrc. For some segments the len of records was 0, so aggregators were being skipped from group by to measure. Ideally, we process the first groupby/measure aggregator for all segments and then rest of the ones are processed.
We cannot remove the check all-together to return the nodeResult if the performAggsOnRecs is true, because for default segmentStats or GroupBy queries with say a statistic expression, we would want to ignore this as computation is already done during the search phase. We only have to return the nodeResult directly when we are coming from GetJsonFromAllRrc and this is the only place from where we will send a non-nil recs map.

For values queries, the runningEvalStats was initialized to a different map rather than strSet. When runningEvalStats does not have a valid strSet we should allocate it with the strSet initialized before so that the same is being passed to ComputeAggEvalForValues.

For the nullif queries we need to returns all the records if there is a stats in the chain, earlier only the first 100 records were being fetched and results were computed. In multi index ingest the order of ingestion differed so results differed. Now, the count shows the correct value that is the number of records with http_status = 200. Corrected the test queries too.

For input lookup one edge case was there that if recordIndexInFinal does not have any entries i.e. the segment does not have any entries, the offset has to be 0 not 1.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Before fix ran for 50+ iterations to identify the issues.
Ran the tests with the same kind of data ingest for 10+ iterations after fix. 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
