### PR TITLE
reuse cval per segment and avoid using it per rec

### DIFF
--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -256,8 +256,10 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 				isTsCol = true
 			}
 
-			cValEnc, err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockIdx, recNum,
-				qid, isTsCol)
+			var cValEnc utils.CValueEnclosure
+
+			err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockIdx, recNum,
+				qid, isTsCol, &cValEnc)
 			if err != nil {
 				// if the column was absent for an entire block and came for other blocks, this will error, hence no error logging here
 			} else {
@@ -267,7 +269,7 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 					if exists {
 						mathOp := aggs.MathOperations[colIndex]
 						fieldToValue := make(map[string]utils.CValueEnclosure)
-						fieldToValue[mathOp.MathCol] = *cValEnc
+						fieldToValue[mathOp.MathCol] = cValEnc
 						valueFloat, err := mathOp.ValueColRequest.EvaluateToFloat(fieldToValue)
 						if err != nil {
 							log.Errorf("qid=%d, failed to evaluate math operation for col %s, err=%v", qid, cname, err)

--- a/pkg/segment/reader/segread/multicolreader_test.go
+++ b/pkg/segment/reader/segread/multicolreader_test.go
@@ -45,7 +45,6 @@ func Test_multiSegReader(t *testing.T) {
 	assert.Equal(t, 3, sharedReader.numReaders)
 
 	multiReader := sharedReader.MultiColReaders[0]
-	var cVal *utils.CValueEnclosure
 	var err error
 	var cKeyidx int
 	for colName := range cols {
@@ -55,18 +54,23 @@ func Test_multiSegReader(t *testing.T) {
 
 		cKeyidx, _ = multiReader.GetColKeyIndex(colName)
 
+		var cValEnc utils.CValueEnclosure
+
 		// invalid block
-		_, err = multiReader.ExtractValueFromColumnFile(cKeyidx, uint16(numBlocks), 0, 0, false)
+		err = multiReader.ExtractValueFromColumnFile(cKeyidx, uint16(numBlocks), 0, 0, false,
+			&cValEnc)
 		assert.NotNil(t, err)
 
 		// correct block, incorrect recordNum
-		_, err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock), 0, false)
+		err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock), 0,
+			false, &cValEnc)
 		assert.NotNil(t, err)
 
-		cVal, err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock-3), 0, false)
+		err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock-3), 0,
+			false, &cValEnc)
 		assert.Nil(t, err)
