### PR TITLE
Global Logger to reduce Log Counts

### DIFF
--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -283,6 +283,20 @@ func processQueryUpdate(conn *websocket.Conn, qid uint64, sizeLimit uint64, scro
 	return numRrcsAdded
 }
 
+func LogGlobalErrors(qid uint64) {
+	nodeRes, err := query.GetOrCreateQuerySearchNodeResult(qid)
+	if err != nil {
+		log.Errorf("LogGlobalErrors: Error getting query search node result for qid: %v", qid)
+		return
+	}
+	for errMsg, errInfo := range nodeRes.GlobalErrors {
+		if errInfo == nil {
+			continue
+		}
+		log.Errorf("qid=%v, %v, Count: %v", qid, errMsg, errInfo.Count)
+	}
+}
+
 func processCompleteUpdate(conn *websocket.Conn, sizeLimit, qid uint64, aggs *structs.QueryAggregators) {
 	queryC := query.GetQueryCountInfoForQid(qid)
 	totalEventsSearched, err := query.GetTotalsRecsSearchedForQid(qid)
@@ -333,6 +347,7 @@ func processCompleteUpdate(conn *websocket.Conn, sizeLimit, qid uint64, aggs *st
 			log.Errorf("qid=%d, processCompleteUpdate: failed to write error response to websocket! err: %+v", qid, wErr)
 		}
 	}
+	LogGlobalErrors(qid)
 }
 
 func processMaxScrollComplete(conn *websocket.Conn, qid uint64) {

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -346,7 +346,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 				// it's an async query we're running this function with
 				// len(segmap)=1 because we try to process the data as the
 				// searched complete.
-				log.Infof("qid=%d, GetJsonFromAllRrc: Did not find index for record indentifier %s.", qid, recInden)
+				nodeRes.StoreGlobalError("GetJsonFromAllRrc: Did not find index for record identifier")
 				unknownIndex = true
 			}
 			if logfmtRequest {

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -346,7 +346,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 				// it's an async query we're running this function with
 				// len(segmap)=1 because we try to process the data as the
 				// searched complete.
-				nodeRes.StoreGlobalError("GetJsonFromAllRrc: Did not find index for record identifier")
+				nodeRes.StoreGlobalSearchError("GetJsonFromAllRrc: Did not find index for record identifier", log.ErrorLevel)
 				unknownIndex = true
 			}
 			if logfmtRequest {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1199,7 +1199,7 @@ func (nodeRes *NodeResult) StoreGlobalError(errMsg string) {
 	if nodeRes.GlobalErrors == nil {
 		nodeRes.GlobalErrors = make(map[string]*ErrorInfo)
 	}
-	
+
 	if globalErr, ok := nodeRes.GlobalErrors[errMsg]; !ok {
 		nodeRes.GlobalErrors[errMsg] = &ErrorInfo{Count: 1}
 	} else {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -439,6 +439,7 @@ type NodeResult struct {
 	CurrentSearchResultCount    int
 	AllSearchColumnsByTimeRange map[string]bool
 	FinalColumns                map[string]bool
+	GlobalErrors                map[string]*ErrorInfo // maps global error from error message -> error stats
 }
 
 type SegStats struct {
@@ -459,6 +460,10 @@ type NumericStats struct {
 
 type StringStats struct {
 	StrSet map[string]struct{}
+}
+
+type ErrorInfo struct {
+	Count int
 }
 
 // json exportable struct for segstats
@@ -1188,4 +1193,16 @@ func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
 		return obj.GroupByRequest != nil || obj.MeasureOperations != nil
 	}
 	return qa.HasInChain(statsAggPresentInCur)
+}
+
+func (nodeRes *NodeResult) StoreGlobalError(errMsg string) {
+	if nodeRes.GlobalErrors == nil {
+		nodeRes.GlobalErrors = make(map[string]*ErrorInfo)
+	}
+	
+	if globalErr, ok := nodeRes.GlobalErrors[errMsg]; !ok {
+		nodeRes.GlobalErrors[errMsg] = &ErrorInfo{Count: 1}
+	} else {
+		globalErr.Count++
+	}
 }

--- a/pkg/utils/logutils.go
+++ b/pkg/utils/logutils.go
@@ -29,3 +29,24 @@ func TeeErrorf(format string, args ...interface{}) error {
 
 	return err
 }
+
+func LogUsingLevel(level log.Level, format string, args ...interface{}) {
+	switch level {
+	case log.TraceLevel:
+		log.Tracef(format, args...)
+	case log.DebugLevel:
+		log.Debugf(format, args...)
+	case log.InfoLevel:
+		log.Infof(format, args...)
+	case log.WarnLevel:
+		log.Warnf(format, args...)
+	case log.ErrorLevel:
+		log.Errorf(format, args...)
+	case log.FatalLevel:
+		log.Fatalf(format, args...)
+	case log.PanicLevel:
+		log.Panicf(format, args...)
+	default:
+		log.Infof(format, args...)
+	}
+}


### PR DESCRIPTION
# Description
Summarize the change.
Added a global logger to log common error and prevent log fill up.
For now, the ErrorInfo struct has Count, later we can add more meta data like segmentkey etc.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
This particular query produces multiple "Did not find index for record identifier" errors for many records.
Verified the count and errors reported.
```
country=United* | fields app_name, app_version, country, city, user_email, http_status, http_method | transaction app_name startswith=eval(http_status=301 OR http_status=200) endswith=eval(http_status>=400)
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
