### PR TITLE
Clean up index stats

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -52,7 +52,7 @@ type Hooks struct {
 	StatsHandlerHook           func(ctx *fasthttp.RequestCtx, myid uint64)
 	SetExtraIngestionStatsHook func(map[string]interface{})
 	MiddlewareExtractOrgIdHook func(ctx *fasthttp.RequestCtx) (uint64, error)
-	AddMultinodeStatsHook      func(indexData map[string]utils.ResultPerIndex, orgId uint64,
+	AddMultinodeStatsHook      func(indexData map[string]utils.AllIndexesStats, orgId uint64,
 		logsIncomingBytes *float64, logsOnDiskBytes *float64, logsEventCount *int64,
 		metricsIncomingBytes *uint64, metricsOnDiskBytes *uint64, metricsDatapointsCount *uint64,
 		queryCount *uint64, totalResponseTime *float64)

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -370,16 +370,24 @@ type DeleteIndexErrorResponseInfo struct {
 	Index        string `json:"index"`
 }
 
-type ResultPerIndex map[string]map[string]interface{} // maps index name to index stats
+type AllIndexesStats struct {
+	IndexToStats map[string]IndexStats
+}
+
+type IndexStats struct {
+	NumBytesIngested uint64
+	NumRecords       uint64
+	NumSegments      uint64
+}
 
 type ClusterStatsResponseInfo struct {
-	IngestionStats  map[string]interface{}            `json:"ingestionStats"`
-	QueryStats      map[string]interface{}            `json:"queryStats"`
-	MetricsStats    map[string]interface{}            `json:"metricsStats"`
-	IndexStats      []ResultPerIndex                  `json:"indexStats"`
-	TraceIndexStats []ResultPerIndex                  `json:"traceIndexStats"`
-	ChartStats      map[string]map[string]interface{} `json:"chartStats"`
-	TraceStats      map[string]interface{}            `json:"traceStats"`
+	IngestionStats  map[string]interface{}              `json:"ingestionStats"`
+	QueryStats      map[string]interface{}              `json:"queryStats"`
+	MetricsStats    map[string]interface{}              `json:"metricsStats"`
+	IndexStats      []map[string]map[string]interface{} `json:"indexStats"`
+	TraceIndexStats []map[string]map[string]interface{} `json:"traceIndexStats"`
+	ChartStats      map[string]map[string]interface{}   `json:"chartStats"`
+	TraceStats      map[string]interface{}              `json:"traceStats"`
 }
 
 type MetricsStatsResponseInfo struct {


### PR DESCRIPTION
# Description
This cleans up some code related to storing index stats. It mainly avoids the need for a type assertion by making a dedicated struct type for handling index stats. I had gotten a panic on one of the type assertions, but can't reliably reproduce in siglens.

The code is still a little awkward. For example, in `getStats()` we return `stats` of type `map[string]utils.AllIndexesStats`; since `AllIndexesStats` has a map of index name to stats for that index, the type of `stats` is basically this: `map index -> map index -> stats for the index`. I only kept it like this because that is what we were doing previously, and I wanted to keep this PR small.

# Testing
I manually checked the MyOrg page after ingesting some data. It looks the same as before this PR. I checked with rotated and unrotated data.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
