### PR TITLE
Fix: Map utils test

### DIFF
--- a/pkg/utils/maputils_test.go
+++ b/pkg/utils/maputils_test.go
@@ -18,7 +18,6 @@
 package utils
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,8 +55,7 @@ func Test_SetDifference(t *testing.T) {
 	addedEntries, removedEntries := SetDifference(set1, set2)
 	assert.Equal(t, 2, len(addedEntries))
 	assert.Equal(t, 0, len(removedEntries))
-	sort.Strings(removedEntries)
-	assert.True(t, CompareStringSlices([]string{"key1", "key2"}, addedEntries))
+	assert.ElementsMatch(t, []string{"key1", "key2"}, addedEntries)
 
 	set1["key3"] = struct{}{}
 	set2["key1"] = struct{}{}
@@ -66,17 +64,16 @@ func Test_SetDifference(t *testing.T) {
 	addedEntries, removedEntries = SetDifference(set1, set2)
 	assert.Equal(t, 1, len(addedEntries))
 	assert.Equal(t, 0, len(removedEntries))
-	assert.True(t, CompareStringSlices([]string{"key3"}, addedEntries))
+	assert.ElementsMatch(t, []string{"key3"}, addedEntries)
 
 	addedEntries, removedEntries = SetDifference(set2, set1)
 	assert.Equal(t, 0, len(addedEntries))
 	assert.Equal(t, 1, len(removedEntries))
-	assert.True(t, CompareStringSlices([]string{"key3"}, removedEntries))
+	assert.ElementsMatch(t, []string{"key3"}, removedEntries)
 
 	set1 = map[string]struct{}{}
 	addedEntries, removedEntries = SetDifference(set1, set2)
 	assert.Equal(t, 0, len(addedEntries))
 	assert.Equal(t, 2, len(removedEntries))
-	sort.Strings(removedEntries)
-	assert.True(t, CompareStringSlices([]string{"key1", "key2"}, removedEntries))
+	assert.ElementsMatch(t, []string{"key1", "key2"}, removedEntries)
 }


### PR DESCRIPTION
# Description
Summarize the change.
Missed to sort the addedEntries in the first test of SetDifference.
Improved it by using ElementsMatch instead of sorting and then comparing slices.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
