### PR TITLE
Add file overwrite option to Lookup File Upload

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -870,6 +870,7 @@ For Gantt chart data specific to a trace ID, modify the request body accordingly
         - Form data:
             - name: [filename]
             - file: [file content]
+            - overwrite: true (optional, to overwrite existing file)
 
     response: 
         File uploaded successfully: [filename]

--- a/pkg/lookups/lookups.go
+++ b/pkg/lookups/lookups.go
@@ -78,16 +78,29 @@ func UploadLookupFile(ctx *fasthttp.RequestCtx) {
 	}
 
 	dstPath := filepath.Join(fullLookupsDir, fileName)
-	if _, err := os.Stat(dstPath); !os.IsNotExist(err) {
+
+	// Check if file exists and handle overwrite
+	fileExists := false
+	if _, err := os.Stat(dstPath); err == nil {
+		fileExists = true
+	}
+
+	overwrite := string(ctx.FormValue("overwrite")) == "true"
+	if fileExists && !overwrite {
 		log.Errorf("UploadLookupFile: File already exists: %s", fileName)
 		ctx.Error("A file with the same name already exists", fasthttp.StatusConflict)
 		return
 	}
 
-	dst, err := os.Create(dstPath)
+	var dst *os.File
+	if overwrite {
+		dst, err = os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	} else {
+		dst, err = os.Create(dstPath)
+	}
 	if err != nil {
-		log.Errorf("UploadLookupFile: Error creating the destination file: %v", err)
-		ctx.Error("Error creating the destination file", fasthttp.StatusInternalServerError)
+		log.Errorf("UploadLookupFile: Error creating/opening the destination file: %v", err)
+		ctx.Error("Error creating/opening the destination file", fasthttp.StatusInternalServerError)
 		return
 	}
 	defer dst.Close()

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -6036,6 +6036,6 @@ input.form-control {
     height: 60px !important;
 }
 
-#cancel-upload-btn{
+#cancel-upload-btn, #cancel-overwrite-btn{
     margin-right: 10px;
 }

--- a/static/lookups.html
+++ b/static/lookups.html
@@ -96,6 +96,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <button type="button" id="upload-btn" class="btn primary-btn w-100">Upload</button>
                 </div>
             </div>
+            <div class="popupContent" id="overwrite-confirmation">
+                <h3 class="header">File Already Exists</h3>
+                <p>A file with the name "<span id="existing-file-name"></span>" already exists. Do you want to overwrite it?</p>
+                <div class="d-flex mt-4">
+                    <button type="button" id="cancel-overwrite-btn" class="btn grey-btn w-100">Cancel</button>
+                    <button type="button" id="confirm-overwrite-btn" class="btn primary-btn w-100">Overwrite</button>
+                </div>
+            </div>
         </div>
 
         <div id="app-footer">


### PR DESCRIPTION
# Description
This PR adds the ability to overwrite existing files when uploading lookup files.

- Modified the backend to accept an 'overwrite' parameter in the form data
- Updated the frontend, added a confirmation dialog in the UI for overwriting files
- Updated API README to reflect the new overwrite option

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/7a7744f3-a1a4-43df-9d13-5b33484caf0b">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
