### PR TITLE
Use pre-compiled regex for applying match filter on records

### DIFF
--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -40,15 +40,15 @@ returns:
 */
 func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
 	bsh *structs.BlockSearchHelper) (bool, error) {
-	var regexp *regexp.Regexp
+	var compiledRegex *regexp.Regexp
 	var err error
 
 	if len(match.MatchWords) == 0 {
 		return false, nil
 	}
 
-	if match.MatchType == structs.MATCH_PHRASE && match.MatchOperator == utils.And {
-		regexp, err = match.GetRegexp()
+	if match.MatchType == structs.MATCH_PHRASE {
+		compiledRegex, err = match.GetRegexp()
 		if err != nil {
 			log.Errorf("ApplySearchToMatchFilterDictCsg: error getting match regex: %v", err)
 			return false, err
@@ -56,7 +56,7 @@ func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.Mat
 	}
 
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, regexp, true)
+		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -19,10 +19,12 @@ package segread
 
 import (
 	"errors"
+	"regexp"
 
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
+	log "github.com/sirupsen/logrus"
 )
 
 /*
@@ -38,13 +40,23 @@ returns:
 */
 func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
 	bsh *structs.BlockSearchHelper) (bool, error) {
+	var regexp *regexp.Regexp
+	var err error
 
 	if len(match.MatchWords) == 0 {
 		return false, nil
 	}
 
+	if match.MatchType == structs.MATCH_PHRASE && match.MatchOperator == utils.And {
+		regexp, err = match.GetRegexp()
+		if err != nil {
+			log.Errorf("ApplySearchToMatchFilterDictCsg: error getting match regex: %v", err)
+			return false, err
+		}
+	}
+
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord)
+		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, regexp, true)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -32,7 +32,7 @@ import (
 func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recordNum uint16, holderDte *DtypeEnclosure, qid uint64,
 	searchReq *SegmentSearchRequest, cmiPassedNonDictColKeyIndices map[int]struct{},
-	queryInfoColKeyIndex int, regexp *regexp.Regexp, fast bool) (bool, error) {
+	queryInfoColKeyIndex int, compiledRegex *regexp.Regexp) (bool, error) {
 
 	switch query.SearchType {
 	case MatchAll:
@@ -44,7 +44,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, regexp, fast)
+		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex)
 	case MatchWordsAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -57,7 +57,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, regexp, fast)
+			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -19,6 +19,7 @@ package search
 
 import (
 	"errors"
+	"regexp"
 
 	"github.com/siglens/siglens/pkg/segment/reader/segread"
 	. "github.com/siglens/siglens/pkg/segment/structs"
@@ -30,8 +31,8 @@ import (
 // TODO: support for complex expressions
 func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recordNum uint16, holderDte *DtypeEnclosure, qid uint64,
-	searchReq *SegmentSearchRequest,
-	cmiPassedNonDictColKeyIndices map[int]struct{}, queryInfoColKeyIndex int) (bool, error) {
+	searchReq *SegmentSearchRequest, cmiPassedNonDictColKeyIndices map[int]struct{},
+	queryInfoColKeyIndex int, regexp *regexp.Regexp, fast bool) (bool, error) {
 
 	switch query.SearchType {
 	case MatchAll:
@@ -43,7 +44,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal)
+		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, regexp, fast)
 	case MatchWordsAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -56,7 +57,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal)
+			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, regexp, fast)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -137,7 +137,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 	// dict encoding file for the column/s
 	cmiPassedCnames := make(map[string]bool)
 	checkAllCols := false
-	var regexp *regexp.Regexp
+	var compiledRegex *regexp.Regexp
 	var err error
 
 	if query.SearchType == structs.MatchWordsAllColumns ||
@@ -205,10 +205,10 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			queryInfoColKeyIndex = cKeyidx
 		}
 
