### PR TITLE
avoid revereKeyIndex lookups per record and do it once every block

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -508,7 +508,7 @@ func GetTestConfig(dataPath string) common.Configuration {
 
 func InitializeTestingConfig(dataPath string) {
 	InitializeDefaultConfig(dataPath)
-	SetDebugMode(true)
+	SetDebugMode(false)
 }
 
 func ReadRunModConfig(fileName string) (common.RunModConfig, error) {

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -254,8 +254,6 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 
 			if cname == config.GetTimeStampKey() {
 				isTsCol = true
-			} else {
-				isTsCol = false
 			}
 
 			cValEnc, err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockIdx, recNum,

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -205,6 +205,7 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 	results := make(map[uint16]map[string]interface{})
 
 	dictEncCols := make(map[string]bool)
+	allColKeyIndices := make(map[int]string)
 	for _, colInfo := range segReader.AllColums {
 		col := colInfo.ColumnName
 		if !esQuery && (col == "_type" || col == "_id") {
@@ -220,6 +221,10 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 			dictEncCols[col] = true
 			allMatchedColumns[col] = true
 		}
+		cKeyidx, ok := segReader.GetColKeyIndex(col)
+		if ok {
+			allColKeyIndices[cKeyidx] = col
+		}
 	}
 
 	var mathColMap map[string]int
@@ -233,42 +238,49 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 		mathColMap = make(map[string]int)
 	}
 
+	var isTsCol bool
 	for _, recNum := range orderedRecNums {
 		_, ok := results[recNum]
 		if !ok {
 			results[recNum] = make(map[string]interface{})
 		}
 
-		for _, colInfo := range segReader.AllColums {
-			col := colInfo.ColumnName
+		for colKeyIdx, cname := range allColKeyIndices {
 
-			_, ok := dictEncCols[col]
+			_, ok := dictEncCols[cname]
 			if ok {
 				continue
 			}
 
-			cValEnc, err := segReader.ExtractValueFromColumnFile(col, blockIdx, recNum, qid)
+			if cname == config.GetTimeStampKey() {
+				isTsCol = true
+			} else {
+				isTsCol = false
+			}
+
+			cValEnc, err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockIdx, recNum,
+				qid, isTsCol)
 			if err != nil {
 				// if the column was absent for an entire block and came for other blocks, this will error, hence no error logging here
 			} else {
 
 				if mathColOpsPresent {
-					colIndex, exists := mathColMap[col]
+					colIndex, exists := mathColMap[cname]
 					if exists {
 						mathOp := aggs.MathOperations[colIndex]
 						fieldToValue := make(map[string]utils.CValueEnclosure)
 						fieldToValue[mathOp.MathCol] = *cValEnc
 						valueFloat, err := mathOp.ValueColRequest.EvaluateToFloat(fieldToValue)
 						if err != nil {
-							log.Errorf("qid=%d, failed to evaluate math operation for col %s, err=%v", qid, col, err)
+							log.Errorf("qid=%d, failed to evaluate math operation for col %s, err=%v", qid, cname, err)
 						} else {
 							cValEnc.CVal = valueFloat
 						}
 					}
 				}
 
-				results[recNum][col] = cValEnc.CVal
-				allMatchedColumns[col] = true
+				results[recNum][cname] = cValEnc.CVal
+				allMatchedColumns[cname] = true
 			}
 		}
 

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -48,6 +48,7 @@ type MultiColSegmentReader struct {
 
 	AllColums              []*ColumnInfo
 	allColInfoReverseIndex map[string]*ColumnInfo
+	maxColIdx              int
 }
 
 type ColumnInfo struct {
@@ -89,6 +90,7 @@ func initNewMultiColumnReader(segKey string, colFDs map[string]*os.File, blockMe
 		allColsReverseIndex: colRevserseIndex,
 		timeStampKey:        tsKey,
 		segKey:              segKey,
+		maxColIdx:           -1,
 	}
 
 	for colName, colFD := range colFDs {
@@ -123,6 +125,7 @@ func initNewMultiColumnReader(segKey string, colFDs map[string]*os.File, blockMe
 
 	retVal.allFileReaders = retVal.allFileReaders[:idx]
 	retVal.AllColums = readCols[:idx]
+	retVal.maxColIdx = idx
 	retVal.allColInfoReverseIndex = readColsReverseIndex
 	return retVal, nil
 }
@@ -243,9 +246,9 @@ func (mcsr *MultiColSegmentReader) GetAllTimeStampsForBlock(blockNum uint16) ([]
 }
 
 // Reads the raw value and returns the []byte in TLV format (type-[length]-value encoding)
-func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(col string, blockNum uint16, recordNum uint16, qid uint64) ([]byte, error) {
+func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(colKeyIndex int, blockNum uint16, recordNum uint16, qid uint64, isTsCol bool) ([]byte, error) {
 
-	if col == mcsr.timeStampKey {
+	if isTsCol {
 		ts, err := mcsr.GetTimeStampForRecord(blockNum, recordNum, qid)
 		if err != nil {
 			return nil, err
@@ -255,20 +258,20 @@ func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(col string, block
 		copy(retVal[1:], toputils.Uint64ToBytesLittleEndian(ts))
 		return retVal, nil
 	}
-	keyIndex, ok := mcsr.allColsReverseIndex[col]
-	if !ok {
+
+	if colKeyIndex == -1 || colKeyIndex >= mcsr.maxColIdx {
 		// Debug to avoid log flood for when the column does not exist
-		log.Debugf("MultiColSegmentReader.ReadRawRecordFromColumnFile: failed to find column %s in multi col reader. All cols: %+v", col, mcsr.allColsReverseIndex)
+		log.Debugf("MultiColSegmentReader.ReadRawRecordFromColumnFile: failed to find colKeyIndex %v in multi col reader. All cols: %+v", colKeyIndex, mcsr.allColsReverseIndex)
 		return nil, errors.New("column not found in MultipleColumnSegmentReader")
 	}
 
-	return mcsr.allFileReaders[keyIndex].ReadRecordFromBlock(blockNum, recordNum)
+	return mcsr.allFileReaders[colKeyIndex].ReadRecordFromBlock(blockNum, recordNum)
 }
 
 // Reads the request value and converts it to a *utils.CValueEnclosure
-func (mcsr *MultiColSegmentReader) ExtractValueFromColumnFile(col string, blockNum uint16, recordNum uint16,
-	qid uint64) (*utils.CValueEnclosure, error) {
-	if col == mcsr.timeStampKey {
+func (mcsr *MultiColSegmentReader) ExtractValueFromColumnFile(colKeyIndex int, blockNum uint16, recordNum uint16,
+	qid uint64, isTsCol bool) (*utils.CValueEnclosure, error) {
+	if isTsCol {
 		ts, err := mcsr.GetTimeStampForRecord(blockNum, recordNum, qid)
 		if err != nil {
 			return &utils.CValueEnclosure{}, err
@@ -280,7 +283,7 @@ func (mcsr *MultiColSegmentReader) ExtractValueFromColumnFile(col string, blockN
 		}, nil
 	}
 
-	rawVal, err := mcsr.ReadRawRecordFromColumnFile(col, blockNum, recordNum, qid)
+	rawVal, err := mcsr.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, isTsCol)
 	if err != nil {
 		return &utils.CValueEnclosure{
 			Dtype: utils.SS_DT_BACKFILL,
@@ -306,8 +309,12 @@ func (mcsr *MultiColSegmentReader) returnBuffers() {
 	}
 }
 
-func (mcsr *MultiColSegmentReader) IncrementColumnUsage(colName string) {
+func (mcsr *MultiColSegmentReader) IncrementColumnUsageByName(colName string) {
 	mcsr.allColInfoReverseIndex[colName].count++
+}
+
+func (mcsr *MultiColSegmentReader) IncrementColumnUsageByIdx(colKeyIndex int) {
+	mcsr.AllColums[colKeyIndex].count++
 }
 
 // reorders mcsr.AllColumns to be ordered on usage
@@ -383,4 +390,9 @@ func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte 
 func (mcsr *MultiColSegmentReader) IsColPresent(cname string) bool {
 	_, ok := mcsr.allColsReverseIndex[cname]
 	return ok
+}
+
+func (mcsr *MultiColSegmentReader) GetColKeyIndex(cname string) (int, bool) {
+	idx, ok := mcsr.allColsReverseIndex[cname]
+	return idx, ok
 }

--- a/pkg/segment/reader/segread/multicolreader_test.go
+++ b/pkg/segment/reader/segread/multicolreader_test.go
@@ -47,19 +47,23 @@ func Test_multiSegReader(t *testing.T) {
 	multiReader := sharedReader.MultiColReaders[0]
 	var cVal *utils.CValueEnclosure
 	var err error
+	var cKeyidx int
 	for colName := range cols {
 		if colName == config.GetTimeStampKey() {
 			continue
 		}
+
+		cKeyidx, _ = multiReader.GetColKeyIndex(colName)
+
 		// invalid block
-		_, err = multiReader.ExtractValueFromColumnFile(colName, uint16(numBlocks), 0, 0)
+		_, err = multiReader.ExtractValueFromColumnFile(cKeyidx, uint16(numBlocks), 0, 0, false)
 		assert.NotNil(t, err)
 
 		// correct block, incorrect recordNum
-		_, err = multiReader.ExtractValueFromColumnFile(colName, 0, uint16(numEntriesInBlock), 0)
+		_, err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock), 0, false)
 		assert.NotNil(t, err)
 
-		cVal, err = multiReader.ExtractValueFromColumnFile(colName, 0, uint16(numEntriesInBlock-3), 0)
+		cVal, err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock-3), 0, false)
 		assert.Nil(t, err)
 		assert.NotNil(t, cVal)
 		log.Infof("ExtractValueFromColumnFile: %+v for column %s", cVal, colName)

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -30,16 +30,17 @@ import (
 // TODO: support for complex expressions
 func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recordNum uint16, holderDte *DtypeEnclosure, qid uint64,
-	dictEncColNames map[string]bool, searchReq *SegmentSearchRequest,
-	cmiPassedCnames map[string]bool) (bool, error) {
+	searchReq *SegmentSearchRequest,
+	cmiPassedNonDictColKeyIndices map[int]struct{}, queryInfoColKeyIndex int,
+	allColKeyIndices map[int]struct{}) (bool, error) {
 
 	switch query.SearchType {
 	case MatchAll:
 		// ts should have already been checked
 		return true, nil
 	case MatchWords:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName,
-			blockNum, recordNum, qid)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex,
+			blockNum, recordNum, qid, false)
 		if err != nil {
 			return false, err
 		}
@@ -47,9 +48,9 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case MatchWordsAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
-		for cname := range cmiPassedCnames {
+		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(cname, blockNum, recordNum, qid)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
 			if err != nil {
 				finalErr = err
 				continue
@@ -58,7 +59,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			}
 			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal)
 			if retVal {
-				multiColReader.IncrementColumnUsage(cname)
+				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
 			}
 		}
@@ -68,13 +69,13 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			return false, finalErr
 		}
 	case SimpleExpression:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
 		if err != nil {
 			return false, err
 		}
 		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte)
 	case RegexExpression:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
 		if err != nil {
 			log.Debugf("ApplyColumnarSearchQuery: failed to read column %v rec from column file. qid: %v, err: %v", query.QueryInfo.ColName, qid, err)
 			return false, nil
@@ -83,16 +84,9 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case RegexExpressionAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
-		for cname := range cmiPassedCnames {
+		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			// we skip rawsearching for columns that are dict encoded,
-			// since we already search for them in the prior call to applyColumnarSearchUsingDictEnc
-			_, ok := dictEncColNames[cname]
-			if ok {
-				continue
-			}
-
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(cname, blockNum, recordNum, qid)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
 			if err != nil {
 				finalErr = err
 				continue
@@ -101,7 +95,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			}
 			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte)
 			if retVal {
-				multiColReader.IncrementColumnUsage(cname)
+				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
 			}
 		}
@@ -113,16 +107,9 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case SimpleExpressionAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
-		for cname := range cmiPassedCnames {
+		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			// we skip rawsearching for columns that are dict encoded,
-			// since we already search for them in the prior call to applyColumnarSearchUsingDictEnc
-			_, ok := dictEncColNames[cname]
-			if ok {
-				continue
-			}
-
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(cname, blockNum, recordNum, qid)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
 			if err != nil {
 				finalErr = err
 				continue
@@ -131,7 +118,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			}
 			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte)
 			if retVal {
-				multiColReader.IncrementColumnUsage(cname)
+				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
 			}
 		}
@@ -141,7 +128,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			return false, finalErr
 		}
 	case MatchDictArraySingleColumn:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(query.QueryInfo.ColName, blockNum, recordNum, qid)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
 		if err != nil {
 			return false, err
 		}
@@ -149,16 +136,9 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case MatchDictArrayAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
-		for _, colInfo := range multiColReader.AllColums {
+		for colKeyIndex := range allColKeyIndices {
 
-			// we skip rawsearching for columns that are dict encoded,
-			// since we already search for them in the prior call to applyColumnarSearchUsingDictEnc
-			_, ok := dictEncColNames[colInfo.ColumnName]
-			if ok {
-				continue
-			}
-
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colInfo.ColumnName, blockNum, recordNum, qid)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
 			if err != nil {
 				finalErr = err
 				continue
@@ -167,7 +147,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			}
 			retVal, _ := writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, query.ExpressionFilter.FilterOp, true, holderDte)
 			if retVal {
-				multiColReader.IncrementColumnUsage(colInfo.ColumnName)
+				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
 			}
 		}
@@ -237,7 +217,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 				continue
 			}
 			if found {
-				mcr.IncrementColumnUsage(cname)
+				mcr.IncrementColumnUsageByName(cname)
 			}
 		}
 		return true, dictEncColNames, nil
@@ -282,7 +262,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 				continue
 			}
 			if found {
-				mcr.IncrementColumnUsage(cname)
+				mcr.IncrementColumnUsageByName(cname)
 			}
 		}
 		return true, dictEncColNames, nil
@@ -306,7 +286,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 				continue
 			}
 			if found {
-				mcr.IncrementColumnUsage(cname)
+				mcr.IncrementColumnUsageByName(cname)
 			}
 		}
 		return true, dictEncColNames, nil

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -31,8 +31,7 @@ import (
 func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recordNum uint16, holderDte *DtypeEnclosure, qid uint64,
 	searchReq *SegmentSearchRequest,
-	cmiPassedNonDictColKeyIndices map[int]struct{}, queryInfoColKeyIndex int,
-	allColKeyIndices map[int]struct{}) (bool, error) {
+	cmiPassedNonDictColKeyIndices map[int]struct{}, queryInfoColKeyIndex int) (bool, error) {
 
 	switch query.SearchType {
 	case MatchAll:
@@ -136,7 +135,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 	case MatchDictArrayAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
-		for colKeyIndex := range allColKeyIndices {
+		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
 			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
 			if err != nil {

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -195,19 +195,6 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			}
 		}
 
-		allColKeyIndices := make(map[int]struct{})
-		// only create the allColKeyIndices only if it is dictarrayallcols search type
-		if query.SearchType == structs.MatchDictArrayAllColumns {
-			for _, colInfo := range multiColReader.AllColums {
-				if colInfo.ColumnName == config.GetTimeStampKey() {
-					continue
-				}
-				cKeyidx, ok := multiColReader.GetColKeyIndex(colInfo.ColumnName)
-				if ok {
-					allColKeyIndices[cKeyidx] = struct{}{}
-				}
-			}
-		}
 		var queryInfoColKeyIndex int
 		cKeyidx, ok := multiColReader.GetColKeyIndex(query.QueryInfo.ColName)
 		if ok {
@@ -218,7 +205,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			if recIT.ShouldProcessRecord(i) {
 				matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
 					qid, searchReq, cmiPassedNonDictColKeyIndices,
-					queryInfoColKeyIndex, allColKeyIndices)
+					queryInfoColKeyIndex)
 				if err != nil {
 					allSearchResults.AddError(err)
 					break

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -177,10 +177,41 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 	hasLimitOption := false
 	groupByColValCnt := make(map[string]int, 0)
 	var timeRangeBuckets []uint64
+
+	byFieldCnameKeyIdx := int(-1)
+	var isTsCol bool
+	groupbyColKeyIndices := make(map[int]struct{})
+	var byField string
 	if usedByTimechart {
+		byField = timeHistogram.Timechart.ByField
 		timeRangeBuckets = aggregations.GenerateTimeRangeBuckets(timeHistogram)
 		hasLimitOption = timeHistogram.Timechart.LimitExpr != nil
+		cKeyidx, ok := multiColReader.GetColKeyIndex(byField)
+		if ok {
+			byFieldCnameKeyIdx = cKeyidx
+		}
+		if timeHistogram.Timechart.ByField == config.GetTimeStampKey() {
+			isTsCol = true
+		} else {
+			isTsCol = false
+		}
+	} else {
+		for _, col := range grpReq.GroupByColumns {
+			cKeyidx, ok := multiColReader.GetColKeyIndex(col)
+			if ok {
+				groupbyColKeyIndices[cKeyidx] = struct{}{}
+			}
+		}
 	}
+
+	measColKeyIdxAndIndices := make(map[int][]int)
+	for cName, indices := range measureInfo {
+		cKeyidx, ok := multiColReader.GetColKeyIndex(cName)
+		if ok {
+			measColKeyIdxAndIndices[cKeyidx] = indices
+		}
+	}
+
 	for recNum := uint16(0); recNum < recIT.AllRecLen; recNum++ {
 		if !recIT.ShouldProcessRecord(uint(recNum)) {
 			continue
@@ -207,9 +238,9 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			currKey.Write(retVal)
 
 			// Get timechart's group by col val, each different val will be a bucket inside each time range bucket
-			byField := timeHistogram.Timechart.ByField
-			if len(byField) > 0 {
-				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(byField, blockNum, recNum, qid)
+			if byFieldCnameKeyIdx != -1 {
+				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(byFieldCnameKeyIdx,
+					blockNum, recNum, qid, isTsCol)
 				if err != nil {
 					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", byField, err)
 				} else {
@@ -233,10 +264,10 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				}
 			}
 		} else {
-			for _, col := range grpReq.GroupByColumns {
-				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(col, blockNum, recNum, qid)
+			for colKeyIndex := range groupbyColKeyIndices {
+				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)
 				if err != nil {
-					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", col, err)
+					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", colKeyIndex, err)
 					currKey.Write(utils.VALTYPE_ENC_BACKFILL)
 				} else {
 					currKey.Write(rawVal)
@@ -244,10 +275,11 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			}
 		}
 
-		for cName, indices := range measureInfo {
-			rawVal, err := multiColReader.ExtractValueFromColumnFile(cName, blockNum, recNum, qid)
+		for colKeyIdx, indices := range measColKeyIdxAndIndices {
+			rawVal, err := multiColReader.ExtractValueFromColumnFile(colKeyIdx, blockNum, recNum,
+				qid, false)
 			if err != nil {
-				log.Errorf("addRecordToAggregations: Failed to extract measure value from column %+v: %v", cName, err)
+				log.Errorf("addRecordToAggregations: Failed to extract measure value from colKeyIdx %+v: %v", colKeyIdx, err)
 				rawVal = &utils.CValueEnclosure{Dtype: utils.SS_DT_BACKFILL}
 			}
 			for _, idx := range indices {
@@ -770,15 +802,24 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 		}
 		sortedMatchedRecs = sortedMatchedRecs[:idx]
 		nonDeCols := applySegmentStatsUsingDictEncoding(multiReader, sortedMatchedRecs, mCols, aggColUsage, valuesUsage, blockStatus.BlockNum, recIT, localStats, bb, qid)
+
+		nonDeColsKeyIndices := make(map[int]string)
+		for cname := range nonDeCols {
+			cKeyidx, ok := multiReader.GetColKeyIndex(cname)
+			if ok {
+				nonDeColsKeyIndices[cKeyidx] = cname
+			}
+		}
+
 		for _, recNum := range sortedMatchedRecs {
-			for colName := range nonDeCols {
-				val, err := multiReader.ExtractValueFromColumnFile(colName, blockStatus.BlockNum, recNum, qid)
+			for colKeyIdx, cname := range nonDeColsKeyIndices {
+				val, err := multiReader.ExtractValueFromColumnFile(colKeyIdx, blockStatus.BlockNum, recNum, qid, false)
 				if err != nil {
-					log.Errorf("qid=%d, segmentStatsWorker failed to extract value for column %+v. Err: %v", qid, colName, err)
+					log.Errorf("qid=%d, segmentStatsWorker failed to extract value for cname %+v. Err: %v", qid, cname, err)
 					continue
 				}
 
-				hasValuesFunc, exists := valuesUsage[colName]
+				hasValuesFunc, exists := valuesUsage[cname]
 				if !exists {
 					hasValuesFunc = false
 				}
@@ -786,17 +827,17 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 				if val.Dtype == utils.SS_DT_STRING {
 					str, err := val.GetString()
 					if err != nil {
-						log.Errorf("qid=%d, segmentStatsWorker failed to extract value for string although type check passed %+v. Err: %v", qid, colName, err)
+						log.Errorf("qid=%d, segmentStatsWorker failed to extract value for string although type check passed %+v. Err: %v", qid, cname, err)
 						continue
 					}
-					stats.AddSegStatsStr(localStats, colName, str, bb, aggColUsage, hasValuesFunc)
+					stats.AddSegStatsStr(localStats, cname, str, bb, aggColUsage, hasValuesFunc)
 				} else {
 					fVal, err := val.GetFloatValue()
 					if err != nil {
 						log.Errorf("qid=%d, segmentStatsWorker failed to extract numerical value for type %+v. Err: %v", qid, val.Dtype, err)
 						continue
 					}
-					stats.AddSegStatsNums(localStats, colName, utils.SS_FLOAT64, 0, 0, fVal, fmt.Sprintf("%v", fVal), bb, aggColUsage, hasValuesFunc)
+					stats.AddSegStatsNums(localStats, cname, utils.SS_FLOAT64, 0, 0, fVal, fmt.Sprintf("%v", fVal), bb, aggColUsage, hasValuesFunc)
 				}
 			}
 		}
@@ -894,6 +935,14 @@ func iterRecsAddRrc(recIT *BlockRecordIterator, mcr *segread.MultiColSegmentRead
 	queryMetrics *structs.QueryProcessingMetrics,
 	allSearchResults *segresults.SearchResults, searchReq *structs.SegmentSearchRequest, qid uint64) {
 
+	var aggsSortColKeyIdx int
+	if aggs != nil && aggs.Sort != nil {
+		colKeyIdx, ok := mcr.GetColKeyIndex(aggs.Sort.ColName)
+		if ok {
+			aggsSortColKeyIdx = colKeyIdx
+		}
+	}
+
 	numRecsMatched := uint16(0)
 	for recNum := uint(0); recNum < uint(recIT.AllRecLen); recNum++ {
 		if !recIT.ShouldProcessRecord(recNum) {
@@ -913,7 +962,7 @@ func iterRecsAddRrc(recIT *BlockRecordIterator, mcr *segread.MultiColSegmentRead
 		}
 		numRecsMatched++
 		if blkResults.ShouldAddMore() {
-			sortVal, invalidCol := extractSortVals(aggs, mcr, blockStatus.BlockNum, recNumUint16, recTs, qid)
+			sortVal, invalidCol := extractSortVals(aggs, mcr, blockStatus.BlockNum, recNumUint16, recTs, qid, aggsSortColKeyIdx)
 			if !invalidCol && blkResults.WillValueBeAdded(sortVal) {
 				rrc := &utils.RecordResultContainer{
 					SegKeyInfo: utils.SegKeyInfo{

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -192,8 +192,6 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 		}
 		if timeHistogram.Timechart.ByField == config.GetTimeStampKey() {
 			isTsCol = true
-		} else {
-			isTsCol = false
 		}
 	} else {
 		for _, col := range grpReq.GroupByColumns {
@@ -204,11 +202,11 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 		}
 	}
 
-	measColKeyIdxAndIndices := make(map[int][]int)
+	measureColKeyIdxAndIndices := make(map[int][]int)
 	for cName, indices := range measureInfo {
 		cKeyidx, ok := multiColReader.GetColKeyIndex(cName)
 		if ok {
-			measColKeyIdxAndIndices[cKeyidx] = indices
+			measureColKeyIdxAndIndices[cKeyidx] = indices
 		}
 	}
 
@@ -275,7 +273,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			}
 		}
 
-		for colKeyIdx, indices := range measColKeyIdxAndIndices {
+		for colKeyIdx, indices := range measureColKeyIdxAndIndices {
 			rawVal, err := multiColReader.ExtractValueFromColumnFile(colKeyIdx, blockNum, recNum,
 				qid, false)
 			if err != nil {

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -180,7 +180,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 
 	byFieldCnameKeyIdx := int(-1)
 	var isTsCol bool
-	groupbyColKeyIndices := make(map[int]struct{})
+	groupbyColKeyIndices := make([]int, 0)
 	var byField string
 	if usedByTimechart {
 		byField = timeHistogram.Timechart.ByField
@@ -197,7 +197,9 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 		for _, col := range grpReq.GroupByColumns {
 			cKeyidx, ok := multiColReader.GetColKeyIndex(col)
 			if ok {
-				groupbyColKeyIndices[cKeyidx] = struct{}{}
+				groupbyColKeyIndices = append(groupbyColKeyIndices, cKeyidx)
+			} else {
+				log.Errorf("addRecordToAggregations: failed to find keyIdx in mcr for groupby cname: %v", col)
 			}
 		}
 	}
@@ -262,7 +264,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				}
 			}
 		} else {
-			for colKeyIndex := range groupbyColKeyIndices {
+			for _, colKeyIndex := range groupbyColKeyIndices {
 				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)
 				if err != nil {
 					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", colKeyIndex, err)


### PR DESCRIPTION
# Description

During multicol file reading, record by record, pull out the fileReader ptr that is inside MultiColReader for a column by passing in the keyIndex, instead of doing a lookup in a colNameToKeyIndex every record, this way we only find all the keyIndices once every block instead of once every record

With this change, if there are `5 Million` records and `270` blocks in one segfile then we do the 
`sfr := mcsr.allColsReverseIndex[cName]` 270 times instead of 5 Million times per segfile

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
