### PR TITLE
fix: Wait for Alert History to be updated

### DIFF
--- a/tools/sigclient/pkg/alerts/alerts.go
+++ b/tools/sigclient/pkg/alerts/alerts.go
@@ -553,6 +553,8 @@ waitForWebhooks:
 		}
 	}
 
+	time.Sleep(5 * time.Second) // Wait for the alerthistory to be updated
+
 	// Get Alert History to verify the notifications
 	err = verifyAlertHistory(host, alerts)
 	if err != nil {


### PR DESCRIPTION
# Description
- Wait for AlertHistory to be updated, before querying it.


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
