### PR TITLE
avoid using buf.Bytes to reduce runtime memory

### DIFF
--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -386,7 +386,11 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 		}
 		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns)
 		b.GroupByAggregation.AllRunningBuckets = append(b.GroupByAggregation.AllRunningBuckets, bucket)
-		b.GroupByAggregation.StringBucketIdx[bKey] = nBuckets
+		// only make a copy if this is the first time we are inserting it
+		// so that the caller may free up the backing space for this currKey/bKey
+		keyCopy := make([]byte, len(bKey))
+		copy(keyCopy, bKey)
+		b.GroupByAggregation.StringBucketIdx[toputils.UnsafeByteSliceToString(keyCopy)] = nBuckets
 	} else {
 		bucket = b.GroupByAggregation.AllRunningBuckets[bucketIdx]
 	}

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -18,7 +18,6 @@
 package blockresults
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
 	"sort"
@@ -371,12 +370,12 @@ func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncose
 
 }
 
-func (b *BlockResults) AddMeasureResultsToKey(currKey bytes.Buffer, measureResults []utils.CValueEnclosure, groupByColVal string, usedByTimechart bool, qid uint64) {
+func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []utils.CValueEnclosure, groupByColVal string, usedByTimechart bool, qid uint64) {
 
 	if b.GroupByAggregation == nil {
 		return
 	}
-	bKey := toputils.UnsafeByteSliceToString(currKey.Bytes())
+	bKey := toputils.UnsafeByteSliceToString(currKey)
 	bucketIdx, ok := b.GroupByAggregation.StringBucketIdx[bKey]
 
 	var bucket *RunningBucketResults

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -566,6 +566,9 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 		var bucketKey interface{}
 		bucketKey, err := utils.ConvertGroupByKey([]byte(key))
+		if len(bucketKey.([]string)) == 1 {
+			bucketKey = bucketKey.([]string)[0]
+		}
 		if err != nil {
 			log.Errorf("GroupByBuckets.ConvertToAggregationResult: failed to convert group by key: %v, err: %v", key, err)
 		}

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -566,6 +566,10 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 		var bucketKey interface{}
 		bucketKey, err := utils.ConvertGroupByKey([]byte(key))
+		if len(bucketKey.([]string)) == 1 {
+			bucketKey = bucketKey.([]string)[0]
+		}
+
 		if err != nil {
 			log.Errorf("GroupByBuckets.ConvertToAggregationResult: failed to convert group by key: %v, err: %v", key, err)
 		}

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -566,9 +566,6 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 		var bucketKey interface{}
 		bucketKey, err := utils.ConvertGroupByKey([]byte(key))
-		if len(bucketKey.([]string)) == 1 {
-			bucketKey = bucketKey.([]string)[0]
-		}
 		if err != nil {
 			log.Errorf("GroupByBuckets.ConvertToAggregationResult: failed to convert group by key: %v, err: %v", key, err)
 		}

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -566,10 +566,6 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 		var bucketKey interface{}
 		bucketKey, err := utils.ConvertGroupByKey([]byte(key))
-		if len(bucketKey.([]string)) == 1 {
-			bucketKey = bucketKey.([]string)[0]
-		}
-
 		if err != nil {
 			log.Errorf("GroupByBuckets.ConvertToAggregationResult: failed to convert group by key: %v, err: %v", key, err)
 		}

--- a/pkg/segment/results/blockresults/runningstats_test.go
+++ b/pkg/segment/results/blockresults/runningstats_test.go
@@ -65,7 +65,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		bRes.AddMeasureResultsToKey(buf, mRes, "", false, 5)
+		bRes.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
 	}
 	assert.NotNil(t, bRes.GroupByAggregation)
 	assert.Len(t, bRes.GroupByAggregation.AllRunningBuckets, 10)
@@ -85,7 +85,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: i, Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		toMerge.AddMeasureResultsToKey(buf, mRes, "", false, 5)
+		toMerge.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
 	}
 
 	bRes.MergeBuckets(toMerge)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -273,9 +273,9 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 
 			// resize the working buf if we cannot accomodate the max value of any
 			// column's record
-			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices) * 65_000 {
+			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices)*65_000 {
 				aggsKeyWorkingBuf = toputils.ResizeSlice(aggsKeyWorkingBuf,
-					len(groupbyColKeyIndices) * 65_000)
+					len(groupbyColKeyIndices)*65_000)
 			}
 			for _, colKeyIndex := range groupbyColKeyIndices {
 				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -301,9 +301,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				measureResults[idx] = *rawVal
 			}
 		}
