### PR TITLE
Show correct total number of records to be searched in progress bar

### DIFF
--- a/pkg/ast/pipesearch/resultStructs.go
+++ b/pkg/ast/pipesearch/resultStructs.go
@@ -53,7 +53,6 @@ type PipeSearchWSUpdateResponse struct {
 	Completion               float64                 `json:"percent_complete"`
 	State                    string                  `json:"state,omitempty"`
 	TotalEventsSearched      interface{}             `json:"total_events_searched,omitempty"`
-	TotalPossibleEvents      interface{}             `json:"total_possible_events,omitempty"`
 	MeasureFunctions         []string                `json:"measureFunctions,omitempty"`
 	MeasureResults           []*structs.BucketHolder `json:"measure,omitempty"`
 	GroupByCols              []string                `json:"groupByCols,omitempty"`

--- a/pkg/ast/pipesearch/resultStructs.go
+++ b/pkg/ast/pipesearch/resultStructs.go
@@ -53,6 +53,7 @@ type PipeSearchWSUpdateResponse struct {
 	Completion               float64                 `json:"percent_complete"`
 	State                    string                  `json:"state,omitempty"`
 	TotalEventsSearched      interface{}             `json:"total_events_searched,omitempty"`
+	TotalPossibleEvents      interface{}             `json:"total_possible_events,omitempty"`
 	MeasureFunctions         []string                `json:"measureFunctions,omitempty"`
 	MeasureResults           []*structs.BucketHolder `json:"measure,omitempty"`
 	GroupByCols              []string                `json:"groupByCols,omitempty"`

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -248,7 +248,7 @@ func processRunningUpdate(conn *websocket.Conn, qid uint64) {
 func processQueryUpdate(conn *websocket.Conn, qid uint64, sizeLimit uint64, scrollFrom int, qscd *query.QueryStateChanData,
 	aggs *structs.QueryAggregators) uint64 {
 	searchPercent := qscd.PercentComplete
-	totalEventsSearched, err := query.GetTotalsRecsSearchedForQid(qid)
+	totalEventsSearched, err := query.GetTotalRecsToBeSearchedForQid(qid)
 	if err != nil {
 		log.Errorf("qid=%d, processQueryUpdate: failed to get total records searched: %+v", qid, err)
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -248,9 +248,19 @@ func processRunningUpdate(conn *websocket.Conn, qid uint64) {
 func processQueryUpdate(conn *websocket.Conn, qid uint64, sizeLimit uint64, scrollFrom int, qscd *query.QueryStateChanData,
 	aggs *structs.QueryAggregators) uint64 {
 	searchPercent := qscd.PercentComplete
-	totalEventsSearched, err := query.GetTotalRecsToBeSearchedForQid(qid)
+	totalEventsSearched, err := query.GetTotalsRecsSearchedForQid(qid)
 	if err != nil {
 		log.Errorf("qid=%d, processQueryUpdate: failed to get total records searched: %+v", qid, err)
+		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
+		if wErr != nil {
+			log.Errorf("qid=%d, processQueryUpdate: failed to write error response to websocket! err: %+v", qid, wErr)
+		}
+		return 0
+	}
+
+	totalPossibleEvents, err := query.GetTotalRecsToBeSearchedForQid(qid)
+	if err != nil {
+		log.Errorf("qid=%d, processQueryUpdate: failed to get total records going to be searched: %+v", qid, err)
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
 		if wErr != nil {
 			log.Errorf("qid=%d, processQueryUpdate: failed to write error response to websocket! err: %+v", qid, wErr)
@@ -268,7 +278,7 @@ func processQueryUpdate(conn *websocket.Conn, qid uint64, sizeLimit uint64, scro
 		return 0
 	}
 
-	wsResponse, numRrcsAdded, err := createRecsWsResp(qid, sizeLimit, searchPercent, scrollFrom, totalEventsSearched, qscd.QueryUpdate, aggs)
+	wsResponse, numRrcsAdded, err := createRecsWsResp(qid, sizeLimit, searchPercent, scrollFrom, totalEventsSearched, qscd.QueryUpdate, aggs, totalPossibleEvents)
 	if err != nil {
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
 		if wErr != nil {
@@ -350,13 +360,14 @@ func processMaxScrollComplete(conn *websocket.Conn, qid uint64) {
 }
 
 func createRecsWsResp(qid uint64, sizeLimit uint64, searchPercent float64, scrollFrom int,
-	totalEventsSearched uint64, qUpdate *query.QueryUpdate, aggs *structs.QueryAggregators) (*PipeSearchWSUpdateResponse, uint64, error) {
+	totalEventsSearched uint64, qUpdate *query.QueryUpdate, aggs *structs.QueryAggregators, totalPossibleEvents uint64) (*PipeSearchWSUpdateResponse, uint64, error) {
 
 	qType := query.GetQueryType(qid)
 	wsResponse := &PipeSearchWSUpdateResponse{
 		Completion:               searchPercent,
 		State:                    query.QUERY_UPDATE.String(),
 		TotalEventsSearched:      humanize.Comma(int64(totalEventsSearched)),
+		TotalPossibleEvents:      humanize.Comma(int64(totalPossibleEvents)),
 		Qtype:                    qType.String(),
 		SortByTimestampAtDefault: !aggs.HasSortBlockInChain(),
 	}

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -248,19 +248,10 @@ func processRunningUpdate(conn *websocket.Conn, qid uint64) {
 func processQueryUpdate(conn *websocket.Conn, qid uint64, sizeLimit uint64, scrollFrom int, qscd *query.QueryStateChanData,
 	aggs *structs.QueryAggregators) uint64 {
 	searchPercent := qscd.PercentComplete
-	totalEventsSearched, err := query.GetTotalsRecsSearchedForQid(qid)
-	if err != nil {
-		log.Errorf("qid=%d, processQueryUpdate: failed to get total records searched: %+v", qid, err)
-		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
-		if wErr != nil {
-			log.Errorf("qid=%d, processQueryUpdate: failed to write error response to websocket! err: %+v", qid, wErr)
-		}
-		return 0
-	}
 
-	totalPossibleEvents, err := query.GetTotalRecsToBeSearchedForQid(qid)
+	totalEventsSearched, totalPossibleEvents, err := query.GetTotalSearchedAndPossibleEventsForQid(qid)
 	if err != nil {
-		log.Errorf("qid=%d, processQueryUpdate: failed to get total records going to be searched: %+v", qid, err)
+		log.Errorf("qid=%d, processQueryUpdate: failed to get total searched and possible records: %+v", qid, err)
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
 		if wErr != nil {
 			log.Errorf("qid=%d, processQueryUpdate: failed to write error response to websocket! err: %+v", qid, wErr)

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -310,21 +310,39 @@ func GetNodeResultsFromQSRS(sortedQSRSlice []*QuerySegmentRequest, queryInfo *Qu
 	}
 }
 
+func getTotalRecordsToBeSearched(qsrs []*QuerySegmentRequest) uint64 {
+	var totalRecsToSearch uint64
+	for _, qsr := range qsrs {
+		if qsr.sType == structs.RAW_SEARCH || qsr.sType == structs.PQS || qsr.sType == structs.SEGMENT_STATS_SEARCH {
+			totalRecsToSearch += metadata.GetNumOfSearchedRecordsRotated(qsr.segKey)
+		} else {
+			totalRecsToSearch += writer.GetNumOfSearchedRecordsUnRotated(qsr.segKey)
+		}
+	}
+
+	return totalRecsToSearch
+}
+
 func GetNodeResultsForRRCCmd(queryInfo *QueryInformation, sTime time.Time, allSegFileResults *segresults.SearchResults,
 	querySummary *summary.QuerySummary, getUnrotated bool, getRotated bool, orgid uint64) *structs.NodeResult {
 
 	sortedQSRSlice, numRawSearch, distributedQueries, numPQS, err := getAllSegmentsInQuery(queryInfo, getUnrotated, getRotated, sTime, orgid)
 	if err != nil {
-		log.Errorf("qid=%d Failed to get all segments in query! Error: %+v", queryInfo.qid, err)
+		log.Errorf("qid=%d GetNodeResultsForRRCCmd: Failed to get all segments in query! Error: %+v", queryInfo.qid, err)
 		return &structs.NodeResult{
 			ErrList: []error{err},
 		}
 	}
-	log.Infof("qid=%d, Received %+v query segment requests. %+v raw search %+v pqs and %+v distribued query elapsed time: %+v",
+	log.Infof("qid=%d, GetNodeResultsForRRCCmd: Received %+v query segment requests. %+v raw search %+v pqs and %+v distribued query elapsed time: %+v",
 		queryInfo.qid, len(sortedQSRSlice), numRawSearch, numPQS, distributedQueries, time.Since(sTime))
 	err = setTotalSegmentsToSearch(queryInfo.qid, numRawSearch+numPQS+distributedQueries)
 	if err != nil {
-		log.Errorf("qid=%d Failed to set total segments to search! Error: %+v", queryInfo.qid, err)
+		log.Errorf("qid=%d GetNodeResultsForRRCCmd: Failed to set total segments to search! Error: %+v", queryInfo.qid, err)
+	}
+	totalRecsToBeSearched := getTotalRecordsToBeSearched(sortedQSRSlice)
+	err = setTotalRecordsToBeSearched(queryInfo.qid, totalRecsToBeSearched)
+	if err != nil {
+		log.Errorf("qid=%d GetNodeResultsForRRCCmd: Failed to set total records to search! Error: %+v", queryInfo.qid, err)
 	}
 	querySummary.UpdateRemainingDistributedQueries(distributedQueries)
 	return GetNodeResultsFromQSRS(sortedQSRSlice, queryInfo, sTime, allSegFileResults, querySummary)
@@ -336,7 +354,7 @@ func GetNodeResultsForSegmentStatsCmd(queryInfo *QueryInformation, sTime time.Ti
 	sortedQSRSlice, numRawSearch, numDistributed, err := getAllSegmentsInAggs(queryInfo, qsrs, queryInfo.aggs,
 		queryInfo.queryRange, queryInfo.indexInfo.GetQueryTables(), queryInfo.qid, getUnrotated, getRotated, sTime, orgid)
 	if err != nil {
-		log.Errorf("GetNodeResultsForSegmentStatsCmd: qid=%d Failed to get all segments in query! Error: %+v", queryInfo.qid, err)
+		log.Errorf("qid=%d GetNodeResultsForSegmentStatsCmd: Failed to get all segments in query! Error: %+v", queryInfo.qid, err)
 		return &structs.NodeResult{
 			ErrList: []error{err},
 		}
@@ -344,14 +362,19 @@ func GetNodeResultsForSegmentStatsCmd(queryInfo *QueryInformation, sTime time.Ti
 
 	err = setTotalSegmentsToSearch(queryInfo.qid, numRawSearch+numDistributed)
 	if err != nil {
-		log.Errorf("GetNodeResultsForSegmentStatsCmd: qid=%d Failed to set total segments to search! Error: %+v", queryInfo.qid, err)
+		log.Errorf("qid=%d GetNodeResultsForSegmentStatsCmd: Failed to set total segments to search! Error: %+v", queryInfo.qid, err)
 		return &structs.NodeResult{
 			ErrList: []error{err},
 		}
 	}
+	totalRecsToBeSearched := getTotalRecordsToBeSearched(sortedQSRSlice)
+	err = setTotalRecordsToBeSearched(queryInfo.qid, totalRecsToBeSearched)
+	if err != nil {
+		log.Errorf("qid=%d GetNodeResultsForSegmentStatsCmd: Failed to set total records to search! Error: %+v", queryInfo.qid, err)
+	}
 
 	querySummary.UpdateRemainingDistributedQueries(numDistributed)
-	log.Infof("qid=%d, Received %+v query segment aggs, with %+v raw search %v distributed, query elapsed time: %+v",
+	log.Infof("qid=%d, GetNodeResultsForSegmentStatsCmd: Received %+v query segment aggs, with %+v raw search %v distributed, query elapsed time: %+v",
 		queryInfo.qid, len(sortedQSRSlice), numRawSearch, numDistributed, time.Since(sTime))
 	if queryInfo.aggs.MeasureOperations != nil {
 		allSegFileResults.InitSegmentStatsResults(queryInfo.aggs.MeasureOperations)


### PR DESCRIPTION
# Description
Summarize the change.
Added totalRecsToBeSearched which has the total number of records to be searched calculated before executing the actual query.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Total possible events should have the correct count seen below. UI can use this variable to update the progress bar.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ae951cbc-e5b1-4046-8a96-3aa7bf1d951b">
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ef5e7b71-93d7-4bdc-98b8-cf68534ea78f">



Always shows the same total number of records to be searched.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
