### PR TITLE
Use pre-alloc byte slice instead of buf.Bytes during AddMeasureToRes

### DIFF
--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -386,7 +386,11 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 		}
 		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns)
 		b.GroupByAggregation.AllRunningBuckets = append(b.GroupByAggregation.AllRunningBuckets, bucket)
-		b.GroupByAggregation.StringBucketIdx[bKey] = nBuckets
+		// only make a copy if this is the first time we are inserting it
+		// so that the caller may free up the backing space for this currKey/bKey
+		keyCopy := make([]byte, len(bKey))
+		copy(keyCopy, bKey)
+		b.GroupByAggregation.StringBucketIdx[toputils.UnsafeByteSliceToString(keyCopy)] = nBuckets
 	} else {
 		bucket = b.GroupByAggregation.AllRunningBuckets[bucketIdx]
 	}

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -18,7 +18,6 @@
 package blockresults
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
 	"sort"
@@ -371,12 +370,12 @@ func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncose
 
 }
 
-func (b *BlockResults) AddMeasureResultsToKey(currKey bytes.Buffer, measureResults []utils.CValueEnclosure, groupByColVal string, usedByTimechart bool, qid uint64) {
+func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []utils.CValueEnclosure, groupByColVal string, usedByTimechart bool, qid uint64) {
 
 	if b.GroupByAggregation == nil {
 		return
 	}
-	bKey := toputils.UnsafeByteSliceToString(currKey.Bytes())
+	bKey := toputils.UnsafeByteSliceToString(currKey)
 	bucketIdx, ok := b.GroupByAggregation.StringBucketIdx[bKey]
 
 	var bucket *RunningBucketResults

--- a/pkg/segment/results/blockresults/runningstats_test.go
+++ b/pkg/segment/results/blockresults/runningstats_test.go
@@ -65,7 +65,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		bRes.AddMeasureResultsToKey(buf, mRes, "", false, 5)
+		bRes.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
 	}
 	assert.NotNil(t, bRes.GroupByAggregation)
 	assert.Len(t, bRes.GroupByAggregation.AllRunningBuckets, 10)
@@ -85,7 +85,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: i, Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		toMerge.AddMeasureResultsToKey(buf, mRes, "", false, 5)
+		toMerge.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
 	}
 
 	bRes.MergeBuckets(toMerge)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -273,9 +273,9 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 
 			// resize the working buf if we cannot accomodate the max value of any
 			// column's record
-			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices) * 65_000 {
+			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices)*65_000 {
 				aggsKeyWorkingBuf = toputils.ResizeSlice(aggsKeyWorkingBuf,
-					len(groupbyColKeyIndices) * 65_000)
+					len(groupbyColKeyIndices)*65_000)
 			}
 			for _, colKeyIndex := range groupbyColKeyIndices {
 				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -301,9 +301,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 				measureResults[idx] = *rawVal
 			}
 		}
-		keyCopy := make([]byte, aggsKeyBufIdx)
-		copy(keyCopy, aggsKeyWorkingBuf[0:aggsKeyBufIdx])
-		blockRes.AddMeasureResultsToKey(keyCopy, measureResults,
+		blockRes.AddMeasureResultsToKey(aggsKeyWorkingBuf[:aggsKeyBufIdx], measureResults,
 			groupByColVal, usedByTimechart, qid)
 	}
 

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -275,9 +275,9 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 
 			// resize the working buf if we cannot accomodate the max value of any
 			// column's record
-			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices)*65_000 {
+			if len(aggsKeyWorkingBuf) < len(groupbyColKeyIndices)*utils.MAX_RECORD_SIZE {
 				aggsKeyWorkingBuf = toputils.ResizeSlice(aggsKeyWorkingBuf,
-					len(groupbyColKeyIndices)*65_000)
+					len(groupbyColKeyIndices)*utils.MAX_RECORD_SIZE)
 			}
 			for _, colKeyIndex := range groupbyColKeyIndices {
 				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -123,6 +123,10 @@ func applyAggregationsToSingleBlock(multiReader *segread.MultiColSegmentReader, 
 
 	// start off with 256 bytes and caller will resize it and return back the new resized buf
 	aggsKeyWorkingBuf := make([]byte, 256)
+	var timeRangeBuckets []uint64
+	if aggs != nil && aggs.TimeHistogram != nil && aggs.TimeHistogram.Timechart != nil {
+		timeRangeBuckets = aggregations.GenerateTimeRangeBuckets(aggs.TimeHistogram)
+	}
 
 	for blockStatus := range blockChan {
 		if !blockStatus.hasAnyMatched {
@@ -169,20 +173,19 @@ func applyAggregationsToSingleBlock(multiReader *segread.MultiColSegmentReader, 
 			}
 		}
 		aggsKeyWorkingBuf = doAggs(aggs, multiReader, blockStatus, recIT, blkResults,
-			isBlkFullyEncosed, qid, aggsKeyWorkingBuf)
+			isBlkFullyEncosed, qid, aggsKeyWorkingBuf, timeRangeBuckets)
 	}
 	allSearchResults.AddBlockResults(blkResults)
 }
 
 func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *structs.TimeBucket, measureInfo map[string][]int, numMFuncs int, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recIT *BlockRecordIterator, blockRes *blockresults.BlockResults,