-		keyCopy := make([]byte, aggsKeyBufIdx)
-		copy(keyCopy, aggsKeyWorkingBuf[0:aggsKeyBufIdx])
-		blockRes.AddMeasureResultsToKey(keyCopy, measureResults,
+		blockRes.AddMeasureResultsToKey(aggsKeyWorkingBuf[:aggsKeyBufIdx], measureResults,
 			groupByColVal, usedByTimechart, qid)
 	}
 

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -253,7 +253,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				if err != nil {
 					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", byField, err)
 				} else {
-					strs, err := utils.ConvertGroupByKeyForSingleRec(rawVal)
+					strs, err := utils.ConvertGroupByKey(rawVal)
 					if err != nil {
 						log.Errorf("addRecordToAggregations: failed to extract raw key: %v", err)
 					}

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -253,7 +253,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				if err != nil {
 					log.Errorf("addRecordToAggregations: Failed to get key for column %v: %v", byField, err)
 				} else {
-					strs, err := utils.ConvertGroupByKey(rawVal)
+					strs, err := utils.ConvertGroupByKeyForSingleRec(rawVal)
 					if err != nil {
 						log.Errorf("addRecordToAggregations: failed to extract raw key: %v", err)
 					}

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -257,7 +257,11 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 					if err != nil {
 						log.Errorf("addRecordToAggregations: failed to extract raw key: %v", err)
 					}
-					groupByColVal = strs
+					if len(strs) == 1 {
+						groupByColVal = strs[0]
+					} else {
+						log.Errorf("addRecordToAggregations: invalid length of groupByColVal")
+					}
 				}
 				if hasLimitOption {
 					cnt, exists := groupByColValCnt[groupByColVal]

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -254,11 +254,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 					if err != nil {
 						log.Errorf("addRecordToAggregations: failed to extract raw key: %v", err)
 					}
-					if len(strs) == 1 {
-						groupByColVal = strs[0]
-					} else {
-						log.Errorf("addRecordToAggregations: invalid length of groupByColVal")
-					}
+					groupByColVal = strs
 				}
 				if hasLimitOption {
 					cnt, exists := groupByColValCnt[groupByColVal]

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -377,7 +377,6 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 		}
 	}
 
-
 	// start off with 256 bytes and caller will resize it and return back the new resized buf
 	aggsKeyWorkingBuf := make([]byte, 256)
 

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -238,7 +238,66 @@ func MaxUint16(a1 uint16, b1 uint16) uint16 {
 }
 
 // converts the input byte slice to a string representation of all read values
