### PR TITLE
Store search text in pqs query info

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -292,6 +292,7 @@ func ParseAndExecutePipeRequest(readJSON map[string]interface{}, qid uint64, myi
 	}
 
 	qc := structs.InitQueryContextWithTableInfo(ti, sizeLimit, scrollFrom, myid, false)
+	qc.RawQuery = searchText
 	result := segment.ExecuteQuery(simpleNode, aggs, qid, qc)
 	httpRespOuter := getQueryResponseJson(result, indexNameIn, queryStart, sizeLimit, qid, aggs, result.TotalRRCCount, dbPanelId)
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -139,6 +139,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthtt
 	sizeLimit = GetFinalSizelimit(aggs, sizeLimit)
 
 	qc := structs.InitQueryContextWithTableInfo(ti, sizeLimit, scrollFrom, orgid, false)
+	qc.RawQuery = searchText
 	eventC, err := segment.ExecuteAsyncQuery(simpleNode, aggs, qid, qc)
 	if err != nil {
 		log.Errorf("qid=%d, ProcessPipeSearchWebsocket: failed to execute query, err: %v", qid, err)

--- a/pkg/querytracker/querytracker_test.go
+++ b/pkg/querytracker/querytracker_test.go
@@ -61,7 +61,7 @@ func Test_GetQTUsageInfo(t *testing.T) {
 	sNodeHash := GetHashForQuery(sNode)
 	tableName := []string{"ind-tab-v1"}
 	for i := 0; i < 90; i++ {
-		UpdateQTUsage(tableName, sNode, nil)
+		UpdateQTUsage(tableName, sNode, nil, "os=iOS")
 	}
 
 	us, err := GetQTUsageInfo(tableName, sNode)
@@ -102,7 +102,7 @@ func Test_GetQTUsageInfo(t *testing.T) {
 		NodeType: MatchAllQuery,
 	}
 
-	UpdateQTUsage(tableName, matchAllOne, nil)
+	UpdateQTUsage(tableName, matchAllOne, nil, "*")
 
 	_, err = GetQTUsageInfo(tableName, matchAllOne)
 	assert.NotNil(t, err, "match all should not be added to query tracker")
@@ -161,7 +161,7 @@ func Test_ReadWriteQTUsage(t *testing.T) {
 		},
 	}
 	aggsHash := GetHashForAggs(aggs)
-	UpdateQTUsage(tableName, sNode, aggs)
+	UpdateQTUsage(tableName, sNode, aggs, "batch=batch-101")
 
 	flushPQueriesToDisk()
 	resetInternalQTInfo()
@@ -188,7 +188,7 @@ func Test_GetTopPersistentAggs(t *testing.T) {
 		},
 	}
 	tableName := []string{"test-1"}
-	UpdateQTUsage(tableName, nil, aggs)
+	UpdateQTUsage(tableName, nil, aggs, "*")
 	grpCols, measure := GetTopPersistentAggs("test-2")
 	assert.Len(t, grpCols, 0)
 	assert.Len(t, measure, 0)
@@ -219,7 +219,7 @@ func Test_GetTopPersistentAggs(t *testing.T) {
 			GroupByColumns: []string{"col3", "col2"},
 		},
 	}
-	UpdateQTUsage(tableName, nil, aggs2)
+	UpdateQTUsage(tableName, nil, aggs2, "*")
 	grpCols, measure = GetTopPersistentAggs("test-1")
 	assert.Len(t, grpCols, 3)
 	assert.Equal(t, "col2", grpCols[0], "only col2 exists in both usages, so it should be first")
@@ -251,7 +251,7 @@ func Test_GetTopPersistentAggs_Jaeger(t *testing.T) {
 		},
 	}
 	tableName := []string{"jaeger-1"}
-	UpdateQTUsage(tableName, nil, aggs)
+	UpdateQTUsage(tableName, nil, aggs, "*")
 
 	grpCols, measure := GetTopPersistentAggs("jaeger-1")
 	assert.Len(t, grpCols, 5)
@@ -282,7 +282,7 @@ func Test_GetTopPersistentAggs_Jaeger(t *testing.T) {
 			GroupByColumns: []string{"col3", "col2"},
 		},
 	}
