### PR TITLE
Run workflow if Draft PR becomes Ready for Review

### DIFF
--- a/.github/workflows/uts.yml
+++ b/.github/workflows/uts.yml
@@ -1,5 +1,7 @@
 name: siglens-lint-ut
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
# Description
When a PR is made in Draft and then marked Ready for Review, the uts.yml action doesn't run, this should fix that.

From the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request):
> By default, a workflow only runs when a `pull_request` event's activity type is `opened`, `synchronize`, or `reopened`

So the only change should be the addition of the `ready_for_review` trigger.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
