### PR TITLE
Fix searches that don't find a column

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -362,3 +362,8 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "app_name=Bracecould | eval mvindex = mvindex(split(""a:bc:123"", "":""), -2, 2) | stats count by mvindex",now-1d,now,*,countRecord:mvindex:*,eq,"bc,123",Splunk QL
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""jim*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,2,Splunk QL
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""abc*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,"",Splunk QL
+weekday=Monday,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday AND invalidColumn=foo,now-1d,now,*,total,eq,0,Splunk QL
+weekday=Monday AND invalidColumn!=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday OR invalidColumn!=foo,now-1d,now,*,total,eq,100000,Splunk QL
+weekday=Monday OR invalidColumn=foo,now-1d,now,*,total,eq,14325,Splunk QL

--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -364,6 +364,10 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""abc*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,"",Splunk QL
 weekday=Monday,now-1d,now,*,total,eq,14325,Splunk QL
 weekday=Monday AND invalidColumn=foo,now-1d,now,*,total,eq,0,Splunk QL
+weekday=Monday AND invalidColumn=false,now-1d,now,*,total,eq,0,Splunk QL
 weekday=Monday AND invalidColumn!=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday AND invalidColumn!=false,now-1d,now,*,total,eq,14325,Splunk QL
 weekday=Monday OR invalidColumn!=foo,now-1d,now,*,total,eq,100000,Splunk QL
+weekday=Monday OR invalidColumn!=false,now-1d,now,*,total,eq,100000,Splunk QL
 weekday=Monday OR invalidColumn=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday OR invalidColumn=false,now-1d,now,*,total,eq,14325,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -345,6 +345,10 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""abc*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,"",Splunk QL
 weekday=Monday,now-1d,now,*,total,eq,14325,Splunk QL
 weekday=Monday AND invalidColumn=foo,now-1d,now,*,total,eq,0,Splunk QL
+weekday=Monday AND invalidColumn=false,now-1d,now,*,total,eq,0,Splunk QL
 weekday=Monday AND invalidColumn!=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday AND invalidColumn!=false,now-1d,now,*,total,eq,14325,Splunk QL
 weekday=Monday OR invalidColumn!=foo,now-1d,now,*,total,eq,100000,Splunk QL
