### PR TITLE
Fix zstd memory overuse issue

### DIFF
--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -67,14 +67,13 @@ type SegmentFileReader struct {
 	currUncompressedBlockLen uint32
 	currRecLen               uint32
 
-	isBlockLoaded        bool
-	currFileBuffer       []byte   // buffer re-used for file reads values
-	currUncompressBuffer []byte   // buffer for zstd uncompress
-	currRawBlockBuffer   []byte   // raw uncompressed block
-	encType              uint8    // encoding type for this block
-	deTlv                [][]byte // deTlv[dWordIdx] --> []byte (the TLV byte slice)
-	deRecToTlv           []uint16 // deRecToTlv[recNum] --> dWordIdx
-	blockSummaries       []*structs.BlockSummary
+	isBlockLoaded      bool
+	currFileBuffer     []byte   // buffer re-used for file reads values
+	currRawBlockBuffer []byte   // raw uncompressed block
+	encType            uint8    // encoding type for this block
+	deTlv              [][]byte // deTlv[dWordIdx] --> []byte (the TLV byte slice)
+	deRecToTlv         []uint16 // deRecToTlv[recNum] --> dWordIdx
+	blockSummaries     []*structs.BlockSummary
 }
 
 // returns a new SegmentFileReader and any errors encountered
@@ -82,18 +81,18 @@ type SegmentFileReader struct {
 func InitNewSegFileReader(fd *os.File, colName string, blockMetadata map[uint16]*structs.BlockMetadataHolder,
 	qid uint64, blockSummaries []*structs.BlockSummary) (*SegmentFileReader, error) {
 	return &SegmentFileReader{
-		ColName:              colName,
-		fileName:             fd.Name(),
-		currFD:               fd,
-		blockMetadata:        blockMetadata,
-		currOffset:           0,
-		currFileBuffer:       *fileReadBufferPool.Get().(*[]byte),
-		currUncompressBuffer: *uncompressedReadBufferPool.Get().(*[]byte),
-		isBlockLoaded:        false,
-		encType:              255,
-		blockSummaries:       blockSummaries,
-		deTlv:                make([][]byte, 0),
-		deRecToTlv:           make([]uint16, 0),
+		ColName:            colName,
+		fileName:           fd.Name(),
+		currFD:             fd,
+		blockMetadata:      blockMetadata,
+		currOffset:         0,
+		currFileBuffer:     *fileReadBufferPool.Get().(*[]byte),
+		currRawBlockBuffer: *uncompressedReadBufferPool.Get().(*[]byte),
+		isBlockLoaded:      false,
+		encType:            255,
+		blockSummaries:     blockSummaries,
+		deTlv:              make([][]byte, 0),
+		deRecToTlv:         make([]uint16, 0),
 	}, nil
 }
 
@@ -353,12 +352,12 @@ func (sfr *SegmentFileReader) readDictEnc(buf []byte, blockNum uint16) error {
 }
 
 func (sfr *SegmentFileReader) unpackRawCsg(buf []byte, blockNum uint16) error {
-
-	uncompressed, err := decoder.DecodeAll(buf[0:], sfr.currUncompressBuffer[:0])
+	uncompressed, err := decoder.DecodeAll(buf[0:], sfr.currRawBlockBuffer[:0])
 	if err != nil {
 		log.Errorf("SegmentFileReader.unpackRawCsg: decompress error: %+v", err)
 		return err
 	}
+
 	sfr.currRawBlockBuffer = uncompressed
 	sfr.currOffset = 0
 


### PR DESCRIPTION
# Description
This was the main change:
```diff
-	uncompressed, err := decoder.DecodeAll(buf[0:], sfr.currUncompressBuffer[:0])
+	uncompressed, err := decoder.DecodeAll(buf[0:], sfr.currRawBlockBuffer[:0])
```
I think the original version was due to a misunderstanding. From the zstd docs on [DecodeAll](https://pkg.go.dev/github.com/klauspost/compress/zstd#Decoder.DecodeAll):
> Output will be appended to [the second parameter]

But I think the original code meant for zstd to use `currUncompressBuffer` for internal use, as `currUncompressBuffer` isn't used anywhere else.

Since immediately after decoding we have `sfr.currRawBlockBuffer = uncompressed`, I used `currRawBlockBuffer` in the decoding and deleted the `currUncompressBuffer` field

# Testing
## Correctness
Unit tests and e2e tests continue to pass

## Performance
I ran the query `whatever*` on a dataset with 200 million records. There was no significant improvement in time (52.0 seconds on `develop`, vs 51.3 seconds with this PR). However, on `develop`, the query allocated 74.5 GB, of which 72.7 GB was for zstd decoding. With this PR a total of 1.7 GB of memory was used, and only about 10 MB was for zstd decoding.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
