### PR TITLE
Increase parallelism per file

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -20,6 +20,7 @@ package query
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 	"time"
 
@@ -194,7 +195,10 @@ func ApplyFilterOperator(node *structs.ASTNode, timeRange *dtu.TimeRange, aggs *
 		containsKibana = true
 	}
 	querytracker.UpdateQTUsage(nonKibanaIndices, searchNode, aggs)
-	parallelismPerFile := int64(1)
+	parallelismPerFile := int64(runtime.GOMAXPROCS(0) / 2)
+	if parallelismPerFile < 1 {
+		parallelismPerFile = 1
+	}
 	_, qType := GetNodeAndQueryTypes(searchNode, aggs)
 	querySummary := summary.InitQuerySummary(summary.LOGS, qid)
 	pqid := querytracker.GetHashForQuery(searchNode)


### PR DESCRIPTION
# Description
When running a single query, this allows for more parallelism in the query and so it runs faster.

# Testing
With about 110 million rows, I ran this query:
```
* | timechart span=1m avg(latency)
```
On my local machine this took 24.7 seconds before. With this PR, it's about 7.4 seconds.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