+weekday=Monday OR invalidColumn!=false,now-1d,now,*,total,eq,100000,Splunk QL
 weekday=Monday OR invalidColumn=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday OR invalidColumn=false,now-1d,now,*,total,eq,14325,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -343,3 +343,8 @@ city=Boston | stats count AS Count BY http_method | eval newField=lower(http_met
 "app_name=Bracecould | eval mvindex = mvindex(split(""a:bc:123"", "":""), -2, 2) | stats count by mvindex",now-1d,now,*,countRecord:mvindex:*,eq,"bc,123",Splunk QL
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""jim*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,2,Splunk QL
 "app_name=Bracecould | eval mvfind = mvfind(split(""jack:john:jimmy:jim"", "":""), ""abc*"") | stats count by mvfind",now-1d,now,*,countRecord:mvfind:*,eq,"",Splunk QL
+weekday=Monday,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday AND invalidColumn=foo,now-1d,now,*,total,eq,0,Splunk QL
+weekday=Monday AND invalidColumn!=foo,now-1d,now,*,total,eq,14325,Splunk QL
+weekday=Monday OR invalidColumn!=foo,now-1d,now,*,total,eq,100000,Splunk QL
+weekday=Monday OR invalidColumn=foo,now-1d,now,*,total,eq,14325,Splunk QL

--- a/pkg/segment/query/metadata/segmentmicroindex.go
+++ b/pkg/segment/query/metadata/segmentmicroindex.go
@@ -205,9 +205,14 @@ func (sm *SegmentMicroIndex) readCmis(blocksToLoad map[uint16]map[string]bool, a
 
 	for fName, cname := range bulkDownloadFiles {
 		fd, err := os.OpenFile(fName, os.O_RDONLY, 0644)
-		if err != nil {
-			log.Errorf("readCmis: open failed cname=%v, fname=%v, err=[%v], continuing with rest", cname, fName, err)
+		if os.IsNotExist(err) {
+			// This can happen if a query specifies a column that does not
+			// exist in the segment.
+			log.Infof("readCmis: no CMI file for column %v", cname)
 			continue
+		}
+		if err != nil {
+			return nil, toputils.TeeErrorf("readCmis: cannot open fname=%v, cname=%v, err=[%v]", fName, cname, err)
 		}
 		defer fd.Close()
 

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -261,7 +261,7 @@ func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(colKeyIndex int, 
 	if colKeyIndex == -1 || colKeyIndex >= mcsr.maxColIdx {
 		// Debug to avoid log flood for when the column does not exist
 		log.Debugf("MultiColSegmentReader.ReadRawRecordFromColumnFile: failed to find colKeyIndex %v in multi col reader. All cols: %+v", colKeyIndex, mcsr.allColsReverseIndex)
-		return nil, errors.New("column not found in MultipleColumnSegmentReader")
+		return nil, nil
 	}
 
 	return mcsr.allFileReaders[colKeyIndex].ReadRecordFromBlock(blockNum, recordNum)

--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -173,7 +173,7 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]struct{}, blockNum uint16) error {
 	for keyIndex := range colsIndexMap {
 		if keyIndex >= len(mcsr.allFileReaders) {
-			return fmt.Errorf("MultiColSegmentReader.ValidateAndReadBlock: keyIndex %v is out of bounds, len of allFileReaders: %v", keyIndex, len(mcsr.allFileReaders))
+			return nil
 		}
 
 		sfr := mcsr.allFileReaders[keyIndex]

--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -173,6 +173,7 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]struct{}, blockNum uint16) error {
 	for keyIndex := range colsIndexMap {
 		if keyIndex >= len(mcsr.allFileReaders) {
+			// This can happen if the column does not exist.
 			return nil
 		}
 

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -221,9 +221,20 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 		}
 		return fopOnString(rec, qValDte, fop, isRegexSearch)
 	case SS_DT_BOOL:
-		if len(rec) == 0 || rec[0] != VALTYPE_ENC_BOOL[0] {
+		if len(rec) == 0 {
+			if fop == Equals {
+				return false, nil
+			} else if fop == NotEquals {
+				return true, nil
+			}
+
+			return false, toputils.TeeErrorf("filterOpOnDataType: invalid bool operator: %v", fop)
+		}
+
+		if rec[0] != VALTYPE_ENC_BOOL[0] {
 			return false, nil
 		}
+
 		return fopOnBool(rec, qValDte, fop)
 	case SS_DT_SIGNED_NUM, SS_DT_UNSIGNED_NUM, SS_DT_FLOAT:
 		return fopOnNumber(rec, qValDte, recDte, fop)

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -218,6 +218,8 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 			if isRegexSearch && isValTypeEncANumber(rec[0]) {
 				return filterOpOnRecNumberEncType(rec, qValDte, fop, isRegexSearch, recDte)
 			}
+
+			return false, nil
 		}
 		return fopOnString(rec, qValDte, fop, isRegexSearch)
 	case SS_DT_BOOL:
@@ -287,7 +289,11 @@ func filterOpOnRecNumberEncType(rec []byte, qValDte *DtypeEnclosure, fop FilterO
 func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 	isRegexSearch bool) (bool, error) {
 
-	const sOff uint16 = 3
+	const sOff int = 3
+	if len(rec) < sOff {
+		return false, toputils.TeeErrorf("fopOnString: invalid rec: %v", rec)
+	}
+
 	switch fop {
 	case Equals:
 		if isRegexSearch {

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -232,7 +232,7 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 		}
 
 		if rec[0] != VALTYPE_ENC_BOOL[0] {
-			return false, nil
+			return false, toputils.TeeErrorf("filterOpOnDataType: expected bool encoding; got %v", rec[0])
 		}
 
 		return fopOnBool(rec, qValDte, fop)

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -276,7 +276,7 @@ func filterOpOnRecNumberEncType(rec []byte, qValDte *DtypeEnclosure, fop FilterO
 func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 	isRegexSearch bool) (bool, error) {
 
-	var sOff uint16 = 3
+	const sOff uint16 = 3
 	switch fop {
 	case Equals:
 		if isRegexSearch {

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -28,6 +28,7 @@ import (
 
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/utils"
+	toputils "github.com/siglens/siglens/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -202,12 +203,21 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 	}
 	switch qValDte.Dtype {
 	case SS_DT_STRING:
-		if len(rec) == 0 || rec[0] != VALTYPE_ENC_SMALL_STRING[0] {
+		if len(rec) == 0 {
+			if fop == Equals {
+				return false, nil
+			} else if fop == NotEquals {
+				return true, nil
+			}
+
+			return false, toputils.TeeErrorf("filterOpOnDataType: invalid string operator: %v", fop)
+		}
+
+		if rec[0] != VALTYPE_ENC_SMALL_STRING[0] {
 			// if we are doing a regex search on a number, we need to convert the number to string
-			if len(rec) > 0 && isRegexSearch && isValTypeEncANumber(rec[0]) {
+			if isRegexSearch && isValTypeEncANumber(rec[0]) {
 				return filterOpOnRecNumberEncType(rec, qValDte, fop, isRegexSearch, recDte)
 			}
-			return false, nil
 		}
 		return fopOnString(rec, qValDte, fop, isRegexSearch)
 	case SS_DT_BOOL:


### PR DESCRIPTION
# Description
Previously, a search containing a column that doesn't exist, like 
```
weekday=Monday OR foo!=false | stats count
```
would show an error on the UI like:
```
Message: MultiColSegmentReader.ValidateAndReadBlock: keyIndex 0 is out of bounds, len of allFileReaders: 0,
```
This PR fixes that so that the query gives proper results. For the above query, `foo` does not exist, so `foo!=false` is always `true`, so all records pass the search

# Testing
New e2e tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