-	qid uint64, aggsKeyWorkingBuf []byte) []byte {
+	qid uint64, aggsKeyWorkingBuf []byte, timeRangeBuckets []uint64) []byte {
 
 	measureResults := make([]utils.CValueEnclosure, numMFuncs)
 	usedByTimechart := (timeHistogram != nil && timeHistogram.Timechart != nil)
 	hasLimitOption := false
 	groupByColValCnt := make(map[string]int, 0)
-	var timeRangeBuckets []uint64
 
 	byFieldCnameKeyIdx := int(-1)
 	var isTsCol bool
@@ -190,7 +193,6 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 	var byField string
 	if usedByTimechart {
 		byField = timeHistogram.Timechart.ByField
-		timeRangeBuckets = aggregations.GenerateTimeRangeBuckets(timeHistogram)
 		hasLimitOption = timeHistogram.Timechart.LimitExpr != nil
 		cKeyidx, ok := multiColReader.GetColKeyIndex(byField)
 		if ok {
@@ -1004,7 +1006,8 @@ func iterRecsAddRrc(recIT *BlockRecordIterator, mcr *segread.MultiColSegmentRead
 
 func doAggs(aggs *structs.QueryAggregators, mcr *segread.MultiColSegmentReader,
 	bss *BlockSearchStatus, recIT *BlockRecordIterator, blkResults *blockresults.BlockResults,
-	isBlkFullyEncosed bool, qid uint64, aggsKeyWorkingBuf []byte) []byte {
+	isBlkFullyEncosed bool, qid uint64, aggsKeyWorkingBuf []byte,
+	timeRangeBuckets []uint64) []byte {
 
 	if aggs == nil || aggs.GroupByRequest == nil {
 		return aggsKeyWorkingBuf // nothing to do
@@ -1012,7 +1015,7 @@ func doAggs(aggs *structs.QueryAggregators, mcr *segread.MultiColSegmentReader,
 
 	measureInfo, internalMops := blkResults.GetConvertedMeasureInfo()
 	return addRecordToAggregations(aggs.GroupByRequest, aggs.TimeHistogram, measureInfo, len(internalMops), mcr,
-		bss.BlockNum, recIT, blkResults, qid, aggsKeyWorkingBuf)
+		bss.BlockNum, recIT, blkResults, qid, aggsKeyWorkingBuf, timeRangeBuckets)
 }
 
 func CanDoStarTree(segKey string, aggs *structs.QueryAggregators,

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -377,7 +377,6 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 		}
 	}
 
-
 	// start off with 256 bytes and caller will resize it and return back the new resized buf
 	aggsKeyWorkingBuf := make([]byte, 256)
 

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -30,6 +30,7 @@ import (
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/querytracker"
+	"github.com/siglens/siglens/pkg/segment/aggregations"
 	"github.com/siglens/siglens/pkg/segment/memory/limit"
 	"github.com/siglens/siglens/pkg/segment/pqmr"
 	"github.com/siglens/siglens/pkg/segment/query/pqs"
@@ -379,6 +380,10 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 
 	// start off with 256 bytes and caller will resize it and return back the new resized buf
 	aggsKeyWorkingBuf := make([]byte, 256)
+	var timeRangeBuckets []uint64
+	if aggs != nil && aggs.TimeHistogram != nil && aggs.TimeHistogram.Timechart != nil {
+		timeRangeBuckets = aggregations.GenerateTimeRangeBuckets(aggs.TimeHistogram)
+	}
 
 	for blockNum := range filterBlockRequestsChan {
 		if req.SearchMetadata == nil || int(blockNum) >= len(req.SearchMetadata.BlockSummaries) {
@@ -459,7 +464,7 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 			recIT := InitIteratorFromPQMR(pqmr, numRecsInBlock)
 			aggsKeyWorkingBuf = addRecordToAggregations(aggs.GroupByRequest, aggs.TimeHistogram,
 				measureInfo, len(internalMops), multiReader, blockNum, recIT, blkResults,
-				qid, aggsKeyWorkingBuf)
+				qid, aggsKeyWorkingBuf, timeRangeBuckets)
 		}
 		numRecsMatched := uint64(pqmr.GetNumberOfSetBits())
 


### PR DESCRIPTION
# Description
For each bucket key we create during historgram queries, we were using bytes.Buffer and growing it by adding all the groupby cols to it. This bytes buffer was reset on every record. Now pre-allocate a byte slice per block worker and reuse that bytes buffer during each record processing. This helps in runtime memory allocations.


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
