### PR TITLE
Fix a bug with merging SegStats maps

### DIFF
--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -252,13 +252,13 @@ func AddSegStatsStr(segstats map[string]*SegStats, cname string, strVal string,
 
 // adds all elements of m2 to m1 and returns m1
 func MergeSegStats(m1, m2 map[string]*SegStats) map[string]*SegStats {
-	for k, v := range m2 {
-		other, ok := m1[k]
+	for k, segStat2 := range m2 {
+		segStat1, ok := m1[k]
 		if !ok {
-			m1[k] = v
+			m1[k] = segStat2
 			continue
 		}
-		m1[k].Merge(other)
+		segStat1.Merge(segStat2)
 	}
 	return m1
 }

--- a/pkg/segment/writer/stats/segstats_test.go
+++ b/pkg/segment/writer/stats/segstats_test.go
@@ -106,3 +106,24 @@ func Test_addSegStatsStrForValuesFunc(t *testing.T) {
 	assert.NotNil(t, sst[cname].StringStats.StrSet)
 	assert.Equal(t, map[string]struct{}{"a": {}, "c": {}}, sst[cname].StringStats.StrSet)
 }
+
+func Test_mergeSegStats(t *testing.T) {
+	map1 := make(map[string]*SegStats)
+	map2 := make(map[string]*SegStats)
+
+	map1["col1"] = &SegStats{IsNumeric: true, Count: 1}
+	map2["col1"] = &SegStats{IsNumeric: true, Count: 2}
+	expectedCol1 := &SegStats{IsNumeric: true, Count: 3}
+
+	map1["col2"] = &SegStats{IsNumeric: true, Count: 42}
+	expectedCol2 := &SegStats{IsNumeric: true, Count: 42}
+
+	map2["col3"] = &SegStats{IsNumeric: true, Count: 10}
+	expectedCol3 := &SegStats{IsNumeric: true, Count: 10}
+
+	mergedMap := MergeSegStats(map1, map2)
+	assert.Equal(t, 3, len(mergedMap))
+	assert.Equal(t, expectedCol1, mergedMap["col1"])
+	assert.Equal(t, expectedCol2, mergedMap["col2"])
+	assert.Equal(t, expectedCol3, mergedMap["col3"])
+}


### PR DESCRIPTION
# Description
Fixes a bug in `MergeSegStats()`. This bug only happens when we have `fileParallelism > 1` here: https://github.com/siglens/siglens/blob/develop/pkg/segment/search/searchaggs.go#L694-L698

We've been using `fileParallelism == 1`, so this hasn't been an issue yet because in that case we never actually merge two non-empty SegStats maps.

# Testing
Added new unit test that fails without this bug fix. It only tests very basic merging behavior.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