-		assert.NotNil(t, cVal)
-		log.Infof("ExtractValueFromColumnFile: %+v for column %s", cVal, colName)
+		assert.NotNil(t, cValEnc)
+		log.Infof("ExtractValueFromColumnFile: %+v for column %s", cValEnc, colName)
 	}
 
 	for blkNum := 0; blkNum < numBlocks; blkNum++ {

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -70,7 +70,9 @@ func Test_segReader(t *testing.T) {
 		arr, err := sReader.ReadRecordFromBlock(0, uint16(numEntriesInBlock-3))
 		assert.Nil(t, err)
 		assert.NotNil(t, arr)
-		cVal, _, err := writer.GetCvalFromRec(arr, 23)
+
+		var cVal segutils.CValueEnclosure
+		_, err = writer.GetCvalFromRec(arr, 23, &cVal)
 		assert.Nil(t, err)
 		assert.NotNil(t, cVal)
 		log.Infof("GetCvalFromRec: %+v for column %s", cVal, queryCol)

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -534,8 +534,9 @@ func extractSortVals(aggs *structs.QueryAggregators, multiColReader *segread.Mul
 		return sortVal, invalidAggsCol
 	}
 
-	colVal, err := multiColReader.ExtractValueFromColumnFile(aggsSortColKeyIdx, blkNum, recNum,
-		qid, false)
+	var colVal utils.CValueEnclosure
+	err = multiColReader.ExtractValueFromColumnFile(aggsSortColKeyIdx, blkNum, recNum,
+		qid, false, &colVal)
 	if err != nil {
 		invalidAggsCol = true
 		return sortVal, invalidAggsCol

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -450,7 +450,8 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 	if cwip.deCount < wipCardLimit {
 		for dword, recNumsArr := range cwip.deMap {
 			if toputils.BinarySearchUint16(recNum, recNumsArr) {
-				mcVal, _, err := GetCvalFromRec([]byte(dword)[0:], 0)
+				var mcVal utils.CValueEnclosure
+				_, err := GetCvalFromRec([]byte(dword)[0:], 0, &mcVal)
 				if err != nil {
 					log.Errorf("getMeasCval: Could not extract val for cname: %v, dword: %v",
 						colName, dword)
@@ -462,7 +463,8 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 		return utils.CValueEnclosure{}, fmt.Errorf("could not find recNum: %v", recNum)
 	}
 
-	cVal, endIdx, err := GetCvalFromRec(cwip.cbuf[cIdx[colNum]:], 0) // todo pass qid
+	var cVal utils.CValueEnclosure
+	endIdx, err := GetCvalFromRec(cwip.cbuf[cIdx[colNum]:], 0, &cVal) // todo pass qid
 	if err != nil {
 		log.Errorf("getMeasCval: Could not extract val for cname: %v, idx: %v",
 			colName, cIdx[colNum])

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -685,18 +685,17 @@ func encJsonNumber(key string, numType SS_IntUintFloatTypes, intVal int64, uintV
 parameters:
    rec: byte slice
    qid
-returns:
    CValEncoslure: Cval encoding of this col entry
+returns:
    uint16: len of this entry inside that was inside the byte slice
    error:
 */
-func GetCvalFromRec(rec []byte, qid uint64) (CValueEnclosure, uint16, error) {
+func GetCvalFromRec(rec []byte, qid uint64, retVal *CValueEnclosure) (uint16, error) {
 
 	if len(rec) == 0 {
-		return CValueEnclosure{}, 0, errors.New("column value is empty")
+		return 0, errors.New("column value is empty")
 	}
 
-	var retVal CValueEnclosure
 	var endIdx uint16
 	switch rec[0] {
 
@@ -764,7 +763,7 @@ func GetCvalFromRec(rec []byte, qid uint64) (CValueEnclosure, uint16, error) {
 		err := json.Unmarshal(data, &entries)
 		if err != nil {
 			log.Errorf("GetCvalFromRec: Error unmarshalling VALTYPE_RAW_JSON = %v", err)
-			return CValueEnclosure{}, 0, err
+			return 0, err
 		}
 		retVal.CVal = entries
 	case VALTYPE_DICT_ARRAY[0]:
@@ -809,7 +808,7 @@ func GetCvalFromRec(rec []byte, qid uint64) (CValueEnclosure, uint16, error) {
 				idx += strlen
 			default:
 				log.Errorf("qid=%d, GetCvalFromRec:SS_DT_ARRAY_DICT unknown type=%v\n", qid, rec[idx])
-				return retVal, endIdx, errors.New("invalid rec type")
+				return endIdx, errors.New("invalid rec type")
 			}
 			cValArray = append(cValArray, cVal)
 		}
@@ -818,10 +817,10 @@ func GetCvalFromRec(rec []byte, qid uint64) (CValueEnclosure, uint16, error) {
 
 	default:
 		log.Errorf("qid=%d, GetCvalFromRec: dont know how to convert type=%v\n", qid, rec[0])
-		return retVal, endIdx, errors.New("invalid rec type")
+		return endIdx, errors.New("invalid rec type")
 	}
 
-	return retVal, endIdx, nil
+	return endIdx, nil
 }
 
 func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[string]*BloomIndex,

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -159,7 +159,8 @@ func TestRecordEncodeDecode(t *testing.T) {
 		assert.GreaterOrEqual(t, maxIdx, uint32(0))
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
-			val, _, _ := GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29)
+			var val CValueEnclosure
+			_, _ = GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29, &val)
 			log.Infof("recNum %+v col %+v:%+v. type %+v", i, key, val, val.Dtype)
 		}
 	}
@@ -198,54 +199,54 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 				"type": "int64",
 				"value": "1"
 			}
-			
+
 			],
 		"logs": [
-    {
-      "timestamp": 1670445474307949,
-      "fields": [
-        {
-          "key": "event",
-          "type": "string",
-          "value": "Searching for nearby drivers"
-        },
-        {
-          "key": "level",
-          "type": "string",
-          "value": "info"
-        },
-        {
-          "key": "location",
-          "type": "string",
-          "value": "577,322"
-        }
-      ]
-    },
-    {
-      "timestamp": 1670445474370633,
-      "fields": [
-        {
-          "key": "event",
-          "type": "string",
-          "value": "Retrying GetDriver after error"
-        },
-        {
-          "key": "level",
-          "type": "string",
-          "value": "error"
-        },
-        {
-          "key": "retry_no",
-          "type": "int64",
-          "value": "1"
-        },
-        {
-          "key": "error",
-          "type": "string",
-          "value": "redis timeout"
-        }
+	{
+	  "timestamp": 1670445474307949,
+	  "fields": [
+		{
+		  "key": "event",
+		  "type": "string",
+		  "value": "Searching for nearby drivers"
+		},
+		{
+		  "key": "level",
+		  "type": "string",
+		  "value": "info"
+		},
+		{
+		  "key": "location",
+		  "type": "string",
+		  "value": "577,322"
+		}
+	  ]
+	},
+	{
+	  "timestamp": 1670445474370633,
+	  "fields": [
+		{
+		  "key": "event",
+		  "type": "string",
+		  "value": "Retrying GetDriver after error"
+		},
+		{
+		  "key": "level",
+		  "type": "string",
+		  "value": "error"
+		},
+		{
+		  "key": "retry_no",
+		  "type": "int64",
+		  "value": "1"
+		},
+		{
+		  "key": "error",
+		  "type": "string",
+		  "value": "redis timeout"
+		}
 
-      
+
 		]
 	}],
 		}`,
@@ -268,7 +269,8 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 		assert.GreaterOrEqual(t, maxIdx, uint32(0))
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
-			val, _, _ := GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29)
+			var val CValueEnclosure
+			_, _ = GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29, &val)
 			log.Infof("recNum %+v col %+v:%+v. type %+v", i, key, val, val.Dtype)
 		}
 	}


### PR DESCRIPTION

# Description

Reuse Cval in each blockworker/segment worker while extracting values from csg files. By doing this we save 10 GB of runtime mem alloc on a 456 million data size for a query like `"* | stats avg(http_status) by hobby, http_method`




Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
