### PR TITLE
UI : Display PQS Details in Separate Tables

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -5965,7 +5965,7 @@ input.form-control {
     margin-bottom: 8px;
 }
 
-.myOrg-inner-container #ag-grid .ag-row:hover {
+.myOrg-inner-container .pqs-grid .ag-row:hover {
     background: var(--alerting-table-hover);
     cursor: pointer;
 }

--- a/static/pqs-settings.html
+++ b/static/pqs-settings.html
@@ -105,7 +105,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 Data</button>
                         </div>
                         <div>
-                            <div id="ag-grid" class="ag-theme-mycustomtheme mt-3 all-pqs" style="height: 500px;"></div>
+                            <div id="ag-grid-promoted-aggregations" class="ag-theme-mycustomtheme mt-3 pqs-grid" style="height: 250px;"></div>
+                            <div id="ag-grid-promoted-searches" class="ag-theme-mycustomtheme mt-3 pqs-grid" style="height: 250px;"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
# Description
1. Separate Tables for Promoted Searches and Promoted Aggregations
2. Total Tracked Row as a Final Non-Sortable Row
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/a826b7c1-3fe1-4acd-97a4-3ec89e4e2620">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
