### PR TITLE
Do not Read cmis for wildcard value searches

### DIFF
--- a/pkg/segment/query/metadata/blockmeta.go
+++ b/pkg/segment/query/metadata/blockmeta.go
@@ -118,7 +118,7 @@ func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
 	}
 
 	var missingBlockCMI bool
-	if len(timeFilteredBlocks) > 0 && !isMatchAll && !segMicroIndex.loadedMicroIndices {
+	if len(timeFilteredBlocks) > 0 && !isMatchAll && !segMicroIndex.loadedMicroIndices && !wildCardValue {
 		totalRequestedMemory += int64(segMicroIndex.MicroIndexSize)
 		err := GlobalBlockMicroIndexCheckLimiter.TryAcquireWithBackoff(int64(segMicroIndex.MicroIndexSize), 10, segkey)
 		if err != nil {


### PR DESCRIPTION
# Description
- For wildcard value searches, the cmi check will not read/load CMIs.

# Testing
- Tested by running the query `whatever*`

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
