### PR TITLE
feat: SigClient: Added a function to get Query Response Times

### DIFF
--- a/tools/sigclient/README.md
+++ b/tools/sigclient/README.md
@@ -24,6 +24,8 @@ Options:
   -e, --eventsPerDay uint    Number of events to ingest per day. If set, the ingestion mode will be assumed to be continuous.
 
   -c  continuous             If true, ignores -t and will continuously send docs to the destination
+  -o  --outputFile           filepath to output the query response Time results in csv format.
+  -t  --runResponseTime      If true, then the queries will be run and the response time will be recorded in the given/default outputFile in CSV Format.
 ```
 
 Different Types of Readers:

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -130,6 +130,8 @@ var esQueryCmd = &cobra.Command{
 		filepath, _ := cmd.Flags().GetString("filePath")
 		randomQueries, _ := cmd.Flags().GetBool("randomQueries")
 		bearerToken, _ := cmd.Flags().GetString("bearerToken")
+		outputFile, _ := cmd.Flags().GetString("outputFile")
+		runResponseTime, _ := cmd.Flags().GetBool("runResponseTime")
 
 		log.Infof("dest : %+v\n", dest)
 		log.Infof("numIterations : %+v\n", numIterations)
@@ -140,7 +142,11 @@ var esQueryCmd = &cobra.Command{
 		log.Infof("randomQueries: %+v\n", randomQueries)
 		log.Infof("bearerToken : %+v\n", bearerToken)
 		if filepath != "" {
-			query.RunQueryFromFile(dest, numIterations, indexPrefix, continuous, verbose, filepath, bearerToken)
+			if runResponseTime {
+				query.RunQueryFromFileAndCheckResponseTimes(dest, filepath, outputFile)
+			} else {
+				query.RunQueryFromFile(dest, numIterations, indexPrefix, continuous, verbose, filepath, bearerToken)
+			}
 		} else {
 			query.StartQuery(dest, numIterations, indexPrefix, continuous, verbose, randomQueries, bearerToken)
 		}
@@ -354,6 +360,8 @@ func init() {
 	queryCmd.PersistentFlags().StringP("filePath", "f", "", "filepath to csv file to use to run queries from")
 	queryCmd.PersistentFlags().BoolP("randomQueries", "", false, "generate random queries")
 	queryCmd.PersistentFlags().StringP("query", "q", "", "promql query to run")
+	queryCmd.PersistentFlags().StringP("outputFile", "o", "", "The filePath to output the Response time of Queries in csv format, When runResponseTime is set to True.")
+	queryCmd.PersistentFlags().BoolP("runResponseTime", "t", false, "Runs the given Queries and outputs the response time into a file in CSV format.")
 
 	traceCmd.PersistentFlags().StringP("filePrefix", "f", "", "Name of file to output to")
 	traceCmd.PersistentFlags().IntP("totalEvents", "t", 1000000, "Total number of traces to generate")

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -143,7 +143,7 @@ var esQueryCmd = &cobra.Command{
 		log.Infof("bearerToken : %+v\n", bearerToken)
 		if filepath != "" {
 			if runResponseTime {
-				query.RunQueryFromFileAndCheckResponseTimes(dest, filepath, outputFile)
+				query.RunQueryFromFileAndOutputResponseTimes(dest, filepath, outputFile)
 			} else {
 				query.RunQueryFromFile(dest, numIterations, indexPrefix, continuous, verbose, filepath, bearerToken)
 			}

--- a/tools/sigclient/pkg/query/query.go
+++ b/tools/sigclient/pkg/query/query.go
@@ -739,7 +739,7 @@ func RunQueryFromFile(dest string, numIterations int, prefix string, continuous,
 	}
 }
 
-func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryResultFile string) {
+func RunQueryFromFileAndOutputResponseTimes(dest string, filepath string, queryResultFile string) {
 	webSocketURL := dest + "/api/search/ws"
 	if queryResultFile == "" {
 		queryResultFile = "./query_results.csv"
@@ -750,19 +750,19 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 
 	csvFile, err := os.Open(filepath)
 	if err != nil {
-		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to open query file: %v", err)
+		log.Fatalf("RunQueryFromFileAndOutputResponseTimes: Failed to open query file: %v", err)
 	}
 	defer csvFile.Close()
 
 	reader := csv.NewReader(csvFile)
 	records, err := reader.ReadAll()
 	if err != nil {
-		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to read query file: %v", err)
+		log.Fatalf("RunQueryFromFileAndOutputResponseTimes: Failed to read query file: %v", err)
 	}
 
 	outputCSVFile, err := os.Create(queryResultFile)
 	if err != nil {
-		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to create CSV file: %v", err)
+		log.Fatalf("RunQueryFromFileAndOutputResponseTimes: Failed to create CSV file: %v", err)
 	}
 	defer outputCSVFile.Close()
 
@@ -772,7 +772,7 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 	// Write header to the output CSV
 	err = writer.Write([]string{"Query", "Response Time (ms)"})
 	if err != nil {
-		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to write header to CSV file: %v", err)
+		log.Fatalf("RunQueryFromFileAndOutputResponseTimes: Failed to write header to CSV file: %v", err)
 	}
 
 	for index, record := range records {
@@ -808,7 +808,7 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 		log.Infof("qid=%v, Running query=%v", qid, query)
 		conn, _, err := websocket.DefaultDialer.Dial(webSocketURL, nil)
 		if err != nil {
-			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error connecting to WebSocket server: %v", qid, err)
+			log.Fatalf("RunQueryFromFileAndOutputResponseTimes: qid=%v, Error connecting to WebSocket server: %v", qid, err)
 			return
 		}
 		defer conn.Close()
@@ -816,7 +816,7 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 		startTime := time.Now()
 		err = conn.WriteJSON(data)
 		if err != nil {
-			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error sending query to server: %v", qid, err)
+			log.Fatalf("RunQueryFromFileAndOutputResponseTimes: qid=%v, Error sending query to server: %v", qid, err)
 			break
 		}
 
@@ -824,7 +824,7 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 		for {
 			err = conn.ReadJSON(&readEvent)
 			if err != nil {
-				log.Infof("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error reading response from server for query. Error=%v", qid, err)
+				log.Infof("RunQueryFromFileAndOutputResponseTimes: qid=%v, Error reading response from server for query. Error=%v", qid, err)
 				break
 			}
 			if state, ok := readEvent["state"]; ok && state == "COMPLETE" {
@@ -832,14 +832,14 @@ func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryRe
 			}
 		}
 		responseTime := time.Since(startTime).Milliseconds()
-		log.Infof("RunQueryFromFileAndCheckResponseTimes: qid=%v, Query=%v,Response Time: %vms", qid, query, responseTime)
+		log.Infof("RunQueryFromFileAndOutputResponseTimes: qid=%v, Query=%v,Response Time: %vms", qid, query, responseTime)
 
 		// Write query and response time to output CSV
 		err = writer.Write([]string{query, strconv.FormatInt(responseTime, 10)})
 		if err != nil {
-			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to write query result to CSV file: %v", err)
+			log.Fatalf("RunQueryFromFileAndOutputResponseTimes: Failed to write query result to CSV file: %v", err)
 		}
 	}
 
-	log.Infof("RunQueryFromFileAndCheckResponseTimes: Query results written to CSV file: %v", queryResultFile)
+	log.Infof("RunQueryFromFileAndOutputResponseTimes: Query results written to CSV file: %v", queryResultFile)
 }

--- a/tools/sigclient/pkg/query/query.go
+++ b/tools/sigclient/pkg/query/query.go
@@ -738,3 +738,108 @@ func RunQueryFromFile(dest string, numIterations int, prefix string, continuous,
 		}
 	}
 }
+
+func RunQueryFromFileAndCheckResponseTimes(dest string, filepath string, queryResultFile string) {
+	webSocketURL := dest + "/api/search/ws"
+	if queryResultFile == "" {
+		queryResultFile = "./query_results.csv"
+	}
+
+	log.Infof("Using Websocket URL %+s", webSocketURL)
+	log.Infof("Using query result file %+s", queryResultFile)
+
+	csvFile, err := os.Open(filepath)
+	if err != nil {
+		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to open query file: %v", err)
+	}
+	defer csvFile.Close()
+
+	reader := csv.NewReader(csvFile)
+	records, err := reader.ReadAll()
+	if err != nil {
+		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to read query file: %v", err)
+	}
+
+	outputCSVFile, err := os.Create(queryResultFile)
+	if err != nil {
+		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to create CSV file: %v", err)
+	}
+	defer outputCSVFile.Close()
+
+	writer := csv.NewWriter(outputCSVFile)
+	defer writer.Flush()
+
+	// Write header to the output CSV
+	err = writer.Write([]string{"Query", "Response Time (ms)"})
+	if err != nil {
+		log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to write header to CSV file: %v", err)
+	}
+
+	for index, record := range records {
+
+		qid := index + 1
+
+		query := record[0]
+		// Default values
+		startEpoch := "now-1h"
+		endEpoch := "now"
+		queryLanguage := "Splunk QL"
+
+		// Update values if provided in the CSV
+		if len(record) > 1 && record[1] != "" {
+			startEpoch = record[1]
+		}
+		if len(record) > 2 && record[2] != "" {
+			endEpoch = record[2]
+		}
+		if len(record) > 3 && record[3] != "" {
+			queryLanguage = record[3]
+		}
+
+		data := map[string]interface{}{
+			"state":         "query",
+			"searchText":    query,
+			"startEpoch":    startEpoch,
+			"endEpoch":      endEpoch,
+			"indexName":     "*",
+			"queryLanguage": queryLanguage,
+		}
+
+		log.Infof("qid=%v, Running query=%v", qid, query)
+		conn, _, err := websocket.DefaultDialer.Dial(webSocketURL, nil)
+		if err != nil {
+			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error connecting to WebSocket server: %v", qid, err)
+			return
+		}
+		defer conn.Close()
+
+		startTime := time.Now()
+		err = conn.WriteJSON(data)
+		if err != nil {
+			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error sending query to server: %v", qid, err)
+			break
+		}
+
+		readEvent := make(map[string]interface{})
+		for {
+			err = conn.ReadJSON(&readEvent)
+			if err != nil {
+				log.Infof("RunQueryFromFileAndCheckResponseTimes: qid=%v, Error reading response from server for query. Error=%v", qid, err)
+				break
+			}
+			if state, ok := readEvent["state"]; ok && state == "COMPLETE" {
+				break
+			}
+		}
+		responseTime := time.Since(startTime).Milliseconds()
+		log.Infof("RunQueryFromFileAndCheckResponseTimes: qid=%v, Query=%v,Response Time: %vms", qid, query, responseTime)
+
+		// Write query and response time to output CSV
+		err = writer.Write([]string{query, strconv.FormatInt(responseTime, 10)})
+		if err != nil {
+			log.Fatalf("RunQueryFromFileAndCheckResponseTimes: Failed to write query result to CSV file: %v", err)
+		}
+	}
+
+	log.Infof("RunQueryFromFileAndCheckResponseTimes: Query results written to CSV file: %v", queryResultFile)
+}


### PR DESCRIPTION
# Description
- Added a new function to run the given queries and the update the response time to the given file.

# Testing
- Tested by running the commands:
`go run main.go query esbulk -d ws://localhost:5122 -f ../../cicd/restart.csv -o local_res.csv -t true`
`go run main.go query esbulk -d ws://localhost:5122 -f ../../cicd/SPL_Playground.csv  -t true`

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
