### PR TITLE
UI: Update Info Icon to Include Response Time Details

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1033,6 +1033,10 @@ progress.hidden {
     vertical-align: middle;
 }
 
+.final-res-time span{
+    font-weight: 600;
+}
+
 [data-theme='light'] #hits-summary {
     color: var(--hits-summary-regular-text-color);
     font-weight: var(--fw-400);
@@ -1272,6 +1276,7 @@ progress.hidden {
 .ui-dialog .ui-dialog-buttonpane button {
     margin: .5em .4em .5em 0;
     cursor: pointer;
+    outline: none;
 }
 
 .ui-draggable .ui-dialog-titlebar {

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -610,7 +610,7 @@ function setShowColumnInfoDialog() {
         buttons: {
             Cancel: {
                 class: 'cancelqButton cancel-record-btn',
-                text: 'Cancel',
+                text: 'OK',
                 click: function () {
                     $('#show-record-popup').dialog('close');
                 },

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -175,6 +175,8 @@ function doSearch(data) {
                 reject(errorMessages);
             }
             console.timeEnd(timerName);
+            const finalResultResponseTime = new Date().getTime() - startQueryTime;
+            $('#hits-summary .final-res-time span').html(`${finalResultResponseTime}`);
         };
 
         socket.addEventListener('error', (event) => {
@@ -893,20 +895,23 @@ function renderTotalHits(totalHits, elapedTimeMS, percentComplete, eventType, to
         if (qtype == 'aggs-query' || qtype === 'segstats-query') {
             let bucketGrammer = totalHits == 1 ? 'bucket was' : 'buckets were';
             $('#hits-summary').html(`
-            <div><b>Response: ${timeToFirstByte} ms</b></div>
+            <div>First Result Response Time: <b>${timeToFirstByte} ms</b></div>
+            <div class="final-res-time">Final Result Response Time: <span></span><b> ms</b></div>
             <div><span class="total-hits"><b>${operatorSign} ${totalHitsFormatted}</b></span><span> ${bucketGrammer} created from <b>${totalEventsSearched}</b> records.</span></div>
             <div>${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
         `);
         } else if (totalHits > 0) {
             $('#hits-summary').html(`
-            <div><b>Response: ${timeToFirstByte} ms</b></div>
+            <div>First Result Response Time: <b>${timeToFirstByte} ms</b></div>
+            <div class="final-res-time">Final Result Response Time: <span></span><b> ms</b></div>
             <div><span class="total-hits"><b>${operatorSign} ${totalHitsFormatted}</b></span><span> of <b>${totalEventsSearched}</b> Records Matched</span></div>
             <div>${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
         `);
         } else {
             $('#hits-summary').html(`
-            <div><b>Response: ${timeToFirstByte} ms</b></div>
-            <div><span><b> ${totalEventsSearched} </b>Records Searched</span></div>
+            <div>First Result Response Time: <b>${timeToFirstByte} ms</b></div>
+            <div class="final-res-time">Final Result Response Time: <span></span><b> ms</b></div>
+            <div>Records Searched: <span><b> ${totalEventsSearched} </b></span></div>
             <div>${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
         `);
         }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -175,7 +175,7 @@ function doSearch(data) {
                 reject(errorMessages);
             }
             console.timeEnd(timerName);
-            const finalResultResponseTime = new Date().getTime() - startQueryTime;
+            const finalResultResponseTime = (new Date().getTime() - startQueryTime).toLocaleString();
             $('#hits-summary .final-res-time span').html(`${finalResultResponseTime}`);
         };
 


### PR DESCRIPTION
# Description
**Enhanced the Info Icon Popup**: The popup now displays additional details about the query response, including:

- First Result Response Time
- Final Result Response Time
- Records Searched
- Time Range of the Query

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/d8cad3f8-1df6-4b24-8843-96acc2b970c4">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