-		if query.MatchFilter != nil && query.MatchFilter.MatchType == structs.MATCH_PHRASE && query.MatchFilter.MatchOperator == utils.And {
-			regexp, err = query.MatchFilter.GetRegexp()
+		if query.MatchFilter != nil && query.MatchFilter.MatchType == structs.MATCH_PHRASE {
+			compiledRegex, err = query.MatchFilter.GetRegexp()
 			if err != nil {
-				log.Errorf("ApplySearchToMatchFilterRawCsg: error getting match regex: %v", err)
+				log.Errorf("filterRecordsFromSearchQuery: error getting match regex: %v", err)
 				return
 			}
 		}
@@ -217,7 +217,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			if recIT.ShouldProcessRecord(i) {
 				matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
 					qid, searchReq, cmiPassedNonDictColKeyIndices,
-					queryInfoColKeyIndex, regexp, true)
+					queryInfoColKeyIndex, compiledRegex)
 				if err != nil {
 					allSearchResults.AddError(err)
 					break

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -18,6 +18,7 @@
 package search
 
 import (
+	"regexp"
 	"sync"
 
 	"github.com/siglens/siglens/pkg/config"
@@ -136,6 +137,9 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 	// dict encoding file for the column/s
 	cmiPassedCnames := make(map[string]bool)
 	checkAllCols := false
+	var regexp *regexp.Regexp
+	var err error
+
 	if query.SearchType == structs.MatchWordsAllColumns ||
 		query.SearchType == structs.RegexExpressionAllColumns ||
 		query.SearchType == structs.MatchDictArrayAllColumns {
@@ -201,11 +205,19 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			queryInfoColKeyIndex = cKeyidx
 		}
 
+		if query.MatchFilter != nil && query.MatchFilter.MatchType == structs.MATCH_PHRASE && query.MatchFilter.MatchOperator == utils.And {
+			regexp, err = query.MatchFilter.GetRegexp()
+			if err != nil {
+				log.Errorf("ApplySearchToMatchFilterRawCsg: error getting match regex: %v", err)
+				return
+			}
+		}
+
 		for i := uint(0); i < uint(recIT.AllRecLen); i++ {
 			if recIT.ShouldProcessRecord(i) {
 				matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
 					qid, searchReq, cmiPassedNonDictColKeyIndices,
-					queryInfoColKeyIndex)
+					queryInfoColKeyIndex, regexp, true)
 				if err != nil {
 					allSearchResults.AddError(err)
 					break

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -32,9 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Fast is a flag to indicate if we should use the fast path for regex matching
-// If fast is true it assumes that the regexp is already compiled
-func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, regexp *regexp.Regexp, fast bool) (bool, error) {
+func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRegex *regexp.Regexp) (bool, error) {
 	var err error
 
 	if len(match.MatchWords) == 0 {
@@ -65,16 +63,16 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, regexp *rege
 	if match.MatchOperator == And {
 		var foundQword bool = true
 		if match.MatchType == MATCH_PHRASE {
-			if !fast {
-				regexp, err = match.GetRegexp()
+			if compiledRegex == nil {
+				compiledRegex, err = match.GetRegexp()
 				if err != nil {
 					log.Errorf("ApplySearchToMatchFilterRawCsg: error getting match regex: %v", err)
 					return false, err
 				}
 			}
 
-			if regexp != nil {
-				foundQword = regexp.Match(asciiBytes)
+			if compiledRegex != nil {
+				foundQword = compiledRegex.Match(asciiBytes)
 			} else {
 				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase)
 			}

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -79,7 +79,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 
 		var found bool
 		for _, colWip := range colWips {
-			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil, false)
+			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil)
 			assert.Nil(t, err)
 			found = result
 			if found {
@@ -96,7 +96,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for val2 in column-a worked")
@@ -107,7 +107,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for val2 in column-d worked (should not be found)")
@@ -118,7 +118,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for two values in column-a worked (should not be found)")
@@ -129,7 +129,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for multiple values in column-a worked (all should be found)")

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -79,7 +79,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 
 		var found bool
 		for _, colWip := range colWips {
-			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:])
+			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil, false)
 			assert.Nil(t, err)
 			found = result
 			if found {
@@ -96,7 +96,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:])
+		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for val2 in column-a worked")
@@ -107,7 +107,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:])
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for val2 in column-d worked (should not be found)")
@@ -118,7 +118,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:])
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for two values in column-a worked (should not be found)")
@@ -129,7 +129,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:])
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for multiple values in column-a worked (all should be found)")

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -112,7 +112,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord())
+		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, false)
 		if err != nil {
 			return false
 		}
@@ -122,7 +122,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord())
+			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, false)
 			if retVal {
 				return true
 			}

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -112,7 +112,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, false)
+		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil)
 		if err != nil {
 			return false
 		}
@@ -122,7 +122,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, false)
+			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil)
 			if retVal {
 				return true
 			}


### PR DESCRIPTION
# Description
Summarize the change.
Pass the compiled regex with a fast flag for applying match filter on records. Compile the regex at block level.

CPU Time
                flat flat%  sum%    cum  cum%
Before: 19.52s 3.92% 58.88%  135.90s 27.32%
After: 15.23s 3.13% 62.73%  128.84s 26.46%
Before Total time: 161.73s
After Total time: 158.17s

Memory Usage:
No change, used 512.06kB memory in regexp.Match for both the cases.

Summary:
Total time reduced by ~3s.
Time reduced in this function ~4s
Memory consumption: No change

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