-	UpdateQTUsage(tableName, nil, aggs2)
+	UpdateQTUsage(tableName, nil, aggs2, "*")
 	grpCols, measure = GetTopPersistentAggs("jaeger-1")
 	assert.Len(t, grpCols, 6)
 	assert.Equal(t, "traceID", grpCols[0], "traceID exists in both usages, so it should be first")
@@ -363,7 +363,7 @@ func Test_PostPqsClear(t *testing.T) {
 	pqid := GetHashForQuery(sNode)
 	tableName := []string{"test-1"}
 	assert.NotNil(t, tableName)
-	UpdateQTUsage(tableName, sNode, nil)
+	UpdateQTUsage(tableName, sNode, nil, "os=iOS")
 
 	expected := map[string]interface{}{
 		"promoted_aggregations": make(map[string]int),
@@ -403,7 +403,7 @@ func Test_getAggPQSById(t *testing.T) {
 	pqid := GetHashForAggs(qa)
 	tableName := []string{"test-1"}
 	assert.NotNil(t, tableName)
-	UpdateQTUsage(tableName, nil, qa)
+	UpdateQTUsage(tableName, nil, qa, "TimeHistogramStartTime=3")
 
 	aggPQS, err := getAggPQSById(pqid)
 	assert.Nil(t, err)
@@ -516,7 +516,7 @@ func Test_GetPQSById_200IfPQIsSpecified(t *testing.T) {
 	qa := &QueryAggregators{TimeHistogram: &TimeBucket{StartTime: 3}}
 	pqid := GetHashForAggs(qa)
 	tableName := []string{"test-1"}
-	UpdateQTUsage(tableName, nil, qa)
+	UpdateQTUsage(tableName, nil, qa, "")
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.SetUserValue("pqid", pqid)

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -194,7 +194,7 @@ func ApplyFilterOperator(node *structs.ASTNode, timeRange *dtu.TimeRange, aggs *
 	if len(kibanaIndices) != 0 {
 		containsKibana = true
 	}
-	querytracker.UpdateQTUsage(nonKibanaIndices, searchNode, aggs)
+	querytracker.UpdateQTUsage(nonKibanaIndices, searchNode, aggs, qc.RawQuery)
 	parallelismPerFile := int64(runtime.GOMAXPROCS(0) / 2)
 	if parallelismPerFile < 1 {
 		parallelismPerFile = 1

--- a/pkg/segment/search/segsearch_test.go
+++ b/pkg/segment/search/segsearch_test.go
@@ -107,7 +107,7 @@ func Test_simpleRawSearch(t *testing.T) {
 	assert.Equal(t, true, os.IsNotExist(err))
 
 	// make query persistent
-	querytracker.UpdateQTUsage([]string{searchReq.VirtualTableName}, node, nil)
+	querytracker.UpdateQTUsage([]string{searchReq.VirtualTableName}, node, nil, "*")
 
 	// Call rawSearchColumnar
 	rawSearchColumnar(searchReq, node, timeRange, 10000, nil, 1, allSegFileResults, 1, querySummary)

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -39,6 +39,7 @@ type QueryContext struct {
 	SizeLimit uint64
 	Scroll    int
 	Orgid     uint64
+	RawQuery  string
 }
 
 // Input for filter operator can either be the result of a ASTNode or an expression

--- a/pkg/segment/writer/unrotatedquery_test.go
+++ b/pkg/segment/writer/unrotatedquery_test.go
@@ -62,7 +62,7 @@ func Test_writePQSFiles(t *testing.T) {
 	}
 	node.AddQueryInfoForNode()
 
-	querytracker.UpdateQTUsage([]string{"test"}, node, nil)
+	querytracker.UpdateQTUsage([]string{"test"}, node, nil, "batch=batch-0")
 
 	for batch := 0; batch < numBatch; batch++ {
 		for rec := 0; rec < numRec; rec++ {


### PR DESCRIPTION
# Description
Store search text in pqs query info for wssearchhandler and searchhandler.

# Testing
- Verified that the searchtext is being populated correctly for simple search without aggs, and also search with aggs.
<img width="822" alt="image" src="https://github.com/user-attachments/assets/02ceaf7e-d645-476b-b987-71507ed7fefb">
<img width="906" alt="image" src="https://github.com/user-attachments/assets/248a43f2-c6c6-44cb-b676-ce97276aace3">
<img width="886" alt="image" src="https://github.com/user-attachments/assets/03de07be-19e8-46fe-8e24-babd381378f5">

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