-func ConvertGroupByKey(rec []byte) (string, error) {
+// returns array of strings with groupBy values
+func ConvertGroupByKey(rec []byte) ([]string, error) {
+	var strArr []string
+	idx := 0
+	for idx < len(rec) {
+		var str strings.Builder
+		switch rec[idx] {
+		case VALTYPE_ENC_SMALL_STRING[0]:
+			idx += 1
+			len := int(toputils.BytesToUint16LittleEndian(rec[idx:]))
+			idx += 2
+			str.WriteString(string(rec[idx : idx+len]))
+			idx += len
+		case VALTYPE_ENC_BOOL[0]:
+			str.WriteString(fmt.Sprintf("%+v", rec[idx+1]))
+			idx += 2
+		case VALTYPE_ENC_INT8[0]:
+			str.WriteString(fmt.Sprintf("%+v", int8(rec[idx+1:][0])))
+			idx += 2
+		case VALTYPE_ENC_INT16[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt16LittleEndian(rec[idx+1:])))
+			idx += 3
+		case VALTYPE_ENC_INT32[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt32LittleEndian(rec[idx+1:])))
+			idx += 5
+		case VALTYPE_ENC_INT64[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt64LittleEndian(rec[idx+1:])))
+			idx += 9
+		case VALTYPE_ENC_UINT8[0]:
+			str.WriteString(fmt.Sprintf("%+v", uint8((rec[idx+1:])[0])))
+			idx += 2
+		case VALTYPE_ENC_UINT16[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint16LittleEndian(rec[idx+1:])))
+			idx += 3
+		case VALTYPE_ENC_UINT32[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint32LittleEndian(rec[idx+1:])))
+			idx += 5
+		case VALTYPE_ENC_UINT64[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint64LittleEndian(rec[idx+1:])))
+			idx += 9
+		case VALTYPE_ENC_FLOAT64[0]:
+			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToFloat64LittleEndian(rec[idx+1:])))
+			idx += 9
+		case VALTYPE_ENC_BACKFILL[0]:
+			str.WriteString("")
+			idx += 1
+		default:
+			log.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v", rec[idx], idx)
+			return nil, fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
+				rec[idx], idx)
+		}
+
+		strArr = append(strArr, str.String())
+
+	}
+	return strArr, nil
+}
+
+// converts the input byte slice to a string representation of all read values
+func ConvertGroupByKeyForSingleRec(rec []byte) (string, error) {
 
 	idx := 0
 	var str strings.Builder

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -238,66 +238,7 @@ func MaxUint16(a1 uint16, b1 uint16) uint16 {
 }
 
 // converts the input byte slice to a string representation of all read values
-// returns array of strings with groupBy values
-func ConvertGroupByKey(rec []byte) ([]string, error) {
-	var strArr []string
-	idx := 0
-	for idx < len(rec) {
-		var str strings.Builder
-		switch rec[idx] {
-		case VALTYPE_ENC_SMALL_STRING[0]:
-			idx += 1
-			len := int(toputils.BytesToUint16LittleEndian(rec[idx:]))
-			idx += 2
-			str.WriteString(string(rec[idx : idx+len]))
-			idx += len
-		case VALTYPE_ENC_BOOL[0]:
-			str.WriteString(fmt.Sprintf("%+v", rec[idx+1]))
-			idx += 2
-		case VALTYPE_ENC_INT8[0]:
-			str.WriteString(fmt.Sprintf("%+v", int8(rec[idx+1:][0])))
-			idx += 2
-		case VALTYPE_ENC_INT16[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt16LittleEndian(rec[idx+1:])))
-			idx += 3
-		case VALTYPE_ENC_INT32[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt32LittleEndian(rec[idx+1:])))
-			idx += 5
-		case VALTYPE_ENC_INT64[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToInt64LittleEndian(rec[idx+1:])))
-			idx += 9
-		case VALTYPE_ENC_UINT8[0]:
-			str.WriteString(fmt.Sprintf("%+v", uint8((rec[idx+1:])[0])))
-			idx += 2
-		case VALTYPE_ENC_UINT16[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint16LittleEndian(rec[idx+1:])))
-			idx += 3
-		case VALTYPE_ENC_UINT32[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint32LittleEndian(rec[idx+1:])))
-			idx += 5
-		case VALTYPE_ENC_UINT64[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToUint64LittleEndian(rec[idx+1:])))
-			idx += 9
-		case VALTYPE_ENC_FLOAT64[0]:
-			str.WriteString(fmt.Sprintf("%+v", toputils.BytesToFloat64LittleEndian(rec[idx+1:])))
-			idx += 9
-		case VALTYPE_ENC_BACKFILL[0]:
-			str.WriteString("")
-			idx += 1
-		default:
-			log.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v", rec[idx], idx)
-			return nil, fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
-				rec[idx], idx)
-		}
-
-		strArr = append(strArr, str.String())
-
-	}
-	return strArr, nil
-}
-
-// converts the input byte slice to a string representation of all read values
-func ConvertGroupByKeyForSingleRec(rec []byte) (string, error) {
+func ConvertGroupByKey(rec []byte) (string, error) {
 
 	idx := 0
 	var str strings.Builder

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -238,11 +238,12 @@ func MaxUint16(a1 uint16, b1 uint16) uint16 {
 }
 
 // converts the input byte slice to a string representation of all read values
-func ConvertGroupByKey(rec []byte) (string, error) {
-
+// returns array of strings with groupBy values
+func ConvertGroupByKey(rec []byte) ([]string, error) {
+	var strArr []string
 	idx := 0
-	var str strings.Builder
 	for idx < len(rec) {
+		var str strings.Builder
 		switch rec[idx] {
 		case VALTYPE_ENC_SMALL_STRING[0]:
 			idx += 1
@@ -285,15 +286,12 @@ func ConvertGroupByKey(rec []byte) (string, error) {
 			idx += 1
 		default:
 			log.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v", rec[idx], idx)
-			return "", fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
+			return nil, fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
 				rec[idx], idx)
 		}
 
-		if len(rec) > idx {
-			log.Errorf("ConvertRowEncodingToString: received multiple recs in creating grpby key len(rec)=%v, idx: %v", len(rec), idx)
-			return "", fmt.Errorf("ConvertRowEncodingToString: received multiple recs in creating grpby key len(rec)=%v, idx: %v", len(rec), idx)
-		}
-	}
+		strArr = append(strArr, str.String())
 
-	return str.String(), nil
+	}
+	return strArr, nil
 }

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -238,12 +238,11 @@ func MaxUint16(a1 uint16, b1 uint16) uint16 {
 }
 
 // converts the input byte slice to a string representation of all read values
-// returns array of strings with groupBy values
-func ConvertGroupByKey(rec []byte) ([]string, error) {
-	var strArr []string
+func ConvertGroupByKey(rec []byte) (string, error) {
+
 	idx := 0
+	var str strings.Builder
 	for idx < len(rec) {
-		var str strings.Builder
 		switch rec[idx] {
 		case VALTYPE_ENC_SMALL_STRING[0]:
 			idx += 1
@@ -286,12 +285,15 @@ func ConvertGroupByKey(rec []byte) ([]string, error) {
 			idx += 1
 		default:
 			log.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v", rec[idx], idx)
-			return nil, fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
+			return "", fmt.Errorf("ConvertRowEncodingToString: dont know how to convert type=%v, idx: %v",
 				rec[idx], idx)
 		}
 
-		strArr = append(strArr, str.String())
-
+		if len(rec) > idx {
+			log.Errorf("ConvertRowEncodingToString: received multiple recs in creating grpby key len(rec)=%v, idx: %v", len(rec), idx)
+			return "", fmt.Errorf("ConvertRowEncodingToString: received multiple recs in creating grpby key len(rec)=%v, idx: %v", len(rec), idx)
+		}
 	}
-	return strArr, nil
+
+	return str.String(), nil
 }


### PR DESCRIPTION

# Description

1. For each bucket key we create during historgram queries, we were using bytes.Buffer and growing it by adding all the groupby cols to it. This bytes buffer was reset on every record. Now pre-allocate a byte slice per block worker and reuse that bytes buffer during each record processing. This helps in runtime memory allocations.


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
