### PR TITLE
fix: Resolved Issue of Incorrect segKeys Addition to pqsmeta When Handling Missing Blocks

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -445,8 +445,9 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 	segsNotSent := int(0)
 	recsSearchedSinceLastUpdate := uint64(0)
 	allEmptySegsForPqid := map[string]bool{}
+	sortedQSRSliceLen := len(sortedQSRSlice)
 	var err error
-	if len(sortedQSRSlice) > 0 && queryInfo.persistentQuery {
+	if sortedQSRSliceLen > 0 && queryInfo.persistentQuery {
 		allEmptySegsForPqid, err = pqsmeta.GetAllEmptySegmentsForPqid(sortedQSRSlice[0].pqid)
 		if err != nil {
 			log.Errorf("qid=%d, Failed to get empty segments for pqid %+v! Error: %v", queryInfo.qid, sortedQSRSlice[0].pqid, err)
@@ -459,7 +460,7 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 	}
 
 	for idx, segReq := range sortedQSRSlice {
-		if idx == len(sortedQSRSlice)-1 {
+		if idx == sortedQSRSliceLen-1 {
 			doBuckPull = true
 		}
 
@@ -560,7 +561,7 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 	if !rrcsCompleted {
 		qs.SetRRCFinishTime()
 	}
-	if len(sortedQSRSlice) == 0 {
+	if sortedQSRSliceLen == 0 {
 		IncrementNumFinishedSegments(0, queryInfo.qid, recsSearchedSinceLastUpdate, 0, "", false, nil)
 	}
 }

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -459,6 +459,9 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 	}
 
 	for idx, segReq := range sortedQSRSlice {
+		if idx == len(sortedQSRSlice)-1 {
+			doBuckPull = true
+		}
 
 		isCancelled, err := checkForCancelledQuery(queryInfo.qid)
 		if err != nil {
@@ -513,6 +516,7 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 					_, ok := allEmptySegsForPqid[segReq.segKey]
 					if ok {
 						log.Debugf("Skipping segKey %v for pqid %v", segReq.segKey, segReq.QueryInformation.pqid)
+						IncrementNumFinishedSegments(1, queryInfo.qid, 0, 0, "", doBuckPull, nil)
 						continue
 					}
 				}
@@ -529,9 +533,6 @@ func applyFopAllRequests(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Query
 			recsSearched = metadata.GetNumOfSearchedRecordsRotated(segReq.segKey)
 		} else {
 			recsSearched = writer.GetNumOfSearchedRecordsUnRotated(segReq.segKey)
-		}
-		if idx == len(sortedQSRSlice)-1 {
-			doBuckPull = true
 		}
 		recsSearchedSinceLastUpdate += recsSearched
 
@@ -900,14 +901,12 @@ func applyFilterOperatorPQSRequest(qsr *QuerySegmentRequest, allSegFileResults *
 		return applyFilterOperatorRawSearchRequest(qsr, allSegFileResults, qs)
 	}
 
-	// Get time range/blocks missing from sqpmr from metadata layer.
-	missingTRange := metadata.GetTSRangeForMissingBlocks(qsr.segKey, qsr.segKeyTsRange, spqmr)
-	if missingTRange == nil || !allSegFileResults.ShouldSearchRange(missingTRange.StartEpochMs, missingTRange.EndEpochMs) {
-		return nil
-	}
-	qsr.sType = structs.RAW_SEARCH
-	qsr.blkTracker = structs.InitExclusionBlockTracker(spqmr) // blocks not found in pqs, that we need to raw search for a key
-	return applyFilterOperatorRawSearchRequest(qsr, allSegFileResults, qs)
+	// We are assuming that all the blocks we need to search are in spqmr, so no need to raw search anything.
+	// But for that assumption to be true, there are two cases that we need to handle where there might be some missing blocks:
+	// 1. If persistent query is enabled in the middle of the segment, we should not create a PQS for that segment.
+	// 2. We should not do `BackFillPQSSegmetaEntry` for the segment if the segment is not fully enclosed in the PQS time range.
+	// We should avoid any other cases where we might have missing blocks.
+	return nil
 }
 
 func applyFilterOperatorRawSearchRequest(qsr *QuerySegmentRequest, allSegFileResults *segresults.SearchResults, qs *summary.QuerySummary) error {


### PR DESCRIPTION
# Description
- Removed the part where we are checking and doing raw search for missing blocks. 
- This fix assumes that there will be no missing blocks.
- And for this we need to handle two cases so that there will be no missing blocks:
   - If persistent query is enabled in the middle of the segment, we should not create a PQS for that segment.
   - We should not do `BackFillPQSSegmetaEntry` for the segment if the segment is not fully enclosed in the PQS time range.
   - We should also avoid any other cases that might create the scenario where there can be missing blocks.
- Also now for PQS, even for the segments that can be skipped, the code will now call `IncrementNumFinishedSegments`, so that query update for this segment is processed.


# Testing
- Tested by running the queries while PQS is enabled.
- Commented the test cases that checks for the case where raw search should happen for the missing blocks.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
