### PR TITLE
feat: Add support for SPL Case insensitive Search and Support for SPL Case.

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -34,12 +34,15 @@ min(latency),now-1d,now,*,group:min(latency):*,eq,110,Pipe QL
 "{weekday=""Sunday""} | logfmt",now-1d,now,*,total,gt,1,Log QL
 "count_over_time({batch=""batch-*""}[1d])", now-1d,now,*,total,gt,100,Log QL
 app_name=Termitehad,now-90d,now,*,total,eq,21,Splunk QL
+app_name=termiteHad,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=*,now-90d,now,*,total,eq,21,Splunk QL
+app_name=termitehad http_status=*,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=***,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=200,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=20*,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2**,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2**********,now-90d,now,*,total,eq,5,Splunk QL
+app_name=termitehad http_status=2**********,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2*0,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2*****0,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=302,now-90d,now,*,total,eq,5,Splunk QL
@@ -50,7 +53,9 @@ app_name=Termitehad http_status=404,now-90d,now,*,total,eq,3,Splunk QL
 app_name=Termitehad http_status=4*4,now-90d,now,*,total,eq,3,Splunk QL
 app_name=Termitehad http_status=4,now-90d,now,*,total,eq,0,Splunk QL
 app_name=Termitehad city=Tucson*,now-90d,now,*,total,eq,1,Splunk QL
+app_name=termitehad city=tucson*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tucso*n*,now-90d,now,*,total,eq,1,Splunk QL
+app_name=TermiteHAD city=tucso*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tuc*s*o*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tuc**s*o*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tucson,now-90d,now,*,total,eq,1,Splunk QL
@@ -59,9 +64,13 @@ app_name=Termitehad city=*on*,now-90d,now,*,total,eq,6,Splunk QL
 app_name=Termitehad city=on*,now-90d,now,*,total,eq,0,Splunk QL
 app_name=Oxam,now-1d,now,*,total,gt,0,Splunk QL
 "question=""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
+"question=""franzen pabst carry yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
 "NOT question=""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,gt,9999,Splunk QL
+"NOT question=""franzen pabst carry Yuccie lomO Gentrify?""",now-1d,now,*,total,eq,99999,Splunk QL
 """Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
+"""franzen pabst carry yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
 "NOT ""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,gt,9999,Splunk QL
+"NOT ""CASE(""Franzen pabst carry Yuccie lomo gentrify?"")""",now-1d,now,*,total,eq,99999,Splunk QL
 search app_name=Oxam,now-1d,now,*,total,gt,0,Splunk QL
 search Sunday,now-1d,now,*,total,gt,1,Splunk QL
 search http_status>400,now-1d,now,*,total,gt,0,Splunk QL
@@ -87,8 +96,10 @@ city=Boston | stats max(latitude),now-1d,now,*,group:max(latitude):*,eq,89.982,S
 city=Boston | stats range(latitude),now-1d,now,*,group:range(latitude):*,eq,179.884,Splunk QL
 city=Boston | stats avg(latitude),now-1d,now,*,group:avg(latitude):*,eq,0.403,Splunk QL
 city=Boston | stats sum(latitude),now-1d,now,*,group:sum(latitude):*,eq,416.553,Splunk QL
+city=boston | stats sum(latitude),now-1d,now,*,group:sum(latitude):*,eq,416.553,Splunk QL
 city=Boston | stats values(gender),now-1d,now,*,group:values(gender):*,eq,"[female male]",Splunk QL
 "first_name=Lavern AND last_name=Douglas | stats list(gender)",now-1d,now,*,group:list(gender):*,eq,"[female]",Splunk QL
+"first_name=CASE(Lavern) AND last_name=(Douglas) | stats list(gender)",now-1d,now,*,group:list(gender):*,eq,"[female]",Splunk QL
 "latency > 9999900 | stats list(latency)", now-1d,now,*,group:list(latency):*,eq,"[9999944]",Splunk QL
 "batch=batch-10 | stats count, min(latitude), max(latitude)",now-1d,now,*,group:max(latitude):*,eq,89.228,Splunk QL
 batch=batch-10 | stats count BY city,now-1d,now,*,group:count(*):St. Louis,eq,2,Splunk QL

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -34,12 +34,15 @@ min(latency),now-1d,now,*,group:min(latency):*,eq,110,Pipe QL
 "{weekday=""Sunday""} | logfmt",now-1d,now,*,total,gt,1,Log QL
 "count_over_time({batch=""batch-*""}[1d])", now-1d,now,*,total,gt,100,Log QL
 app_name=Termitehad,now-90d,now,*,total,eq,21,Splunk QL
+app_name=termiteHad,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=*,now-90d,now,*,total,eq,21,Splunk QL
+app_name=termitehad http_status=*,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=***,now-90d,now,*,total,eq,21,Splunk QL
 app_name=Termitehad http_status=200,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=20*,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2**,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2**********,now-90d,now,*,total,eq,5,Splunk QL
+app_name=termitehad http_status=2**********,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2*0,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=2*****0,now-90d,now,*,total,eq,5,Splunk QL
 app_name=Termitehad http_status=302,now-90d,now,*,total,eq,5,Splunk QL
@@ -50,7 +53,9 @@ app_name=Termitehad http_status=404,now-90d,now,*,total,eq,3,Splunk QL
 app_name=Termitehad http_status=4*4,now-90d,now,*,total,eq,3,Splunk QL
 app_name=Termitehad http_status=4,now-90d,now,*,total,eq,0,Splunk QL
 app_name=Termitehad city=Tucson*,now-90d,now,*,total,eq,1,Splunk QL
+app_name=termitehad city=tucson*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tucso*n*,now-90d,now,*,total,eq,1,Splunk QL
+app_name=TermiteHAD city=tucso*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tuc*s*o*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tuc**s*o*n*,now-90d,now,*,total,eq,1,Splunk QL
 app_name=Termitehad city=Tucson,now-90d,now,*,total,eq,1,Splunk QL
@@ -59,9 +64,13 @@ app_name=Termitehad city=*on*,now-90d,now,*,total,eq,6,Splunk QL
 app_name=Termitehad city=on*,now-90d,now,*,total,eq,0,Splunk QL
 app_name=Oxam,now-90d,now,*,total,gt,0,Splunk QL
 "question=""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
+"question=""franzen pabst carry yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
 "NOT question=""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,99999,Splunk QL
+"NOT question=""franzen pabst carry Yuccie lomO Gentrify?""",now-1d,now,*,total,eq,99999,Splunk QL
 """Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
+"""franzen pabst carry yuccie lomo gentrify?""",now-1d,now,*,total,eq,1,Splunk QL
 "NOT ""Franzen pabst carry Yuccie lomo gentrify?""",now-1d,now,*,total,eq,99999,Splunk QL
+"NOT ""CASE(""Franzen pabst carry Yuccie lomo gentrify?"")""",now-1d,now,*,total,eq,99999,Splunk QL
 search app_name=Oxam,now-90d,now,*,total,gt,0,Splunk QL
 search Sunday,now-90d,now,*,total,gt,1,Splunk QL
 search http_status>400,now-1d,now,*,total,gt,0,Splunk QL

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -40,7 +40,7 @@ import (
 // When valueIsRegex is true, colValue should be a string containing the regex
 // to match and should not have quotation marks as the first and last character
 // unless those are intended to be matched.
-func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, valueIsRegex bool, qid uint64) ([]*FilterCriteria, error) {
+func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, valueIsRegex bool, valueIsCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
 	andFilterCondition := make([]*FilterCriteria, 0)
 	var opr FilterOperator = Equals
 	switch compOpr {
@@ -134,6 +134,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 		log.Errorf("qid=%d, ProcessSingleFilter: Invalid colValue type. ColValue=%v, ColValueType=%T", qid, t, t)
 		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
+	andFilterCondition[0].FilterIsCaseSensitive = valueIsCaseSensitive
 	return andFilterCondition, nil
 }
 

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -260,6 +260,10 @@ func CreateTermFilterCriteria(colName string, colValue interface{}, opr FilterOp
 	cVal, err := CreateDtypeEnclosure(colValue, qid)
 	if err != nil {
 		log.Errorf("qid=%d, createTermFilterCriteria: error creating DtypeEnclosure for ColValue=%v. Error=%+v", qid, colValue, err)
+	} else {
+		if cci != nil {
+			cVal.UpdateTheRegexp(cci.caseInSensitive)
+		}
 	}
 
 	var originalCVal *DtypeEnclosure

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -53,6 +53,7 @@ func (cci *CaseConversionInfo) ShouldSearchWithOriginalCase() bool {
 // When valueIsRegex is true, colValue should be a string containing the regex
 // to match and should not have quotation marks as the first and last character
 // unless those are intended to be matched.
+// If shouldBeCaseSensitive is set to true, valueIsCaseInSensitive will be ignored
 func ProcessSingleFilter(colName string, colValue interface{}, originalColValue interface{}, compOpr string, valueIsRegex bool, valueIsCaseInSensitive bool, shouldBeCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
 	andFilterCondition := make([]*FilterCriteria, 0)
 	var opr FilterOperator = Equals

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -110,7 +110,9 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 					}
 
 					cleanedColVal := strings.ReplaceAll(strings.TrimSpace(t), "\"", "")
-					caseConversion.originalColValue = strings.ReplaceAll(strings.TrimSpace(originalColValue.(string)), "\"", "")
+					if originalColValue != nil {
+						caseConversion.originalColValue = strings.ReplaceAll(strings.TrimSpace(originalColValue.(string)), "\"", "")
+					}
 					if strings.Contains(t, "\"") {
 						criteria := createMatchPhraseFilterCriteria(colName, cleanedColVal, And, negateMatch, caseConversion)
 						andFilterCondition = append(andFilterCondition, criteria)
@@ -135,7 +137,9 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 					andFilterCondition = append(andFilterCondition, criteria)
 				} else {
 					cleanedColVal := strings.ReplaceAll(strings.TrimSpace(t), "\"", "")
-					caseConversion.originalColValue = strings.ReplaceAll(strings.TrimSpace(originalColValue.(string)), "\"", "")
+					if originalColValue != nil {
+						caseConversion.originalColValue = strings.ReplaceAll(strings.TrimSpace(originalColValue.(string)), "\"", "")
+					}
 					criteria := CreateTermFilterCriteria(colName, cleanedColVal, opr, qid, caseConversion)
 					andFilterCondition = append(andFilterCondition, criteria)
 				}

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -40,27 +40,22 @@ import (
 
 type CaseConversionInfo struct {
 	dualCaseCheckEnabled bool
-	caseInSensitive      bool
+	caseInsensitive      bool
 	valueIsRegex         bool
 	IsString             bool
 	colValue             interface{}
 	originalColValue     interface{}
 }
 
-// We will also search with the original case(originalColValue) if the following conditions are met:
-// 1. dualCaseCheckEnabled is true (this is from config: config.IsDualCaseCheckEnabled())
-// 2. caseInSensitive is true
-// 3. valueIsRegex is false
-// 4. colValue is different from originalColValue (if they are same, we don't need to search with original case)
 func (cci *CaseConversionInfo) ShouldAlsoSearchWithOriginalCase() bool {
-	return cci.IsString && cci.dualCaseCheckEnabled && cci.caseInSensitive && !cci.valueIsRegex && cci.colValue != cci.originalColValue
+	return cci.IsString && cci.dualCaseCheckEnabled && cci.caseInsensitive && !cci.valueIsRegex && cci.colValue != cci.originalColValue
 }
 
 // When valueIsRegex is true, colValue should be a string containing the regex
 // to match and should not have quotation marks as the first and last character
 // unless those are intended to be matched.
-// If forceCaseSensitive is set to true, caseInSensitive will be ignored
-func ProcessSingleFilter(colName string, colValue interface{}, originalColValue interface{}, compOpr string, valueIsRegex bool, caseInSensitive bool, forceCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
+// If forceCaseSensitive is set to true, caseInsensitive will be ignored
+func ProcessSingleFilter(colName string, colValue interface{}, originalColValue interface{}, compOpr string, valueIsRegex bool, caseInsensitive bool, forceCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
 	andFilterCondition := make([]*FilterCriteria, 0)
 	var opr FilterOperator = Equals
 	switch compOpr {
@@ -82,7 +77,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 	}
 
 	if forceCaseSensitive {
-		caseInSensitive = false
+		caseInsensitive = false
 		if originalColValue != nil {
 			colValue = originalColValue
 		}
@@ -90,7 +85,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 
 	caseConversion := &CaseConversionInfo{
 		dualCaseCheckEnabled: config.IsDualCaseCheckEnabled(),
-		caseInSensitive:      caseInSensitive,
+		caseInsensitive:      caseInsensitive,
 		valueIsRegex:         valueIsRegex,
 		colValue:             colValue,
 		originalColValue:     originalColValue,
@@ -178,7 +173,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 		log.Errorf("qid=%d, ProcessSingleFilter: Invalid colValue type. ColValue=%v, ColValueType=%T", qid, t, t)
 		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
-	andFilterCondition[0].FilterIsCaseInSensitive = caseInSensitive
+	andFilterCondition[0].FilterIsCaseInsensitive = caseInsensitive
 	return andFilterCondition, nil
 }
 
@@ -269,7 +264,7 @@ func CreateTermFilterCriteria(colName string, colValue interface{}, opr FilterOp
 		log.Errorf("qid=%d, createTermFilterCriteria: error creating DtypeEnclosure for ColValue=%v. Error=%+v", qid, colValue, err)
 	} else {
 		if cci != nil {
-			cVal.UpdateTheRegexp(cci.caseInSensitive)
+			cVal.UpdateRegexp(cci.caseInsensitive)
 		}
 	}
 

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -39,22 +39,22 @@ import (
 )
 
 type CaseConversionInfo struct {
-	dualCaseCheckEnabled   bool
-	valueIsCaseInSensitive bool
-	valueIsRegex           bool
-	IsString               bool
-	originalColValue       interface{}
+	dualCaseCheckEnabled bool
+	caseInSensitive      bool
+	valueIsRegex         bool
+	IsString             bool
+	originalColValue     interface{}
 }
 
 func (cci *CaseConversionInfo) ShouldSearchWithOriginalCase() bool {
-	return cci.IsString && cci.dualCaseCheckEnabled && cci.valueIsCaseInSensitive && !cci.valueIsRegex
+	return cci.IsString && cci.dualCaseCheckEnabled && cci.caseInSensitive && !cci.valueIsRegex
 }
 
 // When valueIsRegex is true, colValue should be a string containing the regex
 // to match and should not have quotation marks as the first and last character
 // unless those are intended to be matched.
-// If shouldBeCaseSensitive is set to true, valueIsCaseInSensitive will be ignored
-func ProcessSingleFilter(colName string, colValue interface{}, originalColValue interface{}, compOpr string, valueIsRegex bool, valueIsCaseInSensitive bool, shouldBeCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
+// If shouldBeCaseSensitive is set to true, caseInSensitive will be ignored
+func ProcessSingleFilter(colName string, colValue interface{}, originalColValue interface{}, compOpr string, valueIsRegex bool, caseInSensitive bool, shouldBeCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
 	andFilterCondition := make([]*FilterCriteria, 0)
 	var opr FilterOperator = Equals
 	switch compOpr {
@@ -76,17 +76,17 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 	}
 
 	if shouldBeCaseSensitive {
-		valueIsCaseInSensitive = false
+		caseInSensitive = false
 		if originalColValue != nil {
 			colValue = originalColValue
 		}
 	}
 
 	caseConversion := &CaseConversionInfo{
-		dualCaseCheckEnabled:   config.IsDualCaseCheckEnabled(),
-		valueIsCaseInSensitive: valueIsCaseInSensitive,
-		valueIsRegex:           valueIsRegex,
-		originalColValue:       originalColValue,
+		dualCaseCheckEnabled: config.IsDualCaseCheckEnabled(),
+		caseInSensitive:      caseInSensitive,
+		valueIsRegex:         valueIsRegex,
+		originalColValue:     originalColValue,
 	}
 
 	switch t := colValue.(type) {
@@ -171,7 +171,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 		log.Errorf("qid=%d, ProcessSingleFilter: Invalid colValue type. ColValue=%v, ColValueType=%T", qid, t, t)
 		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
-	andFilterCondition[0].FilterIsCaseInSensitive = valueIsCaseInSensitive
+	andFilterCondition[0].FilterIsCaseInSensitive = caseInSensitive
 	return andFilterCondition, nil
 }
 

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -74,8 +74,6 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 		return nil, errors.New("ProcessSingleFilter: invalid comparison operator")
 	}
 
-	fmt.Printf("\n ProcessSingleFilter: colName=%v, colValue=%v, originalColValue=%v, compOpr=%v, valueIsRegex=%v, valueIsCaseInSensitive=%v, shouldBeCaseSensitive=%v", colName, colValue, originalColValue, compOpr, valueIsRegex, valueIsCaseInSensitive, shouldBeCaseSensitive)
-
 	if shouldBeCaseSensitive {
 		valueIsCaseInSensitive = false
 		if originalColValue != nil {
@@ -168,7 +166,6 @@ func ProcessSingleFilter(colName string, colValue interface{}, originalColValue 
 		log.Errorf("qid=%d, ProcessSingleFilter: Invalid colValue type. ColValue=%v, ColValueType=%T", qid, t, t)
 		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
-	fmt.Printf("qid=%d, ProcessSingleFilter: colName=%v, colValue=%v, compOpr=%v, valueIsRegex=%v, valueIsCaseInSensitive=%v, shouldBeCaseSensitive=%v", qid, colName, colValue, compOpr, valueIsRegex, valueIsCaseInSensitive, shouldBeCaseSensitive)
 	andFilterCondition[0].FilterIsCaseInSensitive = valueIsCaseInSensitive
 	return andFilterCondition, nil
 }

--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -40,7 +40,7 @@ import (
 // When valueIsRegex is true, colValue should be a string containing the regex
 // to match and should not have quotation marks as the first and last character
 // unless those are intended to be matched.
-func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, valueIsRegex bool, valueIsCaseSensitive bool, qid uint64) ([]*FilterCriteria, error) {
+func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, valueIsRegex bool, valueIsCaseInSensitive bool, qid uint64) ([]*FilterCriteria, error) {
 	andFilterCondition := make([]*FilterCriteria, 0)
 	var opr FilterOperator = Equals
 	switch compOpr {
@@ -134,7 +134,7 @@ func ProcessSingleFilter(colName string, colValue interface{}, compOpr string, v
 		log.Errorf("qid=%d, ProcessSingleFilter: Invalid colValue type. ColValue=%v, ColValueType=%T", qid, t, t)
 		return nil, errors.New("ProcessSingleFilter: Invalid colValue type")
 	}
-	andFilterCondition[0].FilterIsCaseSensitive = valueIsCaseSensitive
+	andFilterCondition[0].FilterIsCaseInSensitive = valueIsCaseInSensitive
 	return andFilterCondition, nil
 }
 

--- a/pkg/ast/logql/tests/logqlParse_test.go
+++ b/pkg/ast/logql/tests/logqlParse_test.go
@@ -33,7 +33,7 @@ func Test_ParseStream(t *testing.T) {
 	res, err := logql.Parse("", json_body)
 	queryJson := res.(ast.QueryStruct).SearchFilter
 	assert.Nil(t, err)
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, queryJson)
 	assert.Equal(t, queryJson.Comparison.Field, "something")
@@ -44,7 +44,7 @@ func Test_ParseStream(t *testing.T) {
 	res, err = logql.Parse("", json_body)
 	queryJson = res.(ast.QueryStruct).SearchFilter
 	assert.Nil(t, err)
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, queryJson)
 	assert.Equal(t, queryJson.Left.Comparison.Field, "something")
@@ -60,7 +60,7 @@ func Test_ParseLabelFilter(t *testing.T) {
 	res, err := logql.Parse("", json_body)
 	queryJson := res.(ast.QueryStruct).SearchFilter
 	assert.Nil(t, err)
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, queryJson.Left.Comparison.Field, "something")
 	assert.Equal(t, queryJson.Left.Comparison.Values, "\"another\"")
@@ -74,7 +74,7 @@ func Test_ParseLogFilter(t *testing.T) {
 	res, err := logql.Parse("", json_body)
 	queryJson := res.(ast.QueryStruct).SearchFilter
 	assert.Nil(t, err)
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, queryJson.Right.Comparison.Values, ast.GrepValue{Field: "\"batch-212\""})
 	assert.Equal(t, queryJson.Left.Right.Comparison.Values, "\"Fresno\"")
@@ -87,7 +87,7 @@ func Test_ParseLogAndLabelFilter(t *testing.T) {
 	res, err := logql.Parse("", json_body)
 	assert.Nil(t, err)
 	queryJson := res.(ast.QueryStruct).SearchFilter
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, queryJson.Right.Right.Comparison.Values, "thing")
 	assert.Equal(t, queryJson.Right.Left.Comparison.Values, ast.GrepValue{Field: "\"batch-212\""})
@@ -103,7 +103,7 @@ func Test_ParseLogfmtKeyword(t *testing.T) {
 	queryJson := res.(ast.QueryStruct).SearchFilter
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	testIncludeValues := append(make([]*structs.IncludeValue, 0), &structs.IncludeValue{ColName: "city", Label: "city_life"}, &structs.IncludeValue{ColName: "gender", Label: "single_gender"}, &structs.IncludeValue{ColName: "host", Label: "host"})
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.IncludeValues, testIncludeValues)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.Logfmt, true)
@@ -116,7 +116,7 @@ func Test_ParseLogfmtKeyword(t *testing.T) {
 	pipeCommands = res.(ast.QueryStruct).PipeCommands
 	queryJson = res.(ast.QueryStruct).SearchFilter
 	astNode = &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.Logfmt, true)
 	assert.Equal(t, len(pipeCommands.OutputTransforms.OutputColumns.IncludeValues), 0)
@@ -134,7 +134,7 @@ func Test_ParseJSONKeyword(t *testing.T) {
 	testRenameColumns := make(map[string]string)
 	testRenameColumns["city"] = "city_life"
 	testIncludeValues := append(make([]*structs.IncludeValue, 0), &structs.IncludeValue{Index: 0, ColName: "gender", Label: "single_gender"})
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.IncludeColumns, testOutputColumns)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.RenameColumns, testRenameColumns)
@@ -148,7 +148,7 @@ func Test_ParseJSONKeyword(t *testing.T) {
 	pipeCommands = res.(ast.QueryStruct).PipeCommands
 	queryJson = res.(ast.QueryStruct).SearchFilter
 	astNode = &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, queryJson.Comparison.Values, "\"female\"")
 	assert.Nil(t, pipeCommands)
@@ -165,7 +165,7 @@ func Test_ParseJSONKeywordAndFilters(t *testing.T) {
 	testRenameColumns := make(map[string]string)
 	testRenameColumns["city"] = "city_life"
 	testIncludeValues := append(make([]*structs.IncludeValue, 0), &structs.IncludeValue{Index: 0, ColName: "gender", Label: "single_gender"})
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.IncludeColumns, testOutputColumns)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.RenameColumns, testRenameColumns)
@@ -180,7 +180,7 @@ func Test_ParseJSONKeywordAndFilters(t *testing.T) {
 	queryJson = res.(ast.QueryStruct).SearchFilter
 	pipeCommands = res.(ast.QueryStruct).PipeCommands
 	astNode = &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(queryJson, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.IncludeColumns, testOutputColumns)
 	assert.Equal(t, pipeCommands.OutputTransforms.OutputColumns.RenameColumns, testRenameColumns)

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -133,7 +133,7 @@ func createMatchAll(qid uint64) *ASTNode {
 	rootNode := &ASTNode{}
 	colName := "*"
 	colValue := "*"
-	criteria := ast.CreateTermFilterCriteria(colName, colValue, Equals, qid)
+	criteria := ast.CreateTermFilterCriteria(colName, colValue, Equals, qid, nil)
 	rootNode.AndFilterCondition = &Condition{FilterCriteria: []*FilterCriteria{criteria}}
 	return rootNode
 }
@@ -388,7 +388,7 @@ func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, SearchQueryToASTnode: Error while processing single filter, error: %v", qid, err)
 			return err
@@ -704,7 +704,7 @@ func parseORCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseORCondition: Error while processing single filter, err: %v", qid, err)
 			return err
@@ -754,7 +754,7 @@ func parseANDCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseANDCondition: Error while processing single filter, err: %v", qid, err)
 			return err

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -393,7 +393,7 @@ func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64, ShouldB
 		}
 
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, ShouldBeCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.CaseInsensitive, ShouldBeCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, SearchQueryToASTnode: Error while processing single filter, error: %v", qid, err)
 			return err
@@ -709,7 +709,7 @@ func parseORCondition(node *ast.Node, boolNode *ASTNode, qid uint64, ShouldBeCas
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, ShouldBeCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.CaseInsensitive, ShouldBeCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseORCondition: Error while processing single filter, err: %v", qid, err)
 			return err
@@ -759,7 +759,7 @@ func parseANDCondition(node *ast.Node, boolNode *ASTNode, qid uint64, ShouldBeCa
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, ShouldBeCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.OriginalValues, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.CaseInsensitive, ShouldBeCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseANDCondition: Error while processing single filter, err: %v", qid, err)
 			return err

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -358,6 +358,7 @@ func extractSearchNodeFromBooleanExpr(boolExpr *BoolExpr) *ast.Node {
 	return extraSearchNode
 }
 
+// If ShouldBeCaseSensitive is true, then the search query will not consider any of the case-insensitive search options.
 func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64, ShouldBeCaseSensitive bool) error {
 	var err error
 	if node == nil {

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -388,7 +388,7 @@ func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, SearchQueryToASTnode: Error while processing single filter, error: %v", qid, err)
 			return err
@@ -704,7 +704,7 @@ func parseORCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseORCondition: Error while processing single filter, err: %v", qid, err)
 			return err
@@ -754,7 +754,7 @@ func parseANDCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseANDCondition: Error while processing single filter, err: %v", qid, err)
 			return err

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -158,6 +158,9 @@ func parsePipeSearch(searchText string, queryLanguage string, qid uint64) (*ASTN
 		leafNode = createMatchAll(qid)
 		return leafNode, nil, nil
 	}
+
+	shouldBeCaseSensitive := true
+
 	//peg parsing to AST tree
 	switch queryLanguage {
 	case "Pipe QL":
@@ -166,6 +169,7 @@ func parsePipeSearch(searchText string, queryLanguage string, qid uint64) (*ASTN
 		res, err = logql.Parse("", []byte(searchText))
 	case "Splunk QL":
 		res, err = spl.Parse("", []byte(searchText))
+		shouldBeCaseSensitive = false
 	default:
 		log.Errorf("qid=%d, parsePipeSearch: Unknown queryLanguage: %v", qid, queryLanguage)
 	}
@@ -196,7 +200,7 @@ func parsePipeSearch(searchText string, queryLanguage string, qid uint64) (*ASTN
 
 	searchNode, aggs = optimizeQuery(searchNode, aggs)
 
-	err = SearchQueryToASTnode(searchNode, boolNode, qid, false)
+	err = SearchQueryToASTnode(searchNode, boolNode, qid, shouldBeCaseSensitive)
 	if err != nil {
 		log.Errorf("qid=%d, parsePipeSearch: SearchQueryToASTnode error: %v", qid, err)
 		return nil, nil, err

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -388,7 +388,7 @@ func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, SearchQueryToASTnode: Error while processing single filter, error: %v", qid, err)
 			return err
@@ -704,7 +704,7 @@ func parseORCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseORCondition: Error while processing single filter, err: %v", qid, err)
 			return err
@@ -754,7 +754,7 @@ func parseANDCondition(node *ast.Node, boolNode *ASTNode, qid uint64) error {
 		}
 		return nil
 	case ast.NodeTerminal:
-		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseSensitive, qid)
+		criteria, err := ast.ProcessSingleFilter(node.Comparison.Field, node.Comparison.Values, node.Comparison.Op, node.Comparison.ValueIsRegex, node.Comparison.ValueIsCaseInSensitive, qid)
 		if err != nil {
 			log.Errorf("qid=%d, parseANDCondition: Error while processing single filter, err: %v", qid, err)
 			return err

--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -393,7 +393,6 @@ func SearchQueryToASTnode(node *ast.Node, boolNode *ASTNode, qid uint64, ShouldB
 			log.Errorf("qid=%d, SearchQueryToASTnode: Error while processing single filter, error: %v", qid, err)
 			return err
 		}
-		fmt.Printf("\ncriteria: %v\n", criteria[0])
 		filtercond := &Condition{
 			FilterCriteria: []*FilterCriteria(criteria),
 		}

--- a/pkg/ast/pipesearch/searchQueryParser_test.go
+++ b/pkg/ast/pipesearch/searchQueryParser_test.go
@@ -35,7 +35,7 @@ func convertAstNodeToCaseSensitive(node *ast.Node) {
 		return
 	}
 
-	node.Comparison.ValueIsCaseInSensitive = false
+	node.Comparison.CaseInsensitive = false
 	node.Comparison.OriginalValues = nil
 	convertAstNodeToCaseSensitive(node.Left)
 	convertAstNodeToCaseSensitive(node.Right)

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -491,6 +491,7 @@ type FormatResultsRequestArguments struct {
 
 type StringSearchRequest struct {
 	value                  interface{}
+	originalValue          interface{}
 	valueIsCaseInSensitive bool
 }
 
@@ -498,166 +499,166 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 484, col: 1, offset: 13717},
+			pos:  position{line: 485, col: 1, offset: 13747},
 			expr: &choiceExpr{
-				pos: position{line: 484, col: 10, offset: 13726},
+				pos: position{line: 485, col: 10, offset: 13756},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 484, col: 10, offset: 13726},
+						pos: position{line: 485, col: 10, offset: 13756},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 484, col: 10, offset: 13726},
+							pos: position{line: 485, col: 10, offset: 13756},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 484, col: 10, offset: 13726},
+									pos: position{line: 485, col: 10, offset: 13756},
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 10, offset: 13726},
+										pos:  position{line: 485, col: 10, offset: 13756},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 17, offset: 13733},
+									pos:   position{line: 485, col: 17, offset: 13763},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 32, offset: 13748},
+										pos:  position{line: 485, col: 32, offset: 13778},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 52, offset: 13768},
+									pos:   position{line: 485, col: 52, offset: 13798},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 484, col: 65, offset: 13781},
+										pos: position{line: 485, col: 65, offset: 13811},
 										expr: &ruleRefExpr{
-											pos:  position{line: 484, col: 66, offset: 13782},
+											pos:  position{line: 485, col: 66, offset: 13812},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 80, offset: 13796},
+									pos:   position{line: 485, col: 80, offset: 13826},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 484, col: 95, offset: 13811},
+										pos: position{line: 485, col: 95, offset: 13841},
 										expr: &ruleRefExpr{
-											pos:  position{line: 484, col: 96, offset: 13812},
+											pos:  position{line: 485, col: 96, offset: 13842},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 484, col: 119, offset: 13835},
+									pos: position{line: 485, col: 119, offset: 13865},
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 119, offset: 13835},
+										pos:  position{line: 485, col: 119, offset: 13865},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 484, col: 126, offset: 13842},
+									pos:  position{line: 485, col: 126, offset: 13872},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 3, offset: 15686},
+						pos: position{line: 547, col: 3, offset: 15716},
 						run: (*parser).callonStart17,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 3, offset: 15686},
+							pos: position{line: 547, col: 3, offset: 15716},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 546, col: 3, offset: 15686},
+									pos: position{line: 547, col: 3, offset: 15716},
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 3, offset: 15686},
+										pos:  position{line: 547, col: 3, offset: 15716},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 10, offset: 15693},
+									pos:  position{line: 547, col: 10, offset: 15723},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 15, offset: 15698},
+									pos:  position{line: 547, col: 15, offset: 15728},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 28, offset: 15711},
+									pos:  position{line: 547, col: 28, offset: 15741},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 34, offset: 15717},
+									pos:   position{line: 547, col: 34, offset: 15747},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 50, offset: 15733},
+										pos:  position{line: 547, col: 50, offset: 15763},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 70, offset: 15753},
+									pos:   position{line: 547, col: 70, offset: 15783},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 546, col: 85, offset: 15768},
+										pos: position{line: 547, col: 85, offset: 15798},
 										expr: &ruleRefExpr{
-											pos:  position{line: 546, col: 86, offset: 15769},
+											pos:  position{line: 547, col: 86, offset: 15799},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 546, col: 109, offset: 15792},
+									pos: position{line: 547, col: 109, offset: 15822},
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 109, offset: 15792},
+										pos:  position{line: 547, col: 109, offset: 15822},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 116, offset: 15799},
+									pos:  position{line: 547, col: 116, offset: 15829},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 564, col: 3, offset: 16254},
+						pos: position{line: 565, col: 3, offset: 16284},
 						run: (*parser).callonStart32,
 						expr: &seqExpr{
-							pos: position{line: 564, col: 3, offset: 16254},
+							pos: position{line: 565, col: 3, offset: 16284},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 564, col: 3, offset: 16254},
+									pos: position{line: 565, col: 3, offset: 16284},
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 3, offset: 16254},
+										pos:  position{line: 565, col: 3, offset: 16284},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 564, col: 10, offset: 16261},
+									pos:   position{line: 565, col: 10, offset: 16291},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 22, offset: 16273},
+										pos:  position{line: 565, col: 22, offset: 16303},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 564, col: 39, offset: 16290},
+									pos:   position{line: 565, col: 39, offset: 16320},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 564, col: 54, offset: 16305},
+										pos: position{line: 565, col: 54, offset: 16335},
 										expr: &ruleRefExpr{
-											pos:  position{line: 564, col: 55, offset: 16306},
+											pos:  position{line: 565, col: 55, offset: 16336},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 564, col: 78, offset: 16329},
+									pos: position{line: 565, col: 78, offset: 16359},
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 78, offset: 16329},
+										pos:  position{line: 565, col: 78, offset: 16359},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 564, col: 85, offset: 16336},
+									pos:  position{line: 565, col: 85, offset: 16366},
 									name: "EOF",
 								},
 							},
@@ -668,76 +669,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 578, col: 1, offset: 16629},
+			pos:  position{line: 579, col: 1, offset: 16659},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 21, offset: 16649},
+				pos: position{line: 579, col: 21, offset: 16679},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 21, offset: 16649},
+					pos: position{line: 579, col: 21, offset: 16679},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 578, col: 21, offset: 16649},
+							pos:        position{line: 579, col: 21, offset: 16679},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 26, offset: 16654},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 578, col: 32, offset: 16660},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 578, col: 36, offset: 16664},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 578, col: 41, offset: 16669},
+							pos:        position{line: 579, col: 26, offset: 16684},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 578, col: 47, offset: 16675},
+							pos:        position{line: 579, col: 32, offset: 16690},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 51, offset: 16679},
+							pos:        position{line: 579, col: 36, offset: 16694},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 56, offset: 16684},
+							pos:        position{line: 579, col: 41, offset: 16699},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 579, col: 47, offset: 16705},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 579, col: 51, offset: 16709},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 61, offset: 16689},
+							pos:        position{line: 579, col: 56, offset: 16714},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 66, offset: 16694},
+							pos:        position{line: 579, col: 61, offset: 16719},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 579, col: 66, offset: 16724},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -749,15 +750,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 585, col: 1, offset: 16835},
+			pos:  position{line: 586, col: 1, offset: 16865},
 			expr: &actionExpr{
-				pos: position{line: 585, col: 31, offset: 16865},
+				pos: position{line: 586, col: 31, offset: 16895},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 585, col: 31, offset: 16865},
+					pos:   position{line: 586, col: 31, offset: 16895},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 585, col: 38, offset: 16872},
+						pos:  position{line: 586, col: 38, offset: 16902},
 						name: "IntegerAsString",
 					},
 				},
@@ -765,22 +766,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 603, col: 1, offset: 17511},
+			pos:  position{line: 604, col: 1, offset: 17541},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 26, offset: 17536},
+				pos: position{line: 604, col: 26, offset: 17566},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 603, col: 26, offset: 17536},
+					pos:   position{line: 604, col: 26, offset: 17566},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 603, col: 37, offset: 17547},
+						pos: position{line: 604, col: 37, offset: 17577},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 603, col: 37, offset: 17547},
+								pos:  position{line: 604, col: 37, offset: 17577},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 603, col: 53, offset: 17563},
+								pos:  position{line: 604, col: 53, offset: 17593},
 								name: "PartialTimestamp",
 							},
 						},
@@ -790,22 +791,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 612, col: 1, offset: 17820},
+			pos:  position{line: 613, col: 1, offset: 17850},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 17, offset: 17836},
+				pos: position{line: 613, col: 17, offset: 17866},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 612, col: 17, offset: 17836},
+					pos:   position{line: 613, col: 17, offset: 17866},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 612, col: 31, offset: 17850},
+						pos: position{line: 613, col: 31, offset: 17880},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 612, col: 31, offset: 17850},
+								pos:  position{line: 613, col: 31, offset: 17880},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 612, col: 55, offset: 17874},
+								pos:  position{line: 613, col: 55, offset: 17904},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -815,28 +816,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 616, col: 1, offset: 17936},
+			pos:  position{line: 617, col: 1, offset: 17966},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 22, offset: 17957},
+				pos: position{line: 617, col: 22, offset: 17987},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 22, offset: 17957},
+					pos: position{line: 617, col: 22, offset: 17987},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 616, col: 22, offset: 17957},
+							pos:        position{line: 617, col: 22, offset: 17987},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 28, offset: 17963},
+							pos:  position{line: 617, col: 28, offset: 17993},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 34, offset: 17969},
+							pos:   position{line: 617, col: 34, offset: 17999},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 45, offset: 17980},
+								pos:  position{line: 617, col: 45, offset: 18010},
 								name: "GenTimestamp",
 							},
 						},
@@ -846,28 +847,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 625, col: 1, offset: 18170},
+			pos:  position{line: 626, col: 1, offset: 18200},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 24, offset: 18193},
+				pos: position{line: 626, col: 24, offset: 18223},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 625, col: 24, offset: 18193},
+					pos: position{line: 626, col: 24, offset: 18223},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 625, col: 24, offset: 18193},
+							pos:        position{line: 626, col: 24, offset: 18223},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 625, col: 32, offset: 18201},
+							pos:  position{line: 626, col: 32, offset: 18231},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 625, col: 38, offset: 18207},
+							pos:   position{line: 626, col: 38, offset: 18237},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 625, col: 49, offset: 18218},
+								pos:  position{line: 626, col: 49, offset: 18248},
 								name: "GenTimestamp",
 							},
 						},
@@ -877,59 +878,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 634, col: 1, offset: 18412},
+			pos:  position{line: 635, col: 1, offset: 18442},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 28, offset: 18439},
+				pos: position{line: 635, col: 28, offset: 18469},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 28, offset: 18439},
+					pos: position{line: 635, col: 28, offset: 18469},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 634, col: 28, offset: 18439},
+							pos:        position{line: 635, col: 28, offset: 18469},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 634, col: 40, offset: 18451},
+							pos:  position{line: 635, col: 40, offset: 18481},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 46, offset: 18457},
+							pos:   position{line: 635, col: 46, offset: 18487},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 53, offset: 18464},
+								pos:  position{line: 635, col: 53, offset: 18494},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 69, offset: 18480},
+							pos:   position{line: 635, col: 69, offset: 18510},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 634, col: 77, offset: 18488},
+								pos: position{line: 635, col: 77, offset: 18518},
 								expr: &choiceExpr{
-									pos: position{line: 634, col: 78, offset: 18489},
+									pos: position{line: 635, col: 78, offset: 18519},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 634, col: 78, offset: 18489},
+											pos:        position{line: 635, col: 78, offset: 18519},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 84, offset: 18495},
+											pos:        position{line: 635, col: 84, offset: 18525},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 90, offset: 18501},
+											pos:        position{line: 635, col: 90, offset: 18531},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 96, offset: 18507},
+											pos:        position{line: 635, col: 96, offset: 18537},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -944,26 +945,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 675, col: 1, offset: 19654},
+			pos:  position{line: 676, col: 1, offset: 19684},
 			expr: &actionExpr{
-				pos: position{line: 675, col: 19, offset: 19672},
+				pos: position{line: 676, col: 19, offset: 19702},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 675, col: 19, offset: 19672},
+					pos:   position{line: 676, col: 19, offset: 19702},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 675, col: 35, offset: 19688},
+						pos: position{line: 676, col: 35, offset: 19718},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 35, offset: 19688},
+								pos:  position{line: 676, col: 35, offset: 19718},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 55, offset: 19708},
+								pos:  position{line: 676, col: 55, offset: 19738},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 77, offset: 19730},
+								pos:  position{line: 676, col: 77, offset: 19760},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -973,35 +974,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 679, col: 1, offset: 19791},
+			pos:  position{line: 680, col: 1, offset: 19821},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 23, offset: 19813},
+				pos: position{line: 680, col: 23, offset: 19843},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 23, offset: 19813},
+					pos: position{line: 680, col: 23, offset: 19843},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 679, col: 23, offset: 19813},
+							pos:   position{line: 680, col: 23, offset: 19843},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 29, offset: 19819},
+								pos:  position{line: 680, col: 29, offset: 19849},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 679, col: 44, offset: 19834},
+							pos:   position{line: 680, col: 44, offset: 19864},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 679, col: 49, offset: 19839},
+								pos: position{line: 680, col: 49, offset: 19869},
 								expr: &seqExpr{
-									pos: position{line: 679, col: 50, offset: 19840},
+									pos: position{line: 680, col: 50, offset: 19870},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 679, col: 50, offset: 19840},
+											pos:  position{line: 680, col: 50, offset: 19870},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 679, col: 56, offset: 19846},
+											pos:  position{line: 680, col: 56, offset: 19876},
 											name: "GenTimesOption",
 										},
 									},
@@ -1014,25 +1015,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 726, col: 1, offset: 21389},
+			pos:  position{line: 727, col: 1, offset: 21419},
 			expr: &actionExpr{
-				pos: position{line: 726, col: 23, offset: 21411},
+				pos: position{line: 727, col: 23, offset: 21441},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 726, col: 23, offset: 21411},
+					pos: position{line: 727, col: 23, offset: 21441},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 726, col: 23, offset: 21411},
+							pos: position{line: 727, col: 23, offset: 21441},
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 23, offset: 21411},
+								pos:  position{line: 727, col: 23, offset: 21441},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 726, col: 35, offset: 21423},
+							pos:   position{line: 727, col: 35, offset: 21453},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 42, offset: 21430},
+								pos:  position{line: 727, col: 42, offset: 21460},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1042,32 +1043,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 730, col: 1, offset: 21471},
+			pos:  position{line: 731, col: 1, offset: 21501},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 16, offset: 21486},
+				pos: position{line: 731, col: 16, offset: 21516},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 730, col: 16, offset: 21486},
+					pos: position{line: 731, col: 16, offset: 21516},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 730, col: 16, offset: 21486},
+							pos: position{line: 731, col: 16, offset: 21516},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 18, offset: 21488},
+								pos:  position{line: 731, col: 18, offset: 21518},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 730, col: 26, offset: 21496},
+							pos: position{line: 731, col: 26, offset: 21526},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 26, offset: 21496},
+								pos:  position{line: 731, col: 26, offset: 21526},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 38, offset: 21508},
+							pos:   position{line: 731, col: 38, offset: 21538},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 45, offset: 21515},
+								pos:  position{line: 731, col: 45, offset: 21545},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1077,33 +1078,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 734, col: 1, offset: 21556},
+			pos:  position{line: 735, col: 1, offset: 21586},
 			expr: &actionExpr{
-				pos: position{line: 734, col: 16, offset: 21571},
+				pos: position{line: 735, col: 16, offset: 21601},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 734, col: 16, offset: 21571},
+					pos: position{line: 735, col: 16, offset: 21601},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 734, col: 16, offset: 21571},
+							pos:  position{line: 735, col: 16, offset: 21601},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 734, col: 21, offset: 21576},
+							pos:   position{line: 735, col: 21, offset: 21606},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 734, col: 28, offset: 21583},
+								pos: position{line: 735, col: 28, offset: 21613},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 28, offset: 21583},
+										pos:  position{line: 735, col: 28, offset: 21613},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 42, offset: 21597},
+										pos:  position{line: 735, col: 42, offset: 21627},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 55, offset: 21610},
+										pos:  position{line: 735, col: 55, offset: 21640},
 										name: "TimeModifiers",
 									},
 								},
@@ -1115,102 +1116,102 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 739, col: 1, offset: 21689},
+			pos:  position{line: 740, col: 1, offset: 21719},
 			expr: &actionExpr{
-				pos: position{line: 739, col: 25, offset: 21713},
+				pos: position{line: 740, col: 25, offset: 21743},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 739, col: 25, offset: 21713},
+					pos:   position{line: 740, col: 25, offset: 21743},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 739, col: 32, offset: 21720},
+						pos: position{line: 740, col: 32, offset: 21750},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 32, offset: 21720},
+								pos:  position{line: 740, col: 32, offset: 21750},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 51, offset: 21739},
+								pos:  position{line: 740, col: 51, offset: 21769},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 69, offset: 21757},
+								pos:  position{line: 740, col: 69, offset: 21787},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 81, offset: 21769},
+								pos:  position{line: 740, col: 81, offset: 21799},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 94, offset: 21782},
+								pos:  position{line: 740, col: 94, offset: 21812},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 106, offset: 21794},
+								pos:  position{line: 740, col: 106, offset: 21824},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 117, offset: 21805},
+								pos:  position{line: 740, col: 117, offset: 21835},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 134, offset: 21822},
+								pos:  position{line: 740, col: 134, offset: 21852},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 148, offset: 21836},
+								pos:  position{line: 740, col: 148, offset: 21866},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 165, offset: 21853},
+								pos:  position{line: 740, col: 165, offset: 21883},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 184, offset: 21872},
+								pos:  position{line: 740, col: 184, offset: 21902},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 197, offset: 21885},
+								pos:  position{line: 740, col: 197, offset: 21915},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 209, offset: 21897},
+								pos:  position{line: 740, col: 209, offset: 21927},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 227, offset: 21915},
+								pos:  position{line: 740, col: 227, offset: 21945},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 240, offset: 21928},
+								pos:  position{line: 740, col: 240, offset: 21958},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 254, offset: 21942},
+								pos:  position{line: 740, col: 254, offset: 21972},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 272, offset: 21960},
+								pos:  position{line: 740, col: 272, offset: 21990},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 284, offset: 21972},
+								pos:  position{line: 740, col: 284, offset: 22002},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 295, offset: 21983},
+								pos:  position{line: 740, col: 295, offset: 22013},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 314, offset: 22002},
+								pos:  position{line: 740, col: 314, offset: 22032},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 330, offset: 22018},
+								pos:  position{line: 740, col: 330, offset: 22048},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 346, offset: 22034},
+								pos:  position{line: 740, col: 346, offset: 22064},
 								name: "InputLookupAggBlock",
 							},
 						},
@@ -1220,37 +1221,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 744, col: 1, offset: 22135},
+			pos:  position{line: 745, col: 1, offset: 22165},
 			expr: &actionExpr{
-				pos: position{line: 744, col: 21, offset: 22155},
+				pos: position{line: 745, col: 21, offset: 22185},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 744, col: 21, offset: 22155},
+					pos: position{line: 745, col: 21, offset: 22185},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 21, offset: 22155},
+							pos:  position{line: 745, col: 21, offset: 22185},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 26, offset: 22160},
+							pos:  position{line: 745, col: 26, offset: 22190},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 37, offset: 22171},
+							pos:   position{line: 745, col: 37, offset: 22201},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 744, col: 40, offset: 22174},
+								pos: position{line: 745, col: 40, offset: 22204},
 								expr: &choiceExpr{
-									pos: position{line: 744, col: 41, offset: 22175},
+									pos: position{line: 745, col: 41, offset: 22205},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 744, col: 41, offset: 22175},
+											pos:        position{line: 745, col: 41, offset: 22205},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 744, col: 47, offset: 22181},
+											pos:        position{line: 745, col: 47, offset: 22211},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1260,14 +1261,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 53, offset: 22187},
+							pos:  position{line: 745, col: 53, offset: 22217},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 68, offset: 22202},
+							pos:   position{line: 745, col: 68, offset: 22232},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 75, offset: 22209},
+								pos:  position{line: 745, col: 75, offset: 22239},
 								name: "FieldNameList",
 							},
 						},
@@ -1277,28 +1278,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 762, col: 1, offset: 22713},
+			pos:  position{line: 763, col: 1, offset: 22743},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 26, offset: 22738},
+				pos: position{line: 763, col: 26, offset: 22768},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 762, col: 26, offset: 22738},
+					pos: position{line: 763, col: 26, offset: 22768},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 762, col: 26, offset: 22738},
+							pos:   position{line: 763, col: 26, offset: 22768},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 762, col: 31, offset: 22743},
+								pos:  position{line: 763, col: 31, offset: 22773},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 762, col: 47, offset: 22759},
+							pos:   position{line: 763, col: 47, offset: 22789},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 762, col: 56, offset: 22768},
+								pos: position{line: 763, col: 56, offset: 22798},
 								expr: &ruleRefExpr{
-									pos:  position{line: 762, col: 57, offset: 22769},
+									pos:  position{line: 763, col: 57, offset: 22799},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1309,36 +1310,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 808, col: 1, offset: 24264},
+			pos:  position{line: 809, col: 1, offset: 24294},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 20, offset: 24283},
+				pos: position{line: 809, col: 20, offset: 24313},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 20, offset: 24283},
+					pos: position{line: 809, col: 20, offset: 24313},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 20, offset: 24283},
+							pos:  position{line: 809, col: 20, offset: 24313},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 25, offset: 24288},
+							pos:  position{line: 809, col: 25, offset: 24318},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 35, offset: 24298},
+							pos:   position{line: 809, col: 35, offset: 24328},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 41, offset: 24304},
+								pos:  position{line: 809, col: 41, offset: 24334},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 64, offset: 24327},
+							pos:   position{line: 809, col: 64, offset: 24357},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 808, col: 72, offset: 24335},
+								pos: position{line: 809, col: 72, offset: 24365},
 								expr: &ruleRefExpr{
-									pos:  position{line: 808, col: 73, offset: 24336},
+									pos:  position{line: 809, col: 73, offset: 24366},
 									name: "StatsOptions",
 								},
 							},
@@ -1349,17 +1350,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 822, col: 1, offset: 24669},
+			pos:  position{line: 823, col: 1, offset: 24699},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 17, offset: 24685},
+				pos: position{line: 823, col: 17, offset: 24715},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 822, col: 17, offset: 24685},
+					pos:   position{line: 823, col: 17, offset: 24715},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 822, col: 24, offset: 24692},
+						pos: position{line: 823, col: 24, offset: 24722},
 						expr: &ruleRefExpr{
-							pos:  position{line: 822, col: 25, offset: 24693},
+							pos:  position{line: 823, col: 25, offset: 24723},
 							name: "StatsOption",
 						},
 					},
@@ -1368,45 +1369,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 860, col: 1, offset: 26134},
+			pos:  position{line: 861, col: 1, offset: 26164},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 16, offset: 26149},
+				pos: position{line: 861, col: 16, offset: 26179},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 860, col: 16, offset: 26149},
+					pos: position{line: 861, col: 16, offset: 26179},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 860, col: 16, offset: 26149},
+							pos:  position{line: 861, col: 16, offset: 26179},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 22, offset: 26155},
+							pos:   position{line: 861, col: 22, offset: 26185},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 860, col: 32, offset: 26165},
+								pos:  position{line: 861, col: 32, offset: 26195},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 860, col: 47, offset: 26180},
+							pos:  position{line: 861, col: 47, offset: 26210},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 53, offset: 26186},
+							pos:   position{line: 861, col: 53, offset: 26216},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 860, col: 58, offset: 26191},
+								pos: position{line: 861, col: 58, offset: 26221},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 58, offset: 26191},
+										pos:  position{line: 861, col: 58, offset: 26221},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 76, offset: 26209},
+										pos:  position{line: 861, col: 76, offset: 26239},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 94, offset: 26227},
+										pos:  position{line: 861, col: 94, offset: 26257},
 										name: "QuotedString",
 									},
 								},
@@ -1418,36 +1419,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 865, col: 1, offset: 26332},
+			pos:  position{line: 866, col: 1, offset: 26362},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 19, offset: 26350},
+				pos: position{line: 866, col: 19, offset: 26380},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 865, col: 19, offset: 26350},
+					pos:   position{line: 866, col: 19, offset: 26380},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 865, col: 27, offset: 26358},
+						pos: position{line: 866, col: 27, offset: 26388},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 865, col: 27, offset: 26358},
+								pos:        position{line: 866, col: 27, offset: 26388},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 38, offset: 26369},
+								pos:        position{line: 866, col: 38, offset: 26399},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 58, offset: 26389},
+								pos:        position{line: 866, col: 58, offset: 26419},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 68, offset: 26399},
+								pos:        position{line: 866, col: 68, offset: 26429},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1459,22 +1460,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 873, col: 1, offset: 26589},
+			pos:  position{line: 874, col: 1, offset: 26619},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 17, offset: 26605},
+				pos: position{line: 874, col: 17, offset: 26635},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 17, offset: 26605},
+					pos: position{line: 874, col: 17, offset: 26635},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 873, col: 17, offset: 26605},
+							pos:  position{line: 874, col: 17, offset: 26635},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 20, offset: 26608},
+							pos:   position{line: 874, col: 20, offset: 26638},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 27, offset: 26615},
+								pos:  position{line: 874, col: 27, offset: 26645},
 								name: "FieldNameList",
 							},
 						},
@@ -1484,28 +1485,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 885, col: 1, offset: 26965},
+			pos:  position{line: 886, col: 1, offset: 26995},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 35, offset: 26999},
+				pos: position{line: 886, col: 35, offset: 27029},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 35, offset: 26999},
+					pos: position{line: 886, col: 35, offset: 27029},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 885, col: 35, offset: 26999},
+							pos:        position{line: 886, col: 35, offset: 27029},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 885, col: 53, offset: 27017},
+							pos:  position{line: 886, col: 53, offset: 27047},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 885, col: 59, offset: 27023},
+							pos:   position{line: 886, col: 59, offset: 27053},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 885, col: 67, offset: 27031},
+								pos:  position{line: 886, col: 67, offset: 27061},
 								name: "Boolean",
 							},
 						},
@@ -1515,28 +1516,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 897, col: 1, offset: 27292},
+			pos:  position{line: 898, col: 1, offset: 27322},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 29, offset: 27320},
+				pos: position{line: 898, col: 29, offset: 27350},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 29, offset: 27320},
+					pos: position{line: 898, col: 29, offset: 27350},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 897, col: 29, offset: 27320},
+							pos:        position{line: 898, col: 29, offset: 27350},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 39, offset: 27330},
+							pos:  position{line: 898, col: 39, offset: 27360},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 897, col: 45, offset: 27336},
+							pos:   position{line: 898, col: 45, offset: 27366},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 53, offset: 27344},
+								pos:  position{line: 898, col: 53, offset: 27374},
 								name: "Boolean",
 							},
 						},
@@ -1546,28 +1547,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 909, col: 1, offset: 27591},
+			pos:  position{line: 910, col: 1, offset: 27621},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 28, offset: 27618},
+				pos: position{line: 910, col: 28, offset: 27648},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 28, offset: 27618},
+					pos: position{line: 910, col: 28, offset: 27648},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 909, col: 28, offset: 27618},
+							pos:        position{line: 910, col: 28, offset: 27648},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 37, offset: 27627},
+							pos:  position{line: 910, col: 37, offset: 27657},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 43, offset: 27633},
+							pos:   position{line: 910, col: 43, offset: 27663},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 51, offset: 27641},
+								pos:  position{line: 910, col: 51, offset: 27671},
 								name: "Boolean",
 							},
 						},
@@ -1577,28 +1578,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 922, col: 1, offset: 27975},
+			pos:  position{line: 923, col: 1, offset: 28005},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 28, offset: 28002},
+				pos: position{line: 923, col: 28, offset: 28032},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 922, col: 28, offset: 28002},
+					pos: position{line: 923, col: 28, offset: 28032},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 922, col: 28, offset: 28002},
+							pos:        position{line: 923, col: 28, offset: 28032},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 922, col: 37, offset: 28011},
+							pos:  position{line: 923, col: 37, offset: 28041},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 922, col: 43, offset: 28017},
+							pos:   position{line: 923, col: 43, offset: 28047},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 922, col: 51, offset: 28025},
+								pos:  position{line: 923, col: 51, offset: 28055},
 								name: "Boolean",
 							},
 						},
@@ -1608,28 +1609,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 935, col: 1, offset: 28359},
+			pos:  position{line: 936, col: 1, offset: 28389},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 28, offset: 28386},
+				pos: position{line: 936, col: 28, offset: 28416},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 935, col: 28, offset: 28386},
+					pos: position{line: 936, col: 28, offset: 28416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 935, col: 28, offset: 28386},
+							pos:        position{line: 936, col: 28, offset: 28416},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 37, offset: 28395},
+							pos:  position{line: 936, col: 37, offset: 28425},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 43, offset: 28401},
+							pos:   position{line: 936, col: 43, offset: 28431},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 54, offset: 28412},
+								pos:  position{line: 936, col: 54, offset: 28442},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1639,37 +1640,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 955, col: 1, offset: 29016},
+			pos:  position{line: 956, col: 1, offset: 29046},
 			expr: &actionExpr{
-				pos: position{line: 955, col: 33, offset: 29048},
+				pos: position{line: 956, col: 33, offset: 29078},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 955, col: 33, offset: 29048},
+					pos: position{line: 956, col: 33, offset: 29078},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 955, col: 33, offset: 29048},
+							pos:        position{line: 956, col: 33, offset: 29078},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 48, offset: 29063},
+							pos:  position{line: 956, col: 48, offset: 29093},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 54, offset: 29069},
+							pos:  position{line: 956, col: 54, offset: 29099},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 955, col: 62, offset: 29077},
+							pos:   position{line: 956, col: 62, offset: 29107},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 955, col: 71, offset: 29086},
+								pos:  position{line: 956, col: 71, offset: 29116},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 80, offset: 29095},
+							pos:  position{line: 956, col: 80, offset: 29125},
 							name: "R_PAREN",
 						},
 					},
@@ -1678,37 +1679,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 967, col: 1, offset: 29365},
+			pos:  position{line: 968, col: 1, offset: 29395},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 32, offset: 29396},
+				pos: position{line: 968, col: 32, offset: 29426},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 967, col: 32, offset: 29396},
+					pos: position{line: 968, col: 32, offset: 29426},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 967, col: 32, offset: 29396},
+							pos:        position{line: 968, col: 32, offset: 29426},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 46, offset: 29410},
+							pos:  position{line: 968, col: 46, offset: 29440},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 52, offset: 29416},
+							pos:  position{line: 968, col: 52, offset: 29446},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 967, col: 60, offset: 29424},
+							pos:   position{line: 968, col: 60, offset: 29454},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 967, col: 69, offset: 29433},
+								pos:  position{line: 968, col: 69, offset: 29463},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 78, offset: 29442},
+							pos:  position{line: 968, col: 78, offset: 29472},
 							name: "R_PAREN",
 						},
 					},
@@ -1717,28 +1718,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 979, col: 1, offset: 29710},
+			pos:  position{line: 980, col: 1, offset: 29740},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 32, offset: 29741},
+				pos: position{line: 980, col: 32, offset: 29771},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 979, col: 32, offset: 29741},
+					pos: position{line: 980, col: 32, offset: 29771},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 979, col: 32, offset: 29741},
+							pos:        position{line: 980, col: 32, offset: 29771},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 979, col: 46, offset: 29755},
+							pos:  position{line: 980, col: 46, offset: 29785},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 979, col: 52, offset: 29761},
+							pos:   position{line: 980, col: 52, offset: 29791},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 979, col: 63, offset: 29772},
+								pos:  position{line: 980, col: 63, offset: 29802},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1748,46 +1749,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 995, col: 1, offset: 30234},
+			pos:  position{line: 996, col: 1, offset: 30264},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 22, offset: 30255},
+				pos: position{line: 996, col: 22, offset: 30285},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 995, col: 22, offset: 30255},
+					pos:   position{line: 996, col: 22, offset: 30285},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 995, col: 32, offset: 30265},
+						pos: position{line: 996, col: 32, offset: 30295},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 32, offset: 30265},
+								pos:  position{line: 996, col: 32, offset: 30295},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 65, offset: 30298},
+								pos:  position{line: 996, col: 65, offset: 30328},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 92, offset: 30325},
+								pos:  position{line: 996, col: 92, offset: 30355},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 118, offset: 30351},
+								pos:  position{line: 996, col: 118, offset: 30381},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 144, offset: 30377},
+								pos:  position{line: 996, col: 144, offset: 30407},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 170, offset: 30403},
+								pos:  position{line: 996, col: 170, offset: 30433},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 201, offset: 30434},
+								pos:  position{line: 996, col: 201, offset: 30464},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 231, offset: 30464},
+								pos:  position{line: 996, col: 231, offset: 30494},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1797,35 +1798,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 999, col: 1, offset: 30523},
+			pos:  position{line: 1000, col: 1, offset: 30553},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 26, offset: 30548},
+				pos: position{line: 1000, col: 26, offset: 30578},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 999, col: 26, offset: 30548},
+					pos: position{line: 1000, col: 26, offset: 30578},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 999, col: 26, offset: 30548},
+							pos:   position{line: 1000, col: 26, offset: 30578},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 32, offset: 30554},
+								pos:  position{line: 1000, col: 32, offset: 30584},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 999, col: 50, offset: 30572},
+							pos:   position{line: 1000, col: 50, offset: 30602},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 999, col: 55, offset: 30577},
+								pos: position{line: 1000, col: 55, offset: 30607},
 								expr: &seqExpr{
-									pos: position{line: 999, col: 56, offset: 30578},
+									pos: position{line: 1000, col: 56, offset: 30608},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 999, col: 56, offset: 30578},
+											pos:  position{line: 1000, col: 56, offset: 30608},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 999, col: 62, offset: 30584},
+											pos:  position{line: 1000, col: 62, offset: 30614},
 											name: "StreamStatsOption",
 										},
 									},
@@ -1838,41 +1839,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1058, col: 1, offset: 32773},
+			pos:  position{line: 1059, col: 1, offset: 32803},
 			expr: &choiceExpr{
-				pos: position{line: 1058, col: 21, offset: 32793},
+				pos: position{line: 1059, col: 21, offset: 32823},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1058, col: 21, offset: 32793},
+						pos: position{line: 1059, col: 21, offset: 32823},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1058, col: 21, offset: 32793},
+							pos: position{line: 1059, col: 21, offset: 32823},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 21, offset: 32793},
+									pos:  position{line: 1059, col: 21, offset: 32823},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 26, offset: 32798},
+									pos:  position{line: 1059, col: 26, offset: 32828},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 42, offset: 32814},
+									pos:   position{line: 1059, col: 42, offset: 32844},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1058, col: 56, offset: 32828},
+										pos:  position{line: 1059, col: 56, offset: 32858},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 79, offset: 32851},
+									pos:  position{line: 1059, col: 79, offset: 32881},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 85, offset: 32857},
+									pos:   position{line: 1059, col: 85, offset: 32887},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1058, col: 91, offset: 32863},
+										pos:  position{line: 1059, col: 91, offset: 32893},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1880,24 +1881,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 3, offset: 33042},
+						pos: position{line: 1066, col: 3, offset: 33072},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 3, offset: 33042},
+							pos: position{line: 1066, col: 3, offset: 33072},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 3, offset: 33042},
+									pos:  position{line: 1066, col: 3, offset: 33072},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 8, offset: 33047},
+									pos:  position{line: 1066, col: 8, offset: 33077},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 24, offset: 33063},
+									pos:   position{line: 1066, col: 24, offset: 33093},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 30, offset: 33069},
+										pos:  position{line: 1066, col: 30, offset: 33099},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1909,31 +1910,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1073, col: 1, offset: 33235},
+			pos:  position{line: 1074, col: 1, offset: 33265},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 15, offset: 33249},
+				pos: position{line: 1074, col: 15, offset: 33279},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1073, col: 15, offset: 33249},
+					pos: position{line: 1074, col: 15, offset: 33279},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1073, col: 15, offset: 33249},
+							pos:  position{line: 1074, col: 15, offset: 33279},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 25, offset: 33259},
+							pos:   position{line: 1074, col: 25, offset: 33289},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1073, col: 34, offset: 33268},
+								pos: position{line: 1074, col: 34, offset: 33298},
 								expr: &seqExpr{
-									pos: position{line: 1073, col: 35, offset: 33269},
+									pos: position{line: 1074, col: 35, offset: 33299},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1073, col: 35, offset: 33269},
+											pos:  position{line: 1074, col: 35, offset: 33299},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1073, col: 45, offset: 33279},
+											pos:  position{line: 1074, col: 45, offset: 33309},
 											name: "EqualityOperator",
 										},
 									},
@@ -1941,10 +1942,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 64, offset: 33298},
+							pos:   position{line: 1074, col: 64, offset: 33328},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 68, offset: 33302},
+								pos:  position{line: 1074, col: 68, offset: 33332},
 								name: "QuotedString",
 							},
 						},
@@ -1954,44 +1955,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1101, col: 1, offset: 33881},
+			pos:  position{line: 1102, col: 1, offset: 33911},
 			expr: &actionExpr{
-				pos: position{line: 1101, col: 17, offset: 33897},
+				pos: position{line: 1102, col: 17, offset: 33927},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1101, col: 17, offset: 33897},
+					pos: position{line: 1102, col: 17, offset: 33927},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1101, col: 17, offset: 33897},
+							pos:   position{line: 1102, col: 17, offset: 33927},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1101, col: 23, offset: 33903},
+								pos:  position{line: 1102, col: 23, offset: 33933},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1101, col: 36, offset: 33916},
+							pos:   position{line: 1102, col: 36, offset: 33946},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1101, col: 41, offset: 33921},
+								pos: position{line: 1102, col: 41, offset: 33951},
 								expr: &seqExpr{
-									pos: position{line: 1101, col: 42, offset: 33922},
+									pos: position{line: 1102, col: 42, offset: 33952},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1101, col: 43, offset: 33923},
+											pos: position{line: 1102, col: 43, offset: 33953},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1101, col: 43, offset: 33923},
+													pos:  position{line: 1102, col: 43, offset: 33953},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1101, col: 49, offset: 33929},
+													pos:  position{line: 1102, col: 49, offset: 33959},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1101, col: 56, offset: 33936},
+											pos:  position{line: 1102, col: 56, offset: 33966},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2004,35 +2005,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1119, col: 1, offset: 34313},
+			pos:  position{line: 1120, col: 1, offset: 34343},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 17, offset: 34329},
+				pos: position{line: 1120, col: 17, offset: 34359},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1119, col: 17, offset: 34329},
+					pos: position{line: 1120, col: 17, offset: 34359},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1119, col: 17, offset: 34329},
+							pos:   position{line: 1120, col: 17, offset: 34359},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1119, col: 23, offset: 34335},
+								pos:  position{line: 1120, col: 23, offset: 34365},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1119, col: 36, offset: 34348},
+							pos:   position{line: 1120, col: 36, offset: 34378},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1119, col: 41, offset: 34353},
+								pos: position{line: 1120, col: 41, offset: 34383},
 								expr: &seqExpr{
-									pos: position{line: 1119, col: 42, offset: 34354},
+									pos: position{line: 1120, col: 42, offset: 34384},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1119, col: 42, offset: 34354},
+											pos:  position{line: 1120, col: 42, offset: 34384},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1119, col: 45, offset: 34357},
+											pos:  position{line: 1120, col: 45, offset: 34387},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2045,32 +2046,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1137, col: 1, offset: 34722},
+			pos:  position{line: 1138, col: 1, offset: 34752},
 			expr: &choiceExpr{
-				pos: position{line: 1137, col: 17, offset: 34738},
+				pos: position{line: 1138, col: 17, offset: 34768},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1137, col: 17, offset: 34738},
+						pos: position{line: 1138, col: 17, offset: 34768},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1137, col: 17, offset: 34738},
+							pos: position{line: 1138, col: 17, offset: 34768},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1137, col: 17, offset: 34738},
+									pos:   position{line: 1138, col: 17, offset: 34768},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1137, col: 25, offset: 34746},
+										pos: position{line: 1138, col: 25, offset: 34776},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1137, col: 25, offset: 34746},
+											pos:  position{line: 1138, col: 25, offset: 34776},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1137, col: 30, offset: 34751},
+									pos:   position{line: 1138, col: 30, offset: 34781},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1137, col: 36, offset: 34757},
+										pos:  position{line: 1138, col: 36, offset: 34787},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2078,13 +2079,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 35053},
+						pos: position{line: 1149, col: 5, offset: 35083},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1148, col: 5, offset: 35053},
+							pos:   position{line: 1149, col: 5, offset: 35083},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 12, offset: 35060},
+								pos:  position{line: 1149, col: 12, offset: 35090},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2094,43 +2095,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1152, col: 1, offset: 35101},
+			pos:  position{line: 1153, col: 1, offset: 35131},
 			expr: &choiceExpr{
-				pos: position{line: 1152, col: 17, offset: 35117},
+				pos: position{line: 1153, col: 17, offset: 35147},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1152, col: 17, offset: 35117},
+						pos: position{line: 1153, col: 17, offset: 35147},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1152, col: 17, offset: 35117},
+							pos: position{line: 1153, col: 17, offset: 35147},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1152, col: 17, offset: 35117},
+									pos:  position{line: 1153, col: 17, offset: 35147},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1152, col: 25, offset: 35125},
+									pos:   position{line: 1153, col: 25, offset: 35155},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1152, col: 32, offset: 35132},
+										pos:  position{line: 1153, col: 32, offset: 35162},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1152, col: 45, offset: 35145},
+									pos:  position{line: 1153, col: 45, offset: 35175},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1154, col: 5, offset: 35182},
+						pos: position{line: 1155, col: 5, offset: 35212},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1154, col: 5, offset: 35182},
+							pos:   position{line: 1155, col: 5, offset: 35212},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1154, col: 10, offset: 35187},
+								pos:  position{line: 1155, col: 10, offset: 35217},
 								name: "SearchTerm",
 							},
 						},
@@ -2140,26 +2141,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1160, col: 1, offset: 35345},
+			pos:  position{line: 1161, col: 1, offset: 35375},
 			expr: &actionExpr{
-				pos: position{line: 1160, col: 15, offset: 35359},
+				pos: position{line: 1161, col: 15, offset: 35389},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1160, col: 15, offset: 35359},
+					pos:   position{line: 1161, col: 15, offset: 35389},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1160, col: 21, offset: 35365},
+						pos: position{line: 1161, col: 21, offset: 35395},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 21, offset: 35365},
+								pos:  position{line: 1161, col: 21, offset: 35395},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 44, offset: 35388},
+								pos:  position{line: 1161, col: 44, offset: 35418},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 68, offset: 35412},
+								pos:  position{line: 1161, col: 68, offset: 35442},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2169,36 +2170,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1165, col: 1, offset: 35553},
+			pos:  position{line: 1166, col: 1, offset: 35583},
 			expr: &actionExpr{
-				pos: position{line: 1165, col: 19, offset: 35571},
+				pos: position{line: 1166, col: 19, offset: 35601},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1165, col: 19, offset: 35571},
+					pos: position{line: 1166, col: 19, offset: 35601},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1165, col: 19, offset: 35571},
+							pos:  position{line: 1166, col: 19, offset: 35601},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1165, col: 24, offset: 35576},
+							pos:  position{line: 1166, col: 24, offset: 35606},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 38, offset: 35590},
+							pos:   position{line: 1166, col: 38, offset: 35620},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1165, col: 45, offset: 35597},
+								pos:  position{line: 1166, col: 45, offset: 35627},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 68, offset: 35620},
+							pos:   position{line: 1166, col: 68, offset: 35650},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1165, col: 78, offset: 35630},
+								pos: position{line: 1166, col: 78, offset: 35660},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1165, col: 79, offset: 35631},
+									pos:  position{line: 1166, col: 79, offset: 35661},
 									name: "LimitExpr",
 								},
 							},
@@ -2209,35 +2210,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1253, col: 1, offset: 38374},
+			pos:  position{line: 1254, col: 1, offset: 38404},
 			expr: &actionExpr{
-				pos: position{line: 1253, col: 27, offset: 38400},
+				pos: position{line: 1254, col: 27, offset: 38430},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1253, col: 27, offset: 38400},
+					pos: position{line: 1254, col: 27, offset: 38430},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1253, col: 27, offset: 38400},
+							pos:   position{line: 1254, col: 27, offset: 38430},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1253, col: 33, offset: 38406},
+								pos:  position{line: 1254, col: 33, offset: 38436},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1253, col: 51, offset: 38424},
+							pos:   position{line: 1254, col: 51, offset: 38454},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1253, col: 56, offset: 38429},
+								pos: position{line: 1254, col: 56, offset: 38459},
 								expr: &seqExpr{
-									pos: position{line: 1253, col: 57, offset: 38430},
+									pos: position{line: 1254, col: 57, offset: 38460},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1253, col: 57, offset: 38430},
+											pos:  position{line: 1254, col: 57, offset: 38460},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1253, col: 63, offset: 38436},
+											pos:  position{line: 1254, col: 63, offset: 38466},
 											name: "TimechartArgument",
 										},
 									},
@@ -2250,22 +2251,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1282, col: 1, offset: 39170},
+			pos:  position{line: 1283, col: 1, offset: 39200},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 22, offset: 39191},
+				pos: position{line: 1283, col: 22, offset: 39221},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1282, col: 22, offset: 39191},
+					pos:   position{line: 1283, col: 22, offset: 39221},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1282, col: 29, offset: 39198},
+						pos: position{line: 1283, col: 29, offset: 39228},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1282, col: 29, offset: 39198},
+								pos:  position{line: 1283, col: 29, offset: 39228},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1282, col: 45, offset: 39214},
+								pos:  position{line: 1283, col: 45, offset: 39244},
 								name: "TcOptions",
 							},
 						},
@@ -2275,28 +2276,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1286, col: 1, offset: 39252},
+			pos:  position{line: 1287, col: 1, offset: 39282},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 18, offset: 39269},
+				pos: position{line: 1287, col: 18, offset: 39299},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 18, offset: 39269},
+					pos: position{line: 1287, col: 18, offset: 39299},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1286, col: 18, offset: 39269},
+							pos:   position{line: 1287, col: 18, offset: 39299},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 23, offset: 39274},
+								pos:  position{line: 1287, col: 23, offset: 39304},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 39, offset: 39290},
+							pos:   position{line: 1287, col: 39, offset: 39320},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1286, col: 53, offset: 39304},
+								pos: position{line: 1287, col: 53, offset: 39334},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1286, col: 53, offset: 39304},
+									pos:  position{line: 1287, col: 53, offset: 39334},
 									name: "SplitByClause",
 								},
 							},
@@ -2307,22 +2308,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1300, col: 1, offset: 39643},
+			pos:  position{line: 1301, col: 1, offset: 39673},
 			expr: &actionExpr{
-				pos: position{line: 1300, col: 18, offset: 39660},
+				pos: position{line: 1301, col: 18, offset: 39690},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1300, col: 18, offset: 39660},
+					pos: position{line: 1301, col: 18, offset: 39690},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1300, col: 18, offset: 39660},
+							pos:  position{line: 1301, col: 18, offset: 39690},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1300, col: 21, offset: 39663},
+							pos:   position{line: 1301, col: 21, offset: 39693},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1300, col: 27, offset: 39669},
+								pos:  position{line: 1301, col: 27, offset: 39699},
 								name: "FieldName",
 							},
 						},
@@ -2332,24 +2333,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1308, col: 1, offset: 39798},
+			pos:  position{line: 1309, col: 1, offset: 39828},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 14, offset: 39811},
+				pos: position{line: 1309, col: 14, offset: 39841},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1308, col: 14, offset: 39811},
+					pos:   position{line: 1309, col: 14, offset: 39841},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1308, col: 22, offset: 39819},
+						pos: position{line: 1309, col: 22, offset: 39849},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1308, col: 22, offset: 39819},
+								pos:  position{line: 1309, col: 22, offset: 39849},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1308, col: 35, offset: 39832},
+								pos: position{line: 1309, col: 35, offset: 39862},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1308, col: 36, offset: 39833},
+									pos:  position{line: 1309, col: 36, offset: 39863},
 									name: "TcOption",
 								},
 							},
@@ -2360,34 +2361,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1350, col: 1, offset: 41353},
+			pos:  position{line: 1351, col: 1, offset: 41383},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 13, offset: 41365},
+				pos: position{line: 1351, col: 13, offset: 41395},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1350, col: 13, offset: 41365},
+					pos: position{line: 1351, col: 13, offset: 41395},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1350, col: 13, offset: 41365},
+							pos:  position{line: 1351, col: 13, offset: 41395},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1350, col: 19, offset: 41371},
+							pos:   position{line: 1351, col: 19, offset: 41401},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1350, col: 31, offset: 41383},
+								pos:  position{line: 1351, col: 31, offset: 41413},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1350, col: 43, offset: 41395},
+							pos:  position{line: 1351, col: 43, offset: 41425},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1350, col: 49, offset: 41401},
+							pos:   position{line: 1351, col: 49, offset: 41431},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1350, col: 53, offset: 41405},
+								pos:  position{line: 1351, col: 53, offset: 41435},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2397,36 +2398,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1355, col: 1, offset: 41518},
+			pos:  position{line: 1356, col: 1, offset: 41548},
 			expr: &actionExpr{
-				pos: position{line: 1355, col: 16, offset: 41533},
+				pos: position{line: 1356, col: 16, offset: 41563},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1355, col: 16, offset: 41533},
+					pos:   position{line: 1356, col: 16, offset: 41563},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1355, col: 24, offset: 41541},
+						pos: position{line: 1356, col: 24, offset: 41571},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1355, col: 24, offset: 41541},
+								pos:        position{line: 1356, col: 24, offset: 41571},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 36, offset: 41553},
+								pos:        position{line: 1356, col: 36, offset: 41583},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 49, offset: 41566},
+								pos:        position{line: 1356, col: 49, offset: 41596},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 61, offset: 41578},
+								pos:        position{line: 1356, col: 61, offset: 41608},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2438,50 +2439,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1363, col: 1, offset: 41774},
+			pos:  position{line: 1364, col: 1, offset: 41804},
 			expr: &actionExpr{
-				pos: position{line: 1363, col: 17, offset: 41790},
+				pos: position{line: 1364, col: 17, offset: 41820},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1363, col: 17, offset: 41790},
+					pos:   position{line: 1364, col: 17, offset: 41820},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1363, col: 27, offset: 41800},
+						pos: position{line: 1364, col: 27, offset: 41830},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 27, offset: 41800},
+								pos:  position{line: 1364, col: 27, offset: 41830},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 36, offset: 41809},
+								pos:  position{line: 1364, col: 36, offset: 41839},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 44, offset: 41817},
+								pos:  position{line: 1364, col: 44, offset: 41847},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 57, offset: 41830},
+								pos:  position{line: 1364, col: 57, offset: 41860},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 66, offset: 41839},
+								pos:  position{line: 1364, col: 66, offset: 41869},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 73, offset: 41846},
+								pos:  position{line: 1364, col: 73, offset: 41876},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 79, offset: 41852},
+								pos:  position{line: 1364, col: 79, offset: 41882},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 86, offset: 41859},
+								pos:  position{line: 1364, col: 86, offset: 41889},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 96, offset: 41869},
+								pos:  position{line: 1364, col: 96, offset: 41899},
 								name: "Year",
 							},
 						},
@@ -2491,37 +2492,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1367, col: 1, offset: 41905},
+			pos:  position{line: 1368, col: 1, offset: 41935},
 			expr: &actionExpr{
-				pos: position{line: 1367, col: 21, offset: 41925},
+				pos: position{line: 1368, col: 21, offset: 41955},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1367, col: 21, offset: 41925},
+					pos: position{line: 1368, col: 21, offset: 41955},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1367, col: 21, offset: 41925},
+							pos:   position{line: 1368, col: 21, offset: 41955},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1367, col: 29, offset: 41933},
+								pos: position{line: 1368, col: 29, offset: 41963},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1367, col: 29, offset: 41933},
+										pos:  position{line: 1368, col: 29, offset: 41963},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1367, col: 45, offset: 41949},
+										pos:  position{line: 1368, col: 45, offset: 41979},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1367, col: 62, offset: 41966},
+							pos:   position{line: 1368, col: 62, offset: 41996},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1367, col: 72, offset: 41976},
+								pos: position{line: 1368, col: 72, offset: 42006},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1367, col: 73, offset: 41977},
+									pos:  position{line: 1368, col: 73, offset: 42007},
 									name: "AllTimeScale",
 								},
 							},
@@ -2532,28 +2533,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1426, col: 1, offset: 44659},
+			pos:  position{line: 1427, col: 1, offset: 44689},
 			expr: &actionExpr{
-				pos: position{line: 1426, col: 21, offset: 44679},
+				pos: position{line: 1427, col: 21, offset: 44709},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1426, col: 21, offset: 44679},
+					pos: position{line: 1427, col: 21, offset: 44709},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1426, col: 21, offset: 44679},
+							pos:        position{line: 1427, col: 21, offset: 44709},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1426, col: 31, offset: 44689},
+							pos:  position{line: 1427, col: 31, offset: 44719},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1426, col: 37, offset: 44695},
+							pos:   position{line: 1427, col: 37, offset: 44725},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1426, col: 48, offset: 44706},
+								pos:  position{line: 1427, col: 48, offset: 44736},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2563,28 +2564,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1437, col: 1, offset: 44947},
+			pos:  position{line: 1438, col: 1, offset: 44977},
 			expr: &actionExpr{
-				pos: position{line: 1437, col: 21, offset: 44967},
+				pos: position{line: 1438, col: 21, offset: 44997},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1437, col: 21, offset: 44967},
+					pos: position{line: 1438, col: 21, offset: 44997},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1437, col: 21, offset: 44967},
+							pos:        position{line: 1438, col: 21, offset: 44997},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1437, col: 28, offset: 44974},
+							pos:  position{line: 1438, col: 28, offset: 45004},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1437, col: 34, offset: 44980},
+							pos:   position{line: 1438, col: 34, offset: 45010},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1437, col: 43, offset: 44989},
+								pos:  position{line: 1438, col: 43, offset: 45019},
 								name: "IntegerAsString",
 							},
 						},
@@ -2594,31 +2595,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1458, col: 1, offset: 45568},
+			pos:  position{line: 1459, col: 1, offset: 45598},
 			expr: &choiceExpr{
-				pos: position{line: 1458, col: 23, offset: 45590},
+				pos: position{line: 1459, col: 23, offset: 45620},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1458, col: 23, offset: 45590},
+						pos: position{line: 1459, col: 23, offset: 45620},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1458, col: 23, offset: 45590},
+							pos: position{line: 1459, col: 23, offset: 45620},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1458, col: 23, offset: 45590},
+									pos:        position{line: 1459, col: 23, offset: 45620},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1458, col: 35, offset: 45602},
+									pos:  position{line: 1459, col: 35, offset: 45632},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1458, col: 41, offset: 45608},
+									pos:   position{line: 1459, col: 41, offset: 45638},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1458, col: 51, offset: 45618},
+										pos:  position{line: 1459, col: 51, offset: 45648},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2626,33 +2627,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 3, offset: 46037},
+						pos: position{line: 1473, col: 3, offset: 46067},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 3, offset: 46037},
+							pos: position{line: 1473, col: 3, offset: 46067},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1472, col: 3, offset: 46037},
+									pos:        position{line: 1473, col: 3, offset: 46067},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1472, col: 15, offset: 46049},
+									pos:  position{line: 1473, col: 15, offset: 46079},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 21, offset: 46055},
+									pos:   position{line: 1473, col: 21, offset: 46085},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1472, col: 32, offset: 46066},
+										pos: position{line: 1473, col: 32, offset: 46096},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1472, col: 32, offset: 46066},
+												pos:  position{line: 1473, col: 32, offset: 46096},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1472, col: 52, offset: 46086},
+												pos:  position{line: 1473, col: 52, offset: 46116},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2666,35 +2667,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1492, col: 1, offset: 46555},
+			pos:  position{line: 1493, col: 1, offset: 46585},
 			expr: &actionExpr{
-				pos: position{line: 1492, col: 19, offset: 46573},
+				pos: position{line: 1493, col: 19, offset: 46603},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1492, col: 19, offset: 46573},
+					pos: position{line: 1493, col: 19, offset: 46603},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1492, col: 19, offset: 46573},
+							pos:        position{line: 1493, col: 19, offset: 46603},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1492, col: 27, offset: 46581},
+							pos:  position{line: 1493, col: 27, offset: 46611},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1492, col: 33, offset: 46587},
+							pos:   position{line: 1493, col: 33, offset: 46617},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1492, col: 41, offset: 46595},
+								pos: position{line: 1493, col: 41, offset: 46625},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1492, col: 41, offset: 46595},
+										pos:  position{line: 1493, col: 41, offset: 46625},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1492, col: 57, offset: 46611},
+										pos:  position{line: 1493, col: 57, offset: 46641},
 										name: "IntegerAsString",
 									},
 								},
@@ -2706,35 +2707,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1507, col: 1, offset: 46990},
+			pos:  position{line: 1508, col: 1, offset: 47020},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 17, offset: 47006},
+				pos: position{line: 1508, col: 17, offset: 47036},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1507, col: 17, offset: 47006},
+					pos: position{line: 1508, col: 17, offset: 47036},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1507, col: 17, offset: 47006},
+							pos:        position{line: 1508, col: 17, offset: 47036},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1507, col: 23, offset: 47012},
+							pos:  position{line: 1508, col: 23, offset: 47042},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 29, offset: 47018},
+							pos:   position{line: 1508, col: 29, offset: 47048},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1507, col: 37, offset: 47026},
+								pos: position{line: 1508, col: 37, offset: 47056},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1507, col: 37, offset: 47026},
+										pos:  position{line: 1508, col: 37, offset: 47056},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1507, col: 53, offset: 47042},
+										pos:  position{line: 1508, col: 53, offset: 47072},
 										name: "IntegerAsString",
 									},
 								},
@@ -2746,40 +2747,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1522, col: 1, offset: 47413},
+			pos:  position{line: 1523, col: 1, offset: 47443},
 			expr: &choiceExpr{
-				pos: position{line: 1522, col: 18, offset: 47430},
+				pos: position{line: 1523, col: 18, offset: 47460},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1522, col: 18, offset: 47430},
+						pos: position{line: 1523, col: 18, offset: 47460},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1522, col: 18, offset: 47430},
+							pos: position{line: 1523, col: 18, offset: 47460},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1522, col: 18, offset: 47430},
+									pos:        position{line: 1523, col: 18, offset: 47460},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1522, col: 25, offset: 47437},
+									pos:  position{line: 1523, col: 25, offset: 47467},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 31, offset: 47443},
+									pos:   position{line: 1523, col: 31, offset: 47473},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1522, col: 36, offset: 47448},
+										pos: position{line: 1523, col: 36, offset: 47478},
 										expr: &choiceExpr{
-											pos: position{line: 1522, col: 37, offset: 47449},
+											pos: position{line: 1523, col: 37, offset: 47479},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 37, offset: 47449},
+													pos:  position{line: 1523, col: 37, offset: 47479},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 53, offset: 47465},
+													pos:  position{line: 1523, col: 53, offset: 47495},
 													name: "IntegerAsString",
 												},
 											},
@@ -2787,25 +2788,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1522, col: 71, offset: 47483},
+									pos:        position{line: 1523, col: 71, offset: 47513},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 77, offset: 47489},
+									pos:   position{line: 1523, col: 77, offset: 47519},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1522, col: 82, offset: 47494},
+										pos: position{line: 1523, col: 82, offset: 47524},
 										expr: &choiceExpr{
-											pos: position{line: 1522, col: 83, offset: 47495},
+											pos: position{line: 1523, col: 83, offset: 47525},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 83, offset: 47495},
+													pos:  position{line: 1523, col: 83, offset: 47525},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 99, offset: 47511},
+													pos:  position{line: 1523, col: 99, offset: 47541},
 													name: "IntegerAsString",
 												},
 											},
@@ -2816,26 +2817,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1565, col: 3, offset: 48947},
+						pos: position{line: 1566, col: 3, offset: 48977},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1565, col: 3, offset: 48947},
+							pos: position{line: 1566, col: 3, offset: 48977},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1565, col: 3, offset: 48947},
+									pos:        position{line: 1566, col: 3, offset: 48977},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1565, col: 10, offset: 48954},
+									pos:  position{line: 1566, col: 10, offset: 48984},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1565, col: 16, offset: 48960},
+									pos:   position{line: 1566, col: 16, offset: 48990},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1565, col: 24, offset: 48968},
+										pos:  position{line: 1566, col: 24, offset: 48998},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -2847,38 +2848,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1580, col: 1, offset: 49299},
+			pos:  position{line: 1581, col: 1, offset: 49329},
 			expr: &actionExpr{
-				pos: position{line: 1580, col: 17, offset: 49315},
+				pos: position{line: 1581, col: 17, offset: 49345},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1580, col: 17, offset: 49315},
+					pos:   position{line: 1581, col: 17, offset: 49345},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1580, col: 25, offset: 49323},
+						pos: position{line: 1581, col: 25, offset: 49353},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 25, offset: 49323},
+								pos:  position{line: 1581, col: 25, offset: 49353},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 46, offset: 49344},
+								pos:  position{line: 1581, col: 46, offset: 49374},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 65, offset: 49363},
+								pos:  position{line: 1581, col: 65, offset: 49393},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 84, offset: 49382},
+								pos:  position{line: 1581, col: 84, offset: 49412},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 101, offset: 49399},
+								pos:  position{line: 1581, col: 101, offset: 49429},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 116, offset: 49414},
+								pos:  position{line: 1581, col: 116, offset: 49444},
 								name: "BinOptionSpan",
 							},
 						},
@@ -2888,35 +2889,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1584, col: 1, offset: 49457},
+			pos:  position{line: 1585, col: 1, offset: 49487},
 			expr: &actionExpr{
-				pos: position{line: 1584, col: 22, offset: 49478},
+				pos: position{line: 1585, col: 22, offset: 49508},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1584, col: 22, offset: 49478},
+					pos: position{line: 1585, col: 22, offset: 49508},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1584, col: 22, offset: 49478},
+							pos:   position{line: 1585, col: 22, offset: 49508},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1584, col: 29, offset: 49485},
+								pos:  position{line: 1585, col: 29, offset: 49515},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1584, col: 42, offset: 49498},
+							pos:   position{line: 1585, col: 42, offset: 49528},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1584, col: 48, offset: 49504},
+								pos: position{line: 1585, col: 48, offset: 49534},
 								expr: &seqExpr{
-									pos: position{line: 1584, col: 49, offset: 49505},
+									pos: position{line: 1585, col: 49, offset: 49535},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1584, col: 49, offset: 49505},
+											pos:  position{line: 1585, col: 49, offset: 49535},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1584, col: 55, offset: 49511},
+											pos:  position{line: 1585, col: 55, offset: 49541},
 											name: "BinCmdOption",
 										},
 									},
@@ -2929,51 +2930,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1630, col: 1, offset: 50995},
+			pos:  position{line: 1631, col: 1, offset: 51025},
 			expr: &choiceExpr{
-				pos: position{line: 1630, col: 13, offset: 51007},
+				pos: position{line: 1631, col: 13, offset: 51037},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1630, col: 13, offset: 51007},
+						pos: position{line: 1631, col: 13, offset: 51037},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 13, offset: 51007},
+							pos: position{line: 1631, col: 13, offset: 51037},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 13, offset: 51007},
+									pos:  position{line: 1631, col: 13, offset: 51037},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 18, offset: 51012},
+									pos:  position{line: 1631, col: 18, offset: 51042},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 26, offset: 51020},
+									pos:   position{line: 1631, col: 26, offset: 51050},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 40, offset: 51034},
+										pos:  position{line: 1631, col: 40, offset: 51064},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 59, offset: 51053},
+									pos:  position{line: 1631, col: 59, offset: 51083},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 65, offset: 51059},
+									pos:   position{line: 1631, col: 65, offset: 51089},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 71, offset: 51065},
+										pos:  position{line: 1631, col: 71, offset: 51095},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 81, offset: 51075},
+									pos:   position{line: 1631, col: 81, offset: 51105},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1630, col: 94, offset: 51088},
+										pos: position{line: 1631, col: 94, offset: 51118},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1630, col: 95, offset: 51089},
+											pos:  position{line: 1631, col: 95, offset: 51119},
 											name: "AsField",
 										},
 									},
@@ -2982,34 +2983,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1653, col: 3, offset: 51718},
+						pos: position{line: 1654, col: 3, offset: 51748},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1653, col: 3, offset: 51718},
+							pos: position{line: 1654, col: 3, offset: 51748},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 3, offset: 51718},
+									pos:  position{line: 1654, col: 3, offset: 51748},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 8, offset: 51723},
+									pos:  position{line: 1654, col: 8, offset: 51753},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1653, col: 16, offset: 51731},
+									pos:   position{line: 1654, col: 16, offset: 51761},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1653, col: 22, offset: 51737},
+										pos:  position{line: 1654, col: 22, offset: 51767},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1653, col: 32, offset: 51747},
+									pos:   position{line: 1654, col: 32, offset: 51777},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1653, col: 45, offset: 51760},
+										pos: position{line: 1654, col: 45, offset: 51790},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1653, col: 46, offset: 51761},
+											pos:  position{line: 1654, col: 46, offset: 51791},
 											name: "AsField",
 										},
 									},
@@ -3022,15 +3023,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1680, col: 1, offset: 52499},
+			pos:  position{line: 1681, col: 1, offset: 52529},
 			expr: &actionExpr{
-				pos: position{line: 1680, col: 15, offset: 52513},
+				pos: position{line: 1681, col: 15, offset: 52543},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1680, col: 15, offset: 52513},
+					pos:   position{line: 1681, col: 15, offset: 52543},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1680, col: 27, offset: 52525},
+						pos:  position{line: 1681, col: 27, offset: 52555},
 						name: "SpanOptions",
 					},
 				},
@@ -3038,26 +3039,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1688, col: 1, offset: 52750},
+			pos:  position{line: 1689, col: 1, offset: 52780},
 			expr: &actionExpr{
-				pos: position{line: 1688, col: 16, offset: 52765},
+				pos: position{line: 1689, col: 16, offset: 52795},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1688, col: 16, offset: 52765},
+					pos: position{line: 1689, col: 16, offset: 52795},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 16, offset: 52765},
+							pos:  position{line: 1689, col: 16, offset: 52795},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 25, offset: 52774},
+							pos:  position{line: 1689, col: 25, offset: 52804},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1688, col: 31, offset: 52780},
+							pos:   position{line: 1689, col: 31, offset: 52810},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1688, col: 42, offset: 52791},
+								pos:  position{line: 1689, col: 42, offset: 52821},
 								name: "SpanLength",
 							},
 						},
@@ -3067,26 +3068,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1695, col: 1, offset: 52937},
+			pos:  position{line: 1696, col: 1, offset: 52967},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 15, offset: 52951},
+				pos: position{line: 1696, col: 15, offset: 52981},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 15, offset: 52951},
+					pos: position{line: 1696, col: 15, offset: 52981},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1695, col: 15, offset: 52951},
+							pos:   position{line: 1696, col: 15, offset: 52981},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 24, offset: 52960},
+								pos:  position{line: 1696, col: 24, offset: 52990},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 40, offset: 52976},
+							pos:   position{line: 1696, col: 40, offset: 53006},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 50, offset: 52986},
+								pos:  position{line: 1696, col: 50, offset: 53016},
 								name: "AllTimeScale",
 							},
 						},
@@ -3096,43 +3097,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1712, col: 1, offset: 53532},
+			pos:  position{line: 1713, col: 1, offset: 53562},
 			expr: &actionExpr{
-				pos: position{line: 1712, col: 14, offset: 53545},
+				pos: position{line: 1713, col: 14, offset: 53575},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1712, col: 14, offset: 53545},
+					pos: position{line: 1713, col: 14, offset: 53575},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 14, offset: 53545},
+							pos:  position{line: 1713, col: 14, offset: 53575},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1712, col: 20, offset: 53551},
+							pos:        position{line: 1713, col: 20, offset: 53581},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 28, offset: 53559},
+							pos:  position{line: 1713, col: 28, offset: 53589},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1712, col: 34, offset: 53565},
+							pos:   position{line: 1713, col: 34, offset: 53595},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1712, col: 41, offset: 53572},
+								pos: position{line: 1713, col: 41, offset: 53602},
 								expr: &choiceExpr{
-									pos: position{line: 1712, col: 42, offset: 53573},
+									pos: position{line: 1713, col: 42, offset: 53603},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1712, col: 42, offset: 53573},
+											pos:        position{line: 1713, col: 42, offset: 53603},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1712, col: 50, offset: 53581},
+											pos:        position{line: 1713, col: 50, offset: 53611},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3142,14 +3143,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 61, offset: 53592},
+							pos:  position{line: 1713, col: 61, offset: 53622},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1712, col: 76, offset: 53607},
+							pos:   position{line: 1713, col: 76, offset: 53637},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1712, col: 86, offset: 53617},
+								pos:  position{line: 1713, col: 86, offset: 53647},
 								name: "IntegerAsString",
 							},
 						},
@@ -3159,22 +3160,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1736, col: 1, offset: 54198},
+			pos:  position{line: 1737, col: 1, offset: 54228},
 			expr: &actionExpr{
-				pos: position{line: 1736, col: 19, offset: 54216},
+				pos: position{line: 1737, col: 19, offset: 54246},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1736, col: 19, offset: 54216},
+					pos: position{line: 1737, col: 19, offset: 54246},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1736, col: 19, offset: 54216},
+							pos:  position{line: 1737, col: 19, offset: 54246},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1736, col: 24, offset: 54221},
+							pos:   position{line: 1737, col: 24, offset: 54251},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1736, col: 38, offset: 54235},
+								pos:  position{line: 1737, col: 38, offset: 54265},
 								name: "StatisticExpr",
 							},
 						},
@@ -3184,76 +3185,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1769, col: 1, offset: 55213},
+			pos:  position{line: 1770, col: 1, offset: 55243},
 			expr: &actionExpr{
-				pos: position{line: 1769, col: 18, offset: 55230},
+				pos: position{line: 1770, col: 18, offset: 55260},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1769, col: 18, offset: 55230},
+					pos: position{line: 1770, col: 18, offset: 55260},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1769, col: 18, offset: 55230},
+							pos:   position{line: 1770, col: 18, offset: 55260},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1769, col: 23, offset: 55235},
+								pos: position{line: 1770, col: 23, offset: 55265},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 23, offset: 55235},
+										pos:  position{line: 1770, col: 23, offset: 55265},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 33, offset: 55245},
+										pos:  position{line: 1770, col: 33, offset: 55275},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 43, offset: 55255},
+							pos:   position{line: 1770, col: 43, offset: 55285},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 49, offset: 55261},
+								pos: position{line: 1770, col: 49, offset: 55291},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 50, offset: 55262},
+									pos:  position{line: 1770, col: 50, offset: 55292},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 67, offset: 55279},
+							pos:   position{line: 1770, col: 67, offset: 55309},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1769, col: 78, offset: 55290},
+								pos: position{line: 1770, col: 78, offset: 55320},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 78, offset: 55290},
+										pos:  position{line: 1770, col: 78, offset: 55320},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 84, offset: 55296},
+										pos:  position{line: 1770, col: 84, offset: 55326},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 99, offset: 55311},
+							pos:   position{line: 1770, col: 99, offset: 55341},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 108, offset: 55320},
+								pos: position{line: 1770, col: 108, offset: 55350},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 109, offset: 55321},
+									pos:  position{line: 1770, col: 109, offset: 55351},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 120, offset: 55332},
+							pos:   position{line: 1770, col: 120, offset: 55362},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 128, offset: 55340},
+								pos: position{line: 1770, col: 128, offset: 55370},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 129, offset: 55341},
+									pos:  position{line: 1770, col: 129, offset: 55371},
 									name: "StatisticOptions",
 								},
 							},
@@ -3264,25 +3265,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1811, col: 1, offset: 56426},
+			pos:  position{line: 1812, col: 1, offset: 56456},
 			expr: &choiceExpr{
-				pos: position{line: 1811, col: 19, offset: 56444},
+				pos: position{line: 1812, col: 19, offset: 56474},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1811, col: 19, offset: 56444},
+						pos: position{line: 1812, col: 19, offset: 56474},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1811, col: 19, offset: 56444},
+							pos: position{line: 1812, col: 19, offset: 56474},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1811, col: 19, offset: 56444},
+									pos:  position{line: 1812, col: 19, offset: 56474},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1811, col: 25, offset: 56450},
+									pos:   position{line: 1812, col: 25, offset: 56480},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1811, col: 32, offset: 56457},
+										pos:  position{line: 1812, col: 32, offset: 56487},
 										name: "IntegerAsString",
 									},
 								},
@@ -3290,30 +3291,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1814, col: 3, offset: 56511},
+						pos: position{line: 1815, col: 3, offset: 56541},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1814, col: 3, offset: 56511},
+							pos: position{line: 1815, col: 3, offset: 56541},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1814, col: 3, offset: 56511},
+									pos:  position{line: 1815, col: 3, offset: 56541},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1814, col: 9, offset: 56517},
+									pos:        position{line: 1815, col: 9, offset: 56547},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1814, col: 17, offset: 56525},
+									pos:  position{line: 1815, col: 17, offset: 56555},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1814, col: 23, offset: 56531},
+									pos:   position{line: 1815, col: 23, offset: 56561},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1814, col: 30, offset: 56538},
+										pos:  position{line: 1815, col: 30, offset: 56568},
 										name: "IntegerAsString",
 									},
 								},
@@ -3325,17 +3326,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1819, col: 1, offset: 56636},
+			pos:  position{line: 1820, col: 1, offset: 56666},
 			expr: &actionExpr{
-				pos: position{line: 1819, col: 21, offset: 56656},
+				pos: position{line: 1820, col: 21, offset: 56686},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1819, col: 21, offset: 56656},
+					pos:   position{line: 1820, col: 21, offset: 56686},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1819, col: 28, offset: 56663},
+						pos: position{line: 1820, col: 28, offset: 56693},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1819, col: 29, offset: 56664},
+							pos:  position{line: 1820, col: 29, offset: 56694},
 							name: "StatisticOption",
 						},
 					},
@@ -3344,34 +3345,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1868, col: 1, offset: 58226},
+			pos:  position{line: 1869, col: 1, offset: 58256},
 			expr: &actionExpr{
-				pos: position{line: 1868, col: 20, offset: 58245},
+				pos: position{line: 1869, col: 20, offset: 58275},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1868, col: 20, offset: 58245},
+					pos: position{line: 1869, col: 20, offset: 58275},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 20, offset: 58245},
+							pos:  position{line: 1869, col: 20, offset: 58275},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 26, offset: 58251},
+							pos:   position{line: 1869, col: 26, offset: 58281},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 36, offset: 58261},
+								pos:  position{line: 1869, col: 36, offset: 58291},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 55, offset: 58280},
+							pos:  position{line: 1869, col: 55, offset: 58310},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 61, offset: 58286},
+							pos:   position{line: 1869, col: 61, offset: 58316},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 67, offset: 58292},
+								pos:  position{line: 1869, col: 67, offset: 58322},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3381,48 +3382,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1873, col: 1, offset: 58401},
+			pos:  position{line: 1874, col: 1, offset: 58431},
 			expr: &actionExpr{
-				pos: position{line: 1873, col: 23, offset: 58423},
+				pos: position{line: 1874, col: 23, offset: 58453},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1873, col: 23, offset: 58423},
+					pos:   position{line: 1874, col: 23, offset: 58453},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1873, col: 31, offset: 58431},
+						pos: position{line: 1874, col: 31, offset: 58461},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1873, col: 31, offset: 58431},
+								pos:        position{line: 1874, col: 31, offset: 58461},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 46, offset: 58446},
+								pos:        position{line: 1874, col: 46, offset: 58476},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 60, offset: 58460},
+								pos:        position{line: 1874, col: 60, offset: 58490},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 73, offset: 58473},
+								pos:        position{line: 1874, col: 73, offset: 58503},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 85, offset: 58485},
+								pos:        position{line: 1874, col: 85, offset: 58515},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 102, offset: 58502},
+								pos:        position{line: 1874, col: 102, offset: 58532},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3434,25 +3435,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1881, col: 1, offset: 58689},
+			pos:  position{line: 1882, col: 1, offset: 58719},
 			expr: &choiceExpr{
-				pos: position{line: 1881, col: 13, offset: 58701},
+				pos: position{line: 1882, col: 13, offset: 58731},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1881, col: 13, offset: 58701},
+						pos: position{line: 1882, col: 13, offset: 58731},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1881, col: 13, offset: 58701},
+							pos: position{line: 1882, col: 13, offset: 58731},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1881, col: 13, offset: 58701},
+									pos:  position{line: 1882, col: 13, offset: 58731},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1881, col: 16, offset: 58704},
+									pos:   position{line: 1882, col: 16, offset: 58734},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1881, col: 26, offset: 58714},
+										pos:  position{line: 1882, col: 26, offset: 58744},
 										name: "FieldNameList",
 									},
 								},
@@ -3460,13 +3461,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1884, col: 3, offset: 58771},
+						pos: position{line: 1885, col: 3, offset: 58801},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1884, col: 3, offset: 58771},
+							pos:   position{line: 1885, col: 3, offset: 58801},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 16, offset: 58784},
+								pos:  position{line: 1885, col: 16, offset: 58814},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3476,26 +3477,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1888, col: 1, offset: 58842},
+			pos:  position{line: 1889, col: 1, offset: 58872},
 			expr: &actionExpr{
-				pos: position{line: 1888, col: 15, offset: 58856},
+				pos: position{line: 1889, col: 15, offset: 58886},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1888, col: 15, offset: 58856},
+					pos: position{line: 1889, col: 15, offset: 58886},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1888, col: 15, offset: 58856},
+							pos:  position{line: 1889, col: 15, offset: 58886},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1888, col: 20, offset: 58861},
+							pos:  position{line: 1889, col: 20, offset: 58891},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1888, col: 30, offset: 58871},
+							pos:   position{line: 1889, col: 30, offset: 58901},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1888, col: 40, offset: 58881},
+								pos:  position{line: 1889, col: 40, offset: 58911},
 								name: "DedupExpr",
 							},
 						},
@@ -3505,27 +3506,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1908, col: 1, offset: 59449},
+			pos:  position{line: 1909, col: 1, offset: 59479},
 			expr: &actionExpr{
-				pos: position{line: 1908, col: 14, offset: 59462},
+				pos: position{line: 1909, col: 14, offset: 59492},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1908, col: 14, offset: 59462},
+					pos: position{line: 1909, col: 14, offset: 59492},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1908, col: 14, offset: 59462},
+							pos:   position{line: 1909, col: 14, offset: 59492},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 23, offset: 59471},
+								pos: position{line: 1909, col: 23, offset: 59501},
 								expr: &seqExpr{
-									pos: position{line: 1908, col: 24, offset: 59472},
+									pos: position{line: 1909, col: 24, offset: 59502},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1908, col: 24, offset: 59472},
+											pos:  position{line: 1909, col: 24, offset: 59502},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1908, col: 30, offset: 59478},
+											pos:  position{line: 1909, col: 30, offset: 59508},
 											name: "IntegerAsString",
 										},
 									},
@@ -3533,45 +3534,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 48, offset: 59496},
+							pos:   position{line: 1909, col: 48, offset: 59526},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 57, offset: 59505},
+								pos: position{line: 1909, col: 57, offset: 59535},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 58, offset: 59506},
+									pos:  position{line: 1909, col: 58, offset: 59536},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 73, offset: 59521},
+							pos:   position{line: 1909, col: 73, offset: 59551},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 83, offset: 59531},
+								pos: position{line: 1909, col: 83, offset: 59561},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 84, offset: 59532},
+									pos:  position{line: 1909, col: 84, offset: 59562},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 101, offset: 59549},
+							pos:   position{line: 1909, col: 101, offset: 59579},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 110, offset: 59558},
+								pos: position{line: 1909, col: 110, offset: 59588},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 111, offset: 59559},
+									pos:  position{line: 1909, col: 111, offset: 59589},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 126, offset: 59574},
+							pos:   position{line: 1909, col: 126, offset: 59604},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 139, offset: 59587},
+								pos: position{line: 1909, col: 139, offset: 59617},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 140, offset: 59588},
+									pos:  position{line: 1909, col: 140, offset: 59618},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3582,27 +3583,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 1965, col: 1, offset: 61326},
+			pos:  position{line: 1966, col: 1, offset: 61356},
 			expr: &actionExpr{
-				pos: position{line: 1965, col: 19, offset: 61344},
+				pos: position{line: 1966, col: 19, offset: 61374},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 1965, col: 19, offset: 61344},
+					pos: position{line: 1966, col: 19, offset: 61374},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1965, col: 19, offset: 61344},
+							pos: position{line: 1966, col: 19, offset: 61374},
 							expr: &litMatcher{
-								pos:        position{line: 1965, col: 21, offset: 61346},
+								pos:        position{line: 1966, col: 21, offset: 61376},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1965, col: 31, offset: 61356},
+							pos:   position{line: 1966, col: 31, offset: 61386},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1965, col: 37, offset: 61362},
+								pos:  position{line: 1966, col: 37, offset: 61392},
 								name: "FieldName",
 							},
 						},
@@ -3612,48 +3613,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 1971, col: 1, offset: 61501},
+			pos:  position{line: 1972, col: 1, offset: 61531},
 			expr: &actionExpr{
-				pos: position{line: 1971, col: 32, offset: 61532},
+				pos: position{line: 1972, col: 32, offset: 61562},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 1971, col: 32, offset: 61532},
+					pos: position{line: 1972, col: 32, offset: 61562},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1971, col: 32, offset: 61532},
+							pos:   position{line: 1972, col: 32, offset: 61562},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 38, offset: 61538},
+								pos:  position{line: 1972, col: 38, offset: 61568},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1971, col: 48, offset: 61548},
+							pos: position{line: 1972, col: 48, offset: 61578},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 50, offset: 61550},
+								pos:  position{line: 1972, col: 50, offset: 61580},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 57, offset: 61557},
+							pos:   position{line: 1972, col: 57, offset: 61587},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1971, col: 62, offset: 61562},
+								pos: position{line: 1972, col: 62, offset: 61592},
 								expr: &seqExpr{
-									pos: position{line: 1971, col: 63, offset: 61563},
+									pos: position{line: 1972, col: 63, offset: 61593},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1971, col: 63, offset: 61563},
+											pos:  position{line: 1972, col: 63, offset: 61593},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1971, col: 69, offset: 61569},
+											pos:  position{line: 1972, col: 69, offset: 61599},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 1971, col: 79, offset: 61579},
+											pos: position{line: 1972, col: 79, offset: 61609},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1971, col: 81, offset: 61581},
+												pos:  position{line: 1972, col: 81, offset: 61611},
 												name: "EQUAL",
 											},
 										},
@@ -3667,45 +3668,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 1982, col: 1, offset: 61856},
+			pos:  position{line: 1983, col: 1, offset: 61886},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 19, offset: 61874},
+				pos: position{line: 1983, col: 19, offset: 61904},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1982, col: 19, offset: 61874},
+					pos: position{line: 1983, col: 19, offset: 61904},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 19, offset: 61874},
+							pos:  position{line: 1983, col: 19, offset: 61904},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 25, offset: 61880},
+							pos:   position{line: 1983, col: 25, offset: 61910},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 31, offset: 61886},
+								pos:  position{line: 1983, col: 31, offset: 61916},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 46, offset: 61901},
+							pos:   position{line: 1983, col: 46, offset: 61931},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1982, col: 51, offset: 61906},
+								pos: position{line: 1983, col: 51, offset: 61936},
 								expr: &seqExpr{
-									pos: position{line: 1982, col: 52, offset: 61907},
+									pos: position{line: 1983, col: 52, offset: 61937},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 52, offset: 61907},
+											pos:  position{line: 1983, col: 52, offset: 61937},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 58, offset: 61913},
+											pos:  position{line: 1983, col: 58, offset: 61943},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 1982, col: 73, offset: 61928},
+											pos: position{line: 1983, col: 73, offset: 61958},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1982, col: 74, offset: 61929},
+												pos:  position{line: 1983, col: 74, offset: 61959},
 												name: "EQUAL",
 											},
 										},
@@ -3719,17 +3720,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2000, col: 1, offset: 62457},
+			pos:  position{line: 2001, col: 1, offset: 62487},
 			expr: &actionExpr{
-				pos: position{line: 2000, col: 17, offset: 62473},
+				pos: position{line: 2001, col: 17, offset: 62503},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2000, col: 17, offset: 62473},
+					pos:   position{line: 2001, col: 17, offset: 62503},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2000, col: 24, offset: 62480},
+						pos: position{line: 2001, col: 24, offset: 62510},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2000, col: 25, offset: 62481},
+							pos:  position{line: 2001, col: 25, offset: 62511},
 							name: "DedupOption",
 						},
 					},
@@ -3738,36 +3739,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2040, col: 1, offset: 63747},
+			pos:  position{line: 2041, col: 1, offset: 63777},
 			expr: &actionExpr{
-				pos: position{line: 2040, col: 16, offset: 63762},
+				pos: position{line: 2041, col: 16, offset: 63792},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2040, col: 16, offset: 63762},
+					pos: position{line: 2041, col: 16, offset: 63792},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2040, col: 16, offset: 63762},
+							pos:  position{line: 2041, col: 16, offset: 63792},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 22, offset: 63768},
+							pos:   position{line: 2041, col: 22, offset: 63798},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 32, offset: 63778},
+								pos:  position{line: 2041, col: 32, offset: 63808},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2040, col: 47, offset: 63793},
+							pos:        position{line: 2041, col: 47, offset: 63823},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 51, offset: 63797},
+							pos:   position{line: 2041, col: 51, offset: 63827},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 57, offset: 63803},
+								pos:  position{line: 2041, col: 57, offset: 63833},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3777,30 +3778,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2045, col: 1, offset: 63912},
+			pos:  position{line: 2046, col: 1, offset: 63942},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 19, offset: 63930},
+				pos: position{line: 2046, col: 19, offset: 63960},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2045, col: 19, offset: 63930},
+					pos:   position{line: 2046, col: 19, offset: 63960},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2045, col: 27, offset: 63938},
+						pos: position{line: 2046, col: 27, offset: 63968},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2045, col: 27, offset: 63938},
+								pos:        position{line: 2046, col: 27, offset: 63968},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2045, col: 43, offset: 63954},
+								pos:        position{line: 2046, col: 43, offset: 63984},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2045, col: 57, offset: 63968},
+								pos:        position{line: 2046, col: 57, offset: 63998},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3812,22 +3813,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2053, col: 1, offset: 64153},
+			pos:  position{line: 2054, col: 1, offset: 64183},
 			expr: &actionExpr{
-				pos: position{line: 2053, col: 22, offset: 64174},
+				pos: position{line: 2054, col: 22, offset: 64204},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2053, col: 22, offset: 64174},
+					pos: position{line: 2054, col: 22, offset: 64204},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2053, col: 22, offset: 64174},
+							pos:  position{line: 2054, col: 22, offset: 64204},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2053, col: 39, offset: 64191},
+							pos:   position{line: 2054, col: 39, offset: 64221},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2053, col: 53, offset: 64205},
+								pos:  position{line: 2054, col: 53, offset: 64235},
 								name: "SortElements",
 							},
 						},
@@ -3837,35 +3838,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2058, col: 1, offset: 64313},
+			pos:  position{line: 2059, col: 1, offset: 64343},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 17, offset: 64329},
+				pos: position{line: 2059, col: 17, offset: 64359},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2058, col: 17, offset: 64329},
+					pos: position{line: 2059, col: 17, offset: 64359},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2058, col: 17, offset: 64329},
+							pos:   position{line: 2059, col: 17, offset: 64359},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2058, col: 23, offset: 64335},
+								pos:  position{line: 2059, col: 23, offset: 64365},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 41, offset: 64353},
+							pos:   position{line: 2059, col: 41, offset: 64383},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2058, col: 46, offset: 64358},
+								pos: position{line: 2059, col: 46, offset: 64388},
 								expr: &seqExpr{
-									pos: position{line: 2058, col: 47, offset: 64359},
+									pos: position{line: 2059, col: 47, offset: 64389},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2058, col: 47, offset: 64359},
+											pos:  position{line: 2059, col: 47, offset: 64389},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2058, col: 62, offset: 64374},
+											pos:  position{line: 2059, col: 62, offset: 64404},
 											name: "SingleSortElement",
 										},
 									},
@@ -3878,22 +3879,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2073, col: 1, offset: 64732},
+			pos:  position{line: 2074, col: 1, offset: 64762},
 			expr: &actionExpr{
-				pos: position{line: 2073, col: 22, offset: 64753},
+				pos: position{line: 2074, col: 22, offset: 64783},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2073, col: 22, offset: 64753},
+					pos:   position{line: 2074, col: 22, offset: 64783},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2073, col: 31, offset: 64762},
+						pos: position{line: 2074, col: 31, offset: 64792},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2073, col: 31, offset: 64762},
+								pos:  position{line: 2074, col: 31, offset: 64792},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2073, col: 59, offset: 64790},
+								pos:  position{line: 2074, col: 59, offset: 64820},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -3903,33 +3904,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2077, col: 1, offset: 64849},
+			pos:  position{line: 2078, col: 1, offset: 64879},
 			expr: &actionExpr{
-				pos: position{line: 2077, col: 33, offset: 64881},
+				pos: position{line: 2078, col: 33, offset: 64911},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2077, col: 33, offset: 64881},
+					pos: position{line: 2078, col: 33, offset: 64911},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2077, col: 33, offset: 64881},
+							pos:   position{line: 2078, col: 33, offset: 64911},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2077, col: 47, offset: 64895},
+								pos: position{line: 2078, col: 47, offset: 64925},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2077, col: 47, offset: 64895},
+										pos:        position{line: 2078, col: 47, offset: 64925},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2077, col: 53, offset: 64901},
+										pos:        position{line: 2078, col: 53, offset: 64931},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2077, col: 59, offset: 64907},
+										pos:        position{line: 2078, col: 59, offset: 64937},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3938,10 +3939,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2077, col: 63, offset: 64911},
+							pos:   position{line: 2078, col: 63, offset: 64941},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2077, col: 69, offset: 64917},
+								pos:  position{line: 2078, col: 69, offset: 64947},
 								name: "FieldName",
 							},
 						},
@@ -3951,33 +3952,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2092, col: 1, offset: 65192},
+			pos:  position{line: 2093, col: 1, offset: 65222},
 			expr: &actionExpr{
-				pos: position{line: 2092, col: 30, offset: 65221},
+				pos: position{line: 2093, col: 30, offset: 65251},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2092, col: 30, offset: 65221},
+					pos: position{line: 2093, col: 30, offset: 65251},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2092, col: 30, offset: 65221},
+							pos:   position{line: 2093, col: 30, offset: 65251},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2092, col: 44, offset: 65235},
+								pos: position{line: 2093, col: 44, offset: 65265},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2092, col: 44, offset: 65235},
+										pos:        position{line: 2093, col: 44, offset: 65265},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 50, offset: 65241},
+										pos:        position{line: 2093, col: 50, offset: 65271},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 56, offset: 65247},
+										pos:        position{line: 2093, col: 56, offset: 65277},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3986,31 +3987,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 60, offset: 65251},
+							pos:   position{line: 2093, col: 60, offset: 65281},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2092, col: 64, offset: 65255},
+								pos: position{line: 2093, col: 64, offset: 65285},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2092, col: 64, offset: 65255},
+										pos:        position{line: 2093, col: 64, offset: 65285},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 73, offset: 65264},
+										pos:        position{line: 2093, col: 73, offset: 65294},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 81, offset: 65272},
+										pos:        position{line: 2093, col: 81, offset: 65302},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 88, offset: 65279},
+										pos:        position{line: 2093, col: 88, offset: 65309},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4019,19 +4020,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 95, offset: 65286},
+							pos:  position{line: 2093, col: 95, offset: 65316},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 103, offset: 65294},
+							pos:   position{line: 2093, col: 103, offset: 65324},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2092, col: 109, offset: 65300},
+								pos:  position{line: 2093, col: 109, offset: 65330},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 119, offset: 65310},
+							pos:  position{line: 2093, col: 119, offset: 65340},
 							name: "R_PAREN",
 						},
 					},
@@ -4040,26 +4041,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2112, col: 1, offset: 65735},
+			pos:  position{line: 2113, col: 1, offset: 65765},
 			expr: &actionExpr{
-				pos: position{line: 2112, col: 16, offset: 65750},
+				pos: position{line: 2113, col: 16, offset: 65780},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2112, col: 16, offset: 65750},
+					pos: position{line: 2113, col: 16, offset: 65780},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 16, offset: 65750},
+							pos:  position{line: 2113, col: 16, offset: 65780},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 21, offset: 65755},
+							pos:  position{line: 2113, col: 21, offset: 65785},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2112, col: 32, offset: 65766},
+							pos:   position{line: 2113, col: 32, offset: 65796},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2112, col: 43, offset: 65777},
+								pos:  position{line: 2113, col: 43, offset: 65807},
 								name: "RenameExpr",
 							},
 						},
@@ -4069,33 +4070,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2128, col: 1, offset: 66152},
+			pos:  position{line: 2129, col: 1, offset: 66182},
 			expr: &choiceExpr{
-				pos: position{line: 2128, col: 15, offset: 66166},
+				pos: position{line: 2129, col: 15, offset: 66196},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2128, col: 15, offset: 66166},
+						pos: position{line: 2129, col: 15, offset: 66196},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2128, col: 15, offset: 66166},
+							pos: position{line: 2129, col: 15, offset: 66196},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2128, col: 15, offset: 66166},
+									pos:   position{line: 2129, col: 15, offset: 66196},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2128, col: 31, offset: 66182},
+										pos:  position{line: 2129, col: 31, offset: 66212},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 45, offset: 66196},
+									pos:  position{line: 2129, col: 45, offset: 66226},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2128, col: 48, offset: 66199},
+									pos:   position{line: 2129, col: 48, offset: 66229},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2128, col: 59, offset: 66210},
+										pos:  position{line: 2129, col: 59, offset: 66240},
 										name: "QuotedString",
 									},
 								},
@@ -4103,28 +4104,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2139, col: 3, offset: 66529},
+						pos: position{line: 2140, col: 3, offset: 66559},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2139, col: 3, offset: 66529},
+							pos: position{line: 2140, col: 3, offset: 66559},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2139, col: 3, offset: 66529},
+									pos:   position{line: 2140, col: 3, offset: 66559},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 19, offset: 66545},
+										pos:  position{line: 2140, col: 19, offset: 66575},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 33, offset: 66559},
+									pos:  position{line: 2140, col: 33, offset: 66589},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2139, col: 36, offset: 66562},
+									pos:   position{line: 2140, col: 36, offset: 66592},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 47, offset: 66573},
+										pos:  position{line: 2140, col: 47, offset: 66603},
 										name: "RenamePattern",
 									},
 								},
@@ -4136,48 +4137,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2161, col: 1, offset: 67139},
+			pos:  position{line: 2162, col: 1, offset: 67169},
 			expr: &actionExpr{
-				pos: position{line: 2161, col: 13, offset: 67151},
+				pos: position{line: 2162, col: 13, offset: 67181},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2161, col: 13, offset: 67151},
+					pos: position{line: 2162, col: 13, offset: 67181},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 13, offset: 67151},
+							pos:  position{line: 2162, col: 13, offset: 67181},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 18, offset: 67156},
+							pos:  position{line: 2162, col: 18, offset: 67186},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2161, col: 26, offset: 67164},
+							pos:        position{line: 2162, col: 26, offset: 67194},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 34, offset: 67172},
+							pos:  position{line: 2162, col: 34, offset: 67202},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 40, offset: 67178},
+							pos:   position{line: 2162, col: 40, offset: 67208},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 46, offset: 67184},
+								pos:  position{line: 2162, col: 46, offset: 67214},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 62, offset: 67200},
+							pos:  position{line: 2162, col: 62, offset: 67230},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 68, offset: 67206},
+							pos:   position{line: 2162, col: 68, offset: 67236},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 72, offset: 67210},
+								pos:  position{line: 2162, col: 72, offset: 67240},
 								name: "QuotedString",
 							},
 						},
@@ -4187,37 +4188,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2189, col: 1, offset: 67913},
+			pos:  position{line: 2190, col: 1, offset: 67943},
 			expr: &actionExpr{
-				pos: position{line: 2189, col: 14, offset: 67926},
+				pos: position{line: 2190, col: 14, offset: 67956},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2189, col: 14, offset: 67926},
+					pos: position{line: 2190, col: 14, offset: 67956},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 14, offset: 67926},
+							pos:  position{line: 2190, col: 14, offset: 67956},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 19, offset: 67931},
+							pos:  position{line: 2190, col: 19, offset: 67961},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 28, offset: 67940},
+							pos:   position{line: 2190, col: 28, offset: 67970},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2189, col: 34, offset: 67946},
+								pos: position{line: 2190, col: 34, offset: 67976},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2189, col: 35, offset: 67947},
+									pos:  position{line: 2190, col: 35, offset: 67977},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 47, offset: 67959},
+							pos:   position{line: 2190, col: 47, offset: 67989},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2189, col: 58, offset: 67970},
+								pos:  position{line: 2190, col: 58, offset: 68000},
 								name: "SortElements",
 							},
 						},
@@ -4227,41 +4228,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2226, col: 1, offset: 68821},
+			pos:  position{line: 2227, col: 1, offset: 68851},
 			expr: &actionExpr{
-				pos: position{line: 2226, col: 14, offset: 68834},
+				pos: position{line: 2227, col: 14, offset: 68864},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2226, col: 14, offset: 68834},
+					pos: position{line: 2227, col: 14, offset: 68864},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2226, col: 14, offset: 68834},
+							pos: position{line: 2227, col: 14, offset: 68864},
 							expr: &seqExpr{
-								pos: position{line: 2226, col: 15, offset: 68835},
+								pos: position{line: 2227, col: 15, offset: 68865},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2226, col: 15, offset: 68835},
+										pos:        position{line: 2227, col: 15, offset: 68865},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2226, col: 23, offset: 68843},
+										pos:  position{line: 2227, col: 23, offset: 68873},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2226, col: 31, offset: 68851},
+							pos:   position{line: 2227, col: 31, offset: 68881},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2226, col: 40, offset: 68860},
+								pos:  position{line: 2227, col: 40, offset: 68890},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2226, col: 56, offset: 68876},
+							pos:  position{line: 2227, col: 56, offset: 68906},
 							name: "SPACE",
 						},
 					},
@@ -4270,43 +4271,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2240, col: 1, offset: 69175},
+			pos:  position{line: 2241, col: 1, offset: 69205},
 			expr: &actionExpr{
-				pos: position{line: 2240, col: 14, offset: 69188},
+				pos: position{line: 2241, col: 14, offset: 69218},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2240, col: 14, offset: 69188},
+					pos: position{line: 2241, col: 14, offset: 69218},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2240, col: 14, offset: 69188},
+							pos:  position{line: 2241, col: 14, offset: 69218},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2240, col: 19, offset: 69193},
+							pos:  position{line: 2241, col: 19, offset: 69223},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2240, col: 28, offset: 69202},
+							pos:   position{line: 2241, col: 28, offset: 69232},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2240, col: 34, offset: 69208},
+								pos:  position{line: 2241, col: 34, offset: 69238},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2240, col: 45, offset: 69219},
+							pos:   position{line: 2241, col: 45, offset: 69249},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2240, col: 50, offset: 69224},
+								pos: position{line: 2241, col: 50, offset: 69254},
 								expr: &seqExpr{
-									pos: position{line: 2240, col: 51, offset: 69225},
+									pos: position{line: 2241, col: 51, offset: 69255},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2240, col: 51, offset: 69225},
+											pos:  position{line: 2241, col: 51, offset: 69255},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2240, col: 57, offset: 69231},
+											pos:  position{line: 2241, col: 57, offset: 69261},
 											name: "SingleEval",
 										},
 									},
@@ -4319,30 +4320,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2267, col: 1, offset: 70032},
+			pos:  position{line: 2268, col: 1, offset: 70062},
 			expr: &actionExpr{
-				pos: position{line: 2267, col: 15, offset: 70046},
+				pos: position{line: 2268, col: 15, offset: 70076},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2267, col: 15, offset: 70046},
+					pos: position{line: 2268, col: 15, offset: 70076},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2267, col: 15, offset: 70046},
+							pos:   position{line: 2268, col: 15, offset: 70076},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2267, col: 21, offset: 70052},
+								pos:  position{line: 2268, col: 21, offset: 70082},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2267, col: 31, offset: 70062},
+							pos:  position{line: 2268, col: 31, offset: 70092},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2267, col: 37, offset: 70068},
+							pos:   position{line: 2268, col: 37, offset: 70098},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2267, col: 42, offset: 70073},
+								pos:  position{line: 2268, col: 42, offset: 70103},
 								name: "EvalExpression",
 							},
 						},
@@ -4352,15 +4353,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2280, col: 1, offset: 70474},
+			pos:  position{line: 2281, col: 1, offset: 70504},
 			expr: &actionExpr{
-				pos: position{line: 2280, col: 19, offset: 70492},
+				pos: position{line: 2281, col: 19, offset: 70522},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2280, col: 19, offset: 70492},
+					pos:   position{line: 2281, col: 19, offset: 70522},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2280, col: 25, offset: 70498},
+						pos:  position{line: 2281, col: 25, offset: 70528},
 						name: "ValueExpr",
 					},
 				},
@@ -4368,85 +4369,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2289, col: 1, offset: 70722},
+			pos:  position{line: 2290, col: 1, offset: 70752},
 			expr: &choiceExpr{
-				pos: position{line: 2289, col: 18, offset: 70739},
+				pos: position{line: 2290, col: 18, offset: 70769},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2289, col: 18, offset: 70739},
+						pos: position{line: 2290, col: 18, offset: 70769},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2289, col: 18, offset: 70739},
+							pos: position{line: 2290, col: 18, offset: 70769},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2289, col: 18, offset: 70739},
+									pos:        position{line: 2290, col: 18, offset: 70769},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 23, offset: 70744},
+									pos:  position{line: 2290, col: 23, offset: 70774},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 31, offset: 70752},
+									pos:   position{line: 2290, col: 31, offset: 70782},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 41, offset: 70762},
+										pos:  position{line: 2290, col: 41, offset: 70792},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 50, offset: 70771},
+									pos:  position{line: 2290, col: 50, offset: 70801},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 56, offset: 70777},
+									pos:   position{line: 2290, col: 56, offset: 70807},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 66, offset: 70787},
+										pos:  position{line: 2290, col: 66, offset: 70817},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 76, offset: 70797},
+									pos:  position{line: 2290, col: 76, offset: 70827},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 82, offset: 70803},
+									pos:   position{line: 2290, col: 82, offset: 70833},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 93, offset: 70814},
+										pos:  position{line: 2290, col: 93, offset: 70844},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 103, offset: 70824},
+									pos:  position{line: 2290, col: 103, offset: 70854},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2300, col: 3, offset: 71075},
+						pos: position{line: 2301, col: 3, offset: 71105},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2300, col: 3, offset: 71075},
+							pos: position{line: 2301, col: 3, offset: 71105},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2300, col: 3, offset: 71075},
+									pos:   position{line: 2301, col: 3, offset: 71105},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2300, col: 11, offset: 71083},
+										pos: position{line: 2301, col: 11, offset: 71113},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2300, col: 11, offset: 71083},
+												pos:        position{line: 2301, col: 11, offset: 71113},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2300, col: 20, offset: 71092},
+												pos:        position{line: 2301, col: 20, offset: 71122},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4455,31 +4456,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2300, col: 32, offset: 71104},
+									pos:  position{line: 2301, col: 32, offset: 71134},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2300, col: 40, offset: 71112},
+									pos:   position{line: 2301, col: 40, offset: 71142},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2300, col: 45, offset: 71117},
+										pos:  position{line: 2301, col: 45, offset: 71147},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2300, col: 64, offset: 71136},
+									pos:   position{line: 2301, col: 64, offset: 71166},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2300, col: 69, offset: 71141},
+										pos: position{line: 2301, col: 69, offset: 71171},
 										expr: &seqExpr{
-											pos: position{line: 2300, col: 70, offset: 71142},
+											pos: position{line: 2301, col: 70, offset: 71172},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2300, col: 70, offset: 71142},
+													pos:  position{line: 2301, col: 70, offset: 71172},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2300, col: 76, offset: 71148},
+													pos:  position{line: 2301, col: 76, offset: 71178},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4487,50 +4488,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2300, col: 97, offset: 71169},
+									pos:  position{line: 2301, col: 97, offset: 71199},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2323, col: 3, offset: 71773},
+						pos: position{line: 2324, col: 3, offset: 71803},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2323, col: 3, offset: 71773},
+							pos: position{line: 2324, col: 3, offset: 71803},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2323, col: 3, offset: 71773},
+									pos:        position{line: 2324, col: 3, offset: 71803},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 14, offset: 71784},
+									pos:  position{line: 2324, col: 14, offset: 71814},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2323, col: 22, offset: 71792},
+									pos:   position{line: 2324, col: 22, offset: 71822},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2323, col: 32, offset: 71802},
+										pos:  position{line: 2324, col: 32, offset: 71832},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2323, col: 42, offset: 71812},
+									pos:   position{line: 2324, col: 42, offset: 71842},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2323, col: 47, offset: 71817},
+										pos: position{line: 2324, col: 47, offset: 71847},
 										expr: &seqExpr{
-											pos: position{line: 2323, col: 48, offset: 71818},
+											pos: position{line: 2324, col: 48, offset: 71848},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2323, col: 48, offset: 71818},
+													pos:  position{line: 2324, col: 48, offset: 71848},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2323, col: 54, offset: 71824},
+													pos:  position{line: 2324, col: 54, offset: 71854},
 													name: "ValueExpr",
 												},
 											},
@@ -4538,73 +4539,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 66, offset: 71836},
+									pos:  position{line: 2324, col: 66, offset: 71866},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2340, col: 3, offset: 72255},
+						pos: position{line: 2341, col: 3, offset: 72285},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2340, col: 3, offset: 72255},
+							pos: position{line: 2341, col: 3, offset: 72285},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2340, col: 3, offset: 72255},
+									pos:        position{line: 2341, col: 3, offset: 72285},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 12, offset: 72264},
+									pos:  position{line: 2341, col: 12, offset: 72294},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2340, col: 20, offset: 72272},
+									pos:   position{line: 2341, col: 20, offset: 72302},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2340, col: 30, offset: 72282},
+										pos:  position{line: 2341, col: 30, offset: 72312},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 40, offset: 72292},
+									pos:  position{line: 2341, col: 40, offset: 72322},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2340, col: 46, offset: 72298},
+									pos:   position{line: 2341, col: 46, offset: 72328},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2340, col: 57, offset: 72309},
+										pos:  position{line: 2341, col: 57, offset: 72339},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 67, offset: 72319},
+									pos:  position{line: 2341, col: 67, offset: 72349},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2352, col: 3, offset: 72599},
+						pos: position{line: 2353, col: 3, offset: 72629},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2352, col: 3, offset: 72599},
+							pos: position{line: 2353, col: 3, offset: 72629},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2352, col: 3, offset: 72599},
+									pos:        position{line: 2353, col: 3, offset: 72629},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2352, col: 10, offset: 72606},
+									pos:  position{line: 2353, col: 10, offset: 72636},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2352, col: 18, offset: 72614},
+									pos:  position{line: 2353, col: 18, offset: 72644},
 									name: "R_PAREN",
 								},
 							},
@@ -4615,30 +4616,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2359, col: 1, offset: 72711},
+			pos:  position{line: 2360, col: 1, offset: 72741},
 			expr: &actionExpr{
-				pos: position{line: 2359, col: 23, offset: 72733},
+				pos: position{line: 2360, col: 23, offset: 72763},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2359, col: 23, offset: 72733},
+					pos: position{line: 2360, col: 23, offset: 72763},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2359, col: 23, offset: 72733},
+							pos:   position{line: 2360, col: 23, offset: 72763},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2359, col: 33, offset: 72743},
+								pos:  position{line: 2360, col: 33, offset: 72773},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2359, col: 42, offset: 72752},
+							pos:  position{line: 2360, col: 42, offset: 72782},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2359, col: 48, offset: 72758},
+							pos:   position{line: 2360, col: 48, offset: 72788},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2359, col: 54, offset: 72764},
+								pos:  position{line: 2360, col: 54, offset: 72794},
 								name: "ValueExpr",
 							},
 						},
@@ -4648,15 +4649,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2367, col: 1, offset: 72969},
+			pos:  position{line: 2368, col: 1, offset: 72999},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 26, offset: 72994},
+				pos: position{line: 2368, col: 26, offset: 73024},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2367, col: 26, offset: 72994},
+					pos:   position{line: 2368, col: 26, offset: 73024},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2367, col: 37, offset: 73005},
+						pos:  position{line: 2368, col: 37, offset: 73035},
 						name: "StringExpr",
 					},
 				},
@@ -4664,15 +4665,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2377, col: 1, offset: 73214},
+			pos:  position{line: 2378, col: 1, offset: 73244},
 			expr: &actionExpr{
-				pos: position{line: 2377, col: 30, offset: 73243},
+				pos: position{line: 2378, col: 30, offset: 73273},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2377, col: 30, offset: 73243},
+					pos:   position{line: 2378, col: 30, offset: 73273},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2377, col: 45, offset: 73258},
+						pos:  position{line: 2378, col: 45, offset: 73288},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4680,22 +4681,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2386, col: 1, offset: 73464},
+			pos:  position{line: 2387, col: 1, offset: 73494},
 			expr: &actionExpr{
-				pos: position{line: 2386, col: 27, offset: 73490},
+				pos: position{line: 2387, col: 27, offset: 73520},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2386, col: 27, offset: 73490},
+					pos:   position{line: 2387, col: 27, offset: 73520},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2386, col: 40, offset: 73503},
+						pos: position{line: 2387, col: 40, offset: 73533},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2386, col: 40, offset: 73503},
+								pos:  position{line: 2387, col: 40, offset: 73533},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2386, col: 68, offset: 73531},
+								pos:  position{line: 2387, col: 68, offset: 73561},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4705,135 +4706,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2390, col: 1, offset: 73608},
+			pos:  position{line: 2391, col: 1, offset: 73638},
 			expr: &choiceExpr{
-				pos: position{line: 2390, col: 19, offset: 73626},
+				pos: position{line: 2391, col: 19, offset: 73656},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2390, col: 19, offset: 73626},
+						pos: position{line: 2391, col: 19, offset: 73656},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2390, col: 20, offset: 73627},
+							pos: position{line: 2391, col: 20, offset: 73657},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2390, col: 20, offset: 73627},
+									pos:   position{line: 2391, col: 20, offset: 73657},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2390, col: 28, offset: 73635},
+										pos:        position{line: 2391, col: 28, offset: 73665},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 37, offset: 73644},
+									pos:  position{line: 2391, col: 37, offset: 73674},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2390, col: 45, offset: 73652},
+									pos:   position{line: 2391, col: 45, offset: 73682},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2390, col: 56, offset: 73663},
+										pos:  position{line: 2391, col: 56, offset: 73693},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 67, offset: 73674},
+									pos:  position{line: 2391, col: 67, offset: 73704},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2390, col: 73, offset: 73680},
+									pos:   position{line: 2391, col: 73, offset: 73710},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2390, col: 79, offset: 73686},
+										pos:  position{line: 2391, col: 79, offset: 73716},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 90, offset: 73697},
+									pos:  position{line: 2391, col: 90, offset: 73727},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2402, col: 3, offset: 74058},
+						pos: position{line: 2403, col: 3, offset: 74088},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2402, col: 4, offset: 74059},
+							pos: position{line: 2403, col: 4, offset: 74089},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2402, col: 4, offset: 74059},
+									pos:   position{line: 2403, col: 4, offset: 74089},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2402, col: 12, offset: 74067},
+										pos:        position{line: 2403, col: 12, offset: 74097},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 23, offset: 74078},
+									pos:  position{line: 2403, col: 23, offset: 74108},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 31, offset: 74086},
+									pos:   position{line: 2403, col: 31, offset: 74116},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2402, col: 46, offset: 74101},
+										pos:  position{line: 2403, col: 46, offset: 74131},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 61, offset: 74116},
+									pos:  position{line: 2403, col: 61, offset: 74146},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 67, offset: 74122},
+									pos:   position{line: 2403, col: 67, offset: 74152},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2402, col: 78, offset: 74133},
+										pos:  position{line: 2403, col: 78, offset: 74163},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 90, offset: 74145},
+									pos:   position{line: 2403, col: 90, offset: 74175},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2402, col: 99, offset: 74154},
+										pos: position{line: 2403, col: 99, offset: 74184},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2402, col: 100, offset: 74155},
+											pos:  position{line: 2403, col: 100, offset: 74185},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 119, offset: 74174},
+									pos:  position{line: 2403, col: 119, offset: 74204},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2418, col: 3, offset: 74736},
+						pos: position{line: 2419, col: 3, offset: 74766},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2418, col: 4, offset: 74737},
+							pos: position{line: 2419, col: 4, offset: 74767},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2418, col: 4, offset: 74737},
+									pos:   position{line: 2419, col: 4, offset: 74767},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2418, col: 12, offset: 74745},
+										pos: position{line: 2419, col: 12, offset: 74775},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2418, col: 12, offset: 74745},
+												pos:        position{line: 2419, col: 12, offset: 74775},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2418, col: 24, offset: 74757},
+												pos:        position{line: 2419, col: 24, offset: 74787},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4842,222 +4843,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2418, col: 34, offset: 74767},
+									pos:  position{line: 2419, col: 34, offset: 74797},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2418, col: 42, offset: 74775},
+									pos:   position{line: 2419, col: 42, offset: 74805},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2418, col: 57, offset: 74790},
+										pos:  position{line: 2419, col: 57, offset: 74820},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2418, col: 72, offset: 74805},
+									pos:  position{line: 2419, col: 72, offset: 74835},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2430, col: 3, offset: 75153},
+						pos: position{line: 2431, col: 3, offset: 75183},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2430, col: 4, offset: 75154},
+							pos: position{line: 2431, col: 4, offset: 75184},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2430, col: 4, offset: 75154},
+									pos:   position{line: 2431, col: 4, offset: 75184},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2430, col: 12, offset: 75162},
+										pos:        position{line: 2431, col: 12, offset: 75192},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2430, col: 24, offset: 75174},
+									pos:  position{line: 2431, col: 24, offset: 75204},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2430, col: 32, offset: 75182},
+									pos:   position{line: 2431, col: 32, offset: 75212},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2430, col: 42, offset: 75192},
+										pos:  position{line: 2431, col: 42, offset: 75222},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2430, col: 51, offset: 75201},
+									pos:  position{line: 2431, col: 51, offset: 75231},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2443, col: 3, offset: 75548},
+						pos: position{line: 2444, col: 3, offset: 75578},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2443, col: 4, offset: 75549},
+							pos: position{line: 2444, col: 4, offset: 75579},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2443, col: 4, offset: 75549},
+									pos:   position{line: 2444, col: 4, offset: 75579},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2443, col: 12, offset: 75557},
+										pos:        position{line: 2444, col: 12, offset: 75587},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 21, offset: 75566},
+									pos:  position{line: 2444, col: 21, offset: 75596},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2443, col: 29, offset: 75574},
+									pos:   position{line: 2444, col: 29, offset: 75604},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2443, col: 44, offset: 75589},
+										pos:  position{line: 2444, col: 44, offset: 75619},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 59, offset: 75604},
+									pos:  position{line: 2444, col: 59, offset: 75634},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2443, col: 65, offset: 75610},
+									pos:   position{line: 2444, col: 65, offset: 75640},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2443, col: 70, offset: 75615},
+										pos:  position{line: 2444, col: 70, offset: 75645},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 80, offset: 75625},
+									pos:  position{line: 2444, col: 80, offset: 75655},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2456, col: 3, offset: 76047},
+						pos: position{line: 2457, col: 3, offset: 76077},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2456, col: 4, offset: 76048},
+							pos: position{line: 2457, col: 4, offset: 76078},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2456, col: 4, offset: 76048},
+									pos:   position{line: 2457, col: 4, offset: 76078},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2456, col: 12, offset: 76056},
+										pos:        position{line: 2457, col: 12, offset: 76086},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 23, offset: 76067},
+									pos:  position{line: 2457, col: 23, offset: 76097},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 31, offset: 76075},
+									pos:   position{line: 2457, col: 31, offset: 76105},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2456, col: 42, offset: 76086},
+										pos:  position{line: 2457, col: 42, offset: 76116},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 54, offset: 76098},
+									pos:  position{line: 2457, col: 54, offset: 76128},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 60, offset: 76104},
+									pos:   position{line: 2457, col: 60, offset: 76134},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2456, col: 69, offset: 76113},
+										pos:  position{line: 2457, col: 69, offset: 76143},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 81, offset: 76125},
+									pos:  position{line: 2457, col: 81, offset: 76155},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 87, offset: 76131},
+									pos:   position{line: 2457, col: 87, offset: 76161},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2456, col: 98, offset: 76142},
+										pos: position{line: 2457, col: 98, offset: 76172},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2456, col: 99, offset: 76143},
+											pos:  position{line: 2457, col: 99, offset: 76173},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 112, offset: 76156},
+									pos:  position{line: 2457, col: 112, offset: 76186},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2469, col: 3, offset: 76607},
+						pos: position{line: 2470, col: 3, offset: 76637},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2469, col: 4, offset: 76608},
+							pos: position{line: 2470, col: 4, offset: 76638},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2469, col: 4, offset: 76608},
+									pos:   position{line: 2470, col: 4, offset: 76638},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2469, col: 12, offset: 76616},
+										pos:        position{line: 2470, col: 12, offset: 76646},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 21, offset: 76625},
+									pos:  position{line: 2470, col: 21, offset: 76655},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 29, offset: 76633},
+									pos:   position{line: 2470, col: 29, offset: 76663},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2469, col: 36, offset: 76640},
+										pos:  position{line: 2470, col: 36, offset: 76670},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 51, offset: 76655},
+									pos:  position{line: 2470, col: 51, offset: 76685},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 57, offset: 76661},
+									pos:   position{line: 2470, col: 57, offset: 76691},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2469, col: 65, offset: 76669},
+										pos:  position{line: 2470, col: 65, offset: 76699},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 80, offset: 76684},
+									pos:   position{line: 2470, col: 80, offset: 76714},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2469, col: 85, offset: 76689},
+										pos: position{line: 2470, col: 85, offset: 76719},
 										expr: &seqExpr{
-											pos: position{line: 2469, col: 86, offset: 76690},
+											pos: position{line: 2470, col: 86, offset: 76720},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2469, col: 86, offset: 76690},
+													pos:  position{line: 2470, col: 86, offset: 76720},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2469, col: 92, offset: 76696},
+													pos:  position{line: 2470, col: 92, offset: 76726},
 													name: "StringExpr",
 												},
 											},
@@ -5065,63 +5066,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 105, offset: 76709},
+									pos:  position{line: 2470, col: 105, offset: 76739},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2486, col: 3, offset: 77237},
+						pos: position{line: 2487, col: 3, offset: 77267},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2486, col: 4, offset: 77238},
+							pos: position{line: 2487, col: 4, offset: 77268},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2486, col: 4, offset: 77238},
+									pos:   position{line: 2487, col: 4, offset: 77268},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2486, col: 12, offset: 77246},
+										pos:        position{line: 2487, col: 12, offset: 77276},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 32, offset: 77266},
+									pos:  position{line: 2487, col: 32, offset: 77296},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 40, offset: 77274},
+									pos:   position{line: 2487, col: 40, offset: 77304},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2486, col: 55, offset: 77289},
+										pos:  position{line: 2487, col: 55, offset: 77319},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 70, offset: 77304},
+									pos:   position{line: 2487, col: 70, offset: 77334},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2486, col: 75, offset: 77309},
+										pos: position{line: 2487, col: 75, offset: 77339},
 										expr: &seqExpr{
-											pos: position{line: 2486, col: 76, offset: 77310},
+											pos: position{line: 2487, col: 76, offset: 77340},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2486, col: 76, offset: 77310},
+													pos:  position{line: 2487, col: 76, offset: 77340},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2486, col: 83, offset: 77317},
+													pos: position{line: 2487, col: 83, offset: 77347},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2486, col: 83, offset: 77317},
+															pos:        position{line: 2487, col: 83, offset: 77347},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2486, col: 92, offset: 77326},
+															pos:        position{line: 2487, col: 92, offset: 77356},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5129,7 +5130,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2486, col: 101, offset: 77335},
+													pos:        position{line: 2487, col: 101, offset: 77365},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5139,54 +5140,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 108, offset: 77342},
+									pos:  position{line: 2487, col: 108, offset: 77372},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2511, col: 3, offset: 78045},
+						pos: position{line: 2512, col: 3, offset: 78075},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2511, col: 4, offset: 78046},
+							pos: position{line: 2512, col: 4, offset: 78076},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2511, col: 4, offset: 78046},
+									pos:   position{line: 2512, col: 4, offset: 78076},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2511, col: 12, offset: 78054},
+										pos:        position{line: 2512, col: 12, offset: 78084},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 24, offset: 78066},
+									pos:  position{line: 2512, col: 24, offset: 78096},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 32, offset: 78074},
+									pos:   position{line: 2512, col: 32, offset: 78104},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 41, offset: 78083},
+										pos:  position{line: 2512, col: 41, offset: 78113},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 64, offset: 78106},
+									pos:   position{line: 2512, col: 64, offset: 78136},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2511, col: 69, offset: 78111},
+										pos: position{line: 2512, col: 69, offset: 78141},
 										expr: &seqExpr{
-											pos: position{line: 2511, col: 70, offset: 78112},
+											pos: position{line: 2512, col: 70, offset: 78142},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2511, col: 70, offset: 78112},
+													pos:  position{line: 2512, col: 70, offset: 78142},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2511, col: 76, offset: 78118},
+													pos:  position{line: 2512, col: 76, offset: 78148},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5194,57 +5195,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 101, offset: 78143},
+									pos:  position{line: 2512, col: 101, offset: 78173},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2531, col: 3, offset: 78731},
+						pos: position{line: 2532, col: 3, offset: 78761},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2531, col: 3, offset: 78731},
+							pos: position{line: 2532, col: 3, offset: 78761},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2531, col: 3, offset: 78731},
+									pos:   position{line: 2532, col: 3, offset: 78761},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2531, col: 9, offset: 78737},
+										pos:  position{line: 2532, col: 9, offset: 78767},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2531, col: 25, offset: 78753},
+									pos: position{line: 2532, col: 25, offset: 78783},
 									expr: &choiceExpr{
-										pos: position{line: 2531, col: 27, offset: 78755},
+										pos: position{line: 2532, col: 27, offset: 78785},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 27, offset: 78755},
+												pos:  position{line: 2532, col: 27, offset: 78785},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 36, offset: 78764},
+												pos:  position{line: 2532, col: 36, offset: 78794},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 46, offset: 78774},
+												pos:  position{line: 2532, col: 46, offset: 78804},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 54, offset: 78782},
+												pos:  position{line: 2532, col: 54, offset: 78812},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 62, offset: 78790},
+												pos:  position{line: 2532, col: 62, offset: 78820},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 70, offset: 78798},
+												pos:  position{line: 2532, col: 70, offset: 78828},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2531, col: 84, offset: 78812},
+												pos:        position{line: 2532, col: 84, offset: 78842},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5260,36 +5261,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2543, col: 1, offset: 79207},
+			pos:  position{line: 2544, col: 1, offset: 79237},
 			expr: &choiceExpr{
-				pos: position{line: 2543, col: 13, offset: 79219},
+				pos: position{line: 2544, col: 13, offset: 79249},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2543, col: 13, offset: 79219},
+						pos: position{line: 2544, col: 13, offset: 79249},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2543, col: 14, offset: 79220},
+							pos: position{line: 2544, col: 14, offset: 79250},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2543, col: 14, offset: 79220},
+									pos:   position{line: 2544, col: 14, offset: 79250},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2543, col: 22, offset: 79228},
+										pos: position{line: 2544, col: 22, offset: 79258},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2543, col: 22, offset: 79228},
+												pos:        position{line: 2544, col: 22, offset: 79258},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2543, col: 32, offset: 79238},
+												pos:        position{line: 2544, col: 32, offset: 79268},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2543, col: 42, offset: 79248},
+												pos:        position{line: 2544, col: 42, offset: 79278},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5298,44 +5299,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2543, col: 55, offset: 79261},
+									pos:  position{line: 2544, col: 55, offset: 79291},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2543, col: 63, offset: 79269},
+									pos:   position{line: 2544, col: 63, offset: 79299},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2543, col: 74, offset: 79280},
+										pos:  position{line: 2544, col: 74, offset: 79310},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2543, col: 85, offset: 79291},
+									pos:  position{line: 2544, col: 85, offset: 79321},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2555, col: 3, offset: 79605},
+						pos: position{line: 2556, col: 3, offset: 79635},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2555, col: 4, offset: 79606},
+							pos: position{line: 2556, col: 4, offset: 79636},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2555, col: 4, offset: 79606},
+									pos:   position{line: 2556, col: 4, offset: 79636},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2555, col: 12, offset: 79614},
+										pos: position{line: 2556, col: 12, offset: 79644},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2555, col: 12, offset: 79614},
+												pos:        position{line: 2556, col: 12, offset: 79644},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2555, col: 20, offset: 79622},
+												pos:        position{line: 2556, col: 20, offset: 79652},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5344,31 +5345,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2555, col: 27, offset: 79629},
+									pos:  position{line: 2556, col: 27, offset: 79659},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2555, col: 35, offset: 79637},
+									pos:   position{line: 2556, col: 35, offset: 79667},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2555, col: 44, offset: 79646},
+										pos:  position{line: 2556, col: 44, offset: 79676},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2555, col: 55, offset: 79657},
+									pos:   position{line: 2556, col: 55, offset: 79687},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2555, col: 60, offset: 79662},
+										pos: position{line: 2556, col: 60, offset: 79692},
 										expr: &seqExpr{
-											pos: position{line: 2555, col: 61, offset: 79663},
+											pos: position{line: 2556, col: 61, offset: 79693},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2555, col: 61, offset: 79663},
+													pos:  position{line: 2556, col: 61, offset: 79693},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2555, col: 67, offset: 79669},
+													pos:  position{line: 2556, col: 67, offset: 79699},
 													name: "StringExpr",
 												},
 											},
@@ -5376,195 +5377,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2555, col: 80, offset: 79682},
+									pos:  position{line: 2556, col: 80, offset: 79712},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2577, col: 3, offset: 80282},
+						pos: position{line: 2578, col: 3, offset: 80312},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2577, col: 4, offset: 80283},
+							pos: position{line: 2578, col: 4, offset: 80313},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2577, col: 4, offset: 80283},
+									pos:   position{line: 2578, col: 4, offset: 80313},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2577, col: 12, offset: 80291},
+										pos:        position{line: 2578, col: 12, offset: 80321},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 23, offset: 80302},
+									pos:  position{line: 2578, col: 23, offset: 80332},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2577, col: 31, offset: 80310},
+									pos:   position{line: 2578, col: 31, offset: 80340},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2577, col: 46, offset: 80325},
+										pos:  position{line: 2578, col: 46, offset: 80355},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 61, offset: 80340},
+									pos:  position{line: 2578, col: 61, offset: 80370},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2588, col: 3, offset: 80642},
+						pos: position{line: 2589, col: 3, offset: 80672},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2588, col: 4, offset: 80643},
+							pos: position{line: 2589, col: 4, offset: 80673},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2588, col: 4, offset: 80643},
+									pos:   position{line: 2589, col: 4, offset: 80673},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2588, col: 12, offset: 80651},
+										pos:        position{line: 2589, col: 12, offset: 80681},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 22, offset: 80661},
+									pos:  position{line: 2589, col: 22, offset: 80691},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2588, col: 30, offset: 80669},
+									pos:   position{line: 2589, col: 30, offset: 80699},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2588, col: 45, offset: 80684},
+										pos:  position{line: 2589, col: 45, offset: 80714},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 60, offset: 80699},
+									pos:  position{line: 2589, col: 60, offset: 80729},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2588, col: 66, offset: 80705},
+									pos:   position{line: 2589, col: 66, offset: 80735},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2588, col: 72, offset: 80711},
+										pos:  position{line: 2589, col: 72, offset: 80741},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 83, offset: 80722},
+									pos:  position{line: 2589, col: 83, offset: 80752},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2600, col: 3, offset: 81072},
+						pos: position{line: 2601, col: 3, offset: 81102},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2600, col: 4, offset: 81073},
+							pos: position{line: 2601, col: 4, offset: 81103},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2600, col: 4, offset: 81073},
+									pos:   position{line: 2601, col: 4, offset: 81103},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2600, col: 12, offset: 81081},
+										pos:        position{line: 2601, col: 12, offset: 81111},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 22, offset: 81091},
+									pos:  position{line: 2601, col: 22, offset: 81121},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2600, col: 30, offset: 81099},
+									pos:   position{line: 2601, col: 30, offset: 81129},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2600, col: 45, offset: 81114},
+										pos:  position{line: 2601, col: 45, offset: 81144},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 60, offset: 81129},
+									pos:  position{line: 2601, col: 60, offset: 81159},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2600, col: 66, offset: 81135},
+									pos:   position{line: 2601, col: 66, offset: 81165},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2600, col: 79, offset: 81148},
+										pos:  position{line: 2601, col: 79, offset: 81178},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 90, offset: 81159},
+									pos:  position{line: 2601, col: 90, offset: 81189},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2624, col: 3, offset: 81828},
+						pos: position{line: 2625, col: 3, offset: 81858},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2624, col: 4, offset: 81829},
+							pos: position{line: 2625, col: 4, offset: 81859},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2624, col: 4, offset: 81829},
+									pos:   position{line: 2625, col: 4, offset: 81859},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2624, col: 12, offset: 81837},
+										pos:        position{line: 2625, col: 12, offset: 81867},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 22, offset: 81847},
+									pos:  position{line: 2625, col: 22, offset: 81877},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 30, offset: 81855},
+									pos:   position{line: 2625, col: 30, offset: 81885},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 41, offset: 81866},
+										pos:  position{line: 2625, col: 41, offset: 81896},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 52, offset: 81877},
+									pos:  position{line: 2625, col: 52, offset: 81907},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 58, offset: 81883},
+									pos:   position{line: 2625, col: 58, offset: 81913},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 69, offset: 81894},
+										pos:  position{line: 2625, col: 69, offset: 81924},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 81, offset: 81906},
+									pos:   position{line: 2625, col: 81, offset: 81936},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2624, col: 93, offset: 81918},
+										pos: position{line: 2625, col: 93, offset: 81948},
 										expr: &seqExpr{
-											pos: position{line: 2624, col: 94, offset: 81919},
+											pos: position{line: 2625, col: 94, offset: 81949},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2624, col: 94, offset: 81919},
+													pos:  position{line: 2625, col: 94, offset: 81949},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2624, col: 100, offset: 81925},
+													pos:  position{line: 2625, col: 100, offset: 81955},
 													name: "NumericExpr",
 												},
 											},
@@ -5572,50 +5573,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 114, offset: 81939},
+									pos:  position{line: 2625, col: 114, offset: 81969},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2649, col: 3, offset: 82769},
+						pos: position{line: 2650, col: 3, offset: 82799},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2649, col: 3, offset: 82769},
+							pos: position{line: 2650, col: 3, offset: 82799},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2649, col: 3, offset: 82769},
+									pos:        position{line: 2650, col: 3, offset: 82799},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 14, offset: 82780},
+									pos:  position{line: 2650, col: 14, offset: 82810},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 22, offset: 82788},
+									pos:   position{line: 2650, col: 22, offset: 82818},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2649, col: 28, offset: 82794},
+										pos:  position{line: 2650, col: 28, offset: 82824},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 38, offset: 82804},
+									pos:   position{line: 2650, col: 38, offset: 82834},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2649, col: 45, offset: 82811},
+										pos: position{line: 2650, col: 45, offset: 82841},
 										expr: &seqExpr{
-											pos: position{line: 2649, col: 46, offset: 82812},
+											pos: position{line: 2650, col: 46, offset: 82842},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2649, col: 46, offset: 82812},
+													pos:  position{line: 2650, col: 46, offset: 82842},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2649, col: 52, offset: 82818},
+													pos:  position{line: 2650, col: 52, offset: 82848},
 													name: "StringExpr",
 												},
 											},
@@ -5623,38 +5624,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 65, offset: 82831},
+									pos:  position{line: 2650, col: 65, offset: 82861},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2662, col: 3, offset: 83199},
+						pos: position{line: 2663, col: 3, offset: 83229},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2662, col: 4, offset: 83200},
+							pos: position{line: 2663, col: 4, offset: 83230},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2662, col: 4, offset: 83200},
+									pos:   position{line: 2663, col: 4, offset: 83230},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2662, col: 12, offset: 83208},
+										pos: position{line: 2663, col: 12, offset: 83238},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2662, col: 12, offset: 83208},
+												pos:        position{line: 2663, col: 12, offset: 83238},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2662, col: 22, offset: 83218},
+												pos:        position{line: 2663, col: 22, offset: 83248},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2662, col: 32, offset: 83228},
+												pos:        position{line: 2663, col: 32, offset: 83258},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5663,223 +5664,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 40, offset: 83236},
+									pos:  position{line: 2663, col: 40, offset: 83266},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 48, offset: 83244},
+									pos:   position{line: 2663, col: 48, offset: 83274},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2662, col: 54, offset: 83250},
+										pos:  position{line: 2663, col: 54, offset: 83280},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 66, offset: 83262},
+									pos:   position{line: 2663, col: 66, offset: 83292},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2662, col: 82, offset: 83278},
+										pos: position{line: 2663, col: 82, offset: 83308},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2662, col: 83, offset: 83279},
+											pos:  position{line: 2663, col: 83, offset: 83309},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 101, offset: 83297},
+									pos:  position{line: 2663, col: 101, offset: 83327},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2681, col: 3, offset: 83737},
+						pos: position{line: 2682, col: 3, offset: 83767},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2681, col: 3, offset: 83737},
+							pos: position{line: 2682, col: 3, offset: 83767},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2681, col: 3, offset: 83737},
+									pos:        position{line: 2682, col: 3, offset: 83767},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 11, offset: 83745},
+									pos:  position{line: 2682, col: 11, offset: 83775},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2681, col: 19, offset: 83753},
+									pos:   position{line: 2682, col: 19, offset: 83783},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2681, col: 30, offset: 83764},
+										pos:  position{line: 2682, col: 30, offset: 83794},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 50, offset: 83784},
+									pos:  position{line: 2682, col: 50, offset: 83814},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2681, col: 56, offset: 83790},
+									pos:   position{line: 2682, col: 56, offset: 83820},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2681, col: 62, offset: 83796},
+										pos: position{line: 2682, col: 62, offset: 83826},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2681, col: 62, offset: 83796},
+												pos:  position{line: 2682, col: 62, offset: 83826},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2681, col: 81, offset: 83815},
+												pos:  position{line: 2682, col: 81, offset: 83845},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 100, offset: 83834},
+									pos:  position{line: 2682, col: 100, offset: 83864},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2692, col: 3, offset: 84139},
+						pos: position{line: 2693, col: 3, offset: 84169},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2692, col: 3, offset: 84139},
+							pos: position{line: 2693, col: 3, offset: 84169},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2692, col: 3, offset: 84139},
+									pos:        position{line: 2693, col: 3, offset: 84169},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 12, offset: 84148},
+									pos:  position{line: 2693, col: 12, offset: 84178},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2692, col: 20, offset: 84156},
+									pos:   position{line: 2693, col: 20, offset: 84186},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 25, offset: 84161},
+										pos:  position{line: 2693, col: 25, offset: 84191},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 36, offset: 84172},
+									pos:  position{line: 2693, col: 36, offset: 84202},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2692, col: 42, offset: 84178},
+									pos:   position{line: 2693, col: 42, offset: 84208},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 45, offset: 84181},
+										pos:  position{line: 2693, col: 45, offset: 84211},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 55, offset: 84191},
+									pos:  position{line: 2693, col: 55, offset: 84221},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2699, col: 3, offset: 84349},
+						pos: position{line: 2700, col: 3, offset: 84379},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2699, col: 3, offset: 84349},
+							pos: position{line: 2700, col: 3, offset: 84379},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2699, col: 3, offset: 84349},
+									pos:        position{line: 2700, col: 3, offset: 84379},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 21, offset: 84367},
+									pos:  position{line: 2700, col: 21, offset: 84397},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 29, offset: 84375},
+									pos:   position{line: 2700, col: 29, offset: 84405},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 33, offset: 84379},
+										pos:  position{line: 2700, col: 33, offset: 84409},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 43, offset: 84389},
+									pos:  position{line: 2700, col: 43, offset: 84419},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 49, offset: 84395},
+									pos:   position{line: 2700, col: 49, offset: 84425},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 53, offset: 84399},
+										pos:  position{line: 2700, col: 53, offset: 84429},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 66, offset: 84412},
+									pos:  position{line: 2700, col: 66, offset: 84442},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 72, offset: 84418},
+									pos:   position{line: 2700, col: 72, offset: 84448},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 78, offset: 84424},
+										pos:  position{line: 2700, col: 78, offset: 84454},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 91, offset: 84437},
+									pos:  position{line: 2700, col: 91, offset: 84467},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2710, col: 3, offset: 84745},
+						pos: position{line: 2711, col: 3, offset: 84775},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2710, col: 3, offset: 84745},
+							pos: position{line: 2711, col: 3, offset: 84775},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2710, col: 3, offset: 84745},
+									pos:        position{line: 2711, col: 3, offset: 84775},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 12, offset: 84754},
+									pos:  position{line: 2711, col: 12, offset: 84784},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 20, offset: 84762},
+									pos:   position{line: 2711, col: 20, offset: 84792},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2710, col: 27, offset: 84769},
+										pos:  position{line: 2711, col: 27, offset: 84799},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 38, offset: 84780},
+									pos:   position{line: 2711, col: 38, offset: 84810},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2710, col: 43, offset: 84785},
+										pos: position{line: 2711, col: 43, offset: 84815},
 										expr: &seqExpr{
-											pos: position{line: 2710, col: 44, offset: 84786},
+											pos: position{line: 2711, col: 44, offset: 84816},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2710, col: 44, offset: 84786},
+													pos:  position{line: 2711, col: 44, offset: 84816},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2710, col: 50, offset: 84792},
+													pos:  position{line: 2711, col: 50, offset: 84822},
 													name: "StringExpr",
 												},
 											},
@@ -5887,47 +5888,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 63, offset: 84805},
+									pos:  position{line: 2711, col: 63, offset: 84835},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2728, col: 3, offset: 85272},
+						pos: position{line: 2729, col: 3, offset: 85302},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2728, col: 3, offset: 85272},
+							pos: position{line: 2729, col: 3, offset: 85302},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2728, col: 3, offset: 85272},
+									pos:        position{line: 2729, col: 3, offset: 85302},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 12, offset: 85281},
+									pos:  position{line: 2729, col: 12, offset: 85311},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2728, col: 20, offset: 85289},
+									pos:   position{line: 2729, col: 20, offset: 85319},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2728, col: 42, offset: 85311},
+										pos: position{line: 2729, col: 42, offset: 85341},
 										expr: &seqExpr{
-											pos: position{line: 2728, col: 43, offset: 85312},
+											pos: position{line: 2729, col: 43, offset: 85342},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2728, col: 44, offset: 85313},
+													pos: position{line: 2729, col: 44, offset: 85343},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2728, col: 44, offset: 85313},
+															pos:        position{line: 2729, col: 44, offset: 85343},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2728, col: 53, offset: 85322},
+															pos:        position{line: 2729, col: 53, offset: 85352},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5935,7 +5936,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2728, col: 62, offset: 85331},
+													pos:        position{line: 2729, col: 62, offset: 85361},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5945,56 +5946,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 69, offset: 85338},
+									pos:  position{line: 2729, col: 69, offset: 85368},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2750, col: 3, offset: 85935},
+						pos: position{line: 2751, col: 3, offset: 85965},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2750, col: 3, offset: 85935},
+							pos: position{line: 2751, col: 3, offset: 85965},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2750, col: 3, offset: 85935},
+									pos:        position{line: 2751, col: 3, offset: 85965},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2750, col: 13, offset: 85945},
+									pos:  position{line: 2751, col: 13, offset: 85975},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 21, offset: 85953},
+									pos:   position{line: 2751, col: 21, offset: 85983},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2750, col: 27, offset: 85959},
+										pos:  position{line: 2751, col: 27, offset: 85989},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 43, offset: 85975},
+									pos:   position{line: 2751, col: 43, offset: 86005},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 53, offset: 85985},
+										pos: position{line: 2751, col: 53, offset: 86015},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 54, offset: 85986},
+											pos: position{line: 2751, col: 54, offset: 86016},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 54, offset: 85986},
+													pos:  position{line: 2751, col: 54, offset: 86016},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 60, offset: 85992},
+													pos:        position{line: 2751, col: 60, offset: 86022},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 73, offset: 86005},
+													pos:  position{line: 2751, col: 73, offset: 86035},
 													name: "FloatAsString",
 												},
 											},
@@ -6002,40 +6003,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 89, offset: 86021},
+									pos:   position{line: 2751, col: 89, offset: 86051},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 95, offset: 86027},
+										pos: position{line: 2751, col: 95, offset: 86057},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 96, offset: 86028},
+											pos: position{line: 2751, col: 96, offset: 86058},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 96, offset: 86028},
+													pos:  position{line: 2751, col: 96, offset: 86058},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 102, offset: 86034},
+													pos:        position{line: 2751, col: 102, offset: 86064},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2750, col: 112, offset: 86044},
+													pos: position{line: 2751, col: 112, offset: 86074},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2750, col: 112, offset: 86044},
+															pos:        position{line: 2751, col: 112, offset: 86074},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2750, col: 125, offset: 86057},
+															pos:        position{line: 2751, col: 125, offset: 86087},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2750, col: 137, offset: 86069},
+															pos:        position{line: 2751, col: 137, offset: 86099},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6047,25 +6048,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 151, offset: 86083},
+									pos:   position{line: 2751, col: 151, offset: 86113},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 158, offset: 86090},
+										pos: position{line: 2751, col: 158, offset: 86120},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 159, offset: 86091},
+											pos: position{line: 2751, col: 159, offset: 86121},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 159, offset: 86091},
+													pos:  position{line: 2751, col: 159, offset: 86121},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 165, offset: 86097},
+													pos:        position{line: 2751, col: 165, offset: 86127},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 175, offset: 86107},
+													pos:  position{line: 2751, col: 175, offset: 86137},
 													name: "QuotedString",
 												},
 											},
@@ -6073,213 +6074,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2750, col: 190, offset: 86122},
+									pos:  position{line: 2751, col: 190, offset: 86152},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2790, col: 3, offset: 87117},
+						pos: position{line: 2791, col: 3, offset: 87147},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2790, col: 3, offset: 87117},
+							pos: position{line: 2791, col: 3, offset: 87147},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2790, col: 3, offset: 87117},
+									pos:        position{line: 2791, col: 3, offset: 87147},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2790, col: 15, offset: 87129},
+									pos:  position{line: 2791, col: 15, offset: 87159},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2790, col: 23, offset: 87137},
+									pos:   position{line: 2791, col: 23, offset: 87167},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2790, col: 30, offset: 87144},
+										pos: position{line: 2791, col: 30, offset: 87174},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2790, col: 31, offset: 87145},
+											pos:  position{line: 2791, col: 31, offset: 87175},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2790, col: 44, offset: 87158},
+									pos:  position{line: 2791, col: 44, offset: 87188},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2801, col: 3, offset: 87349},
+						pos: position{line: 2802, col: 3, offset: 87379},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2801, col: 3, offset: 87349},
+							pos: position{line: 2802, col: 3, offset: 87379},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2801, col: 3, offset: 87349},
+									pos:        position{line: 2802, col: 3, offset: 87379},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2801, col: 12, offset: 87358},
+									pos:  position{line: 2802, col: 12, offset: 87388},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2801, col: 20, offset: 87366},
+									pos:   position{line: 2802, col: 20, offset: 87396},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2801, col: 30, offset: 87376},
+										pos:  position{line: 2802, col: 30, offset: 87406},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2801, col: 40, offset: 87386},
+									pos:  position{line: 2802, col: 40, offset: 87416},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2807, col: 3, offset: 87509},
+						pos: position{line: 2808, col: 3, offset: 87539},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2807, col: 3, offset: 87509},
+							pos: position{line: 2808, col: 3, offset: 87539},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2807, col: 3, offset: 87509},
+									pos:        position{line: 2808, col: 3, offset: 87539},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 13, offset: 87519},
+									pos:  position{line: 2808, col: 13, offset: 87549},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 21, offset: 87527},
+									pos:   position{line: 2808, col: 21, offset: 87557},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 25, offset: 87531},
+										pos:  position{line: 2808, col: 25, offset: 87561},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 35, offset: 87541},
+									pos:  position{line: 2808, col: 35, offset: 87571},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 41, offset: 87547},
+									pos:   position{line: 2808, col: 41, offset: 87577},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 47, offset: 87553},
+										pos:  position{line: 2808, col: 47, offset: 87583},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 58, offset: 87564},
+									pos:  position{line: 2808, col: 58, offset: 87594},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 64, offset: 87570},
+									pos:   position{line: 2808, col: 64, offset: 87600},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 76, offset: 87582},
+										pos:  position{line: 2808, col: 76, offset: 87612},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 87, offset: 87593},
+									pos:  position{line: 2808, col: 87, offset: 87623},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2814, col: 3, offset: 87817},
+						pos: position{line: 2815, col: 3, offset: 87847},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2814, col: 3, offset: 87817},
+							pos: position{line: 2815, col: 3, offset: 87847},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2814, col: 3, offset: 87817},
+									pos:        position{line: 2815, col: 3, offset: 87847},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 14, offset: 87828},
+									pos:  position{line: 2815, col: 14, offset: 87858},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2814, col: 22, offset: 87836},
+									pos:   position{line: 2815, col: 22, offset: 87866},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2814, col: 26, offset: 87840},
+										pos:  position{line: 2815, col: 26, offset: 87870},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 36, offset: 87850},
+									pos:  position{line: 2815, col: 36, offset: 87880},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2814, col: 42, offset: 87856},
+									pos:   position{line: 2815, col: 42, offset: 87886},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2814, col: 49, offset: 87863},
+										pos:  position{line: 2815, col: 49, offset: 87893},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 60, offset: 87874},
+									pos:  position{line: 2815, col: 60, offset: 87904},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2822, col: 3, offset: 88038},
+						pos: position{line: 2823, col: 3, offset: 88068},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2822, col: 3, offset: 88038},
+							pos: position{line: 2823, col: 3, offset: 88068},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2822, col: 3, offset: 88038},
+									pos:        position{line: 2823, col: 3, offset: 88068},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 14, offset: 88049},
+									pos:  position{line: 2823, col: 14, offset: 88079},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 22, offset: 88057},
+									pos:   position{line: 2823, col: 22, offset: 88087},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 26, offset: 88061},
+										pos:  position{line: 2823, col: 26, offset: 88091},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 36, offset: 88071},
+									pos:  position{line: 2823, col: 36, offset: 88101},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 42, offset: 88077},
+									pos:   position{line: 2823, col: 42, offset: 88107},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 49, offset: 88084},
+										pos:  position{line: 2823, col: 49, offset: 88114},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 60, offset: 88095},
+									pos:  position{line: 2823, col: 60, offset: 88125},
 									name: "R_PAREN",
 								},
 							},
@@ -6290,15 +6291,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2830, col: 1, offset: 88257},
+			pos:  position{line: 2831, col: 1, offset: 88287},
 			expr: &actionExpr{
-				pos: position{line: 2830, col: 21, offset: 88277},
+				pos: position{line: 2831, col: 21, offset: 88307},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2830, col: 21, offset: 88277},
+					pos:   position{line: 2831, col: 21, offset: 88307},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2830, col: 25, offset: 88281},
+						pos:  position{line: 2831, col: 25, offset: 88311},
 						name: "QuotedString",
 					},
 				},
@@ -6306,15 +6307,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2837, col: 1, offset: 88408},
+			pos:  position{line: 2838, col: 1, offset: 88438},
 			expr: &actionExpr{
-				pos: position{line: 2837, col: 22, offset: 88429},
+				pos: position{line: 2838, col: 22, offset: 88459},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2837, col: 22, offset: 88429},
+					pos:   position{line: 2838, col: 22, offset: 88459},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2837, col: 26, offset: 88433},
+						pos:  position{line: 2838, col: 26, offset: 88463},
 						name: "UnquotedString",
 					},
 				},
@@ -6322,22 +6323,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2844, col: 1, offset: 88561},
+			pos:  position{line: 2845, col: 1, offset: 88591},
 			expr: &actionExpr{
-				pos: position{line: 2844, col: 20, offset: 88580},
+				pos: position{line: 2845, col: 20, offset: 88610},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2844, col: 20, offset: 88580},
+					pos: position{line: 2845, col: 20, offset: 88610},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2844, col: 20, offset: 88580},
+							pos:  position{line: 2845, col: 20, offset: 88610},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2844, col: 26, offset: 88586},
+							pos:   position{line: 2845, col: 26, offset: 88616},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2844, col: 38, offset: 88598},
+								pos:  position{line: 2845, col: 38, offset: 88628},
 								name: "String",
 							},
 						},
@@ -6347,20 +6348,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2850, col: 1, offset: 88783},
+			pos:  position{line: 2851, col: 1, offset: 88813},
 			expr: &choiceExpr{
-				pos: position{line: 2850, col: 20, offset: 88802},
+				pos: position{line: 2851, col: 20, offset: 88832},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2850, col: 20, offset: 88802},
+						pos: position{line: 2851, col: 20, offset: 88832},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2850, col: 20, offset: 88802},
+							pos: position{line: 2851, col: 20, offset: 88832},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 2850, col: 20, offset: 88802},
+									pos: position{line: 2851, col: 20, offset: 88832},
 									expr: &charClassMatcher{
-										pos:        position{line: 2850, col: 20, offset: 88802},
+										pos:        position{line: 2851, col: 20, offset: 88832},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -6369,9 +6370,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2850, col: 31, offset: 88813},
+									pos: position{line: 2851, col: 31, offset: 88843},
 									expr: &litMatcher{
-										pos:        position{line: 2850, col: 33, offset: 88815},
+										pos:        position{line: 2851, col: 33, offset: 88845},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6381,27 +6382,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2853, col: 3, offset: 88857},
+						pos: position{line: 2854, col: 3, offset: 88887},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 2853, col: 3, offset: 88857},
+							pos: position{line: 2854, col: 3, offset: 88887},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2853, col: 3, offset: 88857},
+									pos:        position{line: 2854, col: 3, offset: 88887},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2853, col: 7, offset: 88861},
+									pos:   position{line: 2854, col: 7, offset: 88891},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2853, col: 13, offset: 88867},
+										pos:  position{line: 2854, col: 13, offset: 88897},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2853, col: 23, offset: 88877},
+									pos:        position{line: 2854, col: 23, offset: 88907},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6414,26 +6415,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2858, col: 1, offset: 88945},
+			pos:  position{line: 2859, col: 1, offset: 88975},
 			expr: &actionExpr{
-				pos: position{line: 2858, col: 15, offset: 88959},
+				pos: position{line: 2859, col: 15, offset: 88989},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2858, col: 15, offset: 88959},
+					pos: position{line: 2859, col: 15, offset: 88989},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2858, col: 15, offset: 88959},
+							pos:  position{line: 2859, col: 15, offset: 88989},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2858, col: 20, offset: 88964},
+							pos:  position{line: 2859, col: 20, offset: 88994},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2858, col: 30, offset: 88974},
+							pos:   position{line: 2859, col: 30, offset: 89004},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2858, col: 40, offset: 88984},
+								pos:  position{line: 2859, col: 40, offset: 89014},
 								name: "BoolExpr",
 							},
 						},
@@ -6443,15 +6444,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2870, col: 1, offset: 89277},
+			pos:  position{line: 2871, col: 1, offset: 89307},
 			expr: &actionExpr{
-				pos: position{line: 2870, col: 13, offset: 89289},
+				pos: position{line: 2871, col: 13, offset: 89319},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2870, col: 13, offset: 89289},
+					pos:   position{line: 2871, col: 13, offset: 89319},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2870, col: 18, offset: 89294},
+						pos:  position{line: 2871, col: 18, offset: 89324},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6459,35 +6460,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2875, col: 1, offset: 89364},
+			pos:  position{line: 2876, col: 1, offset: 89394},
 			expr: &actionExpr{
-				pos: position{line: 2875, col: 19, offset: 89382},
+				pos: position{line: 2876, col: 19, offset: 89412},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2875, col: 19, offset: 89382},
+					pos: position{line: 2876, col: 19, offset: 89412},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2875, col: 19, offset: 89382},
+							pos:   position{line: 2876, col: 19, offset: 89412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2875, col: 25, offset: 89388},
+								pos:  position{line: 2876, col: 25, offset: 89418},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2875, col: 40, offset: 89403},
+							pos:   position{line: 2876, col: 40, offset: 89433},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2875, col: 45, offset: 89408},
+								pos: position{line: 2876, col: 45, offset: 89438},
 								expr: &seqExpr{
-									pos: position{line: 2875, col: 46, offset: 89409},
+									pos: position{line: 2876, col: 46, offset: 89439},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2875, col: 46, offset: 89409},
+											pos:  position{line: 2876, col: 46, offset: 89439},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2875, col: 49, offset: 89412},
+											pos:  position{line: 2876, col: 49, offset: 89442},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6500,35 +6501,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 2895, col: 1, offset: 89850},
+			pos:  position{line: 2896, col: 1, offset: 89880},
 			expr: &actionExpr{
-				pos: position{line: 2895, col: 19, offset: 89868},
+				pos: position{line: 2896, col: 19, offset: 89898},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 2895, col: 19, offset: 89868},
+					pos: position{line: 2896, col: 19, offset: 89898},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2895, col: 19, offset: 89868},
+							pos:   position{line: 2896, col: 19, offset: 89898},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2895, col: 25, offset: 89874},
+								pos:  position{line: 2896, col: 25, offset: 89904},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2895, col: 40, offset: 89889},
+							pos:   position{line: 2896, col: 40, offset: 89919},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2895, col: 45, offset: 89894},
+								pos: position{line: 2896, col: 45, offset: 89924},
 								expr: &seqExpr{
-									pos: position{line: 2895, col: 46, offset: 89895},
+									pos: position{line: 2896, col: 46, offset: 89925},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2895, col: 46, offset: 89895},
+											pos:  position{line: 2896, col: 46, offset: 89925},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2895, col: 50, offset: 89899},
+											pos:  position{line: 2896, col: 50, offset: 89929},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6541,47 +6542,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 2915, col: 1, offset: 90338},
+			pos:  position{line: 2916, col: 1, offset: 90368},
 			expr: &choiceExpr{
-				pos: position{line: 2915, col: 19, offset: 90356},
+				pos: position{line: 2916, col: 19, offset: 90386},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2915, col: 19, offset: 90356},
+						pos: position{line: 2916, col: 19, offset: 90386},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 2915, col: 19, offset: 90356},
+							pos: position{line: 2916, col: 19, offset: 90386},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 19, offset: 90356},
+									pos:  position{line: 2916, col: 19, offset: 90386},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 23, offset: 90360},
+									pos:  position{line: 2916, col: 23, offset: 90390},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 31, offset: 90368},
+									pos:   position{line: 2916, col: 31, offset: 90398},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 37, offset: 90374},
+										pos:  position{line: 2916, col: 37, offset: 90404},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 52, offset: 90389},
+									pos:  position{line: 2916, col: 52, offset: 90419},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2925, col: 3, offset: 90592},
+						pos: position{line: 2926, col: 3, offset: 90622},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 2925, col: 3, offset: 90592},
+							pos:   position{line: 2926, col: 3, offset: 90622},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2925, col: 9, offset: 90598},
+								pos:  position{line: 2926, col: 9, offset: 90628},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6591,50 +6592,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 2930, col: 1, offset: 90669},
+			pos:  position{line: 2931, col: 1, offset: 90699},
 			expr: &choiceExpr{
-				pos: position{line: 2930, col: 19, offset: 90687},
+				pos: position{line: 2931, col: 19, offset: 90717},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2930, col: 19, offset: 90687},
+						pos: position{line: 2931, col: 19, offset: 90717},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 2930, col: 19, offset: 90687},
+							pos: position{line: 2931, col: 19, offset: 90717},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 19, offset: 90687},
+									pos:  position{line: 2931, col: 19, offset: 90717},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 27, offset: 90695},
+									pos:   position{line: 2931, col: 27, offset: 90725},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 33, offset: 90701},
+										pos:  position{line: 2931, col: 33, offset: 90731},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 48, offset: 90716},
+									pos:  position{line: 2931, col: 48, offset: 90746},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2933, col: 3, offset: 90752},
+						pos: position{line: 2934, col: 3, offset: 90782},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 2933, col: 3, offset: 90752},
+							pos:   position{line: 2934, col: 3, offset: 90782},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 2933, col: 10, offset: 90759},
+								pos: position{line: 2934, col: 10, offset: 90789},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2933, col: 10, offset: 90759},
+										pos:  position{line: 2934, col: 10, offset: 90789},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2933, col: 31, offset: 90780},
+										pos:  position{line: 2934, col: 31, offset: 90810},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6646,60 +6647,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 2938, col: 1, offset: 90900},
+			pos:  position{line: 2939, col: 1, offset: 90930},
 			expr: &choiceExpr{
-				pos: position{line: 2938, col: 23, offset: 90922},
+				pos: position{line: 2939, col: 23, offset: 90952},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2938, col: 23, offset: 90922},
+						pos: position{line: 2939, col: 23, offset: 90952},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2938, col: 24, offset: 90923},
+							pos: position{line: 2939, col: 24, offset: 90953},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2938, col: 24, offset: 90923},
+									pos:   position{line: 2939, col: 24, offset: 90953},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 2938, col: 28, offset: 90927},
+										pos: position{line: 2939, col: 28, offset: 90957},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2938, col: 28, offset: 90927},
+												pos:        position{line: 2939, col: 28, offset: 90957},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 39, offset: 90938},
+												pos:        position{line: 2939, col: 39, offset: 90968},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 49, offset: 90948},
+												pos:        position{line: 2939, col: 49, offset: 90978},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 59, offset: 90958},
+												pos:        position{line: 2939, col: 59, offset: 90988},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 70, offset: 90969},
+												pos:        position{line: 2939, col: 70, offset: 90999},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 84, offset: 90983},
+												pos:        position{line: 2939, col: 84, offset: 91013},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 94, offset: 90993},
+												pos:        position{line: 2939, col: 94, offset: 91023},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6708,56 +6709,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 109, offset: 91008},
+									pos:  position{line: 2939, col: 109, offset: 91038},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2938, col: 117, offset: 91016},
+									pos:   position{line: 2939, col: 117, offset: 91046},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2938, col: 123, offset: 91022},
+										pos:  position{line: 2939, col: 123, offset: 91052},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 133, offset: 91032},
+									pos:  position{line: 2939, col: 133, offset: 91062},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2968, col: 3, offset: 91903},
+						pos: position{line: 2969, col: 3, offset: 91933},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 2968, col: 3, offset: 91903},
+							pos: position{line: 2969, col: 3, offset: 91933},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2968, col: 3, offset: 91903},
+									pos:   position{line: 2969, col: 3, offset: 91933},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2968, col: 11, offset: 91911},
+										pos: position{line: 2969, col: 11, offset: 91941},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2968, col: 11, offset: 91911},
+												pos:        position{line: 2969, col: 11, offset: 91941},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 20, offset: 91920},
+												pos:        position{line: 2969, col: 20, offset: 91950},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 29, offset: 91929},
+												pos:        position{line: 2969, col: 29, offset: 91959},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 39, offset: 91939},
+												pos:        position{line: 2969, col: 39, offset: 91969},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6766,86 +6767,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 52, offset: 91952},
+									pos:  position{line: 2969, col: 52, offset: 91982},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 60, offset: 91960},
+									pos:   position{line: 2969, col: 60, offset: 91990},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 70, offset: 91970},
+										pos:  position{line: 2969, col: 70, offset: 92000},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 80, offset: 91980},
+									pos:  position{line: 2969, col: 80, offset: 92010},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 86, offset: 91986},
+									pos:   position{line: 2969, col: 86, offset: 92016},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 97, offset: 91997},
+										pos:  position{line: 2969, col: 97, offset: 92027},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 107, offset: 92007},
+									pos:  position{line: 2969, col: 107, offset: 92037},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2981, col: 3, offset: 92377},
+						pos: position{line: 2982, col: 3, offset: 92407},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 2981, col: 3, offset: 92377},
+							pos: position{line: 2982, col: 3, offset: 92407},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2981, col: 3, offset: 92377},
+									pos:   position{line: 2982, col: 3, offset: 92407},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2981, col: 8, offset: 92382},
+										pos:  position{line: 2982, col: 8, offset: 92412},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 18, offset: 92392},
+									pos:  position{line: 2982, col: 18, offset: 92422},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2981, col: 24, offset: 92398},
+									pos:        position{line: 2982, col: 24, offset: 92428},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 29, offset: 92403},
+									pos:  position{line: 2982, col: 29, offset: 92433},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 37, offset: 92411},
+									pos:   position{line: 2982, col: 37, offset: 92441},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2981, col: 50, offset: 92424},
+										pos:  position{line: 2982, col: 50, offset: 92454},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 60, offset: 92434},
+									pos:   position{line: 2982, col: 60, offset: 92464},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2981, col: 65, offset: 92439},
+										pos: position{line: 2982, col: 65, offset: 92469},
 										expr: &seqExpr{
-											pos: position{line: 2981, col: 66, offset: 92440},
+											pos: position{line: 2982, col: 66, offset: 92470},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 66, offset: 92440},
+													pos:  position{line: 2982, col: 66, offset: 92470},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 72, offset: 92446},
+													pos:  position{line: 2982, col: 72, offset: 92476},
 													name: "ValueExpr",
 												},
 											},
@@ -6853,50 +6854,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 84, offset: 92458},
+									pos:  position{line: 2982, col: 84, offset: 92488},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3000, col: 3, offset: 93009},
+						pos: position{line: 3001, col: 3, offset: 93039},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3000, col: 3, offset: 93009},
+							pos: position{line: 3001, col: 3, offset: 93039},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3000, col: 3, offset: 93009},
+									pos:        position{line: 3001, col: 3, offset: 93039},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3000, col: 8, offset: 93014},
+									pos:  position{line: 3001, col: 8, offset: 93044},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3000, col: 16, offset: 93022},
+									pos:   position{line: 3001, col: 16, offset: 93052},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3000, col: 29, offset: 93035},
+										pos:  position{line: 3001, col: 29, offset: 93065},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3000, col: 39, offset: 93045},
+									pos:   position{line: 3001, col: 39, offset: 93075},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3000, col: 44, offset: 93050},
+										pos: position{line: 3001, col: 44, offset: 93080},
 										expr: &seqExpr{
-											pos: position{line: 3000, col: 45, offset: 93051},
+											pos: position{line: 3001, col: 45, offset: 93081},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3000, col: 45, offset: 93051},
+													pos:  position{line: 3001, col: 45, offset: 93081},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3000, col: 51, offset: 93057},
+													pos:  position{line: 3001, col: 51, offset: 93087},
 													name: "ValueExpr",
 												},
 											},
@@ -6904,7 +6905,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3000, col: 63, offset: 93069},
+									pos:  position{line: 3001, col: 63, offset: 93099},
 									name: "R_PAREN",
 								},
 							},
@@ -6915,34 +6916,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3018, col: 1, offset: 93490},
+			pos:  position{line: 3019, col: 1, offset: 93520},
 			expr: &actionExpr{
-				pos: position{line: 3018, col: 23, offset: 93512},
+				pos: position{line: 3019, col: 23, offset: 93542},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3018, col: 23, offset: 93512},
+					pos: position{line: 3019, col: 23, offset: 93542},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3018, col: 23, offset: 93512},
+							pos:   position{line: 3019, col: 23, offset: 93542},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 28, offset: 93517},
+								pos:  position{line: 3019, col: 28, offset: 93547},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3018, col: 38, offset: 93527},
+							pos:   position{line: 3019, col: 38, offset: 93557},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 41, offset: 93530},
+								pos:  position{line: 3019, col: 41, offset: 93560},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3018, col: 62, offset: 93551},
+							pos:   position{line: 3019, col: 62, offset: 93581},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 68, offset: 93557},
+								pos:  position{line: 3019, col: 68, offset: 93587},
 								name: "ValueExpr",
 							},
 						},
@@ -6952,129 +6953,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3036, col: 1, offset: 94151},
+			pos:  position{line: 3037, col: 1, offset: 94181},
 			expr: &choiceExpr{
-				pos: position{line: 3036, col: 14, offset: 94164},
+				pos: position{line: 3037, col: 14, offset: 94194},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3036, col: 14, offset: 94164},
+						pos: position{line: 3037, col: 14, offset: 94194},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3036, col: 14, offset: 94164},
+							pos:   position{line: 3037, col: 14, offset: 94194},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3036, col: 24, offset: 94174},
+								pos:  position{line: 3037, col: 24, offset: 94204},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3045, col: 3, offset: 94364},
+						pos: position{line: 3046, col: 3, offset: 94394},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3045, col: 3, offset: 94364},
+							pos: position{line: 3046, col: 3, offset: 94394},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 3, offset: 94364},
+									pos:  position{line: 3046, col: 3, offset: 94394},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 12, offset: 94373},
+									pos:   position{line: 3046, col: 12, offset: 94403},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 22, offset: 94383},
+										pos:  position{line: 3046, col: 22, offset: 94413},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 37, offset: 94398},
+									pos:  position{line: 3046, col: 37, offset: 94428},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3054, col: 3, offset: 94582},
+						pos: position{line: 3055, col: 3, offset: 94612},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3054, col: 3, offset: 94582},
+							pos:   position{line: 3055, col: 3, offset: 94612},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3054, col: 11, offset: 94590},
+								pos:  position{line: 3055, col: 11, offset: 94620},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3063, col: 3, offset: 94770},
+						pos: position{line: 3064, col: 3, offset: 94800},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3063, col: 3, offset: 94770},
+							pos:   position{line: 3064, col: 3, offset: 94800},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3063, col: 7, offset: 94774},
+								pos:  position{line: 3064, col: 7, offset: 94804},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3072, col: 3, offset: 94946},
+						pos: position{line: 3073, col: 3, offset: 94976},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3072, col: 3, offset: 94946},
+							pos: position{line: 3073, col: 3, offset: 94976},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3072, col: 3, offset: 94946},
+									pos:  position{line: 3073, col: 3, offset: 94976},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3072, col: 12, offset: 94955},
+									pos:   position{line: 3073, col: 12, offset: 94985},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3072, col: 16, offset: 94959},
+										pos:  position{line: 3073, col: 16, offset: 94989},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3072, col: 28, offset: 94971},
+									pos:  position{line: 3073, col: 28, offset: 95001},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3081, col: 3, offset: 95140},
+						pos: position{line: 3082, col: 3, offset: 95170},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3081, col: 3, offset: 95140},
+							pos: position{line: 3082, col: 3, offset: 95170},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3081, col: 3, offset: 95140},
+									pos:  position{line: 3082, col: 3, offset: 95170},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3081, col: 11, offset: 95148},
+									pos:   position{line: 3082, col: 11, offset: 95178},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3081, col: 19, offset: 95156},
+										pos:  position{line: 3082, col: 19, offset: 95186},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3081, col: 28, offset: 95165},
+									pos:  position{line: 3082, col: 28, offset: 95195},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3090, col: 3, offset: 95337},
+						pos: position{line: 3091, col: 3, offset: 95367},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3090, col: 3, offset: 95337},
+							pos:   position{line: 3091, col: 3, offset: 95367},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3090, col: 18, offset: 95352},
+								pos:  position{line: 3091, col: 18, offset: 95382},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7084,28 +7085,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3100, col: 1, offset: 95549},
+			pos:  position{line: 3101, col: 1, offset: 95579},
 			expr: &choiceExpr{
-				pos: position{line: 3100, col: 15, offset: 95563},
+				pos: position{line: 3101, col: 15, offset: 95593},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3100, col: 15, offset: 95563},
+						pos: position{line: 3101, col: 15, offset: 95593},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3100, col: 15, offset: 95563},
+							pos: position{line: 3101, col: 15, offset: 95593},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3100, col: 15, offset: 95563},
+									pos:   position{line: 3101, col: 15, offset: 95593},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3100, col: 20, offset: 95568},
+										pos:  position{line: 3101, col: 20, offset: 95598},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3100, col: 29, offset: 95577},
+									pos: position{line: 3101, col: 29, offset: 95607},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3100, col: 31, offset: 95579},
+										pos:  position{line: 3101, col: 31, offset: 95609},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7113,23 +7114,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3108, col: 3, offset: 95749},
+						pos: position{line: 3109, col: 3, offset: 95779},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3108, col: 3, offset: 95749},
+							pos: position{line: 3109, col: 3, offset: 95779},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3108, col: 3, offset: 95749},
+									pos:   position{line: 3109, col: 3, offset: 95779},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3108, col: 7, offset: 95753},
+										pos:  position{line: 3109, col: 7, offset: 95783},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3108, col: 20, offset: 95766},
+									pos: position{line: 3109, col: 20, offset: 95796},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3108, col: 22, offset: 95768},
+										pos:  position{line: 3109, col: 22, offset: 95798},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7137,50 +7138,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3116, col: 3, offset: 95933},
+						pos: position{line: 3117, col: 3, offset: 95963},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3116, col: 3, offset: 95933},
+							pos: position{line: 3117, col: 3, offset: 95963},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3116, col: 3, offset: 95933},
+									pos:   position{line: 3117, col: 3, offset: 95963},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3116, col: 9, offset: 95939},
+										pos:  position{line: 3117, col: 9, offset: 95969},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3116, col: 25, offset: 95955},
+									pos: position{line: 3117, col: 25, offset: 95985},
 									expr: &choiceExpr{
-										pos: position{line: 3116, col: 27, offset: 95957},
+										pos: position{line: 3117, col: 27, offset: 95987},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 27, offset: 95957},
+												pos:  position{line: 3117, col: 27, offset: 95987},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 36, offset: 95966},
+												pos:  position{line: 3117, col: 36, offset: 95996},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 46, offset: 95976},
+												pos:  position{line: 3117, col: 46, offset: 96006},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 54, offset: 95984},
+												pos:  position{line: 3117, col: 54, offset: 96014},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 62, offset: 95992},
+												pos:  position{line: 3117, col: 62, offset: 96022},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 70, offset: 96000},
+												pos:  position{line: 3117, col: 70, offset: 96030},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3116, col: 84, offset: 96014},
+												pos:        position{line: 3117, col: 84, offset: 96044},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7192,13 +7193,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3124, col: 3, offset: 96164},
+						pos: position{line: 3125, col: 3, offset: 96194},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3124, col: 3, offset: 96164},
+							pos:   position{line: 3125, col: 3, offset: 96194},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3124, col: 10, offset: 96171},
+								pos:  position{line: 3125, col: 10, offset: 96201},
 								name: "ConcatExpr",
 							},
 						},
@@ -7208,35 +7209,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3134, col: 1, offset: 96377},
+			pos:  position{line: 3135, col: 1, offset: 96407},
 			expr: &actionExpr{
-				pos: position{line: 3134, col: 15, offset: 96391},
+				pos: position{line: 3135, col: 15, offset: 96421},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3134, col: 15, offset: 96391},
+					pos: position{line: 3135, col: 15, offset: 96421},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3134, col: 15, offset: 96391},
+							pos:   position{line: 3135, col: 15, offset: 96421},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3134, col: 21, offset: 96397},
+								pos:  position{line: 3135, col: 21, offset: 96427},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3134, col: 32, offset: 96408},
+							pos:   position{line: 3135, col: 32, offset: 96438},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3134, col: 37, offset: 96413},
+								pos: position{line: 3135, col: 37, offset: 96443},
 								expr: &seqExpr{
-									pos: position{line: 3134, col: 38, offset: 96414},
+									pos: position{line: 3135, col: 38, offset: 96444},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3134, col: 38, offset: 96414},
+											pos:  position{line: 3135, col: 38, offset: 96444},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3134, col: 50, offset: 96426},
+											pos:  position{line: 3135, col: 50, offset: 96456},
 											name: "ConcatAtom",
 										},
 									},
@@ -7244,28 +7245,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3134, col: 63, offset: 96439},
+							pos: position{line: 3135, col: 63, offset: 96469},
 							expr: &choiceExpr{
-								pos: position{line: 3134, col: 65, offset: 96441},
+								pos: position{line: 3135, col: 65, offset: 96471},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 65, offset: 96441},
+										pos:  position{line: 3135, col: 65, offset: 96471},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 74, offset: 96450},
+										pos:  position{line: 3135, col: 74, offset: 96480},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 84, offset: 96460},
+										pos:  position{line: 3135, col: 84, offset: 96490},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 92, offset: 96468},
+										pos:  position{line: 3135, col: 92, offset: 96498},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3134, col: 100, offset: 96476},
+										pos:        position{line: 3135, col: 100, offset: 96506},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7279,54 +7280,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3152, col: 1, offset: 96882},
+			pos:  position{line: 3153, col: 1, offset: 96912},
 			expr: &choiceExpr{
-				pos: position{line: 3152, col: 15, offset: 96896},
+				pos: position{line: 3153, col: 15, offset: 96926},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3152, col: 15, offset: 96896},
+						pos: position{line: 3153, col: 15, offset: 96926},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3152, col: 15, offset: 96896},
+							pos:   position{line: 3153, col: 15, offset: 96926},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3152, col: 20, offset: 96901},
+								pos:  position{line: 3153, col: 20, offset: 96931},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3161, col: 3, offset: 97065},
+						pos: position{line: 3162, col: 3, offset: 97095},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3161, col: 3, offset: 97065},
+							pos:   position{line: 3162, col: 3, offset: 97095},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3161, col: 7, offset: 97069},
+								pos:  position{line: 3162, col: 7, offset: 97099},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3169, col: 3, offset: 97208},
+						pos: position{line: 3170, col: 3, offset: 97238},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3169, col: 3, offset: 97208},
+							pos:   position{line: 3170, col: 3, offset: 97238},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3169, col: 10, offset: 97215},
+								pos:  position{line: 3170, col: 10, offset: 97245},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3177, col: 3, offset: 97354},
+						pos: position{line: 3178, col: 3, offset: 97384},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3177, col: 3, offset: 97354},
+							pos:   position{line: 3178, col: 3, offset: 97384},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3177, col: 9, offset: 97360},
+								pos:  position{line: 3178, col: 9, offset: 97390},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7336,32 +7337,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3187, col: 1, offset: 97529},
+			pos:  position{line: 3188, col: 1, offset: 97559},
 			expr: &actionExpr{
-				pos: position{line: 3187, col: 16, offset: 97544},
+				pos: position{line: 3188, col: 16, offset: 97574},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3187, col: 16, offset: 97544},
+					pos: position{line: 3188, col: 16, offset: 97574},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3187, col: 16, offset: 97544},
+							pos:   position{line: 3188, col: 16, offset: 97574},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3187, col: 21, offset: 97549},
+								pos:  position{line: 3188, col: 21, offset: 97579},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3187, col: 39, offset: 97567},
+							pos: position{line: 3188, col: 39, offset: 97597},
 							expr: &choiceExpr{
-								pos: position{line: 3187, col: 41, offset: 97569},
+								pos: position{line: 3188, col: 41, offset: 97599},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3187, col: 41, offset: 97569},
+										pos:  position{line: 3188, col: 41, offset: 97599},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3187, col: 55, offset: 97583},
+										pos:        position{line: 3188, col: 55, offset: 97613},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7375,44 +7376,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3192, col: 1, offset: 97648},
+			pos:  position{line: 3193, col: 1, offset: 97678},
 			expr: &actionExpr{
-				pos: position{line: 3192, col: 22, offset: 97669},
+				pos: position{line: 3193, col: 22, offset: 97699},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3192, col: 22, offset: 97669},
+					pos: position{line: 3193, col: 22, offset: 97699},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3192, col: 22, offset: 97669},
+							pos:   position{line: 3193, col: 22, offset: 97699},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3192, col: 28, offset: 97675},
+								pos:  position{line: 3193, col: 28, offset: 97705},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3192, col: 46, offset: 97693},
+							pos:   position{line: 3193, col: 46, offset: 97723},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3192, col: 51, offset: 97698},
+								pos: position{line: 3193, col: 51, offset: 97728},
 								expr: &seqExpr{
-									pos: position{line: 3192, col: 52, offset: 97699},
+									pos: position{line: 3193, col: 52, offset: 97729},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3192, col: 53, offset: 97700},
+											pos: position{line: 3193, col: 53, offset: 97730},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3192, col: 53, offset: 97700},
+													pos:  position{line: 3193, col: 53, offset: 97730},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3192, col: 62, offset: 97709},
+													pos:  position{line: 3193, col: 62, offset: 97739},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3192, col: 71, offset: 97718},
+											pos:  position{line: 3193, col: 71, offset: 97748},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7425,48 +7426,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3213, col: 1, offset: 98219},
+			pos:  position{line: 3214, col: 1, offset: 98249},
 			expr: &actionExpr{
-				pos: position{line: 3213, col: 22, offset: 98240},
+				pos: position{line: 3214, col: 22, offset: 98270},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3213, col: 22, offset: 98240},
+					pos: position{line: 3214, col: 22, offset: 98270},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3213, col: 22, offset: 98240},
+							pos:   position{line: 3214, col: 22, offset: 98270},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3213, col: 28, offset: 98246},
+								pos:  position{line: 3214, col: 28, offset: 98276},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3213, col: 46, offset: 98264},
+							pos:   position{line: 3214, col: 46, offset: 98294},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3213, col: 51, offset: 98269},
+								pos: position{line: 3214, col: 51, offset: 98299},
 								expr: &seqExpr{
-									pos: position{line: 3213, col: 52, offset: 98270},
+									pos: position{line: 3214, col: 52, offset: 98300},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3213, col: 53, offset: 98271},
+											pos: position{line: 3214, col: 53, offset: 98301},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 53, offset: 98271},
+													pos:  position{line: 3214, col: 53, offset: 98301},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 61, offset: 98279},
+													pos:  position{line: 3214, col: 61, offset: 98309},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 69, offset: 98287},
+													pos:  position{line: 3214, col: 69, offset: 98317},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3213, col: 76, offset: 98294},
+											pos:  position{line: 3214, col: 76, offset: 98324},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7479,22 +7480,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3233, col: 1, offset: 98763},
+			pos:  position{line: 3234, col: 1, offset: 98793},
 			expr: &actionExpr{
-				pos: position{line: 3233, col: 21, offset: 98783},
+				pos: position{line: 3234, col: 21, offset: 98813},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3233, col: 21, offset: 98783},
+					pos: position{line: 3234, col: 21, offset: 98813},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3233, col: 21, offset: 98783},
+							pos:  position{line: 3234, col: 21, offset: 98813},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3233, col: 27, offset: 98789},
+							pos:   position{line: 3234, col: 27, offset: 98819},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3233, col: 32, offset: 98794},
+								pos:  position{line: 3234, col: 32, offset: 98824},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7504,67 +7505,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3243, col: 1, offset: 99038},
+			pos:  position{line: 3244, col: 1, offset: 99068},
 			expr: &choiceExpr{
-				pos: position{line: 3243, col: 22, offset: 99059},
+				pos: position{line: 3244, col: 22, offset: 99089},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3243, col: 22, offset: 99059},
+						pos: position{line: 3244, col: 22, offset: 99089},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3243, col: 22, offset: 99059},
+							pos: position{line: 3244, col: 22, offset: 99089},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 22, offset: 99059},
+									pos:  position{line: 3244, col: 22, offset: 99089},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3243, col: 30, offset: 99067},
+									pos:   position{line: 3244, col: 30, offset: 99097},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3243, col: 35, offset: 99072},
+										pos:  position{line: 3244, col: 35, offset: 99102},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 53, offset: 99090},
+									pos:  position{line: 3244, col: 53, offset: 99120},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3246, col: 3, offset: 99125},
+						pos: position{line: 3247, col: 3, offset: 99155},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3246, col: 3, offset: 99125},
+							pos:   position{line: 3247, col: 3, offset: 99155},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3246, col: 20, offset: 99142},
+								pos:  position{line: 3247, col: 20, offset: 99172},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3249, col: 3, offset: 99196},
+						pos: position{line: 3250, col: 3, offset: 99226},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3249, col: 3, offset: 99196},
+							pos:   position{line: 3250, col: 3, offset: 99226},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3249, col: 9, offset: 99202},
+								pos:  position{line: 3250, col: 9, offset: 99232},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3259, col: 3, offset: 99421},
+						pos: position{line: 3260, col: 3, offset: 99451},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3259, col: 3, offset: 99421},
+							pos:   position{line: 3260, col: 3, offset: 99451},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3259, col: 10, offset: 99428},
+								pos:  position{line: 3260, col: 10, offset: 99458},
 								name: "NumberAsString",
 							},
 						},
@@ -7574,144 +7575,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3272, col: 1, offset: 99806},
+			pos:  position{line: 3273, col: 1, offset: 99836},
 			expr: &choiceExpr{
-				pos: position{line: 3272, col: 20, offset: 99825},
+				pos: position{line: 3273, col: 20, offset: 99855},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3272, col: 20, offset: 99825},
+						pos: position{line: 3273, col: 20, offset: 99855},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3272, col: 21, offset: 99826},
+							pos: position{line: 3273, col: 21, offset: 99856},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3272, col: 21, offset: 99826},
+									pos:   position{line: 3273, col: 21, offset: 99856},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3272, col: 29, offset: 99834},
+										pos: position{line: 3273, col: 29, offset: 99864},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3272, col: 29, offset: 99834},
+												pos:        position{line: 3273, col: 29, offset: 99864},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 37, offset: 99842},
+												pos:        position{line: 3273, col: 37, offset: 99872},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 46, offset: 99851},
+												pos:        position{line: 3273, col: 46, offset: 99881},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 58, offset: 99863},
+												pos:        position{line: 3273, col: 58, offset: 99893},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 67, offset: 99872},
+												pos:        position{line: 3273, col: 67, offset: 99902},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 77, offset: 99882},
+												pos:        position{line: 3273, col: 77, offset: 99912},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 85, offset: 99890},
+												pos:        position{line: 3273, col: 85, offset: 99920},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 95, offset: 99900},
+												pos:        position{line: 3273, col: 95, offset: 99930},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 102, offset: 99907},
+												pos:        position{line: 3273, col: 102, offset: 99937},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 113, offset: 99918},
+												pos:        position{line: 3273, col: 113, offset: 99948},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 123, offset: 99928},
+												pos:        position{line: 3273, col: 123, offset: 99958},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 132, offset: 99937},
+												pos:        position{line: 3273, col: 132, offset: 99967},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 142, offset: 99947},
+												pos:        position{line: 3273, col: 142, offset: 99977},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 151, offset: 99956},
+												pos:        position{line: 3273, col: 151, offset: 99986},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 161, offset: 99966},
+												pos:        position{line: 3273, col: 161, offset: 99996},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 170, offset: 99975},
+												pos:        position{line: 3273, col: 170, offset: 100005},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 179, offset: 99984},
+												pos:        position{line: 3273, col: 179, offset: 100014},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 187, offset: 99992},
+												pos:        position{line: 3273, col: 187, offset: 100022},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 196, offset: 100001},
+												pos:        position{line: 3273, col: 196, offset: 100031},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 204, offset: 100009},
+												pos:        position{line: 3273, col: 204, offset: 100039},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 213, offset: 100018},
+												pos:        position{line: 3273, col: 213, offset: 100048},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7720,102 +7721,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3272, col: 220, offset: 100025},
+									pos:  position{line: 3273, col: 220, offset: 100055},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3272, col: 228, offset: 100033},
+									pos:   position{line: 3273, col: 228, offset: 100063},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3272, col: 234, offset: 100039},
+										pos:  position{line: 3273, col: 234, offset: 100069},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3272, col: 253, offset: 100058},
+									pos:  position{line: 3273, col: 253, offset: 100088},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3292, col: 3, offset: 100570},
+						pos: position{line: 3293, col: 3, offset: 100600},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3292, col: 3, offset: 100570},
+							pos: position{line: 3293, col: 3, offset: 100600},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3292, col: 3, offset: 100570},
+									pos:   position{line: 3293, col: 3, offset: 100600},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3292, col: 13, offset: 100580},
+										pos:        position{line: 3293, col: 13, offset: 100610},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 21, offset: 100588},
+									pos:  position{line: 3293, col: 21, offset: 100618},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3292, col: 29, offset: 100596},
+									pos:   position{line: 3293, col: 29, offset: 100626},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3292, col: 35, offset: 100602},
+										pos:  position{line: 3293, col: 35, offset: 100632},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3292, col: 54, offset: 100621},
+									pos:   position{line: 3293, col: 54, offset: 100651},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3292, col: 69, offset: 100636},
+										pos: position{line: 3293, col: 69, offset: 100666},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3292, col: 70, offset: 100637},
+											pos:  position{line: 3293, col: 70, offset: 100667},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 89, offset: 100656},
+									pos:  position{line: 3293, col: 89, offset: 100686},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3313, col: 3, offset: 101274},
+						pos: position{line: 3314, col: 3, offset: 101304},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3313, col: 4, offset: 101275},
+							pos: position{line: 3314, col: 4, offset: 101305},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3313, col: 4, offset: 101275},
+									pos:   position{line: 3314, col: 4, offset: 101305},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3313, col: 12, offset: 101283},
+										pos: position{line: 3314, col: 12, offset: 101313},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3313, col: 12, offset: 101283},
+												pos:        position{line: 3314, col: 12, offset: 101313},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 20, offset: 101291},
+												pos:        position{line: 3314, col: 20, offset: 101321},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 27, offset: 101298},
+												pos:        position{line: 3314, col: 27, offset: 101328},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 38, offset: 101309},
+												pos:        position{line: 3314, col: 38, offset: 101339},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7824,54 +7825,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 46, offset: 101317},
+									pos:  position{line: 3314, col: 46, offset: 101347},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 54, offset: 101325},
+									pos:  position{line: 3314, col: 54, offset: 101355},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3326, col: 3, offset: 101611},
+						pos: position{line: 3327, col: 3, offset: 101641},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3326, col: 3, offset: 101611},
+							pos: position{line: 3327, col: 3, offset: 101641},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3326, col: 3, offset: 101611},
+									pos:        position{line: 3327, col: 3, offset: 101641},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3326, col: 14, offset: 101622},
+									pos:  position{line: 3327, col: 14, offset: 101652},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3326, col: 22, offset: 101630},
+									pos:   position{line: 3327, col: 22, offset: 101660},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3326, col: 33, offset: 101641},
+										pos:  position{line: 3327, col: 33, offset: 101671},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3326, col: 44, offset: 101652},
+									pos:   position{line: 3327, col: 44, offset: 101682},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3326, col: 53, offset: 101661},
+										pos: position{line: 3327, col: 53, offset: 101691},
 										expr: &seqExpr{
-											pos: position{line: 3326, col: 54, offset: 101662},
+											pos: position{line: 3327, col: 54, offset: 101692},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3326, col: 54, offset: 101662},
+													pos:  position{line: 3327, col: 54, offset: 101692},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3326, col: 60, offset: 101668},
+													pos:  position{line: 3327, col: 60, offset: 101698},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -7879,73 +7880,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3326, col: 80, offset: 101688},
+									pos:  position{line: 3327, col: 80, offset: 101718},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3354, col: 3, offset: 102530},
+						pos: position{line: 3355, col: 3, offset: 102560},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3354, col: 3, offset: 102530},
+							pos: position{line: 3355, col: 3, offset: 102560},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3354, col: 3, offset: 102530},
+									pos:   position{line: 3355, col: 3, offset: 102560},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3354, col: 12, offset: 102539},
+										pos:        position{line: 3355, col: 12, offset: 102569},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3354, col: 18, offset: 102545},
+									pos:  position{line: 3355, col: 18, offset: 102575},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3354, col: 26, offset: 102553},
+									pos:   position{line: 3355, col: 26, offset: 102583},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3354, col: 31, offset: 102558},
+										pos:  position{line: 3355, col: 31, offset: 102588},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3354, col: 39, offset: 102566},
+									pos:  position{line: 3355, col: 39, offset: 102596},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3357, col: 3, offset: 102601},
+						pos: position{line: 3358, col: 3, offset: 102631},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3357, col: 4, offset: 102602},
+							pos: position{line: 3358, col: 4, offset: 102632},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3357, col: 4, offset: 102602},
+									pos:   position{line: 3358, col: 4, offset: 102632},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3357, col: 12, offset: 102610},
+										pos: position{line: 3358, col: 12, offset: 102640},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3357, col: 12, offset: 102610},
+												pos:        position{line: 3358, col: 12, offset: 102640},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3357, col: 20, offset: 102618},
+												pos:        position{line: 3358, col: 20, offset: 102648},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3357, col: 30, offset: 102628},
+												pos:        position{line: 3358, col: 30, offset: 102658},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -7954,128 +7955,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3357, col: 39, offset: 102637},
+									pos:  position{line: 3358, col: 39, offset: 102667},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3357, col: 47, offset: 102645},
+									pos:   position{line: 3358, col: 47, offset: 102675},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3357, col: 53, offset: 102651},
+										pos:  position{line: 3358, col: 53, offset: 102681},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3357, col: 72, offset: 102670},
+									pos:   position{line: 3358, col: 72, offset: 102700},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3357, col: 79, offset: 102677},
+										pos:  position{line: 3358, col: 79, offset: 102707},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3357, col: 97, offset: 102695},
+									pos:  position{line: 3358, col: 97, offset: 102725},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3387, col: 3, offset: 103534},
+						pos: position{line: 3388, col: 3, offset: 103564},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3387, col: 4, offset: 103535},
+							pos: position{line: 3388, col: 4, offset: 103565},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3387, col: 4, offset: 103535},
+									pos:   position{line: 3388, col: 4, offset: 103565},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3387, col: 11, offset: 103542},
+										pos:        position{line: 3388, col: 11, offset: 103572},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3387, col: 17, offset: 103548},
+									pos:  position{line: 3388, col: 17, offset: 103578},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3387, col: 25, offset: 103556},
+									pos:   position{line: 3388, col: 25, offset: 103586},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3387, col: 31, offset: 103562},
+										pos:  position{line: 3388, col: 31, offset: 103592},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3387, col: 50, offset: 103581},
+									pos:   position{line: 3388, col: 50, offset: 103611},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3387, col: 56, offset: 103587},
+										pos: position{line: 3388, col: 56, offset: 103617},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3387, col: 57, offset: 103588},
+											pos:  position{line: 3388, col: 57, offset: 103618},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3387, col: 76, offset: 103607},
+									pos:  position{line: 3388, col: 76, offset: 103637},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3416, col: 3, offset: 104380},
+						pos: position{line: 3417, col: 3, offset: 104410},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3416, col: 3, offset: 104380},
+							pos: position{line: 3417, col: 3, offset: 104410},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3416, col: 3, offset: 104380},
+									pos:   position{line: 3417, col: 3, offset: 104410},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3416, col: 11, offset: 104388},
+										pos:        position{line: 3417, col: 11, offset: 104418},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 28, offset: 104405},
+									pos:  position{line: 3417, col: 28, offset: 104435},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3416, col: 36, offset: 104413},
+									pos:   position{line: 3417, col: 36, offset: 104443},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3416, col: 42, offset: 104419},
+										pos:  position{line: 3417, col: 42, offset: 104449},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 61, offset: 104438},
+									pos:  position{line: 3417, col: 61, offset: 104468},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 67, offset: 104444},
+									pos:  position{line: 3417, col: 67, offset: 104474},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3416, col: 73, offset: 104450},
+									pos:   position{line: 3417, col: 73, offset: 104480},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3416, col: 84, offset: 104461},
+										pos:  position{line: 3417, col: 84, offset: 104491},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 120, offset: 104497},
+									pos:  position{line: 3417, col: 120, offset: 104527},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 126, offset: 104503},
+									pos:  position{line: 3417, col: 126, offset: 104533},
 									name: "R_PAREN",
 								},
 							},
@@ -8086,28 +8087,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3433, col: 1, offset: 105032},
+			pos:  position{line: 3434, col: 1, offset: 105062},
 			expr: &choiceExpr{
-				pos: position{line: 3433, col: 12, offset: 105043},
+				pos: position{line: 3434, col: 12, offset: 105073},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3433, col: 12, offset: 105043},
+						pos: position{line: 3434, col: 12, offset: 105073},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3433, col: 12, offset: 105043},
+							pos: position{line: 3434, col: 12, offset: 105073},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3433, col: 12, offset: 105043},
+									pos:   position{line: 3434, col: 12, offset: 105073},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3433, col: 16, offset: 105047},
+										pos:  position{line: 3434, col: 16, offset: 105077},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3433, col: 29, offset: 105060},
+									pos: position{line: 3434, col: 29, offset: 105090},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3433, col: 31, offset: 105062},
+										pos:  position{line: 3434, col: 31, offset: 105092},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8115,50 +8116,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3449, col: 3, offset: 105423},
+						pos: position{line: 3450, col: 3, offset: 105453},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3449, col: 3, offset: 105423},
+							pos: position{line: 3450, col: 3, offset: 105453},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3449, col: 3, offset: 105423},
+									pos:   position{line: 3450, col: 3, offset: 105453},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3449, col: 9, offset: 105429},
+										pos:  position{line: 3450, col: 9, offset: 105459},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3449, col: 25, offset: 105445},
+									pos: position{line: 3450, col: 25, offset: 105475},
 									expr: &choiceExpr{
-										pos: position{line: 3449, col: 27, offset: 105447},
+										pos: position{line: 3450, col: 27, offset: 105477},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 27, offset: 105447},
+												pos:  position{line: 3450, col: 27, offset: 105477},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 36, offset: 105456},
+												pos:  position{line: 3450, col: 36, offset: 105486},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 46, offset: 105466},
+												pos:  position{line: 3450, col: 46, offset: 105496},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 54, offset: 105474},
+												pos:  position{line: 3450, col: 54, offset: 105504},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 62, offset: 105482},
+												pos:  position{line: 3450, col: 62, offset: 105512},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 70, offset: 105490},
+												pos:  position{line: 3450, col: 70, offset: 105520},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3449, col: 84, offset: 105504},
+												pos:        position{line: 3450, col: 84, offset: 105534},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8174,28 +8175,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3466, col: 1, offset: 105855},
+			pos:  position{line: 3467, col: 1, offset: 105885},
 			expr: &actionExpr{
-				pos: position{line: 3466, col: 19, offset: 105873},
+				pos: position{line: 3467, col: 19, offset: 105903},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3466, col: 19, offset: 105873},
+					pos: position{line: 3467, col: 19, offset: 105903},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3466, col: 19, offset: 105873},
+							pos:        position{line: 3467, col: 19, offset: 105903},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3466, col: 26, offset: 105880},
+							pos:  position{line: 3467, col: 26, offset: 105910},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3466, col: 32, offset: 105886},
+							pos:   position{line: 3467, col: 32, offset: 105916},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3466, col: 40, offset: 105894},
+								pos:  position{line: 3467, col: 40, offset: 105924},
 								name: "Boolean",
 							},
 						},
@@ -8205,28 +8206,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3477, col: 1, offset: 106083},
+			pos:  position{line: 3478, col: 1, offset: 106113},
 			expr: &actionExpr{
-				pos: position{line: 3477, col: 23, offset: 106105},
+				pos: position{line: 3478, col: 23, offset: 106135},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3477, col: 23, offset: 106105},
+					pos: position{line: 3478, col: 23, offset: 106135},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3477, col: 23, offset: 106105},
+							pos:        position{line: 3478, col: 23, offset: 106135},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3477, col: 34, offset: 106116},
+							pos:  position{line: 3478, col: 34, offset: 106146},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3477, col: 40, offset: 106122},
+							pos:   position{line: 3478, col: 40, offset: 106152},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3477, col: 48, offset: 106130},
+								pos:  position{line: 3478, col: 48, offset: 106160},
 								name: "Boolean",
 							},
 						},
@@ -8236,28 +8237,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3488, col: 1, offset: 106327},
+			pos:  position{line: 3489, col: 1, offset: 106357},
 			expr: &actionExpr{
-				pos: position{line: 3488, col: 20, offset: 106346},
+				pos: position{line: 3489, col: 20, offset: 106376},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3488, col: 20, offset: 106346},
+					pos: position{line: 3489, col: 20, offset: 106376},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3488, col: 20, offset: 106346},
+							pos:        position{line: 3489, col: 20, offset: 106376},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3488, col: 28, offset: 106354},
+							pos:  position{line: 3489, col: 28, offset: 106384},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3488, col: 34, offset: 106360},
+							pos:   position{line: 3489, col: 34, offset: 106390},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3488, col: 43, offset: 106369},
+								pos:  position{line: 3489, col: 43, offset: 106399},
 								name: "IntegerAsString",
 							},
 						},
@@ -8267,15 +8268,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3503, col: 1, offset: 106731},
+			pos:  position{line: 3504, col: 1, offset: 106761},
 			expr: &actionExpr{
-				pos: position{line: 3503, col: 19, offset: 106749},
+				pos: position{line: 3504, col: 19, offset: 106779},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3503, col: 19, offset: 106749},
+					pos:   position{line: 3504, col: 19, offset: 106779},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3503, col: 28, offset: 106758},
+						pos:  position{line: 3504, col: 28, offset: 106788},
 						name: "BoolExpr",
 					},
 				},
@@ -8283,30 +8284,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3514, col: 1, offset: 106970},
+			pos:  position{line: 3515, col: 1, offset: 107000},
 			expr: &actionExpr{
-				pos: position{line: 3514, col: 15, offset: 106984},
+				pos: position{line: 3515, col: 15, offset: 107014},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3514, col: 15, offset: 106984},
+					pos:   position{line: 3515, col: 15, offset: 107014},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3514, col: 23, offset: 106992},
+						pos: position{line: 3515, col: 23, offset: 107022},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 23, offset: 106992},
+								pos:  position{line: 3515, col: 23, offset: 107022},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 44, offset: 107013},
+								pos:  position{line: 3515, col: 44, offset: 107043},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 61, offset: 107030},
+								pos:  position{line: 3515, col: 61, offset: 107060},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 79, offset: 107048},
+								pos:  position{line: 3515, col: 79, offset: 107078},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8316,35 +8317,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3518, col: 1, offset: 107092},
+			pos:  position{line: 3519, col: 1, offset: 107122},
 			expr: &actionExpr{
-				pos: position{line: 3518, col: 19, offset: 107110},
+				pos: position{line: 3519, col: 19, offset: 107140},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3518, col: 19, offset: 107110},
+					pos: position{line: 3519, col: 19, offset: 107140},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3518, col: 19, offset: 107110},
+							pos:   position{line: 3519, col: 19, offset: 107140},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3518, col: 26, offset: 107117},
+								pos:  position{line: 3519, col: 26, offset: 107147},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3518, col: 37, offset: 107128},
+							pos:   position{line: 3519, col: 37, offset: 107158},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3518, col: 43, offset: 107134},
+								pos: position{line: 3519, col: 43, offset: 107164},
 								expr: &seqExpr{
-									pos: position{line: 3518, col: 44, offset: 107135},
+									pos: position{line: 3519, col: 44, offset: 107165},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3518, col: 44, offset: 107135},
+											pos:  position{line: 3519, col: 44, offset: 107165},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3518, col: 50, offset: 107141},
+											pos:  position{line: 3519, col: 50, offset: 107171},
 											name: "HeadOption",
 										},
 									},
@@ -8357,29 +8358,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3580, col: 1, offset: 109188},
+			pos:  position{line: 3581, col: 1, offset: 109218},
 			expr: &choiceExpr{
-				pos: position{line: 3580, col: 14, offset: 109201},
+				pos: position{line: 3581, col: 14, offset: 109231},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3580, col: 14, offset: 109201},
+						pos: position{line: 3581, col: 14, offset: 109231},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3580, col: 14, offset: 109201},
+							pos: position{line: 3581, col: 14, offset: 109231},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 14, offset: 109201},
+									pos:  position{line: 3581, col: 14, offset: 109231},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 19, offset: 109206},
+									pos:  position{line: 3581, col: 19, offset: 109236},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3580, col: 28, offset: 109215},
+									pos:   position{line: 3581, col: 28, offset: 109245},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3580, col: 37, offset: 109224},
+										pos:  position{line: 3581, col: 37, offset: 109254},
 										name: "HeadOptionList",
 									},
 								},
@@ -8387,24 +8388,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3590, col: 3, offset: 109495},
+						pos: position{line: 3591, col: 3, offset: 109525},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3590, col: 3, offset: 109495},
+							pos: position{line: 3591, col: 3, offset: 109525},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3590, col: 3, offset: 109495},
+									pos:  position{line: 3591, col: 3, offset: 109525},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3590, col: 8, offset: 109500},
+									pos:  position{line: 3591, col: 8, offset: 109530},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3590, col: 17, offset: 109509},
+									pos:   position{line: 3591, col: 17, offset: 109539},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3590, col: 26, offset: 109518},
+										pos:  position{line: 3591, col: 26, offset: 109548},
 										name: "IntegerAsString",
 									},
 								},
@@ -8412,17 +8413,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3607, col: 3, offset: 109997},
+						pos: position{line: 3608, col: 3, offset: 110027},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3607, col: 3, offset: 109997},
+							pos: position{line: 3608, col: 3, offset: 110027},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3607, col: 3, offset: 109997},
+									pos:  position{line: 3608, col: 3, offset: 110027},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3607, col: 8, offset: 110002},
+									pos:  position{line: 3608, col: 8, offset: 110032},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8433,29 +8434,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3621, col: 1, offset: 110433},
+			pos:  position{line: 3622, col: 1, offset: 110463},
 			expr: &choiceExpr{
-				pos: position{line: 3621, col: 14, offset: 110446},
+				pos: position{line: 3622, col: 14, offset: 110476},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3621, col: 14, offset: 110446},
+						pos: position{line: 3622, col: 14, offset: 110476},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3621, col: 14, offset: 110446},
+							pos: position{line: 3622, col: 14, offset: 110476},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3621, col: 14, offset: 110446},
+									pos:  position{line: 3622, col: 14, offset: 110476},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3621, col: 19, offset: 110451},
+									pos:  position{line: 3622, col: 19, offset: 110481},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3621, col: 28, offset: 110460},
+									pos:   position{line: 3622, col: 28, offset: 110490},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3621, col: 37, offset: 110469},
+										pos:  position{line: 3622, col: 37, offset: 110499},
 										name: "IntegerAsString",
 									},
 								},
@@ -8463,17 +8464,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3641, col: 3, offset: 111018},
+						pos: position{line: 3642, col: 3, offset: 111048},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3641, col: 3, offset: 111018},
+							pos: position{line: 3642, col: 3, offset: 111048},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3641, col: 3, offset: 111018},
+									pos:  position{line: 3642, col: 3, offset: 111048},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3641, col: 8, offset: 111023},
+									pos:  position{line: 3642, col: 8, offset: 111053},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8484,44 +8485,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3661, col: 1, offset: 111616},
+			pos:  position{line: 3662, col: 1, offset: 111646},
 			expr: &actionExpr{
-				pos: position{line: 3661, col: 20, offset: 111635},
+				pos: position{line: 3662, col: 20, offset: 111665},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3661, col: 20, offset: 111635},
+					pos: position{line: 3662, col: 20, offset: 111665},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3661, col: 20, offset: 111635},
+							pos:   position{line: 3662, col: 20, offset: 111665},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3661, col: 26, offset: 111641},
+								pos:  position{line: 3662, col: 26, offset: 111671},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3661, col: 37, offset: 111652},
+							pos:   position{line: 3662, col: 37, offset: 111682},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3661, col: 42, offset: 111657},
+								pos: position{line: 3662, col: 42, offset: 111687},
 								expr: &seqExpr{
-									pos: position{line: 3661, col: 43, offset: 111658},
+									pos: position{line: 3662, col: 43, offset: 111688},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3661, col: 44, offset: 111659},
+											pos: position{line: 3662, col: 44, offset: 111689},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3661, col: 44, offset: 111659},
+													pos:  position{line: 3662, col: 44, offset: 111689},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3661, col: 52, offset: 111667},
+													pos:  position{line: 3662, col: 52, offset: 111697},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3661, col: 59, offset: 111674},
+											pos:  position{line: 3662, col: 59, offset: 111704},
 											name: "Aggregator",
 										},
 									},
@@ -8534,28 +8535,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3678, col: 1, offset: 112177},
+			pos:  position{line: 3679, col: 1, offset: 112207},
 			expr: &actionExpr{
-				pos: position{line: 3678, col: 15, offset: 112191},
+				pos: position{line: 3679, col: 15, offset: 112221},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3678, col: 15, offset: 112191},
+					pos: position{line: 3679, col: 15, offset: 112221},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3678, col: 15, offset: 112191},
+							pos:   position{line: 3679, col: 15, offset: 112221},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3678, col: 23, offset: 112199},
+								pos:  position{line: 3679, col: 23, offset: 112229},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3678, col: 35, offset: 112211},
+							pos:   position{line: 3679, col: 35, offset: 112241},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3678, col: 43, offset: 112219},
+								pos: position{line: 3679, col: 43, offset: 112249},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3678, col: 43, offset: 112219},
+									pos:  position{line: 3679, col: 43, offset: 112249},
 									name: "AsField",
 								},
 							},
@@ -8566,26 +8567,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3694, col: 1, offset: 113060},
+			pos:  position{line: 3695, col: 1, offset: 113090},
 			expr: &actionExpr{
-				pos: position{line: 3694, col: 16, offset: 113075},
+				pos: position{line: 3695, col: 16, offset: 113105},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3694, col: 16, offset: 113075},
+					pos:   position{line: 3695, col: 16, offset: 113105},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3694, col: 21, offset: 113080},
+						pos: position{line: 3695, col: 21, offset: 113110},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 21, offset: 113080},
+								pos:  position{line: 3695, col: 21, offset: 113110},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 32, offset: 113091},
+								pos:  position{line: 3695, col: 32, offset: 113121},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 48, offset: 113107},
+								pos:  position{line: 3695, col: 48, offset: 113137},
 								name: "AggCommon",
 							},
 						},
@@ -8595,165 +8596,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3699, col: 1, offset: 113313},
+			pos:  position{line: 3700, col: 1, offset: 113343},
 			expr: &actionExpr{
-				pos: position{line: 3699, col: 18, offset: 113330},
+				pos: position{line: 3700, col: 18, offset: 113360},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3699, col: 19, offset: 113331},
+					pos: position{line: 3700, col: 19, offset: 113361},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3699, col: 19, offset: 113331},
+							pos:        position{line: 3700, col: 19, offset: 113361},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 30, offset: 113342},
+							pos:        position{line: 3700, col: 30, offset: 113372},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 39, offset: 113351},
+							pos:        position{line: 3700, col: 39, offset: 113381},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 47, offset: 113359},
+							pos:        position{line: 3700, col: 47, offset: 113389},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 57, offset: 113369},
+							pos:        position{line: 3700, col: 57, offset: 113399},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 65, offset: 113377},
+							pos:        position{line: 3700, col: 65, offset: 113407},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 76, offset: 113388},
+							pos:        position{line: 3700, col: 76, offset: 113418},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 86, offset: 113398},
+							pos:        position{line: 3700, col: 86, offset: 113428},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 95, offset: 113407},
+							pos:        position{line: 3700, col: 95, offset: 113437},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 105, offset: 113417},
+							pos:        position{line: 3700, col: 105, offset: 113447},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 114, offset: 113426},
+							pos:        position{line: 3700, col: 114, offset: 113456},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 122, offset: 113434},
+							pos:        position{line: 3700, col: 122, offset: 113464},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 133, offset: 113445},
+							pos:        position{line: 3700, col: 133, offset: 113475},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 142, offset: 113454},
+							pos:        position{line: 3700, col: 142, offset: 113484},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 1, offset: 113463},
+							pos:        position{line: 3701, col: 1, offset: 113493},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 10, offset: 113472},
+							pos:        position{line: 3701, col: 10, offset: 113502},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 26, offset: 113488},
+							pos:        position{line: 3701, col: 26, offset: 113518},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 37, offset: 113499},
+							pos:        position{line: 3701, col: 37, offset: 113529},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 46, offset: 113508},
+							pos:        position{line: 3701, col: 46, offset: 113538},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 56, offset: 113518},
+							pos:        position{line: 3701, col: 56, offset: 113548},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 72, offset: 113534},
+							pos:        position{line: 3701, col: 72, offset: 113564},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 82, offset: 113544},
+							pos:        position{line: 3701, col: 82, offset: 113574},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 100, offset: 113562},
+							pos:        position{line: 3701, col: 100, offset: 113592},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 113, offset: 113575},
+							pos:        position{line: 3701, col: 113, offset: 113605},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 132, offset: 113594},
+							pos:        position{line: 3701, col: 132, offset: 113624},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 139, offset: 113601},
+							pos:        position{line: 3701, col: 139, offset: 113631},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8764,27 +8765,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3704, col: 1, offset: 113644},
+			pos:  position{line: 3705, col: 1, offset: 113674},
 			expr: &actionExpr{
-				pos: position{line: 3704, col: 22, offset: 113665},
+				pos: position{line: 3705, col: 22, offset: 113695},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3704, col: 23, offset: 113666},
+					pos: position{line: 3705, col: 23, offset: 113696},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3704, col: 23, offset: 113666},
+							pos:        position{line: 3705, col: 23, offset: 113696},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3704, col: 37, offset: 113680},
+							pos:        position{line: 3705, col: 37, offset: 113710},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3704, col: 51, offset: 113694},
+							pos:        position{line: 3705, col: 51, offset: 113724},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8795,29 +8796,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3708, col: 1, offset: 113738},
+			pos:  position{line: 3709, col: 1, offset: 113768},
 			expr: &actionExpr{
-				pos: position{line: 3708, col: 12, offset: 113749},
+				pos: position{line: 3709, col: 12, offset: 113779},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3708, col: 12, offset: 113749},
+					pos: position{line: 3709, col: 12, offset: 113779},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3708, col: 12, offset: 113749},
+							pos:  position{line: 3709, col: 12, offset: 113779},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3708, col: 15, offset: 113752},
+							pos:   position{line: 3709, col: 15, offset: 113782},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3708, col: 23, offset: 113760},
+								pos: position{line: 3709, col: 23, offset: 113790},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3708, col: 23, offset: 113760},
+										pos:  position{line: 3709, col: 23, offset: 113790},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3708, col: 35, offset: 113772},
+										pos:  position{line: 3709, col: 35, offset: 113802},
 										name: "String",
 									},
 								},
@@ -8829,27 +8830,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3722, col: 1, offset: 114101},
+			pos:  position{line: 3723, col: 1, offset: 114131},
 			expr: &choiceExpr{
-				pos: position{line: 3722, col: 13, offset: 114113},
+				pos: position{line: 3723, col: 13, offset: 114143},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3722, col: 13, offset: 114113},
+						pos: position{line: 3723, col: 13, offset: 114143},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3722, col: 13, offset: 114113},
+							pos: position{line: 3723, col: 13, offset: 114143},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3722, col: 14, offset: 114114},
+									pos: position{line: 3723, col: 14, offset: 114144},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3722, col: 14, offset: 114114},
+											pos:        position{line: 3723, col: 14, offset: 114144},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3722, col: 24, offset: 114124},
+											pos:        position{line: 3723, col: 24, offset: 114154},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8857,47 +8858,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3722, col: 29, offset: 114129},
+									pos:  position{line: 3723, col: 29, offset: 114159},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3722, col: 37, offset: 114137},
+									pos:        position{line: 3723, col: 37, offset: 114167},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3722, col: 44, offset: 114144},
+									pos:   position{line: 3723, col: 44, offset: 114174},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3722, col: 54, offset: 114154},
+										pos:  position{line: 3723, col: 54, offset: 114184},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3722, col: 64, offset: 114164},
+									pos:  position{line: 3723, col: 64, offset: 114194},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3732, col: 3, offset: 114392},
+						pos: position{line: 3733, col: 3, offset: 114422},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3732, col: 3, offset: 114392},
+							pos: position{line: 3733, col: 3, offset: 114422},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3732, col: 4, offset: 114393},
+									pos: position{line: 3733, col: 4, offset: 114423},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3732, col: 4, offset: 114393},
+											pos:        position{line: 3733, col: 4, offset: 114423},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3732, col: 14, offset: 114403},
+											pos:        position{line: 3733, col: 14, offset: 114433},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8905,38 +8906,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 19, offset: 114408},
+									pos:  position{line: 3733, col: 19, offset: 114438},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3732, col: 27, offset: 114416},
+									pos:   position{line: 3733, col: 27, offset: 114446},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3732, col: 33, offset: 114422},
+										pos:  position{line: 3733, col: 33, offset: 114452},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 43, offset: 114432},
+									pos:  position{line: 3733, col: 43, offset: 114462},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3739, col: 5, offset: 114583},
+						pos: position{line: 3740, col: 5, offset: 114613},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3739, col: 6, offset: 114584},
+							pos: position{line: 3740, col: 6, offset: 114614},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3739, col: 6, offset: 114584},
+									pos:        position{line: 3740, col: 6, offset: 114614},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3739, col: 16, offset: 114594},
+									pos:        position{line: 3740, col: 16, offset: 114624},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -8949,77 +8950,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3748, col: 1, offset: 114730},
+			pos:  position{line: 3749, col: 1, offset: 114760},
 			expr: &choiceExpr{
-				pos: position{line: 3748, col: 14, offset: 114743},
+				pos: position{line: 3749, col: 14, offset: 114773},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3748, col: 14, offset: 114743},
+						pos: position{line: 3749, col: 14, offset: 114773},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3748, col: 14, offset: 114743},
+							pos: position{line: 3749, col: 14, offset: 114773},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3748, col: 14, offset: 114743},
+									pos:   position{line: 3749, col: 14, offset: 114773},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3748, col: 22, offset: 114751},
+										pos:  position{line: 3749, col: 22, offset: 114781},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 36, offset: 114765},
+									pos:  position{line: 3749, col: 36, offset: 114795},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3748, col: 44, offset: 114773},
+									pos:        position{line: 3749, col: 44, offset: 114803},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3748, col: 51, offset: 114780},
+									pos:   position{line: 3749, col: 51, offset: 114810},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3748, col: 61, offset: 114790},
+										pos:  position{line: 3749, col: 61, offset: 114820},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 71, offset: 114800},
+									pos:  position{line: 3749, col: 71, offset: 114830},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3763, col: 3, offset: 115210},
+						pos: position{line: 3764, col: 3, offset: 115240},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3763, col: 3, offset: 115210},
+							pos: position{line: 3764, col: 3, offset: 115240},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3763, col: 3, offset: 115210},
+									pos:   position{line: 3764, col: 3, offset: 115240},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3763, col: 11, offset: 115218},
+										pos:  position{line: 3764, col: 11, offset: 115248},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3763, col: 25, offset: 115232},
+									pos:  position{line: 3764, col: 25, offset: 115262},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3763, col: 33, offset: 115240},
+									pos:   position{line: 3764, col: 33, offset: 115270},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3763, col: 39, offset: 115246},
+										pos:  position{line: 3764, col: 39, offset: 115276},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3763, col: 49, offset: 115256},
+									pos:  position{line: 3764, col: 49, offset: 115286},
 									name: "R_PAREN",
 								},
 							},
@@ -9030,22 +9031,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3777, col: 1, offset: 115588},
+			pos:  position{line: 3778, col: 1, offset: 115618},
 			expr: &actionExpr{
-				pos: position{line: 3777, col: 18, offset: 115605},
+				pos: position{line: 3778, col: 18, offset: 115635},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3777, col: 18, offset: 115605},
+					pos:   position{line: 3778, col: 18, offset: 115635},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3777, col: 26, offset: 115613},
+						pos: position{line: 3778, col: 26, offset: 115643},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3777, col: 26, offset: 115613},
+								pos:  position{line: 3778, col: 26, offset: 115643},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3777, col: 42, offset: 115629},
+								pos:  position{line: 3778, col: 42, offset: 115659},
 								name: "IntegerAsString",
 							},
 						},
@@ -9055,93 +9056,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3789, col: 1, offset: 116003},
+			pos:  position{line: 3790, col: 1, offset: 116033},
 			expr: &choiceExpr{
-				pos: position{line: 3789, col: 18, offset: 116020},
+				pos: position{line: 3790, col: 18, offset: 116050},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3789, col: 18, offset: 116020},
+						pos: position{line: 3790, col: 18, offset: 116050},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3789, col: 18, offset: 116020},
+							pos: position{line: 3790, col: 18, offset: 116050},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3789, col: 18, offset: 116020},
+									pos:   position{line: 3790, col: 18, offset: 116050},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 26, offset: 116028},
+										pos:  position{line: 3790, col: 26, offset: 116058},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3789, col: 44, offset: 116046},
+									pos:   position{line: 3790, col: 44, offset: 116076},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 58, offset: 116060},
+										pos:  position{line: 3790, col: 58, offset: 116090},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3789, col: 72, offset: 116074},
+									pos:  position{line: 3790, col: 72, offset: 116104},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3789, col: 80, offset: 116082},
+									pos:        position{line: 3790, col: 80, offset: 116112},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3789, col: 87, offset: 116089},
+									pos:   position{line: 3790, col: 87, offset: 116119},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 97, offset: 116099},
+										pos:  position{line: 3790, col: 97, offset: 116129},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3789, col: 107, offset: 116109},
+									pos:  position{line: 3790, col: 107, offset: 116139},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3805, col: 3, offset: 116558},
+						pos: position{line: 3806, col: 3, offset: 116588},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3805, col: 3, offset: 116558},
+							pos: position{line: 3806, col: 3, offset: 116588},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3805, col: 3, offset: 116558},
+									pos:   position{line: 3806, col: 3, offset: 116588},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 11, offset: 116566},
+										pos:  position{line: 3806, col: 11, offset: 116596},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3805, col: 29, offset: 116584},
+									pos:   position{line: 3806, col: 29, offset: 116614},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 43, offset: 116598},
+										pos:  position{line: 3806, col: 43, offset: 116628},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3805, col: 57, offset: 116612},
+									pos:  position{line: 3806, col: 57, offset: 116642},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3805, col: 65, offset: 116620},
+									pos:   position{line: 3806, col: 65, offset: 116650},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 71, offset: 116626},
+										pos:  position{line: 3806, col: 71, offset: 116656},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3805, col: 81, offset: 116636},
+									pos:  position{line: 3806, col: 81, offset: 116666},
 									name: "R_PAREN",
 								},
 							},
@@ -9152,22 +9153,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3821, col: 1, offset: 117008},
+			pos:  position{line: 3822, col: 1, offset: 117038},
 			expr: &actionExpr{
-				pos: position{line: 3821, col: 25, offset: 117032},
+				pos: position{line: 3822, col: 25, offset: 117062},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3821, col: 25, offset: 117032},
+					pos:   position{line: 3822, col: 25, offset: 117062},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3821, col: 39, offset: 117046},
+						pos: position{line: 3822, col: 39, offset: 117076},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3821, col: 39, offset: 117046},
+								pos:  position{line: 3822, col: 39, offset: 117076},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3821, col: 67, offset: 117074},
+								pos:  position{line: 3822, col: 67, offset: 117104},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9177,43 +9178,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3825, col: 1, offset: 117137},
+			pos:  position{line: 3826, col: 1, offset: 117167},
 			expr: &actionExpr{
-				pos: position{line: 3825, col: 30, offset: 117166},
+				pos: position{line: 3826, col: 30, offset: 117196},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3825, col: 30, offset: 117166},
+					pos: position{line: 3826, col: 30, offset: 117196},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3825, col: 30, offset: 117166},
+							pos:   position{line: 3826, col: 30, offset: 117196},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3825, col: 34, offset: 117170},
+								pos:  position{line: 3826, col: 34, offset: 117200},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3825, col: 44, offset: 117180},
+							pos:   position{line: 3826, col: 44, offset: 117210},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3825, col: 48, offset: 117184},
+								pos: position{line: 3826, col: 48, offset: 117214},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3825, col: 48, offset: 117184},
+										pos:  position{line: 3826, col: 48, offset: 117214},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3825, col: 67, offset: 117203},
+										pos:  position{line: 3826, col: 67, offset: 117233},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3825, col: 87, offset: 117223},
+							pos:   position{line: 3826, col: 87, offset: 117253},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3825, col: 93, offset: 117229},
+								pos:  position{line: 3826, col: 93, offset: 117259},
 								name: "Number",
 							},
 						},
@@ -9223,15 +9224,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3838, col: 1, offset: 117463},
+			pos:  position{line: 3839, col: 1, offset: 117493},
 			expr: &actionExpr{
-				pos: position{line: 3838, col: 32, offset: 117494},
+				pos: position{line: 3839, col: 32, offset: 117524},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3838, col: 32, offset: 117494},
+					pos:   position{line: 3839, col: 32, offset: 117524},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3838, col: 38, offset: 117500},
+						pos:  position{line: 3839, col: 38, offset: 117530},
 						name: "Number",
 					},
 				},
@@ -9239,34 +9240,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3851, col: 1, offset: 117717},
+			pos:  position{line: 3852, col: 1, offset: 117747},
 			expr: &actionExpr{
-				pos: position{line: 3851, col: 26, offset: 117742},
+				pos: position{line: 3852, col: 26, offset: 117772},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3851, col: 26, offset: 117742},
+					pos: position{line: 3852, col: 26, offset: 117772},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3851, col: 26, offset: 117742},
+							pos:   position{line: 3852, col: 26, offset: 117772},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 30, offset: 117746},
+								pos:  position{line: 3852, col: 30, offset: 117776},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3851, col: 40, offset: 117756},
+							pos:   position{line: 3852, col: 40, offset: 117786},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 43, offset: 117759},
+								pos:  position{line: 3852, col: 43, offset: 117789},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3851, col: 60, offset: 117776},
+							pos:   position{line: 3852, col: 60, offset: 117806},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 66, offset: 117782},
+								pos:  position{line: 3852, col: 66, offset: 117812},
 								name: "Boolean",
 							},
 						},
@@ -9276,22 +9277,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3864, col: 1, offset: 118017},
+			pos:  position{line: 3865, col: 1, offset: 118047},
 			expr: &actionExpr{
-				pos: position{line: 3864, col: 25, offset: 118041},
+				pos: position{line: 3865, col: 25, offset: 118071},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3864, col: 25, offset: 118041},
+					pos:   position{line: 3865, col: 25, offset: 118071},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3864, col: 39, offset: 118055},
+						pos: position{line: 3865, col: 39, offset: 118085},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3864, col: 39, offset: 118055},
+								pos:  position{line: 3865, col: 39, offset: 118085},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3864, col: 67, offset: 118083},
+								pos:  position{line: 3865, col: 67, offset: 118113},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9301,41 +9302,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3868, col: 1, offset: 118146},
+			pos:  position{line: 3869, col: 1, offset: 118176},
 			expr: &actionExpr{
-				pos: position{line: 3868, col: 30, offset: 118175},
+				pos: position{line: 3869, col: 30, offset: 118205},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3868, col: 30, offset: 118175},
+					pos: position{line: 3869, col: 30, offset: 118205},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3868, col: 30, offset: 118175},
+							pos:   position{line: 3869, col: 30, offset: 118205},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3868, col: 34, offset: 118179},
+								pos:  position{line: 3869, col: 34, offset: 118209},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3868, col: 44, offset: 118189},
+							pos:   position{line: 3869, col: 44, offset: 118219},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3868, col: 47, offset: 118192},
+								pos:  position{line: 3869, col: 47, offset: 118222},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3868, col: 64, offset: 118209},
+							pos:   position{line: 3869, col: 64, offset: 118239},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 3868, col: 81, offset: 118226},
+								pos: position{line: 3869, col: 81, offset: 118256},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3868, col: 81, offset: 118226},
+										pos:  position{line: 3869, col: 81, offset: 118256},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3868, col: 103, offset: 118248},
+										pos:  position{line: 3869, col: 103, offset: 118278},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9347,22 +9348,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3882, col: 1, offset: 118615},
+			pos:  position{line: 3884, col: 1, offset: 118692},
 			expr: &actionExpr{
-				pos: position{line: 3882, col: 32, offset: 118646},
+				pos: position{line: 3884, col: 32, offset: 118723},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3882, col: 32, offset: 118646},
+					pos:   position{line: 3884, col: 32, offset: 118723},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 3882, col: 49, offset: 118663},
+						pos: position{line: 3884, col: 49, offset: 118740},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3882, col: 49, offset: 118663},
+								pos:  position{line: 3884, col: 49, offset: 118740},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3882, col: 71, offset: 118685},
+								pos:  position{line: 3884, col: 71, offset: 118762},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9372,33 +9373,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 3896, col: 1, offset: 119035},
+			pos:  position{line: 3899, col: 1, offset: 119159},
 			expr: &actionExpr{
-				pos: position{line: 3896, col: 24, offset: 119058},
+				pos: position{line: 3899, col: 24, offset: 119182},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 3896, col: 24, offset: 119058},
+					pos: position{line: 3899, col: 24, offset: 119182},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3896, col: 24, offset: 119058},
+							pos:        position{line: 3899, col: 24, offset: 119182},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3896, col: 31, offset: 119065},
+							pos:  position{line: 3899, col: 31, offset: 119189},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 3896, col: 39, offset: 119073},
+							pos:   position{line: 3899, col: 39, offset: 119197},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3896, col: 45, offset: 119079},
+								pos:  position{line: 3899, col: 45, offset: 119203},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3896, col: 52, offset: 119086},
+							pos:  position{line: 3899, col: 52, offset: 119210},
 							name: "R_PAREN",
 						},
 					},
@@ -9407,15 +9408,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 3903, col: 1, offset: 119204},
+			pos:  position{line: 3907, col: 1, offset: 119358},
 			expr: &actionExpr{
-				pos: position{line: 3903, col: 26, offset: 119229},
+				pos: position{line: 3907, col: 26, offset: 119383},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3903, col: 26, offset: 119229},
+					pos:   position{line: 3907, col: 26, offset: 119383},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3903, col: 32, offset: 119235},
+						pos:  position{line: 3907, col: 32, offset: 119389},
 						name: "String",
 					},
 				},
@@ -9423,35 +9424,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 3912, col: 1, offset: 119492},
+			pos:  position{line: 3917, col: 1, offset: 119676},
 			expr: &actionExpr{
-				pos: position{line: 3912, col: 18, offset: 119509},
+				pos: position{line: 3917, col: 18, offset: 119693},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 3912, col: 18, offset: 119509},
+					pos: position{line: 3917, col: 18, offset: 119693},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3912, col: 18, offset: 119509},
+							pos:   position{line: 3917, col: 18, offset: 119693},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3912, col: 24, offset: 119515},
+								pos:  position{line: 3917, col: 24, offset: 119699},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3912, col: 34, offset: 119525},
+							pos:   position{line: 3917, col: 34, offset: 119709},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3912, col: 39, offset: 119530},
+								pos: position{line: 3917, col: 39, offset: 119714},
 								expr: &seqExpr{
-									pos: position{line: 3912, col: 40, offset: 119531},
+									pos: position{line: 3917, col: 40, offset: 119715},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3912, col: 40, offset: 119531},
+											pos:  position{line: 3917, col: 40, offset: 119715},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3912, col: 46, offset: 119537},
+											pos:  position{line: 3917, col: 46, offset: 119721},
 											name: "FieldName",
 										},
 									},
@@ -9464,16 +9465,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 3929, col: 1, offset: 120032},
+			pos:  position{line: 3934, col: 1, offset: 120216},
 			expr: &choiceExpr{
-				pos: position{line: 3929, col: 18, offset: 120049},
+				pos: position{line: 3934, col: 18, offset: 120233},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 3929, col: 18, offset: 120049},
+						pos:  position{line: 3934, col: 18, offset: 120233},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 3929, col: 38, offset: 120069},
+						pos:  position{line: 3934, col: 38, offset: 120253},
 						name: "EarliestOnly",
 					},
 				},
@@ -9481,71 +9482,71 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 3931, col: 1, offset: 120083},
+			pos:  position{line: 3936, col: 1, offset: 120267},
 			expr: &actionExpr{
-				pos: position{line: 3931, col: 22, offset: 120104},
+				pos: position{line: 3936, col: 22, offset: 120288},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 3931, col: 22, offset: 120104},
+					pos: position{line: 3936, col: 22, offset: 120288},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 22, offset: 120104},
+							pos:  position{line: 3936, col: 22, offset: 120288},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 35, offset: 120117},
+							pos:  position{line: 3936, col: 35, offset: 120301},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3931, col: 41, offset: 120123},
+							pos:   position{line: 3936, col: 41, offset: 120307},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3931, col: 55, offset: 120137},
+								pos: position{line: 3936, col: 55, offset: 120321},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 55, offset: 120137},
+										pos:  position{line: 3936, col: 55, offset: 120321},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 75, offset: 120157},
+										pos:  position{line: 3936, col: 75, offset: 120341},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 94, offset: 120176},
+							pos:  position{line: 3936, col: 94, offset: 120360},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 100, offset: 120182},
+							pos:  position{line: 3936, col: 100, offset: 120366},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 111, offset: 120193},
+							pos:  position{line: 3936, col: 111, offset: 120377},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3931, col: 117, offset: 120199},
+							pos:   position{line: 3936, col: 117, offset: 120383},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3931, col: 129, offset: 120211},
+								pos: position{line: 3936, col: 129, offset: 120395},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 129, offset: 120211},
+										pos:  position{line: 3936, col: 129, offset: 120395},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 149, offset: 120231},
+										pos:  position{line: 3936, col: 149, offset: 120415},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3931, col: 168, offset: 120250},
+							pos: position{line: 3936, col: 168, offset: 120434},
 							expr: &anyMatcher{
-								line: 3931, col: 169, offset: 120251,
+								line: 3936, col: 169, offset: 120435,
 							},
 						},
 					},
@@ -9554,42 +9555,42 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 3972, col: 1, offset: 121373},
+			pos:  position{line: 3977, col: 1, offset: 121557},
 			expr: &actionExpr{
-				pos: position{line: 3972, col: 17, offset: 121389},
+				pos: position{line: 3977, col: 17, offset: 121573},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 3972, col: 17, offset: 121389},
+					pos: position{line: 3977, col: 17, offset: 121573},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3972, col: 17, offset: 121389},
+							pos:  position{line: 3977, col: 17, offset: 121573},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3972, col: 30, offset: 121402},
+							pos:  position{line: 3977, col: 30, offset: 121586},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3972, col: 36, offset: 121408},
+							pos:   position{line: 3977, col: 36, offset: 121592},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3972, col: 50, offset: 121422},
+								pos: position{line: 3977, col: 50, offset: 121606},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3972, col: 50, offset: 121422},
+										pos:  position{line: 3977, col: 50, offset: 121606},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3972, col: 70, offset: 121442},
+										pos:  position{line: 3977, col: 70, offset: 121626},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3972, col: 89, offset: 121461},
+							pos: position{line: 3977, col: 89, offset: 121645},
 							expr: &anyMatcher{
-								line: 3972, col: 90, offset: 121462,
+								line: 3977, col: 90, offset: 121646,
 							},
 						},
 					},
@@ -9598,24 +9599,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4000, col: 1, offset: 122153},
+			pos:  position{line: 4005, col: 1, offset: 122337},
 			expr: &actionExpr{
-				pos: position{line: 4000, col: 23, offset: 122175},
+				pos: position{line: 4005, col: 23, offset: 122359},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4000, col: 23, offset: 122175},
+					pos: position{line: 4005, col: 23, offset: 122359},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4000, col: 23, offset: 122175},
+							pos:        position{line: 4005, col: 23, offset: 122359},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4000, col: 27, offset: 122179},
+							pos: position{line: 4005, col: 27, offset: 122363},
 							expr: &charClassMatcher{
-								pos:        position{line: 4000, col: 27, offset: 122179},
+								pos:        position{line: 4005, col: 27, offset: 122363},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9628,21 +9629,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4004, col: 1, offset: 122222},
+			pos:  position{line: 4009, col: 1, offset: 122406},
 			expr: &actionExpr{
-				pos: position{line: 4004, col: 13, offset: 122234},
+				pos: position{line: 4009, col: 13, offset: 122418},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4004, col: 14, offset: 122235},
+					pos: position{line: 4009, col: 14, offset: 122419},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4004, col: 14, offset: 122235},
+							pos:        position{line: 4009, col: 14, offset: 122419},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4004, col: 17, offset: 122238},
+							pos:        position{line: 4009, col: 17, offset: 122422},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9654,15 +9655,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4008, col: 1, offset: 122281},
+			pos:  position{line: 4013, col: 1, offset: 122465},
 			expr: &actionExpr{
-				pos: position{line: 4008, col: 16, offset: 122296},
+				pos: position{line: 4013, col: 16, offset: 122480},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4008, col: 16, offset: 122296},
+					pos:   position{line: 4013, col: 16, offset: 122480},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4008, col: 26, offset: 122306},
+						pos:  position{line: 4013, col: 26, offset: 122490},
 						name: "AllTimeScale",
 					},
 				},
@@ -9670,31 +9671,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4015, col: 1, offset: 122530},
+			pos:  position{line: 4020, col: 1, offset: 122714},
 			expr: &actionExpr{
-				pos: position{line: 4015, col: 9, offset: 122538},
+				pos: position{line: 4020, col: 9, offset: 122722},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4015, col: 9, offset: 122538},
+					pos: position{line: 4020, col: 9, offset: 122722},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4015, col: 9, offset: 122538},
+							pos:        position{line: 4020, col: 9, offset: 122722},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4015, col: 13, offset: 122542},
+							pos:   position{line: 4020, col: 13, offset: 122726},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4015, col: 19, offset: 122548},
+								pos: position{line: 4020, col: 19, offset: 122732},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4015, col: 19, offset: 122548},
+										pos:  position{line: 4020, col: 19, offset: 122732},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4015, col: 30, offset: 122559},
+										pos:  position{line: 4020, col: 30, offset: 122743},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9706,26 +9707,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4019, col: 1, offset: 122607},
+			pos:  position{line: 4024, col: 1, offset: 122791},
 			expr: &actionExpr{
-				pos: position{line: 4019, col: 11, offset: 122617},
+				pos: position{line: 4024, col: 11, offset: 122801},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4019, col: 11, offset: 122617},
+					pos: position{line: 4024, col: 11, offset: 122801},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4019, col: 11, offset: 122617},
+							pos:   position{line: 4024, col: 11, offset: 122801},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4019, col: 16, offset: 122622},
+								pos:  position{line: 4024, col: 16, offset: 122806},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4019, col: 36, offset: 122642},
+							pos:   position{line: 4024, col: 36, offset: 122826},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4019, col: 43, offset: 122649},
+								pos:  position{line: 4024, col: 43, offset: 122833},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9735,44 +9736,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4047, col: 1, offset: 123387},
+			pos:  position{line: 4052, col: 1, offset: 123571},
 			expr: &actionExpr{
-				pos: position{line: 4047, col: 29, offset: 123415},
+				pos: position{line: 4052, col: 29, offset: 123599},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4047, col: 29, offset: 123415},
+					pos: position{line: 4052, col: 29, offset: 123599},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4047, col: 29, offset: 123415},
+							pos:   position{line: 4052, col: 29, offset: 123599},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4047, col: 36, offset: 123422},
+								pos: position{line: 4052, col: 36, offset: 123606},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4047, col: 36, offset: 123422},
+										pos:  position{line: 4052, col: 36, offset: 123606},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4047, col: 45, offset: 123431},
+										pos:  position{line: 4052, col: 45, offset: 123615},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4047, col: 51, offset: 123437},
+							pos:   position{line: 4052, col: 51, offset: 123621},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4047, col: 57, offset: 123443},
+								pos: position{line: 4052, col: 57, offset: 123627},
 								expr: &choiceExpr{
-									pos: position{line: 4047, col: 58, offset: 123444},
+									pos: position{line: 4052, col: 58, offset: 123628},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4047, col: 58, offset: 123444},
+											pos:  position{line: 4052, col: 58, offset: 123628},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4047, col: 67, offset: 123453},
+											pos:  position{line: 4052, col: 67, offset: 123637},
 											name: "Snap",
 										},
 									},
@@ -9785,29 +9786,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4094, col: 1, offset: 124885},
+			pos:  position{line: 4099, col: 1, offset: 125069},
 			expr: &actionExpr{
-				pos: position{line: 4094, col: 22, offset: 124906},
+				pos: position{line: 4099, col: 22, offset: 125090},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4094, col: 22, offset: 124906},
+					pos: position{line: 4099, col: 22, offset: 125090},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4094, col: 22, offset: 124906},
+							pos:   position{line: 4099, col: 22, offset: 125090},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4094, col: 34, offset: 124918},
+								pos: position{line: 4099, col: 34, offset: 125102},
 								expr: &choiceExpr{
-									pos: position{line: 4094, col: 35, offset: 124919},
+									pos: position{line: 4099, col: 35, offset: 125103},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4094, col: 35, offset: 124919},
+											pos:        position{line: 4099, col: 35, offset: 125103},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4094, col: 43, offset: 124927},
+											pos:        position{line: 4099, col: 43, offset: 125111},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9817,12 +9818,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4094, col: 49, offset: 124933},
+							pos:   position{line: 4099, col: 49, offset: 125117},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4094, col: 57, offset: 124941},
+								pos: position{line: 4099, col: 57, offset: 125125},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4094, col: 58, offset: 124942},
+									pos:  position{line: 4099, col: 58, offset: 125126},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9833,31 +9834,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4119, col: 1, offset: 125625},
+			pos:  position{line: 4124, col: 1, offset: 125809},
 			expr: &actionExpr{
-				pos: position{line: 4119, col: 39, offset: 125663},
+				pos: position{line: 4124, col: 39, offset: 125847},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4119, col: 39, offset: 125663},
+					pos: position{line: 4124, col: 39, offset: 125847},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4119, col: 39, offset: 125663},
+							pos:   position{line: 4124, col: 39, offset: 125847},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4119, col: 46, offset: 125670},
+								pos: position{line: 4124, col: 46, offset: 125854},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4119, col: 47, offset: 125671},
+									pos:  position{line: 4124, col: 47, offset: 125855},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4119, col: 56, offset: 125680},
+							pos:   position{line: 4124, col: 56, offset: 125864},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4119, col: 66, offset: 125690},
+								pos: position{line: 4124, col: 66, offset: 125874},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4119, col: 67, offset: 125691},
+									pos:  position{line: 4124, col: 67, offset: 125875},
 									name: "Snap",
 								},
 							},
@@ -9868,136 +9869,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4146, col: 1, offset: 126319},
+			pos:  position{line: 4151, col: 1, offset: 126503},
 			expr: &actionExpr{
-				pos: position{line: 4146, col: 18, offset: 126336},
+				pos: position{line: 4151, col: 18, offset: 126520},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4146, col: 18, offset: 126336},
+					pos: position{line: 4151, col: 18, offset: 126520},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 18, offset: 126336},
+							pos:        position{line: 4151, col: 18, offset: 126520},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 23, offset: 126341},
+							pos:        position{line: 4151, col: 23, offset: 126525},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 29, offset: 126347},
+							pos:        position{line: 4151, col: 29, offset: 126531},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 33, offset: 126351},
+							pos:        position{line: 4151, col: 33, offset: 126535},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 38, offset: 126356},
+							pos:        position{line: 4151, col: 38, offset: 126540},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 44, offset: 126362},
+							pos:        position{line: 4151, col: 44, offset: 126546},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 48, offset: 126366},
+							pos:        position{line: 4151, col: 48, offset: 126550},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 53, offset: 126371},
+							pos:        position{line: 4151, col: 53, offset: 126555},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 58, offset: 126376},
+							pos:        position{line: 4151, col: 58, offset: 126560},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 63, offset: 126381},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4146, col: 69, offset: 126387},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4146, col: 73, offset: 126391},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4146, col: 78, offset: 126396},
+							pos:        position{line: 4151, col: 63, offset: 126565},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 84, offset: 126402},
+							pos:        position{line: 4151, col: 69, offset: 126571},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 88, offset: 126406},
+							pos:        position{line: 4151, col: 73, offset: 126575},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 93, offset: 126411},
+							pos:        position{line: 4151, col: 78, offset: 126580},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 99, offset: 126417},
+							pos:        position{line: 4151, col: 84, offset: 126586},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 103, offset: 126421},
+							pos:        position{line: 4151, col: 88, offset: 126590},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 108, offset: 126426},
+							pos:        position{line: 4151, col: 93, offset: 126595},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4151, col: 99, offset: 126601},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4151, col: 103, offset: 126605},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4151, col: 108, offset: 126610},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10009,15 +10010,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4150, col: 1, offset: 126468},
+			pos:  position{line: 4155, col: 1, offset: 126652},
 			expr: &actionExpr{
-				pos: position{line: 4150, col: 22, offset: 126489},
+				pos: position{line: 4155, col: 22, offset: 126673},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4150, col: 22, offset: 126489},
+					pos:   position{line: 4155, col: 22, offset: 126673},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4150, col: 32, offset: 126499},
+						pos:  position{line: 4155, col: 32, offset: 126683},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10025,15 +10026,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4160, col: 1, offset: 126907},
+			pos:  position{line: 4165, col: 1, offset: 127091},
 			expr: &actionExpr{
-				pos: position{line: 4160, col: 14, offset: 126920},
+				pos: position{line: 4165, col: 14, offset: 127104},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4160, col: 14, offset: 126920},
+					pos: position{line: 4165, col: 14, offset: 127104},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4160, col: 14, offset: 126920},
+							pos:        position{line: 4165, col: 14, offset: 127104},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10041,9 +10042,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4160, col: 27, offset: 126933},
+							pos: position{line: 4165, col: 27, offset: 127117},
 							expr: &charClassMatcher{
-								pos:        position{line: 4160, col: 27, offset: 126933},
+								pos:        position{line: 4165, col: 27, offset: 127117},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10057,15 +10058,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4164, col: 1, offset: 126986},
+			pos:  position{line: 4169, col: 1, offset: 127170},
 			expr: &actionExpr{
-				pos: position{line: 4164, col: 24, offset: 127009},
+				pos: position{line: 4169, col: 24, offset: 127193},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4164, col: 24, offset: 127009},
+					pos: position{line: 4169, col: 24, offset: 127193},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4164, col: 24, offset: 127009},
+							pos:        position{line: 4169, col: 24, offset: 127193},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10073,9 +10074,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4164, col: 39, offset: 127024},
+							pos: position{line: 4169, col: 39, offset: 127208},
 							expr: &charClassMatcher{
-								pos:        position{line: 4164, col: 39, offset: 127024},
+								pos:        position{line: 4169, col: 39, offset: 127208},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10089,22 +10090,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4168, col: 1, offset: 127077},
+			pos:  position{line: 4173, col: 1, offset: 127261},
 			expr: &actionExpr{
-				pos: position{line: 4168, col: 11, offset: 127087},
+				pos: position{line: 4173, col: 11, offset: 127271},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4168, col: 11, offset: 127087},
+					pos:   position{line: 4173, col: 11, offset: 127271},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4168, col: 16, offset: 127092},
+						pos: position{line: 4173, col: 16, offset: 127276},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 16, offset: 127092},
+								pos:  position{line: 4173, col: 16, offset: 127276},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 31, offset: 127107},
+								pos:  position{line: 4173, col: 31, offset: 127291},
 								name: "UnquotedString",
 							},
 						},
@@ -10114,23 +10115,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4172, col: 1, offset: 127148},
+			pos:  position{line: 4177, col: 1, offset: 127332},
 			expr: &actionExpr{
-				pos: position{line: 4172, col: 17, offset: 127164},
+				pos: position{line: 4177, col: 17, offset: 127348},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4172, col: 17, offset: 127164},
+					pos: position{line: 4177, col: 17, offset: 127348},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4172, col: 17, offset: 127164},
+							pos:        position{line: 4177, col: 17, offset: 127348},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4172, col: 21, offset: 127168},
+							pos: position{line: 4177, col: 21, offset: 127352},
 							expr: &charClassMatcher{
-								pos:        position{line: 4172, col: 21, offset: 127168},
+								pos:        position{line: 4177, col: 21, offset: 127352},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10138,7 +10139,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 27, offset: 127174},
+							pos:        position{line: 4177, col: 27, offset: 127358},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10149,48 +10150,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4177, col: 1, offset: 127285},
+			pos:  position{line: 4182, col: 1, offset: 127469},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 19, offset: 127303},
+				pos: position{line: 4182, col: 19, offset: 127487},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4177, col: 19, offset: 127303},
+					pos: position{line: 4182, col: 19, offset: 127487},
 					expr: &choiceExpr{
-						pos: position{line: 4177, col: 20, offset: 127304},
+						pos: position{line: 4182, col: 20, offset: 127488},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4177, col: 20, offset: 127304},
+								pos:        position{line: 4182, col: 20, offset: 127488},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4177, col: 27, offset: 127311},
+								pos: position{line: 4182, col: 27, offset: 127495},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4177, col: 27, offset: 127311},
+										pos: position{line: 4182, col: 27, offset: 127495},
 										expr: &choiceExpr{
-											pos: position{line: 4177, col: 29, offset: 127313},
+											pos: position{line: 4182, col: 29, offset: 127497},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4177, col: 29, offset: 127313},
+													pos:  position{line: 4182, col: 29, offset: 127497},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4177, col: 43, offset: 127327},
+													pos:        position{line: 4182, col: 43, offset: 127511},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4177, col: 49, offset: 127333},
+													pos:  position{line: 4182, col: 49, offset: 127517},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4177, col: 54, offset: 127338,
+										line: 4182, col: 54, offset: 127522,
 									},
 								},
 							},
@@ -10201,12 +10202,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4184, col: 1, offset: 127453},
+			pos:  position{line: 4189, col: 1, offset: 127637},
 			expr: &choiceExpr{
-				pos: position{line: 4184, col: 16, offset: 127468},
+				pos: position{line: 4189, col: 16, offset: 127652},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4184, col: 16, offset: 127468},
+						pos:        position{line: 4189, col: 16, offset: 127652},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10214,18 +10215,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4184, col: 37, offset: 127489},
+						pos: position{line: 4189, col: 37, offset: 127673},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4184, col: 37, offset: 127489},
+								pos:        position{line: 4189, col: 37, offset: 127673},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4184, col: 41, offset: 127493},
+								pos: position{line: 4189, col: 41, offset: 127677},
 								expr: &charClassMatcher{
-									pos:        position{line: 4184, col: 41, offset: 127493},
+									pos:        position{line: 4189, col: 41, offset: 127677},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10233,7 +10234,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4184, col: 48, offset: 127500},
+								pos:        position{line: 4189, col: 48, offset: 127684},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10245,46 +10246,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4186, col: 1, offset: 127506},
+			pos:  position{line: 4191, col: 1, offset: 127690},
 			expr: &actionExpr{
-				pos: position{line: 4186, col: 39, offset: 127544},
+				pos: position{line: 4191, col: 39, offset: 127728},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4186, col: 39, offset: 127544},
+					pos: position{line: 4191, col: 39, offset: 127728},
 					expr: &choiceExpr{
-						pos: position{line: 4186, col: 40, offset: 127545},
+						pos: position{line: 4191, col: 40, offset: 127729},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4186, col: 40, offset: 127545},
+								pos:  position{line: 4191, col: 40, offset: 127729},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4186, col: 54, offset: 127559},
+								pos: position{line: 4191, col: 54, offset: 127743},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4186, col: 54, offset: 127559},
+										pos: position{line: 4191, col: 54, offset: 127743},
 										expr: &choiceExpr{
-											pos: position{line: 4186, col: 56, offset: 127561},
+											pos: position{line: 4191, col: 56, offset: 127745},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4186, col: 56, offset: 127561},
+													pos:  position{line: 4191, col: 56, offset: 127745},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4186, col: 70, offset: 127575},
+													pos:        position{line: 4191, col: 70, offset: 127759},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4186, col: 76, offset: 127581},
+													pos:  position{line: 4191, col: 76, offset: 127765},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4186, col: 81, offset: 127586,
+										line: 4191, col: 81, offset: 127770,
 									},
 								},
 							},
@@ -10295,21 +10296,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4190, col: 1, offset: 127626},
+			pos:  position{line: 4195, col: 1, offset: 127810},
 			expr: &actionExpr{
-				pos: position{line: 4190, col: 12, offset: 127637},
+				pos: position{line: 4195, col: 12, offset: 127821},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4190, col: 13, offset: 127638},
+					pos: position{line: 4195, col: 13, offset: 127822},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4190, col: 13, offset: 127638},
+							pos:        position{line: 4195, col: 13, offset: 127822},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4190, col: 22, offset: 127647},
+							pos:        position{line: 4195, col: 22, offset: 127831},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10320,14 +10321,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4196, col: 1, offset: 127801},
+			pos:  position{line: 4201, col: 1, offset: 127985},
 			expr: &actionExpr{
-				pos: position{line: 4196, col: 18, offset: 127818},
+				pos: position{line: 4201, col: 18, offset: 128002},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4196, col: 18, offset: 127818},
+					pos: position{line: 4201, col: 18, offset: 128002},
 					expr: &charClassMatcher{
-						pos:        position{line: 4196, col: 18, offset: 127818},
+						pos:        position{line: 4201, col: 18, offset: 128002},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10339,15 +10340,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4200, col: 1, offset: 127869},
+			pos:  position{line: 4205, col: 1, offset: 128053},
 			expr: &actionExpr{
-				pos: position{line: 4200, col: 11, offset: 127879},
+				pos: position{line: 4205, col: 11, offset: 128063},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4200, col: 11, offset: 127879},
+					pos:   position{line: 4205, col: 11, offset: 128063},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4200, col: 18, offset: 127886},
+						pos:  position{line: 4205, col: 18, offset: 128070},
 						name: "NumberAsString",
 					},
 				},
@@ -10355,59 +10356,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4206, col: 1, offset: 128075},
+			pos:  position{line: 4211, col: 1, offset: 128259},
 			expr: &actionExpr{
-				pos: position{line: 4206, col: 19, offset: 128093},
+				pos: position{line: 4211, col: 19, offset: 128277},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4206, col: 19, offset: 128093},
+					pos: position{line: 4211, col: 19, offset: 128277},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4206, col: 19, offset: 128093},
+							pos:   position{line: 4211, col: 19, offset: 128277},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4206, col: 27, offset: 128101},
+								pos: position{line: 4211, col: 27, offset: 128285},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 27, offset: 128101},
+										pos:  position{line: 4211, col: 27, offset: 128285},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 43, offset: 128117},
+										pos:  position{line: 4211, col: 43, offset: 128301},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4206, col: 60, offset: 128134},
+							pos: position{line: 4211, col: 60, offset: 128318},
 							expr: &choiceExpr{
-								pos: position{line: 4206, col: 62, offset: 128136},
+								pos: position{line: 4211, col: 62, offset: 128320},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 62, offset: 128136},
+										pos:  position{line: 4211, col: 62, offset: 128320},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 70, offset: 128144},
+										pos:        position{line: 4211, col: 70, offset: 128328},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 76, offset: 128150},
+										pos:        position{line: 4211, col: 76, offset: 128334},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 82, offset: 128156},
+										pos:        position{line: 4211, col: 82, offset: 128340},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 88, offset: 128162},
+										pos:  position{line: 4211, col: 88, offset: 128346},
 										name: "EOF",
 									},
 								},
@@ -10419,17 +10420,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4212, col: 1, offset: 128291},
+			pos:  position{line: 4217, col: 1, offset: 128475},
 			expr: &actionExpr{
-				pos: position{line: 4212, col: 18, offset: 128308},
+				pos: position{line: 4217, col: 18, offset: 128492},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4212, col: 18, offset: 128308},
+					pos: position{line: 4217, col: 18, offset: 128492},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4212, col: 18, offset: 128308},
+							pos: position{line: 4217, col: 18, offset: 128492},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 18, offset: 128308},
+								pos:        position{line: 4217, col: 18, offset: 128492},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10437,9 +10438,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4212, col: 24, offset: 128314},
+							pos: position{line: 4217, col: 24, offset: 128498},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 24, offset: 128314},
+								pos:        position{line: 4217, col: 24, offset: 128498},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10447,15 +10448,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4212, col: 31, offset: 128321},
+							pos:        position{line: 4217, col: 31, offset: 128505},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4212, col: 35, offset: 128325},
+							pos: position{line: 4217, col: 35, offset: 128509},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 35, offset: 128325},
+								pos:        position{line: 4217, col: 35, offset: 128509},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10468,17 +10469,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4217, col: 1, offset: 128420},
+			pos:  position{line: 4222, col: 1, offset: 128604},
 			expr: &actionExpr{
-				pos: position{line: 4217, col: 20, offset: 128439},
+				pos: position{line: 4222, col: 20, offset: 128623},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4217, col: 20, offset: 128439},
+					pos: position{line: 4222, col: 20, offset: 128623},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4217, col: 20, offset: 128439},
+							pos: position{line: 4222, col: 20, offset: 128623},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 20, offset: 128439},
+								pos:        position{line: 4222, col: 20, offset: 128623},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10486,9 +10487,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4217, col: 26, offset: 128445},
+							pos: position{line: 4222, col: 26, offset: 128629},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 26, offset: 128445},
+								pos:        position{line: 4222, col: 26, offset: 128629},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10501,14 +10502,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4221, col: 1, offset: 128488},
+			pos:  position{line: 4226, col: 1, offset: 128672},
 			expr: &actionExpr{
-				pos: position{line: 4221, col: 28, offset: 128515},
+				pos: position{line: 4226, col: 28, offset: 128699},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4221, col: 28, offset: 128515},
+					pos: position{line: 4226, col: 28, offset: 128699},
 					expr: &charClassMatcher{
-						pos:        position{line: 4221, col: 28, offset: 128515},
+						pos:        position{line: 4226, col: 28, offset: 128699},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10519,15 +10520,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4225, col: 1, offset: 128558},
+			pos:  position{line: 4230, col: 1, offset: 128742},
 			expr: &actionExpr{
-				pos: position{line: 4225, col: 20, offset: 128577},
+				pos: position{line: 4230, col: 20, offset: 128761},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4225, col: 20, offset: 128577},
+					pos:   position{line: 4230, col: 20, offset: 128761},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4225, col: 27, offset: 128584},
+						pos:  position{line: 4230, col: 27, offset: 128768},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10535,31 +10536,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4233, col: 1, offset: 128831},
+			pos:  position{line: 4238, col: 1, offset: 129015},
 			expr: &actionExpr{
-				pos: position{line: 4233, col: 21, offset: 128851},
+				pos: position{line: 4238, col: 21, offset: 129035},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4233, col: 21, offset: 128851},
+					pos: position{line: 4238, col: 21, offset: 129035},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 21, offset: 128851},
+							pos:  position{line: 4238, col: 21, offset: 129035},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4233, col: 36, offset: 128866},
+							pos:   position{line: 4238, col: 36, offset: 129050},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4233, col: 40, offset: 128870},
+								pos: position{line: 4238, col: 40, offset: 129054},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4233, col: 40, offset: 128870},
+										pos:        position{line: 4238, col: 40, offset: 129054},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4233, col: 46, offset: 128876},
+										pos:        position{line: 4238, col: 46, offset: 129060},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10568,7 +10569,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 52, offset: 128882},
+							pos:  position{line: 4238, col: 52, offset: 129066},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10577,43 +10578,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4241, col: 1, offset: 129063},
+			pos:  position{line: 4246, col: 1, offset: 129247},
 			expr: &actionExpr{
-				pos: position{line: 4241, col: 23, offset: 129085},
+				pos: position{line: 4246, col: 23, offset: 129269},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4241, col: 23, offset: 129085},
+					pos: position{line: 4246, col: 23, offset: 129269},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 23, offset: 129085},
+							pos:  position{line: 4246, col: 23, offset: 129269},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4241, col: 38, offset: 129100},
+							pos:   position{line: 4246, col: 38, offset: 129284},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4241, col: 42, offset: 129104},
+								pos: position{line: 4246, col: 42, offset: 129288},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4241, col: 42, offset: 129104},
+										pos:        position{line: 4246, col: 42, offset: 129288},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 49, offset: 129111},
+										pos:        position{line: 4246, col: 49, offset: 129295},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 55, offset: 129117},
+										pos:        position{line: 4246, col: 55, offset: 129301},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 62, offset: 129124},
+										pos:        position{line: 4246, col: 62, offset: 129308},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10622,7 +10623,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 67, offset: 129129},
+							pos:  position{line: 4246, col: 67, offset: 129313},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10631,30 +10632,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4249, col: 1, offset: 129312},
+			pos:  position{line: 4254, col: 1, offset: 129496},
 			expr: &choiceExpr{
-				pos: position{line: 4249, col: 25, offset: 129336},
+				pos: position{line: 4254, col: 25, offset: 129520},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4249, col: 25, offset: 129336},
+						pos: position{line: 4254, col: 25, offset: 129520},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4249, col: 25, offset: 129336},
+							pos:   position{line: 4254, col: 25, offset: 129520},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4249, col: 28, offset: 129339},
+								pos:  position{line: 4254, col: 28, offset: 129523},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4252, col: 3, offset: 129381},
+						pos: position{line: 4257, col: 3, offset: 129565},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4252, col: 3, offset: 129381},
+							pos:   position{line: 4257, col: 3, offset: 129565},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4252, col: 6, offset: 129384},
+								pos:  position{line: 4257, col: 6, offset: 129568},
 								name: "InequalityOperator",
 							},
 						},
@@ -10664,25 +10665,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4256, col: 1, offset: 129427},
+			pos:  position{line: 4261, col: 1, offset: 129611},
 			expr: &actionExpr{
-				pos: position{line: 4256, col: 11, offset: 129437},
+				pos: position{line: 4261, col: 11, offset: 129621},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4256, col: 11, offset: 129437},
+					pos: position{line: 4261, col: 11, offset: 129621},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4256, col: 11, offset: 129437},
+							pos:  position{line: 4261, col: 11, offset: 129621},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4256, col: 26, offset: 129452},
+							pos:        position{line: 4261, col: 26, offset: 129636},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4256, col: 30, offset: 129456},
+							pos:  position{line: 4261, col: 30, offset: 129640},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10691,25 +10692,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4260, col: 1, offset: 129496},
+			pos:  position{line: 4265, col: 1, offset: 129680},
 			expr: &actionExpr{
-				pos: position{line: 4260, col: 12, offset: 129507},
+				pos: position{line: 4265, col: 12, offset: 129691},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4260, col: 12, offset: 129507},
+					pos: position{line: 4265, col: 12, offset: 129691},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4260, col: 12, offset: 129507},
+							pos:  position{line: 4265, col: 12, offset: 129691},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4260, col: 27, offset: 129522},
+							pos:        position{line: 4265, col: 27, offset: 129706},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4260, col: 31, offset: 129526},
+							pos:  position{line: 4265, col: 31, offset: 129710},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10718,25 +10719,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4264, col: 1, offset: 129566},
+			pos:  position{line: 4269, col: 1, offset: 129750},
 			expr: &actionExpr{
-				pos: position{line: 4264, col: 10, offset: 129575},
+				pos: position{line: 4269, col: 10, offset: 129759},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4264, col: 10, offset: 129575},
+					pos: position{line: 4269, col: 10, offset: 129759},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4264, col: 10, offset: 129575},
+							pos:  position{line: 4269, col: 10, offset: 129759},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 25, offset: 129590},
+							pos:        position{line: 4269, col: 25, offset: 129774},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4264, col: 29, offset: 129594},
+							pos:  position{line: 4269, col: 29, offset: 129778},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10745,25 +10746,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4268, col: 1, offset: 129634},
+			pos:  position{line: 4273, col: 1, offset: 129818},
 			expr: &actionExpr{
-				pos: position{line: 4268, col: 10, offset: 129643},
+				pos: position{line: 4273, col: 10, offset: 129827},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4268, col: 10, offset: 129643},
+					pos: position{line: 4273, col: 10, offset: 129827},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4268, col: 10, offset: 129643},
+							pos:  position{line: 4273, col: 10, offset: 129827},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4268, col: 25, offset: 129658},
+							pos:        position{line: 4273, col: 25, offset: 129842},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4268, col: 29, offset: 129662},
+							pos:  position{line: 4273, col: 29, offset: 129846},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10772,25 +10773,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4272, col: 1, offset: 129702},
+			pos:  position{line: 4277, col: 1, offset: 129886},
 			expr: &actionExpr{
-				pos: position{line: 4272, col: 10, offset: 129711},
+				pos: position{line: 4277, col: 10, offset: 129895},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4272, col: 10, offset: 129711},
+					pos: position{line: 4277, col: 10, offset: 129895},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4272, col: 10, offset: 129711},
+							pos:  position{line: 4277, col: 10, offset: 129895},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 25, offset: 129726},
+							pos:        position{line: 4277, col: 25, offset: 129910},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4272, col: 29, offset: 129730},
+							pos:  position{line: 4277, col: 29, offset: 129914},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10799,39 +10800,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4277, col: 1, offset: 129794},
+			pos:  position{line: 4282, col: 1, offset: 129978},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 11, offset: 129804},
+				pos: position{line: 4282, col: 11, offset: 129988},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4277, col: 12, offset: 129805},
+					pos: position{line: 4282, col: 12, offset: 129989},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4277, col: 12, offset: 129805},
+							pos:        position{line: 4282, col: 12, offset: 129989},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 24, offset: 129817},
+							pos:        position{line: 4282, col: 24, offset: 130001},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 35, offset: 129828},
+							pos:        position{line: 4282, col: 35, offset: 130012},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 44, offset: 129837},
+							pos:        position{line: 4282, col: 44, offset: 130021},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 52, offset: 129845},
+							pos:        position{line: 4282, col: 52, offset: 130029},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10842,39 +10843,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4281, col: 1, offset: 129886},
+			pos:  position{line: 4286, col: 1, offset: 130070},
 			expr: &actionExpr{
-				pos: position{line: 4281, col: 11, offset: 129896},
+				pos: position{line: 4286, col: 11, offset: 130080},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4281, col: 12, offset: 129897},
+					pos: position{line: 4286, col: 12, offset: 130081},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4281, col: 12, offset: 129897},
+							pos:        position{line: 4286, col: 12, offset: 130081},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 24, offset: 129909},
+							pos:        position{line: 4286, col: 24, offset: 130093},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 35, offset: 129920},
+							pos:        position{line: 4286, col: 35, offset: 130104},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 44, offset: 129929},
+							pos:        position{line: 4286, col: 44, offset: 130113},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 52, offset: 129937},
+							pos:        position{line: 4286, col: 52, offset: 130121},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -10885,39 +10886,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4285, col: 1, offset: 129978},
+			pos:  position{line: 4290, col: 1, offset: 130162},
 			expr: &actionExpr{
-				pos: position{line: 4285, col: 9, offset: 129986},
+				pos: position{line: 4290, col: 9, offset: 130170},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4285, col: 10, offset: 129987},
+					pos: position{line: 4290, col: 10, offset: 130171},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4285, col: 10, offset: 129987},
+							pos:        position{line: 4290, col: 10, offset: 130171},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 20, offset: 129997},
+							pos:        position{line: 4290, col: 20, offset: 130181},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 29, offset: 130006},
+							pos:        position{line: 4290, col: 29, offset: 130190},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 37, offset: 130014},
+							pos:        position{line: 4290, col: 37, offset: 130198},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 44, offset: 130021},
+							pos:        position{line: 4290, col: 44, offset: 130205},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -10928,27 +10929,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4289, col: 1, offset: 130060},
+			pos:  position{line: 4294, col: 1, offset: 130244},
 			expr: &actionExpr{
-				pos: position{line: 4289, col: 8, offset: 130067},
+				pos: position{line: 4294, col: 8, offset: 130251},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4289, col: 9, offset: 130068},
+					pos: position{line: 4294, col: 9, offset: 130252},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4289, col: 9, offset: 130068},
+							pos:        position{line: 4294, col: 9, offset: 130252},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4289, col: 18, offset: 130077},
+							pos:        position{line: 4294, col: 18, offset: 130261},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4289, col: 26, offset: 130085},
+							pos:        position{line: 4294, col: 26, offset: 130269},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -10959,27 +10960,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4293, col: 1, offset: 130123},
+			pos:  position{line: 4298, col: 1, offset: 130307},
 			expr: &actionExpr{
-				pos: position{line: 4293, col: 9, offset: 130131},
+				pos: position{line: 4298, col: 9, offset: 130315},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4293, col: 10, offset: 130132},
+					pos: position{line: 4298, col: 10, offset: 130316},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4293, col: 10, offset: 130132},
+							pos:        position{line: 4298, col: 10, offset: 130316},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4293, col: 20, offset: 130142},
+							pos:        position{line: 4298, col: 20, offset: 130326},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4293, col: 29, offset: 130151},
+							pos:        position{line: 4298, col: 29, offset: 130335},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -10990,27 +10991,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4297, col: 1, offset: 130190},
+			pos:  position{line: 4302, col: 1, offset: 130374},
 			expr: &actionExpr{
-				pos: position{line: 4297, col: 10, offset: 130199},
+				pos: position{line: 4302, col: 10, offset: 130383},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4297, col: 11, offset: 130200},
+					pos: position{line: 4302, col: 11, offset: 130384},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4297, col: 11, offset: 130200},
+							pos:        position{line: 4302, col: 11, offset: 130384},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4297, col: 22, offset: 130211},
+							pos:        position{line: 4302, col: 22, offset: 130395},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4297, col: 32, offset: 130221},
+							pos:        position{line: 4302, col: 32, offset: 130405},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11021,39 +11022,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4301, col: 1, offset: 130263},
+			pos:  position{line: 4306, col: 1, offset: 130447},
 			expr: &actionExpr{
-				pos: position{line: 4301, col: 12, offset: 130274},
+				pos: position{line: 4306, col: 12, offset: 130458},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4301, col: 13, offset: 130275},
+					pos: position{line: 4306, col: 13, offset: 130459},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4301, col: 13, offset: 130275},
+							pos:        position{line: 4306, col: 13, offset: 130459},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 26, offset: 130288},
+							pos:        position{line: 4306, col: 26, offset: 130472},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 38, offset: 130300},
+							pos:        position{line: 4306, col: 38, offset: 130484},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 47, offset: 130309},
+							pos:        position{line: 4306, col: 47, offset: 130493},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 55, offset: 130317},
+							pos:        position{line: 4306, col: 55, offset: 130501},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11064,39 +11065,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4305, col: 1, offset: 130359},
+			pos:  position{line: 4310, col: 1, offset: 130543},
 			expr: &actionExpr{
-				pos: position{line: 4305, col: 9, offset: 130367},
+				pos: position{line: 4310, col: 9, offset: 130551},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4305, col: 10, offset: 130368},
+					pos: position{line: 4310, col: 10, offset: 130552},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4305, col: 10, offset: 130368},
+							pos:        position{line: 4310, col: 10, offset: 130552},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 20, offset: 130378},
+							pos:        position{line: 4310, col: 20, offset: 130562},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 29, offset: 130387},
+							pos:        position{line: 4310, col: 29, offset: 130571},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 37, offset: 130395},
+							pos:        position{line: 4310, col: 37, offset: 130579},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 44, offset: 130402},
+							pos:        position{line: 4310, col: 44, offset: 130586},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11107,33 +11108,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4310, col: 1, offset: 130533},
+			pos:  position{line: 4315, col: 1, offset: 130717},
 			expr: &actionExpr{
-				pos: position{line: 4310, col: 15, offset: 130547},
+				pos: position{line: 4315, col: 15, offset: 130731},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4310, col: 16, offset: 130548},
+					pos: position{line: 4315, col: 16, offset: 130732},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4310, col: 16, offset: 130548},
+							pos:        position{line: 4315, col: 16, offset: 130732},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 23, offset: 130555},
+							pos:        position{line: 4315, col: 23, offset: 130739},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 30, offset: 130562},
+							pos:        position{line: 4315, col: 30, offset: 130746},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 37, offset: 130569},
+							pos:        position{line: 4315, col: 37, offset: 130753},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11144,26 +11145,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4319, col: 1, offset: 130792},
+			pos:  position{line: 4324, col: 1, offset: 130976},
 			expr: &actionExpr{
-				pos: position{line: 4319, col: 21, offset: 130812},
+				pos: position{line: 4324, col: 21, offset: 130996},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4319, col: 21, offset: 130812},
+					pos: position{line: 4324, col: 21, offset: 130996},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4319, col: 21, offset: 130812},
+							pos:  position{line: 4324, col: 21, offset: 130996},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4319, col: 26, offset: 130817},
+							pos:  position{line: 4324, col: 26, offset: 131001},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4319, col: 42, offset: 130833},
+							pos:   position{line: 4324, col: 42, offset: 131017},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4319, col: 53, offset: 130844},
+								pos:  position{line: 4324, col: 53, offset: 131028},
 								name: "TransactionOptions",
 							},
 						},
@@ -11173,17 +11174,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4328, col: 1, offset: 131150},
+			pos:  position{line: 4333, col: 1, offset: 131334},
 			expr: &actionExpr{
-				pos: position{line: 4328, col: 23, offset: 131172},
+				pos: position{line: 4333, col: 23, offset: 131356},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4328, col: 23, offset: 131172},
+					pos:   position{line: 4333, col: 23, offset: 131356},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4328, col: 34, offset: 131183},
+						pos: position{line: 4333, col: 34, offset: 131367},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4328, col: 34, offset: 131183},
+							pos:  position{line: 4333, col: 34, offset: 131367},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11192,35 +11193,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4343, col: 1, offset: 131574},
+			pos:  position{line: 4348, col: 1, offset: 131758},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 37, offset: 131610},
+				pos: position{line: 4348, col: 37, offset: 131794},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4343, col: 37, offset: 131610},
+					pos: position{line: 4348, col: 37, offset: 131794},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4343, col: 37, offset: 131610},
+							pos:   position{line: 4348, col: 37, offset: 131794},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4343, col: 43, offset: 131616},
+								pos:  position{line: 4348, col: 43, offset: 131800},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4343, col: 71, offset: 131644},
+							pos:   position{line: 4348, col: 71, offset: 131828},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4343, col: 76, offset: 131649},
+								pos: position{line: 4348, col: 76, offset: 131833},
 								expr: &seqExpr{
-									pos: position{line: 4343, col: 77, offset: 131650},
+									pos: position{line: 4348, col: 77, offset: 131834},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4343, col: 77, offset: 131650},
+											pos:  position{line: 4348, col: 77, offset: 131834},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4343, col: 83, offset: 131656},
+											pos:  position{line: 4348, col: 83, offset: 131840},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11233,26 +11234,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4378, col: 1, offset: 132645},
+			pos:  position{line: 4383, col: 1, offset: 132829},
 			expr: &actionExpr{
-				pos: position{line: 4378, col: 32, offset: 132676},
+				pos: position{line: 4383, col: 32, offset: 132860},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4378, col: 32, offset: 132676},
+					pos:   position{line: 4383, col: 32, offset: 132860},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4378, col: 40, offset: 132684},
+						pos: position{line: 4383, col: 40, offset: 132868},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 40, offset: 132684},
+								pos:  position{line: 4383, col: 40, offset: 132868},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 77, offset: 132721},
+								pos:  position{line: 4383, col: 77, offset: 132905},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 96, offset: 132740},
+								pos:  position{line: 4383, col: 96, offset: 132924},
 								name: "EndsWithOption",
 							},
 						},
@@ -11262,15 +11263,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4382, col: 1, offset: 132784},
+			pos:  position{line: 4387, col: 1, offset: 132968},
 			expr: &actionExpr{
-				pos: position{line: 4382, col: 39, offset: 132822},
+				pos: position{line: 4387, col: 39, offset: 133006},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4382, col: 39, offset: 132822},
+					pos:   position{line: 4387, col: 39, offset: 133006},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4382, col: 46, offset: 132829},
+						pos:  position{line: 4387, col: 46, offset: 133013},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11278,28 +11279,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4393, col: 1, offset: 133045},
+			pos:  position{line: 4398, col: 1, offset: 133229},
 			expr: &actionExpr{
-				pos: position{line: 4393, col: 21, offset: 133065},
+				pos: position{line: 4398, col: 21, offset: 133249},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4393, col: 21, offset: 133065},
+					pos: position{line: 4398, col: 21, offset: 133249},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4393, col: 21, offset: 133065},
+							pos:        position{line: 4398, col: 21, offset: 133249},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4393, col: 34, offset: 133078},
+							pos:  position{line: 4398, col: 34, offset: 133262},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4393, col: 40, offset: 133084},
+							pos:   position{line: 4398, col: 40, offset: 133268},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4393, col: 48, offset: 133092},
+								pos:  position{line: 4398, col: 48, offset: 133276},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11309,28 +11310,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4403, col: 1, offset: 133330},
+			pos:  position{line: 4408, col: 1, offset: 133514},
 			expr: &actionExpr{
-				pos: position{line: 4403, col: 19, offset: 133348},
+				pos: position{line: 4408, col: 19, offset: 133532},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4403, col: 19, offset: 133348},
+					pos: position{line: 4408, col: 19, offset: 133532},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4403, col: 19, offset: 133348},
+							pos:        position{line: 4408, col: 19, offset: 133532},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4403, col: 30, offset: 133359},
+							pos:  position{line: 4408, col: 30, offset: 133543},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4403, col: 36, offset: 133365},
+							pos:   position{line: 4408, col: 36, offset: 133549},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4403, col: 44, offset: 133373},
+								pos:  position{line: 4408, col: 44, offset: 133557},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11340,26 +11341,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4414, col: 1, offset: 133642},
+			pos:  position{line: 4419, col: 1, offset: 133826},
 			expr: &actionExpr{
-				pos: position{line: 4414, col: 28, offset: 133669},
+				pos: position{line: 4419, col: 28, offset: 133853},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4414, col: 28, offset: 133669},
+					pos:   position{line: 4419, col: 28, offset: 133853},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4414, col: 37, offset: 133678},
+						pos: position{line: 4419, col: 37, offset: 133862},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 37, offset: 133678},
+								pos:  position{line: 4419, col: 37, offset: 133862},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 63, offset: 133704},
+								pos:  position{line: 4419, col: 63, offset: 133888},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 81, offset: 133722},
+								pos:  position{line: 4419, col: 81, offset: 133906},
 								name: "TransactionSearch",
 							},
 						},
@@ -11369,22 +11370,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4418, col: 1, offset: 133770},
+			pos:  position{line: 4423, col: 1, offset: 133954},
 			expr: &actionExpr{
-				pos: position{line: 4418, col: 28, offset: 133797},
+				pos: position{line: 4423, col: 28, offset: 133981},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4418, col: 28, offset: 133797},
+					pos:   position{line: 4423, col: 28, offset: 133981},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4418, col: 33, offset: 133802},
+						pos: position{line: 4423, col: 33, offset: 133986},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4418, col: 33, offset: 133802},
+								pos:  position{line: 4423, col: 33, offset: 133986},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4418, col: 64, offset: 133833},
+								pos:  position{line: 4423, col: 64, offset: 134017},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11394,29 +11395,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4422, col: 1, offset: 133893},
+			pos:  position{line: 4427, col: 1, offset: 134077},
 			expr: &actionExpr{
-				pos: position{line: 4422, col: 38, offset: 133930},
+				pos: position{line: 4427, col: 38, offset: 134114},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4422, col: 38, offset: 133930},
+					pos: position{line: 4427, col: 38, offset: 134114},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4422, col: 38, offset: 133930},
+							pos:        position{line: 4427, col: 38, offset: 134114},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4422, col: 42, offset: 133934},
+							pos:   position{line: 4427, col: 42, offset: 134118},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4422, col: 55, offset: 133947},
+								pos:  position{line: 4427, col: 55, offset: 134131},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4422, col: 68, offset: 133960},
+							pos:        position{line: 4427, col: 68, offset: 134144},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11427,23 +11428,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4430, col: 1, offset: 134099},
+			pos:  position{line: 4435, col: 1, offset: 134283},
 			expr: &actionExpr{
-				pos: position{line: 4430, col: 21, offset: 134119},
+				pos: position{line: 4435, col: 21, offset: 134303},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4430, col: 21, offset: 134119},
+					pos: position{line: 4435, col: 21, offset: 134303},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4430, col: 21, offset: 134119},
+							pos:        position{line: 4435, col: 21, offset: 134303},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4430, col: 25, offset: 134123},
+							pos: position{line: 4435, col: 25, offset: 134307},
 							expr: &charClassMatcher{
-								pos:        position{line: 4430, col: 25, offset: 134123},
+								pos:        position{line: 4435, col: 25, offset: 134307},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11451,7 +11452,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4430, col: 44, offset: 134142},
+							pos:        position{line: 4435, col: 44, offset: 134326},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11462,15 +11463,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4435, col: 1, offset: 134253},
+			pos:  position{line: 4440, col: 1, offset: 134437},
 			expr: &actionExpr{
-				pos: position{line: 4435, col: 33, offset: 134285},
+				pos: position{line: 4440, col: 33, offset: 134469},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4435, col: 33, offset: 134285},
+					pos:   position{line: 4440, col: 33, offset: 134469},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4435, col: 37, offset: 134289},
+						pos:  position{line: 4440, col: 37, offset: 134473},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11478,15 +11479,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4443, col: 1, offset: 134444},
+			pos:  position{line: 4448, col: 1, offset: 134628},
 			expr: &actionExpr{
-				pos: position{line: 4443, col: 22, offset: 134465},
+				pos: position{line: 4448, col: 22, offset: 134649},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4443, col: 22, offset: 134465},
+					pos:   position{line: 4448, col: 22, offset: 134649},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4443, col: 27, offset: 134470},
+						pos:  position{line: 4448, col: 27, offset: 134654},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11494,37 +11495,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4453, col: 1, offset: 134642},
+			pos:  position{line: 4458, col: 1, offset: 134826},
 			expr: &actionExpr{
-				pos: position{line: 4453, col: 20, offset: 134661},
+				pos: position{line: 4458, col: 20, offset: 134845},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4453, col: 20, offset: 134661},
+					pos: position{line: 4458, col: 20, offset: 134845},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4453, col: 20, offset: 134661},
+							pos:        position{line: 4458, col: 20, offset: 134845},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 27, offset: 134668},
+							pos:  position{line: 4458, col: 27, offset: 134852},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 42, offset: 134683},
+							pos:  position{line: 4458, col: 42, offset: 134867},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4453, col: 50, offset: 134691},
+							pos:   position{line: 4458, col: 50, offset: 134875},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4453, col: 60, offset: 134701},
+								pos:  position{line: 4458, col: 60, offset: 134885},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 69, offset: 134710},
+							pos:  position{line: 4458, col: 69, offset: 134894},
 							name: "R_PAREN",
 						},
 					},
@@ -11533,22 +11534,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4463, col: 1, offset: 135013},
+			pos:  position{line: 4468, col: 1, offset: 135197},
 			expr: &actionExpr{
-				pos: position{line: 4463, col: 20, offset: 135032},
+				pos: position{line: 4468, col: 20, offset: 135216},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4463, col: 20, offset: 135032},
+					pos: position{line: 4468, col: 20, offset: 135216},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4463, col: 20, offset: 135032},
+							pos:  position{line: 4468, col: 20, offset: 135216},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4463, col: 25, offset: 135037},
+							pos:   position{line: 4468, col: 25, offset: 135221},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4463, col: 42, offset: 135054},
+								pos:  position{line: 4468, col: 42, offset: 135238},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11558,41 +11559,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4467, col: 1, offset: 135103},
+			pos:  position{line: 4472, col: 1, offset: 135287},
 			expr: &actionExpr{
-				pos: position{line: 4467, col: 16, offset: 135118},
+				pos: position{line: 4472, col: 16, offset: 135302},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4467, col: 16, offset: 135118},
+					pos: position{line: 4472, col: 16, offset: 135302},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 16, offset: 135118},
+							pos:  position{line: 4472, col: 16, offset: 135302},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 27, offset: 135129},
+							pos:  position{line: 4472, col: 27, offset: 135313},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4467, col: 33, offset: 135135},
+							pos:   position{line: 4472, col: 33, offset: 135319},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4467, col: 50, offset: 135152},
+								pos: position{line: 4472, col: 50, offset: 135336},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4467, col: 50, offset: 135152},
+									pos:  position{line: 4472, col: 50, offset: 135336},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 70, offset: 135172},
+							pos:  position{line: 4472, col: 70, offset: 135356},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4467, col: 85, offset: 135187},
+							pos:   position{line: 4472, col: 85, offset: 135371},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4467, col: 91, offset: 135193},
+								pos:  position{line: 4472, col: 91, offset: 135377},
 								name: "FieldName",
 							},
 						},
@@ -11602,35 +11603,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4495, col: 1, offset: 135933},
+			pos:  position{line: 4500, col: 1, offset: 136117},
 			expr: &actionExpr{
-				pos: position{line: 4495, col: 23, offset: 135955},
+				pos: position{line: 4500, col: 23, offset: 136139},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4495, col: 23, offset: 135955},
+					pos: position{line: 4500, col: 23, offset: 136139},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4495, col: 23, offset: 135955},
+							pos:   position{line: 4500, col: 23, offset: 136139},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4495, col: 31, offset: 135963},
+								pos:  position{line: 4500, col: 31, offset: 136147},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4495, col: 46, offset: 135978},
+							pos:   position{line: 4500, col: 46, offset: 136162},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4495, col: 52, offset: 135984},
+								pos: position{line: 4500, col: 52, offset: 136168},
 								expr: &seqExpr{
-									pos: position{line: 4495, col: 53, offset: 135985},
+									pos: position{line: 4500, col: 53, offset: 136169},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4495, col: 53, offset: 135985},
+											pos:  position{line: 4500, col: 53, offset: 136169},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4495, col: 59, offset: 135991},
+											pos:  position{line: 4500, col: 59, offset: 136175},
 											name: "MVBlockOption",
 										},
 									},
@@ -11643,26 +11644,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4529, col: 1, offset: 137047},
+			pos:  position{line: 4534, col: 1, offset: 137231},
 			expr: &actionExpr{
-				pos: position{line: 4529, col: 18, offset: 137064},
+				pos: position{line: 4534, col: 18, offset: 137248},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4529, col: 18, offset: 137064},
+					pos:   position{line: 4534, col: 18, offset: 137248},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4529, col: 27, offset: 137073},
+						pos: position{line: 4534, col: 27, offset: 137257},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 27, offset: 137073},
+								pos:  position{line: 4534, col: 27, offset: 137257},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 41, offset: 137087},
+								pos:  position{line: 4534, col: 41, offset: 137271},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 60, offset: 137106},
+								pos:  position{line: 4534, col: 60, offset: 137290},
 								name: "SetSvOption",
 							},
 						},
@@ -11672,22 +11673,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4533, col: 1, offset: 137147},
+			pos:  position{line: 4538, col: 1, offset: 137331},
 			expr: &actionExpr{
-				pos: position{line: 4533, col: 16, offset: 137162},
+				pos: position{line: 4538, col: 16, offset: 137346},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4533, col: 16, offset: 137162},
+					pos:   position{line: 4538, col: 16, offset: 137346},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4533, col: 28, offset: 137174},
+						pos: position{line: 4538, col: 28, offset: 137358},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4533, col: 28, offset: 137174},
+								pos:  position{line: 4538, col: 28, offset: 137358},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4533, col: 46, offset: 137192},
+								pos:  position{line: 4538, col: 46, offset: 137376},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11697,28 +11698,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4537, col: 1, offset: 137239},
+			pos:  position{line: 4542, col: 1, offset: 137423},
 			expr: &actionExpr{
-				pos: position{line: 4537, col: 20, offset: 137258},
+				pos: position{line: 4542, col: 20, offset: 137442},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4537, col: 20, offset: 137258},
+					pos: position{line: 4542, col: 20, offset: 137442},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4537, col: 20, offset: 137258},
+							pos:        position{line: 4542, col: 20, offset: 137442},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4537, col: 28, offset: 137266},
+							pos:  position{line: 4542, col: 28, offset: 137450},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4537, col: 34, offset: 137272},
+							pos:   position{line: 4542, col: 34, offset: 137456},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4537, col: 38, offset: 137276},
+								pos:  position{line: 4542, col: 38, offset: 137460},
 								name: "QuotedString",
 							},
 						},
@@ -11728,28 +11729,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4548, col: 1, offset: 137527},
+			pos:  position{line: 4553, col: 1, offset: 137711},
 			expr: &actionExpr{
-				pos: position{line: 4548, col: 19, offset: 137545},
+				pos: position{line: 4553, col: 19, offset: 137729},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4548, col: 19, offset: 137545},
+					pos: position{line: 4553, col: 19, offset: 137729},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4548, col: 19, offset: 137545},
+							pos:        position{line: 4553, col: 19, offset: 137729},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4548, col: 31, offset: 137557},
+							pos:  position{line: 4553, col: 31, offset: 137741},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4548, col: 37, offset: 137563},
+							pos:   position{line: 4553, col: 37, offset: 137747},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4548, col: 41, offset: 137567},
+								pos:  position{line: 4553, col: 41, offset: 137751},
 								name: "QuotedString",
 							},
 						},
@@ -11759,28 +11760,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4566, col: 1, offset: 138038},
+			pos:  position{line: 4571, col: 1, offset: 138222},
 			expr: &actionExpr{
-				pos: position{line: 4566, col: 21, offset: 138058},
+				pos: position{line: 4571, col: 21, offset: 138242},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4566, col: 21, offset: 138058},
+					pos: position{line: 4571, col: 21, offset: 138242},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4566, col: 21, offset: 138058},
+							pos:        position{line: 4571, col: 21, offset: 138242},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4566, col: 34, offset: 138071},
+							pos:  position{line: 4571, col: 34, offset: 138255},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4566, col: 40, offset: 138077},
+							pos:   position{line: 4571, col: 40, offset: 138261},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4566, col: 48, offset: 138085},
+								pos:  position{line: 4571, col: 48, offset: 138269},
 								name: "Boolean",
 							},
 						},
@@ -11790,28 +11791,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4578, col: 1, offset: 138325},
+			pos:  position{line: 4583, col: 1, offset: 138509},
 			expr: &actionExpr{
-				pos: position{line: 4578, col: 16, offset: 138340},
+				pos: position{line: 4583, col: 16, offset: 138524},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4578, col: 16, offset: 138340},
+					pos: position{line: 4583, col: 16, offset: 138524},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4578, col: 16, offset: 138340},
+							pos:        position{line: 4583, col: 16, offset: 138524},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4578, col: 24, offset: 138348},
+							pos:  position{line: 4583, col: 24, offset: 138532},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4578, col: 30, offset: 138354},
+							pos:   position{line: 4583, col: 30, offset: 138538},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4578, col: 38, offset: 138362},
+								pos:  position{line: 4583, col: 38, offset: 138546},
 								name: "Boolean",
 							},
 						},
@@ -11821,28 +11822,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4590, col: 1, offset: 138627},
+			pos:  position{line: 4595, col: 1, offset: 138811},
 			expr: &actionExpr{
-				pos: position{line: 4590, col: 15, offset: 138641},
+				pos: position{line: 4595, col: 15, offset: 138825},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4590, col: 15, offset: 138641},
+					pos: position{line: 4595, col: 15, offset: 138825},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4590, col: 15, offset: 138641},
+							pos:  position{line: 4595, col: 15, offset: 138825},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4590, col: 20, offset: 138646},
+							pos:  position{line: 4595, col: 20, offset: 138830},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4590, col: 30, offset: 138656},
+							pos:   position{line: 4595, col: 30, offset: 138840},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4590, col: 40, offset: 138666},
+								pos: position{line: 4595, col: 40, offset: 138850},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4590, col: 40, offset: 138666},
+									pos:  position{line: 4595, col: 40, offset: 138850},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -11853,39 +11854,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4597, col: 1, offset: 138792},
+			pos:  position{line: 4602, col: 1, offset: 138976},
 			expr: &actionExpr{
-				pos: position{line: 4597, col: 23, offset: 138814},
+				pos: position{line: 4602, col: 23, offset: 138998},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4597, col: 23, offset: 138814},
+					pos: position{line: 4602, col: 23, offset: 138998},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4597, col: 23, offset: 138814},
+							pos:  position{line: 4602, col: 23, offset: 138998},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4597, col: 29, offset: 138820},
+							pos:   position{line: 4602, col: 29, offset: 139004},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4597, col: 35, offset: 138826},
+								pos:  position{line: 4602, col: 35, offset: 139010},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4597, col: 49, offset: 138840},
+							pos:   position{line: 4602, col: 49, offset: 139024},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4597, col: 54, offset: 138845},
+								pos: position{line: 4602, col: 54, offset: 139029},
 								expr: &seqExpr{
-									pos: position{line: 4597, col: 55, offset: 138846},
+									pos: position{line: 4602, col: 55, offset: 139030},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4597, col: 55, offset: 138846},
+											pos:  position{line: 4602, col: 55, offset: 139030},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4597, col: 61, offset: 138852},
+											pos:  position{line: 4602, col: 61, offset: 139036},
 											name: "SPathArgument",
 										},
 									},
@@ -11898,26 +11899,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4629, col: 1, offset: 139745},
+			pos:  position{line: 4634, col: 1, offset: 139929},
 			expr: &actionExpr{
-				pos: position{line: 4629, col: 18, offset: 139762},
+				pos: position{line: 4634, col: 18, offset: 139946},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4629, col: 18, offset: 139762},
+					pos:   position{line: 4634, col: 18, offset: 139946},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4629, col: 23, offset: 139767},
+						pos: position{line: 4634, col: 23, offset: 139951},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 23, offset: 139767},
+								pos:  position{line: 4634, col: 23, offset: 139951},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 36, offset: 139780},
+								pos:  position{line: 4634, col: 36, offset: 139964},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 50, offset: 139794},
+								pos:  position{line: 4634, col: 50, offset: 139978},
 								name: "PathField",
 							},
 						},
@@ -11927,28 +11928,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4633, col: 1, offset: 139830},
+			pos:  position{line: 4638, col: 1, offset: 140014},
 			expr: &actionExpr{
-				pos: position{line: 4633, col: 15, offset: 139844},
+				pos: position{line: 4638, col: 15, offset: 140028},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4633, col: 15, offset: 139844},
+					pos: position{line: 4638, col: 15, offset: 140028},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4633, col: 15, offset: 139844},
+							pos:        position{line: 4638, col: 15, offset: 140028},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4633, col: 23, offset: 139852},
+							pos:  position{line: 4638, col: 23, offset: 140036},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4633, col: 29, offset: 139858},
+							pos:   position{line: 4638, col: 29, offset: 140042},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4633, col: 35, offset: 139864},
+								pos:  position{line: 4638, col: 35, offset: 140048},
 								name: "FieldName",
 							},
 						},
@@ -11958,28 +11959,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4636, col: 1, offset: 139920},
+			pos:  position{line: 4641, col: 1, offset: 140104},
 			expr: &actionExpr{
-				pos: position{line: 4636, col: 16, offset: 139935},
+				pos: position{line: 4641, col: 16, offset: 140119},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4636, col: 16, offset: 139935},
+					pos: position{line: 4641, col: 16, offset: 140119},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4636, col: 16, offset: 139935},
+							pos:        position{line: 4641, col: 16, offset: 140119},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4636, col: 25, offset: 139944},
+							pos:  position{line: 4641, col: 25, offset: 140128},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4636, col: 31, offset: 139950},
+							pos:   position{line: 4641, col: 31, offset: 140134},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4636, col: 37, offset: 139956},
+								pos:  position{line: 4641, col: 37, offset: 140140},
 								name: "FieldName",
 							},
 						},
@@ -11989,34 +11990,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4639, col: 1, offset: 140013},
+			pos:  position{line: 4644, col: 1, offset: 140197},
 			expr: &actionExpr{
-				pos: position{line: 4639, col: 14, offset: 140026},
+				pos: position{line: 4644, col: 14, offset: 140210},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4639, col: 15, offset: 140027},
+					pos: position{line: 4644, col: 15, offset: 140211},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4639, col: 15, offset: 140027},
+							pos: position{line: 4644, col: 15, offset: 140211},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4639, col: 15, offset: 140027},
+									pos:        position{line: 4644, col: 15, offset: 140211},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4639, col: 22, offset: 140034},
+									pos:  position{line: 4644, col: 22, offset: 140218},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4639, col: 28, offset: 140040},
+									pos:  position{line: 4644, col: 28, offset: 140224},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4639, col: 47, offset: 140059},
+							pos:  position{line: 4644, col: 47, offset: 140243},
 							name: "SPathFieldString",
 						},
 					},
@@ -12025,16 +12026,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4651, col: 1, offset: 140471},
+			pos:  position{line: 4656, col: 1, offset: 140655},
 			expr: &choiceExpr{
-				pos: position{line: 4651, col: 21, offset: 140491},
+				pos: position{line: 4656, col: 21, offset: 140675},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4651, col: 21, offset: 140491},
+						pos:  position{line: 4656, col: 21, offset: 140675},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4651, col: 36, offset: 140506},
+						pos:  position{line: 4656, col: 36, offset: 140690},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12042,28 +12043,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4654, col: 1, offset: 140579},
+			pos:  position{line: 4659, col: 1, offset: 140763},
 			expr: &actionExpr{
-				pos: position{line: 4654, col: 16, offset: 140594},
+				pos: position{line: 4659, col: 16, offset: 140778},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4654, col: 16, offset: 140594},
+					pos: position{line: 4659, col: 16, offset: 140778},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4654, col: 16, offset: 140594},
+							pos:  position{line: 4659, col: 16, offset: 140778},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4654, col: 21, offset: 140599},
+							pos:  position{line: 4659, col: 21, offset: 140783},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4654, col: 32, offset: 140610},
+							pos:   position{line: 4659, col: 32, offset: 140794},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4654, col: 46, offset: 140624},
+								pos: position{line: 4659, col: 46, offset: 140808},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4654, col: 46, offset: 140624},
+									pos:  position{line: 4659, col: 46, offset: 140808},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12074,39 +12075,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4676, col: 1, offset: 141233},
+			pos:  position{line: 4681, col: 1, offset: 141417},
 			expr: &actionExpr{
-				pos: position{line: 4676, col: 24, offset: 141256},
+				pos: position{line: 4681, col: 24, offset: 141440},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4676, col: 24, offset: 141256},
+					pos: position{line: 4681, col: 24, offset: 141440},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4676, col: 24, offset: 141256},
+							pos:  position{line: 4681, col: 24, offset: 141440},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4676, col: 30, offset: 141262},
+							pos:   position{line: 4681, col: 30, offset: 141446},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4676, col: 37, offset: 141269},
+								pos:  position{line: 4681, col: 37, offset: 141453},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4676, col: 52, offset: 141284},
+							pos:   position{line: 4681, col: 52, offset: 141468},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4676, col: 57, offset: 141289},
+								pos: position{line: 4681, col: 57, offset: 141473},
 								expr: &seqExpr{
-									pos: position{line: 4676, col: 58, offset: 141290},
+									pos: position{line: 4681, col: 58, offset: 141474},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4676, col: 58, offset: 141290},
+											pos:  position{line: 4681, col: 58, offset: 141474},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4676, col: 64, offset: 141296},
+											pos:  position{line: 4681, col: 64, offset: 141480},
 											name: "FormatArgument",
 										},
 									},
@@ -12119,30 +12120,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4710, col: 1, offset: 142485},
+			pos:  position{line: 4715, col: 1, offset: 142669},
 			expr: &actionExpr{
-				pos: position{line: 4710, col: 19, offset: 142503},
+				pos: position{line: 4715, col: 19, offset: 142687},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4710, col: 19, offset: 142503},
+					pos:   position{line: 4715, col: 19, offset: 142687},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4710, col: 28, offset: 142512},
+						pos: position{line: 4715, col: 28, offset: 142696},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 28, offset: 142512},
+								pos:  position{line: 4715, col: 28, offset: 142696},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 46, offset: 142530},
+								pos:  position{line: 4715, col: 46, offset: 142714},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 65, offset: 142549},
+								pos:  position{line: 4715, col: 65, offset: 142733},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 82, offset: 142566},
+								pos:  position{line: 4715, col: 82, offset: 142750},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12152,28 +12153,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4714, col: 1, offset: 142616},
+			pos:  position{line: 4719, col: 1, offset: 142800},
 			expr: &actionExpr{
-				pos: position{line: 4714, col: 20, offset: 142635},
+				pos: position{line: 4719, col: 20, offset: 142819},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4714, col: 20, offset: 142635},
+					pos: position{line: 4719, col: 20, offset: 142819},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4714, col: 20, offset: 142635},
+							pos:        position{line: 4719, col: 20, offset: 142819},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4714, col: 28, offset: 142643},
+							pos:  position{line: 4719, col: 28, offset: 142827},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4714, col: 34, offset: 142649},
+							pos:   position{line: 4719, col: 34, offset: 142833},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4714, col: 38, offset: 142653},
+								pos:  position{line: 4719, col: 38, offset: 142837},
 								name: "QuotedString",
 							},
 						},
@@ -12183,28 +12184,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4723, col: 1, offset: 142865},
+			pos:  position{line: 4728, col: 1, offset: 143049},
 			expr: &actionExpr{
-				pos: position{line: 4723, col: 21, offset: 142885},
+				pos: position{line: 4728, col: 21, offset: 143069},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4723, col: 21, offset: 142885},
+					pos: position{line: 4728, col: 21, offset: 143069},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4723, col: 21, offset: 142885},
+							pos:        position{line: 4728, col: 21, offset: 143069},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4723, col: 34, offset: 142898},
+							pos:  position{line: 4728, col: 34, offset: 143082},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4723, col: 40, offset: 142904},
+							pos:   position{line: 4728, col: 40, offset: 143088},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4723, col: 47, offset: 142911},
+								pos:  position{line: 4728, col: 47, offset: 143095},
 								name: "IntegerAsString",
 							},
 						},
@@ -12214,28 +12215,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4736, col: 1, offset: 143317},
+			pos:  position{line: 4741, col: 1, offset: 143501},
 			expr: &actionExpr{
-				pos: position{line: 4736, col: 19, offset: 143335},
+				pos: position{line: 4741, col: 19, offset: 143519},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4736, col: 19, offset: 143335},
+					pos: position{line: 4741, col: 19, offset: 143519},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4736, col: 19, offset: 143335},
+							pos:        position{line: 4741, col: 19, offset: 143519},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4736, col: 30, offset: 143346},
+							pos:  position{line: 4741, col: 30, offset: 143530},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4736, col: 36, offset: 143352},
+							pos:   position{line: 4741, col: 36, offset: 143536},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4736, col: 40, offset: 143356},
+								pos:  position{line: 4741, col: 40, offset: 143540},
 								name: "QuotedString",
 							},
 						},
@@ -12245,78 +12246,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4745, col: 1, offset: 143571},
+			pos:  position{line: 4750, col: 1, offset: 143755},
 			expr: &actionExpr{
-				pos: position{line: 4745, col: 24, offset: 143594},
+				pos: position{line: 4750, col: 24, offset: 143778},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4745, col: 24, offset: 143594},
+					pos: position{line: 4750, col: 24, offset: 143778},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4745, col: 24, offset: 143594},
+							pos:   position{line: 4750, col: 24, offset: 143778},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 34, offset: 143604},
+								pos:  position{line: 4750, col: 34, offset: 143788},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 47, offset: 143617},
+							pos:  position{line: 4750, col: 47, offset: 143801},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 53, offset: 143623},
+							pos:   position{line: 4750, col: 53, offset: 143807},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 63, offset: 143633},
+								pos:  position{line: 4750, col: 63, offset: 143817},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 76, offset: 143646},
+							pos:  position{line: 4750, col: 76, offset: 143830},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 82, offset: 143652},
+							pos:   position{line: 4750, col: 82, offset: 143836},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 95, offset: 143665},
+								pos:  position{line: 4750, col: 95, offset: 143849},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 108, offset: 143678},
+							pos:  position{line: 4750, col: 108, offset: 143862},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 114, offset: 143684},
+							pos:   position{line: 4750, col: 114, offset: 143868},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 121, offset: 143691},
+								pos:  position{line: 4750, col: 121, offset: 143875},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 134, offset: 143704},
+							pos:  position{line: 4750, col: 134, offset: 143888},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 140, offset: 143710},
+							pos:   position{line: 4750, col: 140, offset: 143894},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 153, offset: 143723},
+								pos:  position{line: 4750, col: 153, offset: 143907},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 166, offset: 143736},
+							pos:  position{line: 4750, col: 166, offset: 143920},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 172, offset: 143742},
+							pos:   position{line: 4750, col: 172, offset: 143926},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 179, offset: 143749},
+								pos:  position{line: 4750, col: 179, offset: 143933},
 								name: "QuotedString",
 							},
 						},
@@ -12326,28 +12327,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4763, col: 1, offset: 144325},
+			pos:  position{line: 4768, col: 1, offset: 144509},
 			expr: &actionExpr{
-				pos: position{line: 4763, col: 20, offset: 144344},
+				pos: position{line: 4768, col: 20, offset: 144528},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4763, col: 20, offset: 144344},
+					pos: position{line: 4768, col: 20, offset: 144528},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 20, offset: 144344},
+							pos:  position{line: 4768, col: 20, offset: 144528},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 25, offset: 144349},
+							pos:  position{line: 4768, col: 25, offset: 144533},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4763, col: 40, offset: 144364},
+							pos:   position{line: 4768, col: 40, offset: 144548},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4763, col: 55, offset: 144379},
+								pos: position{line: 4768, col: 55, offset: 144563},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4763, col: 55, offset: 144379},
+									pos:  position{line: 4768, col: 55, offset: 144563},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12358,42 +12359,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4770, col: 1, offset: 144532},
+			pos:  position{line: 4775, col: 1, offset: 144716},
 			expr: &actionExpr{
-				pos: position{line: 4770, col: 28, offset: 144559},
+				pos: position{line: 4775, col: 28, offset: 144743},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4770, col: 28, offset: 144559},
+					pos: position{line: 4775, col: 28, offset: 144743},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4770, col: 28, offset: 144559},
+							pos:  position{line: 4775, col: 28, offset: 144743},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 34, offset: 144565},
+							pos:   position{line: 4775, col: 34, offset: 144749},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4770, col: 40, offset: 144571},
+								pos: position{line: 4775, col: 40, offset: 144755},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4770, col: 40, offset: 144571},
+									pos:  position{line: 4775, col: 40, offset: 144755},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 60, offset: 144591},
+							pos:   position{line: 4775, col: 60, offset: 144775},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4770, col: 65, offset: 144596},
+								pos: position{line: 4775, col: 65, offset: 144780},
 								expr: &seqExpr{
-									pos: position{line: 4770, col: 66, offset: 144597},
+									pos: position{line: 4775, col: 66, offset: 144781},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 66, offset: 144597},
+											pos:  position{line: 4775, col: 66, offset: 144781},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 72, offset: 144603},
+											pos:  position{line: 4775, col: 72, offset: 144787},
 											name: "EventCountArgument",
 										},
 									},
@@ -12406,30 +12407,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4826, col: 1, offset: 146480},
+			pos:  position{line: 4831, col: 1, offset: 146664},
 			expr: &actionExpr{
-				pos: position{line: 4826, col: 23, offset: 146502},
+				pos: position{line: 4831, col: 23, offset: 146686},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4826, col: 23, offset: 146502},
+					pos:   position{line: 4831, col: 23, offset: 146686},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4826, col: 28, offset: 146507},
+						pos: position{line: 4831, col: 28, offset: 146691},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 28, offset: 146507},
+								pos:  position{line: 4831, col: 28, offset: 146691},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 41, offset: 146520},
+								pos:  position{line: 4831, col: 41, offset: 146704},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 58, offset: 146537},
+								pos:  position{line: 4831, col: 58, offset: 146721},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 76, offset: 146555},
+								pos:  position{line: 4831, col: 76, offset: 146739},
 								name: "ListVixField",
 							},
 						},
@@ -12439,28 +12440,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4830, col: 1, offset: 146594},
+			pos:  position{line: 4835, col: 1, offset: 146778},
 			expr: &actionExpr{
-				pos: position{line: 4830, col: 15, offset: 146608},
+				pos: position{line: 4835, col: 15, offset: 146792},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4830, col: 15, offset: 146608},
+					pos: position{line: 4835, col: 15, offset: 146792},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4830, col: 15, offset: 146608},
+							pos:        position{line: 4835, col: 15, offset: 146792},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4830, col: 23, offset: 146616},
+							pos:  position{line: 4835, col: 23, offset: 146800},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4830, col: 29, offset: 146622},
+							pos:   position{line: 4835, col: 29, offset: 146806},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4830, col: 35, offset: 146628},
+								pos:  position{line: 4835, col: 35, offset: 146812},
 								name: "IndexName",
 							},
 						},
@@ -12470,28 +12471,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4833, col: 1, offset: 146684},
+			pos:  position{line: 4838, col: 1, offset: 146868},
 			expr: &actionExpr{
-				pos: position{line: 4833, col: 19, offset: 146702},
+				pos: position{line: 4838, col: 19, offset: 146886},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4833, col: 19, offset: 146702},
+					pos: position{line: 4838, col: 19, offset: 146886},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4833, col: 19, offset: 146702},
+							pos:        position{line: 4838, col: 19, offset: 146886},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4833, col: 31, offset: 146714},
+							pos:  position{line: 4838, col: 31, offset: 146898},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4833, col: 37, offset: 146720},
+							pos:   position{line: 4838, col: 37, offset: 146904},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4833, col: 43, offset: 146726},
+								pos:  position{line: 4838, col: 43, offset: 146910},
 								name: "Boolean",
 							},
 						},
@@ -12501,28 +12502,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4836, col: 1, offset: 146802},
+			pos:  position{line: 4841, col: 1, offset: 146986},
 			expr: &actionExpr{
-				pos: position{line: 4836, col: 20, offset: 146821},
+				pos: position{line: 4841, col: 20, offset: 147005},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4836, col: 20, offset: 146821},
+					pos: position{line: 4841, col: 20, offset: 147005},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4836, col: 20, offset: 146821},
+							pos:        position{line: 4841, col: 20, offset: 147005},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4836, col: 34, offset: 146835},
+							pos:  position{line: 4841, col: 34, offset: 147019},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4836, col: 40, offset: 146841},
+							pos:   position{line: 4841, col: 40, offset: 147025},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4836, col: 46, offset: 146847},
+								pos:  position{line: 4841, col: 46, offset: 147031},
 								name: "Boolean",
 							},
 						},
@@ -12532,28 +12533,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4839, col: 1, offset: 146925},
+			pos:  position{line: 4844, col: 1, offset: 147109},
 			expr: &actionExpr{
-				pos: position{line: 4839, col: 17, offset: 146941},
+				pos: position{line: 4844, col: 17, offset: 147125},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4839, col: 17, offset: 146941},
+					pos: position{line: 4844, col: 17, offset: 147125},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4839, col: 17, offset: 146941},
+							pos:        position{line: 4844, col: 17, offset: 147125},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4839, col: 28, offset: 146952},
+							pos:  position{line: 4844, col: 28, offset: 147136},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4839, col: 34, offset: 146958},
+							pos:   position{line: 4844, col: 34, offset: 147142},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4839, col: 40, offset: 146964},
+								pos:  position{line: 4844, col: 40, offset: 147148},
 								name: "Boolean",
 							},
 						},
@@ -12563,24 +12564,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4843, col: 1, offset: 147040},
+			pos:  position{line: 4848, col: 1, offset: 147224},
 			expr: &actionExpr{
-				pos: position{line: 4843, col: 14, offset: 147053},
+				pos: position{line: 4848, col: 14, offset: 147237},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4843, col: 14, offset: 147053},
+					pos: position{line: 4848, col: 14, offset: 147237},
 					expr: &seqExpr{
-						pos: position{line: 4843, col: 15, offset: 147054},
+						pos: position{line: 4848, col: 15, offset: 147238},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4843, col: 15, offset: 147054},
+								pos: position{line: 4848, col: 15, offset: 147238},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4843, col: 16, offset: 147055},
+									pos:  position{line: 4848, col: 16, offset: 147239},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4843, col: 22, offset: 147061,
+								line: 4848, col: 22, offset: 147245,
 							},
 						},
 					},
@@ -12589,39 +12590,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4848, col: 1, offset: 147134},
+			pos:  position{line: 4853, col: 1, offset: 147318},
 			expr: &actionExpr{
-				pos: position{line: 4848, col: 18, offset: 147151},
+				pos: position{line: 4853, col: 18, offset: 147335},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4848, col: 18, offset: 147151},
+					pos: position{line: 4853, col: 18, offset: 147335},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4848, col: 18, offset: 147151},
+							pos:  position{line: 4853, col: 18, offset: 147335},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4848, col: 23, offset: 147156},
+							pos:  position{line: 4853, col: 23, offset: 147340},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4848, col: 36, offset: 147169},
+							pos:   position{line: 4853, col: 36, offset: 147353},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4848, col: 49, offset: 147182},
+								pos: position{line: 4853, col: 49, offset: 147366},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4848, col: 49, offset: 147182},
+									pos:  position{line: 4853, col: 49, offset: 147366},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4848, col: 70, offset: 147203},
+							pos:   position{line: 4853, col: 70, offset: 147387},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4848, col: 77, offset: 147210},
+								pos: position{line: 4853, col: 77, offset: 147394},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4848, col: 77, offset: 147210},
+									pos:  position{line: 4853, col: 77, offset: 147394},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12632,32 +12633,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4877, col: 1, offset: 147937},
+			pos:  position{line: 4882, col: 1, offset: 148121},
 			expr: &actionExpr{
-				pos: position{line: 4877, col: 24, offset: 147960},
+				pos: position{line: 4882, col: 24, offset: 148144},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4877, col: 24, offset: 147960},
+					pos: position{line: 4882, col: 24, offset: 148144},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4877, col: 24, offset: 147960},
+							pos:  position{line: 4882, col: 24, offset: 148144},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4877, col: 30, offset: 147966},
+							pos:        position{line: 4882, col: 30, offset: 148150},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4877, col: 38, offset: 147974},
+							pos:  position{line: 4882, col: 38, offset: 148158},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4877, col: 44, offset: 147980},
+							pos:   position{line: 4882, col: 44, offset: 148164},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4877, col: 48, offset: 147984},
+								pos:  position{line: 4882, col: 48, offset: 148168},
 								name: "String",
 							},
 						},
@@ -12667,22 +12668,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 4881, col: 1, offset: 148030},
+			pos:  position{line: 4886, col: 1, offset: 148214},
 			expr: &actionExpr{
-				pos: position{line: 4881, col: 22, offset: 148051},
+				pos: position{line: 4886, col: 22, offset: 148235},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 4881, col: 22, offset: 148051},
+					pos: position{line: 4886, col: 22, offset: 148235},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4881, col: 22, offset: 148051},
+							pos:  position{line: 4886, col: 22, offset: 148235},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4881, col: 28, offset: 148057},
+							pos:   position{line: 4886, col: 28, offset: 148241},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4881, col: 38, offset: 148067},
+								pos:  position{line: 4886, col: 38, offset: 148251},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12692,36 +12693,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 4885, col: 1, offset: 148126},
+			pos:  position{line: 4890, col: 1, offset: 148310},
 			expr: &actionExpr{
-				pos: position{line: 4885, col: 18, offset: 148143},
+				pos: position{line: 4890, col: 18, offset: 148327},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4885, col: 18, offset: 148143},
+					pos: position{line: 4890, col: 18, offset: 148327},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4885, col: 18, offset: 148143},
+							pos:  position{line: 4890, col: 18, offset: 148327},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4885, col: 23, offset: 148148},
+							pos:  position{line: 4890, col: 23, offset: 148332},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 4885, col: 36, offset: 148161},
+							pos:   position{line: 4890, col: 36, offset: 148345},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4885, col: 42, offset: 148167},
+								pos:  position{line: 4890, col: 42, offset: 148351},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4885, col: 56, offset: 148181},
+							pos:   position{line: 4890, col: 56, offset: 148365},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4885, col: 62, offset: 148187},
+								pos: position{line: 4890, col: 62, offset: 148371},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4885, col: 62, offset: 148187},
+									pos:  position{line: 4890, col: 62, offset: 148371},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12732,22 +12733,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 4915, col: 1, offset: 148921},
+			pos:  position{line: 4920, col: 1, offset: 149105},
 			expr: &actionExpr{
-				pos: position{line: 4915, col: 18, offset: 148938},
+				pos: position{line: 4920, col: 18, offset: 149122},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 4915, col: 18, offset: 148938},
+					pos: position{line: 4920, col: 18, offset: 149122},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4915, col: 18, offset: 148938},
+							pos:  position{line: 4920, col: 18, offset: 149122},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4915, col: 24, offset: 148944},
+							pos:   position{line: 4920, col: 24, offset: 149128},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4915, col: 34, offset: 148954},
+								pos:  position{line: 4920, col: 34, offset: 149138},
 								name: "FieldName",
 							},
 						},
@@ -12757,32 +12758,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 4919, col: 1, offset: 148995},
+			pos:  position{line: 4924, col: 1, offset: 149179},
 			expr: &actionExpr{
-				pos: position{line: 4919, col: 18, offset: 149012},
+				pos: position{line: 4924, col: 18, offset: 149196},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4919, col: 18, offset: 149012},
+					pos: position{line: 4924, col: 18, offset: 149196},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4919, col: 18, offset: 149012},
+							pos:  position{line: 4924, col: 18, offset: 149196},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4919, col: 24, offset: 149018},
+							pos:        position{line: 4924, col: 24, offset: 149202},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4919, col: 32, offset: 149026},
+							pos:  position{line: 4924, col: 32, offset: 149210},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4919, col: 38, offset: 149032},
+							pos:   position{line: 4924, col: 38, offset: 149216},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4919, col: 47, offset: 149041},
+								pos:  position{line: 4924, col: 47, offset: 149225},
 								name: "IntegerAsString",
 							},
 						},
@@ -12792,26 +12793,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 4923, col: 1, offset: 149087},
+			pos:  position{line: 4928, col: 1, offset: 149271},
 			expr: &actionExpr{
-				pos: position{line: 4923, col: 16, offset: 149102},
+				pos: position{line: 4928, col: 16, offset: 149286},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 4923, col: 16, offset: 149102},
+					pos: position{line: 4928, col: 16, offset: 149286},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4923, col: 16, offset: 149102},
+							pos:  position{line: 4928, col: 16, offset: 149286},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4923, col: 22, offset: 149108},
+							pos:  position{line: 4928, col: 22, offset: 149292},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4923, col: 32, offset: 149118},
+							pos:   position{line: 4928, col: 32, offset: 149302},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4923, col: 42, offset: 149128},
+								pos:  position{line: 4928, col: 42, offset: 149312},
 								name: "BoolExpr",
 							},
 						},
@@ -12821,28 +12822,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 4927, col: 1, offset: 149188},
+			pos:  position{line: 4932, col: 1, offset: 149372},
 			expr: &actionExpr{
-				pos: position{line: 4927, col: 28, offset: 149215},
+				pos: position{line: 4932, col: 28, offset: 149399},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 4927, col: 28, offset: 149215},
+					pos: position{line: 4932, col: 28, offset: 149399},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4927, col: 28, offset: 149215},
+							pos:        position{line: 4932, col: 28, offset: 149399},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4927, col: 37, offset: 149224},
+							pos:  position{line: 4932, col: 37, offset: 149408},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4927, col: 43, offset: 149230},
+							pos:   position{line: 4932, col: 43, offset: 149414},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4927, col: 51, offset: 149238},
+								pos:  position{line: 4932, col: 51, offset: 149422},
 								name: "Boolean",
 							},
 						},
@@ -12852,28 +12853,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 4936, col: 1, offset: 149422},
+			pos:  position{line: 4941, col: 1, offset: 149606},
 			expr: &actionExpr{
-				pos: position{line: 4936, col: 28, offset: 149449},
+				pos: position{line: 4941, col: 28, offset: 149633},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 4936, col: 28, offset: 149449},
+					pos: position{line: 4941, col: 28, offset: 149633},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4936, col: 28, offset: 149449},
+							pos:        position{line: 4941, col: 28, offset: 149633},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4936, col: 37, offset: 149458},
+							pos:  position{line: 4941, col: 37, offset: 149642},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4936, col: 43, offset: 149464},
+							pos:   position{line: 4941, col: 43, offset: 149648},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4936, col: 51, offset: 149472},
+								pos:  position{line: 4941, col: 51, offset: 149656},
 								name: "Boolean",
 							},
 						},
@@ -12883,28 +12884,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 4945, col: 1, offset: 149656},
+			pos:  position{line: 4950, col: 1, offset: 149840},
 			expr: &actionExpr{
-				pos: position{line: 4945, col: 27, offset: 149682},
+				pos: position{line: 4950, col: 27, offset: 149866},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 4945, col: 27, offset: 149682},
+					pos: position{line: 4950, col: 27, offset: 149866},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4945, col: 27, offset: 149682},
+							pos:        position{line: 4950, col: 27, offset: 149866},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4945, col: 35, offset: 149690},
+							pos:  position{line: 4950, col: 35, offset: 149874},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4945, col: 41, offset: 149696},
+							pos:   position{line: 4950, col: 41, offset: 149880},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4945, col: 48, offset: 149703},
+								pos:  position{line: 4950, col: 48, offset: 149887},
 								name: "PositiveInteger",
 							},
 						},
@@ -12914,28 +12915,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 4954, col: 1, offset: 149894},
+			pos:  position{line: 4959, col: 1, offset: 150078},
 			expr: &actionExpr{
-				pos: position{line: 4954, col: 25, offset: 149918},
+				pos: position{line: 4959, col: 25, offset: 150102},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 4954, col: 25, offset: 149918},
+					pos: position{line: 4959, col: 25, offset: 150102},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4954, col: 25, offset: 149918},
+							pos:        position{line: 4959, col: 25, offset: 150102},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4954, col: 31, offset: 149924},
+							pos:  position{line: 4959, col: 31, offset: 150108},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4954, col: 37, offset: 149930},
+							pos:   position{line: 4959, col: 37, offset: 150114},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4954, col: 44, offset: 149937},
+								pos:  position{line: 4959, col: 44, offset: 150121},
 								name: "PositiveInteger",
 							},
 						},
@@ -12945,30 +12946,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 4963, col: 1, offset: 150124},
+			pos:  position{line: 4968, col: 1, offset: 150308},
 			expr: &actionExpr{
-				pos: position{line: 4963, col: 22, offset: 150145},
+				pos: position{line: 4968, col: 22, offset: 150329},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4963, col: 22, offset: 150145},
+					pos:   position{line: 4968, col: 22, offset: 150329},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 4963, col: 41, offset: 150164},
+						pos: position{line: 4968, col: 41, offset: 150348},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 41, offset: 150164},
+								pos:  position{line: 4968, col: 41, offset: 150348},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 67, offset: 150190},
+								pos:  position{line: 4968, col: 67, offset: 150374},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 93, offset: 150216},
+								pos:  position{line: 4968, col: 93, offset: 150400},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 118, offset: 150241},
+								pos:  position{line: 4968, col: 118, offset: 150425},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -12978,35 +12979,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 4967, col: 1, offset: 150302},
+			pos:  position{line: 4972, col: 1, offset: 150486},
 			expr: &actionExpr{
-				pos: position{line: 4967, col: 26, offset: 150327},
+				pos: position{line: 4972, col: 26, offset: 150511},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4967, col: 26, offset: 150327},
+					pos: position{line: 4972, col: 26, offset: 150511},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4967, col: 26, offset: 150327},
+							pos:   position{line: 4972, col: 26, offset: 150511},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4967, col: 34, offset: 150335},
+								pos:  position{line: 4972, col: 34, offset: 150519},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4967, col: 53, offset: 150354},
+							pos:   position{line: 4972, col: 53, offset: 150538},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4967, col: 58, offset: 150359},
+								pos: position{line: 4972, col: 58, offset: 150543},
 								expr: &seqExpr{
-									pos: position{line: 4967, col: 59, offset: 150360},
+									pos: position{line: 4972, col: 59, offset: 150544},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4967, col: 59, offset: 150360},
+											pos:  position{line: 4972, col: 59, offset: 150544},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4967, col: 65, offset: 150366},
+											pos:  position{line: 4972, col: 65, offset: 150550},
 											name: "InputLookupOption",
 										},
 									},
@@ -13019,35 +13020,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5009, col: 1, offset: 151812},
+			pos:  position{line: 5014, col: 1, offset: 151996},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 21, offset: 151832},
+				pos: position{line: 5014, col: 21, offset: 152016},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 21, offset: 151832},
+					pos: position{line: 5014, col: 21, offset: 152016},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 21, offset: 151832},
+							pos:  position{line: 5014, col: 21, offset: 152016},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 26, offset: 151837},
+							pos:  position{line: 5014, col: 26, offset: 152021},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 42, offset: 151853},
+							pos:   position{line: 5014, col: 42, offset: 152037},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 60, offset: 151871},
+								pos: position{line: 5014, col: 60, offset: 152055},
 								expr: &seqExpr{
-									pos: position{line: 5009, col: 61, offset: 151872},
+									pos: position{line: 5014, col: 61, offset: 152056},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5009, col: 61, offset: 151872},
+											pos:  position{line: 5014, col: 61, offset: 152056},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5009, col: 83, offset: 151894},
+											pos:  position{line: 5014, col: 83, offset: 152078},
 											name: "SPACE",
 										},
 									},
@@ -13055,20 +13056,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 91, offset: 151902},
+							pos:   position{line: 5014, col: 91, offset: 152086},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5009, col: 101, offset: 151912},
+								pos:  position{line: 5014, col: 101, offset: 152096},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 109, offset: 151920},
+							pos:   position{line: 5014, col: 109, offset: 152104},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 121, offset: 151932},
+								pos: position{line: 5014, col: 121, offset: 152116},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5009, col: 122, offset: 151933},
+									pos:  position{line: 5014, col: 122, offset: 152117},
 									name: "WhereClause",
 								},
 							},
@@ -13079,15 +13080,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5031, col: 1, offset: 152583},
+			pos:  position{line: 5036, col: 1, offset: 152767},
 			expr: &actionExpr{
-				pos: position{line: 5031, col: 24, offset: 152606},
+				pos: position{line: 5036, col: 24, offset: 152790},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5031, col: 24, offset: 152606},
+					pos:   position{line: 5036, col: 24, offset: 152790},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5031, col: 41, offset: 152623},
+						pos:  position{line: 5036, col: 41, offset: 152807},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13095,124 +13096,124 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5043, col: 1, offset: 153015},
+			pos:  position{line: 5048, col: 1, offset: 153199},
 			expr: &choiceExpr{
-				pos: position{line: 5043, col: 12, offset: 153026},
+				pos: position{line: 5048, col: 12, offset: 153210},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 12, offset: 153026},
+						pos:  position{line: 5048, col: 12, offset: 153210},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 24, offset: 153038},
+						pos:  position{line: 5048, col: 24, offset: 153222},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 36, offset: 153050},
+						pos:  position{line: 5048, col: 36, offset: 153234},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 49, offset: 153063},
+						pos:  position{line: 5048, col: 49, offset: 153247},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 61, offset: 153075},
+						pos:  position{line: 5048, col: 61, offset: 153259},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 81, offset: 153095},
+						pos:  position{line: 5048, col: 81, offset: 153279},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 92, offset: 153106},
+						pos:  position{line: 5048, col: 92, offset: 153290},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 112, offset: 153126},
+						pos:  position{line: 5048, col: 112, offset: 153310},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 123, offset: 153137},
+						pos:  position{line: 5048, col: 123, offset: 153321},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 134, offset: 153148},
+						pos:  position{line: 5048, col: 134, offset: 153332},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 144, offset: 153158},
+						pos:  position{line: 5048, col: 144, offset: 153342},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 154, offset: 153168},
+						pos:  position{line: 5048, col: 154, offset: 153352},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 165, offset: 153179},
+						pos:  position{line: 5048, col: 165, offset: 153363},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 178, offset: 153192},
+						pos:  position{line: 5048, col: 178, offset: 153376},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 194, offset: 153208},
+						pos:  position{line: 5048, col: 194, offset: 153392},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 212, offset: 153226},
+						pos:  position{line: 5048, col: 212, offset: 153410},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 224, offset: 153238},
+						pos:  position{line: 5048, col: 224, offset: 153422},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 235, offset: 153249},
+						pos:  position{line: 5048, col: 235, offset: 153433},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 248, offset: 153262},
+						pos:  position{line: 5048, col: 248, offset: 153446},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 260, offset: 153274},
+						pos:  position{line: 5048, col: 260, offset: 153458},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 273, offset: 153287},
+						pos:  position{line: 5048, col: 273, offset: 153471},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 288, offset: 153302},
+						pos:  position{line: 5048, col: 288, offset: 153486},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 301, offset: 153315},
+						pos:  position{line: 5048, col: 301, offset: 153499},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 318, offset: 153332},
+						pos:  position{line: 5048, col: 318, offset: 153516},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 328, offset: 153342},
+						pos:  position{line: 5048, col: 328, offset: 153526},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 346, offset: 153360},
+						pos:  position{line: 5048, col: 346, offset: 153544},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 361, offset: 153375},
+						pos:  position{line: 5048, col: 361, offset: 153559},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 376, offset: 153390},
+						pos:  position{line: 5048, col: 376, offset: 153574},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 391, offset: 153405},
+						pos:  position{line: 5048, col: 391, offset: 153589},
 						name: "CMD_INPUTLOOKUP",
 					},
 				},
@@ -13220,18 +13221,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5044, col: 1, offset: 153422},
+			pos:  position{line: 5049, col: 1, offset: 153606},
 			expr: &seqExpr{
-				pos: position{line: 5044, col: 15, offset: 153436},
+				pos: position{line: 5049, col: 15, offset: 153620},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5044, col: 15, offset: 153436},
+						pos:        position{line: 5049, col: 15, offset: 153620},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5044, col: 24, offset: 153445},
+						pos:  position{line: 5049, col: 24, offset: 153629},
 						name: "SPACE",
 					},
 				},
@@ -13239,18 +13240,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5045, col: 1, offset: 153451},
+			pos:  position{line: 5050, col: 1, offset: 153635},
 			expr: &seqExpr{
-				pos: position{line: 5045, col: 14, offset: 153464},
+				pos: position{line: 5050, col: 14, offset: 153648},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5045, col: 14, offset: 153464},
+						pos:        position{line: 5050, col: 14, offset: 153648},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5045, col: 22, offset: 153472},
+						pos:  position{line: 5050, col: 22, offset: 153656},
 						name: "SPACE",
 					},
 				},
@@ -13258,18 +13259,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5046, col: 1, offset: 153478},
+			pos:  position{line: 5051, col: 1, offset: 153662},
 			expr: &seqExpr{
-				pos: position{line: 5046, col: 14, offset: 153491},
+				pos: position{line: 5051, col: 14, offset: 153675},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5046, col: 14, offset: 153491},
+						pos:        position{line: 5051, col: 14, offset: 153675},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5046, col: 22, offset: 153499},
+						pos:  position{line: 5051, col: 22, offset: 153683},
 						name: "SPACE",
 					},
 				},
@@ -13277,18 +13278,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5047, col: 1, offset: 153505},
+			pos:  position{line: 5052, col: 1, offset: 153689},
 			expr: &seqExpr{
-				pos: position{line: 5047, col: 20, offset: 153524},
+				pos: position{line: 5052, col: 20, offset: 153708},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5047, col: 20, offset: 153524},
+						pos:        position{line: 5052, col: 20, offset: 153708},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5047, col: 34, offset: 153538},
+						pos:  position{line: 5052, col: 34, offset: 153722},
 						name: "SPACE",
 					},
 				},
@@ -13296,18 +13297,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5048, col: 1, offset: 153544},
+			pos:  position{line: 5053, col: 1, offset: 153728},
 			expr: &seqExpr{
-				pos: position{line: 5048, col: 15, offset: 153558},
+				pos: position{line: 5053, col: 15, offset: 153742},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5048, col: 15, offset: 153558},
+						pos:        position{line: 5053, col: 15, offset: 153742},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 24, offset: 153567},
+						pos:  position{line: 5053, col: 24, offset: 153751},
 						name: "SPACE",
 					},
 				},
@@ -13315,18 +13316,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5049, col: 1, offset: 153573},
+			pos:  position{line: 5054, col: 1, offset: 153757},
 			expr: &seqExpr{
-				pos: position{line: 5049, col: 14, offset: 153586},
+				pos: position{line: 5054, col: 14, offset: 153770},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5049, col: 14, offset: 153586},
+						pos:        position{line: 5054, col: 14, offset: 153770},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5049, col: 22, offset: 153594},
+						pos:  position{line: 5054, col: 22, offset: 153778},
 						name: "SPACE",
 					},
 				},
@@ -13334,9 +13335,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5050, col: 1, offset: 153600},
+			pos:  position{line: 5055, col: 1, offset: 153784},
 			expr: &litMatcher{
-				pos:        position{line: 5050, col: 22, offset: 153621},
+				pos:        position{line: 5055, col: 22, offset: 153805},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13344,16 +13345,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5051, col: 1, offset: 153628},
+			pos:  position{line: 5056, col: 1, offset: 153812},
 			expr: &seqExpr{
-				pos: position{line: 5051, col: 13, offset: 153640},
+				pos: position{line: 5056, col: 13, offset: 153824},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 13, offset: 153640},
+						pos:  position{line: 5056, col: 13, offset: 153824},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 31, offset: 153658},
+						pos:  position{line: 5056, col: 31, offset: 153842},
 						name: "SPACE",
 					},
 				},
@@ -13361,9 +13362,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5052, col: 1, offset: 153664},
+			pos:  position{line: 5057, col: 1, offset: 153848},
 			expr: &litMatcher{
-				pos:        position{line: 5052, col: 22, offset: 153685},
+				pos:        position{line: 5057, col: 22, offset: 153869},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13371,16 +13372,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5053, col: 1, offset: 153692},
+			pos:  position{line: 5058, col: 1, offset: 153876},
 			expr: &seqExpr{
-				pos: position{line: 5053, col: 13, offset: 153704},
+				pos: position{line: 5058, col: 13, offset: 153888},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5053, col: 13, offset: 153704},
+						pos:  position{line: 5058, col: 13, offset: 153888},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5053, col: 31, offset: 153722},
+						pos:  position{line: 5058, col: 31, offset: 153906},
 						name: "SPACE",
 					},
 				},
@@ -13388,18 +13389,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5054, col: 1, offset: 153728},
+			pos:  position{line: 5059, col: 1, offset: 153912},
 			expr: &seqExpr{
-				pos: position{line: 5054, col: 13, offset: 153740},
+				pos: position{line: 5059, col: 13, offset: 153924},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5054, col: 13, offset: 153740},
+						pos:        position{line: 5059, col: 13, offset: 153924},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5054, col: 20, offset: 153747},
+						pos:  position{line: 5059, col: 20, offset: 153931},
 						name: "SPACE",
 					},
 				},
@@ -13407,18 +13408,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5055, col: 1, offset: 153753},
+			pos:  position{line: 5060, col: 1, offset: 153937},
 			expr: &seqExpr{
-				pos: position{line: 5055, col: 12, offset: 153764},
+				pos: position{line: 5060, col: 12, offset: 153948},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5055, col: 12, offset: 153764},
+						pos:        position{line: 5060, col: 12, offset: 153948},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5055, col: 18, offset: 153770},
+						pos:  position{line: 5060, col: 18, offset: 153954},
 						name: "SPACE",
 					},
 				},
@@ -13426,18 +13427,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5056, col: 1, offset: 153776},
+			pos:  position{line: 5061, col: 1, offset: 153960},
 			expr: &seqExpr{
-				pos: position{line: 5056, col: 13, offset: 153788},
+				pos: position{line: 5061, col: 13, offset: 153972},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5056, col: 13, offset: 153788},
+						pos:        position{line: 5061, col: 13, offset: 153972},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5056, col: 20, offset: 153795},
+						pos:  position{line: 5061, col: 20, offset: 153979},
 						name: "SPACE",
 					},
 				},
@@ -13445,9 +13446,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5057, col: 1, offset: 153801},
+			pos:  position{line: 5062, col: 1, offset: 153985},
 			expr: &litMatcher{
-				pos:        position{line: 5057, col: 12, offset: 153812},
+				pos:        position{line: 5062, col: 12, offset: 153996},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13455,9 +13456,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5058, col: 1, offset: 153818},
+			pos:  position{line: 5063, col: 1, offset: 154002},
 			expr: &litMatcher{
-				pos:        position{line: 5058, col: 13, offset: 153830},
+				pos:        position{line: 5063, col: 13, offset: 154014},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13465,18 +13466,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5059, col: 1, offset: 153837},
+			pos:  position{line: 5064, col: 1, offset: 154021},
 			expr: &seqExpr{
-				pos: position{line: 5059, col: 15, offset: 153851},
+				pos: position{line: 5064, col: 15, offset: 154035},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5059, col: 15, offset: 153851},
+						pos:        position{line: 5064, col: 15, offset: 154035},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5059, col: 24, offset: 153860},
+						pos:  position{line: 5064, col: 24, offset: 154044},
 						name: "SPACE",
 					},
 				},
@@ -13484,18 +13485,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5060, col: 1, offset: 153866},
+			pos:  position{line: 5065, col: 1, offset: 154050},
 			expr: &seqExpr{
-				pos: position{line: 5060, col: 18, offset: 153883},
+				pos: position{line: 5065, col: 18, offset: 154067},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5060, col: 18, offset: 153883},
+						pos:        position{line: 5065, col: 18, offset: 154067},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5060, col: 30, offset: 153895},
+						pos:  position{line: 5065, col: 30, offset: 154079},
 						name: "SPACE",
 					},
 				},
@@ -13503,18 +13504,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5061, col: 1, offset: 153901},
+			pos:  position{line: 5066, col: 1, offset: 154085},
 			expr: &seqExpr{
-				pos: position{line: 5061, col: 12, offset: 153912},
+				pos: position{line: 5066, col: 12, offset: 154096},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5061, col: 12, offset: 153912},
+						pos:        position{line: 5066, col: 12, offset: 154096},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5061, col: 18, offset: 153918},
+						pos:  position{line: 5066, col: 18, offset: 154102},
 						name: "SPACE",
 					},
 				},
@@ -13522,9 +13523,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5062, col: 1, offset: 153924},
+			pos:  position{line: 5067, col: 1, offset: 154108},
 			expr: &litMatcher{
-				pos:        position{line: 5062, col: 13, offset: 153936},
+				pos:        position{line: 5067, col: 13, offset: 154120},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13532,18 +13533,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5063, col: 1, offset: 153943},
+			pos:  position{line: 5068, col: 1, offset: 154127},
 			expr: &seqExpr{
-				pos: position{line: 5063, col: 20, offset: 153962},
+				pos: position{line: 5068, col: 20, offset: 154146},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5063, col: 20, offset: 153962},
+						pos:        position{line: 5068, col: 20, offset: 154146},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5063, col: 34, offset: 153976},
+						pos:  position{line: 5068, col: 34, offset: 154160},
 						name: "SPACE",
 					},
 				},
@@ -13551,9 +13552,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5064, col: 1, offset: 153982},
+			pos:  position{line: 5069, col: 1, offset: 154166},
 			expr: &litMatcher{
-				pos:        position{line: 5064, col: 14, offset: 153995},
+				pos:        position{line: 5069, col: 14, offset: 154179},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13561,22 +13562,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5065, col: 1, offset: 154003},
+			pos:  position{line: 5070, col: 1, offset: 154187},
 			expr: &seqExpr{
-				pos: position{line: 5065, col: 21, offset: 154023},
+				pos: position{line: 5070, col: 21, offset: 154207},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 21, offset: 154023},
+						pos:  position{line: 5070, col: 21, offset: 154207},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5065, col: 27, offset: 154029},
+						pos:        position{line: 5070, col: 27, offset: 154213},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 36, offset: 154038},
+						pos:  position{line: 5070, col: 36, offset: 154222},
 						name: "SPACE",
 					},
 				},
@@ -13584,9 +13585,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5066, col: 1, offset: 154044},
+			pos:  position{line: 5071, col: 1, offset: 154228},
 			expr: &litMatcher{
-				pos:        position{line: 5066, col: 15, offset: 154058},
+				pos:        position{line: 5071, col: 15, offset: 154242},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -13594,9 +13595,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5067, col: 1, offset: 154067},
+			pos:  position{line: 5072, col: 1, offset: 154251},
 			expr: &litMatcher{
-				pos:        position{line: 5067, col: 14, offset: 154080},
+				pos:        position{line: 5072, col: 14, offset: 154264},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -13604,9 +13605,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5068, col: 1, offset: 154088},
+			pos:  position{line: 5073, col: 1, offset: 154272},
 			expr: &litMatcher{
-				pos:        position{line: 5068, col: 15, offset: 154102},
+				pos:        position{line: 5073, col: 15, offset: 154286},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -13614,9 +13615,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5069, col: 1, offset: 154111},
+			pos:  position{line: 5074, col: 1, offset: 154295},
 			expr: &litMatcher{
-				pos:        position{line: 5069, col: 17, offset: 154127},
+				pos:        position{line: 5074, col: 17, offset: 154311},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -13624,9 +13625,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5070, col: 1, offset: 154138},
+			pos:  position{line: 5075, col: 1, offset: 154322},
 			expr: &litMatcher{
-				pos:        position{line: 5070, col: 15, offset: 154152},
+				pos:        position{line: 5075, col: 15, offset: 154336},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -13634,9 +13635,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5071, col: 1, offset: 154161},
+			pos:  position{line: 5076, col: 1, offset: 154345},
 			expr: &litMatcher{
-				pos:        position{line: 5071, col: 19, offset: 154179},
+				pos:        position{line: 5076, col: 19, offset: 154363},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -13644,9 +13645,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5072, col: 1, offset: 154192},
+			pos:  position{line: 5077, col: 1, offset: 154376},
 			expr: &litMatcher{
-				pos:        position{line: 5072, col: 17, offset: 154208},
+				pos:        position{line: 5077, col: 17, offset: 154392},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -13654,9 +13655,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5073, col: 1, offset: 154219},
+			pos:  position{line: 5078, col: 1, offset: 154403},
 			expr: &litMatcher{
-				pos:        position{line: 5073, col: 17, offset: 154235},
+				pos:        position{line: 5078, col: 17, offset: 154419},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -13664,18 +13665,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5074, col: 1, offset: 154246},
+			pos:  position{line: 5079, col: 1, offset: 154430},
 			expr: &seqExpr{
-				pos: position{line: 5074, col: 20, offset: 154265},
+				pos: position{line: 5079, col: 20, offset: 154449},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5074, col: 20, offset: 154265},
+						pos:        position{line: 5079, col: 20, offset: 154449},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5074, col: 34, offset: 154279},
+						pos:  position{line: 5079, col: 34, offset: 154463},
 						name: "SPACE",
 					},
 				},
@@ -13683,27 +13684,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5075, col: 1, offset: 154285},
+			pos:  position{line: 5080, col: 1, offset: 154469},
 			expr: &seqExpr{
-				pos: position{line: 5075, col: 16, offset: 154300},
+				pos: position{line: 5080, col: 16, offset: 154484},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5075, col: 16, offset: 154300},
+						pos: position{line: 5080, col: 16, offset: 154484},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5075, col: 16, offset: 154300},
+							pos:  position{line: 5080, col: 16, offset: 154484},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5075, col: 23, offset: 154307},
+						pos:        position{line: 5080, col: 23, offset: 154491},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5075, col: 27, offset: 154311},
+						pos: position{line: 5080, col: 27, offset: 154495},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5075, col: 27, offset: 154311},
+							pos:  position{line: 5080, col: 27, offset: 154495},
 							name: "SPACE",
 						},
 					},
@@ -13712,9 +13713,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5076, col: 1, offset: 154318},
+			pos:  position{line: 5081, col: 1, offset: 154502},
 			expr: &litMatcher{
-				pos:        position{line: 5076, col: 17, offset: 154334},
+				pos:        position{line: 5081, col: 17, offset: 154518},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -13722,115 +13723,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5079, col: 1, offset: 154449},
+			pos:  position{line: 5084, col: 1, offset: 154633},
 			expr: &choiceExpr{
-				pos: position{line: 5079, col: 16, offset: 154464},
+				pos: position{line: 5084, col: 16, offset: 154648},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5079, col: 16, offset: 154464},
+						pos:        position{line: 5084, col: 16, offset: 154648},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5079, col: 47, offset: 154495},
+						pos:        position{line: 5084, col: 47, offset: 154679},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5079, col: 55, offset: 154503},
+						pos:        position{line: 5084, col: 55, offset: 154687},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 16, offset: 154526},
+						pos:        position{line: 5085, col: 16, offset: 154710},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 26, offset: 154536},
+						pos:        position{line: 5085, col: 26, offset: 154720},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 34, offset: 154544},
+						pos:        position{line: 5085, col: 34, offset: 154728},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 42, offset: 154552},
+						pos:        position{line: 5085, col: 42, offset: 154736},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 50, offset: 154560},
+						pos:        position{line: 5085, col: 50, offset: 154744},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 58, offset: 154568},
+						pos:        position{line: 5085, col: 58, offset: 154752},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 66, offset: 154576},
+						pos:        position{line: 5085, col: 66, offset: 154760},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 16, offset: 154598},
+						pos:        position{line: 5086, col: 16, offset: 154782},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 26, offset: 154608},
+						pos:        position{line: 5086, col: 26, offset: 154792},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 34, offset: 154616},
+						pos:        position{line: 5086, col: 34, offset: 154800},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 42, offset: 154624},
+						pos:        position{line: 5086, col: 42, offset: 154808},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 50, offset: 154632},
+						pos:        position{line: 5086, col: 50, offset: 154816},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 58, offset: 154640},
+						pos:        position{line: 5086, col: 58, offset: 154824},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 66, offset: 154648},
+						pos:        position{line: 5086, col: 66, offset: 154832},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 74, offset: 154656},
+						pos:        position{line: 5086, col: 74, offset: 154840},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -13840,25 +13841,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5082, col: 1, offset: 154662},
+			pos:  position{line: 5087, col: 1, offset: 154846},
 			expr: &choiceExpr{
-				pos: position{line: 5082, col: 16, offset: 154677},
+				pos: position{line: 5087, col: 16, offset: 154861},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5082, col: 16, offset: 154677},
+						pos:        position{line: 5087, col: 16, offset: 154861},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5082, col: 30, offset: 154691},
+						pos:        position{line: 5087, col: 30, offset: 154875},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5082, col: 36, offset: 154697},
+						pos:        position{line: 5087, col: 36, offset: 154881},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -13868,18 +13869,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5086, col: 1, offset: 154853},
+			pos:  position{line: 5091, col: 1, offset: 155037},
 			expr: &seqExpr{
-				pos: position{line: 5086, col: 8, offset: 154860},
+				pos: position{line: 5091, col: 8, offset: 155044},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5086, col: 8, offset: 154860},
+						pos:        position{line: 5091, col: 8, offset: 155044},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5086, col: 14, offset: 154866},
+						pos:  position{line: 5091, col: 14, offset: 155050},
 						name: "SPACE",
 					},
 				},
@@ -13887,22 +13888,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5087, col: 1, offset: 154872},
+			pos:  position{line: 5092, col: 1, offset: 155056},
 			expr: &seqExpr{
-				pos: position{line: 5087, col: 7, offset: 154878},
+				pos: position{line: 5092, col: 7, offset: 155062},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5087, col: 7, offset: 154878},
+						pos:  position{line: 5092, col: 7, offset: 155062},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5087, col: 13, offset: 154884},
+						pos:        position{line: 5092, col: 13, offset: 155068},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5087, col: 18, offset: 154889},
+						pos:  position{line: 5092, col: 18, offset: 155073},
 						name: "SPACE",
 					},
 				},
@@ -13910,22 +13911,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5088, col: 1, offset: 154895},
+			pos:  position{line: 5093, col: 1, offset: 155079},
 			expr: &seqExpr{
-				pos: position{line: 5088, col: 8, offset: 154902},
+				pos: position{line: 5093, col: 8, offset: 155086},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5088, col: 8, offset: 154902},
+						pos:  position{line: 5093, col: 8, offset: 155086},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5088, col: 14, offset: 154908},
+						pos:        position{line: 5093, col: 14, offset: 155092},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5088, col: 20, offset: 154914},
+						pos:  position{line: 5093, col: 20, offset: 155098},
 						name: "SPACE",
 					},
 				},
@@ -13933,22 +13934,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5089, col: 1, offset: 154920},
+			pos:  position{line: 5094, col: 1, offset: 155104},
 			expr: &seqExpr{
-				pos: position{line: 5089, col: 9, offset: 154928},
+				pos: position{line: 5094, col: 9, offset: 155112},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5089, col: 9, offset: 154928},
+						pos:  position{line: 5094, col: 9, offset: 155112},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5089, col: 24, offset: 154943},
+						pos:        position{line: 5094, col: 24, offset: 155127},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5089, col: 28, offset: 154947},
+						pos:  position{line: 5094, col: 28, offset: 155131},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13956,22 +13957,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5090, col: 1, offset: 154962},
+			pos:  position{line: 5095, col: 1, offset: 155146},
 			expr: &seqExpr{
-				pos: position{line: 5090, col: 7, offset: 154968},
+				pos: position{line: 5095, col: 7, offset: 155152},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5090, col: 7, offset: 154968},
+						pos:  position{line: 5095, col: 7, offset: 155152},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5090, col: 13, offset: 154974},
+						pos:        position{line: 5095, col: 13, offset: 155158},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5090, col: 19, offset: 154980},
+						pos:  position{line: 5095, col: 19, offset: 155164},
 						name: "SPACE",
 					},
 				},
@@ -13979,22 +13980,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5091, col: 1, offset: 155006},
+			pos:  position{line: 5096, col: 1, offset: 155190},
 			expr: &seqExpr{
-				pos: position{line: 5091, col: 7, offset: 155012},
+				pos: position{line: 5096, col: 7, offset: 155196},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5091, col: 7, offset: 155012},
+						pos:  position{line: 5096, col: 7, offset: 155196},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5091, col: 13, offset: 155018},
+						pos:        position{line: 5096, col: 13, offset: 155202},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5091, col: 19, offset: 155024},
+						pos:  position{line: 5096, col: 19, offset: 155208},
 						name: "SPACE",
 					},
 				},
@@ -14002,22 +14003,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5093, col: 1, offset: 155051},
+			pos:  position{line: 5098, col: 1, offset: 155235},
 			expr: &seqExpr{
-				pos: position{line: 5093, col: 10, offset: 155060},
+				pos: position{line: 5098, col: 10, offset: 155244},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 10, offset: 155060},
+						pos:  position{line: 5098, col: 10, offset: 155244},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5093, col: 25, offset: 155075},
+						pos:        position{line: 5098, col: 25, offset: 155259},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 29, offset: 155079},
+						pos:  position{line: 5098, col: 29, offset: 155263},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14025,22 +14026,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5094, col: 1, offset: 155094},
+			pos:  position{line: 5099, col: 1, offset: 155278},
 			expr: &seqExpr{
-				pos: position{line: 5094, col: 10, offset: 155103},
+				pos: position{line: 5099, col: 10, offset: 155287},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 10, offset: 155103},
+						pos:  position{line: 5099, col: 10, offset: 155287},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5094, col: 25, offset: 155118},
+						pos:        position{line: 5099, col: 25, offset: 155302},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 29, offset: 155122},
+						pos:  position{line: 5099, col: 29, offset: 155306},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14048,9 +14049,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5095, col: 1, offset: 155137},
+			pos:  position{line: 5100, col: 1, offset: 155321},
 			expr: &litMatcher{
-				pos:        position{line: 5095, col: 10, offset: 155146},
+				pos:        position{line: 5100, col: 10, offset: 155330},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14058,18 +14059,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5096, col: 1, offset: 155150},
+			pos:  position{line: 5101, col: 1, offset: 155334},
 			expr: &seqExpr{
-				pos: position{line: 5096, col: 12, offset: 155161},
+				pos: position{line: 5101, col: 12, offset: 155345},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5096, col: 12, offset: 155161},
+						pos:        position{line: 5101, col: 12, offset: 155345},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5096, col: 16, offset: 155165},
+						pos:  position{line: 5101, col: 16, offset: 155349},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14077,16 +14078,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5097, col: 1, offset: 155180},
+			pos:  position{line: 5102, col: 1, offset: 155364},
 			expr: &seqExpr{
-				pos: position{line: 5097, col: 12, offset: 155191},
+				pos: position{line: 5102, col: 12, offset: 155375},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5097, col: 12, offset: 155191},
+						pos:  position{line: 5102, col: 12, offset: 155375},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5097, col: 27, offset: 155206},
+						pos:        position{line: 5102, col: 27, offset: 155390},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14096,40 +14097,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5099, col: 1, offset: 155211},
+			pos:  position{line: 5104, col: 1, offset: 155395},
 			expr: &notExpr{
-				pos: position{line: 5099, col: 8, offset: 155218},
+				pos: position{line: 5104, col: 8, offset: 155402},
 				expr: &anyMatcher{
-					line: 5099, col: 9, offset: 155219,
+					line: 5104, col: 9, offset: 155403,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5100, col: 1, offset: 155221},
+			pos:  position{line: 5105, col: 1, offset: 155405},
 			expr: &choiceExpr{
-				pos: position{line: 5100, col: 15, offset: 155235},
+				pos: position{line: 5105, col: 15, offset: 155419},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5100, col: 15, offset: 155235},
+						pos:        position{line: 5105, col: 15, offset: 155419},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 21, offset: 155241},
+						pos:        position{line: 5105, col: 21, offset: 155425},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 28, offset: 155248},
+						pos:        position{line: 5105, col: 28, offset: 155432},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 35, offset: 155255},
+						pos:        position{line: 5105, col: 35, offset: 155439},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14139,37 +14140,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5101, col: 1, offset: 155260},
+			pos:  position{line: 5106, col: 1, offset: 155444},
 			expr: &choiceExpr{
-				pos: position{line: 5101, col: 10, offset: 155269},
+				pos: position{line: 5106, col: 10, offset: 155453},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5101, col: 11, offset: 155270},
+						pos: position{line: 5106, col: 11, offset: 155454},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5101, col: 11, offset: 155270},
+								pos: position{line: 5106, col: 11, offset: 155454},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5101, col: 11, offset: 155270},
+									pos:  position{line: 5106, col: 11, offset: 155454},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5101, col: 23, offset: 155282},
+								pos:  position{line: 5106, col: 23, offset: 155466},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5101, col: 31, offset: 155290},
+								pos: position{line: 5106, col: 31, offset: 155474},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5101, col: 31, offset: 155290},
+									pos:  position{line: 5106, col: 31, offset: 155474},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5101, col: 46, offset: 155305},
+						pos: position{line: 5106, col: 46, offset: 155489},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5101, col: 46, offset: 155305},
+							pos:  position{line: 5106, col: 46, offset: 155489},
 							name: "WHITESPACE",
 						},
 					},
@@ -14178,38 +14179,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5102, col: 1, offset: 155317},
+			pos:  position{line: 5107, col: 1, offset: 155501},
 			expr: &seqExpr{
-				pos: position{line: 5102, col: 12, offset: 155328},
+				pos: position{line: 5107, col: 12, offset: 155512},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5102, col: 12, offset: 155328},
+						pos:        position{line: 5107, col: 12, offset: 155512},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5102, col: 18, offset: 155334},
+						pos: position{line: 5107, col: 18, offset: 155518},
 						expr: &seqExpr{
-							pos: position{line: 5102, col: 19, offset: 155335},
+							pos: position{line: 5107, col: 19, offset: 155519},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5102, col: 19, offset: 155335},
+									pos: position{line: 5107, col: 19, offset: 155519},
 									expr: &litMatcher{
-										pos:        position{line: 5102, col: 21, offset: 155337},
+										pos:        position{line: 5107, col: 21, offset: 155521},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5102, col: 28, offset: 155344,
+									line: 5107, col: 28, offset: 155528,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5102, col: 32, offset: 155348},
+						pos:        position{line: 5107, col: 32, offset: 155532},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14219,16 +14220,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5103, col: 1, offset: 155354},
+			pos:  position{line: 5108, col: 1, offset: 155538},
 			expr: &choiceExpr{
-				pos: position{line: 5103, col: 20, offset: 155373},
+				pos: position{line: 5108, col: 20, offset: 155557},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5103, col: 20, offset: 155373},
+						pos:  position{line: 5108, col: 20, offset: 155557},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5103, col: 28, offset: 155381},
+						pos:        position{line: 5108, col: 28, offset: 155565},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14238,16 +14239,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5104, col: 1, offset: 155384},
+			pos:  position{line: 5109, col: 1, offset: 155568},
 			expr: &choiceExpr{
-				pos: position{line: 5104, col: 19, offset: 155402},
+				pos: position{line: 5109, col: 19, offset: 155586},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5104, col: 19, offset: 155402},
+						pos:  position{line: 5109, col: 19, offset: 155586},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5104, col: 27, offset: 155410},
+						pos:  position{line: 5109, col: 27, offset: 155594},
 						name: "SPACE",
 					},
 				},
@@ -18959,6 +18960,7 @@ func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (an
 			Op:                     op.(string),
 			Field:                  key.(string),
 			Values:                 ssr.value,
+			OriginalValues:         ssr.originalValue,
 			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
 		},
 	}
@@ -18979,6 +18981,7 @@ func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, erro
 			Op:                     "=",
 			Field:                  "*",
 			Values:                 ssr.value,
+			OriginalValues:         ssr.originalValue,
 			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
 		},
 	}
@@ -18994,6 +18997,7 @@ func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
 func (c *current) onCaseSensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
 		value:                  value,
+		originalValue:          value,
 		valueIsCaseInSensitive: false,
 	}, nil
 }
@@ -19007,6 +19011,7 @@ func (p *parser) callonCaseSensitiveString1() (any, error) {
 func (c *current) onCaseInsensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
 		value:                  strings.ToLower(value.(string)),
+		originalValue:          value,
 		valueIsCaseInSensitive: true,
 	}, nil
 }

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -490,174 +490,174 @@ type FormatResultsRequestArguments struct {
 }
 
 type StringSearchRequest struct {
-	value                interface{}
-	valueIsCaseSensitive bool
+	value                  interface{}
+	valueIsCaseInSensitive bool
 }
 
 var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 484, col: 1, offset: 13715},
+			pos:  position{line: 484, col: 1, offset: 13717},
 			expr: &choiceExpr{
-				pos: position{line: 484, col: 10, offset: 13724},
+				pos: position{line: 484, col: 10, offset: 13726},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 484, col: 10, offset: 13724},
+						pos: position{line: 484, col: 10, offset: 13726},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 484, col: 10, offset: 13724},
+							pos: position{line: 484, col: 10, offset: 13726},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 484, col: 10, offset: 13724},
+									pos: position{line: 484, col: 10, offset: 13726},
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 10, offset: 13724},
+										pos:  position{line: 484, col: 10, offset: 13726},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 17, offset: 13731},
+									pos:   position{line: 484, col: 17, offset: 13733},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 32, offset: 13746},
+										pos:  position{line: 484, col: 32, offset: 13748},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 52, offset: 13766},
+									pos:   position{line: 484, col: 52, offset: 13768},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 484, col: 65, offset: 13779},
+										pos: position{line: 484, col: 65, offset: 13781},
 										expr: &ruleRefExpr{
-											pos:  position{line: 484, col: 66, offset: 13780},
+											pos:  position{line: 484, col: 66, offset: 13782},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 484, col: 80, offset: 13794},
+									pos:   position{line: 484, col: 80, offset: 13796},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 484, col: 95, offset: 13809},
+										pos: position{line: 484, col: 95, offset: 13811},
 										expr: &ruleRefExpr{
-											pos:  position{line: 484, col: 96, offset: 13810},
+											pos:  position{line: 484, col: 96, offset: 13812},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 484, col: 119, offset: 13833},
+									pos: position{line: 484, col: 119, offset: 13835},
 									expr: &ruleRefExpr{
-										pos:  position{line: 484, col: 119, offset: 13833},
+										pos:  position{line: 484, col: 119, offset: 13835},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 484, col: 126, offset: 13840},
+									pos:  position{line: 484, col: 126, offset: 13842},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 546, col: 3, offset: 15684},
+						pos: position{line: 546, col: 3, offset: 15686},
 						run: (*parser).callonStart17,
 						expr: &seqExpr{
-							pos: position{line: 546, col: 3, offset: 15684},
+							pos: position{line: 546, col: 3, offset: 15686},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 546, col: 3, offset: 15684},
+									pos: position{line: 546, col: 3, offset: 15686},
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 3, offset: 15684},
+										pos:  position{line: 546, col: 3, offset: 15686},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 10, offset: 15691},
+									pos:  position{line: 546, col: 10, offset: 15693},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 15, offset: 15696},
+									pos:  position{line: 546, col: 15, offset: 15698},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 28, offset: 15709},
+									pos:  position{line: 546, col: 28, offset: 15711},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 34, offset: 15715},
+									pos:   position{line: 546, col: 34, offset: 15717},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 50, offset: 15731},
+										pos:  position{line: 546, col: 50, offset: 15733},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 546, col: 70, offset: 15751},
+									pos:   position{line: 546, col: 70, offset: 15753},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 546, col: 85, offset: 15766},
+										pos: position{line: 546, col: 85, offset: 15768},
 										expr: &ruleRefExpr{
-											pos:  position{line: 546, col: 86, offset: 15767},
+											pos:  position{line: 546, col: 86, offset: 15769},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 546, col: 109, offset: 15790},
+									pos: position{line: 546, col: 109, offset: 15792},
 									expr: &ruleRefExpr{
-										pos:  position{line: 546, col: 109, offset: 15790},
+										pos:  position{line: 546, col: 109, offset: 15792},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 546, col: 116, offset: 15797},
+									pos:  position{line: 546, col: 116, offset: 15799},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 564, col: 3, offset: 16252},
+						pos: position{line: 564, col: 3, offset: 16254},
 						run: (*parser).callonStart32,
 						expr: &seqExpr{
-							pos: position{line: 564, col: 3, offset: 16252},
+							pos: position{line: 564, col: 3, offset: 16254},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 564, col: 3, offset: 16252},
+									pos: position{line: 564, col: 3, offset: 16254},
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 3, offset: 16252},
+										pos:  position{line: 564, col: 3, offset: 16254},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 564, col: 10, offset: 16259},
+									pos:   position{line: 564, col: 10, offset: 16261},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 22, offset: 16271},
+										pos:  position{line: 564, col: 22, offset: 16273},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 564, col: 39, offset: 16288},
+									pos:   position{line: 564, col: 39, offset: 16290},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 564, col: 54, offset: 16303},
+										pos: position{line: 564, col: 54, offset: 16305},
 										expr: &ruleRefExpr{
-											pos:  position{line: 564, col: 55, offset: 16304},
+											pos:  position{line: 564, col: 55, offset: 16306},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 564, col: 78, offset: 16327},
+									pos: position{line: 564, col: 78, offset: 16329},
 									expr: &ruleRefExpr{
-										pos:  position{line: 564, col: 78, offset: 16327},
+										pos:  position{line: 564, col: 78, offset: 16329},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 564, col: 85, offset: 16334},
+									pos:  position{line: 564, col: 85, offset: 16336},
 									name: "EOF",
 								},
 							},
@@ -668,76 +668,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 578, col: 1, offset: 16627},
+			pos:  position{line: 578, col: 1, offset: 16629},
 			expr: &actionExpr{
-				pos: position{line: 578, col: 21, offset: 16647},
+				pos: position{line: 578, col: 21, offset: 16649},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 578, col: 21, offset: 16647},
+					pos: position{line: 578, col: 21, offset: 16649},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 578, col: 21, offset: 16647},
+							pos:        position{line: 578, col: 21, offset: 16649},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 26, offset: 16652},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 578, col: 32, offset: 16658},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 578, col: 36, offset: 16662},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 578, col: 41, offset: 16667},
+							pos:        position{line: 578, col: 26, offset: 16654},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 578, col: 47, offset: 16673},
+							pos:        position{line: 578, col: 32, offset: 16660},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 51, offset: 16677},
+							pos:        position{line: 578, col: 36, offset: 16664},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 56, offset: 16682},
+							pos:        position{line: 578, col: 41, offset: 16669},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 578, col: 47, offset: 16675},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 578, col: 51, offset: 16679},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 61, offset: 16687},
+							pos:        position{line: 578, col: 56, offset: 16684},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 578, col: 66, offset: 16692},
+							pos:        position{line: 578, col: 61, offset: 16689},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 578, col: 66, offset: 16694},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -749,15 +749,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 585, col: 1, offset: 16833},
+			pos:  position{line: 585, col: 1, offset: 16835},
 			expr: &actionExpr{
-				pos: position{line: 585, col: 31, offset: 16863},
+				pos: position{line: 585, col: 31, offset: 16865},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 585, col: 31, offset: 16863},
+					pos:   position{line: 585, col: 31, offset: 16865},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 585, col: 38, offset: 16870},
+						pos:  position{line: 585, col: 38, offset: 16872},
 						name: "IntegerAsString",
 					},
 				},
@@ -765,22 +765,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 603, col: 1, offset: 17509},
+			pos:  position{line: 603, col: 1, offset: 17511},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 26, offset: 17534},
+				pos: position{line: 603, col: 26, offset: 17536},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 603, col: 26, offset: 17534},
+					pos:   position{line: 603, col: 26, offset: 17536},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 603, col: 37, offset: 17545},
+						pos: position{line: 603, col: 37, offset: 17547},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 603, col: 37, offset: 17545},
+								pos:  position{line: 603, col: 37, offset: 17547},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 603, col: 53, offset: 17561},
+								pos:  position{line: 603, col: 53, offset: 17563},
 								name: "PartialTimestamp",
 							},
 						},
@@ -790,22 +790,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 612, col: 1, offset: 17818},
+			pos:  position{line: 612, col: 1, offset: 17820},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 17, offset: 17834},
+				pos: position{line: 612, col: 17, offset: 17836},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 612, col: 17, offset: 17834},
+					pos:   position{line: 612, col: 17, offset: 17836},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 612, col: 31, offset: 17848},
+						pos: position{line: 612, col: 31, offset: 17850},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 612, col: 31, offset: 17848},
+								pos:  position{line: 612, col: 31, offset: 17850},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 612, col: 55, offset: 17872},
+								pos:  position{line: 612, col: 55, offset: 17874},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -815,28 +815,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 616, col: 1, offset: 17934},
+			pos:  position{line: 616, col: 1, offset: 17936},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 22, offset: 17955},
+				pos: position{line: 616, col: 22, offset: 17957},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 22, offset: 17955},
+					pos: position{line: 616, col: 22, offset: 17957},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 616, col: 22, offset: 17955},
+							pos:        position{line: 616, col: 22, offset: 17957},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 616, col: 28, offset: 17961},
+							pos:  position{line: 616, col: 28, offset: 17963},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 34, offset: 17967},
+							pos:   position{line: 616, col: 34, offset: 17969},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 45, offset: 17978},
+								pos:  position{line: 616, col: 45, offset: 17980},
 								name: "GenTimestamp",
 							},
 						},
@@ -846,28 +846,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 625, col: 1, offset: 18168},
+			pos:  position{line: 625, col: 1, offset: 18170},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 24, offset: 18191},
+				pos: position{line: 625, col: 24, offset: 18193},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 625, col: 24, offset: 18191},
+					pos: position{line: 625, col: 24, offset: 18193},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 625, col: 24, offset: 18191},
+							pos:        position{line: 625, col: 24, offset: 18193},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 625, col: 32, offset: 18199},
+							pos:  position{line: 625, col: 32, offset: 18201},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 625, col: 38, offset: 18205},
+							pos:   position{line: 625, col: 38, offset: 18207},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 625, col: 49, offset: 18216},
+								pos:  position{line: 625, col: 49, offset: 18218},
 								name: "GenTimestamp",
 							},
 						},
@@ -877,59 +877,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 634, col: 1, offset: 18410},
+			pos:  position{line: 634, col: 1, offset: 18412},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 28, offset: 18437},
+				pos: position{line: 634, col: 28, offset: 18439},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 28, offset: 18437},
+					pos: position{line: 634, col: 28, offset: 18439},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 634, col: 28, offset: 18437},
+							pos:        position{line: 634, col: 28, offset: 18439},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 634, col: 40, offset: 18449},
+							pos:  position{line: 634, col: 40, offset: 18451},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 46, offset: 18455},
+							pos:   position{line: 634, col: 46, offset: 18457},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 53, offset: 18462},
+								pos:  position{line: 634, col: 53, offset: 18464},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 69, offset: 18478},
+							pos:   position{line: 634, col: 69, offset: 18480},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 634, col: 77, offset: 18486},
+								pos: position{line: 634, col: 77, offset: 18488},
 								expr: &choiceExpr{
-									pos: position{line: 634, col: 78, offset: 18487},
+									pos: position{line: 634, col: 78, offset: 18489},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 634, col: 78, offset: 18487},
+											pos:        position{line: 634, col: 78, offset: 18489},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 84, offset: 18493},
+											pos:        position{line: 634, col: 84, offset: 18495},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 90, offset: 18499},
+											pos:        position{line: 634, col: 90, offset: 18501},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 634, col: 96, offset: 18505},
+											pos:        position{line: 634, col: 96, offset: 18507},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -944,26 +944,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 675, col: 1, offset: 19652},
+			pos:  position{line: 675, col: 1, offset: 19654},
 			expr: &actionExpr{
-				pos: position{line: 675, col: 19, offset: 19670},
+				pos: position{line: 675, col: 19, offset: 19672},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 675, col: 19, offset: 19670},
+					pos:   position{line: 675, col: 19, offset: 19672},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 675, col: 35, offset: 19686},
+						pos: position{line: 675, col: 35, offset: 19688},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 35, offset: 19686},
+								pos:  position{line: 675, col: 35, offset: 19688},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 55, offset: 19706},
+								pos:  position{line: 675, col: 55, offset: 19708},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 675, col: 77, offset: 19728},
+								pos:  position{line: 675, col: 77, offset: 19730},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -973,35 +973,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 679, col: 1, offset: 19789},
+			pos:  position{line: 679, col: 1, offset: 19791},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 23, offset: 19811},
+				pos: position{line: 679, col: 23, offset: 19813},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 23, offset: 19811},
+					pos: position{line: 679, col: 23, offset: 19813},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 679, col: 23, offset: 19811},
+							pos:   position{line: 679, col: 23, offset: 19813},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 29, offset: 19817},
+								pos:  position{line: 679, col: 29, offset: 19819},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 679, col: 44, offset: 19832},
+							pos:   position{line: 679, col: 44, offset: 19834},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 679, col: 49, offset: 19837},
+								pos: position{line: 679, col: 49, offset: 19839},
 								expr: &seqExpr{
-									pos: position{line: 679, col: 50, offset: 19838},
+									pos: position{line: 679, col: 50, offset: 19840},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 679, col: 50, offset: 19838},
+											pos:  position{line: 679, col: 50, offset: 19840},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 679, col: 56, offset: 19844},
+											pos:  position{line: 679, col: 56, offset: 19846},
 											name: "GenTimesOption",
 										},
 									},
@@ -1014,25 +1014,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 726, col: 1, offset: 21387},
+			pos:  position{line: 726, col: 1, offset: 21389},
 			expr: &actionExpr{
-				pos: position{line: 726, col: 23, offset: 21409},
+				pos: position{line: 726, col: 23, offset: 21411},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 726, col: 23, offset: 21409},
+					pos: position{line: 726, col: 23, offset: 21411},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 726, col: 23, offset: 21409},
+							pos: position{line: 726, col: 23, offset: 21411},
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 23, offset: 21409},
+								pos:  position{line: 726, col: 23, offset: 21411},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 726, col: 35, offset: 21421},
+							pos:   position{line: 726, col: 35, offset: 21423},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 726, col: 42, offset: 21428},
+								pos:  position{line: 726, col: 42, offset: 21430},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1042,32 +1042,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 730, col: 1, offset: 21469},
+			pos:  position{line: 730, col: 1, offset: 21471},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 16, offset: 21484},
+				pos: position{line: 730, col: 16, offset: 21486},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 730, col: 16, offset: 21484},
+					pos: position{line: 730, col: 16, offset: 21486},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 730, col: 16, offset: 21484},
+							pos: position{line: 730, col: 16, offset: 21486},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 18, offset: 21486},
+								pos:  position{line: 730, col: 18, offset: 21488},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 730, col: 26, offset: 21494},
+							pos: position{line: 730, col: 26, offset: 21496},
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 26, offset: 21494},
+								pos:  position{line: 730, col: 26, offset: 21496},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 730, col: 38, offset: 21506},
+							pos:   position{line: 730, col: 38, offset: 21508},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 730, col: 45, offset: 21513},
+								pos:  position{line: 730, col: 45, offset: 21515},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1077,33 +1077,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 734, col: 1, offset: 21554},
+			pos:  position{line: 734, col: 1, offset: 21556},
 			expr: &actionExpr{
-				pos: position{line: 734, col: 16, offset: 21569},
+				pos: position{line: 734, col: 16, offset: 21571},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 734, col: 16, offset: 21569},
+					pos: position{line: 734, col: 16, offset: 21571},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 734, col: 16, offset: 21569},
+							pos:  position{line: 734, col: 16, offset: 21571},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 734, col: 21, offset: 21574},
+							pos:   position{line: 734, col: 21, offset: 21576},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 734, col: 28, offset: 21581},
+								pos: position{line: 734, col: 28, offset: 21583},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 28, offset: 21581},
+										pos:  position{line: 734, col: 28, offset: 21583},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 42, offset: 21595},
+										pos:  position{line: 734, col: 42, offset: 21597},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 734, col: 55, offset: 21608},
+										pos:  position{line: 734, col: 55, offset: 21610},
 										name: "TimeModifiers",
 									},
 								},
@@ -1115,102 +1115,102 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 739, col: 1, offset: 21687},
+			pos:  position{line: 739, col: 1, offset: 21689},
 			expr: &actionExpr{
-				pos: position{line: 739, col: 25, offset: 21711},
+				pos: position{line: 739, col: 25, offset: 21713},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 739, col: 25, offset: 21711},
+					pos:   position{line: 739, col: 25, offset: 21713},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 739, col: 32, offset: 21718},
+						pos: position{line: 739, col: 32, offset: 21720},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 32, offset: 21718},
+								pos:  position{line: 739, col: 32, offset: 21720},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 51, offset: 21737},
+								pos:  position{line: 739, col: 51, offset: 21739},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 69, offset: 21755},
+								pos:  position{line: 739, col: 69, offset: 21757},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 81, offset: 21767},
+								pos:  position{line: 739, col: 81, offset: 21769},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 94, offset: 21780},
+								pos:  position{line: 739, col: 94, offset: 21782},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 106, offset: 21792},
+								pos:  position{line: 739, col: 106, offset: 21794},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 117, offset: 21803},
+								pos:  position{line: 739, col: 117, offset: 21805},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 134, offset: 21820},
+								pos:  position{line: 739, col: 134, offset: 21822},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 148, offset: 21834},
+								pos:  position{line: 739, col: 148, offset: 21836},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 165, offset: 21851},
+								pos:  position{line: 739, col: 165, offset: 21853},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 184, offset: 21870},
+								pos:  position{line: 739, col: 184, offset: 21872},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 197, offset: 21883},
+								pos:  position{line: 739, col: 197, offset: 21885},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 209, offset: 21895},
+								pos:  position{line: 739, col: 209, offset: 21897},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 227, offset: 21913},
+								pos:  position{line: 739, col: 227, offset: 21915},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 240, offset: 21926},
+								pos:  position{line: 739, col: 240, offset: 21928},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 254, offset: 21940},
+								pos:  position{line: 739, col: 254, offset: 21942},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 272, offset: 21958},
+								pos:  position{line: 739, col: 272, offset: 21960},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 284, offset: 21970},
+								pos:  position{line: 739, col: 284, offset: 21972},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 295, offset: 21981},
+								pos:  position{line: 739, col: 295, offset: 21983},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 314, offset: 22000},
+								pos:  position{line: 739, col: 314, offset: 22002},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 330, offset: 22016},
+								pos:  position{line: 739, col: 330, offset: 22018},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 739, col: 346, offset: 22032},
+								pos:  position{line: 739, col: 346, offset: 22034},
 								name: "InputLookupAggBlock",
 							},
 						},
@@ -1220,37 +1220,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 744, col: 1, offset: 22133},
+			pos:  position{line: 744, col: 1, offset: 22135},
 			expr: &actionExpr{
-				pos: position{line: 744, col: 21, offset: 22153},
+				pos: position{line: 744, col: 21, offset: 22155},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 744, col: 21, offset: 22153},
+					pos: position{line: 744, col: 21, offset: 22155},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 21, offset: 22153},
+							pos:  position{line: 744, col: 21, offset: 22155},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 26, offset: 22158},
+							pos:  position{line: 744, col: 26, offset: 22160},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 37, offset: 22169},
+							pos:   position{line: 744, col: 37, offset: 22171},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 744, col: 40, offset: 22172},
+								pos: position{line: 744, col: 40, offset: 22174},
 								expr: &choiceExpr{
-									pos: position{line: 744, col: 41, offset: 22173},
+									pos: position{line: 744, col: 41, offset: 22175},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 744, col: 41, offset: 22173},
+											pos:        position{line: 744, col: 41, offset: 22175},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 744, col: 47, offset: 22179},
+											pos:        position{line: 744, col: 47, offset: 22181},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1260,14 +1260,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 744, col: 53, offset: 22185},
+							pos:  position{line: 744, col: 53, offset: 22187},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 744, col: 68, offset: 22200},
+							pos:   position{line: 744, col: 68, offset: 22202},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 744, col: 75, offset: 22207},
+								pos:  position{line: 744, col: 75, offset: 22209},
 								name: "FieldNameList",
 							},
 						},
@@ -1277,28 +1277,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 762, col: 1, offset: 22711},
+			pos:  position{line: 762, col: 1, offset: 22713},
 			expr: &actionExpr{
-				pos: position{line: 762, col: 26, offset: 22736},
+				pos: position{line: 762, col: 26, offset: 22738},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 762, col: 26, offset: 22736},
+					pos: position{line: 762, col: 26, offset: 22738},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 762, col: 26, offset: 22736},
+							pos:   position{line: 762, col: 26, offset: 22738},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 762, col: 31, offset: 22741},
+								pos:  position{line: 762, col: 31, offset: 22743},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 762, col: 47, offset: 22757},
+							pos:   position{line: 762, col: 47, offset: 22759},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 762, col: 56, offset: 22766},
+								pos: position{line: 762, col: 56, offset: 22768},
 								expr: &ruleRefExpr{
-									pos:  position{line: 762, col: 57, offset: 22767},
+									pos:  position{line: 762, col: 57, offset: 22769},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1309,36 +1309,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 808, col: 1, offset: 24262},
+			pos:  position{line: 808, col: 1, offset: 24264},
 			expr: &actionExpr{
-				pos: position{line: 808, col: 20, offset: 24281},
+				pos: position{line: 808, col: 20, offset: 24283},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 808, col: 20, offset: 24281},
+					pos: position{line: 808, col: 20, offset: 24283},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 20, offset: 24281},
+							pos:  position{line: 808, col: 20, offset: 24283},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 808, col: 25, offset: 24286},
+							pos:  position{line: 808, col: 25, offset: 24288},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 35, offset: 24296},
+							pos:   position{line: 808, col: 35, offset: 24298},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 808, col: 41, offset: 24302},
+								pos:  position{line: 808, col: 41, offset: 24304},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 808, col: 64, offset: 24325},
+							pos:   position{line: 808, col: 64, offset: 24327},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 808, col: 72, offset: 24333},
+								pos: position{line: 808, col: 72, offset: 24335},
 								expr: &ruleRefExpr{
-									pos:  position{line: 808, col: 73, offset: 24334},
+									pos:  position{line: 808, col: 73, offset: 24336},
 									name: "StatsOptions",
 								},
 							},
@@ -1349,17 +1349,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 822, col: 1, offset: 24667},
+			pos:  position{line: 822, col: 1, offset: 24669},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 17, offset: 24683},
+				pos: position{line: 822, col: 17, offset: 24685},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 822, col: 17, offset: 24683},
+					pos:   position{line: 822, col: 17, offset: 24685},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 822, col: 24, offset: 24690},
+						pos: position{line: 822, col: 24, offset: 24692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 822, col: 25, offset: 24691},
+							pos:  position{line: 822, col: 25, offset: 24693},
 							name: "StatsOption",
 						},
 					},
@@ -1368,45 +1368,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 860, col: 1, offset: 26132},
+			pos:  position{line: 860, col: 1, offset: 26134},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 16, offset: 26147},
+				pos: position{line: 860, col: 16, offset: 26149},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 860, col: 16, offset: 26147},
+					pos: position{line: 860, col: 16, offset: 26149},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 860, col: 16, offset: 26147},
+							pos:  position{line: 860, col: 16, offset: 26149},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 22, offset: 26153},
+							pos:   position{line: 860, col: 22, offset: 26155},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 860, col: 32, offset: 26163},
+								pos:  position{line: 860, col: 32, offset: 26165},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 860, col: 47, offset: 26178},
+							pos:  position{line: 860, col: 47, offset: 26180},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 860, col: 53, offset: 26184},
+							pos:   position{line: 860, col: 53, offset: 26186},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 860, col: 58, offset: 26189},
+								pos: position{line: 860, col: 58, offset: 26191},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 58, offset: 26189},
+										pos:  position{line: 860, col: 58, offset: 26191},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 76, offset: 26207},
+										pos:  position{line: 860, col: 76, offset: 26209},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 860, col: 94, offset: 26225},
+										pos:  position{line: 860, col: 94, offset: 26227},
 										name: "QuotedString",
 									},
 								},
@@ -1418,36 +1418,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 865, col: 1, offset: 26330},
+			pos:  position{line: 865, col: 1, offset: 26332},
 			expr: &actionExpr{
-				pos: position{line: 865, col: 19, offset: 26348},
+				pos: position{line: 865, col: 19, offset: 26350},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 865, col: 19, offset: 26348},
+					pos:   position{line: 865, col: 19, offset: 26350},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 865, col: 27, offset: 26356},
+						pos: position{line: 865, col: 27, offset: 26358},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 865, col: 27, offset: 26356},
+								pos:        position{line: 865, col: 27, offset: 26358},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 38, offset: 26367},
+								pos:        position{line: 865, col: 38, offset: 26369},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 58, offset: 26387},
+								pos:        position{line: 865, col: 58, offset: 26389},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 865, col: 68, offset: 26397},
+								pos:        position{line: 865, col: 68, offset: 26399},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1459,22 +1459,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 873, col: 1, offset: 26587},
+			pos:  position{line: 873, col: 1, offset: 26589},
 			expr: &actionExpr{
-				pos: position{line: 873, col: 17, offset: 26603},
+				pos: position{line: 873, col: 17, offset: 26605},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 873, col: 17, offset: 26603},
+					pos: position{line: 873, col: 17, offset: 26605},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 873, col: 17, offset: 26603},
+							pos:  position{line: 873, col: 17, offset: 26605},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 873, col: 20, offset: 26606},
+							pos:   position{line: 873, col: 20, offset: 26608},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 873, col: 27, offset: 26613},
+								pos:  position{line: 873, col: 27, offset: 26615},
 								name: "FieldNameList",
 							},
 						},
@@ -1484,28 +1484,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 885, col: 1, offset: 26963},
+			pos:  position{line: 885, col: 1, offset: 26965},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 35, offset: 26997},
+				pos: position{line: 885, col: 35, offset: 26999},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 885, col: 35, offset: 26997},
+					pos: position{line: 885, col: 35, offset: 26999},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 885, col: 35, offset: 26997},
+							pos:        position{line: 885, col: 35, offset: 26999},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 885, col: 53, offset: 27015},
+							pos:  position{line: 885, col: 53, offset: 27017},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 885, col: 59, offset: 27021},
+							pos:   position{line: 885, col: 59, offset: 27023},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 885, col: 67, offset: 27029},
+								pos:  position{line: 885, col: 67, offset: 27031},
 								name: "Boolean",
 							},
 						},
@@ -1515,28 +1515,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 897, col: 1, offset: 27290},
+			pos:  position{line: 897, col: 1, offset: 27292},
 			expr: &actionExpr{
-				pos: position{line: 897, col: 29, offset: 27318},
+				pos: position{line: 897, col: 29, offset: 27320},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 897, col: 29, offset: 27318},
+					pos: position{line: 897, col: 29, offset: 27320},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 897, col: 29, offset: 27318},
+							pos:        position{line: 897, col: 29, offset: 27320},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 897, col: 39, offset: 27328},
+							pos:  position{line: 897, col: 39, offset: 27330},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 897, col: 45, offset: 27334},
+							pos:   position{line: 897, col: 45, offset: 27336},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 897, col: 53, offset: 27342},
+								pos:  position{line: 897, col: 53, offset: 27344},
 								name: "Boolean",
 							},
 						},
@@ -1546,28 +1546,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 909, col: 1, offset: 27589},
+			pos:  position{line: 909, col: 1, offset: 27591},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 28, offset: 27616},
+				pos: position{line: 909, col: 28, offset: 27618},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 28, offset: 27616},
+					pos: position{line: 909, col: 28, offset: 27618},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 909, col: 28, offset: 27616},
+							pos:        position{line: 909, col: 28, offset: 27618},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 37, offset: 27625},
+							pos:  position{line: 909, col: 37, offset: 27627},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 909, col: 43, offset: 27631},
+							pos:   position{line: 909, col: 43, offset: 27633},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 909, col: 51, offset: 27639},
+								pos:  position{line: 909, col: 51, offset: 27641},
 								name: "Boolean",
 							},
 						},
@@ -1577,28 +1577,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 922, col: 1, offset: 27973},
+			pos:  position{line: 922, col: 1, offset: 27975},
 			expr: &actionExpr{
-				pos: position{line: 922, col: 28, offset: 28000},
+				pos: position{line: 922, col: 28, offset: 28002},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 922, col: 28, offset: 28000},
+					pos: position{line: 922, col: 28, offset: 28002},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 922, col: 28, offset: 28000},
+							pos:        position{line: 922, col: 28, offset: 28002},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 922, col: 37, offset: 28009},
+							pos:  position{line: 922, col: 37, offset: 28011},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 922, col: 43, offset: 28015},
+							pos:   position{line: 922, col: 43, offset: 28017},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 922, col: 51, offset: 28023},
+								pos:  position{line: 922, col: 51, offset: 28025},
 								name: "Boolean",
 							},
 						},
@@ -1608,28 +1608,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 935, col: 1, offset: 28357},
+			pos:  position{line: 935, col: 1, offset: 28359},
 			expr: &actionExpr{
-				pos: position{line: 935, col: 28, offset: 28384},
+				pos: position{line: 935, col: 28, offset: 28386},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 935, col: 28, offset: 28384},
+					pos: position{line: 935, col: 28, offset: 28386},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 935, col: 28, offset: 28384},
+							pos:        position{line: 935, col: 28, offset: 28386},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 935, col: 37, offset: 28393},
+							pos:  position{line: 935, col: 37, offset: 28395},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 935, col: 43, offset: 28399},
+							pos:   position{line: 935, col: 43, offset: 28401},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 935, col: 54, offset: 28410},
+								pos:  position{line: 935, col: 54, offset: 28412},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1639,37 +1639,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 955, col: 1, offset: 29014},
+			pos:  position{line: 955, col: 1, offset: 29016},
 			expr: &actionExpr{
-				pos: position{line: 955, col: 33, offset: 29046},
+				pos: position{line: 955, col: 33, offset: 29048},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 955, col: 33, offset: 29046},
+					pos: position{line: 955, col: 33, offset: 29048},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 955, col: 33, offset: 29046},
+							pos:        position{line: 955, col: 33, offset: 29048},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 48, offset: 29061},
+							pos:  position{line: 955, col: 48, offset: 29063},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 54, offset: 29067},
+							pos:  position{line: 955, col: 54, offset: 29069},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 955, col: 62, offset: 29075},
+							pos:   position{line: 955, col: 62, offset: 29077},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 955, col: 71, offset: 29084},
+								pos:  position{line: 955, col: 71, offset: 29086},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 955, col: 80, offset: 29093},
+							pos:  position{line: 955, col: 80, offset: 29095},
 							name: "R_PAREN",
 						},
 					},
@@ -1678,37 +1678,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 967, col: 1, offset: 29363},
+			pos:  position{line: 967, col: 1, offset: 29365},
 			expr: &actionExpr{
-				pos: position{line: 967, col: 32, offset: 29394},
+				pos: position{line: 967, col: 32, offset: 29396},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 967, col: 32, offset: 29394},
+					pos: position{line: 967, col: 32, offset: 29396},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 967, col: 32, offset: 29394},
+							pos:        position{line: 967, col: 32, offset: 29396},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 46, offset: 29408},
+							pos:  position{line: 967, col: 46, offset: 29410},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 52, offset: 29414},
+							pos:  position{line: 967, col: 52, offset: 29416},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 967, col: 60, offset: 29422},
+							pos:   position{line: 967, col: 60, offset: 29424},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 967, col: 69, offset: 29431},
+								pos:  position{line: 967, col: 69, offset: 29433},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 967, col: 78, offset: 29440},
+							pos:  position{line: 967, col: 78, offset: 29442},
 							name: "R_PAREN",
 						},
 					},
@@ -1717,28 +1717,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 979, col: 1, offset: 29708},
+			pos:  position{line: 979, col: 1, offset: 29710},
 			expr: &actionExpr{
-				pos: position{line: 979, col: 32, offset: 29739},
+				pos: position{line: 979, col: 32, offset: 29741},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 979, col: 32, offset: 29739},
+					pos: position{line: 979, col: 32, offset: 29741},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 979, col: 32, offset: 29739},
+							pos:        position{line: 979, col: 32, offset: 29741},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 979, col: 46, offset: 29753},
+							pos:  position{line: 979, col: 46, offset: 29755},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 979, col: 52, offset: 29759},
+							pos:   position{line: 979, col: 52, offset: 29761},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 979, col: 63, offset: 29770},
+								pos:  position{line: 979, col: 63, offset: 29772},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1748,46 +1748,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 995, col: 1, offset: 30232},
+			pos:  position{line: 995, col: 1, offset: 30234},
 			expr: &actionExpr{
-				pos: position{line: 995, col: 22, offset: 30253},
+				pos: position{line: 995, col: 22, offset: 30255},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 995, col: 22, offset: 30253},
+					pos:   position{line: 995, col: 22, offset: 30255},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 995, col: 32, offset: 30263},
+						pos: position{line: 995, col: 32, offset: 30265},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 32, offset: 30263},
+								pos:  position{line: 995, col: 32, offset: 30265},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 65, offset: 30296},
+								pos:  position{line: 995, col: 65, offset: 30298},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 92, offset: 30323},
+								pos:  position{line: 995, col: 92, offset: 30325},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 118, offset: 30349},
+								pos:  position{line: 995, col: 118, offset: 30351},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 144, offset: 30375},
+								pos:  position{line: 995, col: 144, offset: 30377},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 170, offset: 30401},
+								pos:  position{line: 995, col: 170, offset: 30403},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 201, offset: 30432},
+								pos:  position{line: 995, col: 201, offset: 30434},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 995, col: 231, offset: 30462},
+								pos:  position{line: 995, col: 231, offset: 30464},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1797,35 +1797,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 999, col: 1, offset: 30521},
+			pos:  position{line: 999, col: 1, offset: 30523},
 			expr: &actionExpr{
-				pos: position{line: 999, col: 26, offset: 30546},
+				pos: position{line: 999, col: 26, offset: 30548},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 999, col: 26, offset: 30546},
+					pos: position{line: 999, col: 26, offset: 30548},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 999, col: 26, offset: 30546},
+							pos:   position{line: 999, col: 26, offset: 30548},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 999, col: 32, offset: 30552},
+								pos:  position{line: 999, col: 32, offset: 30554},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 999, col: 50, offset: 30570},
+							pos:   position{line: 999, col: 50, offset: 30572},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 999, col: 55, offset: 30575},
+								pos: position{line: 999, col: 55, offset: 30577},
 								expr: &seqExpr{
-									pos: position{line: 999, col: 56, offset: 30576},
+									pos: position{line: 999, col: 56, offset: 30578},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 999, col: 56, offset: 30576},
+											pos:  position{line: 999, col: 56, offset: 30578},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 999, col: 62, offset: 30582},
+											pos:  position{line: 999, col: 62, offset: 30584},
 											name: "StreamStatsOption",
 										},
 									},
@@ -1838,41 +1838,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1058, col: 1, offset: 32771},
+			pos:  position{line: 1058, col: 1, offset: 32773},
 			expr: &choiceExpr{
-				pos: position{line: 1058, col: 21, offset: 32791},
+				pos: position{line: 1058, col: 21, offset: 32793},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1058, col: 21, offset: 32791},
+						pos: position{line: 1058, col: 21, offset: 32793},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1058, col: 21, offset: 32791},
+							pos: position{line: 1058, col: 21, offset: 32793},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 21, offset: 32791},
+									pos:  position{line: 1058, col: 21, offset: 32793},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 26, offset: 32796},
+									pos:  position{line: 1058, col: 26, offset: 32798},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 42, offset: 32812},
+									pos:   position{line: 1058, col: 42, offset: 32814},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1058, col: 56, offset: 32826},
+										pos:  position{line: 1058, col: 56, offset: 32828},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1058, col: 79, offset: 32849},
+									pos:  position{line: 1058, col: 79, offset: 32851},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1058, col: 85, offset: 32855},
+									pos:   position{line: 1058, col: 85, offset: 32857},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1058, col: 91, offset: 32861},
+										pos:  position{line: 1058, col: 91, offset: 32863},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1880,24 +1880,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1065, col: 3, offset: 33040},
+						pos: position{line: 1065, col: 3, offset: 33042},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1065, col: 3, offset: 33040},
+							pos: position{line: 1065, col: 3, offset: 33042},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 3, offset: 33040},
+									pos:  position{line: 1065, col: 3, offset: 33042},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1065, col: 8, offset: 33045},
+									pos:  position{line: 1065, col: 8, offset: 33047},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1065, col: 24, offset: 33061},
+									pos:   position{line: 1065, col: 24, offset: 33063},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1065, col: 30, offset: 33067},
+										pos:  position{line: 1065, col: 30, offset: 33069},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1909,31 +1909,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1073, col: 1, offset: 33233},
+			pos:  position{line: 1073, col: 1, offset: 33235},
 			expr: &actionExpr{
-				pos: position{line: 1073, col: 15, offset: 33247},
+				pos: position{line: 1073, col: 15, offset: 33249},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1073, col: 15, offset: 33247},
+					pos: position{line: 1073, col: 15, offset: 33249},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1073, col: 15, offset: 33247},
+							pos:  position{line: 1073, col: 15, offset: 33249},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 25, offset: 33257},
+							pos:   position{line: 1073, col: 25, offset: 33259},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1073, col: 34, offset: 33266},
+								pos: position{line: 1073, col: 34, offset: 33268},
 								expr: &seqExpr{
-									pos: position{line: 1073, col: 35, offset: 33267},
+									pos: position{line: 1073, col: 35, offset: 33269},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1073, col: 35, offset: 33267},
+											pos:  position{line: 1073, col: 35, offset: 33269},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1073, col: 45, offset: 33277},
+											pos:  position{line: 1073, col: 45, offset: 33279},
 											name: "EqualityOperator",
 										},
 									},
@@ -1941,10 +1941,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1073, col: 64, offset: 33296},
+							pos:   position{line: 1073, col: 64, offset: 33298},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1073, col: 68, offset: 33300},
+								pos:  position{line: 1073, col: 68, offset: 33302},
 								name: "QuotedString",
 							},
 						},
@@ -1954,44 +1954,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1101, col: 1, offset: 33879},
+			pos:  position{line: 1101, col: 1, offset: 33881},
 			expr: &actionExpr{
-				pos: position{line: 1101, col: 17, offset: 33895},
+				pos: position{line: 1101, col: 17, offset: 33897},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1101, col: 17, offset: 33895},
+					pos: position{line: 1101, col: 17, offset: 33897},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1101, col: 17, offset: 33895},
+							pos:   position{line: 1101, col: 17, offset: 33897},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1101, col: 23, offset: 33901},
+								pos:  position{line: 1101, col: 23, offset: 33903},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1101, col: 36, offset: 33914},
+							pos:   position{line: 1101, col: 36, offset: 33916},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1101, col: 41, offset: 33919},
+								pos: position{line: 1101, col: 41, offset: 33921},
 								expr: &seqExpr{
-									pos: position{line: 1101, col: 42, offset: 33920},
+									pos: position{line: 1101, col: 42, offset: 33922},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1101, col: 43, offset: 33921},
+											pos: position{line: 1101, col: 43, offset: 33923},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1101, col: 43, offset: 33921},
+													pos:  position{line: 1101, col: 43, offset: 33923},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1101, col: 49, offset: 33927},
+													pos:  position{line: 1101, col: 49, offset: 33929},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1101, col: 56, offset: 33934},
+											pos:  position{line: 1101, col: 56, offset: 33936},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2004,35 +2004,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1119, col: 1, offset: 34311},
+			pos:  position{line: 1119, col: 1, offset: 34313},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 17, offset: 34327},
+				pos: position{line: 1119, col: 17, offset: 34329},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1119, col: 17, offset: 34327},
+					pos: position{line: 1119, col: 17, offset: 34329},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1119, col: 17, offset: 34327},
+							pos:   position{line: 1119, col: 17, offset: 34329},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1119, col: 23, offset: 34333},
+								pos:  position{line: 1119, col: 23, offset: 34335},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1119, col: 36, offset: 34346},
+							pos:   position{line: 1119, col: 36, offset: 34348},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1119, col: 41, offset: 34351},
+								pos: position{line: 1119, col: 41, offset: 34353},
 								expr: &seqExpr{
-									pos: position{line: 1119, col: 42, offset: 34352},
+									pos: position{line: 1119, col: 42, offset: 34354},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1119, col: 42, offset: 34352},
+											pos:  position{line: 1119, col: 42, offset: 34354},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1119, col: 45, offset: 34355},
+											pos:  position{line: 1119, col: 45, offset: 34357},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2045,32 +2045,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1137, col: 1, offset: 34720},
+			pos:  position{line: 1137, col: 1, offset: 34722},
 			expr: &choiceExpr{
-				pos: position{line: 1137, col: 17, offset: 34736},
+				pos: position{line: 1137, col: 17, offset: 34738},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1137, col: 17, offset: 34736},
+						pos: position{line: 1137, col: 17, offset: 34738},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1137, col: 17, offset: 34736},
+							pos: position{line: 1137, col: 17, offset: 34738},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1137, col: 17, offset: 34736},
+									pos:   position{line: 1137, col: 17, offset: 34738},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1137, col: 25, offset: 34744},
+										pos: position{line: 1137, col: 25, offset: 34746},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1137, col: 25, offset: 34744},
+											pos:  position{line: 1137, col: 25, offset: 34746},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1137, col: 30, offset: 34749},
+									pos:   position{line: 1137, col: 30, offset: 34751},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1137, col: 36, offset: 34755},
+										pos:  position{line: 1137, col: 36, offset: 34757},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2078,13 +2078,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1148, col: 5, offset: 35051},
+						pos: position{line: 1148, col: 5, offset: 35053},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1148, col: 5, offset: 35051},
+							pos:   position{line: 1148, col: 5, offset: 35053},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1148, col: 12, offset: 35058},
+								pos:  position{line: 1148, col: 12, offset: 35060},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2094,43 +2094,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1152, col: 1, offset: 35099},
+			pos:  position{line: 1152, col: 1, offset: 35101},
 			expr: &choiceExpr{
-				pos: position{line: 1152, col: 17, offset: 35115},
+				pos: position{line: 1152, col: 17, offset: 35117},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1152, col: 17, offset: 35115},
+						pos: position{line: 1152, col: 17, offset: 35117},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1152, col: 17, offset: 35115},
+							pos: position{line: 1152, col: 17, offset: 35117},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1152, col: 17, offset: 35115},
+									pos:  position{line: 1152, col: 17, offset: 35117},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1152, col: 25, offset: 35123},
+									pos:   position{line: 1152, col: 25, offset: 35125},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1152, col: 32, offset: 35130},
+										pos:  position{line: 1152, col: 32, offset: 35132},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1152, col: 45, offset: 35143},
+									pos:  position{line: 1152, col: 45, offset: 35145},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1154, col: 5, offset: 35180},
+						pos: position{line: 1154, col: 5, offset: 35182},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1154, col: 5, offset: 35180},
+							pos:   position{line: 1154, col: 5, offset: 35182},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1154, col: 10, offset: 35185},
+								pos:  position{line: 1154, col: 10, offset: 35187},
 								name: "SearchTerm",
 							},
 						},
@@ -2140,26 +2140,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1160, col: 1, offset: 35343},
+			pos:  position{line: 1160, col: 1, offset: 35345},
 			expr: &actionExpr{
-				pos: position{line: 1160, col: 15, offset: 35357},
+				pos: position{line: 1160, col: 15, offset: 35359},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1160, col: 15, offset: 35357},
+					pos:   position{line: 1160, col: 15, offset: 35359},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1160, col: 21, offset: 35363},
+						pos: position{line: 1160, col: 21, offset: 35365},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 21, offset: 35363},
+								pos:  position{line: 1160, col: 21, offset: 35365},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 44, offset: 35386},
+								pos:  position{line: 1160, col: 44, offset: 35388},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1160, col: 68, offset: 35410},
+								pos:  position{line: 1160, col: 68, offset: 35412},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2169,36 +2169,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1165, col: 1, offset: 35551},
+			pos:  position{line: 1165, col: 1, offset: 35553},
 			expr: &actionExpr{
-				pos: position{line: 1165, col: 19, offset: 35569},
+				pos: position{line: 1165, col: 19, offset: 35571},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1165, col: 19, offset: 35569},
+					pos: position{line: 1165, col: 19, offset: 35571},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1165, col: 19, offset: 35569},
+							pos:  position{line: 1165, col: 19, offset: 35571},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1165, col: 24, offset: 35574},
+							pos:  position{line: 1165, col: 24, offset: 35576},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 38, offset: 35588},
+							pos:   position{line: 1165, col: 38, offset: 35590},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1165, col: 45, offset: 35595},
+								pos:  position{line: 1165, col: 45, offset: 35597},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 68, offset: 35618},
+							pos:   position{line: 1165, col: 68, offset: 35620},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1165, col: 78, offset: 35628},
+								pos: position{line: 1165, col: 78, offset: 35630},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1165, col: 79, offset: 35629},
+									pos:  position{line: 1165, col: 79, offset: 35631},
 									name: "LimitExpr",
 								},
 							},
@@ -2209,35 +2209,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1253, col: 1, offset: 38372},
+			pos:  position{line: 1253, col: 1, offset: 38374},
 			expr: &actionExpr{
-				pos: position{line: 1253, col: 27, offset: 38398},
+				pos: position{line: 1253, col: 27, offset: 38400},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1253, col: 27, offset: 38398},
+					pos: position{line: 1253, col: 27, offset: 38400},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1253, col: 27, offset: 38398},
+							pos:   position{line: 1253, col: 27, offset: 38400},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1253, col: 33, offset: 38404},
+								pos:  position{line: 1253, col: 33, offset: 38406},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1253, col: 51, offset: 38422},
+							pos:   position{line: 1253, col: 51, offset: 38424},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1253, col: 56, offset: 38427},
+								pos: position{line: 1253, col: 56, offset: 38429},
 								expr: &seqExpr{
-									pos: position{line: 1253, col: 57, offset: 38428},
+									pos: position{line: 1253, col: 57, offset: 38430},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1253, col: 57, offset: 38428},
+											pos:  position{line: 1253, col: 57, offset: 38430},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1253, col: 63, offset: 38434},
+											pos:  position{line: 1253, col: 63, offset: 38436},
 											name: "TimechartArgument",
 										},
 									},
@@ -2250,22 +2250,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1282, col: 1, offset: 39168},
+			pos:  position{line: 1282, col: 1, offset: 39170},
 			expr: &actionExpr{
-				pos: position{line: 1282, col: 22, offset: 39189},
+				pos: position{line: 1282, col: 22, offset: 39191},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1282, col: 22, offset: 39189},
+					pos:   position{line: 1282, col: 22, offset: 39191},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1282, col: 29, offset: 39196},
+						pos: position{line: 1282, col: 29, offset: 39198},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1282, col: 29, offset: 39196},
+								pos:  position{line: 1282, col: 29, offset: 39198},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1282, col: 45, offset: 39212},
+								pos:  position{line: 1282, col: 45, offset: 39214},
 								name: "TcOptions",
 							},
 						},
@@ -2275,28 +2275,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1286, col: 1, offset: 39250},
+			pos:  position{line: 1286, col: 1, offset: 39252},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 18, offset: 39267},
+				pos: position{line: 1286, col: 18, offset: 39269},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 18, offset: 39267},
+					pos: position{line: 1286, col: 18, offset: 39269},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1286, col: 18, offset: 39267},
+							pos:   position{line: 1286, col: 18, offset: 39269},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 23, offset: 39272},
+								pos:  position{line: 1286, col: 23, offset: 39274},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 39, offset: 39288},
+							pos:   position{line: 1286, col: 39, offset: 39290},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1286, col: 53, offset: 39302},
+								pos: position{line: 1286, col: 53, offset: 39304},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1286, col: 53, offset: 39302},
+									pos:  position{line: 1286, col: 53, offset: 39304},
 									name: "SplitByClause",
 								},
 							},
@@ -2307,22 +2307,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1300, col: 1, offset: 39641},
+			pos:  position{line: 1300, col: 1, offset: 39643},
 			expr: &actionExpr{
-				pos: position{line: 1300, col: 18, offset: 39658},
+				pos: position{line: 1300, col: 18, offset: 39660},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1300, col: 18, offset: 39658},
+					pos: position{line: 1300, col: 18, offset: 39660},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1300, col: 18, offset: 39658},
+							pos:  position{line: 1300, col: 18, offset: 39660},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1300, col: 21, offset: 39661},
+							pos:   position{line: 1300, col: 21, offset: 39663},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1300, col: 27, offset: 39667},
+								pos:  position{line: 1300, col: 27, offset: 39669},
 								name: "FieldName",
 							},
 						},
@@ -2332,24 +2332,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1308, col: 1, offset: 39796},
+			pos:  position{line: 1308, col: 1, offset: 39798},
 			expr: &actionExpr{
-				pos: position{line: 1308, col: 14, offset: 39809},
+				pos: position{line: 1308, col: 14, offset: 39811},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1308, col: 14, offset: 39809},
+					pos:   position{line: 1308, col: 14, offset: 39811},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1308, col: 22, offset: 39817},
+						pos: position{line: 1308, col: 22, offset: 39819},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1308, col: 22, offset: 39817},
+								pos:  position{line: 1308, col: 22, offset: 39819},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1308, col: 35, offset: 39830},
+								pos: position{line: 1308, col: 35, offset: 39832},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1308, col: 36, offset: 39831},
+									pos:  position{line: 1308, col: 36, offset: 39833},
 									name: "TcOption",
 								},
 							},
@@ -2360,34 +2360,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1350, col: 1, offset: 41351},
+			pos:  position{line: 1350, col: 1, offset: 41353},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 13, offset: 41363},
+				pos: position{line: 1350, col: 13, offset: 41365},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1350, col: 13, offset: 41363},
+					pos: position{line: 1350, col: 13, offset: 41365},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1350, col: 13, offset: 41363},
+							pos:  position{line: 1350, col: 13, offset: 41365},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1350, col: 19, offset: 41369},
+							pos:   position{line: 1350, col: 19, offset: 41371},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1350, col: 31, offset: 41381},
+								pos:  position{line: 1350, col: 31, offset: 41383},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1350, col: 43, offset: 41393},
+							pos:  position{line: 1350, col: 43, offset: 41395},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1350, col: 49, offset: 41399},
+							pos:   position{line: 1350, col: 49, offset: 41401},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1350, col: 53, offset: 41403},
+								pos:  position{line: 1350, col: 53, offset: 41405},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2397,36 +2397,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1355, col: 1, offset: 41516},
+			pos:  position{line: 1355, col: 1, offset: 41518},
 			expr: &actionExpr{
-				pos: position{line: 1355, col: 16, offset: 41531},
+				pos: position{line: 1355, col: 16, offset: 41533},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1355, col: 16, offset: 41531},
+					pos:   position{line: 1355, col: 16, offset: 41533},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1355, col: 24, offset: 41539},
+						pos: position{line: 1355, col: 24, offset: 41541},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1355, col: 24, offset: 41539},
+								pos:        position{line: 1355, col: 24, offset: 41541},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 36, offset: 41551},
+								pos:        position{line: 1355, col: 36, offset: 41553},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 49, offset: 41564},
+								pos:        position{line: 1355, col: 49, offset: 41566},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1355, col: 61, offset: 41576},
+								pos:        position{line: 1355, col: 61, offset: 41578},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2438,50 +2438,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1363, col: 1, offset: 41772},
+			pos:  position{line: 1363, col: 1, offset: 41774},
 			expr: &actionExpr{
-				pos: position{line: 1363, col: 17, offset: 41788},
+				pos: position{line: 1363, col: 17, offset: 41790},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1363, col: 17, offset: 41788},
+					pos:   position{line: 1363, col: 17, offset: 41790},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1363, col: 27, offset: 41798},
+						pos: position{line: 1363, col: 27, offset: 41800},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 27, offset: 41798},
+								pos:  position{line: 1363, col: 27, offset: 41800},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 36, offset: 41807},
+								pos:  position{line: 1363, col: 36, offset: 41809},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 44, offset: 41815},
+								pos:  position{line: 1363, col: 44, offset: 41817},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 57, offset: 41828},
+								pos:  position{line: 1363, col: 57, offset: 41830},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 66, offset: 41837},
+								pos:  position{line: 1363, col: 66, offset: 41839},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 73, offset: 41844},
+								pos:  position{line: 1363, col: 73, offset: 41846},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 79, offset: 41850},
+								pos:  position{line: 1363, col: 79, offset: 41852},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 86, offset: 41857},
+								pos:  position{line: 1363, col: 86, offset: 41859},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1363, col: 96, offset: 41867},
+								pos:  position{line: 1363, col: 96, offset: 41869},
 								name: "Year",
 							},
 						},
@@ -2491,37 +2491,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1367, col: 1, offset: 41903},
+			pos:  position{line: 1367, col: 1, offset: 41905},
 			expr: &actionExpr{
-				pos: position{line: 1367, col: 21, offset: 41923},
+				pos: position{line: 1367, col: 21, offset: 41925},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1367, col: 21, offset: 41923},
+					pos: position{line: 1367, col: 21, offset: 41925},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1367, col: 21, offset: 41923},
+							pos:   position{line: 1367, col: 21, offset: 41925},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1367, col: 29, offset: 41931},
+								pos: position{line: 1367, col: 29, offset: 41933},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1367, col: 29, offset: 41931},
+										pos:  position{line: 1367, col: 29, offset: 41933},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1367, col: 45, offset: 41947},
+										pos:  position{line: 1367, col: 45, offset: 41949},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1367, col: 62, offset: 41964},
+							pos:   position{line: 1367, col: 62, offset: 41966},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1367, col: 72, offset: 41974},
+								pos: position{line: 1367, col: 72, offset: 41976},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1367, col: 73, offset: 41975},
+									pos:  position{line: 1367, col: 73, offset: 41977},
 									name: "AllTimeScale",
 								},
 							},
@@ -2532,28 +2532,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1426, col: 1, offset: 44657},
+			pos:  position{line: 1426, col: 1, offset: 44659},
 			expr: &actionExpr{
-				pos: position{line: 1426, col: 21, offset: 44677},
+				pos: position{line: 1426, col: 21, offset: 44679},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1426, col: 21, offset: 44677},
+					pos: position{line: 1426, col: 21, offset: 44679},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1426, col: 21, offset: 44677},
+							pos:        position{line: 1426, col: 21, offset: 44679},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1426, col: 31, offset: 44687},
+							pos:  position{line: 1426, col: 31, offset: 44689},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1426, col: 37, offset: 44693},
+							pos:   position{line: 1426, col: 37, offset: 44695},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1426, col: 48, offset: 44704},
+								pos:  position{line: 1426, col: 48, offset: 44706},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2563,28 +2563,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1437, col: 1, offset: 44945},
+			pos:  position{line: 1437, col: 1, offset: 44947},
 			expr: &actionExpr{
-				pos: position{line: 1437, col: 21, offset: 44965},
+				pos: position{line: 1437, col: 21, offset: 44967},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1437, col: 21, offset: 44965},
+					pos: position{line: 1437, col: 21, offset: 44967},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1437, col: 21, offset: 44965},
+							pos:        position{line: 1437, col: 21, offset: 44967},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1437, col: 28, offset: 44972},
+							pos:  position{line: 1437, col: 28, offset: 44974},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1437, col: 34, offset: 44978},
+							pos:   position{line: 1437, col: 34, offset: 44980},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1437, col: 43, offset: 44987},
+								pos:  position{line: 1437, col: 43, offset: 44989},
 								name: "IntegerAsString",
 							},
 						},
@@ -2594,31 +2594,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1458, col: 1, offset: 45566},
+			pos:  position{line: 1458, col: 1, offset: 45568},
 			expr: &choiceExpr{
-				pos: position{line: 1458, col: 23, offset: 45588},
+				pos: position{line: 1458, col: 23, offset: 45590},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1458, col: 23, offset: 45588},
+						pos: position{line: 1458, col: 23, offset: 45590},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1458, col: 23, offset: 45588},
+							pos: position{line: 1458, col: 23, offset: 45590},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1458, col: 23, offset: 45588},
+									pos:        position{line: 1458, col: 23, offset: 45590},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1458, col: 35, offset: 45600},
+									pos:  position{line: 1458, col: 35, offset: 45602},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1458, col: 41, offset: 45606},
+									pos:   position{line: 1458, col: 41, offset: 45608},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1458, col: 51, offset: 45616},
+										pos:  position{line: 1458, col: 51, offset: 45618},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2626,33 +2626,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1472, col: 3, offset: 46035},
+						pos: position{line: 1472, col: 3, offset: 46037},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1472, col: 3, offset: 46035},
+							pos: position{line: 1472, col: 3, offset: 46037},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1472, col: 3, offset: 46035},
+									pos:        position{line: 1472, col: 3, offset: 46037},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1472, col: 15, offset: 46047},
+									pos:  position{line: 1472, col: 15, offset: 46049},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1472, col: 21, offset: 46053},
+									pos:   position{line: 1472, col: 21, offset: 46055},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1472, col: 32, offset: 46064},
+										pos: position{line: 1472, col: 32, offset: 46066},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1472, col: 32, offset: 46064},
+												pos:  position{line: 1472, col: 32, offset: 46066},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1472, col: 52, offset: 46084},
+												pos:  position{line: 1472, col: 52, offset: 46086},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2666,35 +2666,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1492, col: 1, offset: 46553},
+			pos:  position{line: 1492, col: 1, offset: 46555},
 			expr: &actionExpr{
-				pos: position{line: 1492, col: 19, offset: 46571},
+				pos: position{line: 1492, col: 19, offset: 46573},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1492, col: 19, offset: 46571},
+					pos: position{line: 1492, col: 19, offset: 46573},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1492, col: 19, offset: 46571},
+							pos:        position{line: 1492, col: 19, offset: 46573},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1492, col: 27, offset: 46579},
+							pos:  position{line: 1492, col: 27, offset: 46581},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1492, col: 33, offset: 46585},
+							pos:   position{line: 1492, col: 33, offset: 46587},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1492, col: 41, offset: 46593},
+								pos: position{line: 1492, col: 41, offset: 46595},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1492, col: 41, offset: 46593},
+										pos:  position{line: 1492, col: 41, offset: 46595},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1492, col: 57, offset: 46609},
+										pos:  position{line: 1492, col: 57, offset: 46611},
 										name: "IntegerAsString",
 									},
 								},
@@ -2706,35 +2706,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1507, col: 1, offset: 46988},
+			pos:  position{line: 1507, col: 1, offset: 46990},
 			expr: &actionExpr{
-				pos: position{line: 1507, col: 17, offset: 47004},
+				pos: position{line: 1507, col: 17, offset: 47006},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1507, col: 17, offset: 47004},
+					pos: position{line: 1507, col: 17, offset: 47006},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1507, col: 17, offset: 47004},
+							pos:        position{line: 1507, col: 17, offset: 47006},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1507, col: 23, offset: 47010},
+							pos:  position{line: 1507, col: 23, offset: 47012},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1507, col: 29, offset: 47016},
+							pos:   position{line: 1507, col: 29, offset: 47018},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1507, col: 37, offset: 47024},
+								pos: position{line: 1507, col: 37, offset: 47026},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1507, col: 37, offset: 47024},
+										pos:  position{line: 1507, col: 37, offset: 47026},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1507, col: 53, offset: 47040},
+										pos:  position{line: 1507, col: 53, offset: 47042},
 										name: "IntegerAsString",
 									},
 								},
@@ -2746,40 +2746,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1522, col: 1, offset: 47411},
+			pos:  position{line: 1522, col: 1, offset: 47413},
 			expr: &choiceExpr{
-				pos: position{line: 1522, col: 18, offset: 47428},
+				pos: position{line: 1522, col: 18, offset: 47430},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1522, col: 18, offset: 47428},
+						pos: position{line: 1522, col: 18, offset: 47430},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1522, col: 18, offset: 47428},
+							pos: position{line: 1522, col: 18, offset: 47430},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1522, col: 18, offset: 47428},
+									pos:        position{line: 1522, col: 18, offset: 47430},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1522, col: 25, offset: 47435},
+									pos:  position{line: 1522, col: 25, offset: 47437},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 31, offset: 47441},
+									pos:   position{line: 1522, col: 31, offset: 47443},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1522, col: 36, offset: 47446},
+										pos: position{line: 1522, col: 36, offset: 47448},
 										expr: &choiceExpr{
-											pos: position{line: 1522, col: 37, offset: 47447},
+											pos: position{line: 1522, col: 37, offset: 47449},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 37, offset: 47447},
+													pos:  position{line: 1522, col: 37, offset: 47449},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 53, offset: 47463},
+													pos:  position{line: 1522, col: 53, offset: 47465},
 													name: "IntegerAsString",
 												},
 											},
@@ -2787,25 +2787,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1522, col: 71, offset: 47481},
+									pos:        position{line: 1522, col: 71, offset: 47483},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1522, col: 77, offset: 47487},
+									pos:   position{line: 1522, col: 77, offset: 47489},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1522, col: 82, offset: 47492},
+										pos: position{line: 1522, col: 82, offset: 47494},
 										expr: &choiceExpr{
-											pos: position{line: 1522, col: 83, offset: 47493},
+											pos: position{line: 1522, col: 83, offset: 47495},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 83, offset: 47493},
+													pos:  position{line: 1522, col: 83, offset: 47495},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1522, col: 99, offset: 47509},
+													pos:  position{line: 1522, col: 99, offset: 47511},
 													name: "IntegerAsString",
 												},
 											},
@@ -2816,26 +2816,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1565, col: 3, offset: 48945},
+						pos: position{line: 1565, col: 3, offset: 48947},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1565, col: 3, offset: 48945},
+							pos: position{line: 1565, col: 3, offset: 48947},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1565, col: 3, offset: 48945},
+									pos:        position{line: 1565, col: 3, offset: 48947},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1565, col: 10, offset: 48952},
+									pos:  position{line: 1565, col: 10, offset: 48954},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1565, col: 16, offset: 48958},
+									pos:   position{line: 1565, col: 16, offset: 48960},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1565, col: 24, offset: 48966},
+										pos:  position{line: 1565, col: 24, offset: 48968},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -2847,38 +2847,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1580, col: 1, offset: 49297},
+			pos:  position{line: 1580, col: 1, offset: 49299},
 			expr: &actionExpr{
-				pos: position{line: 1580, col: 17, offset: 49313},
+				pos: position{line: 1580, col: 17, offset: 49315},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1580, col: 17, offset: 49313},
+					pos:   position{line: 1580, col: 17, offset: 49315},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1580, col: 25, offset: 49321},
+						pos: position{line: 1580, col: 25, offset: 49323},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 25, offset: 49321},
+								pos:  position{line: 1580, col: 25, offset: 49323},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 46, offset: 49342},
+								pos:  position{line: 1580, col: 46, offset: 49344},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 65, offset: 49361},
+								pos:  position{line: 1580, col: 65, offset: 49363},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 84, offset: 49380},
+								pos:  position{line: 1580, col: 84, offset: 49382},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 101, offset: 49397},
+								pos:  position{line: 1580, col: 101, offset: 49399},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1580, col: 116, offset: 49412},
+								pos:  position{line: 1580, col: 116, offset: 49414},
 								name: "BinOptionSpan",
 							},
 						},
@@ -2888,35 +2888,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1584, col: 1, offset: 49455},
+			pos:  position{line: 1584, col: 1, offset: 49457},
 			expr: &actionExpr{
-				pos: position{line: 1584, col: 22, offset: 49476},
+				pos: position{line: 1584, col: 22, offset: 49478},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1584, col: 22, offset: 49476},
+					pos: position{line: 1584, col: 22, offset: 49478},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1584, col: 22, offset: 49476},
+							pos:   position{line: 1584, col: 22, offset: 49478},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1584, col: 29, offset: 49483},
+								pos:  position{line: 1584, col: 29, offset: 49485},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1584, col: 42, offset: 49496},
+							pos:   position{line: 1584, col: 42, offset: 49498},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1584, col: 48, offset: 49502},
+								pos: position{line: 1584, col: 48, offset: 49504},
 								expr: &seqExpr{
-									pos: position{line: 1584, col: 49, offset: 49503},
+									pos: position{line: 1584, col: 49, offset: 49505},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1584, col: 49, offset: 49503},
+											pos:  position{line: 1584, col: 49, offset: 49505},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1584, col: 55, offset: 49509},
+											pos:  position{line: 1584, col: 55, offset: 49511},
 											name: "BinCmdOption",
 										},
 									},
@@ -2929,51 +2929,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1630, col: 1, offset: 50993},
+			pos:  position{line: 1630, col: 1, offset: 50995},
 			expr: &choiceExpr{
-				pos: position{line: 1630, col: 13, offset: 51005},
+				pos: position{line: 1630, col: 13, offset: 51007},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1630, col: 13, offset: 51005},
+						pos: position{line: 1630, col: 13, offset: 51007},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 13, offset: 51005},
+							pos: position{line: 1630, col: 13, offset: 51007},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 13, offset: 51005},
+									pos:  position{line: 1630, col: 13, offset: 51007},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 18, offset: 51010},
+									pos:  position{line: 1630, col: 18, offset: 51012},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 26, offset: 51018},
+									pos:   position{line: 1630, col: 26, offset: 51020},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 40, offset: 51032},
+										pos:  position{line: 1630, col: 40, offset: 51034},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 59, offset: 51051},
+									pos:  position{line: 1630, col: 59, offset: 51053},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 65, offset: 51057},
+									pos:   position{line: 1630, col: 65, offset: 51059},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 71, offset: 51063},
+										pos:  position{line: 1630, col: 71, offset: 51065},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 81, offset: 51073},
+									pos:   position{line: 1630, col: 81, offset: 51075},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1630, col: 94, offset: 51086},
+										pos: position{line: 1630, col: 94, offset: 51088},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1630, col: 95, offset: 51087},
+											pos:  position{line: 1630, col: 95, offset: 51089},
 											name: "AsField",
 										},
 									},
@@ -2982,34 +2982,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1653, col: 3, offset: 51716},
+						pos: position{line: 1653, col: 3, offset: 51718},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1653, col: 3, offset: 51716},
+							pos: position{line: 1653, col: 3, offset: 51718},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 3, offset: 51716},
+									pos:  position{line: 1653, col: 3, offset: 51718},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1653, col: 8, offset: 51721},
+									pos:  position{line: 1653, col: 8, offset: 51723},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1653, col: 16, offset: 51729},
+									pos:   position{line: 1653, col: 16, offset: 51731},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1653, col: 22, offset: 51735},
+										pos:  position{line: 1653, col: 22, offset: 51737},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1653, col: 32, offset: 51745},
+									pos:   position{line: 1653, col: 32, offset: 51747},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1653, col: 45, offset: 51758},
+										pos: position{line: 1653, col: 45, offset: 51760},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1653, col: 46, offset: 51759},
+											pos:  position{line: 1653, col: 46, offset: 51761},
 											name: "AsField",
 										},
 									},
@@ -3022,15 +3022,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1680, col: 1, offset: 52497},
+			pos:  position{line: 1680, col: 1, offset: 52499},
 			expr: &actionExpr{
-				pos: position{line: 1680, col: 15, offset: 52511},
+				pos: position{line: 1680, col: 15, offset: 52513},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1680, col: 15, offset: 52511},
+					pos:   position{line: 1680, col: 15, offset: 52513},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1680, col: 27, offset: 52523},
+						pos:  position{line: 1680, col: 27, offset: 52525},
 						name: "SpanOptions",
 					},
 				},
@@ -3038,26 +3038,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1688, col: 1, offset: 52748},
+			pos:  position{line: 1688, col: 1, offset: 52750},
 			expr: &actionExpr{
-				pos: position{line: 1688, col: 16, offset: 52763},
+				pos: position{line: 1688, col: 16, offset: 52765},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1688, col: 16, offset: 52763},
+					pos: position{line: 1688, col: 16, offset: 52765},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 16, offset: 52763},
+							pos:  position{line: 1688, col: 16, offset: 52765},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 25, offset: 52772},
+							pos:  position{line: 1688, col: 25, offset: 52774},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1688, col: 31, offset: 52778},
+							pos:   position{line: 1688, col: 31, offset: 52780},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1688, col: 42, offset: 52789},
+								pos:  position{line: 1688, col: 42, offset: 52791},
 								name: "SpanLength",
 							},
 						},
@@ -3067,26 +3067,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1695, col: 1, offset: 52935},
+			pos:  position{line: 1695, col: 1, offset: 52937},
 			expr: &actionExpr{
-				pos: position{line: 1695, col: 15, offset: 52949},
+				pos: position{line: 1695, col: 15, offset: 52951},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1695, col: 15, offset: 52949},
+					pos: position{line: 1695, col: 15, offset: 52951},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1695, col: 15, offset: 52949},
+							pos:   position{line: 1695, col: 15, offset: 52951},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 24, offset: 52958},
+								pos:  position{line: 1695, col: 24, offset: 52960},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1695, col: 40, offset: 52974},
+							pos:   position{line: 1695, col: 40, offset: 52976},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1695, col: 50, offset: 52984},
+								pos:  position{line: 1695, col: 50, offset: 52986},
 								name: "AllTimeScale",
 							},
 						},
@@ -3096,43 +3096,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1712, col: 1, offset: 53530},
+			pos:  position{line: 1712, col: 1, offset: 53532},
 			expr: &actionExpr{
-				pos: position{line: 1712, col: 14, offset: 53543},
+				pos: position{line: 1712, col: 14, offset: 53545},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1712, col: 14, offset: 53543},
+					pos: position{line: 1712, col: 14, offset: 53545},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 14, offset: 53543},
+							pos:  position{line: 1712, col: 14, offset: 53545},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1712, col: 20, offset: 53549},
+							pos:        position{line: 1712, col: 20, offset: 53551},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 28, offset: 53557},
+							pos:  position{line: 1712, col: 28, offset: 53559},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1712, col: 34, offset: 53563},
+							pos:   position{line: 1712, col: 34, offset: 53565},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1712, col: 41, offset: 53570},
+								pos: position{line: 1712, col: 41, offset: 53572},
 								expr: &choiceExpr{
-									pos: position{line: 1712, col: 42, offset: 53571},
+									pos: position{line: 1712, col: 42, offset: 53573},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1712, col: 42, offset: 53571},
+											pos:        position{line: 1712, col: 42, offset: 53573},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1712, col: 50, offset: 53579},
+											pos:        position{line: 1712, col: 50, offset: 53581},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3142,14 +3142,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1712, col: 61, offset: 53590},
+							pos:  position{line: 1712, col: 61, offset: 53592},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1712, col: 76, offset: 53605},
+							pos:   position{line: 1712, col: 76, offset: 53607},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1712, col: 86, offset: 53615},
+								pos:  position{line: 1712, col: 86, offset: 53617},
 								name: "IntegerAsString",
 							},
 						},
@@ -3159,22 +3159,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1736, col: 1, offset: 54196},
+			pos:  position{line: 1736, col: 1, offset: 54198},
 			expr: &actionExpr{
-				pos: position{line: 1736, col: 19, offset: 54214},
+				pos: position{line: 1736, col: 19, offset: 54216},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1736, col: 19, offset: 54214},
+					pos: position{line: 1736, col: 19, offset: 54216},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1736, col: 19, offset: 54214},
+							pos:  position{line: 1736, col: 19, offset: 54216},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1736, col: 24, offset: 54219},
+							pos:   position{line: 1736, col: 24, offset: 54221},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1736, col: 38, offset: 54233},
+								pos:  position{line: 1736, col: 38, offset: 54235},
 								name: "StatisticExpr",
 							},
 						},
@@ -3184,76 +3184,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1769, col: 1, offset: 55211},
+			pos:  position{line: 1769, col: 1, offset: 55213},
 			expr: &actionExpr{
-				pos: position{line: 1769, col: 18, offset: 55228},
+				pos: position{line: 1769, col: 18, offset: 55230},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1769, col: 18, offset: 55228},
+					pos: position{line: 1769, col: 18, offset: 55230},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1769, col: 18, offset: 55228},
+							pos:   position{line: 1769, col: 18, offset: 55230},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1769, col: 23, offset: 55233},
+								pos: position{line: 1769, col: 23, offset: 55235},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 23, offset: 55233},
+										pos:  position{line: 1769, col: 23, offset: 55235},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 33, offset: 55243},
+										pos:  position{line: 1769, col: 33, offset: 55245},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 43, offset: 55253},
+							pos:   position{line: 1769, col: 43, offset: 55255},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 49, offset: 55259},
+								pos: position{line: 1769, col: 49, offset: 55261},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 50, offset: 55260},
+									pos:  position{line: 1769, col: 50, offset: 55262},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 67, offset: 55277},
+							pos:   position{line: 1769, col: 67, offset: 55279},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1769, col: 78, offset: 55288},
+								pos: position{line: 1769, col: 78, offset: 55290},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 78, offset: 55288},
+										pos:  position{line: 1769, col: 78, offset: 55290},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1769, col: 84, offset: 55294},
+										pos:  position{line: 1769, col: 84, offset: 55296},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 99, offset: 55309},
+							pos:   position{line: 1769, col: 99, offset: 55311},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 108, offset: 55318},
+								pos: position{line: 1769, col: 108, offset: 55320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 109, offset: 55319},
+									pos:  position{line: 1769, col: 109, offset: 55321},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1769, col: 120, offset: 55330},
+							pos:   position{line: 1769, col: 120, offset: 55332},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1769, col: 128, offset: 55338},
+								pos: position{line: 1769, col: 128, offset: 55340},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1769, col: 129, offset: 55339},
+									pos:  position{line: 1769, col: 129, offset: 55341},
 									name: "StatisticOptions",
 								},
 							},
@@ -3264,25 +3264,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1811, col: 1, offset: 56424},
+			pos:  position{line: 1811, col: 1, offset: 56426},
 			expr: &choiceExpr{
-				pos: position{line: 1811, col: 19, offset: 56442},
+				pos: position{line: 1811, col: 19, offset: 56444},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1811, col: 19, offset: 56442},
+						pos: position{line: 1811, col: 19, offset: 56444},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1811, col: 19, offset: 56442},
+							pos: position{line: 1811, col: 19, offset: 56444},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1811, col: 19, offset: 56442},
+									pos:  position{line: 1811, col: 19, offset: 56444},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1811, col: 25, offset: 56448},
+									pos:   position{line: 1811, col: 25, offset: 56450},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1811, col: 32, offset: 56455},
+										pos:  position{line: 1811, col: 32, offset: 56457},
 										name: "IntegerAsString",
 									},
 								},
@@ -3290,30 +3290,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1814, col: 3, offset: 56509},
+						pos: position{line: 1814, col: 3, offset: 56511},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1814, col: 3, offset: 56509},
+							pos: position{line: 1814, col: 3, offset: 56511},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1814, col: 3, offset: 56509},
+									pos:  position{line: 1814, col: 3, offset: 56511},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1814, col: 9, offset: 56515},
+									pos:        position{line: 1814, col: 9, offset: 56517},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1814, col: 17, offset: 56523},
+									pos:  position{line: 1814, col: 17, offset: 56525},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1814, col: 23, offset: 56529},
+									pos:   position{line: 1814, col: 23, offset: 56531},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1814, col: 30, offset: 56536},
+										pos:  position{line: 1814, col: 30, offset: 56538},
 										name: "IntegerAsString",
 									},
 								},
@@ -3325,17 +3325,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1819, col: 1, offset: 56634},
+			pos:  position{line: 1819, col: 1, offset: 56636},
 			expr: &actionExpr{
-				pos: position{line: 1819, col: 21, offset: 56654},
+				pos: position{line: 1819, col: 21, offset: 56656},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1819, col: 21, offset: 56654},
+					pos:   position{line: 1819, col: 21, offset: 56656},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1819, col: 28, offset: 56661},
+						pos: position{line: 1819, col: 28, offset: 56663},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1819, col: 29, offset: 56662},
+							pos:  position{line: 1819, col: 29, offset: 56664},
 							name: "StatisticOption",
 						},
 					},
@@ -3344,34 +3344,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1868, col: 1, offset: 58224},
+			pos:  position{line: 1868, col: 1, offset: 58226},
 			expr: &actionExpr{
-				pos: position{line: 1868, col: 20, offset: 58243},
+				pos: position{line: 1868, col: 20, offset: 58245},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1868, col: 20, offset: 58243},
+					pos: position{line: 1868, col: 20, offset: 58245},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 20, offset: 58243},
+							pos:  position{line: 1868, col: 20, offset: 58245},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 26, offset: 58249},
+							pos:   position{line: 1868, col: 26, offset: 58251},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 36, offset: 58259},
+								pos:  position{line: 1868, col: 36, offset: 58261},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 55, offset: 58278},
+							pos:  position{line: 1868, col: 55, offset: 58280},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 61, offset: 58284},
+							pos:   position{line: 1868, col: 61, offset: 58286},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 67, offset: 58290},
+								pos:  position{line: 1868, col: 67, offset: 58292},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3381,48 +3381,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1873, col: 1, offset: 58399},
+			pos:  position{line: 1873, col: 1, offset: 58401},
 			expr: &actionExpr{
-				pos: position{line: 1873, col: 23, offset: 58421},
+				pos: position{line: 1873, col: 23, offset: 58423},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1873, col: 23, offset: 58421},
+					pos:   position{line: 1873, col: 23, offset: 58423},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1873, col: 31, offset: 58429},
+						pos: position{line: 1873, col: 31, offset: 58431},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1873, col: 31, offset: 58429},
+								pos:        position{line: 1873, col: 31, offset: 58431},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 46, offset: 58444},
+								pos:        position{line: 1873, col: 46, offset: 58446},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 60, offset: 58458},
+								pos:        position{line: 1873, col: 60, offset: 58460},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 73, offset: 58471},
+								pos:        position{line: 1873, col: 73, offset: 58473},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 85, offset: 58483},
+								pos:        position{line: 1873, col: 85, offset: 58485},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1873, col: 102, offset: 58500},
+								pos:        position{line: 1873, col: 102, offset: 58502},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3434,25 +3434,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1881, col: 1, offset: 58687},
+			pos:  position{line: 1881, col: 1, offset: 58689},
 			expr: &choiceExpr{
-				pos: position{line: 1881, col: 13, offset: 58699},
+				pos: position{line: 1881, col: 13, offset: 58701},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1881, col: 13, offset: 58699},
+						pos: position{line: 1881, col: 13, offset: 58701},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1881, col: 13, offset: 58699},
+							pos: position{line: 1881, col: 13, offset: 58701},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1881, col: 13, offset: 58699},
+									pos:  position{line: 1881, col: 13, offset: 58701},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1881, col: 16, offset: 58702},
+									pos:   position{line: 1881, col: 16, offset: 58704},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1881, col: 26, offset: 58712},
+										pos:  position{line: 1881, col: 26, offset: 58714},
 										name: "FieldNameList",
 									},
 								},
@@ -3460,13 +3460,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1884, col: 3, offset: 58769},
+						pos: position{line: 1884, col: 3, offset: 58771},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1884, col: 3, offset: 58769},
+							pos:   position{line: 1884, col: 3, offset: 58771},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 16, offset: 58782},
+								pos:  position{line: 1884, col: 16, offset: 58784},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3476,26 +3476,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1888, col: 1, offset: 58840},
+			pos:  position{line: 1888, col: 1, offset: 58842},
 			expr: &actionExpr{
-				pos: position{line: 1888, col: 15, offset: 58854},
+				pos: position{line: 1888, col: 15, offset: 58856},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1888, col: 15, offset: 58854},
+					pos: position{line: 1888, col: 15, offset: 58856},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1888, col: 15, offset: 58854},
+							pos:  position{line: 1888, col: 15, offset: 58856},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1888, col: 20, offset: 58859},
+							pos:  position{line: 1888, col: 20, offset: 58861},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1888, col: 30, offset: 58869},
+							pos:   position{line: 1888, col: 30, offset: 58871},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1888, col: 40, offset: 58879},
+								pos:  position{line: 1888, col: 40, offset: 58881},
 								name: "DedupExpr",
 							},
 						},
@@ -3505,27 +3505,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1908, col: 1, offset: 59447},
+			pos:  position{line: 1908, col: 1, offset: 59449},
 			expr: &actionExpr{
-				pos: position{line: 1908, col: 14, offset: 59460},
+				pos: position{line: 1908, col: 14, offset: 59462},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1908, col: 14, offset: 59460},
+					pos: position{line: 1908, col: 14, offset: 59462},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1908, col: 14, offset: 59460},
+							pos:   position{line: 1908, col: 14, offset: 59462},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 23, offset: 59469},
+								pos: position{line: 1908, col: 23, offset: 59471},
 								expr: &seqExpr{
-									pos: position{line: 1908, col: 24, offset: 59470},
+									pos: position{line: 1908, col: 24, offset: 59472},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1908, col: 24, offset: 59470},
+											pos:  position{line: 1908, col: 24, offset: 59472},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1908, col: 30, offset: 59476},
+											pos:  position{line: 1908, col: 30, offset: 59478},
 											name: "IntegerAsString",
 										},
 									},
@@ -3533,45 +3533,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 48, offset: 59494},
+							pos:   position{line: 1908, col: 48, offset: 59496},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 57, offset: 59503},
+								pos: position{line: 1908, col: 57, offset: 59505},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 58, offset: 59504},
+									pos:  position{line: 1908, col: 58, offset: 59506},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 73, offset: 59519},
+							pos:   position{line: 1908, col: 73, offset: 59521},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 83, offset: 59529},
+								pos: position{line: 1908, col: 83, offset: 59531},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 84, offset: 59530},
+									pos:  position{line: 1908, col: 84, offset: 59532},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 101, offset: 59547},
+							pos:   position{line: 1908, col: 101, offset: 59549},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 110, offset: 59556},
+								pos: position{line: 1908, col: 110, offset: 59558},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 111, offset: 59557},
+									pos:  position{line: 1908, col: 111, offset: 59559},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 126, offset: 59572},
+							pos:   position{line: 1908, col: 126, offset: 59574},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1908, col: 139, offset: 59585},
+								pos: position{line: 1908, col: 139, offset: 59587},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1908, col: 140, offset: 59586},
+									pos:  position{line: 1908, col: 140, offset: 59588},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3582,27 +3582,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 1965, col: 1, offset: 61324},
+			pos:  position{line: 1965, col: 1, offset: 61326},
 			expr: &actionExpr{
-				pos: position{line: 1965, col: 19, offset: 61342},
+				pos: position{line: 1965, col: 19, offset: 61344},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 1965, col: 19, offset: 61342},
+					pos: position{line: 1965, col: 19, offset: 61344},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1965, col: 19, offset: 61342},
+							pos: position{line: 1965, col: 19, offset: 61344},
 							expr: &litMatcher{
-								pos:        position{line: 1965, col: 21, offset: 61344},
+								pos:        position{line: 1965, col: 21, offset: 61346},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1965, col: 31, offset: 61354},
+							pos:   position{line: 1965, col: 31, offset: 61356},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1965, col: 37, offset: 61360},
+								pos:  position{line: 1965, col: 37, offset: 61362},
 								name: "FieldName",
 							},
 						},
@@ -3612,48 +3612,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 1971, col: 1, offset: 61499},
+			pos:  position{line: 1971, col: 1, offset: 61501},
 			expr: &actionExpr{
-				pos: position{line: 1971, col: 32, offset: 61530},
+				pos: position{line: 1971, col: 32, offset: 61532},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 1971, col: 32, offset: 61530},
+					pos: position{line: 1971, col: 32, offset: 61532},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1971, col: 32, offset: 61530},
+							pos:   position{line: 1971, col: 32, offset: 61532},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 38, offset: 61536},
+								pos:  position{line: 1971, col: 38, offset: 61538},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1971, col: 48, offset: 61546},
+							pos: position{line: 1971, col: 48, offset: 61548},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1971, col: 50, offset: 61548},
+								pos:  position{line: 1971, col: 50, offset: 61550},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1971, col: 57, offset: 61555},
+							pos:   position{line: 1971, col: 57, offset: 61557},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1971, col: 62, offset: 61560},
+								pos: position{line: 1971, col: 62, offset: 61562},
 								expr: &seqExpr{
-									pos: position{line: 1971, col: 63, offset: 61561},
+									pos: position{line: 1971, col: 63, offset: 61563},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1971, col: 63, offset: 61561},
+											pos:  position{line: 1971, col: 63, offset: 61563},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1971, col: 69, offset: 61567},
+											pos:  position{line: 1971, col: 69, offset: 61569},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 1971, col: 79, offset: 61577},
+											pos: position{line: 1971, col: 79, offset: 61579},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1971, col: 81, offset: 61579},
+												pos:  position{line: 1971, col: 81, offset: 61581},
 												name: "EQUAL",
 											},
 										},
@@ -3667,45 +3667,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 1982, col: 1, offset: 61854},
+			pos:  position{line: 1982, col: 1, offset: 61856},
 			expr: &actionExpr{
-				pos: position{line: 1982, col: 19, offset: 61872},
+				pos: position{line: 1982, col: 19, offset: 61874},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1982, col: 19, offset: 61872},
+					pos: position{line: 1982, col: 19, offset: 61874},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1982, col: 19, offset: 61872},
+							pos:  position{line: 1982, col: 19, offset: 61874},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 25, offset: 61878},
+							pos:   position{line: 1982, col: 25, offset: 61880},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1982, col: 31, offset: 61884},
+								pos:  position{line: 1982, col: 31, offset: 61886},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1982, col: 46, offset: 61899},
+							pos:   position{line: 1982, col: 46, offset: 61901},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1982, col: 51, offset: 61904},
+								pos: position{line: 1982, col: 51, offset: 61906},
 								expr: &seqExpr{
-									pos: position{line: 1982, col: 52, offset: 61905},
+									pos: position{line: 1982, col: 52, offset: 61907},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 52, offset: 61905},
+											pos:  position{line: 1982, col: 52, offset: 61907},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1982, col: 58, offset: 61911},
+											pos:  position{line: 1982, col: 58, offset: 61913},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 1982, col: 73, offset: 61926},
+											pos: position{line: 1982, col: 73, offset: 61928},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1982, col: 74, offset: 61927},
+												pos:  position{line: 1982, col: 74, offset: 61929},
 												name: "EQUAL",
 											},
 										},
@@ -3719,17 +3719,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2000, col: 1, offset: 62455},
+			pos:  position{line: 2000, col: 1, offset: 62457},
 			expr: &actionExpr{
-				pos: position{line: 2000, col: 17, offset: 62471},
+				pos: position{line: 2000, col: 17, offset: 62473},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2000, col: 17, offset: 62471},
+					pos:   position{line: 2000, col: 17, offset: 62473},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2000, col: 24, offset: 62478},
+						pos: position{line: 2000, col: 24, offset: 62480},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2000, col: 25, offset: 62479},
+							pos:  position{line: 2000, col: 25, offset: 62481},
 							name: "DedupOption",
 						},
 					},
@@ -3738,36 +3738,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2040, col: 1, offset: 63745},
+			pos:  position{line: 2040, col: 1, offset: 63747},
 			expr: &actionExpr{
-				pos: position{line: 2040, col: 16, offset: 63760},
+				pos: position{line: 2040, col: 16, offset: 63762},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2040, col: 16, offset: 63760},
+					pos: position{line: 2040, col: 16, offset: 63762},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2040, col: 16, offset: 63760},
+							pos:  position{line: 2040, col: 16, offset: 63762},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 22, offset: 63766},
+							pos:   position{line: 2040, col: 22, offset: 63768},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 32, offset: 63776},
+								pos:  position{line: 2040, col: 32, offset: 63778},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2040, col: 47, offset: 63791},
+							pos:        position{line: 2040, col: 47, offset: 63793},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 51, offset: 63795},
+							pos:   position{line: 2040, col: 51, offset: 63797},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2040, col: 57, offset: 63801},
+								pos:  position{line: 2040, col: 57, offset: 63803},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3777,30 +3777,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2045, col: 1, offset: 63910},
+			pos:  position{line: 2045, col: 1, offset: 63912},
 			expr: &actionExpr{
-				pos: position{line: 2045, col: 19, offset: 63928},
+				pos: position{line: 2045, col: 19, offset: 63930},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2045, col: 19, offset: 63928},
+					pos:   position{line: 2045, col: 19, offset: 63930},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2045, col: 27, offset: 63936},
+						pos: position{line: 2045, col: 27, offset: 63938},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2045, col: 27, offset: 63936},
+								pos:        position{line: 2045, col: 27, offset: 63938},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2045, col: 43, offset: 63952},
+								pos:        position{line: 2045, col: 43, offset: 63954},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2045, col: 57, offset: 63966},
+								pos:        position{line: 2045, col: 57, offset: 63968},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3812,22 +3812,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2053, col: 1, offset: 64151},
+			pos:  position{line: 2053, col: 1, offset: 64153},
 			expr: &actionExpr{
-				pos: position{line: 2053, col: 22, offset: 64172},
+				pos: position{line: 2053, col: 22, offset: 64174},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2053, col: 22, offset: 64172},
+					pos: position{line: 2053, col: 22, offset: 64174},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2053, col: 22, offset: 64172},
+							pos:  position{line: 2053, col: 22, offset: 64174},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2053, col: 39, offset: 64189},
+							pos:   position{line: 2053, col: 39, offset: 64191},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2053, col: 53, offset: 64203},
+								pos:  position{line: 2053, col: 53, offset: 64205},
 								name: "SortElements",
 							},
 						},
@@ -3837,35 +3837,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2058, col: 1, offset: 64311},
+			pos:  position{line: 2058, col: 1, offset: 64313},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 17, offset: 64327},
+				pos: position{line: 2058, col: 17, offset: 64329},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2058, col: 17, offset: 64327},
+					pos: position{line: 2058, col: 17, offset: 64329},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2058, col: 17, offset: 64327},
+							pos:   position{line: 2058, col: 17, offset: 64329},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2058, col: 23, offset: 64333},
+								pos:  position{line: 2058, col: 23, offset: 64335},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 41, offset: 64351},
+							pos:   position{line: 2058, col: 41, offset: 64353},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2058, col: 46, offset: 64356},
+								pos: position{line: 2058, col: 46, offset: 64358},
 								expr: &seqExpr{
-									pos: position{line: 2058, col: 47, offset: 64357},
+									pos: position{line: 2058, col: 47, offset: 64359},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2058, col: 47, offset: 64357},
+											pos:  position{line: 2058, col: 47, offset: 64359},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2058, col: 62, offset: 64372},
+											pos:  position{line: 2058, col: 62, offset: 64374},
 											name: "SingleSortElement",
 										},
 									},
@@ -3878,22 +3878,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2073, col: 1, offset: 64730},
+			pos:  position{line: 2073, col: 1, offset: 64732},
 			expr: &actionExpr{
-				pos: position{line: 2073, col: 22, offset: 64751},
+				pos: position{line: 2073, col: 22, offset: 64753},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2073, col: 22, offset: 64751},
+					pos:   position{line: 2073, col: 22, offset: 64753},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2073, col: 31, offset: 64760},
+						pos: position{line: 2073, col: 31, offset: 64762},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2073, col: 31, offset: 64760},
+								pos:  position{line: 2073, col: 31, offset: 64762},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2073, col: 59, offset: 64788},
+								pos:  position{line: 2073, col: 59, offset: 64790},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -3903,33 +3903,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2077, col: 1, offset: 64847},
+			pos:  position{line: 2077, col: 1, offset: 64849},
 			expr: &actionExpr{
-				pos: position{line: 2077, col: 33, offset: 64879},
+				pos: position{line: 2077, col: 33, offset: 64881},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2077, col: 33, offset: 64879},
+					pos: position{line: 2077, col: 33, offset: 64881},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2077, col: 33, offset: 64879},
+							pos:   position{line: 2077, col: 33, offset: 64881},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2077, col: 47, offset: 64893},
+								pos: position{line: 2077, col: 47, offset: 64895},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2077, col: 47, offset: 64893},
+										pos:        position{line: 2077, col: 47, offset: 64895},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2077, col: 53, offset: 64899},
+										pos:        position{line: 2077, col: 53, offset: 64901},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2077, col: 59, offset: 64905},
+										pos:        position{line: 2077, col: 59, offset: 64907},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3938,10 +3938,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2077, col: 63, offset: 64909},
+							pos:   position{line: 2077, col: 63, offset: 64911},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2077, col: 69, offset: 64915},
+								pos:  position{line: 2077, col: 69, offset: 64917},
 								name: "FieldName",
 							},
 						},
@@ -3951,33 +3951,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2092, col: 1, offset: 65190},
+			pos:  position{line: 2092, col: 1, offset: 65192},
 			expr: &actionExpr{
-				pos: position{line: 2092, col: 30, offset: 65219},
+				pos: position{line: 2092, col: 30, offset: 65221},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2092, col: 30, offset: 65219},
+					pos: position{line: 2092, col: 30, offset: 65221},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2092, col: 30, offset: 65219},
+							pos:   position{line: 2092, col: 30, offset: 65221},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2092, col: 44, offset: 65233},
+								pos: position{line: 2092, col: 44, offset: 65235},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2092, col: 44, offset: 65233},
+										pos:        position{line: 2092, col: 44, offset: 65235},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 50, offset: 65239},
+										pos:        position{line: 2092, col: 50, offset: 65241},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 56, offset: 65245},
+										pos:        position{line: 2092, col: 56, offset: 65247},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3986,31 +3986,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 60, offset: 65249},
+							pos:   position{line: 2092, col: 60, offset: 65251},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2092, col: 64, offset: 65253},
+								pos: position{line: 2092, col: 64, offset: 65255},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2092, col: 64, offset: 65253},
+										pos:        position{line: 2092, col: 64, offset: 65255},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 73, offset: 65262},
+										pos:        position{line: 2092, col: 73, offset: 65264},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 81, offset: 65270},
+										pos:        position{line: 2092, col: 81, offset: 65272},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2092, col: 88, offset: 65277},
+										pos:        position{line: 2092, col: 88, offset: 65279},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4019,19 +4019,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 95, offset: 65284},
+							pos:  position{line: 2092, col: 95, offset: 65286},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2092, col: 103, offset: 65292},
+							pos:   position{line: 2092, col: 103, offset: 65294},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2092, col: 109, offset: 65298},
+								pos:  position{line: 2092, col: 109, offset: 65300},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2092, col: 119, offset: 65308},
+							pos:  position{line: 2092, col: 119, offset: 65310},
 							name: "R_PAREN",
 						},
 					},
@@ -4040,26 +4040,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2112, col: 1, offset: 65733},
+			pos:  position{line: 2112, col: 1, offset: 65735},
 			expr: &actionExpr{
-				pos: position{line: 2112, col: 16, offset: 65748},
+				pos: position{line: 2112, col: 16, offset: 65750},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2112, col: 16, offset: 65748},
+					pos: position{line: 2112, col: 16, offset: 65750},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 16, offset: 65748},
+							pos:  position{line: 2112, col: 16, offset: 65750},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2112, col: 21, offset: 65753},
+							pos:  position{line: 2112, col: 21, offset: 65755},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2112, col: 32, offset: 65764},
+							pos:   position{line: 2112, col: 32, offset: 65766},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2112, col: 43, offset: 65775},
+								pos:  position{line: 2112, col: 43, offset: 65777},
 								name: "RenameExpr",
 							},
 						},
@@ -4069,33 +4069,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2128, col: 1, offset: 66150},
+			pos:  position{line: 2128, col: 1, offset: 66152},
 			expr: &choiceExpr{
-				pos: position{line: 2128, col: 15, offset: 66164},
+				pos: position{line: 2128, col: 15, offset: 66166},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2128, col: 15, offset: 66164},
+						pos: position{line: 2128, col: 15, offset: 66166},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2128, col: 15, offset: 66164},
+							pos: position{line: 2128, col: 15, offset: 66166},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2128, col: 15, offset: 66164},
+									pos:   position{line: 2128, col: 15, offset: 66166},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2128, col: 31, offset: 66180},
+										pos:  position{line: 2128, col: 31, offset: 66182},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2128, col: 45, offset: 66194},
+									pos:  position{line: 2128, col: 45, offset: 66196},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2128, col: 48, offset: 66197},
+									pos:   position{line: 2128, col: 48, offset: 66199},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2128, col: 59, offset: 66208},
+										pos:  position{line: 2128, col: 59, offset: 66210},
 										name: "QuotedString",
 									},
 								},
@@ -4103,28 +4103,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2139, col: 3, offset: 66527},
+						pos: position{line: 2139, col: 3, offset: 66529},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2139, col: 3, offset: 66527},
+							pos: position{line: 2139, col: 3, offset: 66529},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2139, col: 3, offset: 66527},
+									pos:   position{line: 2139, col: 3, offset: 66529},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 19, offset: 66543},
+										pos:  position{line: 2139, col: 19, offset: 66545},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2139, col: 33, offset: 66557},
+									pos:  position{line: 2139, col: 33, offset: 66559},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2139, col: 36, offset: 66560},
+									pos:   position{line: 2139, col: 36, offset: 66562},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2139, col: 47, offset: 66571},
+										pos:  position{line: 2139, col: 47, offset: 66573},
 										name: "RenamePattern",
 									},
 								},
@@ -4136,48 +4136,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2161, col: 1, offset: 67137},
+			pos:  position{line: 2161, col: 1, offset: 67139},
 			expr: &actionExpr{
-				pos: position{line: 2161, col: 13, offset: 67149},
+				pos: position{line: 2161, col: 13, offset: 67151},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2161, col: 13, offset: 67149},
+					pos: position{line: 2161, col: 13, offset: 67151},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 13, offset: 67149},
+							pos:  position{line: 2161, col: 13, offset: 67151},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 18, offset: 67154},
+							pos:  position{line: 2161, col: 18, offset: 67156},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2161, col: 26, offset: 67162},
+							pos:        position{line: 2161, col: 26, offset: 67164},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 34, offset: 67170},
+							pos:  position{line: 2161, col: 34, offset: 67172},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 40, offset: 67176},
+							pos:   position{line: 2161, col: 40, offset: 67178},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 46, offset: 67182},
+								pos:  position{line: 2161, col: 46, offset: 67184},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2161, col: 62, offset: 67198},
+							pos:  position{line: 2161, col: 62, offset: 67200},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2161, col: 68, offset: 67204},
+							pos:   position{line: 2161, col: 68, offset: 67206},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2161, col: 72, offset: 67208},
+								pos:  position{line: 2161, col: 72, offset: 67210},
 								name: "QuotedString",
 							},
 						},
@@ -4187,37 +4187,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2189, col: 1, offset: 67911},
+			pos:  position{line: 2189, col: 1, offset: 67913},
 			expr: &actionExpr{
-				pos: position{line: 2189, col: 14, offset: 67924},
+				pos: position{line: 2189, col: 14, offset: 67926},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2189, col: 14, offset: 67924},
+					pos: position{line: 2189, col: 14, offset: 67926},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 14, offset: 67924},
+							pos:  position{line: 2189, col: 14, offset: 67926},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2189, col: 19, offset: 67929},
+							pos:  position{line: 2189, col: 19, offset: 67931},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 28, offset: 67938},
+							pos:   position{line: 2189, col: 28, offset: 67940},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2189, col: 34, offset: 67944},
+								pos: position{line: 2189, col: 34, offset: 67946},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2189, col: 35, offset: 67945},
+									pos:  position{line: 2189, col: 35, offset: 67947},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 47, offset: 67957},
+							pos:   position{line: 2189, col: 47, offset: 67959},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2189, col: 58, offset: 67968},
+								pos:  position{line: 2189, col: 58, offset: 67970},
 								name: "SortElements",
 							},
 						},
@@ -4227,41 +4227,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2226, col: 1, offset: 68819},
+			pos:  position{line: 2226, col: 1, offset: 68821},
 			expr: &actionExpr{
-				pos: position{line: 2226, col: 14, offset: 68832},
+				pos: position{line: 2226, col: 14, offset: 68834},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2226, col: 14, offset: 68832},
+					pos: position{line: 2226, col: 14, offset: 68834},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2226, col: 14, offset: 68832},
+							pos: position{line: 2226, col: 14, offset: 68834},
 							expr: &seqExpr{
-								pos: position{line: 2226, col: 15, offset: 68833},
+								pos: position{line: 2226, col: 15, offset: 68835},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2226, col: 15, offset: 68833},
+										pos:        position{line: 2226, col: 15, offset: 68835},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2226, col: 23, offset: 68841},
+										pos:  position{line: 2226, col: 23, offset: 68843},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2226, col: 31, offset: 68849},
+							pos:   position{line: 2226, col: 31, offset: 68851},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2226, col: 40, offset: 68858},
+								pos:  position{line: 2226, col: 40, offset: 68860},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2226, col: 56, offset: 68874},
+							pos:  position{line: 2226, col: 56, offset: 68876},
 							name: "SPACE",
 						},
 					},
@@ -4270,43 +4270,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2240, col: 1, offset: 69173},
+			pos:  position{line: 2240, col: 1, offset: 69175},
 			expr: &actionExpr{
-				pos: position{line: 2240, col: 14, offset: 69186},
+				pos: position{line: 2240, col: 14, offset: 69188},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2240, col: 14, offset: 69186},
+					pos: position{line: 2240, col: 14, offset: 69188},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2240, col: 14, offset: 69186},
+							pos:  position{line: 2240, col: 14, offset: 69188},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2240, col: 19, offset: 69191},
+							pos:  position{line: 2240, col: 19, offset: 69193},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2240, col: 28, offset: 69200},
+							pos:   position{line: 2240, col: 28, offset: 69202},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2240, col: 34, offset: 69206},
+								pos:  position{line: 2240, col: 34, offset: 69208},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2240, col: 45, offset: 69217},
+							pos:   position{line: 2240, col: 45, offset: 69219},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2240, col: 50, offset: 69222},
+								pos: position{line: 2240, col: 50, offset: 69224},
 								expr: &seqExpr{
-									pos: position{line: 2240, col: 51, offset: 69223},
+									pos: position{line: 2240, col: 51, offset: 69225},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2240, col: 51, offset: 69223},
+											pos:  position{line: 2240, col: 51, offset: 69225},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2240, col: 57, offset: 69229},
+											pos:  position{line: 2240, col: 57, offset: 69231},
 											name: "SingleEval",
 										},
 									},
@@ -4319,30 +4319,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2267, col: 1, offset: 70030},
+			pos:  position{line: 2267, col: 1, offset: 70032},
 			expr: &actionExpr{
-				pos: position{line: 2267, col: 15, offset: 70044},
+				pos: position{line: 2267, col: 15, offset: 70046},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2267, col: 15, offset: 70044},
+					pos: position{line: 2267, col: 15, offset: 70046},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2267, col: 15, offset: 70044},
+							pos:   position{line: 2267, col: 15, offset: 70046},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2267, col: 21, offset: 70050},
+								pos:  position{line: 2267, col: 21, offset: 70052},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2267, col: 31, offset: 70060},
+							pos:  position{line: 2267, col: 31, offset: 70062},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2267, col: 37, offset: 70066},
+							pos:   position{line: 2267, col: 37, offset: 70068},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2267, col: 42, offset: 70071},
+								pos:  position{line: 2267, col: 42, offset: 70073},
 								name: "EvalExpression",
 							},
 						},
@@ -4352,15 +4352,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2280, col: 1, offset: 70472},
+			pos:  position{line: 2280, col: 1, offset: 70474},
 			expr: &actionExpr{
-				pos: position{line: 2280, col: 19, offset: 70490},
+				pos: position{line: 2280, col: 19, offset: 70492},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2280, col: 19, offset: 70490},
+					pos:   position{line: 2280, col: 19, offset: 70492},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2280, col: 25, offset: 70496},
+						pos:  position{line: 2280, col: 25, offset: 70498},
 						name: "ValueExpr",
 					},
 				},
@@ -4368,85 +4368,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2289, col: 1, offset: 70720},
+			pos:  position{line: 2289, col: 1, offset: 70722},
 			expr: &choiceExpr{
-				pos: position{line: 2289, col: 18, offset: 70737},
+				pos: position{line: 2289, col: 18, offset: 70739},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2289, col: 18, offset: 70737},
+						pos: position{line: 2289, col: 18, offset: 70739},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2289, col: 18, offset: 70737},
+							pos: position{line: 2289, col: 18, offset: 70739},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2289, col: 18, offset: 70737},
+									pos:        position{line: 2289, col: 18, offset: 70739},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 23, offset: 70742},
+									pos:  position{line: 2289, col: 23, offset: 70744},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 31, offset: 70750},
+									pos:   position{line: 2289, col: 31, offset: 70752},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 41, offset: 70760},
+										pos:  position{line: 2289, col: 41, offset: 70762},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 50, offset: 70769},
+									pos:  position{line: 2289, col: 50, offset: 70771},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 56, offset: 70775},
+									pos:   position{line: 2289, col: 56, offset: 70777},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 66, offset: 70785},
+										pos:  position{line: 2289, col: 66, offset: 70787},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 76, offset: 70795},
+									pos:  position{line: 2289, col: 76, offset: 70797},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2289, col: 82, offset: 70801},
+									pos:   position{line: 2289, col: 82, offset: 70803},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2289, col: 93, offset: 70812},
+										pos:  position{line: 2289, col: 93, offset: 70814},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2289, col: 103, offset: 70822},
+									pos:  position{line: 2289, col: 103, offset: 70824},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2300, col: 3, offset: 71073},
+						pos: position{line: 2300, col: 3, offset: 71075},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2300, col: 3, offset: 71073},
+							pos: position{line: 2300, col: 3, offset: 71075},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2300, col: 3, offset: 71073},
+									pos:   position{line: 2300, col: 3, offset: 71075},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2300, col: 11, offset: 71081},
+										pos: position{line: 2300, col: 11, offset: 71083},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2300, col: 11, offset: 71081},
+												pos:        position{line: 2300, col: 11, offset: 71083},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2300, col: 20, offset: 71090},
+												pos:        position{line: 2300, col: 20, offset: 71092},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4455,31 +4455,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2300, col: 32, offset: 71102},
+									pos:  position{line: 2300, col: 32, offset: 71104},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2300, col: 40, offset: 71110},
+									pos:   position{line: 2300, col: 40, offset: 71112},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2300, col: 45, offset: 71115},
+										pos:  position{line: 2300, col: 45, offset: 71117},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2300, col: 64, offset: 71134},
+									pos:   position{line: 2300, col: 64, offset: 71136},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2300, col: 69, offset: 71139},
+										pos: position{line: 2300, col: 69, offset: 71141},
 										expr: &seqExpr{
-											pos: position{line: 2300, col: 70, offset: 71140},
+											pos: position{line: 2300, col: 70, offset: 71142},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2300, col: 70, offset: 71140},
+													pos:  position{line: 2300, col: 70, offset: 71142},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2300, col: 76, offset: 71146},
+													pos:  position{line: 2300, col: 76, offset: 71148},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4487,50 +4487,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2300, col: 97, offset: 71167},
+									pos:  position{line: 2300, col: 97, offset: 71169},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2323, col: 3, offset: 71771},
+						pos: position{line: 2323, col: 3, offset: 71773},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2323, col: 3, offset: 71771},
+							pos: position{line: 2323, col: 3, offset: 71773},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2323, col: 3, offset: 71771},
+									pos:        position{line: 2323, col: 3, offset: 71773},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 14, offset: 71782},
+									pos:  position{line: 2323, col: 14, offset: 71784},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2323, col: 22, offset: 71790},
+									pos:   position{line: 2323, col: 22, offset: 71792},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2323, col: 32, offset: 71800},
+										pos:  position{line: 2323, col: 32, offset: 71802},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2323, col: 42, offset: 71810},
+									pos:   position{line: 2323, col: 42, offset: 71812},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2323, col: 47, offset: 71815},
+										pos: position{line: 2323, col: 47, offset: 71817},
 										expr: &seqExpr{
-											pos: position{line: 2323, col: 48, offset: 71816},
+											pos: position{line: 2323, col: 48, offset: 71818},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2323, col: 48, offset: 71816},
+													pos:  position{line: 2323, col: 48, offset: 71818},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2323, col: 54, offset: 71822},
+													pos:  position{line: 2323, col: 54, offset: 71824},
 													name: "ValueExpr",
 												},
 											},
@@ -4538,73 +4538,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2323, col: 66, offset: 71834},
+									pos:  position{line: 2323, col: 66, offset: 71836},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2340, col: 3, offset: 72253},
+						pos: position{line: 2340, col: 3, offset: 72255},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2340, col: 3, offset: 72253},
+							pos: position{line: 2340, col: 3, offset: 72255},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2340, col: 3, offset: 72253},
+									pos:        position{line: 2340, col: 3, offset: 72255},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 12, offset: 72262},
+									pos:  position{line: 2340, col: 12, offset: 72264},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2340, col: 20, offset: 72270},
+									pos:   position{line: 2340, col: 20, offset: 72272},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2340, col: 30, offset: 72280},
+										pos:  position{line: 2340, col: 30, offset: 72282},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 40, offset: 72290},
+									pos:  position{line: 2340, col: 40, offset: 72292},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2340, col: 46, offset: 72296},
+									pos:   position{line: 2340, col: 46, offset: 72298},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2340, col: 57, offset: 72307},
+										pos:  position{line: 2340, col: 57, offset: 72309},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2340, col: 67, offset: 72317},
+									pos:  position{line: 2340, col: 67, offset: 72319},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2352, col: 3, offset: 72597},
+						pos: position{line: 2352, col: 3, offset: 72599},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2352, col: 3, offset: 72597},
+							pos: position{line: 2352, col: 3, offset: 72599},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2352, col: 3, offset: 72597},
+									pos:        position{line: 2352, col: 3, offset: 72599},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2352, col: 10, offset: 72604},
+									pos:  position{line: 2352, col: 10, offset: 72606},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2352, col: 18, offset: 72612},
+									pos:  position{line: 2352, col: 18, offset: 72614},
 									name: "R_PAREN",
 								},
 							},
@@ -4615,30 +4615,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2359, col: 1, offset: 72709},
+			pos:  position{line: 2359, col: 1, offset: 72711},
 			expr: &actionExpr{
-				pos: position{line: 2359, col: 23, offset: 72731},
+				pos: position{line: 2359, col: 23, offset: 72733},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2359, col: 23, offset: 72731},
+					pos: position{line: 2359, col: 23, offset: 72733},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2359, col: 23, offset: 72731},
+							pos:   position{line: 2359, col: 23, offset: 72733},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2359, col: 33, offset: 72741},
+								pos:  position{line: 2359, col: 33, offset: 72743},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2359, col: 42, offset: 72750},
+							pos:  position{line: 2359, col: 42, offset: 72752},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2359, col: 48, offset: 72756},
+							pos:   position{line: 2359, col: 48, offset: 72758},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2359, col: 54, offset: 72762},
+								pos:  position{line: 2359, col: 54, offset: 72764},
 								name: "ValueExpr",
 							},
 						},
@@ -4648,15 +4648,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2367, col: 1, offset: 72967},
+			pos:  position{line: 2367, col: 1, offset: 72969},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 26, offset: 72992},
+				pos: position{line: 2367, col: 26, offset: 72994},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2367, col: 26, offset: 72992},
+					pos:   position{line: 2367, col: 26, offset: 72994},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2367, col: 37, offset: 73003},
+						pos:  position{line: 2367, col: 37, offset: 73005},
 						name: "StringExpr",
 					},
 				},
@@ -4664,15 +4664,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2377, col: 1, offset: 73212},
+			pos:  position{line: 2377, col: 1, offset: 73214},
 			expr: &actionExpr{
-				pos: position{line: 2377, col: 30, offset: 73241},
+				pos: position{line: 2377, col: 30, offset: 73243},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2377, col: 30, offset: 73241},
+					pos:   position{line: 2377, col: 30, offset: 73243},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2377, col: 45, offset: 73256},
+						pos:  position{line: 2377, col: 45, offset: 73258},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4680,22 +4680,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2386, col: 1, offset: 73462},
+			pos:  position{line: 2386, col: 1, offset: 73464},
 			expr: &actionExpr{
-				pos: position{line: 2386, col: 27, offset: 73488},
+				pos: position{line: 2386, col: 27, offset: 73490},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2386, col: 27, offset: 73488},
+					pos:   position{line: 2386, col: 27, offset: 73490},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2386, col: 40, offset: 73501},
+						pos: position{line: 2386, col: 40, offset: 73503},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2386, col: 40, offset: 73501},
+								pos:  position{line: 2386, col: 40, offset: 73503},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2386, col: 68, offset: 73529},
+								pos:  position{line: 2386, col: 68, offset: 73531},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4705,135 +4705,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2390, col: 1, offset: 73606},
+			pos:  position{line: 2390, col: 1, offset: 73608},
 			expr: &choiceExpr{
-				pos: position{line: 2390, col: 19, offset: 73624},
+				pos: position{line: 2390, col: 19, offset: 73626},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2390, col: 19, offset: 73624},
+						pos: position{line: 2390, col: 19, offset: 73626},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2390, col: 20, offset: 73625},
+							pos: position{line: 2390, col: 20, offset: 73627},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2390, col: 20, offset: 73625},
+									pos:   position{line: 2390, col: 20, offset: 73627},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2390, col: 28, offset: 73633},
+										pos:        position{line: 2390, col: 28, offset: 73635},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 37, offset: 73642},
+									pos:  position{line: 2390, col: 37, offset: 73644},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2390, col: 45, offset: 73650},
+									pos:   position{line: 2390, col: 45, offset: 73652},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2390, col: 56, offset: 73661},
+										pos:  position{line: 2390, col: 56, offset: 73663},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 67, offset: 73672},
+									pos:  position{line: 2390, col: 67, offset: 73674},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2390, col: 73, offset: 73678},
+									pos:   position{line: 2390, col: 73, offset: 73680},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2390, col: 79, offset: 73684},
+										pos:  position{line: 2390, col: 79, offset: 73686},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2390, col: 90, offset: 73695},
+									pos:  position{line: 2390, col: 90, offset: 73697},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2402, col: 3, offset: 74056},
+						pos: position{line: 2402, col: 3, offset: 74058},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2402, col: 4, offset: 74057},
+							pos: position{line: 2402, col: 4, offset: 74059},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2402, col: 4, offset: 74057},
+									pos:   position{line: 2402, col: 4, offset: 74059},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2402, col: 12, offset: 74065},
+										pos:        position{line: 2402, col: 12, offset: 74067},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 23, offset: 74076},
+									pos:  position{line: 2402, col: 23, offset: 74078},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 31, offset: 74084},
+									pos:   position{line: 2402, col: 31, offset: 74086},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2402, col: 46, offset: 74099},
+										pos:  position{line: 2402, col: 46, offset: 74101},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 61, offset: 74114},
+									pos:  position{line: 2402, col: 61, offset: 74116},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 67, offset: 74120},
+									pos:   position{line: 2402, col: 67, offset: 74122},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2402, col: 78, offset: 74131},
+										pos:  position{line: 2402, col: 78, offset: 74133},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2402, col: 90, offset: 74143},
+									pos:   position{line: 2402, col: 90, offset: 74145},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2402, col: 99, offset: 74152},
+										pos: position{line: 2402, col: 99, offset: 74154},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2402, col: 100, offset: 74153},
+											pos:  position{line: 2402, col: 100, offset: 74155},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2402, col: 119, offset: 74172},
+									pos:  position{line: 2402, col: 119, offset: 74174},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2418, col: 3, offset: 74734},
+						pos: position{line: 2418, col: 3, offset: 74736},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2418, col: 4, offset: 74735},
+							pos: position{line: 2418, col: 4, offset: 74737},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2418, col: 4, offset: 74735},
+									pos:   position{line: 2418, col: 4, offset: 74737},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2418, col: 12, offset: 74743},
+										pos: position{line: 2418, col: 12, offset: 74745},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2418, col: 12, offset: 74743},
+												pos:        position{line: 2418, col: 12, offset: 74745},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2418, col: 24, offset: 74755},
+												pos:        position{line: 2418, col: 24, offset: 74757},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4842,222 +4842,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2418, col: 34, offset: 74765},
+									pos:  position{line: 2418, col: 34, offset: 74767},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2418, col: 42, offset: 74773},
+									pos:   position{line: 2418, col: 42, offset: 74775},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2418, col: 57, offset: 74788},
+										pos:  position{line: 2418, col: 57, offset: 74790},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2418, col: 72, offset: 74803},
+									pos:  position{line: 2418, col: 72, offset: 74805},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2430, col: 3, offset: 75151},
+						pos: position{line: 2430, col: 3, offset: 75153},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2430, col: 4, offset: 75152},
+							pos: position{line: 2430, col: 4, offset: 75154},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2430, col: 4, offset: 75152},
+									pos:   position{line: 2430, col: 4, offset: 75154},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2430, col: 12, offset: 75160},
+										pos:        position{line: 2430, col: 12, offset: 75162},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2430, col: 24, offset: 75172},
+									pos:  position{line: 2430, col: 24, offset: 75174},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2430, col: 32, offset: 75180},
+									pos:   position{line: 2430, col: 32, offset: 75182},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2430, col: 42, offset: 75190},
+										pos:  position{line: 2430, col: 42, offset: 75192},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2430, col: 51, offset: 75199},
+									pos:  position{line: 2430, col: 51, offset: 75201},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2443, col: 3, offset: 75546},
+						pos: position{line: 2443, col: 3, offset: 75548},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2443, col: 4, offset: 75547},
+							pos: position{line: 2443, col: 4, offset: 75549},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2443, col: 4, offset: 75547},
+									pos:   position{line: 2443, col: 4, offset: 75549},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2443, col: 12, offset: 75555},
+										pos:        position{line: 2443, col: 12, offset: 75557},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 21, offset: 75564},
+									pos:  position{line: 2443, col: 21, offset: 75566},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2443, col: 29, offset: 75572},
+									pos:   position{line: 2443, col: 29, offset: 75574},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2443, col: 44, offset: 75587},
+										pos:  position{line: 2443, col: 44, offset: 75589},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 59, offset: 75602},
+									pos:  position{line: 2443, col: 59, offset: 75604},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2443, col: 65, offset: 75608},
+									pos:   position{line: 2443, col: 65, offset: 75610},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2443, col: 70, offset: 75613},
+										pos:  position{line: 2443, col: 70, offset: 75615},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2443, col: 80, offset: 75623},
+									pos:  position{line: 2443, col: 80, offset: 75625},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2456, col: 3, offset: 76045},
+						pos: position{line: 2456, col: 3, offset: 76047},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2456, col: 4, offset: 76046},
+							pos: position{line: 2456, col: 4, offset: 76048},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2456, col: 4, offset: 76046},
+									pos:   position{line: 2456, col: 4, offset: 76048},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2456, col: 12, offset: 76054},
+										pos:        position{line: 2456, col: 12, offset: 76056},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 23, offset: 76065},
+									pos:  position{line: 2456, col: 23, offset: 76067},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 31, offset: 76073},
+									pos:   position{line: 2456, col: 31, offset: 76075},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2456, col: 42, offset: 76084},
+										pos:  position{line: 2456, col: 42, offset: 76086},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 54, offset: 76096},
+									pos:  position{line: 2456, col: 54, offset: 76098},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 60, offset: 76102},
+									pos:   position{line: 2456, col: 60, offset: 76104},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2456, col: 69, offset: 76111},
+										pos:  position{line: 2456, col: 69, offset: 76113},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 81, offset: 76123},
+									pos:  position{line: 2456, col: 81, offset: 76125},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2456, col: 87, offset: 76129},
+									pos:   position{line: 2456, col: 87, offset: 76131},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2456, col: 98, offset: 76140},
+										pos: position{line: 2456, col: 98, offset: 76142},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2456, col: 99, offset: 76141},
+											pos:  position{line: 2456, col: 99, offset: 76143},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2456, col: 112, offset: 76154},
+									pos:  position{line: 2456, col: 112, offset: 76156},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2469, col: 3, offset: 76605},
+						pos: position{line: 2469, col: 3, offset: 76607},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2469, col: 4, offset: 76606},
+							pos: position{line: 2469, col: 4, offset: 76608},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2469, col: 4, offset: 76606},
+									pos:   position{line: 2469, col: 4, offset: 76608},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2469, col: 12, offset: 76614},
+										pos:        position{line: 2469, col: 12, offset: 76616},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 21, offset: 76623},
+									pos:  position{line: 2469, col: 21, offset: 76625},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 29, offset: 76631},
+									pos:   position{line: 2469, col: 29, offset: 76633},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2469, col: 36, offset: 76638},
+										pos:  position{line: 2469, col: 36, offset: 76640},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 51, offset: 76653},
+									pos:  position{line: 2469, col: 51, offset: 76655},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 57, offset: 76659},
+									pos:   position{line: 2469, col: 57, offset: 76661},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2469, col: 65, offset: 76667},
+										pos:  position{line: 2469, col: 65, offset: 76669},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2469, col: 80, offset: 76682},
+									pos:   position{line: 2469, col: 80, offset: 76684},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2469, col: 85, offset: 76687},
+										pos: position{line: 2469, col: 85, offset: 76689},
 										expr: &seqExpr{
-											pos: position{line: 2469, col: 86, offset: 76688},
+											pos: position{line: 2469, col: 86, offset: 76690},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2469, col: 86, offset: 76688},
+													pos:  position{line: 2469, col: 86, offset: 76690},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2469, col: 92, offset: 76694},
+													pos:  position{line: 2469, col: 92, offset: 76696},
 													name: "StringExpr",
 												},
 											},
@@ -5065,63 +5065,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2469, col: 105, offset: 76707},
+									pos:  position{line: 2469, col: 105, offset: 76709},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2486, col: 3, offset: 77235},
+						pos: position{line: 2486, col: 3, offset: 77237},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2486, col: 4, offset: 77236},
+							pos: position{line: 2486, col: 4, offset: 77238},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2486, col: 4, offset: 77236},
+									pos:   position{line: 2486, col: 4, offset: 77238},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2486, col: 12, offset: 77244},
+										pos:        position{line: 2486, col: 12, offset: 77246},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 32, offset: 77264},
+									pos:  position{line: 2486, col: 32, offset: 77266},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 40, offset: 77272},
+									pos:   position{line: 2486, col: 40, offset: 77274},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2486, col: 55, offset: 77287},
+										pos:  position{line: 2486, col: 55, offset: 77289},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 70, offset: 77302},
+									pos:   position{line: 2486, col: 70, offset: 77304},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2486, col: 75, offset: 77307},
+										pos: position{line: 2486, col: 75, offset: 77309},
 										expr: &seqExpr{
-											pos: position{line: 2486, col: 76, offset: 77308},
+											pos: position{line: 2486, col: 76, offset: 77310},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2486, col: 76, offset: 77308},
+													pos:  position{line: 2486, col: 76, offset: 77310},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2486, col: 83, offset: 77315},
+													pos: position{line: 2486, col: 83, offset: 77317},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2486, col: 83, offset: 77315},
+															pos:        position{line: 2486, col: 83, offset: 77317},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2486, col: 92, offset: 77324},
+															pos:        position{line: 2486, col: 92, offset: 77326},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5129,7 +5129,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2486, col: 101, offset: 77333},
+													pos:        position{line: 2486, col: 101, offset: 77335},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5139,54 +5139,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 108, offset: 77340},
+									pos:  position{line: 2486, col: 108, offset: 77342},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2511, col: 3, offset: 78043},
+						pos: position{line: 2511, col: 3, offset: 78045},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2511, col: 4, offset: 78044},
+							pos: position{line: 2511, col: 4, offset: 78046},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2511, col: 4, offset: 78044},
+									pos:   position{line: 2511, col: 4, offset: 78046},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2511, col: 12, offset: 78052},
+										pos:        position{line: 2511, col: 12, offset: 78054},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 24, offset: 78064},
+									pos:  position{line: 2511, col: 24, offset: 78066},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 32, offset: 78072},
+									pos:   position{line: 2511, col: 32, offset: 78074},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 41, offset: 78081},
+										pos:  position{line: 2511, col: 41, offset: 78083},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 64, offset: 78104},
+									pos:   position{line: 2511, col: 64, offset: 78106},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2511, col: 69, offset: 78109},
+										pos: position{line: 2511, col: 69, offset: 78111},
 										expr: &seqExpr{
-											pos: position{line: 2511, col: 70, offset: 78110},
+											pos: position{line: 2511, col: 70, offset: 78112},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2511, col: 70, offset: 78110},
+													pos:  position{line: 2511, col: 70, offset: 78112},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2511, col: 76, offset: 78116},
+													pos:  position{line: 2511, col: 76, offset: 78118},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5194,57 +5194,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 101, offset: 78141},
+									pos:  position{line: 2511, col: 101, offset: 78143},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2531, col: 3, offset: 78729},
+						pos: position{line: 2531, col: 3, offset: 78731},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2531, col: 3, offset: 78729},
+							pos: position{line: 2531, col: 3, offset: 78731},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2531, col: 3, offset: 78729},
+									pos:   position{line: 2531, col: 3, offset: 78731},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2531, col: 9, offset: 78735},
+										pos:  position{line: 2531, col: 9, offset: 78737},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2531, col: 25, offset: 78751},
+									pos: position{line: 2531, col: 25, offset: 78753},
 									expr: &choiceExpr{
-										pos: position{line: 2531, col: 27, offset: 78753},
+										pos: position{line: 2531, col: 27, offset: 78755},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 27, offset: 78753},
+												pos:  position{line: 2531, col: 27, offset: 78755},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 36, offset: 78762},
+												pos:  position{line: 2531, col: 36, offset: 78764},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 46, offset: 78772},
+												pos:  position{line: 2531, col: 46, offset: 78774},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 54, offset: 78780},
+												pos:  position{line: 2531, col: 54, offset: 78782},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 62, offset: 78788},
+												pos:  position{line: 2531, col: 62, offset: 78790},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2531, col: 70, offset: 78796},
+												pos:  position{line: 2531, col: 70, offset: 78798},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2531, col: 84, offset: 78810},
+												pos:        position{line: 2531, col: 84, offset: 78812},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5260,36 +5260,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2543, col: 1, offset: 79205},
+			pos:  position{line: 2543, col: 1, offset: 79207},
 			expr: &choiceExpr{
-				pos: position{line: 2543, col: 13, offset: 79217},
+				pos: position{line: 2543, col: 13, offset: 79219},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2543, col: 13, offset: 79217},
+						pos: position{line: 2543, col: 13, offset: 79219},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2543, col: 14, offset: 79218},
+							pos: position{line: 2543, col: 14, offset: 79220},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2543, col: 14, offset: 79218},
+									pos:   position{line: 2543, col: 14, offset: 79220},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2543, col: 22, offset: 79226},
+										pos: position{line: 2543, col: 22, offset: 79228},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2543, col: 22, offset: 79226},
+												pos:        position{line: 2543, col: 22, offset: 79228},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2543, col: 32, offset: 79236},
+												pos:        position{line: 2543, col: 32, offset: 79238},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2543, col: 42, offset: 79246},
+												pos:        position{line: 2543, col: 42, offset: 79248},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5298,44 +5298,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2543, col: 55, offset: 79259},
+									pos:  position{line: 2543, col: 55, offset: 79261},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2543, col: 63, offset: 79267},
+									pos:   position{line: 2543, col: 63, offset: 79269},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2543, col: 74, offset: 79278},
+										pos:  position{line: 2543, col: 74, offset: 79280},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2543, col: 85, offset: 79289},
+									pos:  position{line: 2543, col: 85, offset: 79291},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2555, col: 3, offset: 79603},
+						pos: position{line: 2555, col: 3, offset: 79605},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2555, col: 4, offset: 79604},
+							pos: position{line: 2555, col: 4, offset: 79606},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2555, col: 4, offset: 79604},
+									pos:   position{line: 2555, col: 4, offset: 79606},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2555, col: 12, offset: 79612},
+										pos: position{line: 2555, col: 12, offset: 79614},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2555, col: 12, offset: 79612},
+												pos:        position{line: 2555, col: 12, offset: 79614},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2555, col: 20, offset: 79620},
+												pos:        position{line: 2555, col: 20, offset: 79622},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5344,31 +5344,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2555, col: 27, offset: 79627},
+									pos:  position{line: 2555, col: 27, offset: 79629},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2555, col: 35, offset: 79635},
+									pos:   position{line: 2555, col: 35, offset: 79637},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2555, col: 44, offset: 79644},
+										pos:  position{line: 2555, col: 44, offset: 79646},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2555, col: 55, offset: 79655},
+									pos:   position{line: 2555, col: 55, offset: 79657},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2555, col: 60, offset: 79660},
+										pos: position{line: 2555, col: 60, offset: 79662},
 										expr: &seqExpr{
-											pos: position{line: 2555, col: 61, offset: 79661},
+											pos: position{line: 2555, col: 61, offset: 79663},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2555, col: 61, offset: 79661},
+													pos:  position{line: 2555, col: 61, offset: 79663},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2555, col: 67, offset: 79667},
+													pos:  position{line: 2555, col: 67, offset: 79669},
 													name: "StringExpr",
 												},
 											},
@@ -5376,195 +5376,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2555, col: 80, offset: 79680},
+									pos:  position{line: 2555, col: 80, offset: 79682},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2577, col: 3, offset: 80280},
+						pos: position{line: 2577, col: 3, offset: 80282},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2577, col: 4, offset: 80281},
+							pos: position{line: 2577, col: 4, offset: 80283},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2577, col: 4, offset: 80281},
+									pos:   position{line: 2577, col: 4, offset: 80283},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2577, col: 12, offset: 80289},
+										pos:        position{line: 2577, col: 12, offset: 80291},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 23, offset: 80300},
+									pos:  position{line: 2577, col: 23, offset: 80302},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2577, col: 31, offset: 80308},
+									pos:   position{line: 2577, col: 31, offset: 80310},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2577, col: 46, offset: 80323},
+										pos:  position{line: 2577, col: 46, offset: 80325},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 61, offset: 80338},
+									pos:  position{line: 2577, col: 61, offset: 80340},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2588, col: 3, offset: 80640},
+						pos: position{line: 2588, col: 3, offset: 80642},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2588, col: 4, offset: 80641},
+							pos: position{line: 2588, col: 4, offset: 80643},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2588, col: 4, offset: 80641},
+									pos:   position{line: 2588, col: 4, offset: 80643},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2588, col: 12, offset: 80649},
+										pos:        position{line: 2588, col: 12, offset: 80651},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 22, offset: 80659},
+									pos:  position{line: 2588, col: 22, offset: 80661},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2588, col: 30, offset: 80667},
+									pos:   position{line: 2588, col: 30, offset: 80669},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2588, col: 45, offset: 80682},
+										pos:  position{line: 2588, col: 45, offset: 80684},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 60, offset: 80697},
+									pos:  position{line: 2588, col: 60, offset: 80699},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2588, col: 66, offset: 80703},
+									pos:   position{line: 2588, col: 66, offset: 80705},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2588, col: 72, offset: 80709},
+										pos:  position{line: 2588, col: 72, offset: 80711},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2588, col: 83, offset: 80720},
+									pos:  position{line: 2588, col: 83, offset: 80722},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2600, col: 3, offset: 81070},
+						pos: position{line: 2600, col: 3, offset: 81072},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2600, col: 4, offset: 81071},
+							pos: position{line: 2600, col: 4, offset: 81073},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2600, col: 4, offset: 81071},
+									pos:   position{line: 2600, col: 4, offset: 81073},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2600, col: 12, offset: 81079},
+										pos:        position{line: 2600, col: 12, offset: 81081},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 22, offset: 81089},
+									pos:  position{line: 2600, col: 22, offset: 81091},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2600, col: 30, offset: 81097},
+									pos:   position{line: 2600, col: 30, offset: 81099},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2600, col: 45, offset: 81112},
+										pos:  position{line: 2600, col: 45, offset: 81114},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 60, offset: 81127},
+									pos:  position{line: 2600, col: 60, offset: 81129},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2600, col: 66, offset: 81133},
+									pos:   position{line: 2600, col: 66, offset: 81135},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2600, col: 79, offset: 81146},
+										pos:  position{line: 2600, col: 79, offset: 81148},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2600, col: 90, offset: 81157},
+									pos:  position{line: 2600, col: 90, offset: 81159},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2624, col: 3, offset: 81826},
+						pos: position{line: 2624, col: 3, offset: 81828},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2624, col: 4, offset: 81827},
+							pos: position{line: 2624, col: 4, offset: 81829},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2624, col: 4, offset: 81827},
+									pos:   position{line: 2624, col: 4, offset: 81829},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2624, col: 12, offset: 81835},
+										pos:        position{line: 2624, col: 12, offset: 81837},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 22, offset: 81845},
+									pos:  position{line: 2624, col: 22, offset: 81847},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 30, offset: 81853},
+									pos:   position{line: 2624, col: 30, offset: 81855},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 41, offset: 81864},
+										pos:  position{line: 2624, col: 41, offset: 81866},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 52, offset: 81875},
+									pos:  position{line: 2624, col: 52, offset: 81877},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 58, offset: 81881},
+									pos:   position{line: 2624, col: 58, offset: 81883},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 69, offset: 81892},
+										pos:  position{line: 2624, col: 69, offset: 81894},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 81, offset: 81904},
+									pos:   position{line: 2624, col: 81, offset: 81906},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2624, col: 93, offset: 81916},
+										pos: position{line: 2624, col: 93, offset: 81918},
 										expr: &seqExpr{
-											pos: position{line: 2624, col: 94, offset: 81917},
+											pos: position{line: 2624, col: 94, offset: 81919},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2624, col: 94, offset: 81917},
+													pos:  position{line: 2624, col: 94, offset: 81919},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2624, col: 100, offset: 81923},
+													pos:  position{line: 2624, col: 100, offset: 81925},
 													name: "NumericExpr",
 												},
 											},
@@ -5572,50 +5572,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 114, offset: 81937},
+									pos:  position{line: 2624, col: 114, offset: 81939},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2649, col: 3, offset: 82767},
+						pos: position{line: 2649, col: 3, offset: 82769},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2649, col: 3, offset: 82767},
+							pos: position{line: 2649, col: 3, offset: 82769},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2649, col: 3, offset: 82767},
+									pos:        position{line: 2649, col: 3, offset: 82769},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 14, offset: 82778},
+									pos:  position{line: 2649, col: 14, offset: 82780},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 22, offset: 82786},
+									pos:   position{line: 2649, col: 22, offset: 82788},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2649, col: 28, offset: 82792},
+										pos:  position{line: 2649, col: 28, offset: 82794},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 38, offset: 82802},
+									pos:   position{line: 2649, col: 38, offset: 82804},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2649, col: 45, offset: 82809},
+										pos: position{line: 2649, col: 45, offset: 82811},
 										expr: &seqExpr{
-											pos: position{line: 2649, col: 46, offset: 82810},
+											pos: position{line: 2649, col: 46, offset: 82812},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2649, col: 46, offset: 82810},
+													pos:  position{line: 2649, col: 46, offset: 82812},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2649, col: 52, offset: 82816},
+													pos:  position{line: 2649, col: 52, offset: 82818},
 													name: "StringExpr",
 												},
 											},
@@ -5623,38 +5623,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 65, offset: 82829},
+									pos:  position{line: 2649, col: 65, offset: 82831},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2662, col: 3, offset: 83197},
+						pos: position{line: 2662, col: 3, offset: 83199},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2662, col: 4, offset: 83198},
+							pos: position{line: 2662, col: 4, offset: 83200},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2662, col: 4, offset: 83198},
+									pos:   position{line: 2662, col: 4, offset: 83200},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2662, col: 12, offset: 83206},
+										pos: position{line: 2662, col: 12, offset: 83208},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2662, col: 12, offset: 83206},
+												pos:        position{line: 2662, col: 12, offset: 83208},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2662, col: 22, offset: 83216},
+												pos:        position{line: 2662, col: 22, offset: 83218},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2662, col: 32, offset: 83226},
+												pos:        position{line: 2662, col: 32, offset: 83228},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5663,223 +5663,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 40, offset: 83234},
+									pos:  position{line: 2662, col: 40, offset: 83236},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 48, offset: 83242},
+									pos:   position{line: 2662, col: 48, offset: 83244},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2662, col: 54, offset: 83248},
+										pos:  position{line: 2662, col: 54, offset: 83250},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 66, offset: 83260},
+									pos:   position{line: 2662, col: 66, offset: 83262},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2662, col: 82, offset: 83276},
+										pos: position{line: 2662, col: 82, offset: 83278},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2662, col: 83, offset: 83277},
+											pos:  position{line: 2662, col: 83, offset: 83279},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 101, offset: 83295},
+									pos:  position{line: 2662, col: 101, offset: 83297},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2681, col: 3, offset: 83735},
+						pos: position{line: 2681, col: 3, offset: 83737},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2681, col: 3, offset: 83735},
+							pos: position{line: 2681, col: 3, offset: 83737},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2681, col: 3, offset: 83735},
+									pos:        position{line: 2681, col: 3, offset: 83737},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 11, offset: 83743},
+									pos:  position{line: 2681, col: 11, offset: 83745},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2681, col: 19, offset: 83751},
+									pos:   position{line: 2681, col: 19, offset: 83753},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2681, col: 30, offset: 83762},
+										pos:  position{line: 2681, col: 30, offset: 83764},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 50, offset: 83782},
+									pos:  position{line: 2681, col: 50, offset: 83784},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2681, col: 56, offset: 83788},
+									pos:   position{line: 2681, col: 56, offset: 83790},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2681, col: 62, offset: 83794},
+										pos: position{line: 2681, col: 62, offset: 83796},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2681, col: 62, offset: 83794},
+												pos:  position{line: 2681, col: 62, offset: 83796},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2681, col: 81, offset: 83813},
+												pos:  position{line: 2681, col: 81, offset: 83815},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2681, col: 100, offset: 83832},
+									pos:  position{line: 2681, col: 100, offset: 83834},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2692, col: 3, offset: 84137},
+						pos: position{line: 2692, col: 3, offset: 84139},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2692, col: 3, offset: 84137},
+							pos: position{line: 2692, col: 3, offset: 84139},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2692, col: 3, offset: 84137},
+									pos:        position{line: 2692, col: 3, offset: 84139},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 12, offset: 84146},
+									pos:  position{line: 2692, col: 12, offset: 84148},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2692, col: 20, offset: 84154},
+									pos:   position{line: 2692, col: 20, offset: 84156},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 25, offset: 84159},
+										pos:  position{line: 2692, col: 25, offset: 84161},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 36, offset: 84170},
+									pos:  position{line: 2692, col: 36, offset: 84172},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2692, col: 42, offset: 84176},
+									pos:   position{line: 2692, col: 42, offset: 84178},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 45, offset: 84179},
+										pos:  position{line: 2692, col: 45, offset: 84181},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 55, offset: 84189},
+									pos:  position{line: 2692, col: 55, offset: 84191},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2699, col: 3, offset: 84347},
+						pos: position{line: 2699, col: 3, offset: 84349},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2699, col: 3, offset: 84347},
+							pos: position{line: 2699, col: 3, offset: 84349},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2699, col: 3, offset: 84347},
+									pos:        position{line: 2699, col: 3, offset: 84349},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 21, offset: 84365},
+									pos:  position{line: 2699, col: 21, offset: 84367},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 29, offset: 84373},
+									pos:   position{line: 2699, col: 29, offset: 84375},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 33, offset: 84377},
+										pos:  position{line: 2699, col: 33, offset: 84379},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 43, offset: 84387},
+									pos:  position{line: 2699, col: 43, offset: 84389},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 49, offset: 84393},
+									pos:   position{line: 2699, col: 49, offset: 84395},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 53, offset: 84397},
+										pos:  position{line: 2699, col: 53, offset: 84399},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 66, offset: 84410},
+									pos:  position{line: 2699, col: 66, offset: 84412},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2699, col: 72, offset: 84416},
+									pos:   position{line: 2699, col: 72, offset: 84418},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2699, col: 78, offset: 84422},
+										pos:  position{line: 2699, col: 78, offset: 84424},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2699, col: 91, offset: 84435},
+									pos:  position{line: 2699, col: 91, offset: 84437},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2710, col: 3, offset: 84743},
+						pos: position{line: 2710, col: 3, offset: 84745},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2710, col: 3, offset: 84743},
+							pos: position{line: 2710, col: 3, offset: 84745},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2710, col: 3, offset: 84743},
+									pos:        position{line: 2710, col: 3, offset: 84745},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 12, offset: 84752},
+									pos:  position{line: 2710, col: 12, offset: 84754},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 20, offset: 84760},
+									pos:   position{line: 2710, col: 20, offset: 84762},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2710, col: 27, offset: 84767},
+										pos:  position{line: 2710, col: 27, offset: 84769},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 38, offset: 84778},
+									pos:   position{line: 2710, col: 38, offset: 84780},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2710, col: 43, offset: 84783},
+										pos: position{line: 2710, col: 43, offset: 84785},
 										expr: &seqExpr{
-											pos: position{line: 2710, col: 44, offset: 84784},
+											pos: position{line: 2710, col: 44, offset: 84786},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2710, col: 44, offset: 84784},
+													pos:  position{line: 2710, col: 44, offset: 84786},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2710, col: 50, offset: 84790},
+													pos:  position{line: 2710, col: 50, offset: 84792},
 													name: "StringExpr",
 												},
 											},
@@ -5887,47 +5887,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 63, offset: 84803},
+									pos:  position{line: 2710, col: 63, offset: 84805},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2728, col: 3, offset: 85270},
+						pos: position{line: 2728, col: 3, offset: 85272},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2728, col: 3, offset: 85270},
+							pos: position{line: 2728, col: 3, offset: 85272},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2728, col: 3, offset: 85270},
+									pos:        position{line: 2728, col: 3, offset: 85272},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 12, offset: 85279},
+									pos:  position{line: 2728, col: 12, offset: 85281},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2728, col: 20, offset: 85287},
+									pos:   position{line: 2728, col: 20, offset: 85289},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2728, col: 42, offset: 85309},
+										pos: position{line: 2728, col: 42, offset: 85311},
 										expr: &seqExpr{
-											pos: position{line: 2728, col: 43, offset: 85310},
+											pos: position{line: 2728, col: 43, offset: 85312},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2728, col: 44, offset: 85311},
+													pos: position{line: 2728, col: 44, offset: 85313},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2728, col: 44, offset: 85311},
+															pos:        position{line: 2728, col: 44, offset: 85313},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2728, col: 53, offset: 85320},
+															pos:        position{line: 2728, col: 53, offset: 85322},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5935,7 +5935,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2728, col: 62, offset: 85329},
+													pos:        position{line: 2728, col: 62, offset: 85331},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5945,56 +5945,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 69, offset: 85336},
+									pos:  position{line: 2728, col: 69, offset: 85338},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2750, col: 3, offset: 85933},
+						pos: position{line: 2750, col: 3, offset: 85935},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2750, col: 3, offset: 85933},
+							pos: position{line: 2750, col: 3, offset: 85935},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2750, col: 3, offset: 85933},
+									pos:        position{line: 2750, col: 3, offset: 85935},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2750, col: 13, offset: 85943},
+									pos:  position{line: 2750, col: 13, offset: 85945},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 21, offset: 85951},
+									pos:   position{line: 2750, col: 21, offset: 85953},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2750, col: 27, offset: 85957},
+										pos:  position{line: 2750, col: 27, offset: 85959},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 43, offset: 85973},
+									pos:   position{line: 2750, col: 43, offset: 85975},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 53, offset: 85983},
+										pos: position{line: 2750, col: 53, offset: 85985},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 54, offset: 85984},
+											pos: position{line: 2750, col: 54, offset: 85986},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 54, offset: 85984},
+													pos:  position{line: 2750, col: 54, offset: 85986},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 60, offset: 85990},
+													pos:        position{line: 2750, col: 60, offset: 85992},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 73, offset: 86003},
+													pos:  position{line: 2750, col: 73, offset: 86005},
 													name: "FloatAsString",
 												},
 											},
@@ -6002,40 +6002,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 89, offset: 86019},
+									pos:   position{line: 2750, col: 89, offset: 86021},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 95, offset: 86025},
+										pos: position{line: 2750, col: 95, offset: 86027},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 96, offset: 86026},
+											pos: position{line: 2750, col: 96, offset: 86028},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 96, offset: 86026},
+													pos:  position{line: 2750, col: 96, offset: 86028},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 102, offset: 86032},
+													pos:        position{line: 2750, col: 102, offset: 86034},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2750, col: 112, offset: 86042},
+													pos: position{line: 2750, col: 112, offset: 86044},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2750, col: 112, offset: 86042},
+															pos:        position{line: 2750, col: 112, offset: 86044},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2750, col: 125, offset: 86055},
+															pos:        position{line: 2750, col: 125, offset: 86057},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2750, col: 137, offset: 86067},
+															pos:        position{line: 2750, col: 137, offset: 86069},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6047,25 +6047,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2750, col: 151, offset: 86081},
+									pos:   position{line: 2750, col: 151, offset: 86083},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2750, col: 158, offset: 86088},
+										pos: position{line: 2750, col: 158, offset: 86090},
 										expr: &seqExpr{
-											pos: position{line: 2750, col: 159, offset: 86089},
+											pos: position{line: 2750, col: 159, offset: 86091},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 159, offset: 86089},
+													pos:  position{line: 2750, col: 159, offset: 86091},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2750, col: 165, offset: 86095},
+													pos:        position{line: 2750, col: 165, offset: 86097},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2750, col: 175, offset: 86105},
+													pos:  position{line: 2750, col: 175, offset: 86107},
 													name: "QuotedString",
 												},
 											},
@@ -6073,213 +6073,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2750, col: 190, offset: 86120},
+									pos:  position{line: 2750, col: 190, offset: 86122},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2790, col: 3, offset: 87115},
+						pos: position{line: 2790, col: 3, offset: 87117},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2790, col: 3, offset: 87115},
+							pos: position{line: 2790, col: 3, offset: 87117},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2790, col: 3, offset: 87115},
+									pos:        position{line: 2790, col: 3, offset: 87117},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2790, col: 15, offset: 87127},
+									pos:  position{line: 2790, col: 15, offset: 87129},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2790, col: 23, offset: 87135},
+									pos:   position{line: 2790, col: 23, offset: 87137},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2790, col: 30, offset: 87142},
+										pos: position{line: 2790, col: 30, offset: 87144},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2790, col: 31, offset: 87143},
+											pos:  position{line: 2790, col: 31, offset: 87145},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2790, col: 44, offset: 87156},
+									pos:  position{line: 2790, col: 44, offset: 87158},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2801, col: 3, offset: 87347},
+						pos: position{line: 2801, col: 3, offset: 87349},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2801, col: 3, offset: 87347},
+							pos: position{line: 2801, col: 3, offset: 87349},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2801, col: 3, offset: 87347},
+									pos:        position{line: 2801, col: 3, offset: 87349},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2801, col: 12, offset: 87356},
+									pos:  position{line: 2801, col: 12, offset: 87358},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2801, col: 20, offset: 87364},
+									pos:   position{line: 2801, col: 20, offset: 87366},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2801, col: 30, offset: 87374},
+										pos:  position{line: 2801, col: 30, offset: 87376},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2801, col: 40, offset: 87384},
+									pos:  position{line: 2801, col: 40, offset: 87386},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2807, col: 3, offset: 87507},
+						pos: position{line: 2807, col: 3, offset: 87509},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2807, col: 3, offset: 87507},
+							pos: position{line: 2807, col: 3, offset: 87509},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2807, col: 3, offset: 87507},
+									pos:        position{line: 2807, col: 3, offset: 87509},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 13, offset: 87517},
+									pos:  position{line: 2807, col: 13, offset: 87519},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 21, offset: 87525},
+									pos:   position{line: 2807, col: 21, offset: 87527},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 25, offset: 87529},
+										pos:  position{line: 2807, col: 25, offset: 87531},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 35, offset: 87539},
+									pos:  position{line: 2807, col: 35, offset: 87541},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 41, offset: 87545},
+									pos:   position{line: 2807, col: 41, offset: 87547},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 47, offset: 87551},
+										pos:  position{line: 2807, col: 47, offset: 87553},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 58, offset: 87562},
+									pos:  position{line: 2807, col: 58, offset: 87564},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 64, offset: 87568},
+									pos:   position{line: 2807, col: 64, offset: 87570},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 76, offset: 87580},
+										pos:  position{line: 2807, col: 76, offset: 87582},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 87, offset: 87591},
+									pos:  position{line: 2807, col: 87, offset: 87593},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2814, col: 3, offset: 87815},
+						pos: position{line: 2814, col: 3, offset: 87817},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2814, col: 3, offset: 87815},
+							pos: position{line: 2814, col: 3, offset: 87817},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2814, col: 3, offset: 87815},
+									pos:        position{line: 2814, col: 3, offset: 87817},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 14, offset: 87826},
+									pos:  position{line: 2814, col: 14, offset: 87828},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2814, col: 22, offset: 87834},
+									pos:   position{line: 2814, col: 22, offset: 87836},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2814, col: 26, offset: 87838},
+										pos:  position{line: 2814, col: 26, offset: 87840},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 36, offset: 87848},
+									pos:  position{line: 2814, col: 36, offset: 87850},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2814, col: 42, offset: 87854},
+									pos:   position{line: 2814, col: 42, offset: 87856},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2814, col: 49, offset: 87861},
+										pos:  position{line: 2814, col: 49, offset: 87863},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2814, col: 60, offset: 87872},
+									pos:  position{line: 2814, col: 60, offset: 87874},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2822, col: 3, offset: 88036},
+						pos: position{line: 2822, col: 3, offset: 88038},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2822, col: 3, offset: 88036},
+							pos: position{line: 2822, col: 3, offset: 88038},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2822, col: 3, offset: 88036},
+									pos:        position{line: 2822, col: 3, offset: 88038},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 14, offset: 88047},
+									pos:  position{line: 2822, col: 14, offset: 88049},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 22, offset: 88055},
+									pos:   position{line: 2822, col: 22, offset: 88057},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 26, offset: 88059},
+										pos:  position{line: 2822, col: 26, offset: 88061},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 36, offset: 88069},
+									pos:  position{line: 2822, col: 36, offset: 88071},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 42, offset: 88075},
+									pos:   position{line: 2822, col: 42, offset: 88077},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 49, offset: 88082},
+										pos:  position{line: 2822, col: 49, offset: 88084},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 60, offset: 88093},
+									pos:  position{line: 2822, col: 60, offset: 88095},
 									name: "R_PAREN",
 								},
 							},
@@ -6290,15 +6290,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2830, col: 1, offset: 88255},
+			pos:  position{line: 2830, col: 1, offset: 88257},
 			expr: &actionExpr{
-				pos: position{line: 2830, col: 21, offset: 88275},
+				pos: position{line: 2830, col: 21, offset: 88277},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2830, col: 21, offset: 88275},
+					pos:   position{line: 2830, col: 21, offset: 88277},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2830, col: 25, offset: 88279},
+						pos:  position{line: 2830, col: 25, offset: 88281},
 						name: "QuotedString",
 					},
 				},
@@ -6306,15 +6306,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2837, col: 1, offset: 88406},
+			pos:  position{line: 2837, col: 1, offset: 88408},
 			expr: &actionExpr{
-				pos: position{line: 2837, col: 22, offset: 88427},
+				pos: position{line: 2837, col: 22, offset: 88429},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2837, col: 22, offset: 88427},
+					pos:   position{line: 2837, col: 22, offset: 88429},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2837, col: 26, offset: 88431},
+						pos:  position{line: 2837, col: 26, offset: 88433},
 						name: "UnquotedString",
 					},
 				},
@@ -6322,22 +6322,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2844, col: 1, offset: 88559},
+			pos:  position{line: 2844, col: 1, offset: 88561},
 			expr: &actionExpr{
-				pos: position{line: 2844, col: 20, offset: 88578},
+				pos: position{line: 2844, col: 20, offset: 88580},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2844, col: 20, offset: 88578},
+					pos: position{line: 2844, col: 20, offset: 88580},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2844, col: 20, offset: 88578},
+							pos:  position{line: 2844, col: 20, offset: 88580},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2844, col: 26, offset: 88584},
+							pos:   position{line: 2844, col: 26, offset: 88586},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2844, col: 38, offset: 88596},
+								pos:  position{line: 2844, col: 38, offset: 88598},
 								name: "String",
 							},
 						},
@@ -6347,20 +6347,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2850, col: 1, offset: 88781},
+			pos:  position{line: 2850, col: 1, offset: 88783},
 			expr: &choiceExpr{
-				pos: position{line: 2850, col: 20, offset: 88800},
+				pos: position{line: 2850, col: 20, offset: 88802},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2850, col: 20, offset: 88800},
+						pos: position{line: 2850, col: 20, offset: 88802},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2850, col: 20, offset: 88800},
+							pos: position{line: 2850, col: 20, offset: 88802},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 2850, col: 20, offset: 88800},
+									pos: position{line: 2850, col: 20, offset: 88802},
 									expr: &charClassMatcher{
-										pos:        position{line: 2850, col: 20, offset: 88800},
+										pos:        position{line: 2850, col: 20, offset: 88802},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -6369,9 +6369,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2850, col: 31, offset: 88811},
+									pos: position{line: 2850, col: 31, offset: 88813},
 									expr: &litMatcher{
-										pos:        position{line: 2850, col: 33, offset: 88813},
+										pos:        position{line: 2850, col: 33, offset: 88815},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6381,27 +6381,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2853, col: 3, offset: 88855},
+						pos: position{line: 2853, col: 3, offset: 88857},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 2853, col: 3, offset: 88855},
+							pos: position{line: 2853, col: 3, offset: 88857},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2853, col: 3, offset: 88855},
+									pos:        position{line: 2853, col: 3, offset: 88857},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2853, col: 7, offset: 88859},
+									pos:   position{line: 2853, col: 7, offset: 88861},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2853, col: 13, offset: 88865},
+										pos:  position{line: 2853, col: 13, offset: 88867},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2853, col: 23, offset: 88875},
+									pos:        position{line: 2853, col: 23, offset: 88877},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6414,26 +6414,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2858, col: 1, offset: 88943},
+			pos:  position{line: 2858, col: 1, offset: 88945},
 			expr: &actionExpr{
-				pos: position{line: 2858, col: 15, offset: 88957},
+				pos: position{line: 2858, col: 15, offset: 88959},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2858, col: 15, offset: 88957},
+					pos: position{line: 2858, col: 15, offset: 88959},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2858, col: 15, offset: 88957},
+							pos:  position{line: 2858, col: 15, offset: 88959},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2858, col: 20, offset: 88962},
+							pos:  position{line: 2858, col: 20, offset: 88964},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2858, col: 30, offset: 88972},
+							pos:   position{line: 2858, col: 30, offset: 88974},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2858, col: 40, offset: 88982},
+								pos:  position{line: 2858, col: 40, offset: 88984},
 								name: "BoolExpr",
 							},
 						},
@@ -6443,15 +6443,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2870, col: 1, offset: 89275},
+			pos:  position{line: 2870, col: 1, offset: 89277},
 			expr: &actionExpr{
-				pos: position{line: 2870, col: 13, offset: 89287},
+				pos: position{line: 2870, col: 13, offset: 89289},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2870, col: 13, offset: 89287},
+					pos:   position{line: 2870, col: 13, offset: 89289},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2870, col: 18, offset: 89292},
+						pos:  position{line: 2870, col: 18, offset: 89294},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6459,35 +6459,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2875, col: 1, offset: 89362},
+			pos:  position{line: 2875, col: 1, offset: 89364},
 			expr: &actionExpr{
-				pos: position{line: 2875, col: 19, offset: 89380},
+				pos: position{line: 2875, col: 19, offset: 89382},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2875, col: 19, offset: 89380},
+					pos: position{line: 2875, col: 19, offset: 89382},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2875, col: 19, offset: 89380},
+							pos:   position{line: 2875, col: 19, offset: 89382},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2875, col: 25, offset: 89386},
+								pos:  position{line: 2875, col: 25, offset: 89388},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2875, col: 40, offset: 89401},
+							pos:   position{line: 2875, col: 40, offset: 89403},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2875, col: 45, offset: 89406},
+								pos: position{line: 2875, col: 45, offset: 89408},
 								expr: &seqExpr{
-									pos: position{line: 2875, col: 46, offset: 89407},
+									pos: position{line: 2875, col: 46, offset: 89409},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2875, col: 46, offset: 89407},
+											pos:  position{line: 2875, col: 46, offset: 89409},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2875, col: 49, offset: 89410},
+											pos:  position{line: 2875, col: 49, offset: 89412},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6500,35 +6500,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 2895, col: 1, offset: 89848},
+			pos:  position{line: 2895, col: 1, offset: 89850},
 			expr: &actionExpr{
-				pos: position{line: 2895, col: 19, offset: 89866},
+				pos: position{line: 2895, col: 19, offset: 89868},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 2895, col: 19, offset: 89866},
+					pos: position{line: 2895, col: 19, offset: 89868},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2895, col: 19, offset: 89866},
+							pos:   position{line: 2895, col: 19, offset: 89868},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2895, col: 25, offset: 89872},
+								pos:  position{line: 2895, col: 25, offset: 89874},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2895, col: 40, offset: 89887},
+							pos:   position{line: 2895, col: 40, offset: 89889},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2895, col: 45, offset: 89892},
+								pos: position{line: 2895, col: 45, offset: 89894},
 								expr: &seqExpr{
-									pos: position{line: 2895, col: 46, offset: 89893},
+									pos: position{line: 2895, col: 46, offset: 89895},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2895, col: 46, offset: 89893},
+											pos:  position{line: 2895, col: 46, offset: 89895},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2895, col: 50, offset: 89897},
+											pos:  position{line: 2895, col: 50, offset: 89899},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6541,47 +6541,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 2915, col: 1, offset: 90336},
+			pos:  position{line: 2915, col: 1, offset: 90338},
 			expr: &choiceExpr{
-				pos: position{line: 2915, col: 19, offset: 90354},
+				pos: position{line: 2915, col: 19, offset: 90356},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2915, col: 19, offset: 90354},
+						pos: position{line: 2915, col: 19, offset: 90356},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 2915, col: 19, offset: 90354},
+							pos: position{line: 2915, col: 19, offset: 90356},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 19, offset: 90354},
+									pos:  position{line: 2915, col: 19, offset: 90356},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 23, offset: 90358},
+									pos:  position{line: 2915, col: 23, offset: 90360},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 31, offset: 90366},
+									pos:   position{line: 2915, col: 31, offset: 90368},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 37, offset: 90372},
+										pos:  position{line: 2915, col: 37, offset: 90374},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 52, offset: 90387},
+									pos:  position{line: 2915, col: 52, offset: 90389},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2925, col: 3, offset: 90590},
+						pos: position{line: 2925, col: 3, offset: 90592},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 2925, col: 3, offset: 90590},
+							pos:   position{line: 2925, col: 3, offset: 90592},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2925, col: 9, offset: 90596},
+								pos:  position{line: 2925, col: 9, offset: 90598},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6591,50 +6591,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 2930, col: 1, offset: 90667},
+			pos:  position{line: 2930, col: 1, offset: 90669},
 			expr: &choiceExpr{
-				pos: position{line: 2930, col: 19, offset: 90685},
+				pos: position{line: 2930, col: 19, offset: 90687},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2930, col: 19, offset: 90685},
+						pos: position{line: 2930, col: 19, offset: 90687},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 2930, col: 19, offset: 90685},
+							pos: position{line: 2930, col: 19, offset: 90687},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 19, offset: 90685},
+									pos:  position{line: 2930, col: 19, offset: 90687},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 27, offset: 90693},
+									pos:   position{line: 2930, col: 27, offset: 90695},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 33, offset: 90699},
+										pos:  position{line: 2930, col: 33, offset: 90701},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 48, offset: 90714},
+									pos:  position{line: 2930, col: 48, offset: 90716},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2933, col: 3, offset: 90750},
+						pos: position{line: 2933, col: 3, offset: 90752},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 2933, col: 3, offset: 90750},
+							pos:   position{line: 2933, col: 3, offset: 90752},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 2933, col: 10, offset: 90757},
+								pos: position{line: 2933, col: 10, offset: 90759},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2933, col: 10, offset: 90757},
+										pos:  position{line: 2933, col: 10, offset: 90759},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2933, col: 31, offset: 90778},
+										pos:  position{line: 2933, col: 31, offset: 90780},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6646,60 +6646,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 2938, col: 1, offset: 90898},
+			pos:  position{line: 2938, col: 1, offset: 90900},
 			expr: &choiceExpr{
-				pos: position{line: 2938, col: 23, offset: 90920},
+				pos: position{line: 2938, col: 23, offset: 90922},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2938, col: 23, offset: 90920},
+						pos: position{line: 2938, col: 23, offset: 90922},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2938, col: 24, offset: 90921},
+							pos: position{line: 2938, col: 24, offset: 90923},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2938, col: 24, offset: 90921},
+									pos:   position{line: 2938, col: 24, offset: 90923},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 2938, col: 28, offset: 90925},
+										pos: position{line: 2938, col: 28, offset: 90927},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2938, col: 28, offset: 90925},
+												pos:        position{line: 2938, col: 28, offset: 90927},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 39, offset: 90936},
+												pos:        position{line: 2938, col: 39, offset: 90938},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 49, offset: 90946},
+												pos:        position{line: 2938, col: 49, offset: 90948},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 59, offset: 90956},
+												pos:        position{line: 2938, col: 59, offset: 90958},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 70, offset: 90967},
+												pos:        position{line: 2938, col: 70, offset: 90969},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 84, offset: 90981},
+												pos:        position{line: 2938, col: 84, offset: 90983},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2938, col: 94, offset: 90991},
+												pos:        position{line: 2938, col: 94, offset: 90993},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6708,56 +6708,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 109, offset: 91006},
+									pos:  position{line: 2938, col: 109, offset: 91008},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2938, col: 117, offset: 91014},
+									pos:   position{line: 2938, col: 117, offset: 91016},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2938, col: 123, offset: 91020},
+										pos:  position{line: 2938, col: 123, offset: 91022},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 133, offset: 91030},
+									pos:  position{line: 2938, col: 133, offset: 91032},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2968, col: 3, offset: 91901},
+						pos: position{line: 2968, col: 3, offset: 91903},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 2968, col: 3, offset: 91901},
+							pos: position{line: 2968, col: 3, offset: 91903},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2968, col: 3, offset: 91901},
+									pos:   position{line: 2968, col: 3, offset: 91903},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2968, col: 11, offset: 91909},
+										pos: position{line: 2968, col: 11, offset: 91911},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2968, col: 11, offset: 91909},
+												pos:        position{line: 2968, col: 11, offset: 91911},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 20, offset: 91918},
+												pos:        position{line: 2968, col: 20, offset: 91920},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 29, offset: 91927},
+												pos:        position{line: 2968, col: 29, offset: 91929},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2968, col: 39, offset: 91937},
+												pos:        position{line: 2968, col: 39, offset: 91939},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6766,86 +6766,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 52, offset: 91950},
+									pos:  position{line: 2968, col: 52, offset: 91952},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 60, offset: 91958},
+									pos:   position{line: 2968, col: 60, offset: 91960},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 70, offset: 91968},
+										pos:  position{line: 2968, col: 70, offset: 91970},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 80, offset: 91978},
+									pos:  position{line: 2968, col: 80, offset: 91980},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 86, offset: 91984},
+									pos:   position{line: 2968, col: 86, offset: 91986},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 97, offset: 91995},
+										pos:  position{line: 2968, col: 97, offset: 91997},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 107, offset: 92005},
+									pos:  position{line: 2968, col: 107, offset: 92007},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2981, col: 3, offset: 92375},
+						pos: position{line: 2981, col: 3, offset: 92377},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 2981, col: 3, offset: 92375},
+							pos: position{line: 2981, col: 3, offset: 92377},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2981, col: 3, offset: 92375},
+									pos:   position{line: 2981, col: 3, offset: 92377},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2981, col: 8, offset: 92380},
+										pos:  position{line: 2981, col: 8, offset: 92382},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 18, offset: 92390},
+									pos:  position{line: 2981, col: 18, offset: 92392},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2981, col: 24, offset: 92396},
+									pos:        position{line: 2981, col: 24, offset: 92398},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 29, offset: 92401},
+									pos:  position{line: 2981, col: 29, offset: 92403},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 37, offset: 92409},
+									pos:   position{line: 2981, col: 37, offset: 92411},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2981, col: 50, offset: 92422},
+										pos:  position{line: 2981, col: 50, offset: 92424},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 60, offset: 92432},
+									pos:   position{line: 2981, col: 60, offset: 92434},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2981, col: 65, offset: 92437},
+										pos: position{line: 2981, col: 65, offset: 92439},
 										expr: &seqExpr{
-											pos: position{line: 2981, col: 66, offset: 92438},
+											pos: position{line: 2981, col: 66, offset: 92440},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 66, offset: 92438},
+													pos:  position{line: 2981, col: 66, offset: 92440},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 72, offset: 92444},
+													pos:  position{line: 2981, col: 72, offset: 92446},
 													name: "ValueExpr",
 												},
 											},
@@ -6853,50 +6853,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 84, offset: 92456},
+									pos:  position{line: 2981, col: 84, offset: 92458},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3000, col: 3, offset: 93007},
+						pos: position{line: 3000, col: 3, offset: 93009},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3000, col: 3, offset: 93007},
+							pos: position{line: 3000, col: 3, offset: 93009},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3000, col: 3, offset: 93007},
+									pos:        position{line: 3000, col: 3, offset: 93009},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3000, col: 8, offset: 93012},
+									pos:  position{line: 3000, col: 8, offset: 93014},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3000, col: 16, offset: 93020},
+									pos:   position{line: 3000, col: 16, offset: 93022},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3000, col: 29, offset: 93033},
+										pos:  position{line: 3000, col: 29, offset: 93035},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3000, col: 39, offset: 93043},
+									pos:   position{line: 3000, col: 39, offset: 93045},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3000, col: 44, offset: 93048},
+										pos: position{line: 3000, col: 44, offset: 93050},
 										expr: &seqExpr{
-											pos: position{line: 3000, col: 45, offset: 93049},
+											pos: position{line: 3000, col: 45, offset: 93051},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3000, col: 45, offset: 93049},
+													pos:  position{line: 3000, col: 45, offset: 93051},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3000, col: 51, offset: 93055},
+													pos:  position{line: 3000, col: 51, offset: 93057},
 													name: "ValueExpr",
 												},
 											},
@@ -6904,7 +6904,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3000, col: 63, offset: 93067},
+									pos:  position{line: 3000, col: 63, offset: 93069},
 									name: "R_PAREN",
 								},
 							},
@@ -6915,34 +6915,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3018, col: 1, offset: 93488},
+			pos:  position{line: 3018, col: 1, offset: 93490},
 			expr: &actionExpr{
-				pos: position{line: 3018, col: 23, offset: 93510},
+				pos: position{line: 3018, col: 23, offset: 93512},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3018, col: 23, offset: 93510},
+					pos: position{line: 3018, col: 23, offset: 93512},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3018, col: 23, offset: 93510},
+							pos:   position{line: 3018, col: 23, offset: 93512},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 28, offset: 93515},
+								pos:  position{line: 3018, col: 28, offset: 93517},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3018, col: 38, offset: 93525},
+							pos:   position{line: 3018, col: 38, offset: 93527},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 41, offset: 93528},
+								pos:  position{line: 3018, col: 41, offset: 93530},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3018, col: 62, offset: 93549},
+							pos:   position{line: 3018, col: 62, offset: 93551},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3018, col: 68, offset: 93555},
+								pos:  position{line: 3018, col: 68, offset: 93557},
 								name: "ValueExpr",
 							},
 						},
@@ -6952,129 +6952,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3036, col: 1, offset: 94149},
+			pos:  position{line: 3036, col: 1, offset: 94151},
 			expr: &choiceExpr{
-				pos: position{line: 3036, col: 14, offset: 94162},
+				pos: position{line: 3036, col: 14, offset: 94164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3036, col: 14, offset: 94162},
+						pos: position{line: 3036, col: 14, offset: 94164},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3036, col: 14, offset: 94162},
+							pos:   position{line: 3036, col: 14, offset: 94164},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3036, col: 24, offset: 94172},
+								pos:  position{line: 3036, col: 24, offset: 94174},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3045, col: 3, offset: 94362},
+						pos: position{line: 3045, col: 3, offset: 94364},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3045, col: 3, offset: 94362},
+							pos: position{line: 3045, col: 3, offset: 94364},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 3, offset: 94362},
+									pos:  position{line: 3045, col: 3, offset: 94364},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 12, offset: 94371},
+									pos:   position{line: 3045, col: 12, offset: 94373},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 22, offset: 94381},
+										pos:  position{line: 3045, col: 22, offset: 94383},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 37, offset: 94396},
+									pos:  position{line: 3045, col: 37, offset: 94398},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3054, col: 3, offset: 94580},
+						pos: position{line: 3054, col: 3, offset: 94582},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3054, col: 3, offset: 94580},
+							pos:   position{line: 3054, col: 3, offset: 94582},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3054, col: 11, offset: 94588},
+								pos:  position{line: 3054, col: 11, offset: 94590},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3063, col: 3, offset: 94768},
+						pos: position{line: 3063, col: 3, offset: 94770},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3063, col: 3, offset: 94768},
+							pos:   position{line: 3063, col: 3, offset: 94770},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3063, col: 7, offset: 94772},
+								pos:  position{line: 3063, col: 7, offset: 94774},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3072, col: 3, offset: 94944},
+						pos: position{line: 3072, col: 3, offset: 94946},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3072, col: 3, offset: 94944},
+							pos: position{line: 3072, col: 3, offset: 94946},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3072, col: 3, offset: 94944},
+									pos:  position{line: 3072, col: 3, offset: 94946},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3072, col: 12, offset: 94953},
+									pos:   position{line: 3072, col: 12, offset: 94955},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3072, col: 16, offset: 94957},
+										pos:  position{line: 3072, col: 16, offset: 94959},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3072, col: 28, offset: 94969},
+									pos:  position{line: 3072, col: 28, offset: 94971},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3081, col: 3, offset: 95138},
+						pos: position{line: 3081, col: 3, offset: 95140},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3081, col: 3, offset: 95138},
+							pos: position{line: 3081, col: 3, offset: 95140},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3081, col: 3, offset: 95138},
+									pos:  position{line: 3081, col: 3, offset: 95140},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3081, col: 11, offset: 95146},
+									pos:   position{line: 3081, col: 11, offset: 95148},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3081, col: 19, offset: 95154},
+										pos:  position{line: 3081, col: 19, offset: 95156},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3081, col: 28, offset: 95163},
+									pos:  position{line: 3081, col: 28, offset: 95165},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3090, col: 3, offset: 95335},
+						pos: position{line: 3090, col: 3, offset: 95337},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3090, col: 3, offset: 95335},
+							pos:   position{line: 3090, col: 3, offset: 95337},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3090, col: 18, offset: 95350},
+								pos:  position{line: 3090, col: 18, offset: 95352},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7084,28 +7084,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3100, col: 1, offset: 95547},
+			pos:  position{line: 3100, col: 1, offset: 95549},
 			expr: &choiceExpr{
-				pos: position{line: 3100, col: 15, offset: 95561},
+				pos: position{line: 3100, col: 15, offset: 95563},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3100, col: 15, offset: 95561},
+						pos: position{line: 3100, col: 15, offset: 95563},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3100, col: 15, offset: 95561},
+							pos: position{line: 3100, col: 15, offset: 95563},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3100, col: 15, offset: 95561},
+									pos:   position{line: 3100, col: 15, offset: 95563},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3100, col: 20, offset: 95566},
+										pos:  position{line: 3100, col: 20, offset: 95568},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3100, col: 29, offset: 95575},
+									pos: position{line: 3100, col: 29, offset: 95577},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3100, col: 31, offset: 95577},
+										pos:  position{line: 3100, col: 31, offset: 95579},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7113,23 +7113,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3108, col: 3, offset: 95747},
+						pos: position{line: 3108, col: 3, offset: 95749},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3108, col: 3, offset: 95747},
+							pos: position{line: 3108, col: 3, offset: 95749},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3108, col: 3, offset: 95747},
+									pos:   position{line: 3108, col: 3, offset: 95749},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3108, col: 7, offset: 95751},
+										pos:  position{line: 3108, col: 7, offset: 95753},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3108, col: 20, offset: 95764},
+									pos: position{line: 3108, col: 20, offset: 95766},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3108, col: 22, offset: 95766},
+										pos:  position{line: 3108, col: 22, offset: 95768},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7137,50 +7137,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3116, col: 3, offset: 95931},
+						pos: position{line: 3116, col: 3, offset: 95933},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3116, col: 3, offset: 95931},
+							pos: position{line: 3116, col: 3, offset: 95933},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3116, col: 3, offset: 95931},
+									pos:   position{line: 3116, col: 3, offset: 95933},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3116, col: 9, offset: 95937},
+										pos:  position{line: 3116, col: 9, offset: 95939},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3116, col: 25, offset: 95953},
+									pos: position{line: 3116, col: 25, offset: 95955},
 									expr: &choiceExpr{
-										pos: position{line: 3116, col: 27, offset: 95955},
+										pos: position{line: 3116, col: 27, offset: 95957},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 27, offset: 95955},
+												pos:  position{line: 3116, col: 27, offset: 95957},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 36, offset: 95964},
+												pos:  position{line: 3116, col: 36, offset: 95966},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 46, offset: 95974},
+												pos:  position{line: 3116, col: 46, offset: 95976},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 54, offset: 95982},
+												pos:  position{line: 3116, col: 54, offset: 95984},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 62, offset: 95990},
+												pos:  position{line: 3116, col: 62, offset: 95992},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3116, col: 70, offset: 95998},
+												pos:  position{line: 3116, col: 70, offset: 96000},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3116, col: 84, offset: 96012},
+												pos:        position{line: 3116, col: 84, offset: 96014},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7192,13 +7192,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3124, col: 3, offset: 96162},
+						pos: position{line: 3124, col: 3, offset: 96164},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3124, col: 3, offset: 96162},
+							pos:   position{line: 3124, col: 3, offset: 96164},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3124, col: 10, offset: 96169},
+								pos:  position{line: 3124, col: 10, offset: 96171},
 								name: "ConcatExpr",
 							},
 						},
@@ -7208,35 +7208,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3134, col: 1, offset: 96375},
+			pos:  position{line: 3134, col: 1, offset: 96377},
 			expr: &actionExpr{
-				pos: position{line: 3134, col: 15, offset: 96389},
+				pos: position{line: 3134, col: 15, offset: 96391},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3134, col: 15, offset: 96389},
+					pos: position{line: 3134, col: 15, offset: 96391},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3134, col: 15, offset: 96389},
+							pos:   position{line: 3134, col: 15, offset: 96391},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3134, col: 21, offset: 96395},
+								pos:  position{line: 3134, col: 21, offset: 96397},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3134, col: 32, offset: 96406},
+							pos:   position{line: 3134, col: 32, offset: 96408},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3134, col: 37, offset: 96411},
+								pos: position{line: 3134, col: 37, offset: 96413},
 								expr: &seqExpr{
-									pos: position{line: 3134, col: 38, offset: 96412},
+									pos: position{line: 3134, col: 38, offset: 96414},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3134, col: 38, offset: 96412},
+											pos:  position{line: 3134, col: 38, offset: 96414},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3134, col: 50, offset: 96424},
+											pos:  position{line: 3134, col: 50, offset: 96426},
 											name: "ConcatAtom",
 										},
 									},
@@ -7244,28 +7244,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3134, col: 63, offset: 96437},
+							pos: position{line: 3134, col: 63, offset: 96439},
 							expr: &choiceExpr{
-								pos: position{line: 3134, col: 65, offset: 96439},
+								pos: position{line: 3134, col: 65, offset: 96441},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 65, offset: 96439},
+										pos:  position{line: 3134, col: 65, offset: 96441},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 74, offset: 96448},
+										pos:  position{line: 3134, col: 74, offset: 96450},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 84, offset: 96458},
+										pos:  position{line: 3134, col: 84, offset: 96460},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3134, col: 92, offset: 96466},
+										pos:  position{line: 3134, col: 92, offset: 96468},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3134, col: 100, offset: 96474},
+										pos:        position{line: 3134, col: 100, offset: 96476},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7279,54 +7279,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3152, col: 1, offset: 96880},
+			pos:  position{line: 3152, col: 1, offset: 96882},
 			expr: &choiceExpr{
-				pos: position{line: 3152, col: 15, offset: 96894},
+				pos: position{line: 3152, col: 15, offset: 96896},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3152, col: 15, offset: 96894},
+						pos: position{line: 3152, col: 15, offset: 96896},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3152, col: 15, offset: 96894},
+							pos:   position{line: 3152, col: 15, offset: 96896},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3152, col: 20, offset: 96899},
+								pos:  position{line: 3152, col: 20, offset: 96901},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3161, col: 3, offset: 97063},
+						pos: position{line: 3161, col: 3, offset: 97065},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3161, col: 3, offset: 97063},
+							pos:   position{line: 3161, col: 3, offset: 97065},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3161, col: 7, offset: 97067},
+								pos:  position{line: 3161, col: 7, offset: 97069},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3169, col: 3, offset: 97206},
+						pos: position{line: 3169, col: 3, offset: 97208},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3169, col: 3, offset: 97206},
+							pos:   position{line: 3169, col: 3, offset: 97208},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3169, col: 10, offset: 97213},
+								pos:  position{line: 3169, col: 10, offset: 97215},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3177, col: 3, offset: 97352},
+						pos: position{line: 3177, col: 3, offset: 97354},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3177, col: 3, offset: 97352},
+							pos:   position{line: 3177, col: 3, offset: 97354},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3177, col: 9, offset: 97358},
+								pos:  position{line: 3177, col: 9, offset: 97360},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7336,32 +7336,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3187, col: 1, offset: 97527},
+			pos:  position{line: 3187, col: 1, offset: 97529},
 			expr: &actionExpr{
-				pos: position{line: 3187, col: 16, offset: 97542},
+				pos: position{line: 3187, col: 16, offset: 97544},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3187, col: 16, offset: 97542},
+					pos: position{line: 3187, col: 16, offset: 97544},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3187, col: 16, offset: 97542},
+							pos:   position{line: 3187, col: 16, offset: 97544},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3187, col: 21, offset: 97547},
+								pos:  position{line: 3187, col: 21, offset: 97549},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3187, col: 39, offset: 97565},
+							pos: position{line: 3187, col: 39, offset: 97567},
 							expr: &choiceExpr{
-								pos: position{line: 3187, col: 41, offset: 97567},
+								pos: position{line: 3187, col: 41, offset: 97569},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3187, col: 41, offset: 97567},
+										pos:  position{line: 3187, col: 41, offset: 97569},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3187, col: 55, offset: 97581},
+										pos:        position{line: 3187, col: 55, offset: 97583},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7375,44 +7375,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3192, col: 1, offset: 97646},
+			pos:  position{line: 3192, col: 1, offset: 97648},
 			expr: &actionExpr{
-				pos: position{line: 3192, col: 22, offset: 97667},
+				pos: position{line: 3192, col: 22, offset: 97669},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3192, col: 22, offset: 97667},
+					pos: position{line: 3192, col: 22, offset: 97669},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3192, col: 22, offset: 97667},
+							pos:   position{line: 3192, col: 22, offset: 97669},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3192, col: 28, offset: 97673},
+								pos:  position{line: 3192, col: 28, offset: 97675},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3192, col: 46, offset: 97691},
+							pos:   position{line: 3192, col: 46, offset: 97693},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3192, col: 51, offset: 97696},
+								pos: position{line: 3192, col: 51, offset: 97698},
 								expr: &seqExpr{
-									pos: position{line: 3192, col: 52, offset: 97697},
+									pos: position{line: 3192, col: 52, offset: 97699},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3192, col: 53, offset: 97698},
+											pos: position{line: 3192, col: 53, offset: 97700},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3192, col: 53, offset: 97698},
+													pos:  position{line: 3192, col: 53, offset: 97700},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3192, col: 62, offset: 97707},
+													pos:  position{line: 3192, col: 62, offset: 97709},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3192, col: 71, offset: 97716},
+											pos:  position{line: 3192, col: 71, offset: 97718},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7425,48 +7425,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3213, col: 1, offset: 98217},
+			pos:  position{line: 3213, col: 1, offset: 98219},
 			expr: &actionExpr{
-				pos: position{line: 3213, col: 22, offset: 98238},
+				pos: position{line: 3213, col: 22, offset: 98240},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3213, col: 22, offset: 98238},
+					pos: position{line: 3213, col: 22, offset: 98240},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3213, col: 22, offset: 98238},
+							pos:   position{line: 3213, col: 22, offset: 98240},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3213, col: 28, offset: 98244},
+								pos:  position{line: 3213, col: 28, offset: 98246},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3213, col: 46, offset: 98262},
+							pos:   position{line: 3213, col: 46, offset: 98264},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3213, col: 51, offset: 98267},
+								pos: position{line: 3213, col: 51, offset: 98269},
 								expr: &seqExpr{
-									pos: position{line: 3213, col: 52, offset: 98268},
+									pos: position{line: 3213, col: 52, offset: 98270},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3213, col: 53, offset: 98269},
+											pos: position{line: 3213, col: 53, offset: 98271},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 53, offset: 98269},
+													pos:  position{line: 3213, col: 53, offset: 98271},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 61, offset: 98277},
+													pos:  position{line: 3213, col: 61, offset: 98279},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 69, offset: 98285},
+													pos:  position{line: 3213, col: 69, offset: 98287},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3213, col: 76, offset: 98292},
+											pos:  position{line: 3213, col: 76, offset: 98294},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7479,22 +7479,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3233, col: 1, offset: 98761},
+			pos:  position{line: 3233, col: 1, offset: 98763},
 			expr: &actionExpr{
-				pos: position{line: 3233, col: 21, offset: 98781},
+				pos: position{line: 3233, col: 21, offset: 98783},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3233, col: 21, offset: 98781},
+					pos: position{line: 3233, col: 21, offset: 98783},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3233, col: 21, offset: 98781},
+							pos:  position{line: 3233, col: 21, offset: 98783},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3233, col: 27, offset: 98787},
+							pos:   position{line: 3233, col: 27, offset: 98789},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3233, col: 32, offset: 98792},
+								pos:  position{line: 3233, col: 32, offset: 98794},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7504,67 +7504,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3243, col: 1, offset: 99036},
+			pos:  position{line: 3243, col: 1, offset: 99038},
 			expr: &choiceExpr{
-				pos: position{line: 3243, col: 22, offset: 99057},
+				pos: position{line: 3243, col: 22, offset: 99059},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3243, col: 22, offset: 99057},
+						pos: position{line: 3243, col: 22, offset: 99059},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3243, col: 22, offset: 99057},
+							pos: position{line: 3243, col: 22, offset: 99059},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 22, offset: 99057},
+									pos:  position{line: 3243, col: 22, offset: 99059},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3243, col: 30, offset: 99065},
+									pos:   position{line: 3243, col: 30, offset: 99067},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3243, col: 35, offset: 99070},
+										pos:  position{line: 3243, col: 35, offset: 99072},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 53, offset: 99088},
+									pos:  position{line: 3243, col: 53, offset: 99090},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3246, col: 3, offset: 99123},
+						pos: position{line: 3246, col: 3, offset: 99125},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3246, col: 3, offset: 99123},
+							pos:   position{line: 3246, col: 3, offset: 99125},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3246, col: 20, offset: 99140},
+								pos:  position{line: 3246, col: 20, offset: 99142},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3249, col: 3, offset: 99194},
+						pos: position{line: 3249, col: 3, offset: 99196},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3249, col: 3, offset: 99194},
+							pos:   position{line: 3249, col: 3, offset: 99196},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3249, col: 9, offset: 99200},
+								pos:  position{line: 3249, col: 9, offset: 99202},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3259, col: 3, offset: 99419},
+						pos: position{line: 3259, col: 3, offset: 99421},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3259, col: 3, offset: 99419},
+							pos:   position{line: 3259, col: 3, offset: 99421},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3259, col: 10, offset: 99426},
+								pos:  position{line: 3259, col: 10, offset: 99428},
 								name: "NumberAsString",
 							},
 						},
@@ -7574,144 +7574,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3272, col: 1, offset: 99804},
+			pos:  position{line: 3272, col: 1, offset: 99806},
 			expr: &choiceExpr{
-				pos: position{line: 3272, col: 20, offset: 99823},
+				pos: position{line: 3272, col: 20, offset: 99825},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3272, col: 20, offset: 99823},
+						pos: position{line: 3272, col: 20, offset: 99825},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3272, col: 21, offset: 99824},
+							pos: position{line: 3272, col: 21, offset: 99826},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3272, col: 21, offset: 99824},
+									pos:   position{line: 3272, col: 21, offset: 99826},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3272, col: 29, offset: 99832},
+										pos: position{line: 3272, col: 29, offset: 99834},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3272, col: 29, offset: 99832},
+												pos:        position{line: 3272, col: 29, offset: 99834},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 37, offset: 99840},
+												pos:        position{line: 3272, col: 37, offset: 99842},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 46, offset: 99849},
+												pos:        position{line: 3272, col: 46, offset: 99851},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 58, offset: 99861},
+												pos:        position{line: 3272, col: 58, offset: 99863},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 67, offset: 99870},
+												pos:        position{line: 3272, col: 67, offset: 99872},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 77, offset: 99880},
+												pos:        position{line: 3272, col: 77, offset: 99882},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 85, offset: 99888},
+												pos:        position{line: 3272, col: 85, offset: 99890},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 95, offset: 99898},
+												pos:        position{line: 3272, col: 95, offset: 99900},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 102, offset: 99905},
+												pos:        position{line: 3272, col: 102, offset: 99907},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 113, offset: 99916},
+												pos:        position{line: 3272, col: 113, offset: 99918},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 123, offset: 99926},
+												pos:        position{line: 3272, col: 123, offset: 99928},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 132, offset: 99935},
+												pos:        position{line: 3272, col: 132, offset: 99937},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 142, offset: 99945},
+												pos:        position{line: 3272, col: 142, offset: 99947},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 151, offset: 99954},
+												pos:        position{line: 3272, col: 151, offset: 99956},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 161, offset: 99964},
+												pos:        position{line: 3272, col: 161, offset: 99966},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 170, offset: 99973},
+												pos:        position{line: 3272, col: 170, offset: 99975},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 179, offset: 99982},
+												pos:        position{line: 3272, col: 179, offset: 99984},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 187, offset: 99990},
+												pos:        position{line: 3272, col: 187, offset: 99992},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 196, offset: 99999},
+												pos:        position{line: 3272, col: 196, offset: 100001},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 204, offset: 100007},
+												pos:        position{line: 3272, col: 204, offset: 100009},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3272, col: 213, offset: 100016},
+												pos:        position{line: 3272, col: 213, offset: 100018},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7720,102 +7720,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3272, col: 220, offset: 100023},
+									pos:  position{line: 3272, col: 220, offset: 100025},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3272, col: 228, offset: 100031},
+									pos:   position{line: 3272, col: 228, offset: 100033},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3272, col: 234, offset: 100037},
+										pos:  position{line: 3272, col: 234, offset: 100039},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3272, col: 253, offset: 100056},
+									pos:  position{line: 3272, col: 253, offset: 100058},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3292, col: 3, offset: 100568},
+						pos: position{line: 3292, col: 3, offset: 100570},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3292, col: 3, offset: 100568},
+							pos: position{line: 3292, col: 3, offset: 100570},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3292, col: 3, offset: 100568},
+									pos:   position{line: 3292, col: 3, offset: 100570},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3292, col: 13, offset: 100578},
+										pos:        position{line: 3292, col: 13, offset: 100580},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 21, offset: 100586},
+									pos:  position{line: 3292, col: 21, offset: 100588},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3292, col: 29, offset: 100594},
+									pos:   position{line: 3292, col: 29, offset: 100596},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3292, col: 35, offset: 100600},
+										pos:  position{line: 3292, col: 35, offset: 100602},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3292, col: 54, offset: 100619},
+									pos:   position{line: 3292, col: 54, offset: 100621},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3292, col: 69, offset: 100634},
+										pos: position{line: 3292, col: 69, offset: 100636},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3292, col: 70, offset: 100635},
+											pos:  position{line: 3292, col: 70, offset: 100637},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 89, offset: 100654},
+									pos:  position{line: 3292, col: 89, offset: 100656},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3313, col: 3, offset: 101272},
+						pos: position{line: 3313, col: 3, offset: 101274},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3313, col: 4, offset: 101273},
+							pos: position{line: 3313, col: 4, offset: 101275},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3313, col: 4, offset: 101273},
+									pos:   position{line: 3313, col: 4, offset: 101275},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3313, col: 12, offset: 101281},
+										pos: position{line: 3313, col: 12, offset: 101283},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3313, col: 12, offset: 101281},
+												pos:        position{line: 3313, col: 12, offset: 101283},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 20, offset: 101289},
+												pos:        position{line: 3313, col: 20, offset: 101291},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 27, offset: 101296},
+												pos:        position{line: 3313, col: 27, offset: 101298},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3313, col: 38, offset: 101307},
+												pos:        position{line: 3313, col: 38, offset: 101309},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7824,54 +7824,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 46, offset: 101315},
+									pos:  position{line: 3313, col: 46, offset: 101317},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 54, offset: 101323},
+									pos:  position{line: 3313, col: 54, offset: 101325},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3326, col: 3, offset: 101609},
+						pos: position{line: 3326, col: 3, offset: 101611},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3326, col: 3, offset: 101609},
+							pos: position{line: 3326, col: 3, offset: 101611},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3326, col: 3, offset: 101609},
+									pos:        position{line: 3326, col: 3, offset: 101611},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3326, col: 14, offset: 101620},
+									pos:  position{line: 3326, col: 14, offset: 101622},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3326, col: 22, offset: 101628},
+									pos:   position{line: 3326, col: 22, offset: 101630},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3326, col: 33, offset: 101639},
+										pos:  position{line: 3326, col: 33, offset: 101641},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3326, col: 44, offset: 101650},
+									pos:   position{line: 3326, col: 44, offset: 101652},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3326, col: 53, offset: 101659},
+										pos: position{line: 3326, col: 53, offset: 101661},
 										expr: &seqExpr{
-											pos: position{line: 3326, col: 54, offset: 101660},
+											pos: position{line: 3326, col: 54, offset: 101662},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3326, col: 54, offset: 101660},
+													pos:  position{line: 3326, col: 54, offset: 101662},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3326, col: 60, offset: 101666},
+													pos:  position{line: 3326, col: 60, offset: 101668},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -7879,73 +7879,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3326, col: 80, offset: 101686},
+									pos:  position{line: 3326, col: 80, offset: 101688},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3354, col: 3, offset: 102528},
+						pos: position{line: 3354, col: 3, offset: 102530},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3354, col: 3, offset: 102528},
+							pos: position{line: 3354, col: 3, offset: 102530},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3354, col: 3, offset: 102528},
+									pos:   position{line: 3354, col: 3, offset: 102530},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3354, col: 12, offset: 102537},
+										pos:        position{line: 3354, col: 12, offset: 102539},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3354, col: 18, offset: 102543},
+									pos:  position{line: 3354, col: 18, offset: 102545},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3354, col: 26, offset: 102551},
+									pos:   position{line: 3354, col: 26, offset: 102553},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3354, col: 31, offset: 102556},
+										pos:  position{line: 3354, col: 31, offset: 102558},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3354, col: 39, offset: 102564},
+									pos:  position{line: 3354, col: 39, offset: 102566},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3357, col: 3, offset: 102599},
+						pos: position{line: 3357, col: 3, offset: 102601},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3357, col: 4, offset: 102600},
+							pos: position{line: 3357, col: 4, offset: 102602},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3357, col: 4, offset: 102600},
+									pos:   position{line: 3357, col: 4, offset: 102602},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3357, col: 12, offset: 102608},
+										pos: position{line: 3357, col: 12, offset: 102610},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3357, col: 12, offset: 102608},
+												pos:        position{line: 3357, col: 12, offset: 102610},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3357, col: 20, offset: 102616},
+												pos:        position{line: 3357, col: 20, offset: 102618},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3357, col: 30, offset: 102626},
+												pos:        position{line: 3357, col: 30, offset: 102628},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -7954,128 +7954,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3357, col: 39, offset: 102635},
+									pos:  position{line: 3357, col: 39, offset: 102637},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3357, col: 47, offset: 102643},
+									pos:   position{line: 3357, col: 47, offset: 102645},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3357, col: 53, offset: 102649},
+										pos:  position{line: 3357, col: 53, offset: 102651},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3357, col: 72, offset: 102668},
+									pos:   position{line: 3357, col: 72, offset: 102670},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3357, col: 79, offset: 102675},
+										pos:  position{line: 3357, col: 79, offset: 102677},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3357, col: 97, offset: 102693},
+									pos:  position{line: 3357, col: 97, offset: 102695},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3387, col: 3, offset: 103532},
+						pos: position{line: 3387, col: 3, offset: 103534},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3387, col: 4, offset: 103533},
+							pos: position{line: 3387, col: 4, offset: 103535},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3387, col: 4, offset: 103533},
+									pos:   position{line: 3387, col: 4, offset: 103535},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3387, col: 11, offset: 103540},
+										pos:        position{line: 3387, col: 11, offset: 103542},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3387, col: 17, offset: 103546},
+									pos:  position{line: 3387, col: 17, offset: 103548},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3387, col: 25, offset: 103554},
+									pos:   position{line: 3387, col: 25, offset: 103556},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3387, col: 31, offset: 103560},
+										pos:  position{line: 3387, col: 31, offset: 103562},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3387, col: 50, offset: 103579},
+									pos:   position{line: 3387, col: 50, offset: 103581},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3387, col: 56, offset: 103585},
+										pos: position{line: 3387, col: 56, offset: 103587},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3387, col: 57, offset: 103586},
+											pos:  position{line: 3387, col: 57, offset: 103588},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3387, col: 76, offset: 103605},
+									pos:  position{line: 3387, col: 76, offset: 103607},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3416, col: 3, offset: 104378},
+						pos: position{line: 3416, col: 3, offset: 104380},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3416, col: 3, offset: 104378},
+							pos: position{line: 3416, col: 3, offset: 104380},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3416, col: 3, offset: 104378},
+									pos:   position{line: 3416, col: 3, offset: 104380},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3416, col: 11, offset: 104386},
+										pos:        position{line: 3416, col: 11, offset: 104388},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 28, offset: 104403},
+									pos:  position{line: 3416, col: 28, offset: 104405},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3416, col: 36, offset: 104411},
+									pos:   position{line: 3416, col: 36, offset: 104413},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3416, col: 42, offset: 104417},
+										pos:  position{line: 3416, col: 42, offset: 104419},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 61, offset: 104436},
+									pos:  position{line: 3416, col: 61, offset: 104438},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 67, offset: 104442},
+									pos:  position{line: 3416, col: 67, offset: 104444},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3416, col: 73, offset: 104448},
+									pos:   position{line: 3416, col: 73, offset: 104450},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3416, col: 84, offset: 104459},
+										pos:  position{line: 3416, col: 84, offset: 104461},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 120, offset: 104495},
+									pos:  position{line: 3416, col: 120, offset: 104497},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 126, offset: 104501},
+									pos:  position{line: 3416, col: 126, offset: 104503},
 									name: "R_PAREN",
 								},
 							},
@@ -8086,28 +8086,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3433, col: 1, offset: 105030},
+			pos:  position{line: 3433, col: 1, offset: 105032},
 			expr: &choiceExpr{
-				pos: position{line: 3433, col: 12, offset: 105041},
+				pos: position{line: 3433, col: 12, offset: 105043},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3433, col: 12, offset: 105041},
+						pos: position{line: 3433, col: 12, offset: 105043},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3433, col: 12, offset: 105041},
+							pos: position{line: 3433, col: 12, offset: 105043},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3433, col: 12, offset: 105041},
+									pos:   position{line: 3433, col: 12, offset: 105043},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3433, col: 16, offset: 105045},
+										pos:  position{line: 3433, col: 16, offset: 105047},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3433, col: 29, offset: 105058},
+									pos: position{line: 3433, col: 29, offset: 105060},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3433, col: 31, offset: 105060},
+										pos:  position{line: 3433, col: 31, offset: 105062},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8115,50 +8115,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3449, col: 3, offset: 105421},
+						pos: position{line: 3449, col: 3, offset: 105423},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3449, col: 3, offset: 105421},
+							pos: position{line: 3449, col: 3, offset: 105423},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3449, col: 3, offset: 105421},
+									pos:   position{line: 3449, col: 3, offset: 105423},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3449, col: 9, offset: 105427},
+										pos:  position{line: 3449, col: 9, offset: 105429},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3449, col: 25, offset: 105443},
+									pos: position{line: 3449, col: 25, offset: 105445},
 									expr: &choiceExpr{
-										pos: position{line: 3449, col: 27, offset: 105445},
+										pos: position{line: 3449, col: 27, offset: 105447},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 27, offset: 105445},
+												pos:  position{line: 3449, col: 27, offset: 105447},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 36, offset: 105454},
+												pos:  position{line: 3449, col: 36, offset: 105456},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 46, offset: 105464},
+												pos:  position{line: 3449, col: 46, offset: 105466},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 54, offset: 105472},
+												pos:  position{line: 3449, col: 54, offset: 105474},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 62, offset: 105480},
+												pos:  position{line: 3449, col: 62, offset: 105482},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3449, col: 70, offset: 105488},
+												pos:  position{line: 3449, col: 70, offset: 105490},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3449, col: 84, offset: 105502},
+												pos:        position{line: 3449, col: 84, offset: 105504},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8174,28 +8174,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3466, col: 1, offset: 105853},
+			pos:  position{line: 3466, col: 1, offset: 105855},
 			expr: &actionExpr{
-				pos: position{line: 3466, col: 19, offset: 105871},
+				pos: position{line: 3466, col: 19, offset: 105873},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3466, col: 19, offset: 105871},
+					pos: position{line: 3466, col: 19, offset: 105873},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3466, col: 19, offset: 105871},
+							pos:        position{line: 3466, col: 19, offset: 105873},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3466, col: 26, offset: 105878},
+							pos:  position{line: 3466, col: 26, offset: 105880},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3466, col: 32, offset: 105884},
+							pos:   position{line: 3466, col: 32, offset: 105886},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3466, col: 40, offset: 105892},
+								pos:  position{line: 3466, col: 40, offset: 105894},
 								name: "Boolean",
 							},
 						},
@@ -8205,28 +8205,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3477, col: 1, offset: 106081},
+			pos:  position{line: 3477, col: 1, offset: 106083},
 			expr: &actionExpr{
-				pos: position{line: 3477, col: 23, offset: 106103},
+				pos: position{line: 3477, col: 23, offset: 106105},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3477, col: 23, offset: 106103},
+					pos: position{line: 3477, col: 23, offset: 106105},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3477, col: 23, offset: 106103},
+							pos:        position{line: 3477, col: 23, offset: 106105},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3477, col: 34, offset: 106114},
+							pos:  position{line: 3477, col: 34, offset: 106116},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3477, col: 40, offset: 106120},
+							pos:   position{line: 3477, col: 40, offset: 106122},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3477, col: 48, offset: 106128},
+								pos:  position{line: 3477, col: 48, offset: 106130},
 								name: "Boolean",
 							},
 						},
@@ -8236,28 +8236,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3488, col: 1, offset: 106325},
+			pos:  position{line: 3488, col: 1, offset: 106327},
 			expr: &actionExpr{
-				pos: position{line: 3488, col: 20, offset: 106344},
+				pos: position{line: 3488, col: 20, offset: 106346},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3488, col: 20, offset: 106344},
+					pos: position{line: 3488, col: 20, offset: 106346},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3488, col: 20, offset: 106344},
+							pos:        position{line: 3488, col: 20, offset: 106346},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3488, col: 28, offset: 106352},
+							pos:  position{line: 3488, col: 28, offset: 106354},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3488, col: 34, offset: 106358},
+							pos:   position{line: 3488, col: 34, offset: 106360},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3488, col: 43, offset: 106367},
+								pos:  position{line: 3488, col: 43, offset: 106369},
 								name: "IntegerAsString",
 							},
 						},
@@ -8267,15 +8267,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3503, col: 1, offset: 106729},
+			pos:  position{line: 3503, col: 1, offset: 106731},
 			expr: &actionExpr{
-				pos: position{line: 3503, col: 19, offset: 106747},
+				pos: position{line: 3503, col: 19, offset: 106749},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3503, col: 19, offset: 106747},
+					pos:   position{line: 3503, col: 19, offset: 106749},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3503, col: 28, offset: 106756},
+						pos:  position{line: 3503, col: 28, offset: 106758},
 						name: "BoolExpr",
 					},
 				},
@@ -8283,30 +8283,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3514, col: 1, offset: 106968},
+			pos:  position{line: 3514, col: 1, offset: 106970},
 			expr: &actionExpr{
-				pos: position{line: 3514, col: 15, offset: 106982},
+				pos: position{line: 3514, col: 15, offset: 106984},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3514, col: 15, offset: 106982},
+					pos:   position{line: 3514, col: 15, offset: 106984},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3514, col: 23, offset: 106990},
+						pos: position{line: 3514, col: 23, offset: 106992},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 23, offset: 106990},
+								pos:  position{line: 3514, col: 23, offset: 106992},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 44, offset: 107011},
+								pos:  position{line: 3514, col: 44, offset: 107013},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 61, offset: 107028},
+								pos:  position{line: 3514, col: 61, offset: 107030},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3514, col: 79, offset: 107046},
+								pos:  position{line: 3514, col: 79, offset: 107048},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8316,35 +8316,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3518, col: 1, offset: 107090},
+			pos:  position{line: 3518, col: 1, offset: 107092},
 			expr: &actionExpr{
-				pos: position{line: 3518, col: 19, offset: 107108},
+				pos: position{line: 3518, col: 19, offset: 107110},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3518, col: 19, offset: 107108},
+					pos: position{line: 3518, col: 19, offset: 107110},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3518, col: 19, offset: 107108},
+							pos:   position{line: 3518, col: 19, offset: 107110},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3518, col: 26, offset: 107115},
+								pos:  position{line: 3518, col: 26, offset: 107117},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3518, col: 37, offset: 107126},
+							pos:   position{line: 3518, col: 37, offset: 107128},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3518, col: 43, offset: 107132},
+								pos: position{line: 3518, col: 43, offset: 107134},
 								expr: &seqExpr{
-									pos: position{line: 3518, col: 44, offset: 107133},
+									pos: position{line: 3518, col: 44, offset: 107135},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3518, col: 44, offset: 107133},
+											pos:  position{line: 3518, col: 44, offset: 107135},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3518, col: 50, offset: 107139},
+											pos:  position{line: 3518, col: 50, offset: 107141},
 											name: "HeadOption",
 										},
 									},
@@ -8357,29 +8357,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3580, col: 1, offset: 109186},
+			pos:  position{line: 3580, col: 1, offset: 109188},
 			expr: &choiceExpr{
-				pos: position{line: 3580, col: 14, offset: 109199},
+				pos: position{line: 3580, col: 14, offset: 109201},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3580, col: 14, offset: 109199},
+						pos: position{line: 3580, col: 14, offset: 109201},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3580, col: 14, offset: 109199},
+							pos: position{line: 3580, col: 14, offset: 109201},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 14, offset: 109199},
+									pos:  position{line: 3580, col: 14, offset: 109201},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 19, offset: 109204},
+									pos:  position{line: 3580, col: 19, offset: 109206},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3580, col: 28, offset: 109213},
+									pos:   position{line: 3580, col: 28, offset: 109215},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3580, col: 37, offset: 109222},
+										pos:  position{line: 3580, col: 37, offset: 109224},
 										name: "HeadOptionList",
 									},
 								},
@@ -8387,24 +8387,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3590, col: 3, offset: 109493},
+						pos: position{line: 3590, col: 3, offset: 109495},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3590, col: 3, offset: 109493},
+							pos: position{line: 3590, col: 3, offset: 109495},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3590, col: 3, offset: 109493},
+									pos:  position{line: 3590, col: 3, offset: 109495},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3590, col: 8, offset: 109498},
+									pos:  position{line: 3590, col: 8, offset: 109500},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3590, col: 17, offset: 109507},
+									pos:   position{line: 3590, col: 17, offset: 109509},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3590, col: 26, offset: 109516},
+										pos:  position{line: 3590, col: 26, offset: 109518},
 										name: "IntegerAsString",
 									},
 								},
@@ -8412,17 +8412,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3607, col: 3, offset: 109995},
+						pos: position{line: 3607, col: 3, offset: 109997},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3607, col: 3, offset: 109995},
+							pos: position{line: 3607, col: 3, offset: 109997},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3607, col: 3, offset: 109995},
+									pos:  position{line: 3607, col: 3, offset: 109997},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3607, col: 8, offset: 110000},
+									pos:  position{line: 3607, col: 8, offset: 110002},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8433,29 +8433,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3621, col: 1, offset: 110431},
+			pos:  position{line: 3621, col: 1, offset: 110433},
 			expr: &choiceExpr{
-				pos: position{line: 3621, col: 14, offset: 110444},
+				pos: position{line: 3621, col: 14, offset: 110446},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3621, col: 14, offset: 110444},
+						pos: position{line: 3621, col: 14, offset: 110446},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3621, col: 14, offset: 110444},
+							pos: position{line: 3621, col: 14, offset: 110446},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3621, col: 14, offset: 110444},
+									pos:  position{line: 3621, col: 14, offset: 110446},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3621, col: 19, offset: 110449},
+									pos:  position{line: 3621, col: 19, offset: 110451},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3621, col: 28, offset: 110458},
+									pos:   position{line: 3621, col: 28, offset: 110460},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3621, col: 37, offset: 110467},
+										pos:  position{line: 3621, col: 37, offset: 110469},
 										name: "IntegerAsString",
 									},
 								},
@@ -8463,17 +8463,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3641, col: 3, offset: 111016},
+						pos: position{line: 3641, col: 3, offset: 111018},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3641, col: 3, offset: 111016},
+							pos: position{line: 3641, col: 3, offset: 111018},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3641, col: 3, offset: 111016},
+									pos:  position{line: 3641, col: 3, offset: 111018},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3641, col: 8, offset: 111021},
+									pos:  position{line: 3641, col: 8, offset: 111023},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8484,44 +8484,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3661, col: 1, offset: 111614},
+			pos:  position{line: 3661, col: 1, offset: 111616},
 			expr: &actionExpr{
-				pos: position{line: 3661, col: 20, offset: 111633},
+				pos: position{line: 3661, col: 20, offset: 111635},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3661, col: 20, offset: 111633},
+					pos: position{line: 3661, col: 20, offset: 111635},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3661, col: 20, offset: 111633},
+							pos:   position{line: 3661, col: 20, offset: 111635},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3661, col: 26, offset: 111639},
+								pos:  position{line: 3661, col: 26, offset: 111641},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3661, col: 37, offset: 111650},
+							pos:   position{line: 3661, col: 37, offset: 111652},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3661, col: 42, offset: 111655},
+								pos: position{line: 3661, col: 42, offset: 111657},
 								expr: &seqExpr{
-									pos: position{line: 3661, col: 43, offset: 111656},
+									pos: position{line: 3661, col: 43, offset: 111658},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3661, col: 44, offset: 111657},
+											pos: position{line: 3661, col: 44, offset: 111659},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3661, col: 44, offset: 111657},
+													pos:  position{line: 3661, col: 44, offset: 111659},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3661, col: 52, offset: 111665},
+													pos:  position{line: 3661, col: 52, offset: 111667},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3661, col: 59, offset: 111672},
+											pos:  position{line: 3661, col: 59, offset: 111674},
 											name: "Aggregator",
 										},
 									},
@@ -8534,28 +8534,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3678, col: 1, offset: 112175},
+			pos:  position{line: 3678, col: 1, offset: 112177},
 			expr: &actionExpr{
-				pos: position{line: 3678, col: 15, offset: 112189},
+				pos: position{line: 3678, col: 15, offset: 112191},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3678, col: 15, offset: 112189},
+					pos: position{line: 3678, col: 15, offset: 112191},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3678, col: 15, offset: 112189},
+							pos:   position{line: 3678, col: 15, offset: 112191},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3678, col: 23, offset: 112197},
+								pos:  position{line: 3678, col: 23, offset: 112199},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3678, col: 35, offset: 112209},
+							pos:   position{line: 3678, col: 35, offset: 112211},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3678, col: 43, offset: 112217},
+								pos: position{line: 3678, col: 43, offset: 112219},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3678, col: 43, offset: 112217},
+									pos:  position{line: 3678, col: 43, offset: 112219},
 									name: "AsField",
 								},
 							},
@@ -8566,26 +8566,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3694, col: 1, offset: 113058},
+			pos:  position{line: 3694, col: 1, offset: 113060},
 			expr: &actionExpr{
-				pos: position{line: 3694, col: 16, offset: 113073},
+				pos: position{line: 3694, col: 16, offset: 113075},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3694, col: 16, offset: 113073},
+					pos:   position{line: 3694, col: 16, offset: 113075},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3694, col: 21, offset: 113078},
+						pos: position{line: 3694, col: 21, offset: 113080},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 21, offset: 113078},
+								pos:  position{line: 3694, col: 21, offset: 113080},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 32, offset: 113089},
+								pos:  position{line: 3694, col: 32, offset: 113091},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3694, col: 48, offset: 113105},
+								pos:  position{line: 3694, col: 48, offset: 113107},
 								name: "AggCommon",
 							},
 						},
@@ -8595,165 +8595,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3699, col: 1, offset: 113311},
+			pos:  position{line: 3699, col: 1, offset: 113313},
 			expr: &actionExpr{
-				pos: position{line: 3699, col: 18, offset: 113328},
+				pos: position{line: 3699, col: 18, offset: 113330},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3699, col: 19, offset: 113329},
+					pos: position{line: 3699, col: 19, offset: 113331},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3699, col: 19, offset: 113329},
+							pos:        position{line: 3699, col: 19, offset: 113331},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 30, offset: 113340},
+							pos:        position{line: 3699, col: 30, offset: 113342},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 39, offset: 113349},
+							pos:        position{line: 3699, col: 39, offset: 113351},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 47, offset: 113357},
+							pos:        position{line: 3699, col: 47, offset: 113359},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 57, offset: 113367},
+							pos:        position{line: 3699, col: 57, offset: 113369},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 65, offset: 113375},
+							pos:        position{line: 3699, col: 65, offset: 113377},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 76, offset: 113386},
+							pos:        position{line: 3699, col: 76, offset: 113388},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 86, offset: 113396},
+							pos:        position{line: 3699, col: 86, offset: 113398},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 95, offset: 113405},
+							pos:        position{line: 3699, col: 95, offset: 113407},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 105, offset: 113415},
+							pos:        position{line: 3699, col: 105, offset: 113417},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 114, offset: 113424},
+							pos:        position{line: 3699, col: 114, offset: 113426},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 122, offset: 113432},
+							pos:        position{line: 3699, col: 122, offset: 113434},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 133, offset: 113443},
+							pos:        position{line: 3699, col: 133, offset: 113445},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 142, offset: 113452},
+							pos:        position{line: 3699, col: 142, offset: 113454},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 1, offset: 113461},
+							pos:        position{line: 3700, col: 1, offset: 113463},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 10, offset: 113470},
+							pos:        position{line: 3700, col: 10, offset: 113472},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 26, offset: 113486},
+							pos:        position{line: 3700, col: 26, offset: 113488},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 37, offset: 113497},
+							pos:        position{line: 3700, col: 37, offset: 113499},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 46, offset: 113506},
+							pos:        position{line: 3700, col: 46, offset: 113508},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 56, offset: 113516},
+							pos:        position{line: 3700, col: 56, offset: 113518},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 72, offset: 113532},
+							pos:        position{line: 3700, col: 72, offset: 113534},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 82, offset: 113542},
+							pos:        position{line: 3700, col: 82, offset: 113544},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 100, offset: 113560},
+							pos:        position{line: 3700, col: 100, offset: 113562},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 113, offset: 113573},
+							pos:        position{line: 3700, col: 113, offset: 113575},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 132, offset: 113592},
+							pos:        position{line: 3700, col: 132, offset: 113594},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 139, offset: 113599},
+							pos:        position{line: 3700, col: 139, offset: 113601},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8764,27 +8764,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3704, col: 1, offset: 113642},
+			pos:  position{line: 3704, col: 1, offset: 113644},
 			expr: &actionExpr{
-				pos: position{line: 3704, col: 22, offset: 113663},
+				pos: position{line: 3704, col: 22, offset: 113665},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3704, col: 23, offset: 113664},
+					pos: position{line: 3704, col: 23, offset: 113666},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3704, col: 23, offset: 113664},
+							pos:        position{line: 3704, col: 23, offset: 113666},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3704, col: 37, offset: 113678},
+							pos:        position{line: 3704, col: 37, offset: 113680},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3704, col: 51, offset: 113692},
+							pos:        position{line: 3704, col: 51, offset: 113694},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8795,29 +8795,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3708, col: 1, offset: 113736},
+			pos:  position{line: 3708, col: 1, offset: 113738},
 			expr: &actionExpr{
-				pos: position{line: 3708, col: 12, offset: 113747},
+				pos: position{line: 3708, col: 12, offset: 113749},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3708, col: 12, offset: 113747},
+					pos: position{line: 3708, col: 12, offset: 113749},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3708, col: 12, offset: 113747},
+							pos:  position{line: 3708, col: 12, offset: 113749},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3708, col: 15, offset: 113750},
+							pos:   position{line: 3708, col: 15, offset: 113752},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3708, col: 23, offset: 113758},
+								pos: position{line: 3708, col: 23, offset: 113760},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3708, col: 23, offset: 113758},
+										pos:  position{line: 3708, col: 23, offset: 113760},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3708, col: 35, offset: 113770},
+										pos:  position{line: 3708, col: 35, offset: 113772},
 										name: "String",
 									},
 								},
@@ -8829,27 +8829,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3722, col: 1, offset: 114099},
+			pos:  position{line: 3722, col: 1, offset: 114101},
 			expr: &choiceExpr{
-				pos: position{line: 3722, col: 13, offset: 114111},
+				pos: position{line: 3722, col: 13, offset: 114113},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3722, col: 13, offset: 114111},
+						pos: position{line: 3722, col: 13, offset: 114113},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3722, col: 13, offset: 114111},
+							pos: position{line: 3722, col: 13, offset: 114113},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3722, col: 14, offset: 114112},
+									pos: position{line: 3722, col: 14, offset: 114114},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3722, col: 14, offset: 114112},
+											pos:        position{line: 3722, col: 14, offset: 114114},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3722, col: 24, offset: 114122},
+											pos:        position{line: 3722, col: 24, offset: 114124},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8857,47 +8857,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3722, col: 29, offset: 114127},
+									pos:  position{line: 3722, col: 29, offset: 114129},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3722, col: 37, offset: 114135},
+									pos:        position{line: 3722, col: 37, offset: 114137},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3722, col: 44, offset: 114142},
+									pos:   position{line: 3722, col: 44, offset: 114144},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3722, col: 54, offset: 114152},
+										pos:  position{line: 3722, col: 54, offset: 114154},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3722, col: 64, offset: 114162},
+									pos:  position{line: 3722, col: 64, offset: 114164},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3732, col: 3, offset: 114390},
+						pos: position{line: 3732, col: 3, offset: 114392},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3732, col: 3, offset: 114390},
+							pos: position{line: 3732, col: 3, offset: 114392},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3732, col: 4, offset: 114391},
+									pos: position{line: 3732, col: 4, offset: 114393},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3732, col: 4, offset: 114391},
+											pos:        position{line: 3732, col: 4, offset: 114393},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3732, col: 14, offset: 114401},
+											pos:        position{line: 3732, col: 14, offset: 114403},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8905,38 +8905,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 19, offset: 114406},
+									pos:  position{line: 3732, col: 19, offset: 114408},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3732, col: 27, offset: 114414},
+									pos:   position{line: 3732, col: 27, offset: 114416},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3732, col: 33, offset: 114420},
+										pos:  position{line: 3732, col: 33, offset: 114422},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 43, offset: 114430},
+									pos:  position{line: 3732, col: 43, offset: 114432},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3739, col: 5, offset: 114581},
+						pos: position{line: 3739, col: 5, offset: 114583},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3739, col: 6, offset: 114582},
+							pos: position{line: 3739, col: 6, offset: 114584},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3739, col: 6, offset: 114582},
+									pos:        position{line: 3739, col: 6, offset: 114584},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3739, col: 16, offset: 114592},
+									pos:        position{line: 3739, col: 16, offset: 114594},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -8949,77 +8949,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3748, col: 1, offset: 114728},
+			pos:  position{line: 3748, col: 1, offset: 114730},
 			expr: &choiceExpr{
-				pos: position{line: 3748, col: 14, offset: 114741},
+				pos: position{line: 3748, col: 14, offset: 114743},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3748, col: 14, offset: 114741},
+						pos: position{line: 3748, col: 14, offset: 114743},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3748, col: 14, offset: 114741},
+							pos: position{line: 3748, col: 14, offset: 114743},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3748, col: 14, offset: 114741},
+									pos:   position{line: 3748, col: 14, offset: 114743},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3748, col: 22, offset: 114749},
+										pos:  position{line: 3748, col: 22, offset: 114751},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 36, offset: 114763},
+									pos:  position{line: 3748, col: 36, offset: 114765},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3748, col: 44, offset: 114771},
+									pos:        position{line: 3748, col: 44, offset: 114773},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3748, col: 51, offset: 114778},
+									pos:   position{line: 3748, col: 51, offset: 114780},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3748, col: 61, offset: 114788},
+										pos:  position{line: 3748, col: 61, offset: 114790},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 71, offset: 114798},
+									pos:  position{line: 3748, col: 71, offset: 114800},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3763, col: 3, offset: 115208},
+						pos: position{line: 3763, col: 3, offset: 115210},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3763, col: 3, offset: 115208},
+							pos: position{line: 3763, col: 3, offset: 115210},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3763, col: 3, offset: 115208},
+									pos:   position{line: 3763, col: 3, offset: 115210},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3763, col: 11, offset: 115216},
+										pos:  position{line: 3763, col: 11, offset: 115218},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3763, col: 25, offset: 115230},
+									pos:  position{line: 3763, col: 25, offset: 115232},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3763, col: 33, offset: 115238},
+									pos:   position{line: 3763, col: 33, offset: 115240},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3763, col: 39, offset: 115244},
+										pos:  position{line: 3763, col: 39, offset: 115246},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3763, col: 49, offset: 115254},
+									pos:  position{line: 3763, col: 49, offset: 115256},
 									name: "R_PAREN",
 								},
 							},
@@ -9030,22 +9030,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3777, col: 1, offset: 115586},
+			pos:  position{line: 3777, col: 1, offset: 115588},
 			expr: &actionExpr{
-				pos: position{line: 3777, col: 18, offset: 115603},
+				pos: position{line: 3777, col: 18, offset: 115605},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3777, col: 18, offset: 115603},
+					pos:   position{line: 3777, col: 18, offset: 115605},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3777, col: 26, offset: 115611},
+						pos: position{line: 3777, col: 26, offset: 115613},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3777, col: 26, offset: 115611},
+								pos:  position{line: 3777, col: 26, offset: 115613},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3777, col: 42, offset: 115627},
+								pos:  position{line: 3777, col: 42, offset: 115629},
 								name: "IntegerAsString",
 							},
 						},
@@ -9055,93 +9055,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3789, col: 1, offset: 116001},
+			pos:  position{line: 3789, col: 1, offset: 116003},
 			expr: &choiceExpr{
-				pos: position{line: 3789, col: 18, offset: 116018},
+				pos: position{line: 3789, col: 18, offset: 116020},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3789, col: 18, offset: 116018},
+						pos: position{line: 3789, col: 18, offset: 116020},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3789, col: 18, offset: 116018},
+							pos: position{line: 3789, col: 18, offset: 116020},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3789, col: 18, offset: 116018},
+									pos:   position{line: 3789, col: 18, offset: 116020},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 26, offset: 116026},
+										pos:  position{line: 3789, col: 26, offset: 116028},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3789, col: 44, offset: 116044},
+									pos:   position{line: 3789, col: 44, offset: 116046},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 58, offset: 116058},
+										pos:  position{line: 3789, col: 58, offset: 116060},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3789, col: 72, offset: 116072},
+									pos:  position{line: 3789, col: 72, offset: 116074},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3789, col: 80, offset: 116080},
+									pos:        position{line: 3789, col: 80, offset: 116082},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3789, col: 87, offset: 116087},
+									pos:   position{line: 3789, col: 87, offset: 116089},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3789, col: 97, offset: 116097},
+										pos:  position{line: 3789, col: 97, offset: 116099},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3789, col: 107, offset: 116107},
+									pos:  position{line: 3789, col: 107, offset: 116109},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3805, col: 3, offset: 116556},
+						pos: position{line: 3805, col: 3, offset: 116558},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3805, col: 3, offset: 116556},
+							pos: position{line: 3805, col: 3, offset: 116558},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3805, col: 3, offset: 116556},
+									pos:   position{line: 3805, col: 3, offset: 116558},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 11, offset: 116564},
+										pos:  position{line: 3805, col: 11, offset: 116566},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3805, col: 29, offset: 116582},
+									pos:   position{line: 3805, col: 29, offset: 116584},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 43, offset: 116596},
+										pos:  position{line: 3805, col: 43, offset: 116598},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3805, col: 57, offset: 116610},
+									pos:  position{line: 3805, col: 57, offset: 116612},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3805, col: 65, offset: 116618},
+									pos:   position{line: 3805, col: 65, offset: 116620},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3805, col: 71, offset: 116624},
+										pos:  position{line: 3805, col: 71, offset: 116626},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3805, col: 81, offset: 116634},
+									pos:  position{line: 3805, col: 81, offset: 116636},
 									name: "R_PAREN",
 								},
 							},
@@ -9152,22 +9152,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3821, col: 1, offset: 117006},
+			pos:  position{line: 3821, col: 1, offset: 117008},
 			expr: &actionExpr{
-				pos: position{line: 3821, col: 25, offset: 117030},
+				pos: position{line: 3821, col: 25, offset: 117032},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3821, col: 25, offset: 117030},
+					pos:   position{line: 3821, col: 25, offset: 117032},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3821, col: 39, offset: 117044},
+						pos: position{line: 3821, col: 39, offset: 117046},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3821, col: 39, offset: 117044},
+								pos:  position{line: 3821, col: 39, offset: 117046},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3821, col: 67, offset: 117072},
+								pos:  position{line: 3821, col: 67, offset: 117074},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9177,43 +9177,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3825, col: 1, offset: 117135},
+			pos:  position{line: 3825, col: 1, offset: 117137},
 			expr: &actionExpr{
-				pos: position{line: 3825, col: 30, offset: 117164},
+				pos: position{line: 3825, col: 30, offset: 117166},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3825, col: 30, offset: 117164},
+					pos: position{line: 3825, col: 30, offset: 117166},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3825, col: 30, offset: 117164},
+							pos:   position{line: 3825, col: 30, offset: 117166},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3825, col: 34, offset: 117168},
+								pos:  position{line: 3825, col: 34, offset: 117170},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3825, col: 44, offset: 117178},
+							pos:   position{line: 3825, col: 44, offset: 117180},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3825, col: 48, offset: 117182},
+								pos: position{line: 3825, col: 48, offset: 117184},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3825, col: 48, offset: 117182},
+										pos:  position{line: 3825, col: 48, offset: 117184},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3825, col: 67, offset: 117201},
+										pos:  position{line: 3825, col: 67, offset: 117203},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3825, col: 87, offset: 117221},
+							pos:   position{line: 3825, col: 87, offset: 117223},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3825, col: 93, offset: 117227},
+								pos:  position{line: 3825, col: 93, offset: 117229},
 								name: "Number",
 							},
 						},
@@ -9223,15 +9223,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3838, col: 1, offset: 117461},
+			pos:  position{line: 3838, col: 1, offset: 117463},
 			expr: &actionExpr{
-				pos: position{line: 3838, col: 32, offset: 117492},
+				pos: position{line: 3838, col: 32, offset: 117494},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3838, col: 32, offset: 117492},
+					pos:   position{line: 3838, col: 32, offset: 117494},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3838, col: 38, offset: 117498},
+						pos:  position{line: 3838, col: 38, offset: 117500},
 						name: "Number",
 					},
 				},
@@ -9239,34 +9239,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3851, col: 1, offset: 117715},
+			pos:  position{line: 3851, col: 1, offset: 117717},
 			expr: &actionExpr{
-				pos: position{line: 3851, col: 26, offset: 117740},
+				pos: position{line: 3851, col: 26, offset: 117742},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3851, col: 26, offset: 117740},
+					pos: position{line: 3851, col: 26, offset: 117742},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3851, col: 26, offset: 117740},
+							pos:   position{line: 3851, col: 26, offset: 117742},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 30, offset: 117744},
+								pos:  position{line: 3851, col: 30, offset: 117746},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3851, col: 40, offset: 117754},
+							pos:   position{line: 3851, col: 40, offset: 117756},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 43, offset: 117757},
+								pos:  position{line: 3851, col: 43, offset: 117759},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3851, col: 60, offset: 117774},
+							pos:   position{line: 3851, col: 60, offset: 117776},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 66, offset: 117780},
+								pos:  position{line: 3851, col: 66, offset: 117782},
 								name: "Boolean",
 							},
 						},
@@ -9276,22 +9276,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3864, col: 1, offset: 118015},
+			pos:  position{line: 3864, col: 1, offset: 118017},
 			expr: &actionExpr{
-				pos: position{line: 3864, col: 25, offset: 118039},
+				pos: position{line: 3864, col: 25, offset: 118041},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3864, col: 25, offset: 118039},
+					pos:   position{line: 3864, col: 25, offset: 118041},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3864, col: 39, offset: 118053},
+						pos: position{line: 3864, col: 39, offset: 118055},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3864, col: 39, offset: 118053},
+								pos:  position{line: 3864, col: 39, offset: 118055},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3864, col: 67, offset: 118081},
+								pos:  position{line: 3864, col: 67, offset: 118083},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9301,41 +9301,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3868, col: 1, offset: 118144},
+			pos:  position{line: 3868, col: 1, offset: 118146},
 			expr: &actionExpr{
-				pos: position{line: 3868, col: 30, offset: 118173},
+				pos: position{line: 3868, col: 30, offset: 118175},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3868, col: 30, offset: 118173},
+					pos: position{line: 3868, col: 30, offset: 118175},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3868, col: 30, offset: 118173},
+							pos:   position{line: 3868, col: 30, offset: 118175},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3868, col: 34, offset: 118177},
+								pos:  position{line: 3868, col: 34, offset: 118179},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3868, col: 44, offset: 118187},
+							pos:   position{line: 3868, col: 44, offset: 118189},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3868, col: 47, offset: 118190},
+								pos:  position{line: 3868, col: 47, offset: 118192},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3868, col: 64, offset: 118207},
+							pos:   position{line: 3868, col: 64, offset: 118209},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 3868, col: 81, offset: 118224},
+								pos: position{line: 3868, col: 81, offset: 118226},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3868, col: 81, offset: 118224},
+										pos:  position{line: 3868, col: 81, offset: 118226},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3868, col: 103, offset: 118246},
+										pos:  position{line: 3868, col: 103, offset: 118248},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9347,22 +9347,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3882, col: 1, offset: 118609},
+			pos:  position{line: 3882, col: 1, offset: 118615},
 			expr: &actionExpr{
-				pos: position{line: 3882, col: 32, offset: 118640},
+				pos: position{line: 3882, col: 32, offset: 118646},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3882, col: 32, offset: 118640},
+					pos:   position{line: 3882, col: 32, offset: 118646},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 3882, col: 49, offset: 118657},
+						pos: position{line: 3882, col: 49, offset: 118663},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3882, col: 49, offset: 118657},
+								pos:  position{line: 3882, col: 49, offset: 118663},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3882, col: 71, offset: 118679},
+								pos:  position{line: 3882, col: 71, offset: 118685},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9372,33 +9372,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 3896, col: 1, offset: 119025},
+			pos:  position{line: 3896, col: 1, offset: 119035},
 			expr: &actionExpr{
-				pos: position{line: 3896, col: 24, offset: 119048},
+				pos: position{line: 3896, col: 24, offset: 119058},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 3896, col: 24, offset: 119048},
+					pos: position{line: 3896, col: 24, offset: 119058},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3896, col: 24, offset: 119048},
+							pos:        position{line: 3896, col: 24, offset: 119058},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3896, col: 31, offset: 119055},
+							pos:  position{line: 3896, col: 31, offset: 119065},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 3896, col: 39, offset: 119063},
+							pos:   position{line: 3896, col: 39, offset: 119073},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3896, col: 45, offset: 119069},
+								pos:  position{line: 3896, col: 45, offset: 119079},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3896, col: 52, offset: 119076},
+							pos:  position{line: 3896, col: 52, offset: 119086},
 							name: "R_PAREN",
 						},
 					},
@@ -9407,15 +9407,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 3903, col: 1, offset: 119191},
+			pos:  position{line: 3903, col: 1, offset: 119204},
 			expr: &actionExpr{
-				pos: position{line: 3903, col: 26, offset: 119216},
+				pos: position{line: 3903, col: 26, offset: 119229},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3903, col: 26, offset: 119216},
+					pos:   position{line: 3903, col: 26, offset: 119229},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3903, col: 32, offset: 119222},
+						pos:  position{line: 3903, col: 32, offset: 119235},
 						name: "String",
 					},
 				},
@@ -9423,35 +9423,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 3912, col: 1, offset: 119478},
+			pos:  position{line: 3912, col: 1, offset: 119492},
 			expr: &actionExpr{
-				pos: position{line: 3912, col: 18, offset: 119495},
+				pos: position{line: 3912, col: 18, offset: 119509},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 3912, col: 18, offset: 119495},
+					pos: position{line: 3912, col: 18, offset: 119509},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3912, col: 18, offset: 119495},
+							pos:   position{line: 3912, col: 18, offset: 119509},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3912, col: 24, offset: 119501},
+								pos:  position{line: 3912, col: 24, offset: 119515},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3912, col: 34, offset: 119511},
+							pos:   position{line: 3912, col: 34, offset: 119525},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3912, col: 39, offset: 119516},
+								pos: position{line: 3912, col: 39, offset: 119530},
 								expr: &seqExpr{
-									pos: position{line: 3912, col: 40, offset: 119517},
+									pos: position{line: 3912, col: 40, offset: 119531},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3912, col: 40, offset: 119517},
+											pos:  position{line: 3912, col: 40, offset: 119531},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3912, col: 46, offset: 119523},
+											pos:  position{line: 3912, col: 46, offset: 119537},
 											name: "FieldName",
 										},
 									},
@@ -9464,16 +9464,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 3929, col: 1, offset: 120018},
+			pos:  position{line: 3929, col: 1, offset: 120032},
 			expr: &choiceExpr{
-				pos: position{line: 3929, col: 18, offset: 120035},
+				pos: position{line: 3929, col: 18, offset: 120049},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 3929, col: 18, offset: 120035},
+						pos:  position{line: 3929, col: 18, offset: 120049},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 3929, col: 38, offset: 120055},
+						pos:  position{line: 3929, col: 38, offset: 120069},
 						name: "EarliestOnly",
 					},
 				},
@@ -9481,71 +9481,71 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 3931, col: 1, offset: 120069},
+			pos:  position{line: 3931, col: 1, offset: 120083},
 			expr: &actionExpr{
-				pos: position{line: 3931, col: 22, offset: 120090},
+				pos: position{line: 3931, col: 22, offset: 120104},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 3931, col: 22, offset: 120090},
+					pos: position{line: 3931, col: 22, offset: 120104},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 22, offset: 120090},
+							pos:  position{line: 3931, col: 22, offset: 120104},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 35, offset: 120103},
+							pos:  position{line: 3931, col: 35, offset: 120117},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3931, col: 41, offset: 120109},
+							pos:   position{line: 3931, col: 41, offset: 120123},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3931, col: 55, offset: 120123},
+								pos: position{line: 3931, col: 55, offset: 120137},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 55, offset: 120123},
+										pos:  position{line: 3931, col: 55, offset: 120137},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 75, offset: 120143},
+										pos:  position{line: 3931, col: 75, offset: 120157},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 94, offset: 120162},
+							pos:  position{line: 3931, col: 94, offset: 120176},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 100, offset: 120168},
+							pos:  position{line: 3931, col: 100, offset: 120182},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3931, col: 111, offset: 120179},
+							pos:  position{line: 3931, col: 111, offset: 120193},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3931, col: 117, offset: 120185},
+							pos:   position{line: 3931, col: 117, offset: 120199},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3931, col: 129, offset: 120197},
+								pos: position{line: 3931, col: 129, offset: 120211},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 129, offset: 120197},
+										pos:  position{line: 3931, col: 129, offset: 120211},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3931, col: 149, offset: 120217},
+										pos:  position{line: 3931, col: 149, offset: 120231},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3931, col: 168, offset: 120236},
+							pos: position{line: 3931, col: 168, offset: 120250},
 							expr: &anyMatcher{
-								line: 3931, col: 169, offset: 120237,
+								line: 3931, col: 169, offset: 120251,
 							},
 						},
 					},
@@ -9554,42 +9554,42 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 3972, col: 1, offset: 121359},
+			pos:  position{line: 3972, col: 1, offset: 121373},
 			expr: &actionExpr{
-				pos: position{line: 3972, col: 17, offset: 121375},
+				pos: position{line: 3972, col: 17, offset: 121389},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 3972, col: 17, offset: 121375},
+					pos: position{line: 3972, col: 17, offset: 121389},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3972, col: 17, offset: 121375},
+							pos:  position{line: 3972, col: 17, offset: 121389},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3972, col: 30, offset: 121388},
+							pos:  position{line: 3972, col: 30, offset: 121402},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3972, col: 36, offset: 121394},
+							pos:   position{line: 3972, col: 36, offset: 121408},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3972, col: 50, offset: 121408},
+								pos: position{line: 3972, col: 50, offset: 121422},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3972, col: 50, offset: 121408},
+										pos:  position{line: 3972, col: 50, offset: 121422},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3972, col: 70, offset: 121428},
+										pos:  position{line: 3972, col: 70, offset: 121442},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3972, col: 89, offset: 121447},
+							pos: position{line: 3972, col: 89, offset: 121461},
 							expr: &anyMatcher{
-								line: 3972, col: 90, offset: 121448,
+								line: 3972, col: 90, offset: 121462,
 							},
 						},
 					},
@@ -9598,24 +9598,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4000, col: 1, offset: 122139},
+			pos:  position{line: 4000, col: 1, offset: 122153},
 			expr: &actionExpr{
-				pos: position{line: 4000, col: 23, offset: 122161},
+				pos: position{line: 4000, col: 23, offset: 122175},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4000, col: 23, offset: 122161},
+					pos: position{line: 4000, col: 23, offset: 122175},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4000, col: 23, offset: 122161},
+							pos:        position{line: 4000, col: 23, offset: 122175},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4000, col: 27, offset: 122165},
+							pos: position{line: 4000, col: 27, offset: 122179},
 							expr: &charClassMatcher{
-								pos:        position{line: 4000, col: 27, offset: 122165},
+								pos:        position{line: 4000, col: 27, offset: 122179},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9628,21 +9628,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4004, col: 1, offset: 122208},
+			pos:  position{line: 4004, col: 1, offset: 122222},
 			expr: &actionExpr{
-				pos: position{line: 4004, col: 13, offset: 122220},
+				pos: position{line: 4004, col: 13, offset: 122234},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4004, col: 14, offset: 122221},
+					pos: position{line: 4004, col: 14, offset: 122235},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4004, col: 14, offset: 122221},
+							pos:        position{line: 4004, col: 14, offset: 122235},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4004, col: 17, offset: 122224},
+							pos:        position{line: 4004, col: 17, offset: 122238},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9654,15 +9654,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4008, col: 1, offset: 122267},
+			pos:  position{line: 4008, col: 1, offset: 122281},
 			expr: &actionExpr{
-				pos: position{line: 4008, col: 16, offset: 122282},
+				pos: position{line: 4008, col: 16, offset: 122296},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4008, col: 16, offset: 122282},
+					pos:   position{line: 4008, col: 16, offset: 122296},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4008, col: 26, offset: 122292},
+						pos:  position{line: 4008, col: 26, offset: 122306},
 						name: "AllTimeScale",
 					},
 				},
@@ -9670,31 +9670,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4015, col: 1, offset: 122516},
+			pos:  position{line: 4015, col: 1, offset: 122530},
 			expr: &actionExpr{
-				pos: position{line: 4015, col: 9, offset: 122524},
+				pos: position{line: 4015, col: 9, offset: 122538},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4015, col: 9, offset: 122524},
+					pos: position{line: 4015, col: 9, offset: 122538},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4015, col: 9, offset: 122524},
+							pos:        position{line: 4015, col: 9, offset: 122538},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4015, col: 13, offset: 122528},
+							pos:   position{line: 4015, col: 13, offset: 122542},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4015, col: 19, offset: 122534},
+								pos: position{line: 4015, col: 19, offset: 122548},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4015, col: 19, offset: 122534},
+										pos:  position{line: 4015, col: 19, offset: 122548},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4015, col: 30, offset: 122545},
+										pos:  position{line: 4015, col: 30, offset: 122559},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9706,26 +9706,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4019, col: 1, offset: 122593},
+			pos:  position{line: 4019, col: 1, offset: 122607},
 			expr: &actionExpr{
-				pos: position{line: 4019, col: 11, offset: 122603},
+				pos: position{line: 4019, col: 11, offset: 122617},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4019, col: 11, offset: 122603},
+					pos: position{line: 4019, col: 11, offset: 122617},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4019, col: 11, offset: 122603},
+							pos:   position{line: 4019, col: 11, offset: 122617},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4019, col: 16, offset: 122608},
+								pos:  position{line: 4019, col: 16, offset: 122622},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4019, col: 36, offset: 122628},
+							pos:   position{line: 4019, col: 36, offset: 122642},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4019, col: 43, offset: 122635},
+								pos:  position{line: 4019, col: 43, offset: 122649},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9735,44 +9735,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4047, col: 1, offset: 123373},
+			pos:  position{line: 4047, col: 1, offset: 123387},
 			expr: &actionExpr{
-				pos: position{line: 4047, col: 29, offset: 123401},
+				pos: position{line: 4047, col: 29, offset: 123415},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4047, col: 29, offset: 123401},
+					pos: position{line: 4047, col: 29, offset: 123415},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4047, col: 29, offset: 123401},
+							pos:   position{line: 4047, col: 29, offset: 123415},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4047, col: 36, offset: 123408},
+								pos: position{line: 4047, col: 36, offset: 123422},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4047, col: 36, offset: 123408},
+										pos:  position{line: 4047, col: 36, offset: 123422},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4047, col: 45, offset: 123417},
+										pos:  position{line: 4047, col: 45, offset: 123431},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4047, col: 51, offset: 123423},
+							pos:   position{line: 4047, col: 51, offset: 123437},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4047, col: 57, offset: 123429},
+								pos: position{line: 4047, col: 57, offset: 123443},
 								expr: &choiceExpr{
-									pos: position{line: 4047, col: 58, offset: 123430},
+									pos: position{line: 4047, col: 58, offset: 123444},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4047, col: 58, offset: 123430},
+											pos:  position{line: 4047, col: 58, offset: 123444},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4047, col: 67, offset: 123439},
+											pos:  position{line: 4047, col: 67, offset: 123453},
 											name: "Snap",
 										},
 									},
@@ -9785,29 +9785,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4094, col: 1, offset: 124871},
+			pos:  position{line: 4094, col: 1, offset: 124885},
 			expr: &actionExpr{
-				pos: position{line: 4094, col: 22, offset: 124892},
+				pos: position{line: 4094, col: 22, offset: 124906},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4094, col: 22, offset: 124892},
+					pos: position{line: 4094, col: 22, offset: 124906},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4094, col: 22, offset: 124892},
+							pos:   position{line: 4094, col: 22, offset: 124906},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4094, col: 34, offset: 124904},
+								pos: position{line: 4094, col: 34, offset: 124918},
 								expr: &choiceExpr{
-									pos: position{line: 4094, col: 35, offset: 124905},
+									pos: position{line: 4094, col: 35, offset: 124919},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4094, col: 35, offset: 124905},
+											pos:        position{line: 4094, col: 35, offset: 124919},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4094, col: 43, offset: 124913},
+											pos:        position{line: 4094, col: 43, offset: 124927},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9817,12 +9817,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4094, col: 49, offset: 124919},
+							pos:   position{line: 4094, col: 49, offset: 124933},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4094, col: 57, offset: 124927},
+								pos: position{line: 4094, col: 57, offset: 124941},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4094, col: 58, offset: 124928},
+									pos:  position{line: 4094, col: 58, offset: 124942},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9833,31 +9833,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4119, col: 1, offset: 125611},
+			pos:  position{line: 4119, col: 1, offset: 125625},
 			expr: &actionExpr{
-				pos: position{line: 4119, col: 39, offset: 125649},
+				pos: position{line: 4119, col: 39, offset: 125663},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4119, col: 39, offset: 125649},
+					pos: position{line: 4119, col: 39, offset: 125663},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4119, col: 39, offset: 125649},
+							pos:   position{line: 4119, col: 39, offset: 125663},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4119, col: 46, offset: 125656},
+								pos: position{line: 4119, col: 46, offset: 125670},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4119, col: 47, offset: 125657},
+									pos:  position{line: 4119, col: 47, offset: 125671},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4119, col: 56, offset: 125666},
+							pos:   position{line: 4119, col: 56, offset: 125680},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4119, col: 66, offset: 125676},
+								pos: position{line: 4119, col: 66, offset: 125690},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4119, col: 67, offset: 125677},
+									pos:  position{line: 4119, col: 67, offset: 125691},
 									name: "Snap",
 								},
 							},
@@ -9868,136 +9868,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4146, col: 1, offset: 126305},
+			pos:  position{line: 4146, col: 1, offset: 126319},
 			expr: &actionExpr{
-				pos: position{line: 4146, col: 18, offset: 126322},
+				pos: position{line: 4146, col: 18, offset: 126336},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4146, col: 18, offset: 126322},
+					pos: position{line: 4146, col: 18, offset: 126336},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 18, offset: 126322},
+							pos:        position{line: 4146, col: 18, offset: 126336},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 23, offset: 126327},
+							pos:        position{line: 4146, col: 23, offset: 126341},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 29, offset: 126333},
+							pos:        position{line: 4146, col: 29, offset: 126347},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 33, offset: 126337},
+							pos:        position{line: 4146, col: 33, offset: 126351},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 38, offset: 126342},
+							pos:        position{line: 4146, col: 38, offset: 126356},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 44, offset: 126348},
+							pos:        position{line: 4146, col: 44, offset: 126362},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 48, offset: 126352},
+							pos:        position{line: 4146, col: 48, offset: 126366},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 53, offset: 126357},
+							pos:        position{line: 4146, col: 53, offset: 126371},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 58, offset: 126362},
+							pos:        position{line: 4146, col: 58, offset: 126376},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 63, offset: 126367},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4146, col: 69, offset: 126373},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4146, col: 73, offset: 126377},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4146, col: 78, offset: 126382},
+							pos:        position{line: 4146, col: 63, offset: 126381},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 84, offset: 126388},
+							pos:        position{line: 4146, col: 69, offset: 126387},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 88, offset: 126392},
+							pos:        position{line: 4146, col: 73, offset: 126391},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 93, offset: 126397},
+							pos:        position{line: 4146, col: 78, offset: 126396},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4146, col: 99, offset: 126403},
+							pos:        position{line: 4146, col: 84, offset: 126402},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 103, offset: 126407},
+							pos:        position{line: 4146, col: 88, offset: 126406},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4146, col: 108, offset: 126412},
+							pos:        position{line: 4146, col: 93, offset: 126411},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4146, col: 99, offset: 126417},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4146, col: 103, offset: 126421},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4146, col: 108, offset: 126426},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10009,15 +10009,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4150, col: 1, offset: 126454},
+			pos:  position{line: 4150, col: 1, offset: 126468},
 			expr: &actionExpr{
-				pos: position{line: 4150, col: 22, offset: 126475},
+				pos: position{line: 4150, col: 22, offset: 126489},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4150, col: 22, offset: 126475},
+					pos:   position{line: 4150, col: 22, offset: 126489},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4150, col: 32, offset: 126485},
+						pos:  position{line: 4150, col: 32, offset: 126499},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10025,15 +10025,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4160, col: 1, offset: 126893},
+			pos:  position{line: 4160, col: 1, offset: 126907},
 			expr: &actionExpr{
-				pos: position{line: 4160, col: 14, offset: 126906},
+				pos: position{line: 4160, col: 14, offset: 126920},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4160, col: 14, offset: 126906},
+					pos: position{line: 4160, col: 14, offset: 126920},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4160, col: 14, offset: 126906},
+							pos:        position{line: 4160, col: 14, offset: 126920},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10041,9 +10041,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4160, col: 27, offset: 126919},
+							pos: position{line: 4160, col: 27, offset: 126933},
 							expr: &charClassMatcher{
-								pos:        position{line: 4160, col: 27, offset: 126919},
+								pos:        position{line: 4160, col: 27, offset: 126933},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10057,15 +10057,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4164, col: 1, offset: 126972},
+			pos:  position{line: 4164, col: 1, offset: 126986},
 			expr: &actionExpr{
-				pos: position{line: 4164, col: 24, offset: 126995},
+				pos: position{line: 4164, col: 24, offset: 127009},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4164, col: 24, offset: 126995},
+					pos: position{line: 4164, col: 24, offset: 127009},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4164, col: 24, offset: 126995},
+							pos:        position{line: 4164, col: 24, offset: 127009},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10073,9 +10073,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4164, col: 39, offset: 127010},
+							pos: position{line: 4164, col: 39, offset: 127024},
 							expr: &charClassMatcher{
-								pos:        position{line: 4164, col: 39, offset: 127010},
+								pos:        position{line: 4164, col: 39, offset: 127024},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10089,22 +10089,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4168, col: 1, offset: 127063},
+			pos:  position{line: 4168, col: 1, offset: 127077},
 			expr: &actionExpr{
-				pos: position{line: 4168, col: 11, offset: 127073},
+				pos: position{line: 4168, col: 11, offset: 127087},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4168, col: 11, offset: 127073},
+					pos:   position{line: 4168, col: 11, offset: 127087},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4168, col: 16, offset: 127078},
+						pos: position{line: 4168, col: 16, offset: 127092},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 16, offset: 127078},
+								pos:  position{line: 4168, col: 16, offset: 127092},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 31, offset: 127093},
+								pos:  position{line: 4168, col: 31, offset: 127107},
 								name: "UnquotedString",
 							},
 						},
@@ -10114,23 +10114,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4172, col: 1, offset: 127134},
+			pos:  position{line: 4172, col: 1, offset: 127148},
 			expr: &actionExpr{
-				pos: position{line: 4172, col: 17, offset: 127150},
+				pos: position{line: 4172, col: 17, offset: 127164},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4172, col: 17, offset: 127150},
+					pos: position{line: 4172, col: 17, offset: 127164},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4172, col: 17, offset: 127150},
+							pos:        position{line: 4172, col: 17, offset: 127164},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4172, col: 21, offset: 127154},
+							pos: position{line: 4172, col: 21, offset: 127168},
 							expr: &charClassMatcher{
-								pos:        position{line: 4172, col: 21, offset: 127154},
+								pos:        position{line: 4172, col: 21, offset: 127168},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10138,7 +10138,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 27, offset: 127160},
+							pos:        position{line: 4172, col: 27, offset: 127174},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10149,48 +10149,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4177, col: 1, offset: 127271},
+			pos:  position{line: 4177, col: 1, offset: 127285},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 19, offset: 127289},
+				pos: position{line: 4177, col: 19, offset: 127303},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4177, col: 19, offset: 127289},
+					pos: position{line: 4177, col: 19, offset: 127303},
 					expr: &choiceExpr{
-						pos: position{line: 4177, col: 20, offset: 127290},
+						pos: position{line: 4177, col: 20, offset: 127304},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4177, col: 20, offset: 127290},
+								pos:        position{line: 4177, col: 20, offset: 127304},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4177, col: 27, offset: 127297},
+								pos: position{line: 4177, col: 27, offset: 127311},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4177, col: 27, offset: 127297},
+										pos: position{line: 4177, col: 27, offset: 127311},
 										expr: &choiceExpr{
-											pos: position{line: 4177, col: 29, offset: 127299},
+											pos: position{line: 4177, col: 29, offset: 127313},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4177, col: 29, offset: 127299},
+													pos:  position{line: 4177, col: 29, offset: 127313},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4177, col: 43, offset: 127313},
+													pos:        position{line: 4177, col: 43, offset: 127327},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4177, col: 49, offset: 127319},
+													pos:  position{line: 4177, col: 49, offset: 127333},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4177, col: 54, offset: 127324,
+										line: 4177, col: 54, offset: 127338,
 									},
 								},
 							},
@@ -10201,12 +10201,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4184, col: 1, offset: 127439},
+			pos:  position{line: 4184, col: 1, offset: 127453},
 			expr: &choiceExpr{
-				pos: position{line: 4184, col: 16, offset: 127454},
+				pos: position{line: 4184, col: 16, offset: 127468},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4184, col: 16, offset: 127454},
+						pos:        position{line: 4184, col: 16, offset: 127468},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10214,18 +10214,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4184, col: 37, offset: 127475},
+						pos: position{line: 4184, col: 37, offset: 127489},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4184, col: 37, offset: 127475},
+								pos:        position{line: 4184, col: 37, offset: 127489},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4184, col: 41, offset: 127479},
+								pos: position{line: 4184, col: 41, offset: 127493},
 								expr: &charClassMatcher{
-									pos:        position{line: 4184, col: 41, offset: 127479},
+									pos:        position{line: 4184, col: 41, offset: 127493},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10233,7 +10233,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4184, col: 48, offset: 127486},
+								pos:        position{line: 4184, col: 48, offset: 127500},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10245,46 +10245,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4186, col: 1, offset: 127492},
+			pos:  position{line: 4186, col: 1, offset: 127506},
 			expr: &actionExpr{
-				pos: position{line: 4186, col: 39, offset: 127530},
+				pos: position{line: 4186, col: 39, offset: 127544},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4186, col: 39, offset: 127530},
+					pos: position{line: 4186, col: 39, offset: 127544},
 					expr: &choiceExpr{
-						pos: position{line: 4186, col: 40, offset: 127531},
+						pos: position{line: 4186, col: 40, offset: 127545},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4186, col: 40, offset: 127531},
+								pos:  position{line: 4186, col: 40, offset: 127545},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4186, col: 54, offset: 127545},
+								pos: position{line: 4186, col: 54, offset: 127559},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4186, col: 54, offset: 127545},
+										pos: position{line: 4186, col: 54, offset: 127559},
 										expr: &choiceExpr{
-											pos: position{line: 4186, col: 56, offset: 127547},
+											pos: position{line: 4186, col: 56, offset: 127561},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4186, col: 56, offset: 127547},
+													pos:  position{line: 4186, col: 56, offset: 127561},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4186, col: 70, offset: 127561},
+													pos:        position{line: 4186, col: 70, offset: 127575},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4186, col: 76, offset: 127567},
+													pos:  position{line: 4186, col: 76, offset: 127581},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4186, col: 81, offset: 127572,
+										line: 4186, col: 81, offset: 127586,
 									},
 								},
 							},
@@ -10295,21 +10295,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4190, col: 1, offset: 127612},
+			pos:  position{line: 4190, col: 1, offset: 127626},
 			expr: &actionExpr{
-				pos: position{line: 4190, col: 12, offset: 127623},
+				pos: position{line: 4190, col: 12, offset: 127637},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4190, col: 13, offset: 127624},
+					pos: position{line: 4190, col: 13, offset: 127638},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4190, col: 13, offset: 127624},
+							pos:        position{line: 4190, col: 13, offset: 127638},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4190, col: 22, offset: 127633},
+							pos:        position{line: 4190, col: 22, offset: 127647},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10320,14 +10320,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4196, col: 1, offset: 127787},
+			pos:  position{line: 4196, col: 1, offset: 127801},
 			expr: &actionExpr{
-				pos: position{line: 4196, col: 18, offset: 127804},
+				pos: position{line: 4196, col: 18, offset: 127818},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4196, col: 18, offset: 127804},
+					pos: position{line: 4196, col: 18, offset: 127818},
 					expr: &charClassMatcher{
-						pos:        position{line: 4196, col: 18, offset: 127804},
+						pos:        position{line: 4196, col: 18, offset: 127818},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10339,15 +10339,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4200, col: 1, offset: 127855},
+			pos:  position{line: 4200, col: 1, offset: 127869},
 			expr: &actionExpr{
-				pos: position{line: 4200, col: 11, offset: 127865},
+				pos: position{line: 4200, col: 11, offset: 127879},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4200, col: 11, offset: 127865},
+					pos:   position{line: 4200, col: 11, offset: 127879},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4200, col: 18, offset: 127872},
+						pos:  position{line: 4200, col: 18, offset: 127886},
 						name: "NumberAsString",
 					},
 				},
@@ -10355,59 +10355,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4206, col: 1, offset: 128061},
+			pos:  position{line: 4206, col: 1, offset: 128075},
 			expr: &actionExpr{
-				pos: position{line: 4206, col: 19, offset: 128079},
+				pos: position{line: 4206, col: 19, offset: 128093},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4206, col: 19, offset: 128079},
+					pos: position{line: 4206, col: 19, offset: 128093},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4206, col: 19, offset: 128079},
+							pos:   position{line: 4206, col: 19, offset: 128093},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4206, col: 27, offset: 128087},
+								pos: position{line: 4206, col: 27, offset: 128101},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 27, offset: 128087},
+										pos:  position{line: 4206, col: 27, offset: 128101},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 43, offset: 128103},
+										pos:  position{line: 4206, col: 43, offset: 128117},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4206, col: 60, offset: 128120},
+							pos: position{line: 4206, col: 60, offset: 128134},
 							expr: &choiceExpr{
-								pos: position{line: 4206, col: 62, offset: 128122},
+								pos: position{line: 4206, col: 62, offset: 128136},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 62, offset: 128122},
+										pos:  position{line: 4206, col: 62, offset: 128136},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 70, offset: 128130},
+										pos:        position{line: 4206, col: 70, offset: 128144},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 76, offset: 128136},
+										pos:        position{line: 4206, col: 76, offset: 128150},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4206, col: 82, offset: 128142},
+										pos:        position{line: 4206, col: 82, offset: 128156},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 88, offset: 128148},
+										pos:  position{line: 4206, col: 88, offset: 128162},
 										name: "EOF",
 									},
 								},
@@ -10419,17 +10419,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4212, col: 1, offset: 128277},
+			pos:  position{line: 4212, col: 1, offset: 128291},
 			expr: &actionExpr{
-				pos: position{line: 4212, col: 18, offset: 128294},
+				pos: position{line: 4212, col: 18, offset: 128308},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4212, col: 18, offset: 128294},
+					pos: position{line: 4212, col: 18, offset: 128308},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4212, col: 18, offset: 128294},
+							pos: position{line: 4212, col: 18, offset: 128308},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 18, offset: 128294},
+								pos:        position{line: 4212, col: 18, offset: 128308},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10437,9 +10437,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4212, col: 24, offset: 128300},
+							pos: position{line: 4212, col: 24, offset: 128314},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 24, offset: 128300},
+								pos:        position{line: 4212, col: 24, offset: 128314},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10447,15 +10447,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4212, col: 31, offset: 128307},
+							pos:        position{line: 4212, col: 31, offset: 128321},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4212, col: 35, offset: 128311},
+							pos: position{line: 4212, col: 35, offset: 128325},
 							expr: &charClassMatcher{
-								pos:        position{line: 4212, col: 35, offset: 128311},
+								pos:        position{line: 4212, col: 35, offset: 128325},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10468,17 +10468,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4217, col: 1, offset: 128406},
+			pos:  position{line: 4217, col: 1, offset: 128420},
 			expr: &actionExpr{
-				pos: position{line: 4217, col: 20, offset: 128425},
+				pos: position{line: 4217, col: 20, offset: 128439},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4217, col: 20, offset: 128425},
+					pos: position{line: 4217, col: 20, offset: 128439},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4217, col: 20, offset: 128425},
+							pos: position{line: 4217, col: 20, offset: 128439},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 20, offset: 128425},
+								pos:        position{line: 4217, col: 20, offset: 128439},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10486,9 +10486,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4217, col: 26, offset: 128431},
+							pos: position{line: 4217, col: 26, offset: 128445},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 26, offset: 128431},
+								pos:        position{line: 4217, col: 26, offset: 128445},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10501,14 +10501,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4221, col: 1, offset: 128474},
+			pos:  position{line: 4221, col: 1, offset: 128488},
 			expr: &actionExpr{
-				pos: position{line: 4221, col: 28, offset: 128501},
+				pos: position{line: 4221, col: 28, offset: 128515},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4221, col: 28, offset: 128501},
+					pos: position{line: 4221, col: 28, offset: 128515},
 					expr: &charClassMatcher{
-						pos:        position{line: 4221, col: 28, offset: 128501},
+						pos:        position{line: 4221, col: 28, offset: 128515},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10519,15 +10519,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4225, col: 1, offset: 128544},
+			pos:  position{line: 4225, col: 1, offset: 128558},
 			expr: &actionExpr{
-				pos: position{line: 4225, col: 20, offset: 128563},
+				pos: position{line: 4225, col: 20, offset: 128577},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4225, col: 20, offset: 128563},
+					pos:   position{line: 4225, col: 20, offset: 128577},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4225, col: 27, offset: 128570},
+						pos:  position{line: 4225, col: 27, offset: 128584},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10535,31 +10535,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4233, col: 1, offset: 128817},
+			pos:  position{line: 4233, col: 1, offset: 128831},
 			expr: &actionExpr{
-				pos: position{line: 4233, col: 21, offset: 128837},
+				pos: position{line: 4233, col: 21, offset: 128851},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4233, col: 21, offset: 128837},
+					pos: position{line: 4233, col: 21, offset: 128851},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 21, offset: 128837},
+							pos:  position{line: 4233, col: 21, offset: 128851},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4233, col: 36, offset: 128852},
+							pos:   position{line: 4233, col: 36, offset: 128866},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4233, col: 40, offset: 128856},
+								pos: position{line: 4233, col: 40, offset: 128870},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4233, col: 40, offset: 128856},
+										pos:        position{line: 4233, col: 40, offset: 128870},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4233, col: 46, offset: 128862},
+										pos:        position{line: 4233, col: 46, offset: 128876},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10568,7 +10568,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 52, offset: 128868},
+							pos:  position{line: 4233, col: 52, offset: 128882},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10577,43 +10577,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4241, col: 1, offset: 129049},
+			pos:  position{line: 4241, col: 1, offset: 129063},
 			expr: &actionExpr{
-				pos: position{line: 4241, col: 23, offset: 129071},
+				pos: position{line: 4241, col: 23, offset: 129085},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4241, col: 23, offset: 129071},
+					pos: position{line: 4241, col: 23, offset: 129085},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 23, offset: 129071},
+							pos:  position{line: 4241, col: 23, offset: 129085},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4241, col: 38, offset: 129086},
+							pos:   position{line: 4241, col: 38, offset: 129100},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4241, col: 42, offset: 129090},
+								pos: position{line: 4241, col: 42, offset: 129104},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4241, col: 42, offset: 129090},
+										pos:        position{line: 4241, col: 42, offset: 129104},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 49, offset: 129097},
+										pos:        position{line: 4241, col: 49, offset: 129111},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 55, offset: 129103},
+										pos:        position{line: 4241, col: 55, offset: 129117},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4241, col: 62, offset: 129110},
+										pos:        position{line: 4241, col: 62, offset: 129124},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10622,7 +10622,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 67, offset: 129115},
+							pos:  position{line: 4241, col: 67, offset: 129129},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10631,30 +10631,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4249, col: 1, offset: 129298},
+			pos:  position{line: 4249, col: 1, offset: 129312},
 			expr: &choiceExpr{
-				pos: position{line: 4249, col: 25, offset: 129322},
+				pos: position{line: 4249, col: 25, offset: 129336},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4249, col: 25, offset: 129322},
+						pos: position{line: 4249, col: 25, offset: 129336},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4249, col: 25, offset: 129322},
+							pos:   position{line: 4249, col: 25, offset: 129336},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4249, col: 28, offset: 129325},
+								pos:  position{line: 4249, col: 28, offset: 129339},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4252, col: 3, offset: 129367},
+						pos: position{line: 4252, col: 3, offset: 129381},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4252, col: 3, offset: 129367},
+							pos:   position{line: 4252, col: 3, offset: 129381},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4252, col: 6, offset: 129370},
+								pos:  position{line: 4252, col: 6, offset: 129384},
 								name: "InequalityOperator",
 							},
 						},
@@ -10664,25 +10664,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4256, col: 1, offset: 129413},
+			pos:  position{line: 4256, col: 1, offset: 129427},
 			expr: &actionExpr{
-				pos: position{line: 4256, col: 11, offset: 129423},
+				pos: position{line: 4256, col: 11, offset: 129437},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4256, col: 11, offset: 129423},
+					pos: position{line: 4256, col: 11, offset: 129437},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4256, col: 11, offset: 129423},
+							pos:  position{line: 4256, col: 11, offset: 129437},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4256, col: 26, offset: 129438},
+							pos:        position{line: 4256, col: 26, offset: 129452},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4256, col: 30, offset: 129442},
+							pos:  position{line: 4256, col: 30, offset: 129456},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10691,25 +10691,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4260, col: 1, offset: 129482},
+			pos:  position{line: 4260, col: 1, offset: 129496},
 			expr: &actionExpr{
-				pos: position{line: 4260, col: 12, offset: 129493},
+				pos: position{line: 4260, col: 12, offset: 129507},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4260, col: 12, offset: 129493},
+					pos: position{line: 4260, col: 12, offset: 129507},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4260, col: 12, offset: 129493},
+							pos:  position{line: 4260, col: 12, offset: 129507},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4260, col: 27, offset: 129508},
+							pos:        position{line: 4260, col: 27, offset: 129522},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4260, col: 31, offset: 129512},
+							pos:  position{line: 4260, col: 31, offset: 129526},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10718,25 +10718,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4264, col: 1, offset: 129552},
+			pos:  position{line: 4264, col: 1, offset: 129566},
 			expr: &actionExpr{
-				pos: position{line: 4264, col: 10, offset: 129561},
+				pos: position{line: 4264, col: 10, offset: 129575},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4264, col: 10, offset: 129561},
+					pos: position{line: 4264, col: 10, offset: 129575},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4264, col: 10, offset: 129561},
+							pos:  position{line: 4264, col: 10, offset: 129575},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 25, offset: 129576},
+							pos:        position{line: 4264, col: 25, offset: 129590},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4264, col: 29, offset: 129580},
+							pos:  position{line: 4264, col: 29, offset: 129594},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10745,25 +10745,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4268, col: 1, offset: 129620},
+			pos:  position{line: 4268, col: 1, offset: 129634},
 			expr: &actionExpr{
-				pos: position{line: 4268, col: 10, offset: 129629},
+				pos: position{line: 4268, col: 10, offset: 129643},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4268, col: 10, offset: 129629},
+					pos: position{line: 4268, col: 10, offset: 129643},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4268, col: 10, offset: 129629},
+							pos:  position{line: 4268, col: 10, offset: 129643},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4268, col: 25, offset: 129644},
+							pos:        position{line: 4268, col: 25, offset: 129658},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4268, col: 29, offset: 129648},
+							pos:  position{line: 4268, col: 29, offset: 129662},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10772,25 +10772,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4272, col: 1, offset: 129688},
+			pos:  position{line: 4272, col: 1, offset: 129702},
 			expr: &actionExpr{
-				pos: position{line: 4272, col: 10, offset: 129697},
+				pos: position{line: 4272, col: 10, offset: 129711},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4272, col: 10, offset: 129697},
+					pos: position{line: 4272, col: 10, offset: 129711},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4272, col: 10, offset: 129697},
+							pos:  position{line: 4272, col: 10, offset: 129711},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 25, offset: 129712},
+							pos:        position{line: 4272, col: 25, offset: 129726},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4272, col: 29, offset: 129716},
+							pos:  position{line: 4272, col: 29, offset: 129730},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10799,39 +10799,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4277, col: 1, offset: 129780},
+			pos:  position{line: 4277, col: 1, offset: 129794},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 11, offset: 129790},
+				pos: position{line: 4277, col: 11, offset: 129804},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4277, col: 12, offset: 129791},
+					pos: position{line: 4277, col: 12, offset: 129805},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4277, col: 12, offset: 129791},
+							pos:        position{line: 4277, col: 12, offset: 129805},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 24, offset: 129803},
+							pos:        position{line: 4277, col: 24, offset: 129817},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 35, offset: 129814},
+							pos:        position{line: 4277, col: 35, offset: 129828},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 44, offset: 129823},
+							pos:        position{line: 4277, col: 44, offset: 129837},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 52, offset: 129831},
+							pos:        position{line: 4277, col: 52, offset: 129845},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10842,39 +10842,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4281, col: 1, offset: 129872},
+			pos:  position{line: 4281, col: 1, offset: 129886},
 			expr: &actionExpr{
-				pos: position{line: 4281, col: 11, offset: 129882},
+				pos: position{line: 4281, col: 11, offset: 129896},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4281, col: 12, offset: 129883},
+					pos: position{line: 4281, col: 12, offset: 129897},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4281, col: 12, offset: 129883},
+							pos:        position{line: 4281, col: 12, offset: 129897},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 24, offset: 129895},
+							pos:        position{line: 4281, col: 24, offset: 129909},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 35, offset: 129906},
+							pos:        position{line: 4281, col: 35, offset: 129920},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 44, offset: 129915},
+							pos:        position{line: 4281, col: 44, offset: 129929},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4281, col: 52, offset: 129923},
+							pos:        position{line: 4281, col: 52, offset: 129937},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -10885,39 +10885,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4285, col: 1, offset: 129964},
+			pos:  position{line: 4285, col: 1, offset: 129978},
 			expr: &actionExpr{
-				pos: position{line: 4285, col: 9, offset: 129972},
+				pos: position{line: 4285, col: 9, offset: 129986},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4285, col: 10, offset: 129973},
+					pos: position{line: 4285, col: 10, offset: 129987},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4285, col: 10, offset: 129973},
+							pos:        position{line: 4285, col: 10, offset: 129987},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 20, offset: 129983},
+							pos:        position{line: 4285, col: 20, offset: 129997},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 29, offset: 129992},
+							pos:        position{line: 4285, col: 29, offset: 130006},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 37, offset: 130000},
+							pos:        position{line: 4285, col: 37, offset: 130014},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4285, col: 44, offset: 130007},
+							pos:        position{line: 4285, col: 44, offset: 130021},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -10928,27 +10928,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4289, col: 1, offset: 130046},
+			pos:  position{line: 4289, col: 1, offset: 130060},
 			expr: &actionExpr{
-				pos: position{line: 4289, col: 8, offset: 130053},
+				pos: position{line: 4289, col: 8, offset: 130067},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4289, col: 9, offset: 130054},
+					pos: position{line: 4289, col: 9, offset: 130068},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4289, col: 9, offset: 130054},
+							pos:        position{line: 4289, col: 9, offset: 130068},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4289, col: 18, offset: 130063},
+							pos:        position{line: 4289, col: 18, offset: 130077},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4289, col: 26, offset: 130071},
+							pos:        position{line: 4289, col: 26, offset: 130085},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -10959,27 +10959,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4293, col: 1, offset: 130109},
+			pos:  position{line: 4293, col: 1, offset: 130123},
 			expr: &actionExpr{
-				pos: position{line: 4293, col: 9, offset: 130117},
+				pos: position{line: 4293, col: 9, offset: 130131},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4293, col: 10, offset: 130118},
+					pos: position{line: 4293, col: 10, offset: 130132},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4293, col: 10, offset: 130118},
+							pos:        position{line: 4293, col: 10, offset: 130132},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4293, col: 20, offset: 130128},
+							pos:        position{line: 4293, col: 20, offset: 130142},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4293, col: 29, offset: 130137},
+							pos:        position{line: 4293, col: 29, offset: 130151},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -10990,27 +10990,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4297, col: 1, offset: 130176},
+			pos:  position{line: 4297, col: 1, offset: 130190},
 			expr: &actionExpr{
-				pos: position{line: 4297, col: 10, offset: 130185},
+				pos: position{line: 4297, col: 10, offset: 130199},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4297, col: 11, offset: 130186},
+					pos: position{line: 4297, col: 11, offset: 130200},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4297, col: 11, offset: 130186},
+							pos:        position{line: 4297, col: 11, offset: 130200},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4297, col: 22, offset: 130197},
+							pos:        position{line: 4297, col: 22, offset: 130211},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4297, col: 32, offset: 130207},
+							pos:        position{line: 4297, col: 32, offset: 130221},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11021,39 +11021,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4301, col: 1, offset: 130249},
+			pos:  position{line: 4301, col: 1, offset: 130263},
 			expr: &actionExpr{
-				pos: position{line: 4301, col: 12, offset: 130260},
+				pos: position{line: 4301, col: 12, offset: 130274},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4301, col: 13, offset: 130261},
+					pos: position{line: 4301, col: 13, offset: 130275},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4301, col: 13, offset: 130261},
+							pos:        position{line: 4301, col: 13, offset: 130275},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 26, offset: 130274},
+							pos:        position{line: 4301, col: 26, offset: 130288},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 38, offset: 130286},
+							pos:        position{line: 4301, col: 38, offset: 130300},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 47, offset: 130295},
+							pos:        position{line: 4301, col: 47, offset: 130309},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4301, col: 55, offset: 130303},
+							pos:        position{line: 4301, col: 55, offset: 130317},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11064,39 +11064,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4305, col: 1, offset: 130345},
+			pos:  position{line: 4305, col: 1, offset: 130359},
 			expr: &actionExpr{
-				pos: position{line: 4305, col: 9, offset: 130353},
+				pos: position{line: 4305, col: 9, offset: 130367},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4305, col: 10, offset: 130354},
+					pos: position{line: 4305, col: 10, offset: 130368},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4305, col: 10, offset: 130354},
+							pos:        position{line: 4305, col: 10, offset: 130368},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 20, offset: 130364},
+							pos:        position{line: 4305, col: 20, offset: 130378},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 29, offset: 130373},
+							pos:        position{line: 4305, col: 29, offset: 130387},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 37, offset: 130381},
+							pos:        position{line: 4305, col: 37, offset: 130395},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 44, offset: 130388},
+							pos:        position{line: 4305, col: 44, offset: 130402},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11107,33 +11107,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4310, col: 1, offset: 130519},
+			pos:  position{line: 4310, col: 1, offset: 130533},
 			expr: &actionExpr{
-				pos: position{line: 4310, col: 15, offset: 130533},
+				pos: position{line: 4310, col: 15, offset: 130547},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4310, col: 16, offset: 130534},
+					pos: position{line: 4310, col: 16, offset: 130548},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4310, col: 16, offset: 130534},
+							pos:        position{line: 4310, col: 16, offset: 130548},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 23, offset: 130541},
+							pos:        position{line: 4310, col: 23, offset: 130555},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 30, offset: 130548},
+							pos:        position{line: 4310, col: 30, offset: 130562},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 37, offset: 130555},
+							pos:        position{line: 4310, col: 37, offset: 130569},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11144,26 +11144,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4319, col: 1, offset: 130778},
+			pos:  position{line: 4319, col: 1, offset: 130792},
 			expr: &actionExpr{
-				pos: position{line: 4319, col: 21, offset: 130798},
+				pos: position{line: 4319, col: 21, offset: 130812},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4319, col: 21, offset: 130798},
+					pos: position{line: 4319, col: 21, offset: 130812},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4319, col: 21, offset: 130798},
+							pos:  position{line: 4319, col: 21, offset: 130812},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4319, col: 26, offset: 130803},
+							pos:  position{line: 4319, col: 26, offset: 130817},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4319, col: 42, offset: 130819},
+							pos:   position{line: 4319, col: 42, offset: 130833},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4319, col: 53, offset: 130830},
+								pos:  position{line: 4319, col: 53, offset: 130844},
 								name: "TransactionOptions",
 							},
 						},
@@ -11173,17 +11173,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4328, col: 1, offset: 131136},
+			pos:  position{line: 4328, col: 1, offset: 131150},
 			expr: &actionExpr{
-				pos: position{line: 4328, col: 23, offset: 131158},
+				pos: position{line: 4328, col: 23, offset: 131172},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4328, col: 23, offset: 131158},
+					pos:   position{line: 4328, col: 23, offset: 131172},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4328, col: 34, offset: 131169},
+						pos: position{line: 4328, col: 34, offset: 131183},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4328, col: 34, offset: 131169},
+							pos:  position{line: 4328, col: 34, offset: 131183},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11192,35 +11192,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4343, col: 1, offset: 131560},
+			pos:  position{line: 4343, col: 1, offset: 131574},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 37, offset: 131596},
+				pos: position{line: 4343, col: 37, offset: 131610},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4343, col: 37, offset: 131596},
+					pos: position{line: 4343, col: 37, offset: 131610},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4343, col: 37, offset: 131596},
+							pos:   position{line: 4343, col: 37, offset: 131610},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4343, col: 43, offset: 131602},
+								pos:  position{line: 4343, col: 43, offset: 131616},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4343, col: 71, offset: 131630},
+							pos:   position{line: 4343, col: 71, offset: 131644},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4343, col: 76, offset: 131635},
+								pos: position{line: 4343, col: 76, offset: 131649},
 								expr: &seqExpr{
-									pos: position{line: 4343, col: 77, offset: 131636},
+									pos: position{line: 4343, col: 77, offset: 131650},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4343, col: 77, offset: 131636},
+											pos:  position{line: 4343, col: 77, offset: 131650},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4343, col: 83, offset: 131642},
+											pos:  position{line: 4343, col: 83, offset: 131656},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11233,26 +11233,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4378, col: 1, offset: 132631},
+			pos:  position{line: 4378, col: 1, offset: 132645},
 			expr: &actionExpr{
-				pos: position{line: 4378, col: 32, offset: 132662},
+				pos: position{line: 4378, col: 32, offset: 132676},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4378, col: 32, offset: 132662},
+					pos:   position{line: 4378, col: 32, offset: 132676},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4378, col: 40, offset: 132670},
+						pos: position{line: 4378, col: 40, offset: 132684},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 40, offset: 132670},
+								pos:  position{line: 4378, col: 40, offset: 132684},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 77, offset: 132707},
+								pos:  position{line: 4378, col: 77, offset: 132721},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4378, col: 96, offset: 132726},
+								pos:  position{line: 4378, col: 96, offset: 132740},
 								name: "EndsWithOption",
 							},
 						},
@@ -11262,15 +11262,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4382, col: 1, offset: 132770},
+			pos:  position{line: 4382, col: 1, offset: 132784},
 			expr: &actionExpr{
-				pos: position{line: 4382, col: 39, offset: 132808},
+				pos: position{line: 4382, col: 39, offset: 132822},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4382, col: 39, offset: 132808},
+					pos:   position{line: 4382, col: 39, offset: 132822},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4382, col: 46, offset: 132815},
+						pos:  position{line: 4382, col: 46, offset: 132829},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11278,28 +11278,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4393, col: 1, offset: 133031},
+			pos:  position{line: 4393, col: 1, offset: 133045},
 			expr: &actionExpr{
-				pos: position{line: 4393, col: 21, offset: 133051},
+				pos: position{line: 4393, col: 21, offset: 133065},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4393, col: 21, offset: 133051},
+					pos: position{line: 4393, col: 21, offset: 133065},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4393, col: 21, offset: 133051},
+							pos:        position{line: 4393, col: 21, offset: 133065},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4393, col: 34, offset: 133064},
+							pos:  position{line: 4393, col: 34, offset: 133078},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4393, col: 40, offset: 133070},
+							pos:   position{line: 4393, col: 40, offset: 133084},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4393, col: 48, offset: 133078},
+								pos:  position{line: 4393, col: 48, offset: 133092},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11309,28 +11309,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4403, col: 1, offset: 133316},
+			pos:  position{line: 4403, col: 1, offset: 133330},
 			expr: &actionExpr{
-				pos: position{line: 4403, col: 19, offset: 133334},
+				pos: position{line: 4403, col: 19, offset: 133348},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4403, col: 19, offset: 133334},
+					pos: position{line: 4403, col: 19, offset: 133348},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4403, col: 19, offset: 133334},
+							pos:        position{line: 4403, col: 19, offset: 133348},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4403, col: 30, offset: 133345},
+							pos:  position{line: 4403, col: 30, offset: 133359},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4403, col: 36, offset: 133351},
+							pos:   position{line: 4403, col: 36, offset: 133365},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4403, col: 44, offset: 133359},
+								pos:  position{line: 4403, col: 44, offset: 133373},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11340,26 +11340,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4414, col: 1, offset: 133628},
+			pos:  position{line: 4414, col: 1, offset: 133642},
 			expr: &actionExpr{
-				pos: position{line: 4414, col: 28, offset: 133655},
+				pos: position{line: 4414, col: 28, offset: 133669},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4414, col: 28, offset: 133655},
+					pos:   position{line: 4414, col: 28, offset: 133669},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4414, col: 37, offset: 133664},
+						pos: position{line: 4414, col: 37, offset: 133678},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 37, offset: 133664},
+								pos:  position{line: 4414, col: 37, offset: 133678},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 63, offset: 133690},
+								pos:  position{line: 4414, col: 63, offset: 133704},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4414, col: 81, offset: 133708},
+								pos:  position{line: 4414, col: 81, offset: 133722},
 								name: "TransactionSearch",
 							},
 						},
@@ -11369,22 +11369,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4418, col: 1, offset: 133756},
+			pos:  position{line: 4418, col: 1, offset: 133770},
 			expr: &actionExpr{
-				pos: position{line: 4418, col: 28, offset: 133783},
+				pos: position{line: 4418, col: 28, offset: 133797},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4418, col: 28, offset: 133783},
+					pos:   position{line: 4418, col: 28, offset: 133797},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4418, col: 33, offset: 133788},
+						pos: position{line: 4418, col: 33, offset: 133802},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4418, col: 33, offset: 133788},
+								pos:  position{line: 4418, col: 33, offset: 133802},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4418, col: 64, offset: 133819},
+								pos:  position{line: 4418, col: 64, offset: 133833},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11394,29 +11394,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4422, col: 1, offset: 133879},
+			pos:  position{line: 4422, col: 1, offset: 133893},
 			expr: &actionExpr{
-				pos: position{line: 4422, col: 38, offset: 133916},
+				pos: position{line: 4422, col: 38, offset: 133930},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4422, col: 38, offset: 133916},
+					pos: position{line: 4422, col: 38, offset: 133930},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4422, col: 38, offset: 133916},
+							pos:        position{line: 4422, col: 38, offset: 133930},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4422, col: 42, offset: 133920},
+							pos:   position{line: 4422, col: 42, offset: 133934},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4422, col: 55, offset: 133933},
+								pos:  position{line: 4422, col: 55, offset: 133947},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4422, col: 68, offset: 133946},
+							pos:        position{line: 4422, col: 68, offset: 133960},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11427,23 +11427,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4430, col: 1, offset: 134085},
+			pos:  position{line: 4430, col: 1, offset: 134099},
 			expr: &actionExpr{
-				pos: position{line: 4430, col: 21, offset: 134105},
+				pos: position{line: 4430, col: 21, offset: 134119},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4430, col: 21, offset: 134105},
+					pos: position{line: 4430, col: 21, offset: 134119},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4430, col: 21, offset: 134105},
+							pos:        position{line: 4430, col: 21, offset: 134119},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4430, col: 25, offset: 134109},
+							pos: position{line: 4430, col: 25, offset: 134123},
 							expr: &charClassMatcher{
-								pos:        position{line: 4430, col: 25, offset: 134109},
+								pos:        position{line: 4430, col: 25, offset: 134123},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11451,7 +11451,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4430, col: 44, offset: 134128},
+							pos:        position{line: 4430, col: 44, offset: 134142},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11462,15 +11462,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4435, col: 1, offset: 134239},
+			pos:  position{line: 4435, col: 1, offset: 134253},
 			expr: &actionExpr{
-				pos: position{line: 4435, col: 33, offset: 134271},
+				pos: position{line: 4435, col: 33, offset: 134285},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4435, col: 33, offset: 134271},
+					pos:   position{line: 4435, col: 33, offset: 134285},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4435, col: 37, offset: 134275},
+						pos:  position{line: 4435, col: 37, offset: 134289},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11478,15 +11478,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4443, col: 1, offset: 134430},
+			pos:  position{line: 4443, col: 1, offset: 134444},
 			expr: &actionExpr{
-				pos: position{line: 4443, col: 22, offset: 134451},
+				pos: position{line: 4443, col: 22, offset: 134465},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4443, col: 22, offset: 134451},
+					pos:   position{line: 4443, col: 22, offset: 134465},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4443, col: 27, offset: 134456},
+						pos:  position{line: 4443, col: 27, offset: 134470},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11494,37 +11494,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4453, col: 1, offset: 134628},
+			pos:  position{line: 4453, col: 1, offset: 134642},
 			expr: &actionExpr{
-				pos: position{line: 4453, col: 20, offset: 134647},
+				pos: position{line: 4453, col: 20, offset: 134661},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4453, col: 20, offset: 134647},
+					pos: position{line: 4453, col: 20, offset: 134661},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4453, col: 20, offset: 134647},
+							pos:        position{line: 4453, col: 20, offset: 134661},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 27, offset: 134654},
+							pos:  position{line: 4453, col: 27, offset: 134668},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 42, offset: 134669},
+							pos:  position{line: 4453, col: 42, offset: 134683},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4453, col: 50, offset: 134677},
+							pos:   position{line: 4453, col: 50, offset: 134691},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4453, col: 60, offset: 134687},
+								pos:  position{line: 4453, col: 60, offset: 134701},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4453, col: 69, offset: 134696},
+							pos:  position{line: 4453, col: 69, offset: 134710},
 							name: "R_PAREN",
 						},
 					},
@@ -11533,22 +11533,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4463, col: 1, offset: 134999},
+			pos:  position{line: 4463, col: 1, offset: 135013},
 			expr: &actionExpr{
-				pos: position{line: 4463, col: 20, offset: 135018},
+				pos: position{line: 4463, col: 20, offset: 135032},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4463, col: 20, offset: 135018},
+					pos: position{line: 4463, col: 20, offset: 135032},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4463, col: 20, offset: 135018},
+							pos:  position{line: 4463, col: 20, offset: 135032},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4463, col: 25, offset: 135023},
+							pos:   position{line: 4463, col: 25, offset: 135037},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4463, col: 42, offset: 135040},
+								pos:  position{line: 4463, col: 42, offset: 135054},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11558,41 +11558,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4467, col: 1, offset: 135089},
+			pos:  position{line: 4467, col: 1, offset: 135103},
 			expr: &actionExpr{
-				pos: position{line: 4467, col: 16, offset: 135104},
+				pos: position{line: 4467, col: 16, offset: 135118},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4467, col: 16, offset: 135104},
+					pos: position{line: 4467, col: 16, offset: 135118},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 16, offset: 135104},
+							pos:  position{line: 4467, col: 16, offset: 135118},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 27, offset: 135115},
+							pos:  position{line: 4467, col: 27, offset: 135129},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4467, col: 33, offset: 135121},
+							pos:   position{line: 4467, col: 33, offset: 135135},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4467, col: 50, offset: 135138},
+								pos: position{line: 4467, col: 50, offset: 135152},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4467, col: 50, offset: 135138},
+									pos:  position{line: 4467, col: 50, offset: 135152},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4467, col: 70, offset: 135158},
+							pos:  position{line: 4467, col: 70, offset: 135172},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4467, col: 85, offset: 135173},
+							pos:   position{line: 4467, col: 85, offset: 135187},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4467, col: 91, offset: 135179},
+								pos:  position{line: 4467, col: 91, offset: 135193},
 								name: "FieldName",
 							},
 						},
@@ -11602,35 +11602,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4495, col: 1, offset: 135919},
+			pos:  position{line: 4495, col: 1, offset: 135933},
 			expr: &actionExpr{
-				pos: position{line: 4495, col: 23, offset: 135941},
+				pos: position{line: 4495, col: 23, offset: 135955},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4495, col: 23, offset: 135941},
+					pos: position{line: 4495, col: 23, offset: 135955},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4495, col: 23, offset: 135941},
+							pos:   position{line: 4495, col: 23, offset: 135955},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4495, col: 31, offset: 135949},
+								pos:  position{line: 4495, col: 31, offset: 135963},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4495, col: 46, offset: 135964},
+							pos:   position{line: 4495, col: 46, offset: 135978},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4495, col: 52, offset: 135970},
+								pos: position{line: 4495, col: 52, offset: 135984},
 								expr: &seqExpr{
-									pos: position{line: 4495, col: 53, offset: 135971},
+									pos: position{line: 4495, col: 53, offset: 135985},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4495, col: 53, offset: 135971},
+											pos:  position{line: 4495, col: 53, offset: 135985},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4495, col: 59, offset: 135977},
+											pos:  position{line: 4495, col: 59, offset: 135991},
 											name: "MVBlockOption",
 										},
 									},
@@ -11643,26 +11643,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4529, col: 1, offset: 137033},
+			pos:  position{line: 4529, col: 1, offset: 137047},
 			expr: &actionExpr{
-				pos: position{line: 4529, col: 18, offset: 137050},
+				pos: position{line: 4529, col: 18, offset: 137064},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4529, col: 18, offset: 137050},
+					pos:   position{line: 4529, col: 18, offset: 137064},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4529, col: 27, offset: 137059},
+						pos: position{line: 4529, col: 27, offset: 137073},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 27, offset: 137059},
+								pos:  position{line: 4529, col: 27, offset: 137073},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 41, offset: 137073},
+								pos:  position{line: 4529, col: 41, offset: 137087},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4529, col: 60, offset: 137092},
+								pos:  position{line: 4529, col: 60, offset: 137106},
 								name: "SetSvOption",
 							},
 						},
@@ -11672,22 +11672,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4533, col: 1, offset: 137133},
+			pos:  position{line: 4533, col: 1, offset: 137147},
 			expr: &actionExpr{
-				pos: position{line: 4533, col: 16, offset: 137148},
+				pos: position{line: 4533, col: 16, offset: 137162},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4533, col: 16, offset: 137148},
+					pos:   position{line: 4533, col: 16, offset: 137162},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4533, col: 28, offset: 137160},
+						pos: position{line: 4533, col: 28, offset: 137174},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4533, col: 28, offset: 137160},
+								pos:  position{line: 4533, col: 28, offset: 137174},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4533, col: 46, offset: 137178},
+								pos:  position{line: 4533, col: 46, offset: 137192},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11697,28 +11697,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4537, col: 1, offset: 137225},
+			pos:  position{line: 4537, col: 1, offset: 137239},
 			expr: &actionExpr{
-				pos: position{line: 4537, col: 20, offset: 137244},
+				pos: position{line: 4537, col: 20, offset: 137258},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4537, col: 20, offset: 137244},
+					pos: position{line: 4537, col: 20, offset: 137258},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4537, col: 20, offset: 137244},
+							pos:        position{line: 4537, col: 20, offset: 137258},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4537, col: 28, offset: 137252},
+							pos:  position{line: 4537, col: 28, offset: 137266},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4537, col: 34, offset: 137258},
+							pos:   position{line: 4537, col: 34, offset: 137272},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4537, col: 38, offset: 137262},
+								pos:  position{line: 4537, col: 38, offset: 137276},
 								name: "QuotedString",
 							},
 						},
@@ -11728,28 +11728,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4548, col: 1, offset: 137513},
+			pos:  position{line: 4548, col: 1, offset: 137527},
 			expr: &actionExpr{
-				pos: position{line: 4548, col: 19, offset: 137531},
+				pos: position{line: 4548, col: 19, offset: 137545},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4548, col: 19, offset: 137531},
+					pos: position{line: 4548, col: 19, offset: 137545},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4548, col: 19, offset: 137531},
+							pos:        position{line: 4548, col: 19, offset: 137545},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4548, col: 31, offset: 137543},
+							pos:  position{line: 4548, col: 31, offset: 137557},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4548, col: 37, offset: 137549},
+							pos:   position{line: 4548, col: 37, offset: 137563},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4548, col: 41, offset: 137553},
+								pos:  position{line: 4548, col: 41, offset: 137567},
 								name: "QuotedString",
 							},
 						},
@@ -11759,28 +11759,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4566, col: 1, offset: 138024},
+			pos:  position{line: 4566, col: 1, offset: 138038},
 			expr: &actionExpr{
-				pos: position{line: 4566, col: 21, offset: 138044},
+				pos: position{line: 4566, col: 21, offset: 138058},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4566, col: 21, offset: 138044},
+					pos: position{line: 4566, col: 21, offset: 138058},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4566, col: 21, offset: 138044},
+							pos:        position{line: 4566, col: 21, offset: 138058},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4566, col: 34, offset: 138057},
+							pos:  position{line: 4566, col: 34, offset: 138071},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4566, col: 40, offset: 138063},
+							pos:   position{line: 4566, col: 40, offset: 138077},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4566, col: 48, offset: 138071},
+								pos:  position{line: 4566, col: 48, offset: 138085},
 								name: "Boolean",
 							},
 						},
@@ -11790,28 +11790,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4578, col: 1, offset: 138311},
+			pos:  position{line: 4578, col: 1, offset: 138325},
 			expr: &actionExpr{
-				pos: position{line: 4578, col: 16, offset: 138326},
+				pos: position{line: 4578, col: 16, offset: 138340},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4578, col: 16, offset: 138326},
+					pos: position{line: 4578, col: 16, offset: 138340},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4578, col: 16, offset: 138326},
+							pos:        position{line: 4578, col: 16, offset: 138340},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4578, col: 24, offset: 138334},
+							pos:  position{line: 4578, col: 24, offset: 138348},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4578, col: 30, offset: 138340},
+							pos:   position{line: 4578, col: 30, offset: 138354},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4578, col: 38, offset: 138348},
+								pos:  position{line: 4578, col: 38, offset: 138362},
 								name: "Boolean",
 							},
 						},
@@ -11821,28 +11821,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4590, col: 1, offset: 138613},
+			pos:  position{line: 4590, col: 1, offset: 138627},
 			expr: &actionExpr{
-				pos: position{line: 4590, col: 15, offset: 138627},
+				pos: position{line: 4590, col: 15, offset: 138641},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4590, col: 15, offset: 138627},
+					pos: position{line: 4590, col: 15, offset: 138641},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4590, col: 15, offset: 138627},
+							pos:  position{line: 4590, col: 15, offset: 138641},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4590, col: 20, offset: 138632},
+							pos:  position{line: 4590, col: 20, offset: 138646},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4590, col: 30, offset: 138642},
+							pos:   position{line: 4590, col: 30, offset: 138656},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4590, col: 40, offset: 138652},
+								pos: position{line: 4590, col: 40, offset: 138666},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4590, col: 40, offset: 138652},
+									pos:  position{line: 4590, col: 40, offset: 138666},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -11853,39 +11853,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4597, col: 1, offset: 138778},
+			pos:  position{line: 4597, col: 1, offset: 138792},
 			expr: &actionExpr{
-				pos: position{line: 4597, col: 23, offset: 138800},
+				pos: position{line: 4597, col: 23, offset: 138814},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4597, col: 23, offset: 138800},
+					pos: position{line: 4597, col: 23, offset: 138814},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4597, col: 23, offset: 138800},
+							pos:  position{line: 4597, col: 23, offset: 138814},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4597, col: 29, offset: 138806},
+							pos:   position{line: 4597, col: 29, offset: 138820},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4597, col: 35, offset: 138812},
+								pos:  position{line: 4597, col: 35, offset: 138826},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4597, col: 49, offset: 138826},
+							pos:   position{line: 4597, col: 49, offset: 138840},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4597, col: 54, offset: 138831},
+								pos: position{line: 4597, col: 54, offset: 138845},
 								expr: &seqExpr{
-									pos: position{line: 4597, col: 55, offset: 138832},
+									pos: position{line: 4597, col: 55, offset: 138846},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4597, col: 55, offset: 138832},
+											pos:  position{line: 4597, col: 55, offset: 138846},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4597, col: 61, offset: 138838},
+											pos:  position{line: 4597, col: 61, offset: 138852},
 											name: "SPathArgument",
 										},
 									},
@@ -11898,26 +11898,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4629, col: 1, offset: 139731},
+			pos:  position{line: 4629, col: 1, offset: 139745},
 			expr: &actionExpr{
-				pos: position{line: 4629, col: 18, offset: 139748},
+				pos: position{line: 4629, col: 18, offset: 139762},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4629, col: 18, offset: 139748},
+					pos:   position{line: 4629, col: 18, offset: 139762},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4629, col: 23, offset: 139753},
+						pos: position{line: 4629, col: 23, offset: 139767},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 23, offset: 139753},
+								pos:  position{line: 4629, col: 23, offset: 139767},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 36, offset: 139766},
+								pos:  position{line: 4629, col: 36, offset: 139780},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4629, col: 50, offset: 139780},
+								pos:  position{line: 4629, col: 50, offset: 139794},
 								name: "PathField",
 							},
 						},
@@ -11927,28 +11927,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4633, col: 1, offset: 139816},
+			pos:  position{line: 4633, col: 1, offset: 139830},
 			expr: &actionExpr{
-				pos: position{line: 4633, col: 15, offset: 139830},
+				pos: position{line: 4633, col: 15, offset: 139844},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4633, col: 15, offset: 139830},
+					pos: position{line: 4633, col: 15, offset: 139844},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4633, col: 15, offset: 139830},
+							pos:        position{line: 4633, col: 15, offset: 139844},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4633, col: 23, offset: 139838},
+							pos:  position{line: 4633, col: 23, offset: 139852},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4633, col: 29, offset: 139844},
+							pos:   position{line: 4633, col: 29, offset: 139858},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4633, col: 35, offset: 139850},
+								pos:  position{line: 4633, col: 35, offset: 139864},
 								name: "FieldName",
 							},
 						},
@@ -11958,28 +11958,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4636, col: 1, offset: 139906},
+			pos:  position{line: 4636, col: 1, offset: 139920},
 			expr: &actionExpr{
-				pos: position{line: 4636, col: 16, offset: 139921},
+				pos: position{line: 4636, col: 16, offset: 139935},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4636, col: 16, offset: 139921},
+					pos: position{line: 4636, col: 16, offset: 139935},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4636, col: 16, offset: 139921},
+							pos:        position{line: 4636, col: 16, offset: 139935},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4636, col: 25, offset: 139930},
+							pos:  position{line: 4636, col: 25, offset: 139944},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4636, col: 31, offset: 139936},
+							pos:   position{line: 4636, col: 31, offset: 139950},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4636, col: 37, offset: 139942},
+								pos:  position{line: 4636, col: 37, offset: 139956},
 								name: "FieldName",
 							},
 						},
@@ -11989,34 +11989,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4639, col: 1, offset: 139999},
+			pos:  position{line: 4639, col: 1, offset: 140013},
 			expr: &actionExpr{
-				pos: position{line: 4639, col: 14, offset: 140012},
+				pos: position{line: 4639, col: 14, offset: 140026},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4639, col: 15, offset: 140013},
+					pos: position{line: 4639, col: 15, offset: 140027},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4639, col: 15, offset: 140013},
+							pos: position{line: 4639, col: 15, offset: 140027},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4639, col: 15, offset: 140013},
+									pos:        position{line: 4639, col: 15, offset: 140027},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4639, col: 22, offset: 140020},
+									pos:  position{line: 4639, col: 22, offset: 140034},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4639, col: 28, offset: 140026},
+									pos:  position{line: 4639, col: 28, offset: 140040},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4639, col: 47, offset: 140045},
+							pos:  position{line: 4639, col: 47, offset: 140059},
 							name: "SPathFieldString",
 						},
 					},
@@ -12025,16 +12025,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4651, col: 1, offset: 140457},
+			pos:  position{line: 4651, col: 1, offset: 140471},
 			expr: &choiceExpr{
-				pos: position{line: 4651, col: 21, offset: 140477},
+				pos: position{line: 4651, col: 21, offset: 140491},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4651, col: 21, offset: 140477},
+						pos:  position{line: 4651, col: 21, offset: 140491},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4651, col: 36, offset: 140492},
+						pos:  position{line: 4651, col: 36, offset: 140506},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12042,28 +12042,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4654, col: 1, offset: 140565},
+			pos:  position{line: 4654, col: 1, offset: 140579},
 			expr: &actionExpr{
-				pos: position{line: 4654, col: 16, offset: 140580},
+				pos: position{line: 4654, col: 16, offset: 140594},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4654, col: 16, offset: 140580},
+					pos: position{line: 4654, col: 16, offset: 140594},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4654, col: 16, offset: 140580},
+							pos:  position{line: 4654, col: 16, offset: 140594},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4654, col: 21, offset: 140585},
+							pos:  position{line: 4654, col: 21, offset: 140599},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4654, col: 32, offset: 140596},
+							pos:   position{line: 4654, col: 32, offset: 140610},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4654, col: 46, offset: 140610},
+								pos: position{line: 4654, col: 46, offset: 140624},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4654, col: 46, offset: 140610},
+									pos:  position{line: 4654, col: 46, offset: 140624},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12074,39 +12074,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4676, col: 1, offset: 141219},
+			pos:  position{line: 4676, col: 1, offset: 141233},
 			expr: &actionExpr{
-				pos: position{line: 4676, col: 24, offset: 141242},
+				pos: position{line: 4676, col: 24, offset: 141256},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4676, col: 24, offset: 141242},
+					pos: position{line: 4676, col: 24, offset: 141256},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4676, col: 24, offset: 141242},
+							pos:  position{line: 4676, col: 24, offset: 141256},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4676, col: 30, offset: 141248},
+							pos:   position{line: 4676, col: 30, offset: 141262},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4676, col: 37, offset: 141255},
+								pos:  position{line: 4676, col: 37, offset: 141269},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4676, col: 52, offset: 141270},
+							pos:   position{line: 4676, col: 52, offset: 141284},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4676, col: 57, offset: 141275},
+								pos: position{line: 4676, col: 57, offset: 141289},
 								expr: &seqExpr{
-									pos: position{line: 4676, col: 58, offset: 141276},
+									pos: position{line: 4676, col: 58, offset: 141290},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4676, col: 58, offset: 141276},
+											pos:  position{line: 4676, col: 58, offset: 141290},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4676, col: 64, offset: 141282},
+											pos:  position{line: 4676, col: 64, offset: 141296},
 											name: "FormatArgument",
 										},
 									},
@@ -12119,30 +12119,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4710, col: 1, offset: 142471},
+			pos:  position{line: 4710, col: 1, offset: 142485},
 			expr: &actionExpr{
-				pos: position{line: 4710, col: 19, offset: 142489},
+				pos: position{line: 4710, col: 19, offset: 142503},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4710, col: 19, offset: 142489},
+					pos:   position{line: 4710, col: 19, offset: 142503},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4710, col: 28, offset: 142498},
+						pos: position{line: 4710, col: 28, offset: 142512},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 28, offset: 142498},
+								pos:  position{line: 4710, col: 28, offset: 142512},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 46, offset: 142516},
+								pos:  position{line: 4710, col: 46, offset: 142530},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 65, offset: 142535},
+								pos:  position{line: 4710, col: 65, offset: 142549},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4710, col: 82, offset: 142552},
+								pos:  position{line: 4710, col: 82, offset: 142566},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12152,28 +12152,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4714, col: 1, offset: 142602},
+			pos:  position{line: 4714, col: 1, offset: 142616},
 			expr: &actionExpr{
-				pos: position{line: 4714, col: 20, offset: 142621},
+				pos: position{line: 4714, col: 20, offset: 142635},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4714, col: 20, offset: 142621},
+					pos: position{line: 4714, col: 20, offset: 142635},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4714, col: 20, offset: 142621},
+							pos:        position{line: 4714, col: 20, offset: 142635},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4714, col: 28, offset: 142629},
+							pos:  position{line: 4714, col: 28, offset: 142643},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4714, col: 34, offset: 142635},
+							pos:   position{line: 4714, col: 34, offset: 142649},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4714, col: 38, offset: 142639},
+								pos:  position{line: 4714, col: 38, offset: 142653},
 								name: "QuotedString",
 							},
 						},
@@ -12183,28 +12183,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4723, col: 1, offset: 142851},
+			pos:  position{line: 4723, col: 1, offset: 142865},
 			expr: &actionExpr{
-				pos: position{line: 4723, col: 21, offset: 142871},
+				pos: position{line: 4723, col: 21, offset: 142885},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4723, col: 21, offset: 142871},
+					pos: position{line: 4723, col: 21, offset: 142885},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4723, col: 21, offset: 142871},
+							pos:        position{line: 4723, col: 21, offset: 142885},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4723, col: 34, offset: 142884},
+							pos:  position{line: 4723, col: 34, offset: 142898},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4723, col: 40, offset: 142890},
+							pos:   position{line: 4723, col: 40, offset: 142904},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4723, col: 47, offset: 142897},
+								pos:  position{line: 4723, col: 47, offset: 142911},
 								name: "IntegerAsString",
 							},
 						},
@@ -12214,28 +12214,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4736, col: 1, offset: 143303},
+			pos:  position{line: 4736, col: 1, offset: 143317},
 			expr: &actionExpr{
-				pos: position{line: 4736, col: 19, offset: 143321},
+				pos: position{line: 4736, col: 19, offset: 143335},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4736, col: 19, offset: 143321},
+					pos: position{line: 4736, col: 19, offset: 143335},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4736, col: 19, offset: 143321},
+							pos:        position{line: 4736, col: 19, offset: 143335},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4736, col: 30, offset: 143332},
+							pos:  position{line: 4736, col: 30, offset: 143346},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4736, col: 36, offset: 143338},
+							pos:   position{line: 4736, col: 36, offset: 143352},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4736, col: 40, offset: 143342},
+								pos:  position{line: 4736, col: 40, offset: 143356},
 								name: "QuotedString",
 							},
 						},
@@ -12245,78 +12245,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4745, col: 1, offset: 143557},
+			pos:  position{line: 4745, col: 1, offset: 143571},
 			expr: &actionExpr{
-				pos: position{line: 4745, col: 24, offset: 143580},
+				pos: position{line: 4745, col: 24, offset: 143594},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4745, col: 24, offset: 143580},
+					pos: position{line: 4745, col: 24, offset: 143594},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4745, col: 24, offset: 143580},
+							pos:   position{line: 4745, col: 24, offset: 143594},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 34, offset: 143590},
+								pos:  position{line: 4745, col: 34, offset: 143604},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 47, offset: 143603},
+							pos:  position{line: 4745, col: 47, offset: 143617},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 53, offset: 143609},
+							pos:   position{line: 4745, col: 53, offset: 143623},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 63, offset: 143619},
+								pos:  position{line: 4745, col: 63, offset: 143633},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 76, offset: 143632},
+							pos:  position{line: 4745, col: 76, offset: 143646},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 82, offset: 143638},
+							pos:   position{line: 4745, col: 82, offset: 143652},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 95, offset: 143651},
+								pos:  position{line: 4745, col: 95, offset: 143665},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 108, offset: 143664},
+							pos:  position{line: 4745, col: 108, offset: 143678},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 114, offset: 143670},
+							pos:   position{line: 4745, col: 114, offset: 143684},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 121, offset: 143677},
+								pos:  position{line: 4745, col: 121, offset: 143691},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 134, offset: 143690},
+							pos:  position{line: 4745, col: 134, offset: 143704},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 140, offset: 143696},
+							pos:   position{line: 4745, col: 140, offset: 143710},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 153, offset: 143709},
+								pos:  position{line: 4745, col: 153, offset: 143723},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4745, col: 166, offset: 143722},
+							pos:  position{line: 4745, col: 166, offset: 143736},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4745, col: 172, offset: 143728},
+							pos:   position{line: 4745, col: 172, offset: 143742},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4745, col: 179, offset: 143735},
+								pos:  position{line: 4745, col: 179, offset: 143749},
 								name: "QuotedString",
 							},
 						},
@@ -12326,28 +12326,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4763, col: 1, offset: 144311},
+			pos:  position{line: 4763, col: 1, offset: 144325},
 			expr: &actionExpr{
-				pos: position{line: 4763, col: 20, offset: 144330},
+				pos: position{line: 4763, col: 20, offset: 144344},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4763, col: 20, offset: 144330},
+					pos: position{line: 4763, col: 20, offset: 144344},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 20, offset: 144330},
+							pos:  position{line: 4763, col: 20, offset: 144344},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 25, offset: 144335},
+							pos:  position{line: 4763, col: 25, offset: 144349},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4763, col: 40, offset: 144350},
+							pos:   position{line: 4763, col: 40, offset: 144364},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4763, col: 55, offset: 144365},
+								pos: position{line: 4763, col: 55, offset: 144379},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4763, col: 55, offset: 144365},
+									pos:  position{line: 4763, col: 55, offset: 144379},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12358,42 +12358,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4770, col: 1, offset: 144518},
+			pos:  position{line: 4770, col: 1, offset: 144532},
 			expr: &actionExpr{
-				pos: position{line: 4770, col: 28, offset: 144545},
+				pos: position{line: 4770, col: 28, offset: 144559},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4770, col: 28, offset: 144545},
+					pos: position{line: 4770, col: 28, offset: 144559},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4770, col: 28, offset: 144545},
+							pos:  position{line: 4770, col: 28, offset: 144559},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 34, offset: 144551},
+							pos:   position{line: 4770, col: 34, offset: 144565},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4770, col: 40, offset: 144557},
+								pos: position{line: 4770, col: 40, offset: 144571},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4770, col: 40, offset: 144557},
+									pos:  position{line: 4770, col: 40, offset: 144571},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 60, offset: 144577},
+							pos:   position{line: 4770, col: 60, offset: 144591},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4770, col: 65, offset: 144582},
+								pos: position{line: 4770, col: 65, offset: 144596},
 								expr: &seqExpr{
-									pos: position{line: 4770, col: 66, offset: 144583},
+									pos: position{line: 4770, col: 66, offset: 144597},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 66, offset: 144583},
+											pos:  position{line: 4770, col: 66, offset: 144597},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 72, offset: 144589},
+											pos:  position{line: 4770, col: 72, offset: 144603},
 											name: "EventCountArgument",
 										},
 									},
@@ -12406,30 +12406,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4826, col: 1, offset: 146466},
+			pos:  position{line: 4826, col: 1, offset: 146480},
 			expr: &actionExpr{
-				pos: position{line: 4826, col: 23, offset: 146488},
+				pos: position{line: 4826, col: 23, offset: 146502},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4826, col: 23, offset: 146488},
+					pos:   position{line: 4826, col: 23, offset: 146502},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4826, col: 28, offset: 146493},
+						pos: position{line: 4826, col: 28, offset: 146507},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 28, offset: 146493},
+								pos:  position{line: 4826, col: 28, offset: 146507},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 41, offset: 146506},
+								pos:  position{line: 4826, col: 41, offset: 146520},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 58, offset: 146523},
+								pos:  position{line: 4826, col: 58, offset: 146537},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4826, col: 76, offset: 146541},
+								pos:  position{line: 4826, col: 76, offset: 146555},
 								name: "ListVixField",
 							},
 						},
@@ -12439,28 +12439,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4830, col: 1, offset: 146580},
+			pos:  position{line: 4830, col: 1, offset: 146594},
 			expr: &actionExpr{
-				pos: position{line: 4830, col: 15, offset: 146594},
+				pos: position{line: 4830, col: 15, offset: 146608},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4830, col: 15, offset: 146594},
+					pos: position{line: 4830, col: 15, offset: 146608},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4830, col: 15, offset: 146594},
+							pos:        position{line: 4830, col: 15, offset: 146608},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4830, col: 23, offset: 146602},
+							pos:  position{line: 4830, col: 23, offset: 146616},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4830, col: 29, offset: 146608},
+							pos:   position{line: 4830, col: 29, offset: 146622},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4830, col: 35, offset: 146614},
+								pos:  position{line: 4830, col: 35, offset: 146628},
 								name: "IndexName",
 							},
 						},
@@ -12470,28 +12470,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4833, col: 1, offset: 146670},
+			pos:  position{line: 4833, col: 1, offset: 146684},
 			expr: &actionExpr{
-				pos: position{line: 4833, col: 19, offset: 146688},
+				pos: position{line: 4833, col: 19, offset: 146702},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4833, col: 19, offset: 146688},
+					pos: position{line: 4833, col: 19, offset: 146702},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4833, col: 19, offset: 146688},
+							pos:        position{line: 4833, col: 19, offset: 146702},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4833, col: 31, offset: 146700},
+							pos:  position{line: 4833, col: 31, offset: 146714},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4833, col: 37, offset: 146706},
+							pos:   position{line: 4833, col: 37, offset: 146720},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4833, col: 43, offset: 146712},
+								pos:  position{line: 4833, col: 43, offset: 146726},
 								name: "Boolean",
 							},
 						},
@@ -12501,28 +12501,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4836, col: 1, offset: 146788},
+			pos:  position{line: 4836, col: 1, offset: 146802},
 			expr: &actionExpr{
-				pos: position{line: 4836, col: 20, offset: 146807},
+				pos: position{line: 4836, col: 20, offset: 146821},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4836, col: 20, offset: 146807},
+					pos: position{line: 4836, col: 20, offset: 146821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4836, col: 20, offset: 146807},
+							pos:        position{line: 4836, col: 20, offset: 146821},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4836, col: 34, offset: 146821},
+							pos:  position{line: 4836, col: 34, offset: 146835},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4836, col: 40, offset: 146827},
+							pos:   position{line: 4836, col: 40, offset: 146841},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4836, col: 46, offset: 146833},
+								pos:  position{line: 4836, col: 46, offset: 146847},
 								name: "Boolean",
 							},
 						},
@@ -12532,28 +12532,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4839, col: 1, offset: 146911},
+			pos:  position{line: 4839, col: 1, offset: 146925},
 			expr: &actionExpr{
-				pos: position{line: 4839, col: 17, offset: 146927},
+				pos: position{line: 4839, col: 17, offset: 146941},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4839, col: 17, offset: 146927},
+					pos: position{line: 4839, col: 17, offset: 146941},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4839, col: 17, offset: 146927},
+							pos:        position{line: 4839, col: 17, offset: 146941},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4839, col: 28, offset: 146938},
+							pos:  position{line: 4839, col: 28, offset: 146952},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4839, col: 34, offset: 146944},
+							pos:   position{line: 4839, col: 34, offset: 146958},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4839, col: 40, offset: 146950},
+								pos:  position{line: 4839, col: 40, offset: 146964},
 								name: "Boolean",
 							},
 						},
@@ -12563,24 +12563,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4843, col: 1, offset: 147026},
+			pos:  position{line: 4843, col: 1, offset: 147040},
 			expr: &actionExpr{
-				pos: position{line: 4843, col: 14, offset: 147039},
+				pos: position{line: 4843, col: 14, offset: 147053},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4843, col: 14, offset: 147039},
+					pos: position{line: 4843, col: 14, offset: 147053},
 					expr: &seqExpr{
-						pos: position{line: 4843, col: 15, offset: 147040},
+						pos: position{line: 4843, col: 15, offset: 147054},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4843, col: 15, offset: 147040},
+								pos: position{line: 4843, col: 15, offset: 147054},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4843, col: 16, offset: 147041},
+									pos:  position{line: 4843, col: 16, offset: 147055},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4843, col: 22, offset: 147047,
+								line: 4843, col: 22, offset: 147061,
 							},
 						},
 					},
@@ -12589,39 +12589,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4848, col: 1, offset: 147120},
+			pos:  position{line: 4848, col: 1, offset: 147134},
 			expr: &actionExpr{
-				pos: position{line: 4848, col: 18, offset: 147137},
+				pos: position{line: 4848, col: 18, offset: 147151},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4848, col: 18, offset: 147137},
+					pos: position{line: 4848, col: 18, offset: 147151},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4848, col: 18, offset: 147137},
+							pos:  position{line: 4848, col: 18, offset: 147151},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4848, col: 23, offset: 147142},
+							pos:  position{line: 4848, col: 23, offset: 147156},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4848, col: 36, offset: 147155},
+							pos:   position{line: 4848, col: 36, offset: 147169},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4848, col: 49, offset: 147168},
+								pos: position{line: 4848, col: 49, offset: 147182},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4848, col: 49, offset: 147168},
+									pos:  position{line: 4848, col: 49, offset: 147182},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4848, col: 70, offset: 147189},
+							pos:   position{line: 4848, col: 70, offset: 147203},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4848, col: 77, offset: 147196},
+								pos: position{line: 4848, col: 77, offset: 147210},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4848, col: 77, offset: 147196},
+									pos:  position{line: 4848, col: 77, offset: 147210},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12632,32 +12632,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4877, col: 1, offset: 147923},
+			pos:  position{line: 4877, col: 1, offset: 147937},
 			expr: &actionExpr{
-				pos: position{line: 4877, col: 24, offset: 147946},
+				pos: position{line: 4877, col: 24, offset: 147960},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4877, col: 24, offset: 147946},
+					pos: position{line: 4877, col: 24, offset: 147960},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4877, col: 24, offset: 147946},
+							pos:  position{line: 4877, col: 24, offset: 147960},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4877, col: 30, offset: 147952},
+							pos:        position{line: 4877, col: 30, offset: 147966},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4877, col: 38, offset: 147960},
+							pos:  position{line: 4877, col: 38, offset: 147974},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4877, col: 44, offset: 147966},
+							pos:   position{line: 4877, col: 44, offset: 147980},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4877, col: 48, offset: 147970},
+								pos:  position{line: 4877, col: 48, offset: 147984},
 								name: "String",
 							},
 						},
@@ -12667,22 +12667,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 4881, col: 1, offset: 148016},
+			pos:  position{line: 4881, col: 1, offset: 148030},
 			expr: &actionExpr{
-				pos: position{line: 4881, col: 22, offset: 148037},
+				pos: position{line: 4881, col: 22, offset: 148051},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 4881, col: 22, offset: 148037},
+					pos: position{line: 4881, col: 22, offset: 148051},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4881, col: 22, offset: 148037},
+							pos:  position{line: 4881, col: 22, offset: 148051},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4881, col: 28, offset: 148043},
+							pos:   position{line: 4881, col: 28, offset: 148057},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4881, col: 38, offset: 148053},
+								pos:  position{line: 4881, col: 38, offset: 148067},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12692,36 +12692,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 4885, col: 1, offset: 148112},
+			pos:  position{line: 4885, col: 1, offset: 148126},
 			expr: &actionExpr{
-				pos: position{line: 4885, col: 18, offset: 148129},
+				pos: position{line: 4885, col: 18, offset: 148143},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4885, col: 18, offset: 148129},
+					pos: position{line: 4885, col: 18, offset: 148143},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4885, col: 18, offset: 148129},
+							pos:  position{line: 4885, col: 18, offset: 148143},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4885, col: 23, offset: 148134},
+							pos:  position{line: 4885, col: 23, offset: 148148},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 4885, col: 36, offset: 148147},
+							pos:   position{line: 4885, col: 36, offset: 148161},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4885, col: 42, offset: 148153},
+								pos:  position{line: 4885, col: 42, offset: 148167},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4885, col: 56, offset: 148167},
+							pos:   position{line: 4885, col: 56, offset: 148181},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4885, col: 62, offset: 148173},
+								pos: position{line: 4885, col: 62, offset: 148187},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4885, col: 62, offset: 148173},
+									pos:  position{line: 4885, col: 62, offset: 148187},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12732,22 +12732,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 4915, col: 1, offset: 148907},
+			pos:  position{line: 4915, col: 1, offset: 148921},
 			expr: &actionExpr{
-				pos: position{line: 4915, col: 18, offset: 148924},
+				pos: position{line: 4915, col: 18, offset: 148938},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 4915, col: 18, offset: 148924},
+					pos: position{line: 4915, col: 18, offset: 148938},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4915, col: 18, offset: 148924},
+							pos:  position{line: 4915, col: 18, offset: 148938},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4915, col: 24, offset: 148930},
+							pos:   position{line: 4915, col: 24, offset: 148944},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4915, col: 34, offset: 148940},
+								pos:  position{line: 4915, col: 34, offset: 148954},
 								name: "FieldName",
 							},
 						},
@@ -12757,32 +12757,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 4919, col: 1, offset: 148981},
+			pos:  position{line: 4919, col: 1, offset: 148995},
 			expr: &actionExpr{
-				pos: position{line: 4919, col: 18, offset: 148998},
+				pos: position{line: 4919, col: 18, offset: 149012},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4919, col: 18, offset: 148998},
+					pos: position{line: 4919, col: 18, offset: 149012},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4919, col: 18, offset: 148998},
+							pos:  position{line: 4919, col: 18, offset: 149012},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4919, col: 24, offset: 149004},
+							pos:        position{line: 4919, col: 24, offset: 149018},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4919, col: 32, offset: 149012},
+							pos:  position{line: 4919, col: 32, offset: 149026},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4919, col: 38, offset: 149018},
+							pos:   position{line: 4919, col: 38, offset: 149032},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4919, col: 47, offset: 149027},
+								pos:  position{line: 4919, col: 47, offset: 149041},
 								name: "IntegerAsString",
 							},
 						},
@@ -12792,26 +12792,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 4923, col: 1, offset: 149073},
+			pos:  position{line: 4923, col: 1, offset: 149087},
 			expr: &actionExpr{
-				pos: position{line: 4923, col: 16, offset: 149088},
+				pos: position{line: 4923, col: 16, offset: 149102},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 4923, col: 16, offset: 149088},
+					pos: position{line: 4923, col: 16, offset: 149102},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4923, col: 16, offset: 149088},
+							pos:  position{line: 4923, col: 16, offset: 149102},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4923, col: 22, offset: 149094},
+							pos:  position{line: 4923, col: 22, offset: 149108},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4923, col: 32, offset: 149104},
+							pos:   position{line: 4923, col: 32, offset: 149118},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4923, col: 42, offset: 149114},
+								pos:  position{line: 4923, col: 42, offset: 149128},
 								name: "BoolExpr",
 							},
 						},
@@ -12821,28 +12821,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 4927, col: 1, offset: 149174},
+			pos:  position{line: 4927, col: 1, offset: 149188},
 			expr: &actionExpr{
-				pos: position{line: 4927, col: 28, offset: 149201},
+				pos: position{line: 4927, col: 28, offset: 149215},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 4927, col: 28, offset: 149201},
+					pos: position{line: 4927, col: 28, offset: 149215},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4927, col: 28, offset: 149201},
+							pos:        position{line: 4927, col: 28, offset: 149215},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4927, col: 37, offset: 149210},
+							pos:  position{line: 4927, col: 37, offset: 149224},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4927, col: 43, offset: 149216},
+							pos:   position{line: 4927, col: 43, offset: 149230},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4927, col: 51, offset: 149224},
+								pos:  position{line: 4927, col: 51, offset: 149238},
 								name: "Boolean",
 							},
 						},
@@ -12852,28 +12852,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 4936, col: 1, offset: 149408},
+			pos:  position{line: 4936, col: 1, offset: 149422},
 			expr: &actionExpr{
-				pos: position{line: 4936, col: 28, offset: 149435},
+				pos: position{line: 4936, col: 28, offset: 149449},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 4936, col: 28, offset: 149435},
+					pos: position{line: 4936, col: 28, offset: 149449},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4936, col: 28, offset: 149435},
+							pos:        position{line: 4936, col: 28, offset: 149449},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4936, col: 37, offset: 149444},
+							pos:  position{line: 4936, col: 37, offset: 149458},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4936, col: 43, offset: 149450},
+							pos:   position{line: 4936, col: 43, offset: 149464},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4936, col: 51, offset: 149458},
+								pos:  position{line: 4936, col: 51, offset: 149472},
 								name: "Boolean",
 							},
 						},
@@ -12883,28 +12883,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 4945, col: 1, offset: 149642},
+			pos:  position{line: 4945, col: 1, offset: 149656},
 			expr: &actionExpr{
-				pos: position{line: 4945, col: 27, offset: 149668},
+				pos: position{line: 4945, col: 27, offset: 149682},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 4945, col: 27, offset: 149668},
+					pos: position{line: 4945, col: 27, offset: 149682},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4945, col: 27, offset: 149668},
+							pos:        position{line: 4945, col: 27, offset: 149682},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4945, col: 35, offset: 149676},
+							pos:  position{line: 4945, col: 35, offset: 149690},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4945, col: 41, offset: 149682},
+							pos:   position{line: 4945, col: 41, offset: 149696},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4945, col: 48, offset: 149689},
+								pos:  position{line: 4945, col: 48, offset: 149703},
 								name: "PositiveInteger",
 							},
 						},
@@ -12914,28 +12914,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 4954, col: 1, offset: 149880},
+			pos:  position{line: 4954, col: 1, offset: 149894},
 			expr: &actionExpr{
-				pos: position{line: 4954, col: 25, offset: 149904},
+				pos: position{line: 4954, col: 25, offset: 149918},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 4954, col: 25, offset: 149904},
+					pos: position{line: 4954, col: 25, offset: 149918},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4954, col: 25, offset: 149904},
+							pos:        position{line: 4954, col: 25, offset: 149918},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4954, col: 31, offset: 149910},
+							pos:  position{line: 4954, col: 31, offset: 149924},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4954, col: 37, offset: 149916},
+							pos:   position{line: 4954, col: 37, offset: 149930},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4954, col: 44, offset: 149923},
+								pos:  position{line: 4954, col: 44, offset: 149937},
 								name: "PositiveInteger",
 							},
 						},
@@ -12945,30 +12945,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 4963, col: 1, offset: 150110},
+			pos:  position{line: 4963, col: 1, offset: 150124},
 			expr: &actionExpr{
-				pos: position{line: 4963, col: 22, offset: 150131},
+				pos: position{line: 4963, col: 22, offset: 150145},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4963, col: 22, offset: 150131},
+					pos:   position{line: 4963, col: 22, offset: 150145},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 4963, col: 41, offset: 150150},
+						pos: position{line: 4963, col: 41, offset: 150164},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 41, offset: 150150},
+								pos:  position{line: 4963, col: 41, offset: 150164},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 67, offset: 150176},
+								pos:  position{line: 4963, col: 67, offset: 150190},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 93, offset: 150202},
+								pos:  position{line: 4963, col: 93, offset: 150216},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 118, offset: 150227},
+								pos:  position{line: 4963, col: 118, offset: 150241},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -12978,35 +12978,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 4967, col: 1, offset: 150288},
+			pos:  position{line: 4967, col: 1, offset: 150302},
 			expr: &actionExpr{
-				pos: position{line: 4967, col: 26, offset: 150313},
+				pos: position{line: 4967, col: 26, offset: 150327},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4967, col: 26, offset: 150313},
+					pos: position{line: 4967, col: 26, offset: 150327},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4967, col: 26, offset: 150313},
+							pos:   position{line: 4967, col: 26, offset: 150327},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4967, col: 34, offset: 150321},
+								pos:  position{line: 4967, col: 34, offset: 150335},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4967, col: 53, offset: 150340},
+							pos:   position{line: 4967, col: 53, offset: 150354},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4967, col: 58, offset: 150345},
+								pos: position{line: 4967, col: 58, offset: 150359},
 								expr: &seqExpr{
-									pos: position{line: 4967, col: 59, offset: 150346},
+									pos: position{line: 4967, col: 59, offset: 150360},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4967, col: 59, offset: 150346},
+											pos:  position{line: 4967, col: 59, offset: 150360},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4967, col: 65, offset: 150352},
+											pos:  position{line: 4967, col: 65, offset: 150366},
 											name: "InputLookupOption",
 										},
 									},
@@ -13019,35 +13019,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5009, col: 1, offset: 151798},
+			pos:  position{line: 5009, col: 1, offset: 151812},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 21, offset: 151818},
+				pos: position{line: 5009, col: 21, offset: 151832},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 21, offset: 151818},
+					pos: position{line: 5009, col: 21, offset: 151832},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 21, offset: 151818},
+							pos:  position{line: 5009, col: 21, offset: 151832},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 26, offset: 151823},
+							pos:  position{line: 5009, col: 26, offset: 151837},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 42, offset: 151839},
+							pos:   position{line: 5009, col: 42, offset: 151853},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 60, offset: 151857},
+								pos: position{line: 5009, col: 60, offset: 151871},
 								expr: &seqExpr{
-									pos: position{line: 5009, col: 61, offset: 151858},
+									pos: position{line: 5009, col: 61, offset: 151872},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5009, col: 61, offset: 151858},
+											pos:  position{line: 5009, col: 61, offset: 151872},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5009, col: 83, offset: 151880},
+											pos:  position{line: 5009, col: 83, offset: 151894},
 											name: "SPACE",
 										},
 									},
@@ -13055,20 +13055,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 91, offset: 151888},
+							pos:   position{line: 5009, col: 91, offset: 151902},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5009, col: 101, offset: 151898},
+								pos:  position{line: 5009, col: 101, offset: 151912},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 109, offset: 151906},
+							pos:   position{line: 5009, col: 109, offset: 151920},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 121, offset: 151918},
+								pos: position{line: 5009, col: 121, offset: 151932},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5009, col: 122, offset: 151919},
+									pos:  position{line: 5009, col: 122, offset: 151933},
 									name: "WhereClause",
 								},
 							},
@@ -13079,15 +13079,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5031, col: 1, offset: 152569},
+			pos:  position{line: 5031, col: 1, offset: 152583},
 			expr: &actionExpr{
-				pos: position{line: 5031, col: 24, offset: 152592},
+				pos: position{line: 5031, col: 24, offset: 152606},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5031, col: 24, offset: 152592},
+					pos:   position{line: 5031, col: 24, offset: 152606},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5031, col: 41, offset: 152609},
+						pos:  position{line: 5031, col: 41, offset: 152623},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13095,124 +13095,124 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5043, col: 1, offset: 153001},
+			pos:  position{line: 5043, col: 1, offset: 153015},
 			expr: &choiceExpr{
-				pos: position{line: 5043, col: 12, offset: 153012},
+				pos: position{line: 5043, col: 12, offset: 153026},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 12, offset: 153012},
+						pos:  position{line: 5043, col: 12, offset: 153026},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 24, offset: 153024},
+						pos:  position{line: 5043, col: 24, offset: 153038},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 36, offset: 153036},
+						pos:  position{line: 5043, col: 36, offset: 153050},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 49, offset: 153049},
+						pos:  position{line: 5043, col: 49, offset: 153063},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 61, offset: 153061},
+						pos:  position{line: 5043, col: 61, offset: 153075},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 81, offset: 153081},
+						pos:  position{line: 5043, col: 81, offset: 153095},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 92, offset: 153092},
+						pos:  position{line: 5043, col: 92, offset: 153106},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 112, offset: 153112},
+						pos:  position{line: 5043, col: 112, offset: 153126},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 123, offset: 153123},
+						pos:  position{line: 5043, col: 123, offset: 153137},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 134, offset: 153134},
+						pos:  position{line: 5043, col: 134, offset: 153148},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 144, offset: 153144},
+						pos:  position{line: 5043, col: 144, offset: 153158},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 154, offset: 153154},
+						pos:  position{line: 5043, col: 154, offset: 153168},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 165, offset: 153165},
+						pos:  position{line: 5043, col: 165, offset: 153179},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 178, offset: 153178},
+						pos:  position{line: 5043, col: 178, offset: 153192},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 194, offset: 153194},
+						pos:  position{line: 5043, col: 194, offset: 153208},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 212, offset: 153212},
+						pos:  position{line: 5043, col: 212, offset: 153226},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 224, offset: 153224},
+						pos:  position{line: 5043, col: 224, offset: 153238},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 235, offset: 153235},
+						pos:  position{line: 5043, col: 235, offset: 153249},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 248, offset: 153248},
+						pos:  position{line: 5043, col: 248, offset: 153262},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 260, offset: 153260},
+						pos:  position{line: 5043, col: 260, offset: 153274},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 273, offset: 153273},
+						pos:  position{line: 5043, col: 273, offset: 153287},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 288, offset: 153288},
+						pos:  position{line: 5043, col: 288, offset: 153302},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 301, offset: 153301},
+						pos:  position{line: 5043, col: 301, offset: 153315},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 318, offset: 153318},
+						pos:  position{line: 5043, col: 318, offset: 153332},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 328, offset: 153328},
+						pos:  position{line: 5043, col: 328, offset: 153342},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 346, offset: 153346},
+						pos:  position{line: 5043, col: 346, offset: 153360},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 361, offset: 153361},
+						pos:  position{line: 5043, col: 361, offset: 153375},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 376, offset: 153376},
+						pos:  position{line: 5043, col: 376, offset: 153390},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5043, col: 391, offset: 153391},
+						pos:  position{line: 5043, col: 391, offset: 153405},
 						name: "CMD_INPUTLOOKUP",
 					},
 				},
@@ -13220,18 +13220,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5044, col: 1, offset: 153408},
+			pos:  position{line: 5044, col: 1, offset: 153422},
 			expr: &seqExpr{
-				pos: position{line: 5044, col: 15, offset: 153422},
+				pos: position{line: 5044, col: 15, offset: 153436},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5044, col: 15, offset: 153422},
+						pos:        position{line: 5044, col: 15, offset: 153436},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5044, col: 24, offset: 153431},
+						pos:  position{line: 5044, col: 24, offset: 153445},
 						name: "SPACE",
 					},
 				},
@@ -13239,18 +13239,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5045, col: 1, offset: 153437},
+			pos:  position{line: 5045, col: 1, offset: 153451},
 			expr: &seqExpr{
-				pos: position{line: 5045, col: 14, offset: 153450},
+				pos: position{line: 5045, col: 14, offset: 153464},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5045, col: 14, offset: 153450},
+						pos:        position{line: 5045, col: 14, offset: 153464},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5045, col: 22, offset: 153458},
+						pos:  position{line: 5045, col: 22, offset: 153472},
 						name: "SPACE",
 					},
 				},
@@ -13258,18 +13258,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5046, col: 1, offset: 153464},
+			pos:  position{line: 5046, col: 1, offset: 153478},
 			expr: &seqExpr{
-				pos: position{line: 5046, col: 14, offset: 153477},
+				pos: position{line: 5046, col: 14, offset: 153491},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5046, col: 14, offset: 153477},
+						pos:        position{line: 5046, col: 14, offset: 153491},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5046, col: 22, offset: 153485},
+						pos:  position{line: 5046, col: 22, offset: 153499},
 						name: "SPACE",
 					},
 				},
@@ -13277,18 +13277,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5047, col: 1, offset: 153491},
+			pos:  position{line: 5047, col: 1, offset: 153505},
 			expr: &seqExpr{
-				pos: position{line: 5047, col: 20, offset: 153510},
+				pos: position{line: 5047, col: 20, offset: 153524},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5047, col: 20, offset: 153510},
+						pos:        position{line: 5047, col: 20, offset: 153524},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5047, col: 34, offset: 153524},
+						pos:  position{line: 5047, col: 34, offset: 153538},
 						name: "SPACE",
 					},
 				},
@@ -13296,18 +13296,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5048, col: 1, offset: 153530},
+			pos:  position{line: 5048, col: 1, offset: 153544},
 			expr: &seqExpr{
-				pos: position{line: 5048, col: 15, offset: 153544},
+				pos: position{line: 5048, col: 15, offset: 153558},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5048, col: 15, offset: 153544},
+						pos:        position{line: 5048, col: 15, offset: 153558},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 24, offset: 153553},
+						pos:  position{line: 5048, col: 24, offset: 153567},
 						name: "SPACE",
 					},
 				},
@@ -13315,18 +13315,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5049, col: 1, offset: 153559},
+			pos:  position{line: 5049, col: 1, offset: 153573},
 			expr: &seqExpr{
-				pos: position{line: 5049, col: 14, offset: 153572},
+				pos: position{line: 5049, col: 14, offset: 153586},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5049, col: 14, offset: 153572},
+						pos:        position{line: 5049, col: 14, offset: 153586},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5049, col: 22, offset: 153580},
+						pos:  position{line: 5049, col: 22, offset: 153594},
 						name: "SPACE",
 					},
 				},
@@ -13334,9 +13334,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5050, col: 1, offset: 153586},
+			pos:  position{line: 5050, col: 1, offset: 153600},
 			expr: &litMatcher{
-				pos:        position{line: 5050, col: 22, offset: 153607},
+				pos:        position{line: 5050, col: 22, offset: 153621},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13344,16 +13344,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5051, col: 1, offset: 153614},
+			pos:  position{line: 5051, col: 1, offset: 153628},
 			expr: &seqExpr{
-				pos: position{line: 5051, col: 13, offset: 153626},
+				pos: position{line: 5051, col: 13, offset: 153640},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 13, offset: 153626},
+						pos:  position{line: 5051, col: 13, offset: 153640},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 31, offset: 153644},
+						pos:  position{line: 5051, col: 31, offset: 153658},
 						name: "SPACE",
 					},
 				},
@@ -13361,9 +13361,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5052, col: 1, offset: 153650},
+			pos:  position{line: 5052, col: 1, offset: 153664},
 			expr: &litMatcher{
-				pos:        position{line: 5052, col: 22, offset: 153671},
+				pos:        position{line: 5052, col: 22, offset: 153685},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13371,16 +13371,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5053, col: 1, offset: 153678},
+			pos:  position{line: 5053, col: 1, offset: 153692},
 			expr: &seqExpr{
-				pos: position{line: 5053, col: 13, offset: 153690},
+				pos: position{line: 5053, col: 13, offset: 153704},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5053, col: 13, offset: 153690},
+						pos:  position{line: 5053, col: 13, offset: 153704},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5053, col: 31, offset: 153708},
+						pos:  position{line: 5053, col: 31, offset: 153722},
 						name: "SPACE",
 					},
 				},
@@ -13388,18 +13388,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5054, col: 1, offset: 153714},
+			pos:  position{line: 5054, col: 1, offset: 153728},
 			expr: &seqExpr{
-				pos: position{line: 5054, col: 13, offset: 153726},
+				pos: position{line: 5054, col: 13, offset: 153740},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5054, col: 13, offset: 153726},
+						pos:        position{line: 5054, col: 13, offset: 153740},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5054, col: 20, offset: 153733},
+						pos:  position{line: 5054, col: 20, offset: 153747},
 						name: "SPACE",
 					},
 				},
@@ -13407,18 +13407,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5055, col: 1, offset: 153739},
+			pos:  position{line: 5055, col: 1, offset: 153753},
 			expr: &seqExpr{
-				pos: position{line: 5055, col: 12, offset: 153750},
+				pos: position{line: 5055, col: 12, offset: 153764},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5055, col: 12, offset: 153750},
+						pos:        position{line: 5055, col: 12, offset: 153764},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5055, col: 18, offset: 153756},
+						pos:  position{line: 5055, col: 18, offset: 153770},
 						name: "SPACE",
 					},
 				},
@@ -13426,18 +13426,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5056, col: 1, offset: 153762},
+			pos:  position{line: 5056, col: 1, offset: 153776},
 			expr: &seqExpr{
-				pos: position{line: 5056, col: 13, offset: 153774},
+				pos: position{line: 5056, col: 13, offset: 153788},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5056, col: 13, offset: 153774},
+						pos:        position{line: 5056, col: 13, offset: 153788},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5056, col: 20, offset: 153781},
+						pos:  position{line: 5056, col: 20, offset: 153795},
 						name: "SPACE",
 					},
 				},
@@ -13445,9 +13445,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5057, col: 1, offset: 153787},
+			pos:  position{line: 5057, col: 1, offset: 153801},
 			expr: &litMatcher{
-				pos:        position{line: 5057, col: 12, offset: 153798},
+				pos:        position{line: 5057, col: 12, offset: 153812},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13455,9 +13455,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5058, col: 1, offset: 153804},
+			pos:  position{line: 5058, col: 1, offset: 153818},
 			expr: &litMatcher{
-				pos:        position{line: 5058, col: 13, offset: 153816},
+				pos:        position{line: 5058, col: 13, offset: 153830},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13465,18 +13465,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5059, col: 1, offset: 153823},
+			pos:  position{line: 5059, col: 1, offset: 153837},
 			expr: &seqExpr{
-				pos: position{line: 5059, col: 15, offset: 153837},
+				pos: position{line: 5059, col: 15, offset: 153851},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5059, col: 15, offset: 153837},
+						pos:        position{line: 5059, col: 15, offset: 153851},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5059, col: 24, offset: 153846},
+						pos:  position{line: 5059, col: 24, offset: 153860},
 						name: "SPACE",
 					},
 				},
@@ -13484,18 +13484,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5060, col: 1, offset: 153852},
+			pos:  position{line: 5060, col: 1, offset: 153866},
 			expr: &seqExpr{
-				pos: position{line: 5060, col: 18, offset: 153869},
+				pos: position{line: 5060, col: 18, offset: 153883},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5060, col: 18, offset: 153869},
+						pos:        position{line: 5060, col: 18, offset: 153883},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5060, col: 30, offset: 153881},
+						pos:  position{line: 5060, col: 30, offset: 153895},
 						name: "SPACE",
 					},
 				},
@@ -13503,18 +13503,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5061, col: 1, offset: 153887},
+			pos:  position{line: 5061, col: 1, offset: 153901},
 			expr: &seqExpr{
-				pos: position{line: 5061, col: 12, offset: 153898},
+				pos: position{line: 5061, col: 12, offset: 153912},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5061, col: 12, offset: 153898},
+						pos:        position{line: 5061, col: 12, offset: 153912},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5061, col: 18, offset: 153904},
+						pos:  position{line: 5061, col: 18, offset: 153918},
 						name: "SPACE",
 					},
 				},
@@ -13522,9 +13522,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5062, col: 1, offset: 153910},
+			pos:  position{line: 5062, col: 1, offset: 153924},
 			expr: &litMatcher{
-				pos:        position{line: 5062, col: 13, offset: 153922},
+				pos:        position{line: 5062, col: 13, offset: 153936},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13532,18 +13532,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5063, col: 1, offset: 153929},
+			pos:  position{line: 5063, col: 1, offset: 153943},
 			expr: &seqExpr{
-				pos: position{line: 5063, col: 20, offset: 153948},
+				pos: position{line: 5063, col: 20, offset: 153962},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5063, col: 20, offset: 153948},
+						pos:        position{line: 5063, col: 20, offset: 153962},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5063, col: 34, offset: 153962},
+						pos:  position{line: 5063, col: 34, offset: 153976},
 						name: "SPACE",
 					},
 				},
@@ -13551,9 +13551,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5064, col: 1, offset: 153968},
+			pos:  position{line: 5064, col: 1, offset: 153982},
 			expr: &litMatcher{
-				pos:        position{line: 5064, col: 14, offset: 153981},
+				pos:        position{line: 5064, col: 14, offset: 153995},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13561,22 +13561,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5065, col: 1, offset: 153989},
+			pos:  position{line: 5065, col: 1, offset: 154003},
 			expr: &seqExpr{
-				pos: position{line: 5065, col: 21, offset: 154009},
+				pos: position{line: 5065, col: 21, offset: 154023},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 21, offset: 154009},
+						pos:  position{line: 5065, col: 21, offset: 154023},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5065, col: 27, offset: 154015},
+						pos:        position{line: 5065, col: 27, offset: 154029},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 36, offset: 154024},
+						pos:  position{line: 5065, col: 36, offset: 154038},
 						name: "SPACE",
 					},
 				},
@@ -13584,9 +13584,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5066, col: 1, offset: 154030},
+			pos:  position{line: 5066, col: 1, offset: 154044},
 			expr: &litMatcher{
-				pos:        position{line: 5066, col: 15, offset: 154044},
+				pos:        position{line: 5066, col: 15, offset: 154058},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -13594,9 +13594,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5067, col: 1, offset: 154053},
+			pos:  position{line: 5067, col: 1, offset: 154067},
 			expr: &litMatcher{
-				pos:        position{line: 5067, col: 14, offset: 154066},
+				pos:        position{line: 5067, col: 14, offset: 154080},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -13604,9 +13604,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5068, col: 1, offset: 154074},
+			pos:  position{line: 5068, col: 1, offset: 154088},
 			expr: &litMatcher{
-				pos:        position{line: 5068, col: 15, offset: 154088},
+				pos:        position{line: 5068, col: 15, offset: 154102},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -13614,9 +13614,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5069, col: 1, offset: 154097},
+			pos:  position{line: 5069, col: 1, offset: 154111},
 			expr: &litMatcher{
-				pos:        position{line: 5069, col: 17, offset: 154113},
+				pos:        position{line: 5069, col: 17, offset: 154127},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -13624,9 +13624,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5070, col: 1, offset: 154124},
+			pos:  position{line: 5070, col: 1, offset: 154138},
 			expr: &litMatcher{
-				pos:        position{line: 5070, col: 15, offset: 154138},
+				pos:        position{line: 5070, col: 15, offset: 154152},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -13634,9 +13634,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5071, col: 1, offset: 154147},
+			pos:  position{line: 5071, col: 1, offset: 154161},
 			expr: &litMatcher{
-				pos:        position{line: 5071, col: 19, offset: 154165},
+				pos:        position{line: 5071, col: 19, offset: 154179},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -13644,9 +13644,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5072, col: 1, offset: 154178},
+			pos:  position{line: 5072, col: 1, offset: 154192},
 			expr: &litMatcher{
-				pos:        position{line: 5072, col: 17, offset: 154194},
+				pos:        position{line: 5072, col: 17, offset: 154208},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -13654,9 +13654,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5073, col: 1, offset: 154205},
+			pos:  position{line: 5073, col: 1, offset: 154219},
 			expr: &litMatcher{
-				pos:        position{line: 5073, col: 17, offset: 154221},
+				pos:        position{line: 5073, col: 17, offset: 154235},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -13664,18 +13664,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5074, col: 1, offset: 154232},
+			pos:  position{line: 5074, col: 1, offset: 154246},
 			expr: &seqExpr{
-				pos: position{line: 5074, col: 20, offset: 154251},
+				pos: position{line: 5074, col: 20, offset: 154265},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5074, col: 20, offset: 154251},
+						pos:        position{line: 5074, col: 20, offset: 154265},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5074, col: 34, offset: 154265},
+						pos:  position{line: 5074, col: 34, offset: 154279},
 						name: "SPACE",
 					},
 				},
@@ -13683,27 +13683,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5075, col: 1, offset: 154271},
+			pos:  position{line: 5075, col: 1, offset: 154285},
 			expr: &seqExpr{
-				pos: position{line: 5075, col: 16, offset: 154286},
+				pos: position{line: 5075, col: 16, offset: 154300},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5075, col: 16, offset: 154286},
+						pos: position{line: 5075, col: 16, offset: 154300},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5075, col: 16, offset: 154286},
+							pos:  position{line: 5075, col: 16, offset: 154300},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5075, col: 23, offset: 154293},
+						pos:        position{line: 5075, col: 23, offset: 154307},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5075, col: 27, offset: 154297},
+						pos: position{line: 5075, col: 27, offset: 154311},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5075, col: 27, offset: 154297},
+							pos:  position{line: 5075, col: 27, offset: 154311},
 							name: "SPACE",
 						},
 					},
@@ -13712,9 +13712,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5076, col: 1, offset: 154304},
+			pos:  position{line: 5076, col: 1, offset: 154318},
 			expr: &litMatcher{
-				pos:        position{line: 5076, col: 17, offset: 154320},
+				pos:        position{line: 5076, col: 17, offset: 154334},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -13722,115 +13722,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5079, col: 1, offset: 154435},
+			pos:  position{line: 5079, col: 1, offset: 154449},
 			expr: &choiceExpr{
-				pos: position{line: 5079, col: 16, offset: 154450},
+				pos: position{line: 5079, col: 16, offset: 154464},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5079, col: 16, offset: 154450},
+						pos:        position{line: 5079, col: 16, offset: 154464},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5079, col: 47, offset: 154481},
+						pos:        position{line: 5079, col: 47, offset: 154495},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5079, col: 55, offset: 154489},
+						pos:        position{line: 5079, col: 55, offset: 154503},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 16, offset: 154512},
+						pos:        position{line: 5080, col: 16, offset: 154526},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 26, offset: 154522},
+						pos:        position{line: 5080, col: 26, offset: 154536},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 34, offset: 154530},
+						pos:        position{line: 5080, col: 34, offset: 154544},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 42, offset: 154538},
+						pos:        position{line: 5080, col: 42, offset: 154552},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 50, offset: 154546},
+						pos:        position{line: 5080, col: 50, offset: 154560},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 58, offset: 154554},
+						pos:        position{line: 5080, col: 58, offset: 154568},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 66, offset: 154562},
+						pos:        position{line: 5080, col: 66, offset: 154576},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 16, offset: 154584},
+						pos:        position{line: 5081, col: 16, offset: 154598},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 26, offset: 154594},
+						pos:        position{line: 5081, col: 26, offset: 154608},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 34, offset: 154602},
+						pos:        position{line: 5081, col: 34, offset: 154616},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 42, offset: 154610},
+						pos:        position{line: 5081, col: 42, offset: 154624},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 50, offset: 154618},
+						pos:        position{line: 5081, col: 50, offset: 154632},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 58, offset: 154626},
+						pos:        position{line: 5081, col: 58, offset: 154640},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 66, offset: 154634},
+						pos:        position{line: 5081, col: 66, offset: 154648},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5081, col: 74, offset: 154642},
+						pos:        position{line: 5081, col: 74, offset: 154656},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -13840,25 +13840,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5082, col: 1, offset: 154648},
+			pos:  position{line: 5082, col: 1, offset: 154662},
 			expr: &choiceExpr{
-				pos: position{line: 5082, col: 16, offset: 154663},
+				pos: position{line: 5082, col: 16, offset: 154677},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5082, col: 16, offset: 154663},
+						pos:        position{line: 5082, col: 16, offset: 154677},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5082, col: 30, offset: 154677},
+						pos:        position{line: 5082, col: 30, offset: 154691},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5082, col: 36, offset: 154683},
+						pos:        position{line: 5082, col: 36, offset: 154697},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -13868,18 +13868,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5086, col: 1, offset: 154839},
+			pos:  position{line: 5086, col: 1, offset: 154853},
 			expr: &seqExpr{
-				pos: position{line: 5086, col: 8, offset: 154846},
+				pos: position{line: 5086, col: 8, offset: 154860},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5086, col: 8, offset: 154846},
+						pos:        position{line: 5086, col: 8, offset: 154860},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5086, col: 14, offset: 154852},
+						pos:  position{line: 5086, col: 14, offset: 154866},
 						name: "SPACE",
 					},
 				},
@@ -13887,22 +13887,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5087, col: 1, offset: 154858},
+			pos:  position{line: 5087, col: 1, offset: 154872},
 			expr: &seqExpr{
-				pos: position{line: 5087, col: 7, offset: 154864},
+				pos: position{line: 5087, col: 7, offset: 154878},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5087, col: 7, offset: 154864},
+						pos:  position{line: 5087, col: 7, offset: 154878},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5087, col: 13, offset: 154870},
+						pos:        position{line: 5087, col: 13, offset: 154884},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5087, col: 18, offset: 154875},
+						pos:  position{line: 5087, col: 18, offset: 154889},
 						name: "SPACE",
 					},
 				},
@@ -13910,22 +13910,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5088, col: 1, offset: 154881},
+			pos:  position{line: 5088, col: 1, offset: 154895},
 			expr: &seqExpr{
-				pos: position{line: 5088, col: 8, offset: 154888},
+				pos: position{line: 5088, col: 8, offset: 154902},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5088, col: 8, offset: 154888},
+						pos:  position{line: 5088, col: 8, offset: 154902},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5088, col: 14, offset: 154894},
+						pos:        position{line: 5088, col: 14, offset: 154908},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5088, col: 20, offset: 154900},
+						pos:  position{line: 5088, col: 20, offset: 154914},
 						name: "SPACE",
 					},
 				},
@@ -13933,22 +13933,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5089, col: 1, offset: 154906},
+			pos:  position{line: 5089, col: 1, offset: 154920},
 			expr: &seqExpr{
-				pos: position{line: 5089, col: 9, offset: 154914},
+				pos: position{line: 5089, col: 9, offset: 154928},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5089, col: 9, offset: 154914},
+						pos:  position{line: 5089, col: 9, offset: 154928},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5089, col: 24, offset: 154929},
+						pos:        position{line: 5089, col: 24, offset: 154943},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5089, col: 28, offset: 154933},
+						pos:  position{line: 5089, col: 28, offset: 154947},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13956,22 +13956,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5090, col: 1, offset: 154948},
+			pos:  position{line: 5090, col: 1, offset: 154962},
 			expr: &seqExpr{
-				pos: position{line: 5090, col: 7, offset: 154954},
+				pos: position{line: 5090, col: 7, offset: 154968},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5090, col: 7, offset: 154954},
+						pos:  position{line: 5090, col: 7, offset: 154968},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5090, col: 13, offset: 154960},
+						pos:        position{line: 5090, col: 13, offset: 154974},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5090, col: 19, offset: 154966},
+						pos:  position{line: 5090, col: 19, offset: 154980},
 						name: "SPACE",
 					},
 				},
@@ -13979,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5091, col: 1, offset: 154992},
+			pos:  position{line: 5091, col: 1, offset: 155006},
 			expr: &seqExpr{
-				pos: position{line: 5091, col: 7, offset: 154998},
+				pos: position{line: 5091, col: 7, offset: 155012},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5091, col: 7, offset: 154998},
+						pos:  position{line: 5091, col: 7, offset: 155012},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5091, col: 13, offset: 155004},
+						pos:        position{line: 5091, col: 13, offset: 155018},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5091, col: 19, offset: 155010},
+						pos:  position{line: 5091, col: 19, offset: 155024},
 						name: "SPACE",
 					},
 				},
@@ -14002,22 +14002,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5093, col: 1, offset: 155037},
+			pos:  position{line: 5093, col: 1, offset: 155051},
 			expr: &seqExpr{
-				pos: position{line: 5093, col: 10, offset: 155046},
+				pos: position{line: 5093, col: 10, offset: 155060},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 10, offset: 155046},
+						pos:  position{line: 5093, col: 10, offset: 155060},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5093, col: 25, offset: 155061},
+						pos:        position{line: 5093, col: 25, offset: 155075},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 29, offset: 155065},
+						pos:  position{line: 5093, col: 29, offset: 155079},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14025,22 +14025,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5094, col: 1, offset: 155080},
+			pos:  position{line: 5094, col: 1, offset: 155094},
 			expr: &seqExpr{
-				pos: position{line: 5094, col: 10, offset: 155089},
+				pos: position{line: 5094, col: 10, offset: 155103},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 10, offset: 155089},
+						pos:  position{line: 5094, col: 10, offset: 155103},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5094, col: 25, offset: 155104},
+						pos:        position{line: 5094, col: 25, offset: 155118},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 29, offset: 155108},
+						pos:  position{line: 5094, col: 29, offset: 155122},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14048,9 +14048,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5095, col: 1, offset: 155123},
+			pos:  position{line: 5095, col: 1, offset: 155137},
 			expr: &litMatcher{
-				pos:        position{line: 5095, col: 10, offset: 155132},
+				pos:        position{line: 5095, col: 10, offset: 155146},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14058,18 +14058,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5096, col: 1, offset: 155136},
+			pos:  position{line: 5096, col: 1, offset: 155150},
 			expr: &seqExpr{
-				pos: position{line: 5096, col: 12, offset: 155147},
+				pos: position{line: 5096, col: 12, offset: 155161},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5096, col: 12, offset: 155147},
+						pos:        position{line: 5096, col: 12, offset: 155161},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5096, col: 16, offset: 155151},
+						pos:  position{line: 5096, col: 16, offset: 155165},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14077,16 +14077,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5097, col: 1, offset: 155166},
+			pos:  position{line: 5097, col: 1, offset: 155180},
 			expr: &seqExpr{
-				pos: position{line: 5097, col: 12, offset: 155177},
+				pos: position{line: 5097, col: 12, offset: 155191},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5097, col: 12, offset: 155177},
+						pos:  position{line: 5097, col: 12, offset: 155191},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5097, col: 27, offset: 155192},
+						pos:        position{line: 5097, col: 27, offset: 155206},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14096,40 +14096,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5099, col: 1, offset: 155197},
+			pos:  position{line: 5099, col: 1, offset: 155211},
 			expr: &notExpr{
-				pos: position{line: 5099, col: 8, offset: 155204},
+				pos: position{line: 5099, col: 8, offset: 155218},
 				expr: &anyMatcher{
-					line: 5099, col: 9, offset: 155205,
+					line: 5099, col: 9, offset: 155219,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5100, col: 1, offset: 155207},
+			pos:  position{line: 5100, col: 1, offset: 155221},
 			expr: &choiceExpr{
-				pos: position{line: 5100, col: 15, offset: 155221},
+				pos: position{line: 5100, col: 15, offset: 155235},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5100, col: 15, offset: 155221},
+						pos:        position{line: 5100, col: 15, offset: 155235},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 21, offset: 155227},
+						pos:        position{line: 5100, col: 21, offset: 155241},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 28, offset: 155234},
+						pos:        position{line: 5100, col: 28, offset: 155248},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5100, col: 35, offset: 155241},
+						pos:        position{line: 5100, col: 35, offset: 155255},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14139,37 +14139,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5101, col: 1, offset: 155246},
+			pos:  position{line: 5101, col: 1, offset: 155260},
 			expr: &choiceExpr{
-				pos: position{line: 5101, col: 10, offset: 155255},
+				pos: position{line: 5101, col: 10, offset: 155269},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5101, col: 11, offset: 155256},
+						pos: position{line: 5101, col: 11, offset: 155270},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5101, col: 11, offset: 155256},
+								pos: position{line: 5101, col: 11, offset: 155270},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5101, col: 11, offset: 155256},
+									pos:  position{line: 5101, col: 11, offset: 155270},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5101, col: 23, offset: 155268},
+								pos:  position{line: 5101, col: 23, offset: 155282},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5101, col: 31, offset: 155276},
+								pos: position{line: 5101, col: 31, offset: 155290},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5101, col: 31, offset: 155276},
+									pos:  position{line: 5101, col: 31, offset: 155290},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5101, col: 46, offset: 155291},
+						pos: position{line: 5101, col: 46, offset: 155305},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5101, col: 46, offset: 155291},
+							pos:  position{line: 5101, col: 46, offset: 155305},
 							name: "WHITESPACE",
 						},
 					},
@@ -14178,38 +14178,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5102, col: 1, offset: 155303},
+			pos:  position{line: 5102, col: 1, offset: 155317},
 			expr: &seqExpr{
-				pos: position{line: 5102, col: 12, offset: 155314},
+				pos: position{line: 5102, col: 12, offset: 155328},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5102, col: 12, offset: 155314},
+						pos:        position{line: 5102, col: 12, offset: 155328},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5102, col: 18, offset: 155320},
+						pos: position{line: 5102, col: 18, offset: 155334},
 						expr: &seqExpr{
-							pos: position{line: 5102, col: 19, offset: 155321},
+							pos: position{line: 5102, col: 19, offset: 155335},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5102, col: 19, offset: 155321},
+									pos: position{line: 5102, col: 19, offset: 155335},
 									expr: &litMatcher{
-										pos:        position{line: 5102, col: 21, offset: 155323},
+										pos:        position{line: 5102, col: 21, offset: 155337},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5102, col: 28, offset: 155330,
+									line: 5102, col: 28, offset: 155344,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5102, col: 32, offset: 155334},
+						pos:        position{line: 5102, col: 32, offset: 155348},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14219,16 +14219,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5103, col: 1, offset: 155340},
+			pos:  position{line: 5103, col: 1, offset: 155354},
 			expr: &choiceExpr{
-				pos: position{line: 5103, col: 20, offset: 155359},
+				pos: position{line: 5103, col: 20, offset: 155373},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5103, col: 20, offset: 155359},
+						pos:  position{line: 5103, col: 20, offset: 155373},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5103, col: 28, offset: 155367},
+						pos:        position{line: 5103, col: 28, offset: 155381},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14238,16 +14238,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5104, col: 1, offset: 155370},
+			pos:  position{line: 5104, col: 1, offset: 155384},
 			expr: &choiceExpr{
-				pos: position{line: 5104, col: 19, offset: 155388},
+				pos: position{line: 5104, col: 19, offset: 155402},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5104, col: 19, offset: 155388},
+						pos:  position{line: 5104, col: 19, offset: 155402},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5104, col: 27, offset: 155396},
+						pos:  position{line: 5104, col: 27, offset: 155410},
 						name: "SPACE",
 					},
 				},
@@ -18956,10 +18956,10 @@ func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (an
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:                   op.(string),
-			Field:                key.(string),
-			Values:               ssr.value,
-			ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
+			Op:                     op.(string),
+			Field:                  key.(string),
+			Values:                 ssr.value,
+			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
 		},
 	}
 	return node, nil
@@ -18976,10 +18976,10 @@ func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, erro
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:                   "=",
-			Field:                "*",
-			Values:               ssr.value,
-			ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
+			Op:                     "=",
+			Field:                  "*",
+			Values:                 ssr.value,
+			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
 		},
 	}
 	return node, nil
@@ -18993,8 +18993,8 @@ func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
 
 func (c *current) onCaseSensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
-		value:                value,
-		valueIsCaseSensitive: true,
+		value:                  value,
+		valueIsCaseInSensitive: false,
 	}, nil
 }
 
@@ -19006,8 +19006,8 @@ func (p *parser) callonCaseSensitiveString1() (any, error) {
 
 func (c *current) onCaseInsensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
-		value:                strings.ToLower(value.(string)),
-		valueIsCaseSensitive: false,
+		value:                  strings.ToLower(value.(string)),
+		valueIsCaseInSensitive: true,
 	}, nil
 }
 

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -490,175 +490,175 @@ type FormatResultsRequestArguments struct {
 }
 
 type StringSearchRequest struct {
-	value                  interface{}
-	originalValue          interface{}
-	valueIsCaseInSensitive bool
+	value           interface{}
+	originalValue   interface{}
+	caseInsensitive bool
 }
 
 var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 485, col: 1, offset: 13747},
+			pos:  position{line: 485, col: 1, offset: 13746},
 			expr: &choiceExpr{
-				pos: position{line: 485, col: 10, offset: 13756},
+				pos: position{line: 485, col: 10, offset: 13755},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 485, col: 10, offset: 13756},
+						pos: position{line: 485, col: 10, offset: 13755},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 485, col: 10, offset: 13756},
+							pos: position{line: 485, col: 10, offset: 13755},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 485, col: 10, offset: 13756},
+									pos: position{line: 485, col: 10, offset: 13755},
 									expr: &ruleRefExpr{
-										pos:  position{line: 485, col: 10, offset: 13756},
+										pos:  position{line: 485, col: 10, offset: 13755},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 485, col: 17, offset: 13763},
+									pos:   position{line: 485, col: 17, offset: 13762},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 485, col: 32, offset: 13778},
+										pos:  position{line: 485, col: 32, offset: 13777},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 485, col: 52, offset: 13798},
+									pos:   position{line: 485, col: 52, offset: 13797},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 485, col: 65, offset: 13811},
+										pos: position{line: 485, col: 65, offset: 13810},
 										expr: &ruleRefExpr{
-											pos:  position{line: 485, col: 66, offset: 13812},
+											pos:  position{line: 485, col: 66, offset: 13811},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 485, col: 80, offset: 13826},
+									pos:   position{line: 485, col: 80, offset: 13825},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 485, col: 95, offset: 13841},
+										pos: position{line: 485, col: 95, offset: 13840},
 										expr: &ruleRefExpr{
-											pos:  position{line: 485, col: 96, offset: 13842},
+											pos:  position{line: 485, col: 96, offset: 13841},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 485, col: 119, offset: 13865},
+									pos: position{line: 485, col: 119, offset: 13864},
 									expr: &ruleRefExpr{
-										pos:  position{line: 485, col: 119, offset: 13865},
+										pos:  position{line: 485, col: 119, offset: 13864},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 485, col: 126, offset: 13872},
+									pos:  position{line: 485, col: 126, offset: 13871},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 547, col: 3, offset: 15716},
+						pos: position{line: 547, col: 3, offset: 15715},
 						run: (*parser).callonStart17,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 3, offset: 15716},
+							pos: position{line: 547, col: 3, offset: 15715},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 547, col: 3, offset: 15716},
+									pos: position{line: 547, col: 3, offset: 15715},
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 3, offset: 15716},
+										pos:  position{line: 547, col: 3, offset: 15715},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 10, offset: 15723},
+									pos:  position{line: 547, col: 10, offset: 15722},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 15, offset: 15728},
+									pos:  position{line: 547, col: 15, offset: 15727},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 28, offset: 15741},
+									pos:  position{line: 547, col: 28, offset: 15740},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 34, offset: 15747},
+									pos:   position{line: 547, col: 34, offset: 15746},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 50, offset: 15763},
+										pos:  position{line: 547, col: 50, offset: 15762},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 547, col: 70, offset: 15783},
+									pos:   position{line: 547, col: 70, offset: 15782},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 547, col: 85, offset: 15798},
+										pos: position{line: 547, col: 85, offset: 15797},
 										expr: &ruleRefExpr{
-											pos:  position{line: 547, col: 86, offset: 15799},
+											pos:  position{line: 547, col: 86, offset: 15798},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 547, col: 109, offset: 15822},
+									pos: position{line: 547, col: 109, offset: 15821},
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 109, offset: 15822},
+										pos:  position{line: 547, col: 109, offset: 15821},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 116, offset: 15829},
+									pos:  position{line: 547, col: 116, offset: 15828},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 565, col: 3, offset: 16284},
+						pos: position{line: 565, col: 3, offset: 16283},
 						run: (*parser).callonStart32,
 						expr: &seqExpr{
-							pos: position{line: 565, col: 3, offset: 16284},
+							pos: position{line: 565, col: 3, offset: 16283},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 565, col: 3, offset: 16284},
+									pos: position{line: 565, col: 3, offset: 16283},
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 3, offset: 16284},
+										pos:  position{line: 565, col: 3, offset: 16283},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 565, col: 10, offset: 16291},
+									pos:   position{line: 565, col: 10, offset: 16290},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 22, offset: 16303},
+										pos:  position{line: 565, col: 22, offset: 16302},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 565, col: 39, offset: 16320},
+									pos:   position{line: 565, col: 39, offset: 16319},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 565, col: 54, offset: 16335},
+										pos: position{line: 565, col: 54, offset: 16334},
 										expr: &ruleRefExpr{
-											pos:  position{line: 565, col: 55, offset: 16336},
+											pos:  position{line: 565, col: 55, offset: 16335},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 565, col: 78, offset: 16359},
+									pos: position{line: 565, col: 78, offset: 16358},
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 78, offset: 16359},
+										pos:  position{line: 565, col: 78, offset: 16358},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 565, col: 85, offset: 16366},
+									pos:  position{line: 565, col: 85, offset: 16365},
 									name: "EOF",
 								},
 							},
@@ -669,76 +669,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 579, col: 1, offset: 16659},
+			pos:  position{line: 579, col: 1, offset: 16658},
 			expr: &actionExpr{
-				pos: position{line: 579, col: 21, offset: 16679},
+				pos: position{line: 579, col: 21, offset: 16678},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 579, col: 21, offset: 16679},
+					pos: position{line: 579, col: 21, offset: 16678},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 579, col: 21, offset: 16679},
+							pos:        position{line: 579, col: 21, offset: 16678},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 579, col: 26, offset: 16684},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 579, col: 32, offset: 16690},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 579, col: 36, offset: 16694},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 579, col: 41, offset: 16699},
+							pos:        position{line: 579, col: 26, offset: 16683},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 579, col: 47, offset: 16705},
+							pos:        position{line: 579, col: 32, offset: 16689},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 579, col: 51, offset: 16709},
+							pos:        position{line: 579, col: 36, offset: 16693},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 579, col: 56, offset: 16714},
+							pos:        position{line: 579, col: 41, offset: 16698},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 579, col: 47, offset: 16704},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 579, col: 51, offset: 16708},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 579, col: 61, offset: 16719},
+							pos:        position{line: 579, col: 56, offset: 16713},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 579, col: 66, offset: 16724},
+							pos:        position{line: 579, col: 61, offset: 16718},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 579, col: 66, offset: 16723},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -750,15 +750,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 586, col: 1, offset: 16865},
+			pos:  position{line: 586, col: 1, offset: 16864},
 			expr: &actionExpr{
-				pos: position{line: 586, col: 31, offset: 16895},
+				pos: position{line: 586, col: 31, offset: 16894},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 586, col: 31, offset: 16895},
+					pos:   position{line: 586, col: 31, offset: 16894},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 586, col: 38, offset: 16902},
+						pos:  position{line: 586, col: 38, offset: 16901},
 						name: "IntegerAsString",
 					},
 				},
@@ -766,22 +766,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 604, col: 1, offset: 17541},
+			pos:  position{line: 604, col: 1, offset: 17540},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 26, offset: 17566},
+				pos: position{line: 604, col: 26, offset: 17565},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 604, col: 26, offset: 17566},
+					pos:   position{line: 604, col: 26, offset: 17565},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 604, col: 37, offset: 17577},
+						pos: position{line: 604, col: 37, offset: 17576},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 37, offset: 17577},
+								pos:  position{line: 604, col: 37, offset: 17576},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 53, offset: 17593},
+								pos:  position{line: 604, col: 53, offset: 17592},
 								name: "PartialTimestamp",
 							},
 						},
@@ -791,22 +791,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 613, col: 1, offset: 17850},
+			pos:  position{line: 613, col: 1, offset: 17849},
 			expr: &actionExpr{
-				pos: position{line: 613, col: 17, offset: 17866},
+				pos: position{line: 613, col: 17, offset: 17865},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 613, col: 17, offset: 17866},
+					pos:   position{line: 613, col: 17, offset: 17865},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 613, col: 31, offset: 17880},
+						pos: position{line: 613, col: 31, offset: 17879},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 613, col: 31, offset: 17880},
+								pos:  position{line: 613, col: 31, offset: 17879},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 613, col: 55, offset: 17904},
+								pos:  position{line: 613, col: 55, offset: 17903},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -816,28 +816,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 617, col: 1, offset: 17966},
+			pos:  position{line: 617, col: 1, offset: 17965},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 22, offset: 17987},
+				pos: position{line: 617, col: 22, offset: 17986},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 617, col: 22, offset: 17987},
+					pos: position{line: 617, col: 22, offset: 17986},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 617, col: 22, offset: 17987},
+							pos:        position{line: 617, col: 22, offset: 17986},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 617, col: 28, offset: 17993},
+							pos:  position{line: 617, col: 28, offset: 17992},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 617, col: 34, offset: 17999},
+							pos:   position{line: 617, col: 34, offset: 17998},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 617, col: 45, offset: 18010},
+								pos:  position{line: 617, col: 45, offset: 18009},
 								name: "GenTimestamp",
 							},
 						},
@@ -847,28 +847,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 626, col: 1, offset: 18200},
+			pos:  position{line: 626, col: 1, offset: 18199},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 24, offset: 18223},
+				pos: position{line: 626, col: 24, offset: 18222},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 24, offset: 18223},
+					pos: position{line: 626, col: 24, offset: 18222},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 626, col: 24, offset: 18223},
+							pos:        position{line: 626, col: 24, offset: 18222},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 626, col: 32, offset: 18231},
+							pos:  position{line: 626, col: 32, offset: 18230},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 626, col: 38, offset: 18237},
+							pos:   position{line: 626, col: 38, offset: 18236},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 49, offset: 18248},
+								pos:  position{line: 626, col: 49, offset: 18247},
 								name: "GenTimestamp",
 							},
 						},
@@ -878,59 +878,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 635, col: 1, offset: 18442},
+			pos:  position{line: 635, col: 1, offset: 18441},
 			expr: &actionExpr{
-				pos: position{line: 635, col: 28, offset: 18469},
+				pos: position{line: 635, col: 28, offset: 18468},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 635, col: 28, offset: 18469},
+					pos: position{line: 635, col: 28, offset: 18468},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 635, col: 28, offset: 18469},
+							pos:        position{line: 635, col: 28, offset: 18468},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 635, col: 40, offset: 18481},
+							pos:  position{line: 635, col: 40, offset: 18480},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 46, offset: 18487},
+							pos:   position{line: 635, col: 46, offset: 18486},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 53, offset: 18494},
+								pos:  position{line: 635, col: 53, offset: 18493},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 635, col: 69, offset: 18510},
+							pos:   position{line: 635, col: 69, offset: 18509},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 635, col: 77, offset: 18518},
+								pos: position{line: 635, col: 77, offset: 18517},
 								expr: &choiceExpr{
-									pos: position{line: 635, col: 78, offset: 18519},
+									pos: position{line: 635, col: 78, offset: 18518},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 635, col: 78, offset: 18519},
+											pos:        position{line: 635, col: 78, offset: 18518},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 635, col: 84, offset: 18525},
+											pos:        position{line: 635, col: 84, offset: 18524},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 635, col: 90, offset: 18531},
+											pos:        position{line: 635, col: 90, offset: 18530},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 635, col: 96, offset: 18537},
+											pos:        position{line: 635, col: 96, offset: 18536},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -945,26 +945,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 676, col: 1, offset: 19684},
+			pos:  position{line: 676, col: 1, offset: 19683},
 			expr: &actionExpr{
-				pos: position{line: 676, col: 19, offset: 19702},
+				pos: position{line: 676, col: 19, offset: 19701},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 676, col: 19, offset: 19702},
+					pos:   position{line: 676, col: 19, offset: 19701},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 676, col: 35, offset: 19718},
+						pos: position{line: 676, col: 35, offset: 19717},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 676, col: 35, offset: 19718},
+								pos:  position{line: 676, col: 35, offset: 19717},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 676, col: 55, offset: 19738},
+								pos:  position{line: 676, col: 55, offset: 19737},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 676, col: 77, offset: 19760},
+								pos:  position{line: 676, col: 77, offset: 19759},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -974,35 +974,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 680, col: 1, offset: 19821},
+			pos:  position{line: 680, col: 1, offset: 19820},
 			expr: &actionExpr{
-				pos: position{line: 680, col: 23, offset: 19843},
+				pos: position{line: 680, col: 23, offset: 19842},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 680, col: 23, offset: 19843},
+					pos: position{line: 680, col: 23, offset: 19842},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 680, col: 23, offset: 19843},
+							pos:   position{line: 680, col: 23, offset: 19842},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 680, col: 29, offset: 19849},
+								pos:  position{line: 680, col: 29, offset: 19848},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 680, col: 44, offset: 19864},
+							pos:   position{line: 680, col: 44, offset: 19863},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 680, col: 49, offset: 19869},
+								pos: position{line: 680, col: 49, offset: 19868},
 								expr: &seqExpr{
-									pos: position{line: 680, col: 50, offset: 19870},
+									pos: position{line: 680, col: 50, offset: 19869},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 680, col: 50, offset: 19870},
+											pos:  position{line: 680, col: 50, offset: 19869},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 680, col: 56, offset: 19876},
+											pos:  position{line: 680, col: 56, offset: 19875},
 											name: "GenTimesOption",
 										},
 									},
@@ -1015,25 +1015,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 727, col: 1, offset: 21419},
+			pos:  position{line: 727, col: 1, offset: 21418},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 23, offset: 21441},
+				pos: position{line: 727, col: 23, offset: 21440},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 23, offset: 21441},
+					pos: position{line: 727, col: 23, offset: 21440},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 727, col: 23, offset: 21441},
+							pos: position{line: 727, col: 23, offset: 21440},
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 23, offset: 21441},
+								pos:  position{line: 727, col: 23, offset: 21440},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 35, offset: 21453},
+							pos:   position{line: 727, col: 35, offset: 21452},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 42, offset: 21460},
+								pos:  position{line: 727, col: 42, offset: 21459},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1043,32 +1043,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 731, col: 1, offset: 21501},
+			pos:  position{line: 731, col: 1, offset: 21500},
 			expr: &actionExpr{
-				pos: position{line: 731, col: 16, offset: 21516},
+				pos: position{line: 731, col: 16, offset: 21515},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 731, col: 16, offset: 21516},
+					pos: position{line: 731, col: 16, offset: 21515},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 731, col: 16, offset: 21516},
+							pos: position{line: 731, col: 16, offset: 21515},
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 18, offset: 21518},
+								pos:  position{line: 731, col: 18, offset: 21517},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 731, col: 26, offset: 21526},
+							pos: position{line: 731, col: 26, offset: 21525},
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 26, offset: 21526},
+								pos:  position{line: 731, col: 26, offset: 21525},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 731, col: 38, offset: 21538},
+							pos:   position{line: 731, col: 38, offset: 21537},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 731, col: 45, offset: 21545},
+								pos:  position{line: 731, col: 45, offset: 21544},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1078,33 +1078,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 735, col: 1, offset: 21586},
+			pos:  position{line: 735, col: 1, offset: 21585},
 			expr: &actionExpr{
-				pos: position{line: 735, col: 16, offset: 21601},
+				pos: position{line: 735, col: 16, offset: 21600},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 735, col: 16, offset: 21601},
+					pos: position{line: 735, col: 16, offset: 21600},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 735, col: 16, offset: 21601},
+							pos:  position{line: 735, col: 16, offset: 21600},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 735, col: 21, offset: 21606},
+							pos:   position{line: 735, col: 21, offset: 21605},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 735, col: 28, offset: 21613},
+								pos: position{line: 735, col: 28, offset: 21612},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 735, col: 28, offset: 21613},
+										pos:  position{line: 735, col: 28, offset: 21612},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 735, col: 42, offset: 21627},
+										pos:  position{line: 735, col: 42, offset: 21626},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 735, col: 55, offset: 21640},
+										pos:  position{line: 735, col: 55, offset: 21639},
 										name: "TimeModifiers",
 									},
 								},
@@ -1116,102 +1116,102 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 740, col: 1, offset: 21719},
+			pos:  position{line: 740, col: 1, offset: 21718},
 			expr: &actionExpr{
-				pos: position{line: 740, col: 25, offset: 21743},
+				pos: position{line: 740, col: 25, offset: 21742},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 740, col: 25, offset: 21743},
+					pos:   position{line: 740, col: 25, offset: 21742},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 740, col: 32, offset: 21750},
+						pos: position{line: 740, col: 32, offset: 21749},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 32, offset: 21750},
+								pos:  position{line: 740, col: 32, offset: 21749},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 51, offset: 21769},
+								pos:  position{line: 740, col: 51, offset: 21768},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 69, offset: 21787},
+								pos:  position{line: 740, col: 69, offset: 21786},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 81, offset: 21799},
+								pos:  position{line: 740, col: 81, offset: 21798},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 94, offset: 21812},
+								pos:  position{line: 740, col: 94, offset: 21811},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 106, offset: 21824},
+								pos:  position{line: 740, col: 106, offset: 21823},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 117, offset: 21835},
+								pos:  position{line: 740, col: 117, offset: 21834},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 134, offset: 21852},
+								pos:  position{line: 740, col: 134, offset: 21851},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 148, offset: 21866},
+								pos:  position{line: 740, col: 148, offset: 21865},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 165, offset: 21883},
+								pos:  position{line: 740, col: 165, offset: 21882},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 184, offset: 21902},
+								pos:  position{line: 740, col: 184, offset: 21901},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 197, offset: 21915},
+								pos:  position{line: 740, col: 197, offset: 21914},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 209, offset: 21927},
+								pos:  position{line: 740, col: 209, offset: 21926},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 227, offset: 21945},
+								pos:  position{line: 740, col: 227, offset: 21944},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 240, offset: 21958},
+								pos:  position{line: 740, col: 240, offset: 21957},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 254, offset: 21972},
+								pos:  position{line: 740, col: 254, offset: 21971},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 272, offset: 21990},
+								pos:  position{line: 740, col: 272, offset: 21989},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 284, offset: 22002},
+								pos:  position{line: 740, col: 284, offset: 22001},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 295, offset: 22013},
+								pos:  position{line: 740, col: 295, offset: 22012},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 314, offset: 22032},
+								pos:  position{line: 740, col: 314, offset: 22031},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 330, offset: 22048},
+								pos:  position{line: 740, col: 330, offset: 22047},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 740, col: 346, offset: 22064},
+								pos:  position{line: 740, col: 346, offset: 22063},
 								name: "InputLookupAggBlock",
 							},
 						},
@@ -1221,37 +1221,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 745, col: 1, offset: 22165},
+			pos:  position{line: 745, col: 1, offset: 22164},
 			expr: &actionExpr{
-				pos: position{line: 745, col: 21, offset: 22185},
+				pos: position{line: 745, col: 21, offset: 22184},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 745, col: 21, offset: 22185},
+					pos: position{line: 745, col: 21, offset: 22184},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 21, offset: 22185},
+							pos:  position{line: 745, col: 21, offset: 22184},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 26, offset: 22190},
+							pos:  position{line: 745, col: 26, offset: 22189},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 745, col: 37, offset: 22201},
+							pos:   position{line: 745, col: 37, offset: 22200},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 745, col: 40, offset: 22204},
+								pos: position{line: 745, col: 40, offset: 22203},
 								expr: &choiceExpr{
-									pos: position{line: 745, col: 41, offset: 22205},
+									pos: position{line: 745, col: 41, offset: 22204},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 745, col: 41, offset: 22205},
+											pos:        position{line: 745, col: 41, offset: 22204},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 745, col: 47, offset: 22211},
+											pos:        position{line: 745, col: 47, offset: 22210},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1261,14 +1261,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 745, col: 53, offset: 22217},
+							pos:  position{line: 745, col: 53, offset: 22216},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 745, col: 68, offset: 22232},
+							pos:   position{line: 745, col: 68, offset: 22231},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 745, col: 75, offset: 22239},
+								pos:  position{line: 745, col: 75, offset: 22238},
 								name: "FieldNameList",
 							},
 						},
@@ -1278,28 +1278,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 763, col: 1, offset: 22743},
+			pos:  position{line: 763, col: 1, offset: 22742},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 26, offset: 22768},
+				pos: position{line: 763, col: 26, offset: 22767},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 26, offset: 22768},
+					pos: position{line: 763, col: 26, offset: 22767},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 763, col: 26, offset: 22768},
+							pos:   position{line: 763, col: 26, offset: 22767},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 31, offset: 22773},
+								pos:  position{line: 763, col: 31, offset: 22772},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 763, col: 47, offset: 22789},
+							pos:   position{line: 763, col: 47, offset: 22788},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 763, col: 56, offset: 22798},
+								pos: position{line: 763, col: 56, offset: 22797},
 								expr: &ruleRefExpr{
-									pos:  position{line: 763, col: 57, offset: 22799},
+									pos:  position{line: 763, col: 57, offset: 22798},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1310,36 +1310,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 809, col: 1, offset: 24294},
+			pos:  position{line: 809, col: 1, offset: 24293},
 			expr: &actionExpr{
-				pos: position{line: 809, col: 20, offset: 24313},
+				pos: position{line: 809, col: 20, offset: 24312},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 809, col: 20, offset: 24313},
+					pos: position{line: 809, col: 20, offset: 24312},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 20, offset: 24313},
+							pos:  position{line: 809, col: 20, offset: 24312},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 809, col: 25, offset: 24318},
+							pos:  position{line: 809, col: 25, offset: 24317},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 35, offset: 24328},
+							pos:   position{line: 809, col: 35, offset: 24327},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 809, col: 41, offset: 24334},
+								pos:  position{line: 809, col: 41, offset: 24333},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 809, col: 64, offset: 24357},
+							pos:   position{line: 809, col: 64, offset: 24356},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 809, col: 72, offset: 24365},
+								pos: position{line: 809, col: 72, offset: 24364},
 								expr: &ruleRefExpr{
-									pos:  position{line: 809, col: 73, offset: 24366},
+									pos:  position{line: 809, col: 73, offset: 24365},
 									name: "StatsOptions",
 								},
 							},
@@ -1350,17 +1350,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 823, col: 1, offset: 24699},
+			pos:  position{line: 823, col: 1, offset: 24698},
 			expr: &actionExpr{
-				pos: position{line: 823, col: 17, offset: 24715},
+				pos: position{line: 823, col: 17, offset: 24714},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 823, col: 17, offset: 24715},
+					pos:   position{line: 823, col: 17, offset: 24714},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 823, col: 24, offset: 24722},
+						pos: position{line: 823, col: 24, offset: 24721},
 						expr: &ruleRefExpr{
-							pos:  position{line: 823, col: 25, offset: 24723},
+							pos:  position{line: 823, col: 25, offset: 24722},
 							name: "StatsOption",
 						},
 					},
@@ -1369,45 +1369,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 861, col: 1, offset: 26164},
+			pos:  position{line: 861, col: 1, offset: 26163},
 			expr: &actionExpr{
-				pos: position{line: 861, col: 16, offset: 26179},
+				pos: position{line: 861, col: 16, offset: 26178},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 861, col: 16, offset: 26179},
+					pos: position{line: 861, col: 16, offset: 26178},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 861, col: 16, offset: 26179},
+							pos:  position{line: 861, col: 16, offset: 26178},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 22, offset: 26185},
+							pos:   position{line: 861, col: 22, offset: 26184},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 861, col: 32, offset: 26195},
+								pos:  position{line: 861, col: 32, offset: 26194},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 861, col: 47, offset: 26210},
+							pos:  position{line: 861, col: 47, offset: 26209},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 861, col: 53, offset: 26216},
+							pos:   position{line: 861, col: 53, offset: 26215},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 861, col: 58, offset: 26221},
+								pos: position{line: 861, col: 58, offset: 26220},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 861, col: 58, offset: 26221},
+										pos:  position{line: 861, col: 58, offset: 26220},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 861, col: 76, offset: 26239},
+										pos:  position{line: 861, col: 76, offset: 26238},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 861, col: 94, offset: 26257},
+										pos:  position{line: 861, col: 94, offset: 26256},
 										name: "QuotedString",
 									},
 								},
@@ -1419,36 +1419,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 866, col: 1, offset: 26362},
+			pos:  position{line: 866, col: 1, offset: 26361},
 			expr: &actionExpr{
-				pos: position{line: 866, col: 19, offset: 26380},
+				pos: position{line: 866, col: 19, offset: 26379},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 866, col: 19, offset: 26380},
+					pos:   position{line: 866, col: 19, offset: 26379},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 866, col: 27, offset: 26388},
+						pos: position{line: 866, col: 27, offset: 26387},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 866, col: 27, offset: 26388},
+								pos:        position{line: 866, col: 27, offset: 26387},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 866, col: 38, offset: 26399},
+								pos:        position{line: 866, col: 38, offset: 26398},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 866, col: 58, offset: 26419},
+								pos:        position{line: 866, col: 58, offset: 26418},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 866, col: 68, offset: 26429},
+								pos:        position{line: 866, col: 68, offset: 26428},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1460,22 +1460,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 874, col: 1, offset: 26619},
+			pos:  position{line: 874, col: 1, offset: 26618},
 			expr: &actionExpr{
-				pos: position{line: 874, col: 17, offset: 26635},
+				pos: position{line: 874, col: 17, offset: 26634},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 874, col: 17, offset: 26635},
+					pos: position{line: 874, col: 17, offset: 26634},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 874, col: 17, offset: 26635},
+							pos:  position{line: 874, col: 17, offset: 26634},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 874, col: 20, offset: 26638},
+							pos:   position{line: 874, col: 20, offset: 26637},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 874, col: 27, offset: 26645},
+								pos:  position{line: 874, col: 27, offset: 26644},
 								name: "FieldNameList",
 							},
 						},
@@ -1485,28 +1485,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 886, col: 1, offset: 26995},
+			pos:  position{line: 886, col: 1, offset: 26994},
 			expr: &actionExpr{
-				pos: position{line: 886, col: 35, offset: 27029},
+				pos: position{line: 886, col: 35, offset: 27028},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 886, col: 35, offset: 27029},
+					pos: position{line: 886, col: 35, offset: 27028},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 886, col: 35, offset: 27029},
+							pos:        position{line: 886, col: 35, offset: 27028},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 886, col: 53, offset: 27047},
+							pos:  position{line: 886, col: 53, offset: 27046},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 886, col: 59, offset: 27053},
+							pos:   position{line: 886, col: 59, offset: 27052},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 886, col: 67, offset: 27061},
+								pos:  position{line: 886, col: 67, offset: 27060},
 								name: "Boolean",
 							},
 						},
@@ -1516,28 +1516,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 898, col: 1, offset: 27322},
+			pos:  position{line: 898, col: 1, offset: 27321},
 			expr: &actionExpr{
-				pos: position{line: 898, col: 29, offset: 27350},
+				pos: position{line: 898, col: 29, offset: 27349},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 898, col: 29, offset: 27350},
+					pos: position{line: 898, col: 29, offset: 27349},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 898, col: 29, offset: 27350},
+							pos:        position{line: 898, col: 29, offset: 27349},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 898, col: 39, offset: 27360},
+							pos:  position{line: 898, col: 39, offset: 27359},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 898, col: 45, offset: 27366},
+							pos:   position{line: 898, col: 45, offset: 27365},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 898, col: 53, offset: 27374},
+								pos:  position{line: 898, col: 53, offset: 27373},
 								name: "Boolean",
 							},
 						},
@@ -1547,28 +1547,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 910, col: 1, offset: 27621},
+			pos:  position{line: 910, col: 1, offset: 27620},
 			expr: &actionExpr{
-				pos: position{line: 910, col: 28, offset: 27648},
+				pos: position{line: 910, col: 28, offset: 27647},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 910, col: 28, offset: 27648},
+					pos: position{line: 910, col: 28, offset: 27647},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 910, col: 28, offset: 27648},
+							pos:        position{line: 910, col: 28, offset: 27647},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 910, col: 37, offset: 27657},
+							pos:  position{line: 910, col: 37, offset: 27656},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 910, col: 43, offset: 27663},
+							pos:   position{line: 910, col: 43, offset: 27662},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 910, col: 51, offset: 27671},
+								pos:  position{line: 910, col: 51, offset: 27670},
 								name: "Boolean",
 							},
 						},
@@ -1578,28 +1578,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 923, col: 1, offset: 28005},
+			pos:  position{line: 923, col: 1, offset: 28004},
 			expr: &actionExpr{
-				pos: position{line: 923, col: 28, offset: 28032},
+				pos: position{line: 923, col: 28, offset: 28031},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 923, col: 28, offset: 28032},
+					pos: position{line: 923, col: 28, offset: 28031},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 923, col: 28, offset: 28032},
+							pos:        position{line: 923, col: 28, offset: 28031},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 923, col: 37, offset: 28041},
+							pos:  position{line: 923, col: 37, offset: 28040},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 923, col: 43, offset: 28047},
+							pos:   position{line: 923, col: 43, offset: 28046},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 923, col: 51, offset: 28055},
+								pos:  position{line: 923, col: 51, offset: 28054},
 								name: "Boolean",
 							},
 						},
@@ -1609,28 +1609,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 936, col: 1, offset: 28389},
+			pos:  position{line: 936, col: 1, offset: 28388},
 			expr: &actionExpr{
-				pos: position{line: 936, col: 28, offset: 28416},
+				pos: position{line: 936, col: 28, offset: 28415},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 936, col: 28, offset: 28416},
+					pos: position{line: 936, col: 28, offset: 28415},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 936, col: 28, offset: 28416},
+							pos:        position{line: 936, col: 28, offset: 28415},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 936, col: 37, offset: 28425},
+							pos:  position{line: 936, col: 37, offset: 28424},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 936, col: 43, offset: 28431},
+							pos:   position{line: 936, col: 43, offset: 28430},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 936, col: 54, offset: 28442},
+								pos:  position{line: 936, col: 54, offset: 28441},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1640,37 +1640,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 956, col: 1, offset: 29046},
+			pos:  position{line: 956, col: 1, offset: 29045},
 			expr: &actionExpr{
-				pos: position{line: 956, col: 33, offset: 29078},
+				pos: position{line: 956, col: 33, offset: 29077},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 956, col: 33, offset: 29078},
+					pos: position{line: 956, col: 33, offset: 29077},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 956, col: 33, offset: 29078},
+							pos:        position{line: 956, col: 33, offset: 29077},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 956, col: 48, offset: 29093},
+							pos:  position{line: 956, col: 48, offset: 29092},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 956, col: 54, offset: 29099},
+							pos:  position{line: 956, col: 54, offset: 29098},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 956, col: 62, offset: 29107},
+							pos:   position{line: 956, col: 62, offset: 29106},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 956, col: 71, offset: 29116},
+								pos:  position{line: 956, col: 71, offset: 29115},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 956, col: 80, offset: 29125},
+							pos:  position{line: 956, col: 80, offset: 29124},
 							name: "R_PAREN",
 						},
 					},
@@ -1679,37 +1679,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 968, col: 1, offset: 29395},
+			pos:  position{line: 968, col: 1, offset: 29394},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 32, offset: 29426},
+				pos: position{line: 968, col: 32, offset: 29425},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 968, col: 32, offset: 29426},
+					pos: position{line: 968, col: 32, offset: 29425},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 968, col: 32, offset: 29426},
+							pos:        position{line: 968, col: 32, offset: 29425},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 46, offset: 29440},
+							pos:  position{line: 968, col: 46, offset: 29439},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 52, offset: 29446},
+							pos:  position{line: 968, col: 52, offset: 29445},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 60, offset: 29454},
+							pos:   position{line: 968, col: 60, offset: 29453},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 968, col: 69, offset: 29463},
+								pos:  position{line: 968, col: 69, offset: 29462},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 78, offset: 29472},
+							pos:  position{line: 968, col: 78, offset: 29471},
 							name: "R_PAREN",
 						},
 					},
@@ -1718,28 +1718,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 980, col: 1, offset: 29740},
+			pos:  position{line: 980, col: 1, offset: 29739},
 			expr: &actionExpr{
-				pos: position{line: 980, col: 32, offset: 29771},
+				pos: position{line: 980, col: 32, offset: 29770},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 980, col: 32, offset: 29771},
+					pos: position{line: 980, col: 32, offset: 29770},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 980, col: 32, offset: 29771},
+							pos:        position{line: 980, col: 32, offset: 29770},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 980, col: 46, offset: 29785},
+							pos:  position{line: 980, col: 46, offset: 29784},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 980, col: 52, offset: 29791},
+							pos:   position{line: 980, col: 52, offset: 29790},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 980, col: 63, offset: 29802},
+								pos:  position{line: 980, col: 63, offset: 29801},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1749,46 +1749,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 996, col: 1, offset: 30264},
+			pos:  position{line: 996, col: 1, offset: 30263},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 22, offset: 30285},
+				pos: position{line: 996, col: 22, offset: 30284},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 996, col: 22, offset: 30285},
+					pos:   position{line: 996, col: 22, offset: 30284},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 996, col: 32, offset: 30295},
+						pos: position{line: 996, col: 32, offset: 30294},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 32, offset: 30295},
+								pos:  position{line: 996, col: 32, offset: 30294},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 65, offset: 30328},
+								pos:  position{line: 996, col: 65, offset: 30327},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 92, offset: 30355},
+								pos:  position{line: 996, col: 92, offset: 30354},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 118, offset: 30381},
+								pos:  position{line: 996, col: 118, offset: 30380},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 144, offset: 30407},
+								pos:  position{line: 996, col: 144, offset: 30406},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 170, offset: 30433},
+								pos:  position{line: 996, col: 170, offset: 30432},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 201, offset: 30464},
+								pos:  position{line: 996, col: 201, offset: 30463},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 996, col: 231, offset: 30494},
+								pos:  position{line: 996, col: 231, offset: 30493},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1798,35 +1798,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1000, col: 1, offset: 30553},
+			pos:  position{line: 1000, col: 1, offset: 30552},
 			expr: &actionExpr{
-				pos: position{line: 1000, col: 26, offset: 30578},
+				pos: position{line: 1000, col: 26, offset: 30577},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1000, col: 26, offset: 30578},
+					pos: position{line: 1000, col: 26, offset: 30577},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1000, col: 26, offset: 30578},
+							pos:   position{line: 1000, col: 26, offset: 30577},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1000, col: 32, offset: 30584},
+								pos:  position{line: 1000, col: 32, offset: 30583},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1000, col: 50, offset: 30602},
+							pos:   position{line: 1000, col: 50, offset: 30601},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1000, col: 55, offset: 30607},
+								pos: position{line: 1000, col: 55, offset: 30606},
 								expr: &seqExpr{
-									pos: position{line: 1000, col: 56, offset: 30608},
+									pos: position{line: 1000, col: 56, offset: 30607},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1000, col: 56, offset: 30608},
+											pos:  position{line: 1000, col: 56, offset: 30607},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1000, col: 62, offset: 30614},
+											pos:  position{line: 1000, col: 62, offset: 30613},
 											name: "StreamStatsOption",
 										},
 									},
@@ -1839,41 +1839,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1059, col: 1, offset: 32803},
+			pos:  position{line: 1059, col: 1, offset: 32802},
 			expr: &choiceExpr{
-				pos: position{line: 1059, col: 21, offset: 32823},
+				pos: position{line: 1059, col: 21, offset: 32822},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1059, col: 21, offset: 32823},
+						pos: position{line: 1059, col: 21, offset: 32822},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1059, col: 21, offset: 32823},
+							pos: position{line: 1059, col: 21, offset: 32822},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 21, offset: 32823},
+									pos:  position{line: 1059, col: 21, offset: 32822},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 26, offset: 32828},
+									pos:  position{line: 1059, col: 26, offset: 32827},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1059, col: 42, offset: 32844},
+									pos:   position{line: 1059, col: 42, offset: 32843},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 56, offset: 32858},
+										pos:  position{line: 1059, col: 56, offset: 32857},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1059, col: 79, offset: 32881},
+									pos:  position{line: 1059, col: 79, offset: 32880},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1059, col: 85, offset: 32887},
+									pos:   position{line: 1059, col: 85, offset: 32886},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1059, col: 91, offset: 32893},
+										pos:  position{line: 1059, col: 91, offset: 32892},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1881,24 +1881,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1066, col: 3, offset: 33072},
+						pos: position{line: 1066, col: 3, offset: 33071},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1066, col: 3, offset: 33072},
+							pos: position{line: 1066, col: 3, offset: 33071},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 3, offset: 33072},
+									pos:  position{line: 1066, col: 3, offset: 33071},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1066, col: 8, offset: 33077},
+									pos:  position{line: 1066, col: 8, offset: 33076},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1066, col: 24, offset: 33093},
+									pos:   position{line: 1066, col: 24, offset: 33092},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1066, col: 30, offset: 33099},
+										pos:  position{line: 1066, col: 30, offset: 33098},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1910,31 +1910,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1074, col: 1, offset: 33265},
+			pos:  position{line: 1074, col: 1, offset: 33264},
 			expr: &actionExpr{
-				pos: position{line: 1074, col: 15, offset: 33279},
+				pos: position{line: 1074, col: 15, offset: 33278},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1074, col: 15, offset: 33279},
+					pos: position{line: 1074, col: 15, offset: 33278},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1074, col: 15, offset: 33279},
+							pos:  position{line: 1074, col: 15, offset: 33278},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1074, col: 25, offset: 33289},
+							pos:   position{line: 1074, col: 25, offset: 33288},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1074, col: 34, offset: 33298},
+								pos: position{line: 1074, col: 34, offset: 33297},
 								expr: &seqExpr{
-									pos: position{line: 1074, col: 35, offset: 33299},
+									pos: position{line: 1074, col: 35, offset: 33298},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1074, col: 35, offset: 33299},
+											pos:  position{line: 1074, col: 35, offset: 33298},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1074, col: 45, offset: 33309},
+											pos:  position{line: 1074, col: 45, offset: 33308},
 											name: "EqualityOperator",
 										},
 									},
@@ -1942,10 +1942,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1074, col: 64, offset: 33328},
+							pos:   position{line: 1074, col: 64, offset: 33327},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1074, col: 68, offset: 33332},
+								pos:  position{line: 1074, col: 68, offset: 33331},
 								name: "QuotedString",
 							},
 						},
@@ -1955,44 +1955,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1102, col: 1, offset: 33911},
+			pos:  position{line: 1102, col: 1, offset: 33910},
 			expr: &actionExpr{
-				pos: position{line: 1102, col: 17, offset: 33927},
+				pos: position{line: 1102, col: 17, offset: 33926},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1102, col: 17, offset: 33927},
+					pos: position{line: 1102, col: 17, offset: 33926},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1102, col: 17, offset: 33927},
+							pos:   position{line: 1102, col: 17, offset: 33926},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1102, col: 23, offset: 33933},
+								pos:  position{line: 1102, col: 23, offset: 33932},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1102, col: 36, offset: 33946},
+							pos:   position{line: 1102, col: 36, offset: 33945},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1102, col: 41, offset: 33951},
+								pos: position{line: 1102, col: 41, offset: 33950},
 								expr: &seqExpr{
-									pos: position{line: 1102, col: 42, offset: 33952},
+									pos: position{line: 1102, col: 42, offset: 33951},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1102, col: 43, offset: 33953},
+											pos: position{line: 1102, col: 43, offset: 33952},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1102, col: 43, offset: 33953},
+													pos:  position{line: 1102, col: 43, offset: 33952},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1102, col: 49, offset: 33959},
+													pos:  position{line: 1102, col: 49, offset: 33958},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1102, col: 56, offset: 33966},
+											pos:  position{line: 1102, col: 56, offset: 33965},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2005,35 +2005,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1120, col: 1, offset: 34343},
+			pos:  position{line: 1120, col: 1, offset: 34342},
 			expr: &actionExpr{
-				pos: position{line: 1120, col: 17, offset: 34359},
+				pos: position{line: 1120, col: 17, offset: 34358},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1120, col: 17, offset: 34359},
+					pos: position{line: 1120, col: 17, offset: 34358},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1120, col: 17, offset: 34359},
+							pos:   position{line: 1120, col: 17, offset: 34358},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1120, col: 23, offset: 34365},
+								pos:  position{line: 1120, col: 23, offset: 34364},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1120, col: 36, offset: 34378},
+							pos:   position{line: 1120, col: 36, offset: 34377},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1120, col: 41, offset: 34383},
+								pos: position{line: 1120, col: 41, offset: 34382},
 								expr: &seqExpr{
-									pos: position{line: 1120, col: 42, offset: 34384},
+									pos: position{line: 1120, col: 42, offset: 34383},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1120, col: 42, offset: 34384},
+											pos:  position{line: 1120, col: 42, offset: 34383},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1120, col: 45, offset: 34387},
+											pos:  position{line: 1120, col: 45, offset: 34386},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2046,32 +2046,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1138, col: 1, offset: 34752},
+			pos:  position{line: 1138, col: 1, offset: 34751},
 			expr: &choiceExpr{
-				pos: position{line: 1138, col: 17, offset: 34768},
+				pos: position{line: 1138, col: 17, offset: 34767},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1138, col: 17, offset: 34768},
+						pos: position{line: 1138, col: 17, offset: 34767},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1138, col: 17, offset: 34768},
+							pos: position{line: 1138, col: 17, offset: 34767},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1138, col: 17, offset: 34768},
+									pos:   position{line: 1138, col: 17, offset: 34767},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1138, col: 25, offset: 34776},
+										pos: position{line: 1138, col: 25, offset: 34775},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1138, col: 25, offset: 34776},
+											pos:  position{line: 1138, col: 25, offset: 34775},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1138, col: 30, offset: 34781},
+									pos:   position{line: 1138, col: 30, offset: 34780},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1138, col: 36, offset: 34787},
+										pos:  position{line: 1138, col: 36, offset: 34786},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2079,13 +2079,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 35083},
+						pos: position{line: 1149, col: 5, offset: 35082},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1149, col: 5, offset: 35083},
+							pos:   position{line: 1149, col: 5, offset: 35082},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 12, offset: 35090},
+								pos:  position{line: 1149, col: 12, offset: 35089},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2095,43 +2095,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1153, col: 1, offset: 35131},
+			pos:  position{line: 1153, col: 1, offset: 35130},
 			expr: &choiceExpr{
-				pos: position{line: 1153, col: 17, offset: 35147},
+				pos: position{line: 1153, col: 17, offset: 35146},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1153, col: 17, offset: 35147},
+						pos: position{line: 1153, col: 17, offset: 35146},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1153, col: 17, offset: 35147},
+							pos: position{line: 1153, col: 17, offset: 35146},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1153, col: 17, offset: 35147},
+									pos:  position{line: 1153, col: 17, offset: 35146},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1153, col: 25, offset: 35155},
+									pos:   position{line: 1153, col: 25, offset: 35154},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1153, col: 32, offset: 35162},
+										pos:  position{line: 1153, col: 32, offset: 35161},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1153, col: 45, offset: 35175},
+									pos:  position{line: 1153, col: 45, offset: 35174},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1155, col: 5, offset: 35212},
+						pos: position{line: 1155, col: 5, offset: 35211},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1155, col: 5, offset: 35212},
+							pos:   position{line: 1155, col: 5, offset: 35211},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1155, col: 10, offset: 35217},
+								pos:  position{line: 1155, col: 10, offset: 35216},
 								name: "SearchTerm",
 							},
 						},
@@ -2141,26 +2141,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1161, col: 1, offset: 35375},
+			pos:  position{line: 1161, col: 1, offset: 35374},
 			expr: &actionExpr{
-				pos: position{line: 1161, col: 15, offset: 35389},
+				pos: position{line: 1161, col: 15, offset: 35388},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1161, col: 15, offset: 35389},
+					pos:   position{line: 1161, col: 15, offset: 35388},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1161, col: 21, offset: 35395},
+						pos: position{line: 1161, col: 21, offset: 35394},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1161, col: 21, offset: 35395},
+								pos:  position{line: 1161, col: 21, offset: 35394},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1161, col: 44, offset: 35418},
+								pos:  position{line: 1161, col: 44, offset: 35417},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1161, col: 68, offset: 35442},
+								pos:  position{line: 1161, col: 68, offset: 35441},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2170,36 +2170,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1166, col: 1, offset: 35583},
+			pos:  position{line: 1166, col: 1, offset: 35582},
 			expr: &actionExpr{
-				pos: position{line: 1166, col: 19, offset: 35601},
+				pos: position{line: 1166, col: 19, offset: 35600},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1166, col: 19, offset: 35601},
+					pos: position{line: 1166, col: 19, offset: 35600},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 19, offset: 35601},
+							pos:  position{line: 1166, col: 19, offset: 35600},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1166, col: 24, offset: 35606},
+							pos:  position{line: 1166, col: 24, offset: 35605},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 38, offset: 35620},
+							pos:   position{line: 1166, col: 38, offset: 35619},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1166, col: 45, offset: 35627},
+								pos:  position{line: 1166, col: 45, offset: 35626},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1166, col: 68, offset: 35650},
+							pos:   position{line: 1166, col: 68, offset: 35649},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1166, col: 78, offset: 35660},
+								pos: position{line: 1166, col: 78, offset: 35659},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1166, col: 79, offset: 35661},
+									pos:  position{line: 1166, col: 79, offset: 35660},
 									name: "LimitExpr",
 								},
 							},
@@ -2210,35 +2210,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1254, col: 1, offset: 38404},
+			pos:  position{line: 1254, col: 1, offset: 38403},
 			expr: &actionExpr{
-				pos: position{line: 1254, col: 27, offset: 38430},
+				pos: position{line: 1254, col: 27, offset: 38429},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1254, col: 27, offset: 38430},
+					pos: position{line: 1254, col: 27, offset: 38429},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1254, col: 27, offset: 38430},
+							pos:   position{line: 1254, col: 27, offset: 38429},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1254, col: 33, offset: 38436},
+								pos:  position{line: 1254, col: 33, offset: 38435},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1254, col: 51, offset: 38454},
+							pos:   position{line: 1254, col: 51, offset: 38453},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1254, col: 56, offset: 38459},
+								pos: position{line: 1254, col: 56, offset: 38458},
 								expr: &seqExpr{
-									pos: position{line: 1254, col: 57, offset: 38460},
+									pos: position{line: 1254, col: 57, offset: 38459},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1254, col: 57, offset: 38460},
+											pos:  position{line: 1254, col: 57, offset: 38459},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1254, col: 63, offset: 38466},
+											pos:  position{line: 1254, col: 63, offset: 38465},
 											name: "TimechartArgument",
 										},
 									},
@@ -2251,22 +2251,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1283, col: 1, offset: 39200},
+			pos:  position{line: 1283, col: 1, offset: 39199},
 			expr: &actionExpr{
-				pos: position{line: 1283, col: 22, offset: 39221},
+				pos: position{line: 1283, col: 22, offset: 39220},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1283, col: 22, offset: 39221},
+					pos:   position{line: 1283, col: 22, offset: 39220},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1283, col: 29, offset: 39228},
+						pos: position{line: 1283, col: 29, offset: 39227},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1283, col: 29, offset: 39228},
+								pos:  position{line: 1283, col: 29, offset: 39227},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1283, col: 45, offset: 39244},
+								pos:  position{line: 1283, col: 45, offset: 39243},
 								name: "TcOptions",
 							},
 						},
@@ -2276,28 +2276,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1287, col: 1, offset: 39282},
+			pos:  position{line: 1287, col: 1, offset: 39281},
 			expr: &actionExpr{
-				pos: position{line: 1287, col: 18, offset: 39299},
+				pos: position{line: 1287, col: 18, offset: 39298},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1287, col: 18, offset: 39299},
+					pos: position{line: 1287, col: 18, offset: 39298},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1287, col: 18, offset: 39299},
+							pos:   position{line: 1287, col: 18, offset: 39298},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1287, col: 23, offset: 39304},
+								pos:  position{line: 1287, col: 23, offset: 39303},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1287, col: 39, offset: 39320},
+							pos:   position{line: 1287, col: 39, offset: 39319},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1287, col: 53, offset: 39334},
+								pos: position{line: 1287, col: 53, offset: 39333},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1287, col: 53, offset: 39334},
+									pos:  position{line: 1287, col: 53, offset: 39333},
 									name: "SplitByClause",
 								},
 							},
@@ -2308,22 +2308,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1301, col: 1, offset: 39673},
+			pos:  position{line: 1301, col: 1, offset: 39672},
 			expr: &actionExpr{
-				pos: position{line: 1301, col: 18, offset: 39690},
+				pos: position{line: 1301, col: 18, offset: 39689},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1301, col: 18, offset: 39690},
+					pos: position{line: 1301, col: 18, offset: 39689},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1301, col: 18, offset: 39690},
+							pos:  position{line: 1301, col: 18, offset: 39689},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1301, col: 21, offset: 39693},
+							pos:   position{line: 1301, col: 21, offset: 39692},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1301, col: 27, offset: 39699},
+								pos:  position{line: 1301, col: 27, offset: 39698},
 								name: "FieldName",
 							},
 						},
@@ -2333,24 +2333,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1309, col: 1, offset: 39828},
+			pos:  position{line: 1309, col: 1, offset: 39827},
 			expr: &actionExpr{
-				pos: position{line: 1309, col: 14, offset: 39841},
+				pos: position{line: 1309, col: 14, offset: 39840},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1309, col: 14, offset: 39841},
+					pos:   position{line: 1309, col: 14, offset: 39840},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1309, col: 22, offset: 39849},
+						pos: position{line: 1309, col: 22, offset: 39848},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1309, col: 22, offset: 39849},
+								pos:  position{line: 1309, col: 22, offset: 39848},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1309, col: 35, offset: 39862},
+								pos: position{line: 1309, col: 35, offset: 39861},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1309, col: 36, offset: 39863},
+									pos:  position{line: 1309, col: 36, offset: 39862},
 									name: "TcOption",
 								},
 							},
@@ -2361,34 +2361,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1351, col: 1, offset: 41383},
+			pos:  position{line: 1351, col: 1, offset: 41382},
 			expr: &actionExpr{
-				pos: position{line: 1351, col: 13, offset: 41395},
+				pos: position{line: 1351, col: 13, offset: 41394},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1351, col: 13, offset: 41395},
+					pos: position{line: 1351, col: 13, offset: 41394},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1351, col: 13, offset: 41395},
+							pos:  position{line: 1351, col: 13, offset: 41394},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1351, col: 19, offset: 41401},
+							pos:   position{line: 1351, col: 19, offset: 41400},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1351, col: 31, offset: 41413},
+								pos:  position{line: 1351, col: 31, offset: 41412},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1351, col: 43, offset: 41425},
+							pos:  position{line: 1351, col: 43, offset: 41424},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1351, col: 49, offset: 41431},
+							pos:   position{line: 1351, col: 49, offset: 41430},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1351, col: 53, offset: 41435},
+								pos:  position{line: 1351, col: 53, offset: 41434},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2398,36 +2398,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1356, col: 1, offset: 41548},
+			pos:  position{line: 1356, col: 1, offset: 41547},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 16, offset: 41563},
+				pos: position{line: 1356, col: 16, offset: 41562},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1356, col: 16, offset: 41563},
+					pos:   position{line: 1356, col: 16, offset: 41562},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1356, col: 24, offset: 41571},
+						pos: position{line: 1356, col: 24, offset: 41570},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1356, col: 24, offset: 41571},
+								pos:        position{line: 1356, col: 24, offset: 41570},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1356, col: 36, offset: 41583},
+								pos:        position{line: 1356, col: 36, offset: 41582},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1356, col: 49, offset: 41596},
+								pos:        position{line: 1356, col: 49, offset: 41595},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1356, col: 61, offset: 41608},
+								pos:        position{line: 1356, col: 61, offset: 41607},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2439,50 +2439,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1364, col: 1, offset: 41804},
+			pos:  position{line: 1364, col: 1, offset: 41803},
 			expr: &actionExpr{
-				pos: position{line: 1364, col: 17, offset: 41820},
+				pos: position{line: 1364, col: 17, offset: 41819},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1364, col: 17, offset: 41820},
+					pos:   position{line: 1364, col: 17, offset: 41819},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1364, col: 27, offset: 41830},
+						pos: position{line: 1364, col: 27, offset: 41829},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 27, offset: 41830},
+								pos:  position{line: 1364, col: 27, offset: 41829},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 36, offset: 41839},
+								pos:  position{line: 1364, col: 36, offset: 41838},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 44, offset: 41847},
+								pos:  position{line: 1364, col: 44, offset: 41846},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 57, offset: 41860},
+								pos:  position{line: 1364, col: 57, offset: 41859},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 66, offset: 41869},
+								pos:  position{line: 1364, col: 66, offset: 41868},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 73, offset: 41876},
+								pos:  position{line: 1364, col: 73, offset: 41875},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 79, offset: 41882},
+								pos:  position{line: 1364, col: 79, offset: 41881},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 86, offset: 41889},
+								pos:  position{line: 1364, col: 86, offset: 41888},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1364, col: 96, offset: 41899},
+								pos:  position{line: 1364, col: 96, offset: 41898},
 								name: "Year",
 							},
 						},
@@ -2492,37 +2492,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1368, col: 1, offset: 41935},
+			pos:  position{line: 1368, col: 1, offset: 41934},
 			expr: &actionExpr{
-				pos: position{line: 1368, col: 21, offset: 41955},
+				pos: position{line: 1368, col: 21, offset: 41954},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1368, col: 21, offset: 41955},
+					pos: position{line: 1368, col: 21, offset: 41954},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1368, col: 21, offset: 41955},
+							pos:   position{line: 1368, col: 21, offset: 41954},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1368, col: 29, offset: 41963},
+								pos: position{line: 1368, col: 29, offset: 41962},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1368, col: 29, offset: 41963},
+										pos:  position{line: 1368, col: 29, offset: 41962},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1368, col: 45, offset: 41979},
+										pos:  position{line: 1368, col: 45, offset: 41978},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1368, col: 62, offset: 41996},
+							pos:   position{line: 1368, col: 62, offset: 41995},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1368, col: 72, offset: 42006},
+								pos: position{line: 1368, col: 72, offset: 42005},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1368, col: 73, offset: 42007},
+									pos:  position{line: 1368, col: 73, offset: 42006},
 									name: "AllTimeScale",
 								},
 							},
@@ -2533,28 +2533,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1427, col: 1, offset: 44689},
+			pos:  position{line: 1427, col: 1, offset: 44688},
 			expr: &actionExpr{
-				pos: position{line: 1427, col: 21, offset: 44709},
+				pos: position{line: 1427, col: 21, offset: 44708},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1427, col: 21, offset: 44709},
+					pos: position{line: 1427, col: 21, offset: 44708},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1427, col: 21, offset: 44709},
+							pos:        position{line: 1427, col: 21, offset: 44708},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1427, col: 31, offset: 44719},
+							pos:  position{line: 1427, col: 31, offset: 44718},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1427, col: 37, offset: 44725},
+							pos:   position{line: 1427, col: 37, offset: 44724},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1427, col: 48, offset: 44736},
+								pos:  position{line: 1427, col: 48, offset: 44735},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2564,28 +2564,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1438, col: 1, offset: 44977},
+			pos:  position{line: 1438, col: 1, offset: 44976},
 			expr: &actionExpr{
-				pos: position{line: 1438, col: 21, offset: 44997},
+				pos: position{line: 1438, col: 21, offset: 44996},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1438, col: 21, offset: 44997},
+					pos: position{line: 1438, col: 21, offset: 44996},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1438, col: 21, offset: 44997},
+							pos:        position{line: 1438, col: 21, offset: 44996},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1438, col: 28, offset: 45004},
+							pos:  position{line: 1438, col: 28, offset: 45003},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1438, col: 34, offset: 45010},
+							pos:   position{line: 1438, col: 34, offset: 45009},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1438, col: 43, offset: 45019},
+								pos:  position{line: 1438, col: 43, offset: 45018},
 								name: "IntegerAsString",
 							},
 						},
@@ -2595,31 +2595,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1459, col: 1, offset: 45598},
+			pos:  position{line: 1459, col: 1, offset: 45597},
 			expr: &choiceExpr{
-				pos: position{line: 1459, col: 23, offset: 45620},
+				pos: position{line: 1459, col: 23, offset: 45619},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1459, col: 23, offset: 45620},
+						pos: position{line: 1459, col: 23, offset: 45619},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1459, col: 23, offset: 45620},
+							pos: position{line: 1459, col: 23, offset: 45619},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1459, col: 23, offset: 45620},
+									pos:        position{line: 1459, col: 23, offset: 45619},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1459, col: 35, offset: 45632},
+									pos:  position{line: 1459, col: 35, offset: 45631},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1459, col: 41, offset: 45638},
+									pos:   position{line: 1459, col: 41, offset: 45637},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1459, col: 51, offset: 45648},
+										pos:  position{line: 1459, col: 51, offset: 45647},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2627,33 +2627,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1473, col: 3, offset: 46067},
+						pos: position{line: 1473, col: 3, offset: 46066},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1473, col: 3, offset: 46067},
+							pos: position{line: 1473, col: 3, offset: 46066},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1473, col: 3, offset: 46067},
+									pos:        position{line: 1473, col: 3, offset: 46066},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1473, col: 15, offset: 46079},
+									pos:  position{line: 1473, col: 15, offset: 46078},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1473, col: 21, offset: 46085},
+									pos:   position{line: 1473, col: 21, offset: 46084},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1473, col: 32, offset: 46096},
+										pos: position{line: 1473, col: 32, offset: 46095},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1473, col: 32, offset: 46096},
+												pos:  position{line: 1473, col: 32, offset: 46095},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1473, col: 52, offset: 46116},
+												pos:  position{line: 1473, col: 52, offset: 46115},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2667,35 +2667,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1493, col: 1, offset: 46585},
+			pos:  position{line: 1493, col: 1, offset: 46584},
 			expr: &actionExpr{
-				pos: position{line: 1493, col: 19, offset: 46603},
+				pos: position{line: 1493, col: 19, offset: 46602},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1493, col: 19, offset: 46603},
+					pos: position{line: 1493, col: 19, offset: 46602},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1493, col: 19, offset: 46603},
+							pos:        position{line: 1493, col: 19, offset: 46602},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1493, col: 27, offset: 46611},
+							pos:  position{line: 1493, col: 27, offset: 46610},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1493, col: 33, offset: 46617},
+							pos:   position{line: 1493, col: 33, offset: 46616},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1493, col: 41, offset: 46625},
+								pos: position{line: 1493, col: 41, offset: 46624},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1493, col: 41, offset: 46625},
+										pos:  position{line: 1493, col: 41, offset: 46624},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1493, col: 57, offset: 46641},
+										pos:  position{line: 1493, col: 57, offset: 46640},
 										name: "IntegerAsString",
 									},
 								},
@@ -2707,35 +2707,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1508, col: 1, offset: 47020},
+			pos:  position{line: 1508, col: 1, offset: 47019},
 			expr: &actionExpr{
-				pos: position{line: 1508, col: 17, offset: 47036},
+				pos: position{line: 1508, col: 17, offset: 47035},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1508, col: 17, offset: 47036},
+					pos: position{line: 1508, col: 17, offset: 47035},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1508, col: 17, offset: 47036},
+							pos:        position{line: 1508, col: 17, offset: 47035},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1508, col: 23, offset: 47042},
+							pos:  position{line: 1508, col: 23, offset: 47041},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1508, col: 29, offset: 47048},
+							pos:   position{line: 1508, col: 29, offset: 47047},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1508, col: 37, offset: 47056},
+								pos: position{line: 1508, col: 37, offset: 47055},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1508, col: 37, offset: 47056},
+										pos:  position{line: 1508, col: 37, offset: 47055},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1508, col: 53, offset: 47072},
+										pos:  position{line: 1508, col: 53, offset: 47071},
 										name: "IntegerAsString",
 									},
 								},
@@ -2747,40 +2747,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1523, col: 1, offset: 47443},
+			pos:  position{line: 1523, col: 1, offset: 47442},
 			expr: &choiceExpr{
-				pos: position{line: 1523, col: 18, offset: 47460},
+				pos: position{line: 1523, col: 18, offset: 47459},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1523, col: 18, offset: 47460},
+						pos: position{line: 1523, col: 18, offset: 47459},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1523, col: 18, offset: 47460},
+							pos: position{line: 1523, col: 18, offset: 47459},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1523, col: 18, offset: 47460},
+									pos:        position{line: 1523, col: 18, offset: 47459},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1523, col: 25, offset: 47467},
+									pos:  position{line: 1523, col: 25, offset: 47466},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1523, col: 31, offset: 47473},
+									pos:   position{line: 1523, col: 31, offset: 47472},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1523, col: 36, offset: 47478},
+										pos: position{line: 1523, col: 36, offset: 47477},
 										expr: &choiceExpr{
-											pos: position{line: 1523, col: 37, offset: 47479},
+											pos: position{line: 1523, col: 37, offset: 47478},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1523, col: 37, offset: 47479},
+													pos:  position{line: 1523, col: 37, offset: 47478},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1523, col: 53, offset: 47495},
+													pos:  position{line: 1523, col: 53, offset: 47494},
 													name: "IntegerAsString",
 												},
 											},
@@ -2788,25 +2788,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1523, col: 71, offset: 47513},
+									pos:        position{line: 1523, col: 71, offset: 47512},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1523, col: 77, offset: 47519},
+									pos:   position{line: 1523, col: 77, offset: 47518},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1523, col: 82, offset: 47524},
+										pos: position{line: 1523, col: 82, offset: 47523},
 										expr: &choiceExpr{
-											pos: position{line: 1523, col: 83, offset: 47525},
+											pos: position{line: 1523, col: 83, offset: 47524},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1523, col: 83, offset: 47525},
+													pos:  position{line: 1523, col: 83, offset: 47524},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1523, col: 99, offset: 47541},
+													pos:  position{line: 1523, col: 99, offset: 47540},
 													name: "IntegerAsString",
 												},
 											},
@@ -2817,26 +2817,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1566, col: 3, offset: 48977},
+						pos: position{line: 1566, col: 3, offset: 48976},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1566, col: 3, offset: 48977},
+							pos: position{line: 1566, col: 3, offset: 48976},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1566, col: 3, offset: 48977},
+									pos:        position{line: 1566, col: 3, offset: 48976},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1566, col: 10, offset: 48984},
+									pos:  position{line: 1566, col: 10, offset: 48983},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1566, col: 16, offset: 48990},
+									pos:   position{line: 1566, col: 16, offset: 48989},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1566, col: 24, offset: 48998},
+										pos:  position{line: 1566, col: 24, offset: 48997},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -2848,38 +2848,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1581, col: 1, offset: 49329},
+			pos:  position{line: 1581, col: 1, offset: 49328},
 			expr: &actionExpr{
-				pos: position{line: 1581, col: 17, offset: 49345},
+				pos: position{line: 1581, col: 17, offset: 49344},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1581, col: 17, offset: 49345},
+					pos:   position{line: 1581, col: 17, offset: 49344},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1581, col: 25, offset: 49353},
+						pos: position{line: 1581, col: 25, offset: 49352},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 25, offset: 49353},
+								pos:  position{line: 1581, col: 25, offset: 49352},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 46, offset: 49374},
+								pos:  position{line: 1581, col: 46, offset: 49373},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 65, offset: 49393},
+								pos:  position{line: 1581, col: 65, offset: 49392},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 84, offset: 49412},
+								pos:  position{line: 1581, col: 84, offset: 49411},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 101, offset: 49429},
+								pos:  position{line: 1581, col: 101, offset: 49428},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1581, col: 116, offset: 49444},
+								pos:  position{line: 1581, col: 116, offset: 49443},
 								name: "BinOptionSpan",
 							},
 						},
@@ -2889,35 +2889,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1585, col: 1, offset: 49487},
+			pos:  position{line: 1585, col: 1, offset: 49486},
 			expr: &actionExpr{
-				pos: position{line: 1585, col: 22, offset: 49508},
+				pos: position{line: 1585, col: 22, offset: 49507},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1585, col: 22, offset: 49508},
+					pos: position{line: 1585, col: 22, offset: 49507},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1585, col: 22, offset: 49508},
+							pos:   position{line: 1585, col: 22, offset: 49507},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1585, col: 29, offset: 49515},
+								pos:  position{line: 1585, col: 29, offset: 49514},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1585, col: 42, offset: 49528},
+							pos:   position{line: 1585, col: 42, offset: 49527},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1585, col: 48, offset: 49534},
+								pos: position{line: 1585, col: 48, offset: 49533},
 								expr: &seqExpr{
-									pos: position{line: 1585, col: 49, offset: 49535},
+									pos: position{line: 1585, col: 49, offset: 49534},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1585, col: 49, offset: 49535},
+											pos:  position{line: 1585, col: 49, offset: 49534},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1585, col: 55, offset: 49541},
+											pos:  position{line: 1585, col: 55, offset: 49540},
 											name: "BinCmdOption",
 										},
 									},
@@ -2930,51 +2930,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1631, col: 1, offset: 51025},
+			pos:  position{line: 1631, col: 1, offset: 51024},
 			expr: &choiceExpr{
-				pos: position{line: 1631, col: 13, offset: 51037},
+				pos: position{line: 1631, col: 13, offset: 51036},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1631, col: 13, offset: 51037},
+						pos: position{line: 1631, col: 13, offset: 51036},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1631, col: 13, offset: 51037},
+							pos: position{line: 1631, col: 13, offset: 51036},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1631, col: 13, offset: 51037},
+									pos:  position{line: 1631, col: 13, offset: 51036},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1631, col: 18, offset: 51042},
+									pos:  position{line: 1631, col: 18, offset: 51041},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1631, col: 26, offset: 51050},
+									pos:   position{line: 1631, col: 26, offset: 51049},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1631, col: 40, offset: 51064},
+										pos:  position{line: 1631, col: 40, offset: 51063},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1631, col: 59, offset: 51083},
+									pos:  position{line: 1631, col: 59, offset: 51082},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1631, col: 65, offset: 51089},
+									pos:   position{line: 1631, col: 65, offset: 51088},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1631, col: 71, offset: 51095},
+										pos:  position{line: 1631, col: 71, offset: 51094},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1631, col: 81, offset: 51105},
+									pos:   position{line: 1631, col: 81, offset: 51104},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1631, col: 94, offset: 51118},
+										pos: position{line: 1631, col: 94, offset: 51117},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1631, col: 95, offset: 51119},
+											pos:  position{line: 1631, col: 95, offset: 51118},
 											name: "AsField",
 										},
 									},
@@ -2983,34 +2983,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1654, col: 3, offset: 51748},
+						pos: position{line: 1654, col: 3, offset: 51747},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1654, col: 3, offset: 51748},
+							pos: position{line: 1654, col: 3, offset: 51747},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1654, col: 3, offset: 51748},
+									pos:  position{line: 1654, col: 3, offset: 51747},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1654, col: 8, offset: 51753},
+									pos:  position{line: 1654, col: 8, offset: 51752},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1654, col: 16, offset: 51761},
+									pos:   position{line: 1654, col: 16, offset: 51760},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1654, col: 22, offset: 51767},
+										pos:  position{line: 1654, col: 22, offset: 51766},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1654, col: 32, offset: 51777},
+									pos:   position{line: 1654, col: 32, offset: 51776},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1654, col: 45, offset: 51790},
+										pos: position{line: 1654, col: 45, offset: 51789},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1654, col: 46, offset: 51791},
+											pos:  position{line: 1654, col: 46, offset: 51790},
 											name: "AsField",
 										},
 									},
@@ -3023,15 +3023,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1681, col: 1, offset: 52529},
+			pos:  position{line: 1681, col: 1, offset: 52528},
 			expr: &actionExpr{
-				pos: position{line: 1681, col: 15, offset: 52543},
+				pos: position{line: 1681, col: 15, offset: 52542},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1681, col: 15, offset: 52543},
+					pos:   position{line: 1681, col: 15, offset: 52542},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1681, col: 27, offset: 52555},
+						pos:  position{line: 1681, col: 27, offset: 52554},
 						name: "SpanOptions",
 					},
 				},
@@ -3039,26 +3039,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1689, col: 1, offset: 52780},
+			pos:  position{line: 1689, col: 1, offset: 52779},
 			expr: &actionExpr{
-				pos: position{line: 1689, col: 16, offset: 52795},
+				pos: position{line: 1689, col: 16, offset: 52794},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1689, col: 16, offset: 52795},
+					pos: position{line: 1689, col: 16, offset: 52794},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1689, col: 16, offset: 52795},
+							pos:  position{line: 1689, col: 16, offset: 52794},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1689, col: 25, offset: 52804},
+							pos:  position{line: 1689, col: 25, offset: 52803},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1689, col: 31, offset: 52810},
+							pos:   position{line: 1689, col: 31, offset: 52809},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1689, col: 42, offset: 52821},
+								pos:  position{line: 1689, col: 42, offset: 52820},
 								name: "SpanLength",
 							},
 						},
@@ -3068,26 +3068,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1696, col: 1, offset: 52967},
+			pos:  position{line: 1696, col: 1, offset: 52966},
 			expr: &actionExpr{
-				pos: position{line: 1696, col: 15, offset: 52981},
+				pos: position{line: 1696, col: 15, offset: 52980},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1696, col: 15, offset: 52981},
+					pos: position{line: 1696, col: 15, offset: 52980},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1696, col: 15, offset: 52981},
+							pos:   position{line: 1696, col: 15, offset: 52980},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1696, col: 24, offset: 52990},
+								pos:  position{line: 1696, col: 24, offset: 52989},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1696, col: 40, offset: 53006},
+							pos:   position{line: 1696, col: 40, offset: 53005},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1696, col: 50, offset: 53016},
+								pos:  position{line: 1696, col: 50, offset: 53015},
 								name: "AllTimeScale",
 							},
 						},
@@ -3097,43 +3097,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1713, col: 1, offset: 53562},
+			pos:  position{line: 1713, col: 1, offset: 53561},
 			expr: &actionExpr{
-				pos: position{line: 1713, col: 14, offset: 53575},
+				pos: position{line: 1713, col: 14, offset: 53574},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1713, col: 14, offset: 53575},
+					pos: position{line: 1713, col: 14, offset: 53574},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1713, col: 14, offset: 53575},
+							pos:  position{line: 1713, col: 14, offset: 53574},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1713, col: 20, offset: 53581},
+							pos:        position{line: 1713, col: 20, offset: 53580},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1713, col: 28, offset: 53589},
+							pos:  position{line: 1713, col: 28, offset: 53588},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1713, col: 34, offset: 53595},
+							pos:   position{line: 1713, col: 34, offset: 53594},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1713, col: 41, offset: 53602},
+								pos: position{line: 1713, col: 41, offset: 53601},
 								expr: &choiceExpr{
-									pos: position{line: 1713, col: 42, offset: 53603},
+									pos: position{line: 1713, col: 42, offset: 53602},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1713, col: 42, offset: 53603},
+											pos:        position{line: 1713, col: 42, offset: 53602},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1713, col: 50, offset: 53611},
+											pos:        position{line: 1713, col: 50, offset: 53610},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3143,14 +3143,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1713, col: 61, offset: 53622},
+							pos:  position{line: 1713, col: 61, offset: 53621},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1713, col: 76, offset: 53637},
+							pos:   position{line: 1713, col: 76, offset: 53636},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1713, col: 86, offset: 53647},
+								pos:  position{line: 1713, col: 86, offset: 53646},
 								name: "IntegerAsString",
 							},
 						},
@@ -3160,22 +3160,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1737, col: 1, offset: 54228},
+			pos:  position{line: 1737, col: 1, offset: 54227},
 			expr: &actionExpr{
-				pos: position{line: 1737, col: 19, offset: 54246},
+				pos: position{line: 1737, col: 19, offset: 54245},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1737, col: 19, offset: 54246},
+					pos: position{line: 1737, col: 19, offset: 54245},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1737, col: 19, offset: 54246},
+							pos:  position{line: 1737, col: 19, offset: 54245},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1737, col: 24, offset: 54251},
+							pos:   position{line: 1737, col: 24, offset: 54250},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1737, col: 38, offset: 54265},
+								pos:  position{line: 1737, col: 38, offset: 54264},
 								name: "StatisticExpr",
 							},
 						},
@@ -3185,76 +3185,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1770, col: 1, offset: 55243},
+			pos:  position{line: 1770, col: 1, offset: 55242},
 			expr: &actionExpr{
-				pos: position{line: 1770, col: 18, offset: 55260},
+				pos: position{line: 1770, col: 18, offset: 55259},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1770, col: 18, offset: 55260},
+					pos: position{line: 1770, col: 18, offset: 55259},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1770, col: 18, offset: 55260},
+							pos:   position{line: 1770, col: 18, offset: 55259},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1770, col: 23, offset: 55265},
+								pos: position{line: 1770, col: 23, offset: 55264},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1770, col: 23, offset: 55265},
+										pos:  position{line: 1770, col: 23, offset: 55264},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1770, col: 33, offset: 55275},
+										pos:  position{line: 1770, col: 33, offset: 55274},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 43, offset: 55285},
+							pos:   position{line: 1770, col: 43, offset: 55284},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1770, col: 49, offset: 55291},
+								pos: position{line: 1770, col: 49, offset: 55290},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 50, offset: 55292},
+									pos:  position{line: 1770, col: 50, offset: 55291},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 67, offset: 55309},
+							pos:   position{line: 1770, col: 67, offset: 55308},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1770, col: 78, offset: 55320},
+								pos: position{line: 1770, col: 78, offset: 55319},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1770, col: 78, offset: 55320},
+										pos:  position{line: 1770, col: 78, offset: 55319},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1770, col: 84, offset: 55326},
+										pos:  position{line: 1770, col: 84, offset: 55325},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 99, offset: 55341},
+							pos:   position{line: 1770, col: 99, offset: 55340},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1770, col: 108, offset: 55350},
+								pos: position{line: 1770, col: 108, offset: 55349},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 109, offset: 55351},
+									pos:  position{line: 1770, col: 109, offset: 55350},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1770, col: 120, offset: 55362},
+							pos:   position{line: 1770, col: 120, offset: 55361},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1770, col: 128, offset: 55370},
+								pos: position{line: 1770, col: 128, offset: 55369},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1770, col: 129, offset: 55371},
+									pos:  position{line: 1770, col: 129, offset: 55370},
 									name: "StatisticOptions",
 								},
 							},
@@ -3265,25 +3265,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1812, col: 1, offset: 56456},
+			pos:  position{line: 1812, col: 1, offset: 56455},
 			expr: &choiceExpr{
-				pos: position{line: 1812, col: 19, offset: 56474},
+				pos: position{line: 1812, col: 19, offset: 56473},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1812, col: 19, offset: 56474},
+						pos: position{line: 1812, col: 19, offset: 56473},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1812, col: 19, offset: 56474},
+							pos: position{line: 1812, col: 19, offset: 56473},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1812, col: 19, offset: 56474},
+									pos:  position{line: 1812, col: 19, offset: 56473},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1812, col: 25, offset: 56480},
+									pos:   position{line: 1812, col: 25, offset: 56479},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1812, col: 32, offset: 56487},
+										pos:  position{line: 1812, col: 32, offset: 56486},
 										name: "IntegerAsString",
 									},
 								},
@@ -3291,30 +3291,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1815, col: 3, offset: 56541},
+						pos: position{line: 1815, col: 3, offset: 56540},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1815, col: 3, offset: 56541},
+							pos: position{line: 1815, col: 3, offset: 56540},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1815, col: 3, offset: 56541},
+									pos:  position{line: 1815, col: 3, offset: 56540},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1815, col: 9, offset: 56547},
+									pos:        position{line: 1815, col: 9, offset: 56546},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1815, col: 17, offset: 56555},
+									pos:  position{line: 1815, col: 17, offset: 56554},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1815, col: 23, offset: 56561},
+									pos:   position{line: 1815, col: 23, offset: 56560},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1815, col: 30, offset: 56568},
+										pos:  position{line: 1815, col: 30, offset: 56567},
 										name: "IntegerAsString",
 									},
 								},
@@ -3326,17 +3326,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1820, col: 1, offset: 56666},
+			pos:  position{line: 1820, col: 1, offset: 56665},
 			expr: &actionExpr{
-				pos: position{line: 1820, col: 21, offset: 56686},
+				pos: position{line: 1820, col: 21, offset: 56685},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1820, col: 21, offset: 56686},
+					pos:   position{line: 1820, col: 21, offset: 56685},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1820, col: 28, offset: 56693},
+						pos: position{line: 1820, col: 28, offset: 56692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1820, col: 29, offset: 56694},
+							pos:  position{line: 1820, col: 29, offset: 56693},
 							name: "StatisticOption",
 						},
 					},
@@ -3345,34 +3345,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1869, col: 1, offset: 58256},
+			pos:  position{line: 1869, col: 1, offset: 58255},
 			expr: &actionExpr{
-				pos: position{line: 1869, col: 20, offset: 58275},
+				pos: position{line: 1869, col: 20, offset: 58274},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1869, col: 20, offset: 58275},
+					pos: position{line: 1869, col: 20, offset: 58274},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1869, col: 20, offset: 58275},
+							pos:  position{line: 1869, col: 20, offset: 58274},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1869, col: 26, offset: 58281},
+							pos:   position{line: 1869, col: 26, offset: 58280},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1869, col: 36, offset: 58291},
+								pos:  position{line: 1869, col: 36, offset: 58290},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1869, col: 55, offset: 58310},
+							pos:  position{line: 1869, col: 55, offset: 58309},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1869, col: 61, offset: 58316},
+							pos:   position{line: 1869, col: 61, offset: 58315},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1869, col: 67, offset: 58322},
+								pos:  position{line: 1869, col: 67, offset: 58321},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3382,48 +3382,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1874, col: 1, offset: 58431},
+			pos:  position{line: 1874, col: 1, offset: 58430},
 			expr: &actionExpr{
-				pos: position{line: 1874, col: 23, offset: 58453},
+				pos: position{line: 1874, col: 23, offset: 58452},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1874, col: 23, offset: 58453},
+					pos:   position{line: 1874, col: 23, offset: 58452},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1874, col: 31, offset: 58461},
+						pos: position{line: 1874, col: 31, offset: 58460},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1874, col: 31, offset: 58461},
+								pos:        position{line: 1874, col: 31, offset: 58460},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1874, col: 46, offset: 58476},
+								pos:        position{line: 1874, col: 46, offset: 58475},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1874, col: 60, offset: 58490},
+								pos:        position{line: 1874, col: 60, offset: 58489},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1874, col: 73, offset: 58503},
+								pos:        position{line: 1874, col: 73, offset: 58502},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1874, col: 85, offset: 58515},
+								pos:        position{line: 1874, col: 85, offset: 58514},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1874, col: 102, offset: 58532},
+								pos:        position{line: 1874, col: 102, offset: 58531},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3435,25 +3435,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1882, col: 1, offset: 58719},
+			pos:  position{line: 1882, col: 1, offset: 58718},
 			expr: &choiceExpr{
-				pos: position{line: 1882, col: 13, offset: 58731},
+				pos: position{line: 1882, col: 13, offset: 58730},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1882, col: 13, offset: 58731},
+						pos: position{line: 1882, col: 13, offset: 58730},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1882, col: 13, offset: 58731},
+							pos: position{line: 1882, col: 13, offset: 58730},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1882, col: 13, offset: 58731},
+									pos:  position{line: 1882, col: 13, offset: 58730},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1882, col: 16, offset: 58734},
+									pos:   position{line: 1882, col: 16, offset: 58733},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1882, col: 26, offset: 58744},
+										pos:  position{line: 1882, col: 26, offset: 58743},
 										name: "FieldNameList",
 									},
 								},
@@ -3461,13 +3461,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1885, col: 3, offset: 58801},
+						pos: position{line: 1885, col: 3, offset: 58800},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1885, col: 3, offset: 58801},
+							pos:   position{line: 1885, col: 3, offset: 58800},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1885, col: 16, offset: 58814},
+								pos:  position{line: 1885, col: 16, offset: 58813},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3477,26 +3477,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1889, col: 1, offset: 58872},
+			pos:  position{line: 1889, col: 1, offset: 58871},
 			expr: &actionExpr{
-				pos: position{line: 1889, col: 15, offset: 58886},
+				pos: position{line: 1889, col: 15, offset: 58885},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1889, col: 15, offset: 58886},
+					pos: position{line: 1889, col: 15, offset: 58885},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1889, col: 15, offset: 58886},
+							pos:  position{line: 1889, col: 15, offset: 58885},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1889, col: 20, offset: 58891},
+							pos:  position{line: 1889, col: 20, offset: 58890},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 30, offset: 58901},
+							pos:   position{line: 1889, col: 30, offset: 58900},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1889, col: 40, offset: 58911},
+								pos:  position{line: 1889, col: 40, offset: 58910},
 								name: "DedupExpr",
 							},
 						},
@@ -3506,27 +3506,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1909, col: 1, offset: 59479},
+			pos:  position{line: 1909, col: 1, offset: 59478},
 			expr: &actionExpr{
-				pos: position{line: 1909, col: 14, offset: 59492},
+				pos: position{line: 1909, col: 14, offset: 59491},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1909, col: 14, offset: 59492},
+					pos: position{line: 1909, col: 14, offset: 59491},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1909, col: 14, offset: 59492},
+							pos:   position{line: 1909, col: 14, offset: 59491},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1909, col: 23, offset: 59501},
+								pos: position{line: 1909, col: 23, offset: 59500},
 								expr: &seqExpr{
-									pos: position{line: 1909, col: 24, offset: 59502},
+									pos: position{line: 1909, col: 24, offset: 59501},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1909, col: 24, offset: 59502},
+											pos:  position{line: 1909, col: 24, offset: 59501},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1909, col: 30, offset: 59508},
+											pos:  position{line: 1909, col: 30, offset: 59507},
 											name: "IntegerAsString",
 										},
 									},
@@ -3534,45 +3534,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1909, col: 48, offset: 59526},
+							pos:   position{line: 1909, col: 48, offset: 59525},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1909, col: 57, offset: 59535},
+								pos: position{line: 1909, col: 57, offset: 59534},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1909, col: 58, offset: 59536},
+									pos:  position{line: 1909, col: 58, offset: 59535},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1909, col: 73, offset: 59551},
+							pos:   position{line: 1909, col: 73, offset: 59550},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1909, col: 83, offset: 59561},
+								pos: position{line: 1909, col: 83, offset: 59560},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1909, col: 84, offset: 59562},
+									pos:  position{line: 1909, col: 84, offset: 59561},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1909, col: 101, offset: 59579},
+							pos:   position{line: 1909, col: 101, offset: 59578},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1909, col: 110, offset: 59588},
+								pos: position{line: 1909, col: 110, offset: 59587},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1909, col: 111, offset: 59589},
+									pos:  position{line: 1909, col: 111, offset: 59588},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1909, col: 126, offset: 59604},
+							pos:   position{line: 1909, col: 126, offset: 59603},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1909, col: 139, offset: 59617},
+								pos: position{line: 1909, col: 139, offset: 59616},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1909, col: 140, offset: 59618},
+									pos:  position{line: 1909, col: 140, offset: 59617},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3583,27 +3583,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 1966, col: 1, offset: 61356},
+			pos:  position{line: 1966, col: 1, offset: 61355},
 			expr: &actionExpr{
-				pos: position{line: 1966, col: 19, offset: 61374},
+				pos: position{line: 1966, col: 19, offset: 61373},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 1966, col: 19, offset: 61374},
+					pos: position{line: 1966, col: 19, offset: 61373},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1966, col: 19, offset: 61374},
+							pos: position{line: 1966, col: 19, offset: 61373},
 							expr: &litMatcher{
-								pos:        position{line: 1966, col: 21, offset: 61376},
+								pos:        position{line: 1966, col: 21, offset: 61375},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 31, offset: 61386},
+							pos:   position{line: 1966, col: 31, offset: 61385},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 37, offset: 61392},
+								pos:  position{line: 1966, col: 37, offset: 61391},
 								name: "FieldName",
 							},
 						},
@@ -3613,48 +3613,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 1972, col: 1, offset: 61531},
+			pos:  position{line: 1972, col: 1, offset: 61530},
 			expr: &actionExpr{
-				pos: position{line: 1972, col: 32, offset: 61562},
+				pos: position{line: 1972, col: 32, offset: 61561},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 1972, col: 32, offset: 61562},
+					pos: position{line: 1972, col: 32, offset: 61561},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1972, col: 32, offset: 61562},
+							pos:   position{line: 1972, col: 32, offset: 61561},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1972, col: 38, offset: 61568},
+								pos:  position{line: 1972, col: 38, offset: 61567},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1972, col: 48, offset: 61578},
+							pos: position{line: 1972, col: 48, offset: 61577},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1972, col: 50, offset: 61580},
+								pos:  position{line: 1972, col: 50, offset: 61579},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1972, col: 57, offset: 61587},
+							pos:   position{line: 1972, col: 57, offset: 61586},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1972, col: 62, offset: 61592},
+								pos: position{line: 1972, col: 62, offset: 61591},
 								expr: &seqExpr{
-									pos: position{line: 1972, col: 63, offset: 61593},
+									pos: position{line: 1972, col: 63, offset: 61592},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1972, col: 63, offset: 61593},
+											pos:  position{line: 1972, col: 63, offset: 61592},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1972, col: 69, offset: 61599},
+											pos:  position{line: 1972, col: 69, offset: 61598},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 1972, col: 79, offset: 61609},
+											pos: position{line: 1972, col: 79, offset: 61608},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1972, col: 81, offset: 61611},
+												pos:  position{line: 1972, col: 81, offset: 61610},
 												name: "EQUAL",
 											},
 										},
@@ -3668,45 +3668,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 1983, col: 1, offset: 61886},
+			pos:  position{line: 1983, col: 1, offset: 61885},
 			expr: &actionExpr{
-				pos: position{line: 1983, col: 19, offset: 61904},
+				pos: position{line: 1983, col: 19, offset: 61903},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1983, col: 19, offset: 61904},
+					pos: position{line: 1983, col: 19, offset: 61903},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1983, col: 19, offset: 61904},
+							pos:  position{line: 1983, col: 19, offset: 61903},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1983, col: 25, offset: 61910},
+							pos:   position{line: 1983, col: 25, offset: 61909},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1983, col: 31, offset: 61916},
+								pos:  position{line: 1983, col: 31, offset: 61915},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1983, col: 46, offset: 61931},
+							pos:   position{line: 1983, col: 46, offset: 61930},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1983, col: 51, offset: 61936},
+								pos: position{line: 1983, col: 51, offset: 61935},
 								expr: &seqExpr{
-									pos: position{line: 1983, col: 52, offset: 61937},
+									pos: position{line: 1983, col: 52, offset: 61936},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1983, col: 52, offset: 61937},
+											pos:  position{line: 1983, col: 52, offset: 61936},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1983, col: 58, offset: 61943},
+											pos:  position{line: 1983, col: 58, offset: 61942},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 1983, col: 73, offset: 61958},
+											pos: position{line: 1983, col: 73, offset: 61957},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1983, col: 74, offset: 61959},
+												pos:  position{line: 1983, col: 74, offset: 61958},
 												name: "EQUAL",
 											},
 										},
@@ -3720,17 +3720,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2001, col: 1, offset: 62487},
+			pos:  position{line: 2001, col: 1, offset: 62486},
 			expr: &actionExpr{
-				pos: position{line: 2001, col: 17, offset: 62503},
+				pos: position{line: 2001, col: 17, offset: 62502},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2001, col: 17, offset: 62503},
+					pos:   position{line: 2001, col: 17, offset: 62502},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2001, col: 24, offset: 62510},
+						pos: position{line: 2001, col: 24, offset: 62509},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2001, col: 25, offset: 62511},
+							pos:  position{line: 2001, col: 25, offset: 62510},
 							name: "DedupOption",
 						},
 					},
@@ -3739,36 +3739,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2041, col: 1, offset: 63777},
+			pos:  position{line: 2041, col: 1, offset: 63776},
 			expr: &actionExpr{
-				pos: position{line: 2041, col: 16, offset: 63792},
+				pos: position{line: 2041, col: 16, offset: 63791},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2041, col: 16, offset: 63792},
+					pos: position{line: 2041, col: 16, offset: 63791},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2041, col: 16, offset: 63792},
+							pos:  position{line: 2041, col: 16, offset: 63791},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2041, col: 22, offset: 63798},
+							pos:   position{line: 2041, col: 22, offset: 63797},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 32, offset: 63808},
+								pos:  position{line: 2041, col: 32, offset: 63807},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2041, col: 47, offset: 63823},
+							pos:        position{line: 2041, col: 47, offset: 63822},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2041, col: 51, offset: 63827},
+							pos:   position{line: 2041, col: 51, offset: 63826},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 57, offset: 63833},
+								pos:  position{line: 2041, col: 57, offset: 63832},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3778,30 +3778,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2046, col: 1, offset: 63942},
+			pos:  position{line: 2046, col: 1, offset: 63941},
 			expr: &actionExpr{
-				pos: position{line: 2046, col: 19, offset: 63960},
+				pos: position{line: 2046, col: 19, offset: 63959},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2046, col: 19, offset: 63960},
+					pos:   position{line: 2046, col: 19, offset: 63959},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2046, col: 27, offset: 63968},
+						pos: position{line: 2046, col: 27, offset: 63967},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2046, col: 27, offset: 63968},
+								pos:        position{line: 2046, col: 27, offset: 63967},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2046, col: 43, offset: 63984},
+								pos:        position{line: 2046, col: 43, offset: 63983},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2046, col: 57, offset: 63998},
+								pos:        position{line: 2046, col: 57, offset: 63997},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3813,22 +3813,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2054, col: 1, offset: 64183},
+			pos:  position{line: 2054, col: 1, offset: 64182},
 			expr: &actionExpr{
-				pos: position{line: 2054, col: 22, offset: 64204},
+				pos: position{line: 2054, col: 22, offset: 64203},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2054, col: 22, offset: 64204},
+					pos: position{line: 2054, col: 22, offset: 64203},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2054, col: 22, offset: 64204},
+							pos:  position{line: 2054, col: 22, offset: 64203},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 39, offset: 64221},
+							pos:   position{line: 2054, col: 39, offset: 64220},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2054, col: 53, offset: 64235},
+								pos:  position{line: 2054, col: 53, offset: 64234},
 								name: "SortElements",
 							},
 						},
@@ -3838,35 +3838,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2059, col: 1, offset: 64343},
+			pos:  position{line: 2059, col: 1, offset: 64342},
 			expr: &actionExpr{
-				pos: position{line: 2059, col: 17, offset: 64359},
+				pos: position{line: 2059, col: 17, offset: 64358},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2059, col: 17, offset: 64359},
+					pos: position{line: 2059, col: 17, offset: 64358},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2059, col: 17, offset: 64359},
+							pos:   position{line: 2059, col: 17, offset: 64358},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2059, col: 23, offset: 64365},
+								pos:  position{line: 2059, col: 23, offset: 64364},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2059, col: 41, offset: 64383},
+							pos:   position{line: 2059, col: 41, offset: 64382},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2059, col: 46, offset: 64388},
+								pos: position{line: 2059, col: 46, offset: 64387},
 								expr: &seqExpr{
-									pos: position{line: 2059, col: 47, offset: 64389},
+									pos: position{line: 2059, col: 47, offset: 64388},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2059, col: 47, offset: 64389},
+											pos:  position{line: 2059, col: 47, offset: 64388},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2059, col: 62, offset: 64404},
+											pos:  position{line: 2059, col: 62, offset: 64403},
 											name: "SingleSortElement",
 										},
 									},
@@ -3879,22 +3879,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2074, col: 1, offset: 64762},
+			pos:  position{line: 2074, col: 1, offset: 64761},
 			expr: &actionExpr{
-				pos: position{line: 2074, col: 22, offset: 64783},
+				pos: position{line: 2074, col: 22, offset: 64782},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2074, col: 22, offset: 64783},
+					pos:   position{line: 2074, col: 22, offset: 64782},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2074, col: 31, offset: 64792},
+						pos: position{line: 2074, col: 31, offset: 64791},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2074, col: 31, offset: 64792},
+								pos:  position{line: 2074, col: 31, offset: 64791},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2074, col: 59, offset: 64820},
+								pos:  position{line: 2074, col: 59, offset: 64819},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -3904,33 +3904,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2078, col: 1, offset: 64879},
+			pos:  position{line: 2078, col: 1, offset: 64878},
 			expr: &actionExpr{
-				pos: position{line: 2078, col: 33, offset: 64911},
+				pos: position{line: 2078, col: 33, offset: 64910},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2078, col: 33, offset: 64911},
+					pos: position{line: 2078, col: 33, offset: 64910},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2078, col: 33, offset: 64911},
+							pos:   position{line: 2078, col: 33, offset: 64910},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2078, col: 47, offset: 64925},
+								pos: position{line: 2078, col: 47, offset: 64924},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2078, col: 47, offset: 64925},
+										pos:        position{line: 2078, col: 47, offset: 64924},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2078, col: 53, offset: 64931},
+										pos:        position{line: 2078, col: 53, offset: 64930},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2078, col: 59, offset: 64937},
+										pos:        position{line: 2078, col: 59, offset: 64936},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3939,10 +3939,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2078, col: 63, offset: 64941},
+							pos:   position{line: 2078, col: 63, offset: 64940},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2078, col: 69, offset: 64947},
+								pos:  position{line: 2078, col: 69, offset: 64946},
 								name: "FieldName",
 							},
 						},
@@ -3952,33 +3952,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2093, col: 1, offset: 65222},
+			pos:  position{line: 2093, col: 1, offset: 65221},
 			expr: &actionExpr{
-				pos: position{line: 2093, col: 30, offset: 65251},
+				pos: position{line: 2093, col: 30, offset: 65250},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2093, col: 30, offset: 65251},
+					pos: position{line: 2093, col: 30, offset: 65250},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2093, col: 30, offset: 65251},
+							pos:   position{line: 2093, col: 30, offset: 65250},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2093, col: 44, offset: 65265},
+								pos: position{line: 2093, col: 44, offset: 65264},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2093, col: 44, offset: 65265},
+										pos:        position{line: 2093, col: 44, offset: 65264},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2093, col: 50, offset: 65271},
+										pos:        position{line: 2093, col: 50, offset: 65270},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2093, col: 56, offset: 65277},
+										pos:        position{line: 2093, col: 56, offset: 65276},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3987,31 +3987,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 60, offset: 65281},
+							pos:   position{line: 2093, col: 60, offset: 65280},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2093, col: 64, offset: 65285},
+								pos: position{line: 2093, col: 64, offset: 65284},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2093, col: 64, offset: 65285},
+										pos:        position{line: 2093, col: 64, offset: 65284},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2093, col: 73, offset: 65294},
+										pos:        position{line: 2093, col: 73, offset: 65293},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2093, col: 81, offset: 65302},
+										pos:        position{line: 2093, col: 81, offset: 65301},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2093, col: 88, offset: 65309},
+										pos:        position{line: 2093, col: 88, offset: 65308},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4020,19 +4020,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2093, col: 95, offset: 65316},
+							pos:  position{line: 2093, col: 95, offset: 65315},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2093, col: 103, offset: 65324},
+							pos:   position{line: 2093, col: 103, offset: 65323},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2093, col: 109, offset: 65330},
+								pos:  position{line: 2093, col: 109, offset: 65329},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2093, col: 119, offset: 65340},
+							pos:  position{line: 2093, col: 119, offset: 65339},
 							name: "R_PAREN",
 						},
 					},
@@ -4041,26 +4041,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2113, col: 1, offset: 65765},
+			pos:  position{line: 2113, col: 1, offset: 65764},
 			expr: &actionExpr{
-				pos: position{line: 2113, col: 16, offset: 65780},
+				pos: position{line: 2113, col: 16, offset: 65779},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2113, col: 16, offset: 65780},
+					pos: position{line: 2113, col: 16, offset: 65779},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2113, col: 16, offset: 65780},
+							pos:  position{line: 2113, col: 16, offset: 65779},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2113, col: 21, offset: 65785},
+							pos:  position{line: 2113, col: 21, offset: 65784},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2113, col: 32, offset: 65796},
+							pos:   position{line: 2113, col: 32, offset: 65795},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 43, offset: 65807},
+								pos:  position{line: 2113, col: 43, offset: 65806},
 								name: "RenameExpr",
 							},
 						},
@@ -4070,33 +4070,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2129, col: 1, offset: 66182},
+			pos:  position{line: 2129, col: 1, offset: 66181},
 			expr: &choiceExpr{
-				pos: position{line: 2129, col: 15, offset: 66196},
+				pos: position{line: 2129, col: 15, offset: 66195},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2129, col: 15, offset: 66196},
+						pos: position{line: 2129, col: 15, offset: 66195},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2129, col: 15, offset: 66196},
+							pos: position{line: 2129, col: 15, offset: 66195},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2129, col: 15, offset: 66196},
+									pos:   position{line: 2129, col: 15, offset: 66195},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2129, col: 31, offset: 66212},
+										pos:  position{line: 2129, col: 31, offset: 66211},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2129, col: 45, offset: 66226},
+									pos:  position{line: 2129, col: 45, offset: 66225},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2129, col: 48, offset: 66229},
+									pos:   position{line: 2129, col: 48, offset: 66228},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2129, col: 59, offset: 66240},
+										pos:  position{line: 2129, col: 59, offset: 66239},
 										name: "QuotedString",
 									},
 								},
@@ -4104,28 +4104,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2140, col: 3, offset: 66559},
+						pos: position{line: 2140, col: 3, offset: 66558},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2140, col: 3, offset: 66559},
+							pos: position{line: 2140, col: 3, offset: 66558},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2140, col: 3, offset: 66559},
+									pos:   position{line: 2140, col: 3, offset: 66558},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2140, col: 19, offset: 66575},
+										pos:  position{line: 2140, col: 19, offset: 66574},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2140, col: 33, offset: 66589},
+									pos:  position{line: 2140, col: 33, offset: 66588},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2140, col: 36, offset: 66592},
+									pos:   position{line: 2140, col: 36, offset: 66591},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2140, col: 47, offset: 66603},
+										pos:  position{line: 2140, col: 47, offset: 66602},
 										name: "RenamePattern",
 									},
 								},
@@ -4137,48 +4137,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2162, col: 1, offset: 67169},
+			pos:  position{line: 2162, col: 1, offset: 67168},
 			expr: &actionExpr{
-				pos: position{line: 2162, col: 13, offset: 67181},
+				pos: position{line: 2162, col: 13, offset: 67180},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2162, col: 13, offset: 67181},
+					pos: position{line: 2162, col: 13, offset: 67180},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 13, offset: 67181},
+							pos:  position{line: 2162, col: 13, offset: 67180},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 18, offset: 67186},
+							pos:  position{line: 2162, col: 18, offset: 67185},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2162, col: 26, offset: 67194},
+							pos:        position{line: 2162, col: 26, offset: 67193},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 34, offset: 67202},
+							pos:  position{line: 2162, col: 34, offset: 67201},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 40, offset: 67208},
+							pos:   position{line: 2162, col: 40, offset: 67207},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 46, offset: 67214},
+								pos:  position{line: 2162, col: 46, offset: 67213},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2162, col: 62, offset: 67230},
+							pos:  position{line: 2162, col: 62, offset: 67229},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2162, col: 68, offset: 67236},
+							pos:   position{line: 2162, col: 68, offset: 67235},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2162, col: 72, offset: 67240},
+								pos:  position{line: 2162, col: 72, offset: 67239},
 								name: "QuotedString",
 							},
 						},
@@ -4188,37 +4188,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2190, col: 1, offset: 67943},
+			pos:  position{line: 2190, col: 1, offset: 67942},
 			expr: &actionExpr{
-				pos: position{line: 2190, col: 14, offset: 67956},
+				pos: position{line: 2190, col: 14, offset: 67955},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2190, col: 14, offset: 67956},
+					pos: position{line: 2190, col: 14, offset: 67955},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2190, col: 14, offset: 67956},
+							pos:  position{line: 2190, col: 14, offset: 67955},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2190, col: 19, offset: 67961},
+							pos:  position{line: 2190, col: 19, offset: 67960},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2190, col: 28, offset: 67970},
+							pos:   position{line: 2190, col: 28, offset: 67969},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2190, col: 34, offset: 67976},
+								pos: position{line: 2190, col: 34, offset: 67975},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2190, col: 35, offset: 67977},
+									pos:  position{line: 2190, col: 35, offset: 67976},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2190, col: 47, offset: 67989},
+							pos:   position{line: 2190, col: 47, offset: 67988},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2190, col: 58, offset: 68000},
+								pos:  position{line: 2190, col: 58, offset: 67999},
 								name: "SortElements",
 							},
 						},
@@ -4228,41 +4228,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2227, col: 1, offset: 68851},
+			pos:  position{line: 2227, col: 1, offset: 68850},
 			expr: &actionExpr{
-				pos: position{line: 2227, col: 14, offset: 68864},
+				pos: position{line: 2227, col: 14, offset: 68863},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2227, col: 14, offset: 68864},
+					pos: position{line: 2227, col: 14, offset: 68863},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2227, col: 14, offset: 68864},
+							pos: position{line: 2227, col: 14, offset: 68863},
 							expr: &seqExpr{
-								pos: position{line: 2227, col: 15, offset: 68865},
+								pos: position{line: 2227, col: 15, offset: 68864},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2227, col: 15, offset: 68865},
+										pos:        position{line: 2227, col: 15, offset: 68864},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2227, col: 23, offset: 68873},
+										pos:  position{line: 2227, col: 23, offset: 68872},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2227, col: 31, offset: 68881},
+							pos:   position{line: 2227, col: 31, offset: 68880},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2227, col: 40, offset: 68890},
+								pos:  position{line: 2227, col: 40, offset: 68889},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2227, col: 56, offset: 68906},
+							pos:  position{line: 2227, col: 56, offset: 68905},
 							name: "SPACE",
 						},
 					},
@@ -4271,43 +4271,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2241, col: 1, offset: 69205},
+			pos:  position{line: 2241, col: 1, offset: 69204},
 			expr: &actionExpr{
-				pos: position{line: 2241, col: 14, offset: 69218},
+				pos: position{line: 2241, col: 14, offset: 69217},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2241, col: 14, offset: 69218},
+					pos: position{line: 2241, col: 14, offset: 69217},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2241, col: 14, offset: 69218},
+							pos:  position{line: 2241, col: 14, offset: 69217},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2241, col: 19, offset: 69223},
+							pos:  position{line: 2241, col: 19, offset: 69222},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2241, col: 28, offset: 69232},
+							pos:   position{line: 2241, col: 28, offset: 69231},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2241, col: 34, offset: 69238},
+								pos:  position{line: 2241, col: 34, offset: 69237},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2241, col: 45, offset: 69249},
+							pos:   position{line: 2241, col: 45, offset: 69248},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2241, col: 50, offset: 69254},
+								pos: position{line: 2241, col: 50, offset: 69253},
 								expr: &seqExpr{
-									pos: position{line: 2241, col: 51, offset: 69255},
+									pos: position{line: 2241, col: 51, offset: 69254},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2241, col: 51, offset: 69255},
+											pos:  position{line: 2241, col: 51, offset: 69254},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2241, col: 57, offset: 69261},
+											pos:  position{line: 2241, col: 57, offset: 69260},
 											name: "SingleEval",
 										},
 									},
@@ -4320,30 +4320,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2268, col: 1, offset: 70062},
+			pos:  position{line: 2268, col: 1, offset: 70061},
 			expr: &actionExpr{
-				pos: position{line: 2268, col: 15, offset: 70076},
+				pos: position{line: 2268, col: 15, offset: 70075},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2268, col: 15, offset: 70076},
+					pos: position{line: 2268, col: 15, offset: 70075},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2268, col: 15, offset: 70076},
+							pos:   position{line: 2268, col: 15, offset: 70075},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 21, offset: 70082},
+								pos:  position{line: 2268, col: 21, offset: 70081},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2268, col: 31, offset: 70092},
+							pos:  position{line: 2268, col: 31, offset: 70091},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2268, col: 37, offset: 70098},
+							pos:   position{line: 2268, col: 37, offset: 70097},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 42, offset: 70103},
+								pos:  position{line: 2268, col: 42, offset: 70102},
 								name: "EvalExpression",
 							},
 						},
@@ -4353,15 +4353,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2281, col: 1, offset: 70504},
+			pos:  position{line: 2281, col: 1, offset: 70503},
 			expr: &actionExpr{
-				pos: position{line: 2281, col: 19, offset: 70522},
+				pos: position{line: 2281, col: 19, offset: 70521},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2281, col: 19, offset: 70522},
+					pos:   position{line: 2281, col: 19, offset: 70521},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2281, col: 25, offset: 70528},
+						pos:  position{line: 2281, col: 25, offset: 70527},
 						name: "ValueExpr",
 					},
 				},
@@ -4369,85 +4369,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2290, col: 1, offset: 70752},
+			pos:  position{line: 2290, col: 1, offset: 70751},
 			expr: &choiceExpr{
-				pos: position{line: 2290, col: 18, offset: 70769},
+				pos: position{line: 2290, col: 18, offset: 70768},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2290, col: 18, offset: 70769},
+						pos: position{line: 2290, col: 18, offset: 70768},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2290, col: 18, offset: 70769},
+							pos: position{line: 2290, col: 18, offset: 70768},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2290, col: 18, offset: 70769},
+									pos:        position{line: 2290, col: 18, offset: 70768},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 23, offset: 70774},
+									pos:  position{line: 2290, col: 23, offset: 70773},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 31, offset: 70782},
+									pos:   position{line: 2290, col: 31, offset: 70781},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 41, offset: 70792},
+										pos:  position{line: 2290, col: 41, offset: 70791},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 50, offset: 70801},
+									pos:  position{line: 2290, col: 50, offset: 70800},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 56, offset: 70807},
+									pos:   position{line: 2290, col: 56, offset: 70806},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 66, offset: 70817},
+										pos:  position{line: 2290, col: 66, offset: 70816},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 76, offset: 70827},
+									pos:  position{line: 2290, col: 76, offset: 70826},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 82, offset: 70833},
+									pos:   position{line: 2290, col: 82, offset: 70832},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 93, offset: 70844},
+										pos:  position{line: 2290, col: 93, offset: 70843},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 103, offset: 70854},
+									pos:  position{line: 2290, col: 103, offset: 70853},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2301, col: 3, offset: 71105},
+						pos: position{line: 2301, col: 3, offset: 71104},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2301, col: 3, offset: 71105},
+							pos: position{line: 2301, col: 3, offset: 71104},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2301, col: 3, offset: 71105},
+									pos:   position{line: 2301, col: 3, offset: 71104},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2301, col: 11, offset: 71113},
+										pos: position{line: 2301, col: 11, offset: 71112},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2301, col: 11, offset: 71113},
+												pos:        position{line: 2301, col: 11, offset: 71112},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2301, col: 20, offset: 71122},
+												pos:        position{line: 2301, col: 20, offset: 71121},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4456,31 +4456,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 32, offset: 71134},
+									pos:  position{line: 2301, col: 32, offset: 71133},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2301, col: 40, offset: 71142},
+									pos:   position{line: 2301, col: 40, offset: 71141},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2301, col: 45, offset: 71147},
+										pos:  position{line: 2301, col: 45, offset: 71146},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2301, col: 64, offset: 71166},
+									pos:   position{line: 2301, col: 64, offset: 71165},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2301, col: 69, offset: 71171},
+										pos: position{line: 2301, col: 69, offset: 71170},
 										expr: &seqExpr{
-											pos: position{line: 2301, col: 70, offset: 71172},
+											pos: position{line: 2301, col: 70, offset: 71171},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2301, col: 70, offset: 71172},
+													pos:  position{line: 2301, col: 70, offset: 71171},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2301, col: 76, offset: 71178},
+													pos:  position{line: 2301, col: 76, offset: 71177},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4488,50 +4488,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2301, col: 97, offset: 71199},
+									pos:  position{line: 2301, col: 97, offset: 71198},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2324, col: 3, offset: 71803},
+						pos: position{line: 2324, col: 3, offset: 71802},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2324, col: 3, offset: 71803},
+							pos: position{line: 2324, col: 3, offset: 71802},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2324, col: 3, offset: 71803},
+									pos:        position{line: 2324, col: 3, offset: 71802},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 14, offset: 71814},
+									pos:  position{line: 2324, col: 14, offset: 71813},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2324, col: 22, offset: 71822},
+									pos:   position{line: 2324, col: 22, offset: 71821},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2324, col: 32, offset: 71832},
+										pos:  position{line: 2324, col: 32, offset: 71831},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2324, col: 42, offset: 71842},
+									pos:   position{line: 2324, col: 42, offset: 71841},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2324, col: 47, offset: 71847},
+										pos: position{line: 2324, col: 47, offset: 71846},
 										expr: &seqExpr{
-											pos: position{line: 2324, col: 48, offset: 71848},
+											pos: position{line: 2324, col: 48, offset: 71847},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2324, col: 48, offset: 71848},
+													pos:  position{line: 2324, col: 48, offset: 71847},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2324, col: 54, offset: 71854},
+													pos:  position{line: 2324, col: 54, offset: 71853},
 													name: "ValueExpr",
 												},
 											},
@@ -4539,73 +4539,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2324, col: 66, offset: 71866},
+									pos:  position{line: 2324, col: 66, offset: 71865},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2341, col: 3, offset: 72285},
+						pos: position{line: 2341, col: 3, offset: 72284},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2341, col: 3, offset: 72285},
+							pos: position{line: 2341, col: 3, offset: 72284},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2341, col: 3, offset: 72285},
+									pos:        position{line: 2341, col: 3, offset: 72284},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 12, offset: 72294},
+									pos:  position{line: 2341, col: 12, offset: 72293},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2341, col: 20, offset: 72302},
+									pos:   position{line: 2341, col: 20, offset: 72301},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2341, col: 30, offset: 72312},
+										pos:  position{line: 2341, col: 30, offset: 72311},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 40, offset: 72322},
+									pos:  position{line: 2341, col: 40, offset: 72321},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2341, col: 46, offset: 72328},
+									pos:   position{line: 2341, col: 46, offset: 72327},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2341, col: 57, offset: 72339},
+										pos:  position{line: 2341, col: 57, offset: 72338},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2341, col: 67, offset: 72349},
+									pos:  position{line: 2341, col: 67, offset: 72348},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2353, col: 3, offset: 72629},
+						pos: position{line: 2353, col: 3, offset: 72628},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2353, col: 3, offset: 72629},
+							pos: position{line: 2353, col: 3, offset: 72628},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2353, col: 3, offset: 72629},
+									pos:        position{line: 2353, col: 3, offset: 72628},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2353, col: 10, offset: 72636},
+									pos:  position{line: 2353, col: 10, offset: 72635},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2353, col: 18, offset: 72644},
+									pos:  position{line: 2353, col: 18, offset: 72643},
 									name: "R_PAREN",
 								},
 							},
@@ -4616,30 +4616,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2360, col: 1, offset: 72741},
+			pos:  position{line: 2360, col: 1, offset: 72740},
 			expr: &actionExpr{
-				pos: position{line: 2360, col: 23, offset: 72763},
+				pos: position{line: 2360, col: 23, offset: 72762},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2360, col: 23, offset: 72763},
+					pos: position{line: 2360, col: 23, offset: 72762},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2360, col: 23, offset: 72763},
+							pos:   position{line: 2360, col: 23, offset: 72762},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2360, col: 33, offset: 72773},
+								pos:  position{line: 2360, col: 33, offset: 72772},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2360, col: 42, offset: 72782},
+							pos:  position{line: 2360, col: 42, offset: 72781},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2360, col: 48, offset: 72788},
+							pos:   position{line: 2360, col: 48, offset: 72787},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2360, col: 54, offset: 72794},
+								pos:  position{line: 2360, col: 54, offset: 72793},
 								name: "ValueExpr",
 							},
 						},
@@ -4649,15 +4649,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2368, col: 1, offset: 72999},
+			pos:  position{line: 2368, col: 1, offset: 72998},
 			expr: &actionExpr{
-				pos: position{line: 2368, col: 26, offset: 73024},
+				pos: position{line: 2368, col: 26, offset: 73023},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2368, col: 26, offset: 73024},
+					pos:   position{line: 2368, col: 26, offset: 73023},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2368, col: 37, offset: 73035},
+						pos:  position{line: 2368, col: 37, offset: 73034},
 						name: "StringExpr",
 					},
 				},
@@ -4665,15 +4665,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2378, col: 1, offset: 73244},
+			pos:  position{line: 2378, col: 1, offset: 73243},
 			expr: &actionExpr{
-				pos: position{line: 2378, col: 30, offset: 73273},
+				pos: position{line: 2378, col: 30, offset: 73272},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2378, col: 30, offset: 73273},
+					pos:   position{line: 2378, col: 30, offset: 73272},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2378, col: 45, offset: 73288},
+						pos:  position{line: 2378, col: 45, offset: 73287},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4681,22 +4681,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2387, col: 1, offset: 73494},
+			pos:  position{line: 2387, col: 1, offset: 73493},
 			expr: &actionExpr{
-				pos: position{line: 2387, col: 27, offset: 73520},
+				pos: position{line: 2387, col: 27, offset: 73519},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2387, col: 27, offset: 73520},
+					pos:   position{line: 2387, col: 27, offset: 73519},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2387, col: 40, offset: 73533},
+						pos: position{line: 2387, col: 40, offset: 73532},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2387, col: 40, offset: 73533},
+								pos:  position{line: 2387, col: 40, offset: 73532},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2387, col: 68, offset: 73561},
+								pos:  position{line: 2387, col: 68, offset: 73560},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4706,135 +4706,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2391, col: 1, offset: 73638},
+			pos:  position{line: 2391, col: 1, offset: 73637},
 			expr: &choiceExpr{
-				pos: position{line: 2391, col: 19, offset: 73656},
+				pos: position{line: 2391, col: 19, offset: 73655},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2391, col: 19, offset: 73656},
+						pos: position{line: 2391, col: 19, offset: 73655},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2391, col: 20, offset: 73657},
+							pos: position{line: 2391, col: 20, offset: 73656},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2391, col: 20, offset: 73657},
+									pos:   position{line: 2391, col: 20, offset: 73656},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2391, col: 28, offset: 73665},
+										pos:        position{line: 2391, col: 28, offset: 73664},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2391, col: 37, offset: 73674},
+									pos:  position{line: 2391, col: 37, offset: 73673},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2391, col: 45, offset: 73682},
+									pos:   position{line: 2391, col: 45, offset: 73681},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2391, col: 56, offset: 73693},
+										pos:  position{line: 2391, col: 56, offset: 73692},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2391, col: 67, offset: 73704},
+									pos:  position{line: 2391, col: 67, offset: 73703},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2391, col: 73, offset: 73710},
+									pos:   position{line: 2391, col: 73, offset: 73709},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2391, col: 79, offset: 73716},
+										pos:  position{line: 2391, col: 79, offset: 73715},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2391, col: 90, offset: 73727},
+									pos:  position{line: 2391, col: 90, offset: 73726},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2403, col: 3, offset: 74088},
+						pos: position{line: 2403, col: 3, offset: 74087},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2403, col: 4, offset: 74089},
+							pos: position{line: 2403, col: 4, offset: 74088},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2403, col: 4, offset: 74089},
+									pos:   position{line: 2403, col: 4, offset: 74088},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2403, col: 12, offset: 74097},
+										pos:        position{line: 2403, col: 12, offset: 74096},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2403, col: 23, offset: 74108},
+									pos:  position{line: 2403, col: 23, offset: 74107},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2403, col: 31, offset: 74116},
+									pos:   position{line: 2403, col: 31, offset: 74115},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2403, col: 46, offset: 74131},
+										pos:  position{line: 2403, col: 46, offset: 74130},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2403, col: 61, offset: 74146},
+									pos:  position{line: 2403, col: 61, offset: 74145},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2403, col: 67, offset: 74152},
+									pos:   position{line: 2403, col: 67, offset: 74151},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2403, col: 78, offset: 74163},
+										pos:  position{line: 2403, col: 78, offset: 74162},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2403, col: 90, offset: 74175},
+									pos:   position{line: 2403, col: 90, offset: 74174},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2403, col: 99, offset: 74184},
+										pos: position{line: 2403, col: 99, offset: 74183},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2403, col: 100, offset: 74185},
+											pos:  position{line: 2403, col: 100, offset: 74184},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2403, col: 119, offset: 74204},
+									pos:  position{line: 2403, col: 119, offset: 74203},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2419, col: 3, offset: 74766},
+						pos: position{line: 2419, col: 3, offset: 74765},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2419, col: 4, offset: 74767},
+							pos: position{line: 2419, col: 4, offset: 74766},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2419, col: 4, offset: 74767},
+									pos:   position{line: 2419, col: 4, offset: 74766},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2419, col: 12, offset: 74775},
+										pos: position{line: 2419, col: 12, offset: 74774},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2419, col: 12, offset: 74775},
+												pos:        position{line: 2419, col: 12, offset: 74774},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2419, col: 24, offset: 74787},
+												pos:        position{line: 2419, col: 24, offset: 74786},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4843,222 +4843,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2419, col: 34, offset: 74797},
+									pos:  position{line: 2419, col: 34, offset: 74796},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2419, col: 42, offset: 74805},
+									pos:   position{line: 2419, col: 42, offset: 74804},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2419, col: 57, offset: 74820},
+										pos:  position{line: 2419, col: 57, offset: 74819},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2419, col: 72, offset: 74835},
+									pos:  position{line: 2419, col: 72, offset: 74834},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2431, col: 3, offset: 75183},
+						pos: position{line: 2431, col: 3, offset: 75182},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2431, col: 4, offset: 75184},
+							pos: position{line: 2431, col: 4, offset: 75183},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2431, col: 4, offset: 75184},
+									pos:   position{line: 2431, col: 4, offset: 75183},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2431, col: 12, offset: 75192},
+										pos:        position{line: 2431, col: 12, offset: 75191},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2431, col: 24, offset: 75204},
+									pos:  position{line: 2431, col: 24, offset: 75203},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2431, col: 32, offset: 75212},
+									pos:   position{line: 2431, col: 32, offset: 75211},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2431, col: 42, offset: 75222},
+										pos:  position{line: 2431, col: 42, offset: 75221},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2431, col: 51, offset: 75231},
+									pos:  position{line: 2431, col: 51, offset: 75230},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2444, col: 3, offset: 75578},
+						pos: position{line: 2444, col: 3, offset: 75577},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2444, col: 4, offset: 75579},
+							pos: position{line: 2444, col: 4, offset: 75578},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2444, col: 4, offset: 75579},
+									pos:   position{line: 2444, col: 4, offset: 75578},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2444, col: 12, offset: 75587},
+										pos:        position{line: 2444, col: 12, offset: 75586},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2444, col: 21, offset: 75596},
+									pos:  position{line: 2444, col: 21, offset: 75595},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2444, col: 29, offset: 75604},
+									pos:   position{line: 2444, col: 29, offset: 75603},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2444, col: 44, offset: 75619},
+										pos:  position{line: 2444, col: 44, offset: 75618},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2444, col: 59, offset: 75634},
+									pos:  position{line: 2444, col: 59, offset: 75633},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2444, col: 65, offset: 75640},
+									pos:   position{line: 2444, col: 65, offset: 75639},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2444, col: 70, offset: 75645},
+										pos:  position{line: 2444, col: 70, offset: 75644},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2444, col: 80, offset: 75655},
+									pos:  position{line: 2444, col: 80, offset: 75654},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2457, col: 3, offset: 76077},
+						pos: position{line: 2457, col: 3, offset: 76076},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2457, col: 4, offset: 76078},
+							pos: position{line: 2457, col: 4, offset: 76077},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2457, col: 4, offset: 76078},
+									pos:   position{line: 2457, col: 4, offset: 76077},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2457, col: 12, offset: 76086},
+										pos:        position{line: 2457, col: 12, offset: 76085},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2457, col: 23, offset: 76097},
+									pos:  position{line: 2457, col: 23, offset: 76096},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2457, col: 31, offset: 76105},
+									pos:   position{line: 2457, col: 31, offset: 76104},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2457, col: 42, offset: 76116},
+										pos:  position{line: 2457, col: 42, offset: 76115},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2457, col: 54, offset: 76128},
+									pos:  position{line: 2457, col: 54, offset: 76127},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2457, col: 60, offset: 76134},
+									pos:   position{line: 2457, col: 60, offset: 76133},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2457, col: 69, offset: 76143},
+										pos:  position{line: 2457, col: 69, offset: 76142},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2457, col: 81, offset: 76155},
+									pos:  position{line: 2457, col: 81, offset: 76154},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2457, col: 87, offset: 76161},
+									pos:   position{line: 2457, col: 87, offset: 76160},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2457, col: 98, offset: 76172},
+										pos: position{line: 2457, col: 98, offset: 76171},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2457, col: 99, offset: 76173},
+											pos:  position{line: 2457, col: 99, offset: 76172},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2457, col: 112, offset: 76186},
+									pos:  position{line: 2457, col: 112, offset: 76185},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2470, col: 3, offset: 76637},
+						pos: position{line: 2470, col: 3, offset: 76636},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2470, col: 4, offset: 76638},
+							pos: position{line: 2470, col: 4, offset: 76637},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2470, col: 4, offset: 76638},
+									pos:   position{line: 2470, col: 4, offset: 76637},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2470, col: 12, offset: 76646},
+										pos:        position{line: 2470, col: 12, offset: 76645},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2470, col: 21, offset: 76655},
+									pos:  position{line: 2470, col: 21, offset: 76654},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2470, col: 29, offset: 76663},
+									pos:   position{line: 2470, col: 29, offset: 76662},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2470, col: 36, offset: 76670},
+										pos:  position{line: 2470, col: 36, offset: 76669},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2470, col: 51, offset: 76685},
+									pos:  position{line: 2470, col: 51, offset: 76684},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2470, col: 57, offset: 76691},
+									pos:   position{line: 2470, col: 57, offset: 76690},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2470, col: 65, offset: 76699},
+										pos:  position{line: 2470, col: 65, offset: 76698},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2470, col: 80, offset: 76714},
+									pos:   position{line: 2470, col: 80, offset: 76713},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2470, col: 85, offset: 76719},
+										pos: position{line: 2470, col: 85, offset: 76718},
 										expr: &seqExpr{
-											pos: position{line: 2470, col: 86, offset: 76720},
+											pos: position{line: 2470, col: 86, offset: 76719},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2470, col: 86, offset: 76720},
+													pos:  position{line: 2470, col: 86, offset: 76719},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2470, col: 92, offset: 76726},
+													pos:  position{line: 2470, col: 92, offset: 76725},
 													name: "StringExpr",
 												},
 											},
@@ -5066,63 +5066,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2470, col: 105, offset: 76739},
+									pos:  position{line: 2470, col: 105, offset: 76738},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2487, col: 3, offset: 77267},
+						pos: position{line: 2487, col: 3, offset: 77266},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2487, col: 4, offset: 77268},
+							pos: position{line: 2487, col: 4, offset: 77267},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2487, col: 4, offset: 77268},
+									pos:   position{line: 2487, col: 4, offset: 77267},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2487, col: 12, offset: 77276},
+										pos:        position{line: 2487, col: 12, offset: 77275},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2487, col: 32, offset: 77296},
+									pos:  position{line: 2487, col: 32, offset: 77295},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2487, col: 40, offset: 77304},
+									pos:   position{line: 2487, col: 40, offset: 77303},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2487, col: 55, offset: 77319},
+										pos:  position{line: 2487, col: 55, offset: 77318},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2487, col: 70, offset: 77334},
+									pos:   position{line: 2487, col: 70, offset: 77333},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2487, col: 75, offset: 77339},
+										pos: position{line: 2487, col: 75, offset: 77338},
 										expr: &seqExpr{
-											pos: position{line: 2487, col: 76, offset: 77340},
+											pos: position{line: 2487, col: 76, offset: 77339},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2487, col: 76, offset: 77340},
+													pos:  position{line: 2487, col: 76, offset: 77339},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2487, col: 83, offset: 77347},
+													pos: position{line: 2487, col: 83, offset: 77346},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2487, col: 83, offset: 77347},
+															pos:        position{line: 2487, col: 83, offset: 77346},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2487, col: 92, offset: 77356},
+															pos:        position{line: 2487, col: 92, offset: 77355},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5130,7 +5130,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2487, col: 101, offset: 77365},
+													pos:        position{line: 2487, col: 101, offset: 77364},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5140,54 +5140,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2487, col: 108, offset: 77372},
+									pos:  position{line: 2487, col: 108, offset: 77371},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2512, col: 3, offset: 78075},
+						pos: position{line: 2512, col: 3, offset: 78074},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2512, col: 4, offset: 78076},
+							pos: position{line: 2512, col: 4, offset: 78075},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2512, col: 4, offset: 78076},
+									pos:   position{line: 2512, col: 4, offset: 78075},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2512, col: 12, offset: 78084},
+										pos:        position{line: 2512, col: 12, offset: 78083},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2512, col: 24, offset: 78096},
+									pos:  position{line: 2512, col: 24, offset: 78095},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2512, col: 32, offset: 78104},
+									pos:   position{line: 2512, col: 32, offset: 78103},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2512, col: 41, offset: 78113},
+										pos:  position{line: 2512, col: 41, offset: 78112},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2512, col: 64, offset: 78136},
+									pos:   position{line: 2512, col: 64, offset: 78135},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2512, col: 69, offset: 78141},
+										pos: position{line: 2512, col: 69, offset: 78140},
 										expr: &seqExpr{
-											pos: position{line: 2512, col: 70, offset: 78142},
+											pos: position{line: 2512, col: 70, offset: 78141},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2512, col: 70, offset: 78142},
+													pos:  position{line: 2512, col: 70, offset: 78141},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2512, col: 76, offset: 78148},
+													pos:  position{line: 2512, col: 76, offset: 78147},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5195,57 +5195,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2512, col: 101, offset: 78173},
+									pos:  position{line: 2512, col: 101, offset: 78172},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2532, col: 3, offset: 78761},
+						pos: position{line: 2532, col: 3, offset: 78760},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2532, col: 3, offset: 78761},
+							pos: position{line: 2532, col: 3, offset: 78760},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2532, col: 3, offset: 78761},
+									pos:   position{line: 2532, col: 3, offset: 78760},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2532, col: 9, offset: 78767},
+										pos:  position{line: 2532, col: 9, offset: 78766},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2532, col: 25, offset: 78783},
+									pos: position{line: 2532, col: 25, offset: 78782},
 									expr: &choiceExpr{
-										pos: position{line: 2532, col: 27, offset: 78785},
+										pos: position{line: 2532, col: 27, offset: 78784},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 27, offset: 78785},
+												pos:  position{line: 2532, col: 27, offset: 78784},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 36, offset: 78794},
+												pos:  position{line: 2532, col: 36, offset: 78793},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 46, offset: 78804},
+												pos:  position{line: 2532, col: 46, offset: 78803},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 54, offset: 78812},
+												pos:  position{line: 2532, col: 54, offset: 78811},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 62, offset: 78820},
+												pos:  position{line: 2532, col: 62, offset: 78819},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2532, col: 70, offset: 78828},
+												pos:  position{line: 2532, col: 70, offset: 78827},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2532, col: 84, offset: 78842},
+												pos:        position{line: 2532, col: 84, offset: 78841},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5261,36 +5261,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2544, col: 1, offset: 79237},
+			pos:  position{line: 2544, col: 1, offset: 79236},
 			expr: &choiceExpr{
-				pos: position{line: 2544, col: 13, offset: 79249},
+				pos: position{line: 2544, col: 13, offset: 79248},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2544, col: 13, offset: 79249},
+						pos: position{line: 2544, col: 13, offset: 79248},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2544, col: 14, offset: 79250},
+							pos: position{line: 2544, col: 14, offset: 79249},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2544, col: 14, offset: 79250},
+									pos:   position{line: 2544, col: 14, offset: 79249},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2544, col: 22, offset: 79258},
+										pos: position{line: 2544, col: 22, offset: 79257},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2544, col: 22, offset: 79258},
+												pos:        position{line: 2544, col: 22, offset: 79257},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2544, col: 32, offset: 79268},
+												pos:        position{line: 2544, col: 32, offset: 79267},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2544, col: 42, offset: 79278},
+												pos:        position{line: 2544, col: 42, offset: 79277},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5299,44 +5299,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2544, col: 55, offset: 79291},
+									pos:  position{line: 2544, col: 55, offset: 79290},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2544, col: 63, offset: 79299},
+									pos:   position{line: 2544, col: 63, offset: 79298},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2544, col: 74, offset: 79310},
+										pos:  position{line: 2544, col: 74, offset: 79309},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2544, col: 85, offset: 79321},
+									pos:  position{line: 2544, col: 85, offset: 79320},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2556, col: 3, offset: 79635},
+						pos: position{line: 2556, col: 3, offset: 79634},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2556, col: 4, offset: 79636},
+							pos: position{line: 2556, col: 4, offset: 79635},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2556, col: 4, offset: 79636},
+									pos:   position{line: 2556, col: 4, offset: 79635},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2556, col: 12, offset: 79644},
+										pos: position{line: 2556, col: 12, offset: 79643},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2556, col: 12, offset: 79644},
+												pos:        position{line: 2556, col: 12, offset: 79643},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2556, col: 20, offset: 79652},
+												pos:        position{line: 2556, col: 20, offset: 79651},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5345,31 +5345,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2556, col: 27, offset: 79659},
+									pos:  position{line: 2556, col: 27, offset: 79658},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2556, col: 35, offset: 79667},
+									pos:   position{line: 2556, col: 35, offset: 79666},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2556, col: 44, offset: 79676},
+										pos:  position{line: 2556, col: 44, offset: 79675},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2556, col: 55, offset: 79687},
+									pos:   position{line: 2556, col: 55, offset: 79686},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2556, col: 60, offset: 79692},
+										pos: position{line: 2556, col: 60, offset: 79691},
 										expr: &seqExpr{
-											pos: position{line: 2556, col: 61, offset: 79693},
+											pos: position{line: 2556, col: 61, offset: 79692},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2556, col: 61, offset: 79693},
+													pos:  position{line: 2556, col: 61, offset: 79692},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2556, col: 67, offset: 79699},
+													pos:  position{line: 2556, col: 67, offset: 79698},
 													name: "StringExpr",
 												},
 											},
@@ -5377,195 +5377,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2556, col: 80, offset: 79712},
+									pos:  position{line: 2556, col: 80, offset: 79711},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2578, col: 3, offset: 80312},
+						pos: position{line: 2578, col: 3, offset: 80311},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2578, col: 4, offset: 80313},
+							pos: position{line: 2578, col: 4, offset: 80312},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2578, col: 4, offset: 80313},
+									pos:   position{line: 2578, col: 4, offset: 80312},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2578, col: 12, offset: 80321},
+										pos:        position{line: 2578, col: 12, offset: 80320},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2578, col: 23, offset: 80332},
+									pos:  position{line: 2578, col: 23, offset: 80331},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2578, col: 31, offset: 80340},
+									pos:   position{line: 2578, col: 31, offset: 80339},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2578, col: 46, offset: 80355},
+										pos:  position{line: 2578, col: 46, offset: 80354},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2578, col: 61, offset: 80370},
+									pos:  position{line: 2578, col: 61, offset: 80369},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2589, col: 3, offset: 80672},
+						pos: position{line: 2589, col: 3, offset: 80671},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2589, col: 4, offset: 80673},
+							pos: position{line: 2589, col: 4, offset: 80672},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2589, col: 4, offset: 80673},
+									pos:   position{line: 2589, col: 4, offset: 80672},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2589, col: 12, offset: 80681},
+										pos:        position{line: 2589, col: 12, offset: 80680},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2589, col: 22, offset: 80691},
+									pos:  position{line: 2589, col: 22, offset: 80690},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2589, col: 30, offset: 80699},
+									pos:   position{line: 2589, col: 30, offset: 80698},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2589, col: 45, offset: 80714},
+										pos:  position{line: 2589, col: 45, offset: 80713},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2589, col: 60, offset: 80729},
+									pos:  position{line: 2589, col: 60, offset: 80728},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2589, col: 66, offset: 80735},
+									pos:   position{line: 2589, col: 66, offset: 80734},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2589, col: 72, offset: 80741},
+										pos:  position{line: 2589, col: 72, offset: 80740},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2589, col: 83, offset: 80752},
+									pos:  position{line: 2589, col: 83, offset: 80751},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2601, col: 3, offset: 81102},
+						pos: position{line: 2601, col: 3, offset: 81101},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2601, col: 4, offset: 81103},
+							pos: position{line: 2601, col: 4, offset: 81102},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2601, col: 4, offset: 81103},
+									pos:   position{line: 2601, col: 4, offset: 81102},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2601, col: 12, offset: 81111},
+										pos:        position{line: 2601, col: 12, offset: 81110},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2601, col: 22, offset: 81121},
+									pos:  position{line: 2601, col: 22, offset: 81120},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2601, col: 30, offset: 81129},
+									pos:   position{line: 2601, col: 30, offset: 81128},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2601, col: 45, offset: 81144},
+										pos:  position{line: 2601, col: 45, offset: 81143},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2601, col: 60, offset: 81159},
+									pos:  position{line: 2601, col: 60, offset: 81158},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2601, col: 66, offset: 81165},
+									pos:   position{line: 2601, col: 66, offset: 81164},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2601, col: 79, offset: 81178},
+										pos:  position{line: 2601, col: 79, offset: 81177},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2601, col: 90, offset: 81189},
+									pos:  position{line: 2601, col: 90, offset: 81188},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2625, col: 3, offset: 81858},
+						pos: position{line: 2625, col: 3, offset: 81857},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2625, col: 4, offset: 81859},
+							pos: position{line: 2625, col: 4, offset: 81858},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2625, col: 4, offset: 81859},
+									pos:   position{line: 2625, col: 4, offset: 81858},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2625, col: 12, offset: 81867},
+										pos:        position{line: 2625, col: 12, offset: 81866},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2625, col: 22, offset: 81877},
+									pos:  position{line: 2625, col: 22, offset: 81876},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2625, col: 30, offset: 81885},
+									pos:   position{line: 2625, col: 30, offset: 81884},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2625, col: 41, offset: 81896},
+										pos:  position{line: 2625, col: 41, offset: 81895},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2625, col: 52, offset: 81907},
+									pos:  position{line: 2625, col: 52, offset: 81906},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2625, col: 58, offset: 81913},
+									pos:   position{line: 2625, col: 58, offset: 81912},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2625, col: 69, offset: 81924},
+										pos:  position{line: 2625, col: 69, offset: 81923},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2625, col: 81, offset: 81936},
+									pos:   position{line: 2625, col: 81, offset: 81935},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2625, col: 93, offset: 81948},
+										pos: position{line: 2625, col: 93, offset: 81947},
 										expr: &seqExpr{
-											pos: position{line: 2625, col: 94, offset: 81949},
+											pos: position{line: 2625, col: 94, offset: 81948},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2625, col: 94, offset: 81949},
+													pos:  position{line: 2625, col: 94, offset: 81948},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2625, col: 100, offset: 81955},
+													pos:  position{line: 2625, col: 100, offset: 81954},
 													name: "NumericExpr",
 												},
 											},
@@ -5573,50 +5573,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2625, col: 114, offset: 81969},
+									pos:  position{line: 2625, col: 114, offset: 81968},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2650, col: 3, offset: 82799},
+						pos: position{line: 2650, col: 3, offset: 82798},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2650, col: 3, offset: 82799},
+							pos: position{line: 2650, col: 3, offset: 82798},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2650, col: 3, offset: 82799},
+									pos:        position{line: 2650, col: 3, offset: 82798},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2650, col: 14, offset: 82810},
+									pos:  position{line: 2650, col: 14, offset: 82809},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2650, col: 22, offset: 82818},
+									pos:   position{line: 2650, col: 22, offset: 82817},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2650, col: 28, offset: 82824},
+										pos:  position{line: 2650, col: 28, offset: 82823},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2650, col: 38, offset: 82834},
+									pos:   position{line: 2650, col: 38, offset: 82833},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2650, col: 45, offset: 82841},
+										pos: position{line: 2650, col: 45, offset: 82840},
 										expr: &seqExpr{
-											pos: position{line: 2650, col: 46, offset: 82842},
+											pos: position{line: 2650, col: 46, offset: 82841},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2650, col: 46, offset: 82842},
+													pos:  position{line: 2650, col: 46, offset: 82841},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2650, col: 52, offset: 82848},
+													pos:  position{line: 2650, col: 52, offset: 82847},
 													name: "StringExpr",
 												},
 											},
@@ -5624,38 +5624,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2650, col: 65, offset: 82861},
+									pos:  position{line: 2650, col: 65, offset: 82860},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2663, col: 3, offset: 83229},
+						pos: position{line: 2663, col: 3, offset: 83228},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2663, col: 4, offset: 83230},
+							pos: position{line: 2663, col: 4, offset: 83229},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2663, col: 4, offset: 83230},
+									pos:   position{line: 2663, col: 4, offset: 83229},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2663, col: 12, offset: 83238},
+										pos: position{line: 2663, col: 12, offset: 83237},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2663, col: 12, offset: 83238},
+												pos:        position{line: 2663, col: 12, offset: 83237},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2663, col: 22, offset: 83248},
+												pos:        position{line: 2663, col: 22, offset: 83247},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2663, col: 32, offset: 83258},
+												pos:        position{line: 2663, col: 32, offset: 83257},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5664,223 +5664,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2663, col: 40, offset: 83266},
+									pos:  position{line: 2663, col: 40, offset: 83265},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2663, col: 48, offset: 83274},
+									pos:   position{line: 2663, col: 48, offset: 83273},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2663, col: 54, offset: 83280},
+										pos:  position{line: 2663, col: 54, offset: 83279},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2663, col: 66, offset: 83292},
+									pos:   position{line: 2663, col: 66, offset: 83291},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2663, col: 82, offset: 83308},
+										pos: position{line: 2663, col: 82, offset: 83307},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2663, col: 83, offset: 83309},
+											pos:  position{line: 2663, col: 83, offset: 83308},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2663, col: 101, offset: 83327},
+									pos:  position{line: 2663, col: 101, offset: 83326},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2682, col: 3, offset: 83767},
+						pos: position{line: 2682, col: 3, offset: 83766},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2682, col: 3, offset: 83767},
+							pos: position{line: 2682, col: 3, offset: 83766},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2682, col: 3, offset: 83767},
+									pos:        position{line: 2682, col: 3, offset: 83766},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 11, offset: 83775},
+									pos:  position{line: 2682, col: 11, offset: 83774},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2682, col: 19, offset: 83783},
+									pos:   position{line: 2682, col: 19, offset: 83782},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2682, col: 30, offset: 83794},
+										pos:  position{line: 2682, col: 30, offset: 83793},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 50, offset: 83814},
+									pos:  position{line: 2682, col: 50, offset: 83813},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2682, col: 56, offset: 83820},
+									pos:   position{line: 2682, col: 56, offset: 83819},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2682, col: 62, offset: 83826},
+										pos: position{line: 2682, col: 62, offset: 83825},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2682, col: 62, offset: 83826},
+												pos:  position{line: 2682, col: 62, offset: 83825},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2682, col: 81, offset: 83845},
+												pos:  position{line: 2682, col: 81, offset: 83844},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 100, offset: 83864},
+									pos:  position{line: 2682, col: 100, offset: 83863},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2693, col: 3, offset: 84169},
+						pos: position{line: 2693, col: 3, offset: 84168},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2693, col: 3, offset: 84169},
+							pos: position{line: 2693, col: 3, offset: 84168},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2693, col: 3, offset: 84169},
+									pos:        position{line: 2693, col: 3, offset: 84168},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2693, col: 12, offset: 84178},
+									pos:  position{line: 2693, col: 12, offset: 84177},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2693, col: 20, offset: 84186},
+									pos:   position{line: 2693, col: 20, offset: 84185},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2693, col: 25, offset: 84191},
+										pos:  position{line: 2693, col: 25, offset: 84190},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2693, col: 36, offset: 84202},
+									pos:  position{line: 2693, col: 36, offset: 84201},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2693, col: 42, offset: 84208},
+									pos:   position{line: 2693, col: 42, offset: 84207},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2693, col: 45, offset: 84211},
+										pos:  position{line: 2693, col: 45, offset: 84210},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2693, col: 55, offset: 84221},
+									pos:  position{line: 2693, col: 55, offset: 84220},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2700, col: 3, offset: 84379},
+						pos: position{line: 2700, col: 3, offset: 84378},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2700, col: 3, offset: 84379},
+							pos: position{line: 2700, col: 3, offset: 84378},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2700, col: 3, offset: 84379},
+									pos:        position{line: 2700, col: 3, offset: 84378},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2700, col: 21, offset: 84397},
+									pos:  position{line: 2700, col: 21, offset: 84396},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2700, col: 29, offset: 84405},
+									pos:   position{line: 2700, col: 29, offset: 84404},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2700, col: 33, offset: 84409},
+										pos:  position{line: 2700, col: 33, offset: 84408},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2700, col: 43, offset: 84419},
+									pos:  position{line: 2700, col: 43, offset: 84418},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2700, col: 49, offset: 84425},
+									pos:   position{line: 2700, col: 49, offset: 84424},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2700, col: 53, offset: 84429},
+										pos:  position{line: 2700, col: 53, offset: 84428},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2700, col: 66, offset: 84442},
+									pos:  position{line: 2700, col: 66, offset: 84441},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2700, col: 72, offset: 84448},
+									pos:   position{line: 2700, col: 72, offset: 84447},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2700, col: 78, offset: 84454},
+										pos:  position{line: 2700, col: 78, offset: 84453},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2700, col: 91, offset: 84467},
+									pos:  position{line: 2700, col: 91, offset: 84466},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2711, col: 3, offset: 84775},
+						pos: position{line: 2711, col: 3, offset: 84774},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2711, col: 3, offset: 84775},
+							pos: position{line: 2711, col: 3, offset: 84774},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2711, col: 3, offset: 84775},
+									pos:        position{line: 2711, col: 3, offset: 84774},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2711, col: 12, offset: 84784},
+									pos:  position{line: 2711, col: 12, offset: 84783},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2711, col: 20, offset: 84792},
+									pos:   position{line: 2711, col: 20, offset: 84791},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2711, col: 27, offset: 84799},
+										pos:  position{line: 2711, col: 27, offset: 84798},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2711, col: 38, offset: 84810},
+									pos:   position{line: 2711, col: 38, offset: 84809},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2711, col: 43, offset: 84815},
+										pos: position{line: 2711, col: 43, offset: 84814},
 										expr: &seqExpr{
-											pos: position{line: 2711, col: 44, offset: 84816},
+											pos: position{line: 2711, col: 44, offset: 84815},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2711, col: 44, offset: 84816},
+													pos:  position{line: 2711, col: 44, offset: 84815},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2711, col: 50, offset: 84822},
+													pos:  position{line: 2711, col: 50, offset: 84821},
 													name: "StringExpr",
 												},
 											},
@@ -5888,47 +5888,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2711, col: 63, offset: 84835},
+									pos:  position{line: 2711, col: 63, offset: 84834},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2729, col: 3, offset: 85302},
+						pos: position{line: 2729, col: 3, offset: 85301},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2729, col: 3, offset: 85302},
+							pos: position{line: 2729, col: 3, offset: 85301},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2729, col: 3, offset: 85302},
+									pos:        position{line: 2729, col: 3, offset: 85301},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2729, col: 12, offset: 85311},
+									pos:  position{line: 2729, col: 12, offset: 85310},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2729, col: 20, offset: 85319},
+									pos:   position{line: 2729, col: 20, offset: 85318},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2729, col: 42, offset: 85341},
+										pos: position{line: 2729, col: 42, offset: 85340},
 										expr: &seqExpr{
-											pos: position{line: 2729, col: 43, offset: 85342},
+											pos: position{line: 2729, col: 43, offset: 85341},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2729, col: 44, offset: 85343},
+													pos: position{line: 2729, col: 44, offset: 85342},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2729, col: 44, offset: 85343},
+															pos:        position{line: 2729, col: 44, offset: 85342},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2729, col: 53, offset: 85352},
+															pos:        position{line: 2729, col: 53, offset: 85351},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5936,7 +5936,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2729, col: 62, offset: 85361},
+													pos:        position{line: 2729, col: 62, offset: 85360},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5946,56 +5946,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2729, col: 69, offset: 85368},
+									pos:  position{line: 2729, col: 69, offset: 85367},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2751, col: 3, offset: 85965},
+						pos: position{line: 2751, col: 3, offset: 85964},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2751, col: 3, offset: 85965},
+							pos: position{line: 2751, col: 3, offset: 85964},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2751, col: 3, offset: 85965},
+									pos:        position{line: 2751, col: 3, offset: 85964},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2751, col: 13, offset: 85975},
+									pos:  position{line: 2751, col: 13, offset: 85974},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 21, offset: 85983},
+									pos:   position{line: 2751, col: 21, offset: 85982},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2751, col: 27, offset: 85989},
+										pos:  position{line: 2751, col: 27, offset: 85988},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 43, offset: 86005},
+									pos:   position{line: 2751, col: 43, offset: 86004},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2751, col: 53, offset: 86015},
+										pos: position{line: 2751, col: 53, offset: 86014},
 										expr: &seqExpr{
-											pos: position{line: 2751, col: 54, offset: 86016},
+											pos: position{line: 2751, col: 54, offset: 86015},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2751, col: 54, offset: 86016},
+													pos:  position{line: 2751, col: 54, offset: 86015},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2751, col: 60, offset: 86022},
+													pos:        position{line: 2751, col: 60, offset: 86021},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2751, col: 73, offset: 86035},
+													pos:  position{line: 2751, col: 73, offset: 86034},
 													name: "FloatAsString",
 												},
 											},
@@ -6003,40 +6003,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 89, offset: 86051},
+									pos:   position{line: 2751, col: 89, offset: 86050},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2751, col: 95, offset: 86057},
+										pos: position{line: 2751, col: 95, offset: 86056},
 										expr: &seqExpr{
-											pos: position{line: 2751, col: 96, offset: 86058},
+											pos: position{line: 2751, col: 96, offset: 86057},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2751, col: 96, offset: 86058},
+													pos:  position{line: 2751, col: 96, offset: 86057},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2751, col: 102, offset: 86064},
+													pos:        position{line: 2751, col: 102, offset: 86063},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2751, col: 112, offset: 86074},
+													pos: position{line: 2751, col: 112, offset: 86073},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2751, col: 112, offset: 86074},
+															pos:        position{line: 2751, col: 112, offset: 86073},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2751, col: 125, offset: 86087},
+															pos:        position{line: 2751, col: 125, offset: 86086},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2751, col: 137, offset: 86099},
+															pos:        position{line: 2751, col: 137, offset: 86098},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6048,25 +6048,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 151, offset: 86113},
+									pos:   position{line: 2751, col: 151, offset: 86112},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2751, col: 158, offset: 86120},
+										pos: position{line: 2751, col: 158, offset: 86119},
 										expr: &seqExpr{
-											pos: position{line: 2751, col: 159, offset: 86121},
+											pos: position{line: 2751, col: 159, offset: 86120},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2751, col: 159, offset: 86121},
+													pos:  position{line: 2751, col: 159, offset: 86120},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2751, col: 165, offset: 86127},
+													pos:        position{line: 2751, col: 165, offset: 86126},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2751, col: 175, offset: 86137},
+													pos:  position{line: 2751, col: 175, offset: 86136},
 													name: "QuotedString",
 												},
 											},
@@ -6074,213 +6074,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2751, col: 190, offset: 86152},
+									pos:  position{line: 2751, col: 190, offset: 86151},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2791, col: 3, offset: 87147},
+						pos: position{line: 2791, col: 3, offset: 87146},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2791, col: 3, offset: 87147},
+							pos: position{line: 2791, col: 3, offset: 87146},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2791, col: 3, offset: 87147},
+									pos:        position{line: 2791, col: 3, offset: 87146},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2791, col: 15, offset: 87159},
+									pos:  position{line: 2791, col: 15, offset: 87158},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2791, col: 23, offset: 87167},
+									pos:   position{line: 2791, col: 23, offset: 87166},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2791, col: 30, offset: 87174},
+										pos: position{line: 2791, col: 30, offset: 87173},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2791, col: 31, offset: 87175},
+											pos:  position{line: 2791, col: 31, offset: 87174},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2791, col: 44, offset: 87188},
+									pos:  position{line: 2791, col: 44, offset: 87187},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2802, col: 3, offset: 87379},
+						pos: position{line: 2802, col: 3, offset: 87378},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2802, col: 3, offset: 87379},
+							pos: position{line: 2802, col: 3, offset: 87378},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2802, col: 3, offset: 87379},
+									pos:        position{line: 2802, col: 3, offset: 87378},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 12, offset: 87388},
+									pos:  position{line: 2802, col: 12, offset: 87387},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2802, col: 20, offset: 87396},
+									pos:   position{line: 2802, col: 20, offset: 87395},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2802, col: 30, offset: 87406},
+										pos:  position{line: 2802, col: 30, offset: 87405},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 40, offset: 87416},
+									pos:  position{line: 2802, col: 40, offset: 87415},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2808, col: 3, offset: 87539},
+						pos: position{line: 2808, col: 3, offset: 87538},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2808, col: 3, offset: 87539},
+							pos: position{line: 2808, col: 3, offset: 87538},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2808, col: 3, offset: 87539},
+									pos:        position{line: 2808, col: 3, offset: 87538},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2808, col: 13, offset: 87549},
+									pos:  position{line: 2808, col: 13, offset: 87548},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2808, col: 21, offset: 87557},
+									pos:   position{line: 2808, col: 21, offset: 87556},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2808, col: 25, offset: 87561},
+										pos:  position{line: 2808, col: 25, offset: 87560},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2808, col: 35, offset: 87571},
+									pos:  position{line: 2808, col: 35, offset: 87570},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2808, col: 41, offset: 87577},
+									pos:   position{line: 2808, col: 41, offset: 87576},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2808, col: 47, offset: 87583},
+										pos:  position{line: 2808, col: 47, offset: 87582},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2808, col: 58, offset: 87594},
+									pos:  position{line: 2808, col: 58, offset: 87593},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2808, col: 64, offset: 87600},
+									pos:   position{line: 2808, col: 64, offset: 87599},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2808, col: 76, offset: 87612},
+										pos:  position{line: 2808, col: 76, offset: 87611},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2808, col: 87, offset: 87623},
+									pos:  position{line: 2808, col: 87, offset: 87622},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2815, col: 3, offset: 87847},
+						pos: position{line: 2815, col: 3, offset: 87846},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2815, col: 3, offset: 87847},
+							pos: position{line: 2815, col: 3, offset: 87846},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2815, col: 3, offset: 87847},
+									pos:        position{line: 2815, col: 3, offset: 87846},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2815, col: 14, offset: 87858},
+									pos:  position{line: 2815, col: 14, offset: 87857},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2815, col: 22, offset: 87866},
+									pos:   position{line: 2815, col: 22, offset: 87865},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2815, col: 26, offset: 87870},
+										pos:  position{line: 2815, col: 26, offset: 87869},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2815, col: 36, offset: 87880},
+									pos:  position{line: 2815, col: 36, offset: 87879},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2815, col: 42, offset: 87886},
+									pos:   position{line: 2815, col: 42, offset: 87885},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2815, col: 49, offset: 87893},
+										pos:  position{line: 2815, col: 49, offset: 87892},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2815, col: 60, offset: 87904},
+									pos:  position{line: 2815, col: 60, offset: 87903},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2823, col: 3, offset: 88068},
+						pos: position{line: 2823, col: 3, offset: 88067},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2823, col: 3, offset: 88068},
+							pos: position{line: 2823, col: 3, offset: 88067},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2823, col: 3, offset: 88068},
+									pos:        position{line: 2823, col: 3, offset: 88067},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 14, offset: 88079},
+									pos:  position{line: 2823, col: 14, offset: 88078},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 22, offset: 88087},
+									pos:   position{line: 2823, col: 22, offset: 88086},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2823, col: 26, offset: 88091},
+										pos:  position{line: 2823, col: 26, offset: 88090},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 36, offset: 88101},
+									pos:  position{line: 2823, col: 36, offset: 88100},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 42, offset: 88107},
+									pos:   position{line: 2823, col: 42, offset: 88106},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2823, col: 49, offset: 88114},
+										pos:  position{line: 2823, col: 49, offset: 88113},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 60, offset: 88125},
+									pos:  position{line: 2823, col: 60, offset: 88124},
 									name: "R_PAREN",
 								},
 							},
@@ -6291,15 +6291,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2831, col: 1, offset: 88287},
+			pos:  position{line: 2831, col: 1, offset: 88286},
 			expr: &actionExpr{
-				pos: position{line: 2831, col: 21, offset: 88307},
+				pos: position{line: 2831, col: 21, offset: 88306},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2831, col: 21, offset: 88307},
+					pos:   position{line: 2831, col: 21, offset: 88306},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2831, col: 25, offset: 88311},
+						pos:  position{line: 2831, col: 25, offset: 88310},
 						name: "QuotedString",
 					},
 				},
@@ -6307,15 +6307,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2838, col: 1, offset: 88438},
+			pos:  position{line: 2838, col: 1, offset: 88437},
 			expr: &actionExpr{
-				pos: position{line: 2838, col: 22, offset: 88459},
+				pos: position{line: 2838, col: 22, offset: 88458},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2838, col: 22, offset: 88459},
+					pos:   position{line: 2838, col: 22, offset: 88458},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2838, col: 26, offset: 88463},
+						pos:  position{line: 2838, col: 26, offset: 88462},
 						name: "UnquotedString",
 					},
 				},
@@ -6323,22 +6323,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2845, col: 1, offset: 88591},
+			pos:  position{line: 2845, col: 1, offset: 88590},
 			expr: &actionExpr{
-				pos: position{line: 2845, col: 20, offset: 88610},
+				pos: position{line: 2845, col: 20, offset: 88609},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2845, col: 20, offset: 88610},
+					pos: position{line: 2845, col: 20, offset: 88609},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2845, col: 20, offset: 88610},
+							pos:  position{line: 2845, col: 20, offset: 88609},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2845, col: 26, offset: 88616},
+							pos:   position{line: 2845, col: 26, offset: 88615},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2845, col: 38, offset: 88628},
+								pos:  position{line: 2845, col: 38, offset: 88627},
 								name: "String",
 							},
 						},
@@ -6348,20 +6348,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2851, col: 1, offset: 88813},
+			pos:  position{line: 2851, col: 1, offset: 88812},
 			expr: &choiceExpr{
-				pos: position{line: 2851, col: 20, offset: 88832},
+				pos: position{line: 2851, col: 20, offset: 88831},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2851, col: 20, offset: 88832},
+						pos: position{line: 2851, col: 20, offset: 88831},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2851, col: 20, offset: 88832},
+							pos: position{line: 2851, col: 20, offset: 88831},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 2851, col: 20, offset: 88832},
+									pos: position{line: 2851, col: 20, offset: 88831},
 									expr: &charClassMatcher{
-										pos:        position{line: 2851, col: 20, offset: 88832},
+										pos:        position{line: 2851, col: 20, offset: 88831},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -6370,9 +6370,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2851, col: 31, offset: 88843},
+									pos: position{line: 2851, col: 31, offset: 88842},
 									expr: &litMatcher{
-										pos:        position{line: 2851, col: 33, offset: 88845},
+										pos:        position{line: 2851, col: 33, offset: 88844},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6382,27 +6382,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2854, col: 3, offset: 88887},
+						pos: position{line: 2854, col: 3, offset: 88886},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 2854, col: 3, offset: 88887},
+							pos: position{line: 2854, col: 3, offset: 88886},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2854, col: 3, offset: 88887},
+									pos:        position{line: 2854, col: 3, offset: 88886},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2854, col: 7, offset: 88891},
+									pos:   position{line: 2854, col: 7, offset: 88890},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2854, col: 13, offset: 88897},
+										pos:  position{line: 2854, col: 13, offset: 88896},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2854, col: 23, offset: 88907},
+									pos:        position{line: 2854, col: 23, offset: 88906},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6415,26 +6415,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2859, col: 1, offset: 88975},
+			pos:  position{line: 2859, col: 1, offset: 88974},
 			expr: &actionExpr{
-				pos: position{line: 2859, col: 15, offset: 88989},
+				pos: position{line: 2859, col: 15, offset: 88988},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2859, col: 15, offset: 88989},
+					pos: position{line: 2859, col: 15, offset: 88988},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2859, col: 15, offset: 88989},
+							pos:  position{line: 2859, col: 15, offset: 88988},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2859, col: 20, offset: 88994},
+							pos:  position{line: 2859, col: 20, offset: 88993},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2859, col: 30, offset: 89004},
+							pos:   position{line: 2859, col: 30, offset: 89003},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2859, col: 40, offset: 89014},
+								pos:  position{line: 2859, col: 40, offset: 89013},
 								name: "BoolExpr",
 							},
 						},
@@ -6444,15 +6444,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2871, col: 1, offset: 89307},
+			pos:  position{line: 2871, col: 1, offset: 89306},
 			expr: &actionExpr{
-				pos: position{line: 2871, col: 13, offset: 89319},
+				pos: position{line: 2871, col: 13, offset: 89318},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2871, col: 13, offset: 89319},
+					pos:   position{line: 2871, col: 13, offset: 89318},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2871, col: 18, offset: 89324},
+						pos:  position{line: 2871, col: 18, offset: 89323},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6460,35 +6460,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2876, col: 1, offset: 89394},
+			pos:  position{line: 2876, col: 1, offset: 89393},
 			expr: &actionExpr{
-				pos: position{line: 2876, col: 19, offset: 89412},
+				pos: position{line: 2876, col: 19, offset: 89411},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2876, col: 19, offset: 89412},
+					pos: position{line: 2876, col: 19, offset: 89411},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2876, col: 19, offset: 89412},
+							pos:   position{line: 2876, col: 19, offset: 89411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2876, col: 25, offset: 89418},
+								pos:  position{line: 2876, col: 25, offset: 89417},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2876, col: 40, offset: 89433},
+							pos:   position{line: 2876, col: 40, offset: 89432},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2876, col: 45, offset: 89438},
+								pos: position{line: 2876, col: 45, offset: 89437},
 								expr: &seqExpr{
-									pos: position{line: 2876, col: 46, offset: 89439},
+									pos: position{line: 2876, col: 46, offset: 89438},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2876, col: 46, offset: 89439},
+											pos:  position{line: 2876, col: 46, offset: 89438},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2876, col: 49, offset: 89442},
+											pos:  position{line: 2876, col: 49, offset: 89441},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6501,35 +6501,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 2896, col: 1, offset: 89880},
+			pos:  position{line: 2896, col: 1, offset: 89879},
 			expr: &actionExpr{
-				pos: position{line: 2896, col: 19, offset: 89898},
+				pos: position{line: 2896, col: 19, offset: 89897},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 2896, col: 19, offset: 89898},
+					pos: position{line: 2896, col: 19, offset: 89897},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2896, col: 19, offset: 89898},
+							pos:   position{line: 2896, col: 19, offset: 89897},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2896, col: 25, offset: 89904},
+								pos:  position{line: 2896, col: 25, offset: 89903},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2896, col: 40, offset: 89919},
+							pos:   position{line: 2896, col: 40, offset: 89918},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2896, col: 45, offset: 89924},
+								pos: position{line: 2896, col: 45, offset: 89923},
 								expr: &seqExpr{
-									pos: position{line: 2896, col: 46, offset: 89925},
+									pos: position{line: 2896, col: 46, offset: 89924},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2896, col: 46, offset: 89925},
+											pos:  position{line: 2896, col: 46, offset: 89924},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2896, col: 50, offset: 89929},
+											pos:  position{line: 2896, col: 50, offset: 89928},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6542,47 +6542,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 2916, col: 1, offset: 90368},
+			pos:  position{line: 2916, col: 1, offset: 90367},
 			expr: &choiceExpr{
-				pos: position{line: 2916, col: 19, offset: 90386},
+				pos: position{line: 2916, col: 19, offset: 90385},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2916, col: 19, offset: 90386},
+						pos: position{line: 2916, col: 19, offset: 90385},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 2916, col: 19, offset: 90386},
+							pos: position{line: 2916, col: 19, offset: 90385},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2916, col: 19, offset: 90386},
+									pos:  position{line: 2916, col: 19, offset: 90385},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2916, col: 23, offset: 90390},
+									pos:  position{line: 2916, col: 23, offset: 90389},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2916, col: 31, offset: 90398},
+									pos:   position{line: 2916, col: 31, offset: 90397},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2916, col: 37, offset: 90404},
+										pos:  position{line: 2916, col: 37, offset: 90403},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2916, col: 52, offset: 90419},
+									pos:  position{line: 2916, col: 52, offset: 90418},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2926, col: 3, offset: 90622},
+						pos: position{line: 2926, col: 3, offset: 90621},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 2926, col: 3, offset: 90622},
+							pos:   position{line: 2926, col: 3, offset: 90621},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2926, col: 9, offset: 90628},
+								pos:  position{line: 2926, col: 9, offset: 90627},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6592,50 +6592,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 2931, col: 1, offset: 90699},
+			pos:  position{line: 2931, col: 1, offset: 90698},
 			expr: &choiceExpr{
-				pos: position{line: 2931, col: 19, offset: 90717},
+				pos: position{line: 2931, col: 19, offset: 90716},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2931, col: 19, offset: 90717},
+						pos: position{line: 2931, col: 19, offset: 90716},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 2931, col: 19, offset: 90717},
+							pos: position{line: 2931, col: 19, offset: 90716},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2931, col: 19, offset: 90717},
+									pos:  position{line: 2931, col: 19, offset: 90716},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2931, col: 27, offset: 90725},
+									pos:   position{line: 2931, col: 27, offset: 90724},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2931, col: 33, offset: 90731},
+										pos:  position{line: 2931, col: 33, offset: 90730},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2931, col: 48, offset: 90746},
+									pos:  position{line: 2931, col: 48, offset: 90745},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2934, col: 3, offset: 90782},
+						pos: position{line: 2934, col: 3, offset: 90781},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 2934, col: 3, offset: 90782},
+							pos:   position{line: 2934, col: 3, offset: 90781},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 2934, col: 10, offset: 90789},
+								pos: position{line: 2934, col: 10, offset: 90788},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2934, col: 10, offset: 90789},
+										pos:  position{line: 2934, col: 10, offset: 90788},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2934, col: 31, offset: 90810},
+										pos:  position{line: 2934, col: 31, offset: 90809},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6647,60 +6647,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 2939, col: 1, offset: 90930},
+			pos:  position{line: 2939, col: 1, offset: 90929},
 			expr: &choiceExpr{
-				pos: position{line: 2939, col: 23, offset: 90952},
+				pos: position{line: 2939, col: 23, offset: 90951},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2939, col: 23, offset: 90952},
+						pos: position{line: 2939, col: 23, offset: 90951},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2939, col: 24, offset: 90953},
+							pos: position{line: 2939, col: 24, offset: 90952},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2939, col: 24, offset: 90953},
+									pos:   position{line: 2939, col: 24, offset: 90952},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 2939, col: 28, offset: 90957},
+										pos: position{line: 2939, col: 28, offset: 90956},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2939, col: 28, offset: 90957},
+												pos:        position{line: 2939, col: 28, offset: 90956},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 39, offset: 90968},
+												pos:        position{line: 2939, col: 39, offset: 90967},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 49, offset: 90978},
+												pos:        position{line: 2939, col: 49, offset: 90977},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 59, offset: 90988},
+												pos:        position{line: 2939, col: 59, offset: 90987},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 70, offset: 90999},
+												pos:        position{line: 2939, col: 70, offset: 90998},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 84, offset: 91013},
+												pos:        position{line: 2939, col: 84, offset: 91012},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 94, offset: 91023},
+												pos:        position{line: 2939, col: 94, offset: 91022},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6709,56 +6709,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2939, col: 109, offset: 91038},
+									pos:  position{line: 2939, col: 109, offset: 91037},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2939, col: 117, offset: 91046},
+									pos:   position{line: 2939, col: 117, offset: 91045},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2939, col: 123, offset: 91052},
+										pos:  position{line: 2939, col: 123, offset: 91051},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2939, col: 133, offset: 91062},
+									pos:  position{line: 2939, col: 133, offset: 91061},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2969, col: 3, offset: 91933},
+						pos: position{line: 2969, col: 3, offset: 91932},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 2969, col: 3, offset: 91933},
+							pos: position{line: 2969, col: 3, offset: 91932},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2969, col: 3, offset: 91933},
+									pos:   position{line: 2969, col: 3, offset: 91932},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2969, col: 11, offset: 91941},
+										pos: position{line: 2969, col: 11, offset: 91940},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2969, col: 11, offset: 91941},
+												pos:        position{line: 2969, col: 11, offset: 91940},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2969, col: 20, offset: 91950},
+												pos:        position{line: 2969, col: 20, offset: 91949},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2969, col: 29, offset: 91959},
+												pos:        position{line: 2969, col: 29, offset: 91958},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2969, col: 39, offset: 91969},
+												pos:        position{line: 2969, col: 39, offset: 91968},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6767,86 +6767,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2969, col: 52, offset: 91982},
+									pos:  position{line: 2969, col: 52, offset: 91981},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2969, col: 60, offset: 91990},
+									pos:   position{line: 2969, col: 60, offset: 91989},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2969, col: 70, offset: 92000},
+										pos:  position{line: 2969, col: 70, offset: 91999},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2969, col: 80, offset: 92010},
+									pos:  position{line: 2969, col: 80, offset: 92009},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2969, col: 86, offset: 92016},
+									pos:   position{line: 2969, col: 86, offset: 92015},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2969, col: 97, offset: 92027},
+										pos:  position{line: 2969, col: 97, offset: 92026},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2969, col: 107, offset: 92037},
+									pos:  position{line: 2969, col: 107, offset: 92036},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2982, col: 3, offset: 92407},
+						pos: position{line: 2982, col: 3, offset: 92406},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 2982, col: 3, offset: 92407},
+							pos: position{line: 2982, col: 3, offset: 92406},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2982, col: 3, offset: 92407},
+									pos:   position{line: 2982, col: 3, offset: 92406},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2982, col: 8, offset: 92412},
+										pos:  position{line: 2982, col: 8, offset: 92411},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2982, col: 18, offset: 92422},
+									pos:  position{line: 2982, col: 18, offset: 92421},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2982, col: 24, offset: 92428},
+									pos:        position{line: 2982, col: 24, offset: 92427},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2982, col: 29, offset: 92433},
+									pos:  position{line: 2982, col: 29, offset: 92432},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2982, col: 37, offset: 92441},
+									pos:   position{line: 2982, col: 37, offset: 92440},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2982, col: 50, offset: 92454},
+										pos:  position{line: 2982, col: 50, offset: 92453},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2982, col: 60, offset: 92464},
+									pos:   position{line: 2982, col: 60, offset: 92463},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2982, col: 65, offset: 92469},
+										pos: position{line: 2982, col: 65, offset: 92468},
 										expr: &seqExpr{
-											pos: position{line: 2982, col: 66, offset: 92470},
+											pos: position{line: 2982, col: 66, offset: 92469},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2982, col: 66, offset: 92470},
+													pos:  position{line: 2982, col: 66, offset: 92469},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2982, col: 72, offset: 92476},
+													pos:  position{line: 2982, col: 72, offset: 92475},
 													name: "ValueExpr",
 												},
 											},
@@ -6854,50 +6854,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2982, col: 84, offset: 92488},
+									pos:  position{line: 2982, col: 84, offset: 92487},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3001, col: 3, offset: 93039},
+						pos: position{line: 3001, col: 3, offset: 93038},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3001, col: 3, offset: 93039},
+							pos: position{line: 3001, col: 3, offset: 93038},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3001, col: 3, offset: 93039},
+									pos:        position{line: 3001, col: 3, offset: 93038},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3001, col: 8, offset: 93044},
+									pos:  position{line: 3001, col: 8, offset: 93043},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3001, col: 16, offset: 93052},
+									pos:   position{line: 3001, col: 16, offset: 93051},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3001, col: 29, offset: 93065},
+										pos:  position{line: 3001, col: 29, offset: 93064},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3001, col: 39, offset: 93075},
+									pos:   position{line: 3001, col: 39, offset: 93074},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3001, col: 44, offset: 93080},
+										pos: position{line: 3001, col: 44, offset: 93079},
 										expr: &seqExpr{
-											pos: position{line: 3001, col: 45, offset: 93081},
+											pos: position{line: 3001, col: 45, offset: 93080},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3001, col: 45, offset: 93081},
+													pos:  position{line: 3001, col: 45, offset: 93080},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3001, col: 51, offset: 93087},
+													pos:  position{line: 3001, col: 51, offset: 93086},
 													name: "ValueExpr",
 												},
 											},
@@ -6905,7 +6905,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3001, col: 63, offset: 93099},
+									pos:  position{line: 3001, col: 63, offset: 93098},
 									name: "R_PAREN",
 								},
 							},
@@ -6916,34 +6916,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3019, col: 1, offset: 93520},
+			pos:  position{line: 3019, col: 1, offset: 93519},
 			expr: &actionExpr{
-				pos: position{line: 3019, col: 23, offset: 93542},
+				pos: position{line: 3019, col: 23, offset: 93541},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3019, col: 23, offset: 93542},
+					pos: position{line: 3019, col: 23, offset: 93541},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3019, col: 23, offset: 93542},
+							pos:   position{line: 3019, col: 23, offset: 93541},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3019, col: 28, offset: 93547},
+								pos:  position{line: 3019, col: 28, offset: 93546},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3019, col: 38, offset: 93557},
+							pos:   position{line: 3019, col: 38, offset: 93556},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3019, col: 41, offset: 93560},
+								pos:  position{line: 3019, col: 41, offset: 93559},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3019, col: 62, offset: 93581},
+							pos:   position{line: 3019, col: 62, offset: 93580},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3019, col: 68, offset: 93587},
+								pos:  position{line: 3019, col: 68, offset: 93586},
 								name: "ValueExpr",
 							},
 						},
@@ -6953,129 +6953,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3037, col: 1, offset: 94181},
+			pos:  position{line: 3037, col: 1, offset: 94180},
 			expr: &choiceExpr{
-				pos: position{line: 3037, col: 14, offset: 94194},
+				pos: position{line: 3037, col: 14, offset: 94193},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3037, col: 14, offset: 94194},
+						pos: position{line: 3037, col: 14, offset: 94193},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3037, col: 14, offset: 94194},
+							pos:   position{line: 3037, col: 14, offset: 94193},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3037, col: 24, offset: 94204},
+								pos:  position{line: 3037, col: 24, offset: 94203},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3046, col: 3, offset: 94394},
+						pos: position{line: 3046, col: 3, offset: 94393},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3046, col: 3, offset: 94394},
+							pos: position{line: 3046, col: 3, offset: 94393},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3046, col: 3, offset: 94394},
+									pos:  position{line: 3046, col: 3, offset: 94393},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3046, col: 12, offset: 94403},
+									pos:   position{line: 3046, col: 12, offset: 94402},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3046, col: 22, offset: 94413},
+										pos:  position{line: 3046, col: 22, offset: 94412},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3046, col: 37, offset: 94428},
+									pos:  position{line: 3046, col: 37, offset: 94427},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3055, col: 3, offset: 94612},
+						pos: position{line: 3055, col: 3, offset: 94611},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3055, col: 3, offset: 94612},
+							pos:   position{line: 3055, col: 3, offset: 94611},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3055, col: 11, offset: 94620},
+								pos:  position{line: 3055, col: 11, offset: 94619},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3064, col: 3, offset: 94800},
+						pos: position{line: 3064, col: 3, offset: 94799},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3064, col: 3, offset: 94800},
+							pos:   position{line: 3064, col: 3, offset: 94799},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3064, col: 7, offset: 94804},
+								pos:  position{line: 3064, col: 7, offset: 94803},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3073, col: 3, offset: 94976},
+						pos: position{line: 3073, col: 3, offset: 94975},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3073, col: 3, offset: 94976},
+							pos: position{line: 3073, col: 3, offset: 94975},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3073, col: 3, offset: 94976},
+									pos:  position{line: 3073, col: 3, offset: 94975},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3073, col: 12, offset: 94985},
+									pos:   position{line: 3073, col: 12, offset: 94984},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3073, col: 16, offset: 94989},
+										pos:  position{line: 3073, col: 16, offset: 94988},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3073, col: 28, offset: 95001},
+									pos:  position{line: 3073, col: 28, offset: 95000},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3082, col: 3, offset: 95170},
+						pos: position{line: 3082, col: 3, offset: 95169},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3082, col: 3, offset: 95170},
+							pos: position{line: 3082, col: 3, offset: 95169},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3082, col: 3, offset: 95170},
+									pos:  position{line: 3082, col: 3, offset: 95169},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3082, col: 11, offset: 95178},
+									pos:   position{line: 3082, col: 11, offset: 95177},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3082, col: 19, offset: 95186},
+										pos:  position{line: 3082, col: 19, offset: 95185},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3082, col: 28, offset: 95195},
+									pos:  position{line: 3082, col: 28, offset: 95194},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3091, col: 3, offset: 95367},
+						pos: position{line: 3091, col: 3, offset: 95366},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3091, col: 3, offset: 95367},
+							pos:   position{line: 3091, col: 3, offset: 95366},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3091, col: 18, offset: 95382},
+								pos:  position{line: 3091, col: 18, offset: 95381},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7085,28 +7085,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3101, col: 1, offset: 95579},
+			pos:  position{line: 3101, col: 1, offset: 95578},
 			expr: &choiceExpr{
-				pos: position{line: 3101, col: 15, offset: 95593},
+				pos: position{line: 3101, col: 15, offset: 95592},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3101, col: 15, offset: 95593},
+						pos: position{line: 3101, col: 15, offset: 95592},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3101, col: 15, offset: 95593},
+							pos: position{line: 3101, col: 15, offset: 95592},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3101, col: 15, offset: 95593},
+									pos:   position{line: 3101, col: 15, offset: 95592},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3101, col: 20, offset: 95598},
+										pos:  position{line: 3101, col: 20, offset: 95597},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3101, col: 29, offset: 95607},
+									pos: position{line: 3101, col: 29, offset: 95606},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3101, col: 31, offset: 95609},
+										pos:  position{line: 3101, col: 31, offset: 95608},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7114,23 +7114,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3109, col: 3, offset: 95779},
+						pos: position{line: 3109, col: 3, offset: 95778},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3109, col: 3, offset: 95779},
+							pos: position{line: 3109, col: 3, offset: 95778},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3109, col: 3, offset: 95779},
+									pos:   position{line: 3109, col: 3, offset: 95778},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3109, col: 7, offset: 95783},
+										pos:  position{line: 3109, col: 7, offset: 95782},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3109, col: 20, offset: 95796},
+									pos: position{line: 3109, col: 20, offset: 95795},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3109, col: 22, offset: 95798},
+										pos:  position{line: 3109, col: 22, offset: 95797},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7138,50 +7138,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3117, col: 3, offset: 95963},
+						pos: position{line: 3117, col: 3, offset: 95962},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3117, col: 3, offset: 95963},
+							pos: position{line: 3117, col: 3, offset: 95962},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3117, col: 3, offset: 95963},
+									pos:   position{line: 3117, col: 3, offset: 95962},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3117, col: 9, offset: 95969},
+										pos:  position{line: 3117, col: 9, offset: 95968},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3117, col: 25, offset: 95985},
+									pos: position{line: 3117, col: 25, offset: 95984},
 									expr: &choiceExpr{
-										pos: position{line: 3117, col: 27, offset: 95987},
+										pos: position{line: 3117, col: 27, offset: 95986},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 27, offset: 95987},
+												pos:  position{line: 3117, col: 27, offset: 95986},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 36, offset: 95996},
+												pos:  position{line: 3117, col: 36, offset: 95995},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 46, offset: 96006},
+												pos:  position{line: 3117, col: 46, offset: 96005},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 54, offset: 96014},
+												pos:  position{line: 3117, col: 54, offset: 96013},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 62, offset: 96022},
+												pos:  position{line: 3117, col: 62, offset: 96021},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3117, col: 70, offset: 96030},
+												pos:  position{line: 3117, col: 70, offset: 96029},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3117, col: 84, offset: 96044},
+												pos:        position{line: 3117, col: 84, offset: 96043},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7193,13 +7193,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3125, col: 3, offset: 96194},
+						pos: position{line: 3125, col: 3, offset: 96193},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3125, col: 3, offset: 96194},
+							pos:   position{line: 3125, col: 3, offset: 96193},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3125, col: 10, offset: 96201},
+								pos:  position{line: 3125, col: 10, offset: 96200},
 								name: "ConcatExpr",
 							},
 						},
@@ -7209,35 +7209,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3135, col: 1, offset: 96407},
+			pos:  position{line: 3135, col: 1, offset: 96406},
 			expr: &actionExpr{
-				pos: position{line: 3135, col: 15, offset: 96421},
+				pos: position{line: 3135, col: 15, offset: 96420},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3135, col: 15, offset: 96421},
+					pos: position{line: 3135, col: 15, offset: 96420},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3135, col: 15, offset: 96421},
+							pos:   position{line: 3135, col: 15, offset: 96420},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3135, col: 21, offset: 96427},
+								pos:  position{line: 3135, col: 21, offset: 96426},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3135, col: 32, offset: 96438},
+							pos:   position{line: 3135, col: 32, offset: 96437},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3135, col: 37, offset: 96443},
+								pos: position{line: 3135, col: 37, offset: 96442},
 								expr: &seqExpr{
-									pos: position{line: 3135, col: 38, offset: 96444},
+									pos: position{line: 3135, col: 38, offset: 96443},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3135, col: 38, offset: 96444},
+											pos:  position{line: 3135, col: 38, offset: 96443},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3135, col: 50, offset: 96456},
+											pos:  position{line: 3135, col: 50, offset: 96455},
 											name: "ConcatAtom",
 										},
 									},
@@ -7245,28 +7245,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3135, col: 63, offset: 96469},
+							pos: position{line: 3135, col: 63, offset: 96468},
 							expr: &choiceExpr{
-								pos: position{line: 3135, col: 65, offset: 96471},
+								pos: position{line: 3135, col: 65, offset: 96470},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3135, col: 65, offset: 96471},
+										pos:  position{line: 3135, col: 65, offset: 96470},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3135, col: 74, offset: 96480},
+										pos:  position{line: 3135, col: 74, offset: 96479},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3135, col: 84, offset: 96490},
+										pos:  position{line: 3135, col: 84, offset: 96489},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3135, col: 92, offset: 96498},
+										pos:  position{line: 3135, col: 92, offset: 96497},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3135, col: 100, offset: 96506},
+										pos:        position{line: 3135, col: 100, offset: 96505},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7280,54 +7280,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3153, col: 1, offset: 96912},
+			pos:  position{line: 3153, col: 1, offset: 96911},
 			expr: &choiceExpr{
-				pos: position{line: 3153, col: 15, offset: 96926},
+				pos: position{line: 3153, col: 15, offset: 96925},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3153, col: 15, offset: 96926},
+						pos: position{line: 3153, col: 15, offset: 96925},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3153, col: 15, offset: 96926},
+							pos:   position{line: 3153, col: 15, offset: 96925},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3153, col: 20, offset: 96931},
+								pos:  position{line: 3153, col: 20, offset: 96930},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3162, col: 3, offset: 97095},
+						pos: position{line: 3162, col: 3, offset: 97094},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3162, col: 3, offset: 97095},
+							pos:   position{line: 3162, col: 3, offset: 97094},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3162, col: 7, offset: 97099},
+								pos:  position{line: 3162, col: 7, offset: 97098},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3170, col: 3, offset: 97238},
+						pos: position{line: 3170, col: 3, offset: 97237},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3170, col: 3, offset: 97238},
+							pos:   position{line: 3170, col: 3, offset: 97237},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3170, col: 10, offset: 97245},
+								pos:  position{line: 3170, col: 10, offset: 97244},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3178, col: 3, offset: 97384},
+						pos: position{line: 3178, col: 3, offset: 97383},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3178, col: 3, offset: 97384},
+							pos:   position{line: 3178, col: 3, offset: 97383},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3178, col: 9, offset: 97390},
+								pos:  position{line: 3178, col: 9, offset: 97389},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7337,32 +7337,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3188, col: 1, offset: 97559},
+			pos:  position{line: 3188, col: 1, offset: 97558},
 			expr: &actionExpr{
-				pos: position{line: 3188, col: 16, offset: 97574},
+				pos: position{line: 3188, col: 16, offset: 97573},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3188, col: 16, offset: 97574},
+					pos: position{line: 3188, col: 16, offset: 97573},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3188, col: 16, offset: 97574},
+							pos:   position{line: 3188, col: 16, offset: 97573},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3188, col: 21, offset: 97579},
+								pos:  position{line: 3188, col: 21, offset: 97578},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3188, col: 39, offset: 97597},
+							pos: position{line: 3188, col: 39, offset: 97596},
 							expr: &choiceExpr{
-								pos: position{line: 3188, col: 41, offset: 97599},
+								pos: position{line: 3188, col: 41, offset: 97598},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3188, col: 41, offset: 97599},
+										pos:  position{line: 3188, col: 41, offset: 97598},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3188, col: 55, offset: 97613},
+										pos:        position{line: 3188, col: 55, offset: 97612},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7376,44 +7376,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3193, col: 1, offset: 97678},
+			pos:  position{line: 3193, col: 1, offset: 97677},
 			expr: &actionExpr{
-				pos: position{line: 3193, col: 22, offset: 97699},
+				pos: position{line: 3193, col: 22, offset: 97698},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3193, col: 22, offset: 97699},
+					pos: position{line: 3193, col: 22, offset: 97698},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3193, col: 22, offset: 97699},
+							pos:   position{line: 3193, col: 22, offset: 97698},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3193, col: 28, offset: 97705},
+								pos:  position{line: 3193, col: 28, offset: 97704},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3193, col: 46, offset: 97723},
+							pos:   position{line: 3193, col: 46, offset: 97722},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3193, col: 51, offset: 97728},
+								pos: position{line: 3193, col: 51, offset: 97727},
 								expr: &seqExpr{
-									pos: position{line: 3193, col: 52, offset: 97729},
+									pos: position{line: 3193, col: 52, offset: 97728},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3193, col: 53, offset: 97730},
+											pos: position{line: 3193, col: 53, offset: 97729},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3193, col: 53, offset: 97730},
+													pos:  position{line: 3193, col: 53, offset: 97729},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3193, col: 62, offset: 97739},
+													pos:  position{line: 3193, col: 62, offset: 97738},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3193, col: 71, offset: 97748},
+											pos:  position{line: 3193, col: 71, offset: 97747},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7426,48 +7426,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3214, col: 1, offset: 98249},
+			pos:  position{line: 3214, col: 1, offset: 98248},
 			expr: &actionExpr{
-				pos: position{line: 3214, col: 22, offset: 98270},
+				pos: position{line: 3214, col: 22, offset: 98269},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3214, col: 22, offset: 98270},
+					pos: position{line: 3214, col: 22, offset: 98269},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3214, col: 22, offset: 98270},
+							pos:   position{line: 3214, col: 22, offset: 98269},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3214, col: 28, offset: 98276},
+								pos:  position{line: 3214, col: 28, offset: 98275},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3214, col: 46, offset: 98294},
+							pos:   position{line: 3214, col: 46, offset: 98293},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3214, col: 51, offset: 98299},
+								pos: position{line: 3214, col: 51, offset: 98298},
 								expr: &seqExpr{
-									pos: position{line: 3214, col: 52, offset: 98300},
+									pos: position{line: 3214, col: 52, offset: 98299},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3214, col: 53, offset: 98301},
+											pos: position{line: 3214, col: 53, offset: 98300},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3214, col: 53, offset: 98301},
+													pos:  position{line: 3214, col: 53, offset: 98300},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3214, col: 61, offset: 98309},
+													pos:  position{line: 3214, col: 61, offset: 98308},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3214, col: 69, offset: 98317},
+													pos:  position{line: 3214, col: 69, offset: 98316},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3214, col: 76, offset: 98324},
+											pos:  position{line: 3214, col: 76, offset: 98323},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7480,22 +7480,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3234, col: 1, offset: 98793},
+			pos:  position{line: 3234, col: 1, offset: 98792},
 			expr: &actionExpr{
-				pos: position{line: 3234, col: 21, offset: 98813},
+				pos: position{line: 3234, col: 21, offset: 98812},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3234, col: 21, offset: 98813},
+					pos: position{line: 3234, col: 21, offset: 98812},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3234, col: 21, offset: 98813},
+							pos:  position{line: 3234, col: 21, offset: 98812},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3234, col: 27, offset: 98819},
+							pos:   position{line: 3234, col: 27, offset: 98818},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3234, col: 32, offset: 98824},
+								pos:  position{line: 3234, col: 32, offset: 98823},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7505,67 +7505,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3244, col: 1, offset: 99068},
+			pos:  position{line: 3244, col: 1, offset: 99067},
 			expr: &choiceExpr{
-				pos: position{line: 3244, col: 22, offset: 99089},
+				pos: position{line: 3244, col: 22, offset: 99088},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3244, col: 22, offset: 99089},
+						pos: position{line: 3244, col: 22, offset: 99088},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3244, col: 22, offset: 99089},
+							pos: position{line: 3244, col: 22, offset: 99088},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3244, col: 22, offset: 99089},
+									pos:  position{line: 3244, col: 22, offset: 99088},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3244, col: 30, offset: 99097},
+									pos:   position{line: 3244, col: 30, offset: 99096},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3244, col: 35, offset: 99102},
+										pos:  position{line: 3244, col: 35, offset: 99101},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3244, col: 53, offset: 99120},
+									pos:  position{line: 3244, col: 53, offset: 99119},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3247, col: 3, offset: 99155},
+						pos: position{line: 3247, col: 3, offset: 99154},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3247, col: 3, offset: 99155},
+							pos:   position{line: 3247, col: 3, offset: 99154},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3247, col: 20, offset: 99172},
+								pos:  position{line: 3247, col: 20, offset: 99171},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3250, col: 3, offset: 99226},
+						pos: position{line: 3250, col: 3, offset: 99225},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3250, col: 3, offset: 99226},
+							pos:   position{line: 3250, col: 3, offset: 99225},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3250, col: 9, offset: 99232},
+								pos:  position{line: 3250, col: 9, offset: 99231},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3260, col: 3, offset: 99451},
+						pos: position{line: 3260, col: 3, offset: 99450},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3260, col: 3, offset: 99451},
+							pos:   position{line: 3260, col: 3, offset: 99450},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3260, col: 10, offset: 99458},
+								pos:  position{line: 3260, col: 10, offset: 99457},
 								name: "NumberAsString",
 							},
 						},
@@ -7575,144 +7575,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3273, col: 1, offset: 99836},
+			pos:  position{line: 3273, col: 1, offset: 99835},
 			expr: &choiceExpr{
-				pos: position{line: 3273, col: 20, offset: 99855},
+				pos: position{line: 3273, col: 20, offset: 99854},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3273, col: 20, offset: 99855},
+						pos: position{line: 3273, col: 20, offset: 99854},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3273, col: 21, offset: 99856},
+							pos: position{line: 3273, col: 21, offset: 99855},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3273, col: 21, offset: 99856},
+									pos:   position{line: 3273, col: 21, offset: 99855},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3273, col: 29, offset: 99864},
+										pos: position{line: 3273, col: 29, offset: 99863},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3273, col: 29, offset: 99864},
+												pos:        position{line: 3273, col: 29, offset: 99863},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 37, offset: 99872},
+												pos:        position{line: 3273, col: 37, offset: 99871},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 46, offset: 99881},
+												pos:        position{line: 3273, col: 46, offset: 99880},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 58, offset: 99893},
+												pos:        position{line: 3273, col: 58, offset: 99892},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 67, offset: 99902},
+												pos:        position{line: 3273, col: 67, offset: 99901},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 77, offset: 99912},
+												pos:        position{line: 3273, col: 77, offset: 99911},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 85, offset: 99920},
+												pos:        position{line: 3273, col: 85, offset: 99919},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 95, offset: 99930},
+												pos:        position{line: 3273, col: 95, offset: 99929},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 102, offset: 99937},
+												pos:        position{line: 3273, col: 102, offset: 99936},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 113, offset: 99948},
+												pos:        position{line: 3273, col: 113, offset: 99947},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 123, offset: 99958},
+												pos:        position{line: 3273, col: 123, offset: 99957},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 132, offset: 99967},
+												pos:        position{line: 3273, col: 132, offset: 99966},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 142, offset: 99977},
+												pos:        position{line: 3273, col: 142, offset: 99976},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 151, offset: 99986},
+												pos:        position{line: 3273, col: 151, offset: 99985},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 161, offset: 99996},
+												pos:        position{line: 3273, col: 161, offset: 99995},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 170, offset: 100005},
+												pos:        position{line: 3273, col: 170, offset: 100004},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 179, offset: 100014},
+												pos:        position{line: 3273, col: 179, offset: 100013},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 187, offset: 100022},
+												pos:        position{line: 3273, col: 187, offset: 100021},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 196, offset: 100031},
+												pos:        position{line: 3273, col: 196, offset: 100030},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 204, offset: 100039},
+												pos:        position{line: 3273, col: 204, offset: 100038},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3273, col: 213, offset: 100048},
+												pos:        position{line: 3273, col: 213, offset: 100047},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7721,102 +7721,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3273, col: 220, offset: 100055},
+									pos:  position{line: 3273, col: 220, offset: 100054},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3273, col: 228, offset: 100063},
+									pos:   position{line: 3273, col: 228, offset: 100062},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3273, col: 234, offset: 100069},
+										pos:  position{line: 3273, col: 234, offset: 100068},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3273, col: 253, offset: 100088},
+									pos:  position{line: 3273, col: 253, offset: 100087},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3293, col: 3, offset: 100600},
+						pos: position{line: 3293, col: 3, offset: 100599},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3293, col: 3, offset: 100600},
+							pos: position{line: 3293, col: 3, offset: 100599},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3293, col: 3, offset: 100600},
+									pos:   position{line: 3293, col: 3, offset: 100599},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3293, col: 13, offset: 100610},
+										pos:        position{line: 3293, col: 13, offset: 100609},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3293, col: 21, offset: 100618},
+									pos:  position{line: 3293, col: 21, offset: 100617},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3293, col: 29, offset: 100626},
+									pos:   position{line: 3293, col: 29, offset: 100625},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3293, col: 35, offset: 100632},
+										pos:  position{line: 3293, col: 35, offset: 100631},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3293, col: 54, offset: 100651},
+									pos:   position{line: 3293, col: 54, offset: 100650},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3293, col: 69, offset: 100666},
+										pos: position{line: 3293, col: 69, offset: 100665},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3293, col: 70, offset: 100667},
+											pos:  position{line: 3293, col: 70, offset: 100666},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3293, col: 89, offset: 100686},
+									pos:  position{line: 3293, col: 89, offset: 100685},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3314, col: 3, offset: 101304},
+						pos: position{line: 3314, col: 3, offset: 101303},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3314, col: 4, offset: 101305},
+							pos: position{line: 3314, col: 4, offset: 101304},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3314, col: 4, offset: 101305},
+									pos:   position{line: 3314, col: 4, offset: 101304},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3314, col: 12, offset: 101313},
+										pos: position{line: 3314, col: 12, offset: 101312},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3314, col: 12, offset: 101313},
+												pos:        position{line: 3314, col: 12, offset: 101312},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3314, col: 20, offset: 101321},
+												pos:        position{line: 3314, col: 20, offset: 101320},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3314, col: 27, offset: 101328},
+												pos:        position{line: 3314, col: 27, offset: 101327},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3314, col: 38, offset: 101339},
+												pos:        position{line: 3314, col: 38, offset: 101338},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7825,54 +7825,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3314, col: 46, offset: 101347},
+									pos:  position{line: 3314, col: 46, offset: 101346},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3314, col: 54, offset: 101355},
+									pos:  position{line: 3314, col: 54, offset: 101354},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3327, col: 3, offset: 101641},
+						pos: position{line: 3327, col: 3, offset: 101640},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3327, col: 3, offset: 101641},
+							pos: position{line: 3327, col: 3, offset: 101640},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3327, col: 3, offset: 101641},
+									pos:        position{line: 3327, col: 3, offset: 101640},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3327, col: 14, offset: 101652},
+									pos:  position{line: 3327, col: 14, offset: 101651},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3327, col: 22, offset: 101660},
+									pos:   position{line: 3327, col: 22, offset: 101659},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3327, col: 33, offset: 101671},
+										pos:  position{line: 3327, col: 33, offset: 101670},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3327, col: 44, offset: 101682},
+									pos:   position{line: 3327, col: 44, offset: 101681},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3327, col: 53, offset: 101691},
+										pos: position{line: 3327, col: 53, offset: 101690},
 										expr: &seqExpr{
-											pos: position{line: 3327, col: 54, offset: 101692},
+											pos: position{line: 3327, col: 54, offset: 101691},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3327, col: 54, offset: 101692},
+													pos:  position{line: 3327, col: 54, offset: 101691},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3327, col: 60, offset: 101698},
+													pos:  position{line: 3327, col: 60, offset: 101697},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -7880,73 +7880,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3327, col: 80, offset: 101718},
+									pos:  position{line: 3327, col: 80, offset: 101717},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3355, col: 3, offset: 102560},
+						pos: position{line: 3355, col: 3, offset: 102559},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3355, col: 3, offset: 102560},
+							pos: position{line: 3355, col: 3, offset: 102559},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3355, col: 3, offset: 102560},
+									pos:   position{line: 3355, col: 3, offset: 102559},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3355, col: 12, offset: 102569},
+										pos:        position{line: 3355, col: 12, offset: 102568},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3355, col: 18, offset: 102575},
+									pos:  position{line: 3355, col: 18, offset: 102574},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3355, col: 26, offset: 102583},
+									pos:   position{line: 3355, col: 26, offset: 102582},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3355, col: 31, offset: 102588},
+										pos:  position{line: 3355, col: 31, offset: 102587},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3355, col: 39, offset: 102596},
+									pos:  position{line: 3355, col: 39, offset: 102595},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3358, col: 3, offset: 102631},
+						pos: position{line: 3358, col: 3, offset: 102630},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3358, col: 4, offset: 102632},
+							pos: position{line: 3358, col: 4, offset: 102631},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3358, col: 4, offset: 102632},
+									pos:   position{line: 3358, col: 4, offset: 102631},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3358, col: 12, offset: 102640},
+										pos: position{line: 3358, col: 12, offset: 102639},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3358, col: 12, offset: 102640},
+												pos:        position{line: 3358, col: 12, offset: 102639},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3358, col: 20, offset: 102648},
+												pos:        position{line: 3358, col: 20, offset: 102647},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3358, col: 30, offset: 102658},
+												pos:        position{line: 3358, col: 30, offset: 102657},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -7955,128 +7955,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3358, col: 39, offset: 102667},
+									pos:  position{line: 3358, col: 39, offset: 102666},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3358, col: 47, offset: 102675},
+									pos:   position{line: 3358, col: 47, offset: 102674},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3358, col: 53, offset: 102681},
+										pos:  position{line: 3358, col: 53, offset: 102680},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3358, col: 72, offset: 102700},
+									pos:   position{line: 3358, col: 72, offset: 102699},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3358, col: 79, offset: 102707},
+										pos:  position{line: 3358, col: 79, offset: 102706},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3358, col: 97, offset: 102725},
+									pos:  position{line: 3358, col: 97, offset: 102724},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3388, col: 3, offset: 103564},
+						pos: position{line: 3388, col: 3, offset: 103563},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3388, col: 4, offset: 103565},
+							pos: position{line: 3388, col: 4, offset: 103564},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3388, col: 4, offset: 103565},
+									pos:   position{line: 3388, col: 4, offset: 103564},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3388, col: 11, offset: 103572},
+										pos:        position{line: 3388, col: 11, offset: 103571},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3388, col: 17, offset: 103578},
+									pos:  position{line: 3388, col: 17, offset: 103577},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3388, col: 25, offset: 103586},
+									pos:   position{line: 3388, col: 25, offset: 103585},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3388, col: 31, offset: 103592},
+										pos:  position{line: 3388, col: 31, offset: 103591},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3388, col: 50, offset: 103611},
+									pos:   position{line: 3388, col: 50, offset: 103610},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3388, col: 56, offset: 103617},
+										pos: position{line: 3388, col: 56, offset: 103616},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3388, col: 57, offset: 103618},
+											pos:  position{line: 3388, col: 57, offset: 103617},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3388, col: 76, offset: 103637},
+									pos:  position{line: 3388, col: 76, offset: 103636},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3417, col: 3, offset: 104410},
+						pos: position{line: 3417, col: 3, offset: 104409},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3417, col: 3, offset: 104410},
+							pos: position{line: 3417, col: 3, offset: 104409},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3417, col: 3, offset: 104410},
+									pos:   position{line: 3417, col: 3, offset: 104409},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3417, col: 11, offset: 104418},
+										pos:        position{line: 3417, col: 11, offset: 104417},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3417, col: 28, offset: 104435},
+									pos:  position{line: 3417, col: 28, offset: 104434},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3417, col: 36, offset: 104443},
+									pos:   position{line: 3417, col: 36, offset: 104442},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3417, col: 42, offset: 104449},
+										pos:  position{line: 3417, col: 42, offset: 104448},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3417, col: 61, offset: 104468},
+									pos:  position{line: 3417, col: 61, offset: 104467},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3417, col: 67, offset: 104474},
+									pos:  position{line: 3417, col: 67, offset: 104473},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3417, col: 73, offset: 104480},
+									pos:   position{line: 3417, col: 73, offset: 104479},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3417, col: 84, offset: 104491},
+										pos:  position{line: 3417, col: 84, offset: 104490},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3417, col: 120, offset: 104527},
+									pos:  position{line: 3417, col: 120, offset: 104526},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3417, col: 126, offset: 104533},
+									pos:  position{line: 3417, col: 126, offset: 104532},
 									name: "R_PAREN",
 								},
 							},
@@ -8087,28 +8087,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3434, col: 1, offset: 105062},
+			pos:  position{line: 3434, col: 1, offset: 105061},
 			expr: &choiceExpr{
-				pos: position{line: 3434, col: 12, offset: 105073},
+				pos: position{line: 3434, col: 12, offset: 105072},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3434, col: 12, offset: 105073},
+						pos: position{line: 3434, col: 12, offset: 105072},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3434, col: 12, offset: 105073},
+							pos: position{line: 3434, col: 12, offset: 105072},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3434, col: 12, offset: 105073},
+									pos:   position{line: 3434, col: 12, offset: 105072},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3434, col: 16, offset: 105077},
+										pos:  position{line: 3434, col: 16, offset: 105076},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3434, col: 29, offset: 105090},
+									pos: position{line: 3434, col: 29, offset: 105089},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3434, col: 31, offset: 105092},
+										pos:  position{line: 3434, col: 31, offset: 105091},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8116,50 +8116,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3450, col: 3, offset: 105453},
+						pos: position{line: 3450, col: 3, offset: 105452},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3450, col: 3, offset: 105453},
+							pos: position{line: 3450, col: 3, offset: 105452},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3450, col: 3, offset: 105453},
+									pos:   position{line: 3450, col: 3, offset: 105452},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3450, col: 9, offset: 105459},
+										pos:  position{line: 3450, col: 9, offset: 105458},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3450, col: 25, offset: 105475},
+									pos: position{line: 3450, col: 25, offset: 105474},
 									expr: &choiceExpr{
-										pos: position{line: 3450, col: 27, offset: 105477},
+										pos: position{line: 3450, col: 27, offset: 105476},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 27, offset: 105477},
+												pos:  position{line: 3450, col: 27, offset: 105476},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 36, offset: 105486},
+												pos:  position{line: 3450, col: 36, offset: 105485},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 46, offset: 105496},
+												pos:  position{line: 3450, col: 46, offset: 105495},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 54, offset: 105504},
+												pos:  position{line: 3450, col: 54, offset: 105503},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 62, offset: 105512},
+												pos:  position{line: 3450, col: 62, offset: 105511},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3450, col: 70, offset: 105520},
+												pos:  position{line: 3450, col: 70, offset: 105519},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3450, col: 84, offset: 105534},
+												pos:        position{line: 3450, col: 84, offset: 105533},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8175,28 +8175,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3467, col: 1, offset: 105885},
+			pos:  position{line: 3467, col: 1, offset: 105884},
 			expr: &actionExpr{
-				pos: position{line: 3467, col: 19, offset: 105903},
+				pos: position{line: 3467, col: 19, offset: 105902},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3467, col: 19, offset: 105903},
+					pos: position{line: 3467, col: 19, offset: 105902},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3467, col: 19, offset: 105903},
+							pos:        position{line: 3467, col: 19, offset: 105902},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3467, col: 26, offset: 105910},
+							pos:  position{line: 3467, col: 26, offset: 105909},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3467, col: 32, offset: 105916},
+							pos:   position{line: 3467, col: 32, offset: 105915},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3467, col: 40, offset: 105924},
+								pos:  position{line: 3467, col: 40, offset: 105923},
 								name: "Boolean",
 							},
 						},
@@ -8206,28 +8206,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3478, col: 1, offset: 106113},
+			pos:  position{line: 3478, col: 1, offset: 106112},
 			expr: &actionExpr{
-				pos: position{line: 3478, col: 23, offset: 106135},
+				pos: position{line: 3478, col: 23, offset: 106134},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3478, col: 23, offset: 106135},
+					pos: position{line: 3478, col: 23, offset: 106134},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3478, col: 23, offset: 106135},
+							pos:        position{line: 3478, col: 23, offset: 106134},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3478, col: 34, offset: 106146},
+							pos:  position{line: 3478, col: 34, offset: 106145},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3478, col: 40, offset: 106152},
+							pos:   position{line: 3478, col: 40, offset: 106151},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3478, col: 48, offset: 106160},
+								pos:  position{line: 3478, col: 48, offset: 106159},
 								name: "Boolean",
 							},
 						},
@@ -8237,28 +8237,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3489, col: 1, offset: 106357},
+			pos:  position{line: 3489, col: 1, offset: 106356},
 			expr: &actionExpr{
-				pos: position{line: 3489, col: 20, offset: 106376},
+				pos: position{line: 3489, col: 20, offset: 106375},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3489, col: 20, offset: 106376},
+					pos: position{line: 3489, col: 20, offset: 106375},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3489, col: 20, offset: 106376},
+							pos:        position{line: 3489, col: 20, offset: 106375},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3489, col: 28, offset: 106384},
+							pos:  position{line: 3489, col: 28, offset: 106383},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3489, col: 34, offset: 106390},
+							pos:   position{line: 3489, col: 34, offset: 106389},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3489, col: 43, offset: 106399},
+								pos:  position{line: 3489, col: 43, offset: 106398},
 								name: "IntegerAsString",
 							},
 						},
@@ -8268,15 +8268,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3504, col: 1, offset: 106761},
+			pos:  position{line: 3504, col: 1, offset: 106760},
 			expr: &actionExpr{
-				pos: position{line: 3504, col: 19, offset: 106779},
+				pos: position{line: 3504, col: 19, offset: 106778},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3504, col: 19, offset: 106779},
+					pos:   position{line: 3504, col: 19, offset: 106778},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3504, col: 28, offset: 106788},
+						pos:  position{line: 3504, col: 28, offset: 106787},
 						name: "BoolExpr",
 					},
 				},
@@ -8284,30 +8284,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3515, col: 1, offset: 107000},
+			pos:  position{line: 3515, col: 1, offset: 106999},
 			expr: &actionExpr{
-				pos: position{line: 3515, col: 15, offset: 107014},
+				pos: position{line: 3515, col: 15, offset: 107013},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3515, col: 15, offset: 107014},
+					pos:   position{line: 3515, col: 15, offset: 107013},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3515, col: 23, offset: 107022},
+						pos: position{line: 3515, col: 23, offset: 107021},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3515, col: 23, offset: 107022},
+								pos:  position{line: 3515, col: 23, offset: 107021},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3515, col: 44, offset: 107043},
+								pos:  position{line: 3515, col: 44, offset: 107042},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3515, col: 61, offset: 107060},
+								pos:  position{line: 3515, col: 61, offset: 107059},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3515, col: 79, offset: 107078},
+								pos:  position{line: 3515, col: 79, offset: 107077},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8317,35 +8317,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3519, col: 1, offset: 107122},
+			pos:  position{line: 3519, col: 1, offset: 107121},
 			expr: &actionExpr{
-				pos: position{line: 3519, col: 19, offset: 107140},
+				pos: position{line: 3519, col: 19, offset: 107139},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3519, col: 19, offset: 107140},
+					pos: position{line: 3519, col: 19, offset: 107139},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3519, col: 19, offset: 107140},
+							pos:   position{line: 3519, col: 19, offset: 107139},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3519, col: 26, offset: 107147},
+								pos:  position{line: 3519, col: 26, offset: 107146},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3519, col: 37, offset: 107158},
+							pos:   position{line: 3519, col: 37, offset: 107157},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3519, col: 43, offset: 107164},
+								pos: position{line: 3519, col: 43, offset: 107163},
 								expr: &seqExpr{
-									pos: position{line: 3519, col: 44, offset: 107165},
+									pos: position{line: 3519, col: 44, offset: 107164},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3519, col: 44, offset: 107165},
+											pos:  position{line: 3519, col: 44, offset: 107164},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3519, col: 50, offset: 107171},
+											pos:  position{line: 3519, col: 50, offset: 107170},
 											name: "HeadOption",
 										},
 									},
@@ -8358,29 +8358,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3581, col: 1, offset: 109218},
+			pos:  position{line: 3581, col: 1, offset: 109217},
 			expr: &choiceExpr{
-				pos: position{line: 3581, col: 14, offset: 109231},
+				pos: position{line: 3581, col: 14, offset: 109230},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3581, col: 14, offset: 109231},
+						pos: position{line: 3581, col: 14, offset: 109230},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3581, col: 14, offset: 109231},
+							pos: position{line: 3581, col: 14, offset: 109230},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3581, col: 14, offset: 109231},
+									pos:  position{line: 3581, col: 14, offset: 109230},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3581, col: 19, offset: 109236},
+									pos:  position{line: 3581, col: 19, offset: 109235},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3581, col: 28, offset: 109245},
+									pos:   position{line: 3581, col: 28, offset: 109244},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3581, col: 37, offset: 109254},
+										pos:  position{line: 3581, col: 37, offset: 109253},
 										name: "HeadOptionList",
 									},
 								},
@@ -8388,24 +8388,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3591, col: 3, offset: 109525},
+						pos: position{line: 3591, col: 3, offset: 109524},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3591, col: 3, offset: 109525},
+							pos: position{line: 3591, col: 3, offset: 109524},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3591, col: 3, offset: 109525},
+									pos:  position{line: 3591, col: 3, offset: 109524},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3591, col: 8, offset: 109530},
+									pos:  position{line: 3591, col: 8, offset: 109529},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3591, col: 17, offset: 109539},
+									pos:   position{line: 3591, col: 17, offset: 109538},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3591, col: 26, offset: 109548},
+										pos:  position{line: 3591, col: 26, offset: 109547},
 										name: "IntegerAsString",
 									},
 								},
@@ -8413,17 +8413,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3608, col: 3, offset: 110027},
+						pos: position{line: 3608, col: 3, offset: 110026},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3608, col: 3, offset: 110027},
+							pos: position{line: 3608, col: 3, offset: 110026},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3608, col: 3, offset: 110027},
+									pos:  position{line: 3608, col: 3, offset: 110026},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3608, col: 8, offset: 110032},
+									pos:  position{line: 3608, col: 8, offset: 110031},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8434,29 +8434,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3622, col: 1, offset: 110463},
+			pos:  position{line: 3622, col: 1, offset: 110462},
 			expr: &choiceExpr{
-				pos: position{line: 3622, col: 14, offset: 110476},
+				pos: position{line: 3622, col: 14, offset: 110475},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3622, col: 14, offset: 110476},
+						pos: position{line: 3622, col: 14, offset: 110475},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3622, col: 14, offset: 110476},
+							pos: position{line: 3622, col: 14, offset: 110475},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3622, col: 14, offset: 110476},
+									pos:  position{line: 3622, col: 14, offset: 110475},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3622, col: 19, offset: 110481},
+									pos:  position{line: 3622, col: 19, offset: 110480},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3622, col: 28, offset: 110490},
+									pos:   position{line: 3622, col: 28, offset: 110489},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3622, col: 37, offset: 110499},
+										pos:  position{line: 3622, col: 37, offset: 110498},
 										name: "IntegerAsString",
 									},
 								},
@@ -8464,17 +8464,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3642, col: 3, offset: 111048},
+						pos: position{line: 3642, col: 3, offset: 111047},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3642, col: 3, offset: 111048},
+							pos: position{line: 3642, col: 3, offset: 111047},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3642, col: 3, offset: 111048},
+									pos:  position{line: 3642, col: 3, offset: 111047},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3642, col: 8, offset: 111053},
+									pos:  position{line: 3642, col: 8, offset: 111052},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8485,44 +8485,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3662, col: 1, offset: 111646},
+			pos:  position{line: 3662, col: 1, offset: 111645},
 			expr: &actionExpr{
-				pos: position{line: 3662, col: 20, offset: 111665},
+				pos: position{line: 3662, col: 20, offset: 111664},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3662, col: 20, offset: 111665},
+					pos: position{line: 3662, col: 20, offset: 111664},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3662, col: 20, offset: 111665},
+							pos:   position{line: 3662, col: 20, offset: 111664},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3662, col: 26, offset: 111671},
+								pos:  position{line: 3662, col: 26, offset: 111670},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3662, col: 37, offset: 111682},
+							pos:   position{line: 3662, col: 37, offset: 111681},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3662, col: 42, offset: 111687},
+								pos: position{line: 3662, col: 42, offset: 111686},
 								expr: &seqExpr{
-									pos: position{line: 3662, col: 43, offset: 111688},
+									pos: position{line: 3662, col: 43, offset: 111687},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3662, col: 44, offset: 111689},
+											pos: position{line: 3662, col: 44, offset: 111688},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3662, col: 44, offset: 111689},
+													pos:  position{line: 3662, col: 44, offset: 111688},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3662, col: 52, offset: 111697},
+													pos:  position{line: 3662, col: 52, offset: 111696},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3662, col: 59, offset: 111704},
+											pos:  position{line: 3662, col: 59, offset: 111703},
 											name: "Aggregator",
 										},
 									},
@@ -8535,28 +8535,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3679, col: 1, offset: 112207},
+			pos:  position{line: 3679, col: 1, offset: 112206},
 			expr: &actionExpr{
-				pos: position{line: 3679, col: 15, offset: 112221},
+				pos: position{line: 3679, col: 15, offset: 112220},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3679, col: 15, offset: 112221},
+					pos: position{line: 3679, col: 15, offset: 112220},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3679, col: 15, offset: 112221},
+							pos:   position{line: 3679, col: 15, offset: 112220},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3679, col: 23, offset: 112229},
+								pos:  position{line: 3679, col: 23, offset: 112228},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3679, col: 35, offset: 112241},
+							pos:   position{line: 3679, col: 35, offset: 112240},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3679, col: 43, offset: 112249},
+								pos: position{line: 3679, col: 43, offset: 112248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3679, col: 43, offset: 112249},
+									pos:  position{line: 3679, col: 43, offset: 112248},
 									name: "AsField",
 								},
 							},
@@ -8567,26 +8567,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3695, col: 1, offset: 113090},
+			pos:  position{line: 3695, col: 1, offset: 113089},
 			expr: &actionExpr{
-				pos: position{line: 3695, col: 16, offset: 113105},
+				pos: position{line: 3695, col: 16, offset: 113104},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3695, col: 16, offset: 113105},
+					pos:   position{line: 3695, col: 16, offset: 113104},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3695, col: 21, offset: 113110},
+						pos: position{line: 3695, col: 21, offset: 113109},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3695, col: 21, offset: 113110},
+								pos:  position{line: 3695, col: 21, offset: 113109},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3695, col: 32, offset: 113121},
+								pos:  position{line: 3695, col: 32, offset: 113120},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3695, col: 48, offset: 113137},
+								pos:  position{line: 3695, col: 48, offset: 113136},
 								name: "AggCommon",
 							},
 						},
@@ -8596,165 +8596,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3700, col: 1, offset: 113343},
+			pos:  position{line: 3700, col: 1, offset: 113342},
 			expr: &actionExpr{
-				pos: position{line: 3700, col: 18, offset: 113360},
+				pos: position{line: 3700, col: 18, offset: 113359},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3700, col: 19, offset: 113361},
+					pos: position{line: 3700, col: 19, offset: 113360},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3700, col: 19, offset: 113361},
+							pos:        position{line: 3700, col: 19, offset: 113360},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 30, offset: 113372},
+							pos:        position{line: 3700, col: 30, offset: 113371},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 39, offset: 113381},
+							pos:        position{line: 3700, col: 39, offset: 113380},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 47, offset: 113389},
+							pos:        position{line: 3700, col: 47, offset: 113388},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 57, offset: 113399},
+							pos:        position{line: 3700, col: 57, offset: 113398},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 65, offset: 113407},
+							pos:        position{line: 3700, col: 65, offset: 113406},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 76, offset: 113418},
+							pos:        position{line: 3700, col: 76, offset: 113417},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 86, offset: 113428},
+							pos:        position{line: 3700, col: 86, offset: 113427},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 95, offset: 113437},
+							pos:        position{line: 3700, col: 95, offset: 113436},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 105, offset: 113447},
+							pos:        position{line: 3700, col: 105, offset: 113446},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 114, offset: 113456},
+							pos:        position{line: 3700, col: 114, offset: 113455},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 122, offset: 113464},
+							pos:        position{line: 3700, col: 122, offset: 113463},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 133, offset: 113475},
+							pos:        position{line: 3700, col: 133, offset: 113474},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3700, col: 142, offset: 113484},
+							pos:        position{line: 3700, col: 142, offset: 113483},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 1, offset: 113493},
+							pos:        position{line: 3701, col: 1, offset: 113492},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 10, offset: 113502},
+							pos:        position{line: 3701, col: 10, offset: 113501},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 26, offset: 113518},
+							pos:        position{line: 3701, col: 26, offset: 113517},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 37, offset: 113529},
+							pos:        position{line: 3701, col: 37, offset: 113528},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 46, offset: 113538},
+							pos:        position{line: 3701, col: 46, offset: 113537},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 56, offset: 113548},
+							pos:        position{line: 3701, col: 56, offset: 113547},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 72, offset: 113564},
+							pos:        position{line: 3701, col: 72, offset: 113563},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 82, offset: 113574},
+							pos:        position{line: 3701, col: 82, offset: 113573},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 100, offset: 113592},
+							pos:        position{line: 3701, col: 100, offset: 113591},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 113, offset: 113605},
+							pos:        position{line: 3701, col: 113, offset: 113604},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 132, offset: 113624},
+							pos:        position{line: 3701, col: 132, offset: 113623},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3701, col: 139, offset: 113631},
+							pos:        position{line: 3701, col: 139, offset: 113630},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8765,27 +8765,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3705, col: 1, offset: 113674},
+			pos:  position{line: 3705, col: 1, offset: 113673},
 			expr: &actionExpr{
-				pos: position{line: 3705, col: 22, offset: 113695},
+				pos: position{line: 3705, col: 22, offset: 113694},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3705, col: 23, offset: 113696},
+					pos: position{line: 3705, col: 23, offset: 113695},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3705, col: 23, offset: 113696},
+							pos:        position{line: 3705, col: 23, offset: 113695},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3705, col: 37, offset: 113710},
+							pos:        position{line: 3705, col: 37, offset: 113709},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3705, col: 51, offset: 113724},
+							pos:        position{line: 3705, col: 51, offset: 113723},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8796,29 +8796,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3709, col: 1, offset: 113768},
+			pos:  position{line: 3709, col: 1, offset: 113767},
 			expr: &actionExpr{
-				pos: position{line: 3709, col: 12, offset: 113779},
+				pos: position{line: 3709, col: 12, offset: 113778},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3709, col: 12, offset: 113779},
+					pos: position{line: 3709, col: 12, offset: 113778},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3709, col: 12, offset: 113779},
+							pos:  position{line: 3709, col: 12, offset: 113778},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3709, col: 15, offset: 113782},
+							pos:   position{line: 3709, col: 15, offset: 113781},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3709, col: 23, offset: 113790},
+								pos: position{line: 3709, col: 23, offset: 113789},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3709, col: 23, offset: 113790},
+										pos:  position{line: 3709, col: 23, offset: 113789},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3709, col: 35, offset: 113802},
+										pos:  position{line: 3709, col: 35, offset: 113801},
 										name: "String",
 									},
 								},
@@ -8830,27 +8830,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3723, col: 1, offset: 114131},
+			pos:  position{line: 3723, col: 1, offset: 114130},
 			expr: &choiceExpr{
-				pos: position{line: 3723, col: 13, offset: 114143},
+				pos: position{line: 3723, col: 13, offset: 114142},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3723, col: 13, offset: 114143},
+						pos: position{line: 3723, col: 13, offset: 114142},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3723, col: 13, offset: 114143},
+							pos: position{line: 3723, col: 13, offset: 114142},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3723, col: 14, offset: 114144},
+									pos: position{line: 3723, col: 14, offset: 114143},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3723, col: 14, offset: 114144},
+											pos:        position{line: 3723, col: 14, offset: 114143},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3723, col: 24, offset: 114154},
+											pos:        position{line: 3723, col: 24, offset: 114153},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8858,47 +8858,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3723, col: 29, offset: 114159},
+									pos:  position{line: 3723, col: 29, offset: 114158},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3723, col: 37, offset: 114167},
+									pos:        position{line: 3723, col: 37, offset: 114166},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3723, col: 44, offset: 114174},
+									pos:   position{line: 3723, col: 44, offset: 114173},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3723, col: 54, offset: 114184},
+										pos:  position{line: 3723, col: 54, offset: 114183},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3723, col: 64, offset: 114194},
+									pos:  position{line: 3723, col: 64, offset: 114193},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3733, col: 3, offset: 114422},
+						pos: position{line: 3733, col: 3, offset: 114421},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3733, col: 3, offset: 114422},
+							pos: position{line: 3733, col: 3, offset: 114421},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3733, col: 4, offset: 114423},
+									pos: position{line: 3733, col: 4, offset: 114422},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3733, col: 4, offset: 114423},
+											pos:        position{line: 3733, col: 4, offset: 114422},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3733, col: 14, offset: 114433},
+											pos:        position{line: 3733, col: 14, offset: 114432},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8906,38 +8906,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3733, col: 19, offset: 114438},
+									pos:  position{line: 3733, col: 19, offset: 114437},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3733, col: 27, offset: 114446},
+									pos:   position{line: 3733, col: 27, offset: 114445},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3733, col: 33, offset: 114452},
+										pos:  position{line: 3733, col: 33, offset: 114451},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3733, col: 43, offset: 114462},
+									pos:  position{line: 3733, col: 43, offset: 114461},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3740, col: 5, offset: 114613},
+						pos: position{line: 3740, col: 5, offset: 114612},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3740, col: 6, offset: 114614},
+							pos: position{line: 3740, col: 6, offset: 114613},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3740, col: 6, offset: 114614},
+									pos:        position{line: 3740, col: 6, offset: 114613},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3740, col: 16, offset: 114624},
+									pos:        position{line: 3740, col: 16, offset: 114623},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -8950,77 +8950,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3749, col: 1, offset: 114760},
+			pos:  position{line: 3749, col: 1, offset: 114759},
 			expr: &choiceExpr{
-				pos: position{line: 3749, col: 14, offset: 114773},
+				pos: position{line: 3749, col: 14, offset: 114772},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3749, col: 14, offset: 114773},
+						pos: position{line: 3749, col: 14, offset: 114772},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3749, col: 14, offset: 114773},
+							pos: position{line: 3749, col: 14, offset: 114772},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3749, col: 14, offset: 114773},
+									pos:   position{line: 3749, col: 14, offset: 114772},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3749, col: 22, offset: 114781},
+										pos:  position{line: 3749, col: 22, offset: 114780},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3749, col: 36, offset: 114795},
+									pos:  position{line: 3749, col: 36, offset: 114794},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3749, col: 44, offset: 114803},
+									pos:        position{line: 3749, col: 44, offset: 114802},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3749, col: 51, offset: 114810},
+									pos:   position{line: 3749, col: 51, offset: 114809},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3749, col: 61, offset: 114820},
+										pos:  position{line: 3749, col: 61, offset: 114819},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3749, col: 71, offset: 114830},
+									pos:  position{line: 3749, col: 71, offset: 114829},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3764, col: 3, offset: 115240},
+						pos: position{line: 3764, col: 3, offset: 115239},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3764, col: 3, offset: 115240},
+							pos: position{line: 3764, col: 3, offset: 115239},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3764, col: 3, offset: 115240},
+									pos:   position{line: 3764, col: 3, offset: 115239},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3764, col: 11, offset: 115248},
+										pos:  position{line: 3764, col: 11, offset: 115247},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3764, col: 25, offset: 115262},
+									pos:  position{line: 3764, col: 25, offset: 115261},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3764, col: 33, offset: 115270},
+									pos:   position{line: 3764, col: 33, offset: 115269},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3764, col: 39, offset: 115276},
+										pos:  position{line: 3764, col: 39, offset: 115275},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3764, col: 49, offset: 115286},
+									pos:  position{line: 3764, col: 49, offset: 115285},
 									name: "R_PAREN",
 								},
 							},
@@ -9031,22 +9031,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3778, col: 1, offset: 115618},
+			pos:  position{line: 3778, col: 1, offset: 115617},
 			expr: &actionExpr{
-				pos: position{line: 3778, col: 18, offset: 115635},
+				pos: position{line: 3778, col: 18, offset: 115634},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3778, col: 18, offset: 115635},
+					pos:   position{line: 3778, col: 18, offset: 115634},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3778, col: 26, offset: 115643},
+						pos: position{line: 3778, col: 26, offset: 115642},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3778, col: 26, offset: 115643},
+								pos:  position{line: 3778, col: 26, offset: 115642},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3778, col: 42, offset: 115659},
+								pos:  position{line: 3778, col: 42, offset: 115658},
 								name: "IntegerAsString",
 							},
 						},
@@ -9056,93 +9056,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3790, col: 1, offset: 116033},
+			pos:  position{line: 3790, col: 1, offset: 116032},
 			expr: &choiceExpr{
-				pos: position{line: 3790, col: 18, offset: 116050},
+				pos: position{line: 3790, col: 18, offset: 116049},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3790, col: 18, offset: 116050},
+						pos: position{line: 3790, col: 18, offset: 116049},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3790, col: 18, offset: 116050},
+							pos: position{line: 3790, col: 18, offset: 116049},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3790, col: 18, offset: 116050},
+									pos:   position{line: 3790, col: 18, offset: 116049},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3790, col: 26, offset: 116058},
+										pos:  position{line: 3790, col: 26, offset: 116057},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3790, col: 44, offset: 116076},
+									pos:   position{line: 3790, col: 44, offset: 116075},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3790, col: 58, offset: 116090},
+										pos:  position{line: 3790, col: 58, offset: 116089},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3790, col: 72, offset: 116104},
+									pos:  position{line: 3790, col: 72, offset: 116103},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3790, col: 80, offset: 116112},
+									pos:        position{line: 3790, col: 80, offset: 116111},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3790, col: 87, offset: 116119},
+									pos:   position{line: 3790, col: 87, offset: 116118},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3790, col: 97, offset: 116129},
+										pos:  position{line: 3790, col: 97, offset: 116128},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3790, col: 107, offset: 116139},
+									pos:  position{line: 3790, col: 107, offset: 116138},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3806, col: 3, offset: 116588},
+						pos: position{line: 3806, col: 3, offset: 116587},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3806, col: 3, offset: 116588},
+							pos: position{line: 3806, col: 3, offset: 116587},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3806, col: 3, offset: 116588},
+									pos:   position{line: 3806, col: 3, offset: 116587},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3806, col: 11, offset: 116596},
+										pos:  position{line: 3806, col: 11, offset: 116595},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3806, col: 29, offset: 116614},
+									pos:   position{line: 3806, col: 29, offset: 116613},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3806, col: 43, offset: 116628},
+										pos:  position{line: 3806, col: 43, offset: 116627},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3806, col: 57, offset: 116642},
+									pos:  position{line: 3806, col: 57, offset: 116641},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3806, col: 65, offset: 116650},
+									pos:   position{line: 3806, col: 65, offset: 116649},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3806, col: 71, offset: 116656},
+										pos:  position{line: 3806, col: 71, offset: 116655},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3806, col: 81, offset: 116666},
+									pos:  position{line: 3806, col: 81, offset: 116665},
 									name: "R_PAREN",
 								},
 							},
@@ -9153,22 +9153,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3822, col: 1, offset: 117038},
+			pos:  position{line: 3822, col: 1, offset: 117037},
 			expr: &actionExpr{
-				pos: position{line: 3822, col: 25, offset: 117062},
+				pos: position{line: 3822, col: 25, offset: 117061},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3822, col: 25, offset: 117062},
+					pos:   position{line: 3822, col: 25, offset: 117061},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3822, col: 39, offset: 117076},
+						pos: position{line: 3822, col: 39, offset: 117075},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3822, col: 39, offset: 117076},
+								pos:  position{line: 3822, col: 39, offset: 117075},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3822, col: 67, offset: 117104},
+								pos:  position{line: 3822, col: 67, offset: 117103},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9178,43 +9178,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3826, col: 1, offset: 117167},
+			pos:  position{line: 3826, col: 1, offset: 117166},
 			expr: &actionExpr{
-				pos: position{line: 3826, col: 30, offset: 117196},
+				pos: position{line: 3826, col: 30, offset: 117195},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3826, col: 30, offset: 117196},
+					pos: position{line: 3826, col: 30, offset: 117195},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3826, col: 30, offset: 117196},
+							pos:   position{line: 3826, col: 30, offset: 117195},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3826, col: 34, offset: 117200},
+								pos:  position{line: 3826, col: 34, offset: 117199},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3826, col: 44, offset: 117210},
+							pos:   position{line: 3826, col: 44, offset: 117209},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3826, col: 48, offset: 117214},
+								pos: position{line: 3826, col: 48, offset: 117213},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3826, col: 48, offset: 117214},
+										pos:  position{line: 3826, col: 48, offset: 117213},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3826, col: 67, offset: 117233},
+										pos:  position{line: 3826, col: 67, offset: 117232},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3826, col: 87, offset: 117253},
+							pos:   position{line: 3826, col: 87, offset: 117252},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3826, col: 93, offset: 117259},
+								pos:  position{line: 3826, col: 93, offset: 117258},
 								name: "Number",
 							},
 						},
@@ -9224,15 +9224,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3839, col: 1, offset: 117493},
+			pos:  position{line: 3839, col: 1, offset: 117492},
 			expr: &actionExpr{
-				pos: position{line: 3839, col: 32, offset: 117524},
+				pos: position{line: 3839, col: 32, offset: 117523},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3839, col: 32, offset: 117524},
+					pos:   position{line: 3839, col: 32, offset: 117523},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3839, col: 38, offset: 117530},
+						pos:  position{line: 3839, col: 38, offset: 117529},
 						name: "Number",
 					},
 				},
@@ -9240,34 +9240,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3852, col: 1, offset: 117747},
+			pos:  position{line: 3852, col: 1, offset: 117746},
 			expr: &actionExpr{
-				pos: position{line: 3852, col: 26, offset: 117772},
+				pos: position{line: 3852, col: 26, offset: 117771},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3852, col: 26, offset: 117772},
+					pos: position{line: 3852, col: 26, offset: 117771},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3852, col: 26, offset: 117772},
+							pos:   position{line: 3852, col: 26, offset: 117771},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3852, col: 30, offset: 117776},
+								pos:  position{line: 3852, col: 30, offset: 117775},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3852, col: 40, offset: 117786},
+							pos:   position{line: 3852, col: 40, offset: 117785},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3852, col: 43, offset: 117789},
+								pos:  position{line: 3852, col: 43, offset: 117788},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3852, col: 60, offset: 117806},
+							pos:   position{line: 3852, col: 60, offset: 117805},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3852, col: 66, offset: 117812},
+								pos:  position{line: 3852, col: 66, offset: 117811},
 								name: "Boolean",
 							},
 						},
@@ -9277,22 +9277,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3865, col: 1, offset: 118047},
+			pos:  position{line: 3865, col: 1, offset: 118046},
 			expr: &actionExpr{
-				pos: position{line: 3865, col: 25, offset: 118071},
+				pos: position{line: 3865, col: 25, offset: 118070},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3865, col: 25, offset: 118071},
+					pos:   position{line: 3865, col: 25, offset: 118070},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3865, col: 39, offset: 118085},
+						pos: position{line: 3865, col: 39, offset: 118084},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3865, col: 39, offset: 118085},
+								pos:  position{line: 3865, col: 39, offset: 118084},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3865, col: 67, offset: 118113},
+								pos:  position{line: 3865, col: 67, offset: 118112},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9302,41 +9302,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3869, col: 1, offset: 118176},
+			pos:  position{line: 3869, col: 1, offset: 118175},
 			expr: &actionExpr{
-				pos: position{line: 3869, col: 30, offset: 118205},
+				pos: position{line: 3869, col: 30, offset: 118204},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3869, col: 30, offset: 118205},
+					pos: position{line: 3869, col: 30, offset: 118204},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3869, col: 30, offset: 118205},
+							pos:   position{line: 3869, col: 30, offset: 118204},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3869, col: 34, offset: 118209},
+								pos:  position{line: 3869, col: 34, offset: 118208},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3869, col: 44, offset: 118219},
+							pos:   position{line: 3869, col: 44, offset: 118218},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3869, col: 47, offset: 118222},
+								pos:  position{line: 3869, col: 47, offset: 118221},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3869, col: 64, offset: 118239},
+							pos:   position{line: 3869, col: 64, offset: 118238},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 3869, col: 81, offset: 118256},
+								pos: position{line: 3869, col: 81, offset: 118255},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3869, col: 81, offset: 118256},
+										pos:  position{line: 3869, col: 81, offset: 118255},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3869, col: 103, offset: 118278},
+										pos:  position{line: 3869, col: 103, offset: 118277},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9348,22 +9348,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3884, col: 1, offset: 118692},
+			pos:  position{line: 3884, col: 1, offset: 118677},
 			expr: &actionExpr{
-				pos: position{line: 3884, col: 32, offset: 118723},
+				pos: position{line: 3884, col: 32, offset: 118708},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3884, col: 32, offset: 118723},
+					pos:   position{line: 3884, col: 32, offset: 118708},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 3884, col: 49, offset: 118740},
+						pos: position{line: 3884, col: 49, offset: 118725},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3884, col: 49, offset: 118740},
+								pos:  position{line: 3884, col: 49, offset: 118725},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3884, col: 71, offset: 118762},
+								pos:  position{line: 3884, col: 71, offset: 118747},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9373,33 +9373,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 3899, col: 1, offset: 119159},
+			pos:  position{line: 3899, col: 1, offset: 119130},
 			expr: &actionExpr{
-				pos: position{line: 3899, col: 24, offset: 119182},
+				pos: position{line: 3899, col: 24, offset: 119153},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 3899, col: 24, offset: 119182},
+					pos: position{line: 3899, col: 24, offset: 119153},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3899, col: 24, offset: 119182},
+							pos:        position{line: 3899, col: 24, offset: 119153},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3899, col: 31, offset: 119189},
+							pos:  position{line: 3899, col: 31, offset: 119160},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 3899, col: 39, offset: 119197},
+							pos:   position{line: 3899, col: 39, offset: 119168},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3899, col: 45, offset: 119203},
+								pos:  position{line: 3899, col: 45, offset: 119174},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3899, col: 52, offset: 119210},
+							pos:  position{line: 3899, col: 52, offset: 119181},
 							name: "R_PAREN",
 						},
 					},
@@ -9408,15 +9408,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 3907, col: 1, offset: 119358},
+			pos:  position{line: 3907, col: 1, offset: 119322},
 			expr: &actionExpr{
-				pos: position{line: 3907, col: 26, offset: 119383},
+				pos: position{line: 3907, col: 26, offset: 119347},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3907, col: 26, offset: 119383},
+					pos:   position{line: 3907, col: 26, offset: 119347},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3907, col: 32, offset: 119389},
+						pos:  position{line: 3907, col: 32, offset: 119353},
 						name: "String",
 					},
 				},
@@ -9424,35 +9424,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 3917, col: 1, offset: 119676},
+			pos:  position{line: 3917, col: 1, offset: 119633},
 			expr: &actionExpr{
-				pos: position{line: 3917, col: 18, offset: 119693},
+				pos: position{line: 3917, col: 18, offset: 119650},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 3917, col: 18, offset: 119693},
+					pos: position{line: 3917, col: 18, offset: 119650},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3917, col: 18, offset: 119693},
+							pos:   position{line: 3917, col: 18, offset: 119650},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3917, col: 24, offset: 119699},
+								pos:  position{line: 3917, col: 24, offset: 119656},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3917, col: 34, offset: 119709},
+							pos:   position{line: 3917, col: 34, offset: 119666},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3917, col: 39, offset: 119714},
+								pos: position{line: 3917, col: 39, offset: 119671},
 								expr: &seqExpr{
-									pos: position{line: 3917, col: 40, offset: 119715},
+									pos: position{line: 3917, col: 40, offset: 119672},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3917, col: 40, offset: 119715},
+											pos:  position{line: 3917, col: 40, offset: 119672},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3917, col: 46, offset: 119721},
+											pos:  position{line: 3917, col: 46, offset: 119678},
 											name: "FieldName",
 										},
 									},
@@ -9465,16 +9465,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 3934, col: 1, offset: 120216},
+			pos:  position{line: 3934, col: 1, offset: 120173},
 			expr: &choiceExpr{
-				pos: position{line: 3934, col: 18, offset: 120233},
+				pos: position{line: 3934, col: 18, offset: 120190},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 3934, col: 18, offset: 120233},
+						pos:  position{line: 3934, col: 18, offset: 120190},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 3934, col: 38, offset: 120253},
+						pos:  position{line: 3934, col: 38, offset: 120210},
 						name: "EarliestOnly",
 					},
 				},
@@ -9482,71 +9482,71 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 3936, col: 1, offset: 120267},
+			pos:  position{line: 3936, col: 1, offset: 120224},
 			expr: &actionExpr{
-				pos: position{line: 3936, col: 22, offset: 120288},
+				pos: position{line: 3936, col: 22, offset: 120245},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 3936, col: 22, offset: 120288},
+					pos: position{line: 3936, col: 22, offset: 120245},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3936, col: 22, offset: 120288},
+							pos:  position{line: 3936, col: 22, offset: 120245},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3936, col: 35, offset: 120301},
+							pos:  position{line: 3936, col: 35, offset: 120258},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3936, col: 41, offset: 120307},
+							pos:   position{line: 3936, col: 41, offset: 120264},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3936, col: 55, offset: 120321},
+								pos: position{line: 3936, col: 55, offset: 120278},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3936, col: 55, offset: 120321},
+										pos:  position{line: 3936, col: 55, offset: 120278},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3936, col: 75, offset: 120341},
+										pos:  position{line: 3936, col: 75, offset: 120298},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3936, col: 94, offset: 120360},
+							pos:  position{line: 3936, col: 94, offset: 120317},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3936, col: 100, offset: 120366},
+							pos:  position{line: 3936, col: 100, offset: 120323},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3936, col: 111, offset: 120377},
+							pos:  position{line: 3936, col: 111, offset: 120334},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3936, col: 117, offset: 120383},
+							pos:   position{line: 3936, col: 117, offset: 120340},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3936, col: 129, offset: 120395},
+								pos: position{line: 3936, col: 129, offset: 120352},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3936, col: 129, offset: 120395},
+										pos:  position{line: 3936, col: 129, offset: 120352},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3936, col: 149, offset: 120415},
+										pos:  position{line: 3936, col: 149, offset: 120372},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3936, col: 168, offset: 120434},
+							pos: position{line: 3936, col: 168, offset: 120391},
 							expr: &anyMatcher{
-								line: 3936, col: 169, offset: 120435,
+								line: 3936, col: 169, offset: 120392,
 							},
 						},
 					},
@@ -9555,42 +9555,42 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 3977, col: 1, offset: 121557},
+			pos:  position{line: 3977, col: 1, offset: 121514},
 			expr: &actionExpr{
-				pos: position{line: 3977, col: 17, offset: 121573},
+				pos: position{line: 3977, col: 17, offset: 121530},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 3977, col: 17, offset: 121573},
+					pos: position{line: 3977, col: 17, offset: 121530},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3977, col: 17, offset: 121573},
+							pos:  position{line: 3977, col: 17, offset: 121530},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3977, col: 30, offset: 121586},
+							pos:  position{line: 3977, col: 30, offset: 121543},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3977, col: 36, offset: 121592},
+							pos:   position{line: 3977, col: 36, offset: 121549},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3977, col: 50, offset: 121606},
+								pos: position{line: 3977, col: 50, offset: 121563},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3977, col: 50, offset: 121606},
+										pos:  position{line: 3977, col: 50, offset: 121563},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3977, col: 70, offset: 121626},
+										pos:  position{line: 3977, col: 70, offset: 121583},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3977, col: 89, offset: 121645},
+							pos: position{line: 3977, col: 89, offset: 121602},
 							expr: &anyMatcher{
-								line: 3977, col: 90, offset: 121646,
+								line: 3977, col: 90, offset: 121603,
 							},
 						},
 					},
@@ -9599,24 +9599,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4005, col: 1, offset: 122337},
+			pos:  position{line: 4005, col: 1, offset: 122294},
 			expr: &actionExpr{
-				pos: position{line: 4005, col: 23, offset: 122359},
+				pos: position{line: 4005, col: 23, offset: 122316},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4005, col: 23, offset: 122359},
+					pos: position{line: 4005, col: 23, offset: 122316},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4005, col: 23, offset: 122359},
+							pos:        position{line: 4005, col: 23, offset: 122316},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4005, col: 27, offset: 122363},
+							pos: position{line: 4005, col: 27, offset: 122320},
 							expr: &charClassMatcher{
-								pos:        position{line: 4005, col: 27, offset: 122363},
+								pos:        position{line: 4005, col: 27, offset: 122320},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9629,21 +9629,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4009, col: 1, offset: 122406},
+			pos:  position{line: 4009, col: 1, offset: 122363},
 			expr: &actionExpr{
-				pos: position{line: 4009, col: 13, offset: 122418},
+				pos: position{line: 4009, col: 13, offset: 122375},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4009, col: 14, offset: 122419},
+					pos: position{line: 4009, col: 14, offset: 122376},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4009, col: 14, offset: 122419},
+							pos:        position{line: 4009, col: 14, offset: 122376},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4009, col: 17, offset: 122422},
+							pos:        position{line: 4009, col: 17, offset: 122379},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9655,15 +9655,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4013, col: 1, offset: 122465},
+			pos:  position{line: 4013, col: 1, offset: 122422},
 			expr: &actionExpr{
-				pos: position{line: 4013, col: 16, offset: 122480},
+				pos: position{line: 4013, col: 16, offset: 122437},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4013, col: 16, offset: 122480},
+					pos:   position{line: 4013, col: 16, offset: 122437},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4013, col: 26, offset: 122490},
+						pos:  position{line: 4013, col: 26, offset: 122447},
 						name: "AllTimeScale",
 					},
 				},
@@ -9671,31 +9671,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4020, col: 1, offset: 122714},
+			pos:  position{line: 4020, col: 1, offset: 122671},
 			expr: &actionExpr{
-				pos: position{line: 4020, col: 9, offset: 122722},
+				pos: position{line: 4020, col: 9, offset: 122679},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4020, col: 9, offset: 122722},
+					pos: position{line: 4020, col: 9, offset: 122679},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4020, col: 9, offset: 122722},
+							pos:        position{line: 4020, col: 9, offset: 122679},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4020, col: 13, offset: 122726},
+							pos:   position{line: 4020, col: 13, offset: 122683},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4020, col: 19, offset: 122732},
+								pos: position{line: 4020, col: 19, offset: 122689},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4020, col: 19, offset: 122732},
+										pos:  position{line: 4020, col: 19, offset: 122689},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4020, col: 30, offset: 122743},
+										pos:  position{line: 4020, col: 30, offset: 122700},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9707,26 +9707,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4024, col: 1, offset: 122791},
+			pos:  position{line: 4024, col: 1, offset: 122748},
 			expr: &actionExpr{
-				pos: position{line: 4024, col: 11, offset: 122801},
+				pos: position{line: 4024, col: 11, offset: 122758},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4024, col: 11, offset: 122801},
+					pos: position{line: 4024, col: 11, offset: 122758},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4024, col: 11, offset: 122801},
+							pos:   position{line: 4024, col: 11, offset: 122758},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4024, col: 16, offset: 122806},
+								pos:  position{line: 4024, col: 16, offset: 122763},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4024, col: 36, offset: 122826},
+							pos:   position{line: 4024, col: 36, offset: 122783},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4024, col: 43, offset: 122833},
+								pos:  position{line: 4024, col: 43, offset: 122790},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9736,44 +9736,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4052, col: 1, offset: 123571},
+			pos:  position{line: 4052, col: 1, offset: 123528},
 			expr: &actionExpr{
-				pos: position{line: 4052, col: 29, offset: 123599},
+				pos: position{line: 4052, col: 29, offset: 123556},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4052, col: 29, offset: 123599},
+					pos: position{line: 4052, col: 29, offset: 123556},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4052, col: 29, offset: 123599},
+							pos:   position{line: 4052, col: 29, offset: 123556},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4052, col: 36, offset: 123606},
+								pos: position{line: 4052, col: 36, offset: 123563},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4052, col: 36, offset: 123606},
+										pos:  position{line: 4052, col: 36, offset: 123563},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4052, col: 45, offset: 123615},
+										pos:  position{line: 4052, col: 45, offset: 123572},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4052, col: 51, offset: 123621},
+							pos:   position{line: 4052, col: 51, offset: 123578},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4052, col: 57, offset: 123627},
+								pos: position{line: 4052, col: 57, offset: 123584},
 								expr: &choiceExpr{
-									pos: position{line: 4052, col: 58, offset: 123628},
+									pos: position{line: 4052, col: 58, offset: 123585},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4052, col: 58, offset: 123628},
+											pos:  position{line: 4052, col: 58, offset: 123585},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4052, col: 67, offset: 123637},
+											pos:  position{line: 4052, col: 67, offset: 123594},
 											name: "Snap",
 										},
 									},
@@ -9786,29 +9786,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4099, col: 1, offset: 125069},
+			pos:  position{line: 4099, col: 1, offset: 125026},
 			expr: &actionExpr{
-				pos: position{line: 4099, col: 22, offset: 125090},
+				pos: position{line: 4099, col: 22, offset: 125047},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4099, col: 22, offset: 125090},
+					pos: position{line: 4099, col: 22, offset: 125047},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4099, col: 22, offset: 125090},
+							pos:   position{line: 4099, col: 22, offset: 125047},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4099, col: 34, offset: 125102},
+								pos: position{line: 4099, col: 34, offset: 125059},
 								expr: &choiceExpr{
-									pos: position{line: 4099, col: 35, offset: 125103},
+									pos: position{line: 4099, col: 35, offset: 125060},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4099, col: 35, offset: 125103},
+											pos:        position{line: 4099, col: 35, offset: 125060},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4099, col: 43, offset: 125111},
+											pos:        position{line: 4099, col: 43, offset: 125068},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9818,12 +9818,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4099, col: 49, offset: 125117},
+							pos:   position{line: 4099, col: 49, offset: 125074},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4099, col: 57, offset: 125125},
+								pos: position{line: 4099, col: 57, offset: 125082},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4099, col: 58, offset: 125126},
+									pos:  position{line: 4099, col: 58, offset: 125083},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9834,31 +9834,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4124, col: 1, offset: 125809},
+			pos:  position{line: 4124, col: 1, offset: 125766},
 			expr: &actionExpr{
-				pos: position{line: 4124, col: 39, offset: 125847},
+				pos: position{line: 4124, col: 39, offset: 125804},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4124, col: 39, offset: 125847},
+					pos: position{line: 4124, col: 39, offset: 125804},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4124, col: 39, offset: 125847},
+							pos:   position{line: 4124, col: 39, offset: 125804},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4124, col: 46, offset: 125854},
+								pos: position{line: 4124, col: 46, offset: 125811},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4124, col: 47, offset: 125855},
+									pos:  position{line: 4124, col: 47, offset: 125812},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4124, col: 56, offset: 125864},
+							pos:   position{line: 4124, col: 56, offset: 125821},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4124, col: 66, offset: 125874},
+								pos: position{line: 4124, col: 66, offset: 125831},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4124, col: 67, offset: 125875},
+									pos:  position{line: 4124, col: 67, offset: 125832},
 									name: "Snap",
 								},
 							},
@@ -9869,136 +9869,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4151, col: 1, offset: 126503},
+			pos:  position{line: 4151, col: 1, offset: 126460},
 			expr: &actionExpr{
-				pos: position{line: 4151, col: 18, offset: 126520},
+				pos: position{line: 4151, col: 18, offset: 126477},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4151, col: 18, offset: 126520},
+					pos: position{line: 4151, col: 18, offset: 126477},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 18, offset: 126520},
+							pos:        position{line: 4151, col: 18, offset: 126477},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 23, offset: 126525},
+							pos:        position{line: 4151, col: 23, offset: 126482},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4151, col: 29, offset: 126531},
+							pos:        position{line: 4151, col: 29, offset: 126488},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 33, offset: 126535},
+							pos:        position{line: 4151, col: 33, offset: 126492},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 38, offset: 126540},
+							pos:        position{line: 4151, col: 38, offset: 126497},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4151, col: 44, offset: 126546},
+							pos:        position{line: 4151, col: 44, offset: 126503},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 48, offset: 126550},
+							pos:        position{line: 4151, col: 48, offset: 126507},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 53, offset: 126555},
+							pos:        position{line: 4151, col: 53, offset: 126512},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 58, offset: 126560},
+							pos:        position{line: 4151, col: 58, offset: 126517},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 63, offset: 126565},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4151, col: 69, offset: 126571},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4151, col: 73, offset: 126575},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4151, col: 78, offset: 126580},
+							pos:        position{line: 4151, col: 63, offset: 126522},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4151, col: 84, offset: 126586},
+							pos:        position{line: 4151, col: 69, offset: 126528},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 88, offset: 126590},
+							pos:        position{line: 4151, col: 73, offset: 126532},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 93, offset: 126595},
+							pos:        position{line: 4151, col: 78, offset: 126537},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4151, col: 99, offset: 126601},
+							pos:        position{line: 4151, col: 84, offset: 126543},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 103, offset: 126605},
+							pos:        position{line: 4151, col: 88, offset: 126547},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4151, col: 108, offset: 126610},
+							pos:        position{line: 4151, col: 93, offset: 126552},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4151, col: 99, offset: 126558},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4151, col: 103, offset: 126562},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4151, col: 108, offset: 126567},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10010,15 +10010,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4155, col: 1, offset: 126652},
+			pos:  position{line: 4155, col: 1, offset: 126609},
 			expr: &actionExpr{
-				pos: position{line: 4155, col: 22, offset: 126673},
+				pos: position{line: 4155, col: 22, offset: 126630},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4155, col: 22, offset: 126673},
+					pos:   position{line: 4155, col: 22, offset: 126630},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4155, col: 32, offset: 126683},
+						pos:  position{line: 4155, col: 32, offset: 126640},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10026,15 +10026,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4165, col: 1, offset: 127091},
+			pos:  position{line: 4165, col: 1, offset: 127048},
 			expr: &actionExpr{
-				pos: position{line: 4165, col: 14, offset: 127104},
+				pos: position{line: 4165, col: 14, offset: 127061},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4165, col: 14, offset: 127104},
+					pos: position{line: 4165, col: 14, offset: 127061},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4165, col: 14, offset: 127104},
+							pos:        position{line: 4165, col: 14, offset: 127061},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10042,9 +10042,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4165, col: 27, offset: 127117},
+							pos: position{line: 4165, col: 27, offset: 127074},
 							expr: &charClassMatcher{
-								pos:        position{line: 4165, col: 27, offset: 127117},
+								pos:        position{line: 4165, col: 27, offset: 127074},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10058,15 +10058,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4169, col: 1, offset: 127170},
+			pos:  position{line: 4169, col: 1, offset: 127127},
 			expr: &actionExpr{
-				pos: position{line: 4169, col: 24, offset: 127193},
+				pos: position{line: 4169, col: 24, offset: 127150},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4169, col: 24, offset: 127193},
+					pos: position{line: 4169, col: 24, offset: 127150},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4169, col: 24, offset: 127193},
+							pos:        position{line: 4169, col: 24, offset: 127150},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10074,9 +10074,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4169, col: 39, offset: 127208},
+							pos: position{line: 4169, col: 39, offset: 127165},
 							expr: &charClassMatcher{
-								pos:        position{line: 4169, col: 39, offset: 127208},
+								pos:        position{line: 4169, col: 39, offset: 127165},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10090,22 +10090,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4173, col: 1, offset: 127261},
+			pos:  position{line: 4173, col: 1, offset: 127218},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 11, offset: 127271},
+				pos: position{line: 4173, col: 11, offset: 127228},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4173, col: 11, offset: 127271},
+					pos:   position{line: 4173, col: 11, offset: 127228},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4173, col: 16, offset: 127276},
+						pos: position{line: 4173, col: 16, offset: 127233},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4173, col: 16, offset: 127276},
+								pos:  position{line: 4173, col: 16, offset: 127233},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4173, col: 31, offset: 127291},
+								pos:  position{line: 4173, col: 31, offset: 127248},
 								name: "UnquotedString",
 							},
 						},
@@ -10115,23 +10115,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4177, col: 1, offset: 127332},
+			pos:  position{line: 4177, col: 1, offset: 127289},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 17, offset: 127348},
+				pos: position{line: 4177, col: 17, offset: 127305},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4177, col: 17, offset: 127348},
+					pos: position{line: 4177, col: 17, offset: 127305},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4177, col: 17, offset: 127348},
+							pos:        position{line: 4177, col: 17, offset: 127305},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4177, col: 21, offset: 127352},
+							pos: position{line: 4177, col: 21, offset: 127309},
 							expr: &charClassMatcher{
-								pos:        position{line: 4177, col: 21, offset: 127352},
+								pos:        position{line: 4177, col: 21, offset: 127309},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10139,7 +10139,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4177, col: 27, offset: 127358},
+							pos:        position{line: 4177, col: 27, offset: 127315},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10150,48 +10150,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4182, col: 1, offset: 127469},
+			pos:  position{line: 4182, col: 1, offset: 127426},
 			expr: &actionExpr{
-				pos: position{line: 4182, col: 19, offset: 127487},
+				pos: position{line: 4182, col: 19, offset: 127444},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4182, col: 19, offset: 127487},
+					pos: position{line: 4182, col: 19, offset: 127444},
 					expr: &choiceExpr{
-						pos: position{line: 4182, col: 20, offset: 127488},
+						pos: position{line: 4182, col: 20, offset: 127445},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4182, col: 20, offset: 127488},
+								pos:        position{line: 4182, col: 20, offset: 127445},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4182, col: 27, offset: 127495},
+								pos: position{line: 4182, col: 27, offset: 127452},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4182, col: 27, offset: 127495},
+										pos: position{line: 4182, col: 27, offset: 127452},
 										expr: &choiceExpr{
-											pos: position{line: 4182, col: 29, offset: 127497},
+											pos: position{line: 4182, col: 29, offset: 127454},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4182, col: 29, offset: 127497},
+													pos:  position{line: 4182, col: 29, offset: 127454},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4182, col: 43, offset: 127511},
+													pos:        position{line: 4182, col: 43, offset: 127468},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4182, col: 49, offset: 127517},
+													pos:  position{line: 4182, col: 49, offset: 127474},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4182, col: 54, offset: 127522,
+										line: 4182, col: 54, offset: 127479,
 									},
 								},
 							},
@@ -10202,12 +10202,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4189, col: 1, offset: 127637},
+			pos:  position{line: 4189, col: 1, offset: 127594},
 			expr: &choiceExpr{
-				pos: position{line: 4189, col: 16, offset: 127652},
+				pos: position{line: 4189, col: 16, offset: 127609},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4189, col: 16, offset: 127652},
+						pos:        position{line: 4189, col: 16, offset: 127609},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10215,18 +10215,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4189, col: 37, offset: 127673},
+						pos: position{line: 4189, col: 37, offset: 127630},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4189, col: 37, offset: 127673},
+								pos:        position{line: 4189, col: 37, offset: 127630},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4189, col: 41, offset: 127677},
+								pos: position{line: 4189, col: 41, offset: 127634},
 								expr: &charClassMatcher{
-									pos:        position{line: 4189, col: 41, offset: 127677},
+									pos:        position{line: 4189, col: 41, offset: 127634},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10234,7 +10234,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4189, col: 48, offset: 127684},
+								pos:        position{line: 4189, col: 48, offset: 127641},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10246,46 +10246,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4191, col: 1, offset: 127690},
+			pos:  position{line: 4191, col: 1, offset: 127647},
 			expr: &actionExpr{
-				pos: position{line: 4191, col: 39, offset: 127728},
+				pos: position{line: 4191, col: 39, offset: 127685},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4191, col: 39, offset: 127728},
+					pos: position{line: 4191, col: 39, offset: 127685},
 					expr: &choiceExpr{
-						pos: position{line: 4191, col: 40, offset: 127729},
+						pos: position{line: 4191, col: 40, offset: 127686},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4191, col: 40, offset: 127729},
+								pos:  position{line: 4191, col: 40, offset: 127686},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4191, col: 54, offset: 127743},
+								pos: position{line: 4191, col: 54, offset: 127700},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4191, col: 54, offset: 127743},
+										pos: position{line: 4191, col: 54, offset: 127700},
 										expr: &choiceExpr{
-											pos: position{line: 4191, col: 56, offset: 127745},
+											pos: position{line: 4191, col: 56, offset: 127702},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4191, col: 56, offset: 127745},
+													pos:  position{line: 4191, col: 56, offset: 127702},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4191, col: 70, offset: 127759},
+													pos:        position{line: 4191, col: 70, offset: 127716},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4191, col: 76, offset: 127765},
+													pos:  position{line: 4191, col: 76, offset: 127722},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4191, col: 81, offset: 127770,
+										line: 4191, col: 81, offset: 127727,
 									},
 								},
 							},
@@ -10296,21 +10296,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4195, col: 1, offset: 127810},
+			pos:  position{line: 4195, col: 1, offset: 127767},
 			expr: &actionExpr{
-				pos: position{line: 4195, col: 12, offset: 127821},
+				pos: position{line: 4195, col: 12, offset: 127778},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4195, col: 13, offset: 127822},
+					pos: position{line: 4195, col: 13, offset: 127779},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4195, col: 13, offset: 127822},
+							pos:        position{line: 4195, col: 13, offset: 127779},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4195, col: 22, offset: 127831},
+							pos:        position{line: 4195, col: 22, offset: 127788},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10321,14 +10321,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4201, col: 1, offset: 127985},
+			pos:  position{line: 4201, col: 1, offset: 127942},
 			expr: &actionExpr{
-				pos: position{line: 4201, col: 18, offset: 128002},
+				pos: position{line: 4201, col: 18, offset: 127959},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4201, col: 18, offset: 128002},
+					pos: position{line: 4201, col: 18, offset: 127959},
 					expr: &charClassMatcher{
-						pos:        position{line: 4201, col: 18, offset: 128002},
+						pos:        position{line: 4201, col: 18, offset: 127959},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10340,15 +10340,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4205, col: 1, offset: 128053},
+			pos:  position{line: 4205, col: 1, offset: 128010},
 			expr: &actionExpr{
-				pos: position{line: 4205, col: 11, offset: 128063},
+				pos: position{line: 4205, col: 11, offset: 128020},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4205, col: 11, offset: 128063},
+					pos:   position{line: 4205, col: 11, offset: 128020},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4205, col: 18, offset: 128070},
+						pos:  position{line: 4205, col: 18, offset: 128027},
 						name: "NumberAsString",
 					},
 				},
@@ -10356,59 +10356,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4211, col: 1, offset: 128259},
+			pos:  position{line: 4211, col: 1, offset: 128216},
 			expr: &actionExpr{
-				pos: position{line: 4211, col: 19, offset: 128277},
+				pos: position{line: 4211, col: 19, offset: 128234},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4211, col: 19, offset: 128277},
+					pos: position{line: 4211, col: 19, offset: 128234},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4211, col: 19, offset: 128277},
+							pos:   position{line: 4211, col: 19, offset: 128234},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4211, col: 27, offset: 128285},
+								pos: position{line: 4211, col: 27, offset: 128242},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4211, col: 27, offset: 128285},
+										pos:  position{line: 4211, col: 27, offset: 128242},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4211, col: 43, offset: 128301},
+										pos:  position{line: 4211, col: 43, offset: 128258},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4211, col: 60, offset: 128318},
+							pos: position{line: 4211, col: 60, offset: 128275},
 							expr: &choiceExpr{
-								pos: position{line: 4211, col: 62, offset: 128320},
+								pos: position{line: 4211, col: 62, offset: 128277},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4211, col: 62, offset: 128320},
+										pos:  position{line: 4211, col: 62, offset: 128277},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4211, col: 70, offset: 128328},
+										pos:        position{line: 4211, col: 70, offset: 128285},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4211, col: 76, offset: 128334},
+										pos:        position{line: 4211, col: 76, offset: 128291},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4211, col: 82, offset: 128340},
+										pos:        position{line: 4211, col: 82, offset: 128297},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4211, col: 88, offset: 128346},
+										pos:  position{line: 4211, col: 88, offset: 128303},
 										name: "EOF",
 									},
 								},
@@ -10420,17 +10420,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4217, col: 1, offset: 128475},
+			pos:  position{line: 4217, col: 1, offset: 128432},
 			expr: &actionExpr{
-				pos: position{line: 4217, col: 18, offset: 128492},
+				pos: position{line: 4217, col: 18, offset: 128449},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4217, col: 18, offset: 128492},
+					pos: position{line: 4217, col: 18, offset: 128449},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4217, col: 18, offset: 128492},
+							pos: position{line: 4217, col: 18, offset: 128449},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 18, offset: 128492},
+								pos:        position{line: 4217, col: 18, offset: 128449},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10438,9 +10438,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4217, col: 24, offset: 128498},
+							pos: position{line: 4217, col: 24, offset: 128455},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 24, offset: 128498},
+								pos:        position{line: 4217, col: 24, offset: 128455},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10448,15 +10448,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4217, col: 31, offset: 128505},
+							pos:        position{line: 4217, col: 31, offset: 128462},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4217, col: 35, offset: 128509},
+							pos: position{line: 4217, col: 35, offset: 128466},
 							expr: &charClassMatcher{
-								pos:        position{line: 4217, col: 35, offset: 128509},
+								pos:        position{line: 4217, col: 35, offset: 128466},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10469,17 +10469,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4222, col: 1, offset: 128604},
+			pos:  position{line: 4222, col: 1, offset: 128561},
 			expr: &actionExpr{
-				pos: position{line: 4222, col: 20, offset: 128623},
+				pos: position{line: 4222, col: 20, offset: 128580},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4222, col: 20, offset: 128623},
+					pos: position{line: 4222, col: 20, offset: 128580},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4222, col: 20, offset: 128623},
+							pos: position{line: 4222, col: 20, offset: 128580},
 							expr: &charClassMatcher{
-								pos:        position{line: 4222, col: 20, offset: 128623},
+								pos:        position{line: 4222, col: 20, offset: 128580},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10487,9 +10487,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4222, col: 26, offset: 128629},
+							pos: position{line: 4222, col: 26, offset: 128586},
 							expr: &charClassMatcher{
-								pos:        position{line: 4222, col: 26, offset: 128629},
+								pos:        position{line: 4222, col: 26, offset: 128586},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10502,14 +10502,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4226, col: 1, offset: 128672},
+			pos:  position{line: 4226, col: 1, offset: 128629},
 			expr: &actionExpr{
-				pos: position{line: 4226, col: 28, offset: 128699},
+				pos: position{line: 4226, col: 28, offset: 128656},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4226, col: 28, offset: 128699},
+					pos: position{line: 4226, col: 28, offset: 128656},
 					expr: &charClassMatcher{
-						pos:        position{line: 4226, col: 28, offset: 128699},
+						pos:        position{line: 4226, col: 28, offset: 128656},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10520,15 +10520,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4230, col: 1, offset: 128742},
+			pos:  position{line: 4230, col: 1, offset: 128699},
 			expr: &actionExpr{
-				pos: position{line: 4230, col: 20, offset: 128761},
+				pos: position{line: 4230, col: 20, offset: 128718},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4230, col: 20, offset: 128761},
+					pos:   position{line: 4230, col: 20, offset: 128718},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4230, col: 27, offset: 128768},
+						pos:  position{line: 4230, col: 27, offset: 128725},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10536,31 +10536,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4238, col: 1, offset: 129015},
+			pos:  position{line: 4238, col: 1, offset: 128972},
 			expr: &actionExpr{
-				pos: position{line: 4238, col: 21, offset: 129035},
+				pos: position{line: 4238, col: 21, offset: 128992},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4238, col: 21, offset: 129035},
+					pos: position{line: 4238, col: 21, offset: 128992},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4238, col: 21, offset: 129035},
+							pos:  position{line: 4238, col: 21, offset: 128992},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4238, col: 36, offset: 129050},
+							pos:   position{line: 4238, col: 36, offset: 129007},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4238, col: 40, offset: 129054},
+								pos: position{line: 4238, col: 40, offset: 129011},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4238, col: 40, offset: 129054},
+										pos:        position{line: 4238, col: 40, offset: 129011},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4238, col: 46, offset: 129060},
+										pos:        position{line: 4238, col: 46, offset: 129017},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10569,7 +10569,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4238, col: 52, offset: 129066},
+							pos:  position{line: 4238, col: 52, offset: 129023},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10578,43 +10578,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4246, col: 1, offset: 129247},
+			pos:  position{line: 4246, col: 1, offset: 129204},
 			expr: &actionExpr{
-				pos: position{line: 4246, col: 23, offset: 129269},
+				pos: position{line: 4246, col: 23, offset: 129226},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4246, col: 23, offset: 129269},
+					pos: position{line: 4246, col: 23, offset: 129226},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4246, col: 23, offset: 129269},
+							pos:  position{line: 4246, col: 23, offset: 129226},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4246, col: 38, offset: 129284},
+							pos:   position{line: 4246, col: 38, offset: 129241},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4246, col: 42, offset: 129288},
+								pos: position{line: 4246, col: 42, offset: 129245},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4246, col: 42, offset: 129288},
+										pos:        position{line: 4246, col: 42, offset: 129245},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4246, col: 49, offset: 129295},
+										pos:        position{line: 4246, col: 49, offset: 129252},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4246, col: 55, offset: 129301},
+										pos:        position{line: 4246, col: 55, offset: 129258},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4246, col: 62, offset: 129308},
+										pos:        position{line: 4246, col: 62, offset: 129265},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10623,7 +10623,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4246, col: 67, offset: 129313},
+							pos:  position{line: 4246, col: 67, offset: 129270},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10632,30 +10632,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4254, col: 1, offset: 129496},
+			pos:  position{line: 4254, col: 1, offset: 129453},
 			expr: &choiceExpr{
-				pos: position{line: 4254, col: 25, offset: 129520},
+				pos: position{line: 4254, col: 25, offset: 129477},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4254, col: 25, offset: 129520},
+						pos: position{line: 4254, col: 25, offset: 129477},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4254, col: 25, offset: 129520},
+							pos:   position{line: 4254, col: 25, offset: 129477},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4254, col: 28, offset: 129523},
+								pos:  position{line: 4254, col: 28, offset: 129480},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4257, col: 3, offset: 129565},
+						pos: position{line: 4257, col: 3, offset: 129522},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4257, col: 3, offset: 129565},
+							pos:   position{line: 4257, col: 3, offset: 129522},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4257, col: 6, offset: 129568},
+								pos:  position{line: 4257, col: 6, offset: 129525},
 								name: "InequalityOperator",
 							},
 						},
@@ -10665,25 +10665,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4261, col: 1, offset: 129611},
+			pos:  position{line: 4261, col: 1, offset: 129568},
 			expr: &actionExpr{
-				pos: position{line: 4261, col: 11, offset: 129621},
+				pos: position{line: 4261, col: 11, offset: 129578},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4261, col: 11, offset: 129621},
+					pos: position{line: 4261, col: 11, offset: 129578},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4261, col: 11, offset: 129621},
+							pos:  position{line: 4261, col: 11, offset: 129578},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4261, col: 26, offset: 129636},
+							pos:        position{line: 4261, col: 26, offset: 129593},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4261, col: 30, offset: 129640},
+							pos:  position{line: 4261, col: 30, offset: 129597},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10692,25 +10692,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4265, col: 1, offset: 129680},
+			pos:  position{line: 4265, col: 1, offset: 129637},
 			expr: &actionExpr{
-				pos: position{line: 4265, col: 12, offset: 129691},
+				pos: position{line: 4265, col: 12, offset: 129648},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4265, col: 12, offset: 129691},
+					pos: position{line: 4265, col: 12, offset: 129648},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4265, col: 12, offset: 129691},
+							pos:  position{line: 4265, col: 12, offset: 129648},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4265, col: 27, offset: 129706},
+							pos:        position{line: 4265, col: 27, offset: 129663},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4265, col: 31, offset: 129710},
+							pos:  position{line: 4265, col: 31, offset: 129667},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10719,25 +10719,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4269, col: 1, offset: 129750},
+			pos:  position{line: 4269, col: 1, offset: 129707},
 			expr: &actionExpr{
-				pos: position{line: 4269, col: 10, offset: 129759},
+				pos: position{line: 4269, col: 10, offset: 129716},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4269, col: 10, offset: 129759},
+					pos: position{line: 4269, col: 10, offset: 129716},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4269, col: 10, offset: 129759},
+							pos:  position{line: 4269, col: 10, offset: 129716},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4269, col: 25, offset: 129774},
+							pos:        position{line: 4269, col: 25, offset: 129731},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4269, col: 29, offset: 129778},
+							pos:  position{line: 4269, col: 29, offset: 129735},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10746,25 +10746,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4273, col: 1, offset: 129818},
+			pos:  position{line: 4273, col: 1, offset: 129775},
 			expr: &actionExpr{
-				pos: position{line: 4273, col: 10, offset: 129827},
+				pos: position{line: 4273, col: 10, offset: 129784},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4273, col: 10, offset: 129827},
+					pos: position{line: 4273, col: 10, offset: 129784},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4273, col: 10, offset: 129827},
+							pos:  position{line: 4273, col: 10, offset: 129784},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 25, offset: 129842},
+							pos:        position{line: 4273, col: 25, offset: 129799},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4273, col: 29, offset: 129846},
+							pos:  position{line: 4273, col: 29, offset: 129803},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10773,25 +10773,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4277, col: 1, offset: 129886},
+			pos:  position{line: 4277, col: 1, offset: 129843},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 10, offset: 129895},
+				pos: position{line: 4277, col: 10, offset: 129852},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4277, col: 10, offset: 129895},
+					pos: position{line: 4277, col: 10, offset: 129852},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 10, offset: 129895},
+							pos:  position{line: 4277, col: 10, offset: 129852},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 25, offset: 129910},
+							pos:        position{line: 4277, col: 25, offset: 129867},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 29, offset: 129914},
+							pos:  position{line: 4277, col: 29, offset: 129871},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10800,39 +10800,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4282, col: 1, offset: 129978},
+			pos:  position{line: 4282, col: 1, offset: 129935},
 			expr: &actionExpr{
-				pos: position{line: 4282, col: 11, offset: 129988},
+				pos: position{line: 4282, col: 11, offset: 129945},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4282, col: 12, offset: 129989},
+					pos: position{line: 4282, col: 12, offset: 129946},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4282, col: 12, offset: 129989},
+							pos:        position{line: 4282, col: 12, offset: 129946},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 24, offset: 130001},
+							pos:        position{line: 4282, col: 24, offset: 129958},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 35, offset: 130012},
+							pos:        position{line: 4282, col: 35, offset: 129969},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 44, offset: 130021},
+							pos:        position{line: 4282, col: 44, offset: 129978},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 52, offset: 130029},
+							pos:        position{line: 4282, col: 52, offset: 129986},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10843,39 +10843,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4286, col: 1, offset: 130070},
+			pos:  position{line: 4286, col: 1, offset: 130027},
 			expr: &actionExpr{
-				pos: position{line: 4286, col: 11, offset: 130080},
+				pos: position{line: 4286, col: 11, offset: 130037},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4286, col: 12, offset: 130081},
+					pos: position{line: 4286, col: 12, offset: 130038},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4286, col: 12, offset: 130081},
+							pos:        position{line: 4286, col: 12, offset: 130038},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4286, col: 24, offset: 130093},
+							pos:        position{line: 4286, col: 24, offset: 130050},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4286, col: 35, offset: 130104},
+							pos:        position{line: 4286, col: 35, offset: 130061},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4286, col: 44, offset: 130113},
+							pos:        position{line: 4286, col: 44, offset: 130070},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4286, col: 52, offset: 130121},
+							pos:        position{line: 4286, col: 52, offset: 130078},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -10886,39 +10886,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4290, col: 1, offset: 130162},
+			pos:  position{line: 4290, col: 1, offset: 130119},
 			expr: &actionExpr{
-				pos: position{line: 4290, col: 9, offset: 130170},
+				pos: position{line: 4290, col: 9, offset: 130127},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4290, col: 10, offset: 130171},
+					pos: position{line: 4290, col: 10, offset: 130128},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4290, col: 10, offset: 130171},
+							pos:        position{line: 4290, col: 10, offset: 130128},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4290, col: 20, offset: 130181},
+							pos:        position{line: 4290, col: 20, offset: 130138},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4290, col: 29, offset: 130190},
+							pos:        position{line: 4290, col: 29, offset: 130147},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4290, col: 37, offset: 130198},
+							pos:        position{line: 4290, col: 37, offset: 130155},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4290, col: 44, offset: 130205},
+							pos:        position{line: 4290, col: 44, offset: 130162},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -10929,27 +10929,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4294, col: 1, offset: 130244},
+			pos:  position{line: 4294, col: 1, offset: 130201},
 			expr: &actionExpr{
-				pos: position{line: 4294, col: 8, offset: 130251},
+				pos: position{line: 4294, col: 8, offset: 130208},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4294, col: 9, offset: 130252},
+					pos: position{line: 4294, col: 9, offset: 130209},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4294, col: 9, offset: 130252},
+							pos:        position{line: 4294, col: 9, offset: 130209},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4294, col: 18, offset: 130261},
+							pos:        position{line: 4294, col: 18, offset: 130218},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4294, col: 26, offset: 130269},
+							pos:        position{line: 4294, col: 26, offset: 130226},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -10960,27 +10960,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4298, col: 1, offset: 130307},
+			pos:  position{line: 4298, col: 1, offset: 130264},
 			expr: &actionExpr{
-				pos: position{line: 4298, col: 9, offset: 130315},
+				pos: position{line: 4298, col: 9, offset: 130272},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4298, col: 10, offset: 130316},
+					pos: position{line: 4298, col: 10, offset: 130273},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4298, col: 10, offset: 130316},
+							pos:        position{line: 4298, col: 10, offset: 130273},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4298, col: 20, offset: 130326},
+							pos:        position{line: 4298, col: 20, offset: 130283},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4298, col: 29, offset: 130335},
+							pos:        position{line: 4298, col: 29, offset: 130292},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -10991,27 +10991,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4302, col: 1, offset: 130374},
+			pos:  position{line: 4302, col: 1, offset: 130331},
 			expr: &actionExpr{
-				pos: position{line: 4302, col: 10, offset: 130383},
+				pos: position{line: 4302, col: 10, offset: 130340},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4302, col: 11, offset: 130384},
+					pos: position{line: 4302, col: 11, offset: 130341},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4302, col: 11, offset: 130384},
+							pos:        position{line: 4302, col: 11, offset: 130341},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4302, col: 22, offset: 130395},
+							pos:        position{line: 4302, col: 22, offset: 130352},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4302, col: 32, offset: 130405},
+							pos:        position{line: 4302, col: 32, offset: 130362},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11022,39 +11022,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4306, col: 1, offset: 130447},
+			pos:  position{line: 4306, col: 1, offset: 130404},
 			expr: &actionExpr{
-				pos: position{line: 4306, col: 12, offset: 130458},
+				pos: position{line: 4306, col: 12, offset: 130415},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4306, col: 13, offset: 130459},
+					pos: position{line: 4306, col: 13, offset: 130416},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4306, col: 13, offset: 130459},
+							pos:        position{line: 4306, col: 13, offset: 130416},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4306, col: 26, offset: 130472},
+							pos:        position{line: 4306, col: 26, offset: 130429},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4306, col: 38, offset: 130484},
+							pos:        position{line: 4306, col: 38, offset: 130441},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4306, col: 47, offset: 130493},
+							pos:        position{line: 4306, col: 47, offset: 130450},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4306, col: 55, offset: 130501},
+							pos:        position{line: 4306, col: 55, offset: 130458},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11065,39 +11065,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4310, col: 1, offset: 130543},
+			pos:  position{line: 4310, col: 1, offset: 130500},
 			expr: &actionExpr{
-				pos: position{line: 4310, col: 9, offset: 130551},
+				pos: position{line: 4310, col: 9, offset: 130508},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4310, col: 10, offset: 130552},
+					pos: position{line: 4310, col: 10, offset: 130509},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4310, col: 10, offset: 130552},
+							pos:        position{line: 4310, col: 10, offset: 130509},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 20, offset: 130562},
+							pos:        position{line: 4310, col: 20, offset: 130519},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 29, offset: 130571},
+							pos:        position{line: 4310, col: 29, offset: 130528},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 37, offset: 130579},
+							pos:        position{line: 4310, col: 37, offset: 130536},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 44, offset: 130586},
+							pos:        position{line: 4310, col: 44, offset: 130543},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11108,33 +11108,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4315, col: 1, offset: 130717},
+			pos:  position{line: 4315, col: 1, offset: 130674},
 			expr: &actionExpr{
-				pos: position{line: 4315, col: 15, offset: 130731},
+				pos: position{line: 4315, col: 15, offset: 130688},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4315, col: 16, offset: 130732},
+					pos: position{line: 4315, col: 16, offset: 130689},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4315, col: 16, offset: 130732},
+							pos:        position{line: 4315, col: 16, offset: 130689},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4315, col: 23, offset: 130739},
+							pos:        position{line: 4315, col: 23, offset: 130696},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4315, col: 30, offset: 130746},
+							pos:        position{line: 4315, col: 30, offset: 130703},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4315, col: 37, offset: 130753},
+							pos:        position{line: 4315, col: 37, offset: 130710},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11145,26 +11145,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4324, col: 1, offset: 130976},
+			pos:  position{line: 4324, col: 1, offset: 130933},
 			expr: &actionExpr{
-				pos: position{line: 4324, col: 21, offset: 130996},
+				pos: position{line: 4324, col: 21, offset: 130953},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4324, col: 21, offset: 130996},
+					pos: position{line: 4324, col: 21, offset: 130953},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4324, col: 21, offset: 130996},
+							pos:  position{line: 4324, col: 21, offset: 130953},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4324, col: 26, offset: 131001},
+							pos:  position{line: 4324, col: 26, offset: 130958},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4324, col: 42, offset: 131017},
+							pos:   position{line: 4324, col: 42, offset: 130974},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4324, col: 53, offset: 131028},
+								pos:  position{line: 4324, col: 53, offset: 130985},
 								name: "TransactionOptions",
 							},
 						},
@@ -11174,17 +11174,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4333, col: 1, offset: 131334},
+			pos:  position{line: 4333, col: 1, offset: 131291},
 			expr: &actionExpr{
-				pos: position{line: 4333, col: 23, offset: 131356},
+				pos: position{line: 4333, col: 23, offset: 131313},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4333, col: 23, offset: 131356},
+					pos:   position{line: 4333, col: 23, offset: 131313},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4333, col: 34, offset: 131367},
+						pos: position{line: 4333, col: 34, offset: 131324},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4333, col: 34, offset: 131367},
+							pos:  position{line: 4333, col: 34, offset: 131324},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11193,35 +11193,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4348, col: 1, offset: 131758},
+			pos:  position{line: 4348, col: 1, offset: 131715},
 			expr: &actionExpr{
-				pos: position{line: 4348, col: 37, offset: 131794},
+				pos: position{line: 4348, col: 37, offset: 131751},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4348, col: 37, offset: 131794},
+					pos: position{line: 4348, col: 37, offset: 131751},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4348, col: 37, offset: 131794},
+							pos:   position{line: 4348, col: 37, offset: 131751},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4348, col: 43, offset: 131800},
+								pos:  position{line: 4348, col: 43, offset: 131757},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4348, col: 71, offset: 131828},
+							pos:   position{line: 4348, col: 71, offset: 131785},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4348, col: 76, offset: 131833},
+								pos: position{line: 4348, col: 76, offset: 131790},
 								expr: &seqExpr{
-									pos: position{line: 4348, col: 77, offset: 131834},
+									pos: position{line: 4348, col: 77, offset: 131791},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4348, col: 77, offset: 131834},
+											pos:  position{line: 4348, col: 77, offset: 131791},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4348, col: 83, offset: 131840},
+											pos:  position{line: 4348, col: 83, offset: 131797},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11234,26 +11234,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4383, col: 1, offset: 132829},
+			pos:  position{line: 4383, col: 1, offset: 132786},
 			expr: &actionExpr{
-				pos: position{line: 4383, col: 32, offset: 132860},
+				pos: position{line: 4383, col: 32, offset: 132817},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4383, col: 32, offset: 132860},
+					pos:   position{line: 4383, col: 32, offset: 132817},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4383, col: 40, offset: 132868},
+						pos: position{line: 4383, col: 40, offset: 132825},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4383, col: 40, offset: 132868},
+								pos:  position{line: 4383, col: 40, offset: 132825},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4383, col: 77, offset: 132905},
+								pos:  position{line: 4383, col: 77, offset: 132862},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4383, col: 96, offset: 132924},
+								pos:  position{line: 4383, col: 96, offset: 132881},
 								name: "EndsWithOption",
 							},
 						},
@@ -11263,15 +11263,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4387, col: 1, offset: 132968},
+			pos:  position{line: 4387, col: 1, offset: 132925},
 			expr: &actionExpr{
-				pos: position{line: 4387, col: 39, offset: 133006},
+				pos: position{line: 4387, col: 39, offset: 132963},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4387, col: 39, offset: 133006},
+					pos:   position{line: 4387, col: 39, offset: 132963},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4387, col: 46, offset: 133013},
+						pos:  position{line: 4387, col: 46, offset: 132970},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11279,28 +11279,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4398, col: 1, offset: 133229},
+			pos:  position{line: 4398, col: 1, offset: 133186},
 			expr: &actionExpr{
-				pos: position{line: 4398, col: 21, offset: 133249},
+				pos: position{line: 4398, col: 21, offset: 133206},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4398, col: 21, offset: 133249},
+					pos: position{line: 4398, col: 21, offset: 133206},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4398, col: 21, offset: 133249},
+							pos:        position{line: 4398, col: 21, offset: 133206},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4398, col: 34, offset: 133262},
+							pos:  position{line: 4398, col: 34, offset: 133219},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4398, col: 40, offset: 133268},
+							pos:   position{line: 4398, col: 40, offset: 133225},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4398, col: 48, offset: 133276},
+								pos:  position{line: 4398, col: 48, offset: 133233},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11310,28 +11310,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4408, col: 1, offset: 133514},
+			pos:  position{line: 4408, col: 1, offset: 133471},
 			expr: &actionExpr{
-				pos: position{line: 4408, col: 19, offset: 133532},
+				pos: position{line: 4408, col: 19, offset: 133489},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4408, col: 19, offset: 133532},
+					pos: position{line: 4408, col: 19, offset: 133489},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4408, col: 19, offset: 133532},
+							pos:        position{line: 4408, col: 19, offset: 133489},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4408, col: 30, offset: 133543},
+							pos:  position{line: 4408, col: 30, offset: 133500},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4408, col: 36, offset: 133549},
+							pos:   position{line: 4408, col: 36, offset: 133506},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4408, col: 44, offset: 133557},
+								pos:  position{line: 4408, col: 44, offset: 133514},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11341,26 +11341,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4419, col: 1, offset: 133826},
+			pos:  position{line: 4419, col: 1, offset: 133783},
 			expr: &actionExpr{
-				pos: position{line: 4419, col: 28, offset: 133853},
+				pos: position{line: 4419, col: 28, offset: 133810},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4419, col: 28, offset: 133853},
+					pos:   position{line: 4419, col: 28, offset: 133810},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4419, col: 37, offset: 133862},
+						pos: position{line: 4419, col: 37, offset: 133819},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4419, col: 37, offset: 133862},
+								pos:  position{line: 4419, col: 37, offset: 133819},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4419, col: 63, offset: 133888},
+								pos:  position{line: 4419, col: 63, offset: 133845},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4419, col: 81, offset: 133906},
+								pos:  position{line: 4419, col: 81, offset: 133863},
 								name: "TransactionSearch",
 							},
 						},
@@ -11370,22 +11370,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4423, col: 1, offset: 133954},
+			pos:  position{line: 4423, col: 1, offset: 133911},
 			expr: &actionExpr{
-				pos: position{line: 4423, col: 28, offset: 133981},
+				pos: position{line: 4423, col: 28, offset: 133938},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4423, col: 28, offset: 133981},
+					pos:   position{line: 4423, col: 28, offset: 133938},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4423, col: 33, offset: 133986},
+						pos: position{line: 4423, col: 33, offset: 133943},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4423, col: 33, offset: 133986},
+								pos:  position{line: 4423, col: 33, offset: 133943},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4423, col: 64, offset: 134017},
+								pos:  position{line: 4423, col: 64, offset: 133974},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11395,29 +11395,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4427, col: 1, offset: 134077},
+			pos:  position{line: 4427, col: 1, offset: 134034},
 			expr: &actionExpr{
-				pos: position{line: 4427, col: 38, offset: 134114},
+				pos: position{line: 4427, col: 38, offset: 134071},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4427, col: 38, offset: 134114},
+					pos: position{line: 4427, col: 38, offset: 134071},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4427, col: 38, offset: 134114},
+							pos:        position{line: 4427, col: 38, offset: 134071},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4427, col: 42, offset: 134118},
+							pos:   position{line: 4427, col: 42, offset: 134075},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4427, col: 55, offset: 134131},
+								pos:  position{line: 4427, col: 55, offset: 134088},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 68, offset: 134144},
+							pos:        position{line: 4427, col: 68, offset: 134101},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11428,23 +11428,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4435, col: 1, offset: 134283},
+			pos:  position{line: 4435, col: 1, offset: 134240},
 			expr: &actionExpr{
-				pos: position{line: 4435, col: 21, offset: 134303},
+				pos: position{line: 4435, col: 21, offset: 134260},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4435, col: 21, offset: 134303},
+					pos: position{line: 4435, col: 21, offset: 134260},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4435, col: 21, offset: 134303},
+							pos:        position{line: 4435, col: 21, offset: 134260},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4435, col: 25, offset: 134307},
+							pos: position{line: 4435, col: 25, offset: 134264},
 							expr: &charClassMatcher{
-								pos:        position{line: 4435, col: 25, offset: 134307},
+								pos:        position{line: 4435, col: 25, offset: 134264},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11452,7 +11452,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 44, offset: 134326},
+							pos:        position{line: 4435, col: 44, offset: 134283},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11463,15 +11463,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4440, col: 1, offset: 134437},
+			pos:  position{line: 4440, col: 1, offset: 134394},
 			expr: &actionExpr{
-				pos: position{line: 4440, col: 33, offset: 134469},
+				pos: position{line: 4440, col: 33, offset: 134426},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4440, col: 33, offset: 134469},
+					pos:   position{line: 4440, col: 33, offset: 134426},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4440, col: 37, offset: 134473},
+						pos:  position{line: 4440, col: 37, offset: 134430},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11479,15 +11479,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4448, col: 1, offset: 134628},
+			pos:  position{line: 4448, col: 1, offset: 134585},
 			expr: &actionExpr{
-				pos: position{line: 4448, col: 22, offset: 134649},
+				pos: position{line: 4448, col: 22, offset: 134606},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4448, col: 22, offset: 134649},
+					pos:   position{line: 4448, col: 22, offset: 134606},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4448, col: 27, offset: 134654},
+						pos:  position{line: 4448, col: 27, offset: 134611},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11495,37 +11495,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4458, col: 1, offset: 134826},
+			pos:  position{line: 4458, col: 1, offset: 134783},
 			expr: &actionExpr{
-				pos: position{line: 4458, col: 20, offset: 134845},
+				pos: position{line: 4458, col: 20, offset: 134802},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4458, col: 20, offset: 134845},
+					pos: position{line: 4458, col: 20, offset: 134802},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4458, col: 20, offset: 134845},
+							pos:        position{line: 4458, col: 20, offset: 134802},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4458, col: 27, offset: 134852},
+							pos:  position{line: 4458, col: 27, offset: 134809},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4458, col: 42, offset: 134867},
+							pos:  position{line: 4458, col: 42, offset: 134824},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4458, col: 50, offset: 134875},
+							pos:   position{line: 4458, col: 50, offset: 134832},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4458, col: 60, offset: 134885},
+								pos:  position{line: 4458, col: 60, offset: 134842},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4458, col: 69, offset: 134894},
+							pos:  position{line: 4458, col: 69, offset: 134851},
 							name: "R_PAREN",
 						},
 					},
@@ -11534,22 +11534,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4468, col: 1, offset: 135197},
+			pos:  position{line: 4468, col: 1, offset: 135154},
 			expr: &actionExpr{
-				pos: position{line: 4468, col: 20, offset: 135216},
+				pos: position{line: 4468, col: 20, offset: 135173},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4468, col: 20, offset: 135216},
+					pos: position{line: 4468, col: 20, offset: 135173},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 20, offset: 135216},
+							pos:  position{line: 4468, col: 20, offset: 135173},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4468, col: 25, offset: 135221},
+							pos:   position{line: 4468, col: 25, offset: 135178},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4468, col: 42, offset: 135238},
+								pos:  position{line: 4468, col: 42, offset: 135195},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11559,41 +11559,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4472, col: 1, offset: 135287},
+			pos:  position{line: 4472, col: 1, offset: 135244},
 			expr: &actionExpr{
-				pos: position{line: 4472, col: 16, offset: 135302},
+				pos: position{line: 4472, col: 16, offset: 135259},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4472, col: 16, offset: 135302},
+					pos: position{line: 4472, col: 16, offset: 135259},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4472, col: 16, offset: 135302},
+							pos:  position{line: 4472, col: 16, offset: 135259},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4472, col: 27, offset: 135313},
+							pos:  position{line: 4472, col: 27, offset: 135270},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4472, col: 33, offset: 135319},
+							pos:   position{line: 4472, col: 33, offset: 135276},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4472, col: 50, offset: 135336},
+								pos: position{line: 4472, col: 50, offset: 135293},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4472, col: 50, offset: 135336},
+									pos:  position{line: 4472, col: 50, offset: 135293},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4472, col: 70, offset: 135356},
+							pos:  position{line: 4472, col: 70, offset: 135313},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4472, col: 85, offset: 135371},
+							pos:   position{line: 4472, col: 85, offset: 135328},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4472, col: 91, offset: 135377},
+								pos:  position{line: 4472, col: 91, offset: 135334},
 								name: "FieldName",
 							},
 						},
@@ -11603,35 +11603,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4500, col: 1, offset: 136117},
+			pos:  position{line: 4500, col: 1, offset: 136074},
 			expr: &actionExpr{
-				pos: position{line: 4500, col: 23, offset: 136139},
+				pos: position{line: 4500, col: 23, offset: 136096},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4500, col: 23, offset: 136139},
+					pos: position{line: 4500, col: 23, offset: 136096},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4500, col: 23, offset: 136139},
+							pos:   position{line: 4500, col: 23, offset: 136096},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4500, col: 31, offset: 136147},
+								pos:  position{line: 4500, col: 31, offset: 136104},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4500, col: 46, offset: 136162},
+							pos:   position{line: 4500, col: 46, offset: 136119},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4500, col: 52, offset: 136168},
+								pos: position{line: 4500, col: 52, offset: 136125},
 								expr: &seqExpr{
-									pos: position{line: 4500, col: 53, offset: 136169},
+									pos: position{line: 4500, col: 53, offset: 136126},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4500, col: 53, offset: 136169},
+											pos:  position{line: 4500, col: 53, offset: 136126},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4500, col: 59, offset: 136175},
+											pos:  position{line: 4500, col: 59, offset: 136132},
 											name: "MVBlockOption",
 										},
 									},
@@ -11644,26 +11644,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4534, col: 1, offset: 137231},
+			pos:  position{line: 4534, col: 1, offset: 137188},
 			expr: &actionExpr{
-				pos: position{line: 4534, col: 18, offset: 137248},
+				pos: position{line: 4534, col: 18, offset: 137205},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4534, col: 18, offset: 137248},
+					pos:   position{line: 4534, col: 18, offset: 137205},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4534, col: 27, offset: 137257},
+						pos: position{line: 4534, col: 27, offset: 137214},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4534, col: 27, offset: 137257},
+								pos:  position{line: 4534, col: 27, offset: 137214},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4534, col: 41, offset: 137271},
+								pos:  position{line: 4534, col: 41, offset: 137228},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4534, col: 60, offset: 137290},
+								pos:  position{line: 4534, col: 60, offset: 137247},
 								name: "SetSvOption",
 							},
 						},
@@ -11673,22 +11673,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4538, col: 1, offset: 137331},
+			pos:  position{line: 4538, col: 1, offset: 137288},
 			expr: &actionExpr{
-				pos: position{line: 4538, col: 16, offset: 137346},
+				pos: position{line: 4538, col: 16, offset: 137303},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4538, col: 16, offset: 137346},
+					pos:   position{line: 4538, col: 16, offset: 137303},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4538, col: 28, offset: 137358},
+						pos: position{line: 4538, col: 28, offset: 137315},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4538, col: 28, offset: 137358},
+								pos:  position{line: 4538, col: 28, offset: 137315},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4538, col: 46, offset: 137376},
+								pos:  position{line: 4538, col: 46, offset: 137333},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11698,28 +11698,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4542, col: 1, offset: 137423},
+			pos:  position{line: 4542, col: 1, offset: 137380},
 			expr: &actionExpr{
-				pos: position{line: 4542, col: 20, offset: 137442},
+				pos: position{line: 4542, col: 20, offset: 137399},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4542, col: 20, offset: 137442},
+					pos: position{line: 4542, col: 20, offset: 137399},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4542, col: 20, offset: 137442},
+							pos:        position{line: 4542, col: 20, offset: 137399},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4542, col: 28, offset: 137450},
+							pos:  position{line: 4542, col: 28, offset: 137407},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4542, col: 34, offset: 137456},
+							pos:   position{line: 4542, col: 34, offset: 137413},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4542, col: 38, offset: 137460},
+								pos:  position{line: 4542, col: 38, offset: 137417},
 								name: "QuotedString",
 							},
 						},
@@ -11729,28 +11729,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4553, col: 1, offset: 137711},
+			pos:  position{line: 4553, col: 1, offset: 137668},
 			expr: &actionExpr{
-				pos: position{line: 4553, col: 19, offset: 137729},
+				pos: position{line: 4553, col: 19, offset: 137686},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4553, col: 19, offset: 137729},
+					pos: position{line: 4553, col: 19, offset: 137686},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4553, col: 19, offset: 137729},
+							pos:        position{line: 4553, col: 19, offset: 137686},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4553, col: 31, offset: 137741},
+							pos:  position{line: 4553, col: 31, offset: 137698},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4553, col: 37, offset: 137747},
+							pos:   position{line: 4553, col: 37, offset: 137704},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4553, col: 41, offset: 137751},
+								pos:  position{line: 4553, col: 41, offset: 137708},
 								name: "QuotedString",
 							},
 						},
@@ -11760,28 +11760,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4571, col: 1, offset: 138222},
+			pos:  position{line: 4571, col: 1, offset: 138179},
 			expr: &actionExpr{
-				pos: position{line: 4571, col: 21, offset: 138242},
+				pos: position{line: 4571, col: 21, offset: 138199},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4571, col: 21, offset: 138242},
+					pos: position{line: 4571, col: 21, offset: 138199},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4571, col: 21, offset: 138242},
+							pos:        position{line: 4571, col: 21, offset: 138199},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4571, col: 34, offset: 138255},
+							pos:  position{line: 4571, col: 34, offset: 138212},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4571, col: 40, offset: 138261},
+							pos:   position{line: 4571, col: 40, offset: 138218},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4571, col: 48, offset: 138269},
+								pos:  position{line: 4571, col: 48, offset: 138226},
 								name: "Boolean",
 							},
 						},
@@ -11791,28 +11791,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4583, col: 1, offset: 138509},
+			pos:  position{line: 4583, col: 1, offset: 138466},
 			expr: &actionExpr{
-				pos: position{line: 4583, col: 16, offset: 138524},
+				pos: position{line: 4583, col: 16, offset: 138481},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4583, col: 16, offset: 138524},
+					pos: position{line: 4583, col: 16, offset: 138481},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4583, col: 16, offset: 138524},
+							pos:        position{line: 4583, col: 16, offset: 138481},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4583, col: 24, offset: 138532},
+							pos:  position{line: 4583, col: 24, offset: 138489},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4583, col: 30, offset: 138538},
+							pos:   position{line: 4583, col: 30, offset: 138495},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4583, col: 38, offset: 138546},
+								pos:  position{line: 4583, col: 38, offset: 138503},
 								name: "Boolean",
 							},
 						},
@@ -11822,28 +11822,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4595, col: 1, offset: 138811},
+			pos:  position{line: 4595, col: 1, offset: 138768},
 			expr: &actionExpr{
-				pos: position{line: 4595, col: 15, offset: 138825},
+				pos: position{line: 4595, col: 15, offset: 138782},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4595, col: 15, offset: 138825},
+					pos: position{line: 4595, col: 15, offset: 138782},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4595, col: 15, offset: 138825},
+							pos:  position{line: 4595, col: 15, offset: 138782},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4595, col: 20, offset: 138830},
+							pos:  position{line: 4595, col: 20, offset: 138787},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4595, col: 30, offset: 138840},
+							pos:   position{line: 4595, col: 30, offset: 138797},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4595, col: 40, offset: 138850},
+								pos: position{line: 4595, col: 40, offset: 138807},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4595, col: 40, offset: 138850},
+									pos:  position{line: 4595, col: 40, offset: 138807},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -11854,39 +11854,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4602, col: 1, offset: 138976},
+			pos:  position{line: 4602, col: 1, offset: 138933},
 			expr: &actionExpr{
-				pos: position{line: 4602, col: 23, offset: 138998},
+				pos: position{line: 4602, col: 23, offset: 138955},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4602, col: 23, offset: 138998},
+					pos: position{line: 4602, col: 23, offset: 138955},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4602, col: 23, offset: 138998},
+							pos:  position{line: 4602, col: 23, offset: 138955},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4602, col: 29, offset: 139004},
+							pos:   position{line: 4602, col: 29, offset: 138961},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4602, col: 35, offset: 139010},
+								pos:  position{line: 4602, col: 35, offset: 138967},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4602, col: 49, offset: 139024},
+							pos:   position{line: 4602, col: 49, offset: 138981},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4602, col: 54, offset: 139029},
+								pos: position{line: 4602, col: 54, offset: 138986},
 								expr: &seqExpr{
-									pos: position{line: 4602, col: 55, offset: 139030},
+									pos: position{line: 4602, col: 55, offset: 138987},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4602, col: 55, offset: 139030},
+											pos:  position{line: 4602, col: 55, offset: 138987},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4602, col: 61, offset: 139036},
+											pos:  position{line: 4602, col: 61, offset: 138993},
 											name: "SPathArgument",
 										},
 									},
@@ -11899,26 +11899,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4634, col: 1, offset: 139929},
+			pos:  position{line: 4634, col: 1, offset: 139886},
 			expr: &actionExpr{
-				pos: position{line: 4634, col: 18, offset: 139946},
+				pos: position{line: 4634, col: 18, offset: 139903},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4634, col: 18, offset: 139946},
+					pos:   position{line: 4634, col: 18, offset: 139903},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4634, col: 23, offset: 139951},
+						pos: position{line: 4634, col: 23, offset: 139908},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4634, col: 23, offset: 139951},
+								pos:  position{line: 4634, col: 23, offset: 139908},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4634, col: 36, offset: 139964},
+								pos:  position{line: 4634, col: 36, offset: 139921},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4634, col: 50, offset: 139978},
+								pos:  position{line: 4634, col: 50, offset: 139935},
 								name: "PathField",
 							},
 						},
@@ -11928,28 +11928,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4638, col: 1, offset: 140014},
+			pos:  position{line: 4638, col: 1, offset: 139971},
 			expr: &actionExpr{
-				pos: position{line: 4638, col: 15, offset: 140028},
+				pos: position{line: 4638, col: 15, offset: 139985},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4638, col: 15, offset: 140028},
+					pos: position{line: 4638, col: 15, offset: 139985},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4638, col: 15, offset: 140028},
+							pos:        position{line: 4638, col: 15, offset: 139985},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4638, col: 23, offset: 140036},
+							pos:  position{line: 4638, col: 23, offset: 139993},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4638, col: 29, offset: 140042},
+							pos:   position{line: 4638, col: 29, offset: 139999},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4638, col: 35, offset: 140048},
+								pos:  position{line: 4638, col: 35, offset: 140005},
 								name: "FieldName",
 							},
 						},
@@ -11959,28 +11959,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4641, col: 1, offset: 140104},
+			pos:  position{line: 4641, col: 1, offset: 140061},
 			expr: &actionExpr{
-				pos: position{line: 4641, col: 16, offset: 140119},
+				pos: position{line: 4641, col: 16, offset: 140076},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4641, col: 16, offset: 140119},
+					pos: position{line: 4641, col: 16, offset: 140076},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4641, col: 16, offset: 140119},
+							pos:        position{line: 4641, col: 16, offset: 140076},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4641, col: 25, offset: 140128},
+							pos:  position{line: 4641, col: 25, offset: 140085},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4641, col: 31, offset: 140134},
+							pos:   position{line: 4641, col: 31, offset: 140091},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4641, col: 37, offset: 140140},
+								pos:  position{line: 4641, col: 37, offset: 140097},
 								name: "FieldName",
 							},
 						},
@@ -11990,34 +11990,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4644, col: 1, offset: 140197},
+			pos:  position{line: 4644, col: 1, offset: 140154},
 			expr: &actionExpr{
-				pos: position{line: 4644, col: 14, offset: 140210},
+				pos: position{line: 4644, col: 14, offset: 140167},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4644, col: 15, offset: 140211},
+					pos: position{line: 4644, col: 15, offset: 140168},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4644, col: 15, offset: 140211},
+							pos: position{line: 4644, col: 15, offset: 140168},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4644, col: 15, offset: 140211},
+									pos:        position{line: 4644, col: 15, offset: 140168},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4644, col: 22, offset: 140218},
+									pos:  position{line: 4644, col: 22, offset: 140175},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4644, col: 28, offset: 140224},
+									pos:  position{line: 4644, col: 28, offset: 140181},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4644, col: 47, offset: 140243},
+							pos:  position{line: 4644, col: 47, offset: 140200},
 							name: "SPathFieldString",
 						},
 					},
@@ -12026,16 +12026,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4656, col: 1, offset: 140655},
+			pos:  position{line: 4656, col: 1, offset: 140612},
 			expr: &choiceExpr{
-				pos: position{line: 4656, col: 21, offset: 140675},
+				pos: position{line: 4656, col: 21, offset: 140632},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4656, col: 21, offset: 140675},
+						pos:  position{line: 4656, col: 21, offset: 140632},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4656, col: 36, offset: 140690},
+						pos:  position{line: 4656, col: 36, offset: 140647},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12043,28 +12043,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4659, col: 1, offset: 140763},
+			pos:  position{line: 4659, col: 1, offset: 140720},
 			expr: &actionExpr{
-				pos: position{line: 4659, col: 16, offset: 140778},
+				pos: position{line: 4659, col: 16, offset: 140735},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4659, col: 16, offset: 140778},
+					pos: position{line: 4659, col: 16, offset: 140735},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4659, col: 16, offset: 140778},
+							pos:  position{line: 4659, col: 16, offset: 140735},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4659, col: 21, offset: 140783},
+							pos:  position{line: 4659, col: 21, offset: 140740},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4659, col: 32, offset: 140794},
+							pos:   position{line: 4659, col: 32, offset: 140751},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4659, col: 46, offset: 140808},
+								pos: position{line: 4659, col: 46, offset: 140765},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4659, col: 46, offset: 140808},
+									pos:  position{line: 4659, col: 46, offset: 140765},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12075,39 +12075,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4681, col: 1, offset: 141417},
+			pos:  position{line: 4681, col: 1, offset: 141374},
 			expr: &actionExpr{
-				pos: position{line: 4681, col: 24, offset: 141440},
+				pos: position{line: 4681, col: 24, offset: 141397},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4681, col: 24, offset: 141440},
+					pos: position{line: 4681, col: 24, offset: 141397},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4681, col: 24, offset: 141440},
+							pos:  position{line: 4681, col: 24, offset: 141397},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4681, col: 30, offset: 141446},
+							pos:   position{line: 4681, col: 30, offset: 141403},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4681, col: 37, offset: 141453},
+								pos:  position{line: 4681, col: 37, offset: 141410},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4681, col: 52, offset: 141468},
+							pos:   position{line: 4681, col: 52, offset: 141425},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4681, col: 57, offset: 141473},
+								pos: position{line: 4681, col: 57, offset: 141430},
 								expr: &seqExpr{
-									pos: position{line: 4681, col: 58, offset: 141474},
+									pos: position{line: 4681, col: 58, offset: 141431},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4681, col: 58, offset: 141474},
+											pos:  position{line: 4681, col: 58, offset: 141431},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4681, col: 64, offset: 141480},
+											pos:  position{line: 4681, col: 64, offset: 141437},
 											name: "FormatArgument",
 										},
 									},
@@ -12120,30 +12120,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4715, col: 1, offset: 142669},
+			pos:  position{line: 4715, col: 1, offset: 142626},
 			expr: &actionExpr{
-				pos: position{line: 4715, col: 19, offset: 142687},
+				pos: position{line: 4715, col: 19, offset: 142644},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4715, col: 19, offset: 142687},
+					pos:   position{line: 4715, col: 19, offset: 142644},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4715, col: 28, offset: 142696},
+						pos: position{line: 4715, col: 28, offset: 142653},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4715, col: 28, offset: 142696},
+								pos:  position{line: 4715, col: 28, offset: 142653},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4715, col: 46, offset: 142714},
+								pos:  position{line: 4715, col: 46, offset: 142671},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4715, col: 65, offset: 142733},
+								pos:  position{line: 4715, col: 65, offset: 142690},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4715, col: 82, offset: 142750},
+								pos:  position{line: 4715, col: 82, offset: 142707},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12153,28 +12153,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4719, col: 1, offset: 142800},
+			pos:  position{line: 4719, col: 1, offset: 142757},
 			expr: &actionExpr{
-				pos: position{line: 4719, col: 20, offset: 142819},
+				pos: position{line: 4719, col: 20, offset: 142776},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4719, col: 20, offset: 142819},
+					pos: position{line: 4719, col: 20, offset: 142776},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4719, col: 20, offset: 142819},
+							pos:        position{line: 4719, col: 20, offset: 142776},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4719, col: 28, offset: 142827},
+							pos:  position{line: 4719, col: 28, offset: 142784},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4719, col: 34, offset: 142833},
+							pos:   position{line: 4719, col: 34, offset: 142790},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4719, col: 38, offset: 142837},
+								pos:  position{line: 4719, col: 38, offset: 142794},
 								name: "QuotedString",
 							},
 						},
@@ -12184,28 +12184,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4728, col: 1, offset: 143049},
+			pos:  position{line: 4728, col: 1, offset: 143006},
 			expr: &actionExpr{
-				pos: position{line: 4728, col: 21, offset: 143069},
+				pos: position{line: 4728, col: 21, offset: 143026},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4728, col: 21, offset: 143069},
+					pos: position{line: 4728, col: 21, offset: 143026},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4728, col: 21, offset: 143069},
+							pos:        position{line: 4728, col: 21, offset: 143026},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4728, col: 34, offset: 143082},
+							pos:  position{line: 4728, col: 34, offset: 143039},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4728, col: 40, offset: 143088},
+							pos:   position{line: 4728, col: 40, offset: 143045},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4728, col: 47, offset: 143095},
+								pos:  position{line: 4728, col: 47, offset: 143052},
 								name: "IntegerAsString",
 							},
 						},
@@ -12215,28 +12215,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4741, col: 1, offset: 143501},
+			pos:  position{line: 4741, col: 1, offset: 143458},
 			expr: &actionExpr{
-				pos: position{line: 4741, col: 19, offset: 143519},
+				pos: position{line: 4741, col: 19, offset: 143476},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4741, col: 19, offset: 143519},
+					pos: position{line: 4741, col: 19, offset: 143476},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4741, col: 19, offset: 143519},
+							pos:        position{line: 4741, col: 19, offset: 143476},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4741, col: 30, offset: 143530},
+							pos:  position{line: 4741, col: 30, offset: 143487},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4741, col: 36, offset: 143536},
+							pos:   position{line: 4741, col: 36, offset: 143493},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4741, col: 40, offset: 143540},
+								pos:  position{line: 4741, col: 40, offset: 143497},
 								name: "QuotedString",
 							},
 						},
@@ -12246,78 +12246,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4750, col: 1, offset: 143755},
+			pos:  position{line: 4750, col: 1, offset: 143712},
 			expr: &actionExpr{
-				pos: position{line: 4750, col: 24, offset: 143778},
+				pos: position{line: 4750, col: 24, offset: 143735},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4750, col: 24, offset: 143778},
+					pos: position{line: 4750, col: 24, offset: 143735},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4750, col: 24, offset: 143778},
+							pos:   position{line: 4750, col: 24, offset: 143735},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 34, offset: 143788},
+								pos:  position{line: 4750, col: 34, offset: 143745},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4750, col: 47, offset: 143801},
+							pos:  position{line: 4750, col: 47, offset: 143758},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4750, col: 53, offset: 143807},
+							pos:   position{line: 4750, col: 53, offset: 143764},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 63, offset: 143817},
+								pos:  position{line: 4750, col: 63, offset: 143774},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4750, col: 76, offset: 143830},
+							pos:  position{line: 4750, col: 76, offset: 143787},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4750, col: 82, offset: 143836},
+							pos:   position{line: 4750, col: 82, offset: 143793},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 95, offset: 143849},
+								pos:  position{line: 4750, col: 95, offset: 143806},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4750, col: 108, offset: 143862},
+							pos:  position{line: 4750, col: 108, offset: 143819},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4750, col: 114, offset: 143868},
+							pos:   position{line: 4750, col: 114, offset: 143825},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 121, offset: 143875},
+								pos:  position{line: 4750, col: 121, offset: 143832},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4750, col: 134, offset: 143888},
+							pos:  position{line: 4750, col: 134, offset: 143845},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4750, col: 140, offset: 143894},
+							pos:   position{line: 4750, col: 140, offset: 143851},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 153, offset: 143907},
+								pos:  position{line: 4750, col: 153, offset: 143864},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4750, col: 166, offset: 143920},
+							pos:  position{line: 4750, col: 166, offset: 143877},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4750, col: 172, offset: 143926},
+							pos:   position{line: 4750, col: 172, offset: 143883},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4750, col: 179, offset: 143933},
+								pos:  position{line: 4750, col: 179, offset: 143890},
 								name: "QuotedString",
 							},
 						},
@@ -12327,28 +12327,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4768, col: 1, offset: 144509},
+			pos:  position{line: 4768, col: 1, offset: 144466},
 			expr: &actionExpr{
-				pos: position{line: 4768, col: 20, offset: 144528},
+				pos: position{line: 4768, col: 20, offset: 144485},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4768, col: 20, offset: 144528},
+					pos: position{line: 4768, col: 20, offset: 144485},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4768, col: 20, offset: 144528},
+							pos:  position{line: 4768, col: 20, offset: 144485},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4768, col: 25, offset: 144533},
+							pos:  position{line: 4768, col: 25, offset: 144490},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4768, col: 40, offset: 144548},
+							pos:   position{line: 4768, col: 40, offset: 144505},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4768, col: 55, offset: 144563},
+								pos: position{line: 4768, col: 55, offset: 144520},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4768, col: 55, offset: 144563},
+									pos:  position{line: 4768, col: 55, offset: 144520},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12359,42 +12359,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4775, col: 1, offset: 144716},
+			pos:  position{line: 4775, col: 1, offset: 144673},
 			expr: &actionExpr{
-				pos: position{line: 4775, col: 28, offset: 144743},
+				pos: position{line: 4775, col: 28, offset: 144700},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4775, col: 28, offset: 144743},
+					pos: position{line: 4775, col: 28, offset: 144700},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4775, col: 28, offset: 144743},
+							pos:  position{line: 4775, col: 28, offset: 144700},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4775, col: 34, offset: 144749},
+							pos:   position{line: 4775, col: 34, offset: 144706},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4775, col: 40, offset: 144755},
+								pos: position{line: 4775, col: 40, offset: 144712},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4775, col: 40, offset: 144755},
+									pos:  position{line: 4775, col: 40, offset: 144712},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4775, col: 60, offset: 144775},
+							pos:   position{line: 4775, col: 60, offset: 144732},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4775, col: 65, offset: 144780},
+								pos: position{line: 4775, col: 65, offset: 144737},
 								expr: &seqExpr{
-									pos: position{line: 4775, col: 66, offset: 144781},
+									pos: position{line: 4775, col: 66, offset: 144738},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4775, col: 66, offset: 144781},
+											pos:  position{line: 4775, col: 66, offset: 144738},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4775, col: 72, offset: 144787},
+											pos:  position{line: 4775, col: 72, offset: 144744},
 											name: "EventCountArgument",
 										},
 									},
@@ -12407,30 +12407,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4831, col: 1, offset: 146664},
+			pos:  position{line: 4831, col: 1, offset: 146621},
 			expr: &actionExpr{
-				pos: position{line: 4831, col: 23, offset: 146686},
+				pos: position{line: 4831, col: 23, offset: 146643},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4831, col: 23, offset: 146686},
+					pos:   position{line: 4831, col: 23, offset: 146643},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4831, col: 28, offset: 146691},
+						pos: position{line: 4831, col: 28, offset: 146648},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4831, col: 28, offset: 146691},
+								pos:  position{line: 4831, col: 28, offset: 146648},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4831, col: 41, offset: 146704},
+								pos:  position{line: 4831, col: 41, offset: 146661},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4831, col: 58, offset: 146721},
+								pos:  position{line: 4831, col: 58, offset: 146678},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4831, col: 76, offset: 146739},
+								pos:  position{line: 4831, col: 76, offset: 146696},
 								name: "ListVixField",
 							},
 						},
@@ -12440,28 +12440,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4835, col: 1, offset: 146778},
+			pos:  position{line: 4835, col: 1, offset: 146735},
 			expr: &actionExpr{
-				pos: position{line: 4835, col: 15, offset: 146792},
+				pos: position{line: 4835, col: 15, offset: 146749},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4835, col: 15, offset: 146792},
+					pos: position{line: 4835, col: 15, offset: 146749},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4835, col: 15, offset: 146792},
+							pos:        position{line: 4835, col: 15, offset: 146749},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4835, col: 23, offset: 146800},
+							pos:  position{line: 4835, col: 23, offset: 146757},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4835, col: 29, offset: 146806},
+							pos:   position{line: 4835, col: 29, offset: 146763},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4835, col: 35, offset: 146812},
+								pos:  position{line: 4835, col: 35, offset: 146769},
 								name: "IndexName",
 							},
 						},
@@ -12471,28 +12471,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4838, col: 1, offset: 146868},
+			pos:  position{line: 4838, col: 1, offset: 146825},
 			expr: &actionExpr{
-				pos: position{line: 4838, col: 19, offset: 146886},
+				pos: position{line: 4838, col: 19, offset: 146843},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4838, col: 19, offset: 146886},
+					pos: position{line: 4838, col: 19, offset: 146843},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4838, col: 19, offset: 146886},
+							pos:        position{line: 4838, col: 19, offset: 146843},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4838, col: 31, offset: 146898},
+							pos:  position{line: 4838, col: 31, offset: 146855},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4838, col: 37, offset: 146904},
+							pos:   position{line: 4838, col: 37, offset: 146861},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4838, col: 43, offset: 146910},
+								pos:  position{line: 4838, col: 43, offset: 146867},
 								name: "Boolean",
 							},
 						},
@@ -12502,28 +12502,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4841, col: 1, offset: 146986},
+			pos:  position{line: 4841, col: 1, offset: 146943},
 			expr: &actionExpr{
-				pos: position{line: 4841, col: 20, offset: 147005},
+				pos: position{line: 4841, col: 20, offset: 146962},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4841, col: 20, offset: 147005},
+					pos: position{line: 4841, col: 20, offset: 146962},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4841, col: 20, offset: 147005},
+							pos:        position{line: 4841, col: 20, offset: 146962},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4841, col: 34, offset: 147019},
+							pos:  position{line: 4841, col: 34, offset: 146976},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4841, col: 40, offset: 147025},
+							pos:   position{line: 4841, col: 40, offset: 146982},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4841, col: 46, offset: 147031},
+								pos:  position{line: 4841, col: 46, offset: 146988},
 								name: "Boolean",
 							},
 						},
@@ -12533,28 +12533,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4844, col: 1, offset: 147109},
+			pos:  position{line: 4844, col: 1, offset: 147066},
 			expr: &actionExpr{
-				pos: position{line: 4844, col: 17, offset: 147125},
+				pos: position{line: 4844, col: 17, offset: 147082},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4844, col: 17, offset: 147125},
+					pos: position{line: 4844, col: 17, offset: 147082},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4844, col: 17, offset: 147125},
+							pos:        position{line: 4844, col: 17, offset: 147082},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4844, col: 28, offset: 147136},
+							pos:  position{line: 4844, col: 28, offset: 147093},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4844, col: 34, offset: 147142},
+							pos:   position{line: 4844, col: 34, offset: 147099},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4844, col: 40, offset: 147148},
+								pos:  position{line: 4844, col: 40, offset: 147105},
 								name: "Boolean",
 							},
 						},
@@ -12564,24 +12564,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4848, col: 1, offset: 147224},
+			pos:  position{line: 4848, col: 1, offset: 147181},
 			expr: &actionExpr{
-				pos: position{line: 4848, col: 14, offset: 147237},
+				pos: position{line: 4848, col: 14, offset: 147194},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4848, col: 14, offset: 147237},
+					pos: position{line: 4848, col: 14, offset: 147194},
 					expr: &seqExpr{
-						pos: position{line: 4848, col: 15, offset: 147238},
+						pos: position{line: 4848, col: 15, offset: 147195},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4848, col: 15, offset: 147238},
+								pos: position{line: 4848, col: 15, offset: 147195},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4848, col: 16, offset: 147239},
+									pos:  position{line: 4848, col: 16, offset: 147196},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4848, col: 22, offset: 147245,
+								line: 4848, col: 22, offset: 147202,
 							},
 						},
 					},
@@ -12590,39 +12590,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4853, col: 1, offset: 147318},
+			pos:  position{line: 4853, col: 1, offset: 147275},
 			expr: &actionExpr{
-				pos: position{line: 4853, col: 18, offset: 147335},
+				pos: position{line: 4853, col: 18, offset: 147292},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4853, col: 18, offset: 147335},
+					pos: position{line: 4853, col: 18, offset: 147292},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4853, col: 18, offset: 147335},
+							pos:  position{line: 4853, col: 18, offset: 147292},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4853, col: 23, offset: 147340},
+							pos:  position{line: 4853, col: 23, offset: 147297},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4853, col: 36, offset: 147353},
+							pos:   position{line: 4853, col: 36, offset: 147310},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4853, col: 49, offset: 147366},
+								pos: position{line: 4853, col: 49, offset: 147323},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4853, col: 49, offset: 147366},
+									pos:  position{line: 4853, col: 49, offset: 147323},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4853, col: 70, offset: 147387},
+							pos:   position{line: 4853, col: 70, offset: 147344},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4853, col: 77, offset: 147394},
+								pos: position{line: 4853, col: 77, offset: 147351},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4853, col: 77, offset: 147394},
+									pos:  position{line: 4853, col: 77, offset: 147351},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12633,32 +12633,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4882, col: 1, offset: 148121},
+			pos:  position{line: 4882, col: 1, offset: 148078},
 			expr: &actionExpr{
-				pos: position{line: 4882, col: 24, offset: 148144},
+				pos: position{line: 4882, col: 24, offset: 148101},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4882, col: 24, offset: 148144},
+					pos: position{line: 4882, col: 24, offset: 148101},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4882, col: 24, offset: 148144},
+							pos:  position{line: 4882, col: 24, offset: 148101},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4882, col: 30, offset: 148150},
+							pos:        position{line: 4882, col: 30, offset: 148107},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4882, col: 38, offset: 148158},
+							pos:  position{line: 4882, col: 38, offset: 148115},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4882, col: 44, offset: 148164},
+							pos:   position{line: 4882, col: 44, offset: 148121},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4882, col: 48, offset: 148168},
+								pos:  position{line: 4882, col: 48, offset: 148125},
 								name: "String",
 							},
 						},
@@ -12668,22 +12668,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 4886, col: 1, offset: 148214},
+			pos:  position{line: 4886, col: 1, offset: 148171},
 			expr: &actionExpr{
-				pos: position{line: 4886, col: 22, offset: 148235},
+				pos: position{line: 4886, col: 22, offset: 148192},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 4886, col: 22, offset: 148235},
+					pos: position{line: 4886, col: 22, offset: 148192},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4886, col: 22, offset: 148235},
+							pos:  position{line: 4886, col: 22, offset: 148192},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4886, col: 28, offset: 148241},
+							pos:   position{line: 4886, col: 28, offset: 148198},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4886, col: 38, offset: 148251},
+								pos:  position{line: 4886, col: 38, offset: 148208},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12693,36 +12693,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 4890, col: 1, offset: 148310},
+			pos:  position{line: 4890, col: 1, offset: 148267},
 			expr: &actionExpr{
-				pos: position{line: 4890, col: 18, offset: 148327},
+				pos: position{line: 4890, col: 18, offset: 148284},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4890, col: 18, offset: 148327},
+					pos: position{line: 4890, col: 18, offset: 148284},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4890, col: 18, offset: 148327},
+							pos:  position{line: 4890, col: 18, offset: 148284},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4890, col: 23, offset: 148332},
+							pos:  position{line: 4890, col: 23, offset: 148289},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 4890, col: 36, offset: 148345},
+							pos:   position{line: 4890, col: 36, offset: 148302},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4890, col: 42, offset: 148351},
+								pos:  position{line: 4890, col: 42, offset: 148308},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4890, col: 56, offset: 148365},
+							pos:   position{line: 4890, col: 56, offset: 148322},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4890, col: 62, offset: 148371},
+								pos: position{line: 4890, col: 62, offset: 148328},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4890, col: 62, offset: 148371},
+									pos:  position{line: 4890, col: 62, offset: 148328},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12733,22 +12733,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 4920, col: 1, offset: 149105},
+			pos:  position{line: 4920, col: 1, offset: 149062},
 			expr: &actionExpr{
-				pos: position{line: 4920, col: 18, offset: 149122},
+				pos: position{line: 4920, col: 18, offset: 149079},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 4920, col: 18, offset: 149122},
+					pos: position{line: 4920, col: 18, offset: 149079},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 18, offset: 149122},
+							pos:  position{line: 4920, col: 18, offset: 149079},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 24, offset: 149128},
+							pos:   position{line: 4920, col: 24, offset: 149085},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 34, offset: 149138},
+								pos:  position{line: 4920, col: 34, offset: 149095},
 								name: "FieldName",
 							},
 						},
@@ -12758,32 +12758,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 4924, col: 1, offset: 149179},
+			pos:  position{line: 4924, col: 1, offset: 149136},
 			expr: &actionExpr{
-				pos: position{line: 4924, col: 18, offset: 149196},
+				pos: position{line: 4924, col: 18, offset: 149153},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4924, col: 18, offset: 149196},
+					pos: position{line: 4924, col: 18, offset: 149153},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4924, col: 18, offset: 149196},
+							pos:  position{line: 4924, col: 18, offset: 149153},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4924, col: 24, offset: 149202},
+							pos:        position{line: 4924, col: 24, offset: 149159},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4924, col: 32, offset: 149210},
+							pos:  position{line: 4924, col: 32, offset: 149167},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4924, col: 38, offset: 149216},
+							pos:   position{line: 4924, col: 38, offset: 149173},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4924, col: 47, offset: 149225},
+								pos:  position{line: 4924, col: 47, offset: 149182},
 								name: "IntegerAsString",
 							},
 						},
@@ -12793,26 +12793,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 4928, col: 1, offset: 149271},
+			pos:  position{line: 4928, col: 1, offset: 149228},
 			expr: &actionExpr{
-				pos: position{line: 4928, col: 16, offset: 149286},
+				pos: position{line: 4928, col: 16, offset: 149243},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 4928, col: 16, offset: 149286},
+					pos: position{line: 4928, col: 16, offset: 149243},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4928, col: 16, offset: 149286},
+							pos:  position{line: 4928, col: 16, offset: 149243},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4928, col: 22, offset: 149292},
+							pos:  position{line: 4928, col: 22, offset: 149249},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4928, col: 32, offset: 149302},
+							pos:   position{line: 4928, col: 32, offset: 149259},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4928, col: 42, offset: 149312},
+								pos:  position{line: 4928, col: 42, offset: 149269},
 								name: "BoolExpr",
 							},
 						},
@@ -12822,28 +12822,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 4932, col: 1, offset: 149372},
+			pos:  position{line: 4932, col: 1, offset: 149329},
 			expr: &actionExpr{
-				pos: position{line: 4932, col: 28, offset: 149399},
+				pos: position{line: 4932, col: 28, offset: 149356},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 4932, col: 28, offset: 149399},
+					pos: position{line: 4932, col: 28, offset: 149356},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4932, col: 28, offset: 149399},
+							pos:        position{line: 4932, col: 28, offset: 149356},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4932, col: 37, offset: 149408},
+							pos:  position{line: 4932, col: 37, offset: 149365},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4932, col: 43, offset: 149414},
+							pos:   position{line: 4932, col: 43, offset: 149371},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4932, col: 51, offset: 149422},
+								pos:  position{line: 4932, col: 51, offset: 149379},
 								name: "Boolean",
 							},
 						},
@@ -12853,28 +12853,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 4941, col: 1, offset: 149606},
+			pos:  position{line: 4941, col: 1, offset: 149563},
 			expr: &actionExpr{
-				pos: position{line: 4941, col: 28, offset: 149633},
+				pos: position{line: 4941, col: 28, offset: 149590},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 4941, col: 28, offset: 149633},
+					pos: position{line: 4941, col: 28, offset: 149590},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4941, col: 28, offset: 149633},
+							pos:        position{line: 4941, col: 28, offset: 149590},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4941, col: 37, offset: 149642},
+							pos:  position{line: 4941, col: 37, offset: 149599},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4941, col: 43, offset: 149648},
+							pos:   position{line: 4941, col: 43, offset: 149605},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4941, col: 51, offset: 149656},
+								pos:  position{line: 4941, col: 51, offset: 149613},
 								name: "Boolean",
 							},
 						},
@@ -12884,28 +12884,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 4950, col: 1, offset: 149840},
+			pos:  position{line: 4950, col: 1, offset: 149797},
 			expr: &actionExpr{
-				pos: position{line: 4950, col: 27, offset: 149866},
+				pos: position{line: 4950, col: 27, offset: 149823},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 4950, col: 27, offset: 149866},
+					pos: position{line: 4950, col: 27, offset: 149823},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4950, col: 27, offset: 149866},
+							pos:        position{line: 4950, col: 27, offset: 149823},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4950, col: 35, offset: 149874},
+							pos:  position{line: 4950, col: 35, offset: 149831},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4950, col: 41, offset: 149880},
+							pos:   position{line: 4950, col: 41, offset: 149837},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4950, col: 48, offset: 149887},
+								pos:  position{line: 4950, col: 48, offset: 149844},
 								name: "PositiveInteger",
 							},
 						},
@@ -12915,28 +12915,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 4959, col: 1, offset: 150078},
+			pos:  position{line: 4959, col: 1, offset: 150035},
 			expr: &actionExpr{
-				pos: position{line: 4959, col: 25, offset: 150102},
+				pos: position{line: 4959, col: 25, offset: 150059},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 4959, col: 25, offset: 150102},
+					pos: position{line: 4959, col: 25, offset: 150059},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4959, col: 25, offset: 150102},
+							pos:        position{line: 4959, col: 25, offset: 150059},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4959, col: 31, offset: 150108},
+							pos:  position{line: 4959, col: 31, offset: 150065},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4959, col: 37, offset: 150114},
+							pos:   position{line: 4959, col: 37, offset: 150071},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4959, col: 44, offset: 150121},
+								pos:  position{line: 4959, col: 44, offset: 150078},
 								name: "PositiveInteger",
 							},
 						},
@@ -12946,30 +12946,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 4968, col: 1, offset: 150308},
+			pos:  position{line: 4968, col: 1, offset: 150265},
 			expr: &actionExpr{
-				pos: position{line: 4968, col: 22, offset: 150329},
+				pos: position{line: 4968, col: 22, offset: 150286},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4968, col: 22, offset: 150329},
+					pos:   position{line: 4968, col: 22, offset: 150286},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 4968, col: 41, offset: 150348},
+						pos: position{line: 4968, col: 41, offset: 150305},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4968, col: 41, offset: 150348},
+								pos:  position{line: 4968, col: 41, offset: 150305},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4968, col: 67, offset: 150374},
+								pos:  position{line: 4968, col: 67, offset: 150331},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4968, col: 93, offset: 150400},
+								pos:  position{line: 4968, col: 93, offset: 150357},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4968, col: 118, offset: 150425},
+								pos:  position{line: 4968, col: 118, offset: 150382},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -12979,35 +12979,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 4972, col: 1, offset: 150486},
+			pos:  position{line: 4972, col: 1, offset: 150443},
 			expr: &actionExpr{
-				pos: position{line: 4972, col: 26, offset: 150511},
+				pos: position{line: 4972, col: 26, offset: 150468},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4972, col: 26, offset: 150511},
+					pos: position{line: 4972, col: 26, offset: 150468},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4972, col: 26, offset: 150511},
+							pos:   position{line: 4972, col: 26, offset: 150468},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4972, col: 34, offset: 150519},
+								pos:  position{line: 4972, col: 34, offset: 150476},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4972, col: 53, offset: 150538},
+							pos:   position{line: 4972, col: 53, offset: 150495},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4972, col: 58, offset: 150543},
+								pos: position{line: 4972, col: 58, offset: 150500},
 								expr: &seqExpr{
-									pos: position{line: 4972, col: 59, offset: 150544},
+									pos: position{line: 4972, col: 59, offset: 150501},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4972, col: 59, offset: 150544},
+											pos:  position{line: 4972, col: 59, offset: 150501},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4972, col: 65, offset: 150550},
+											pos:  position{line: 4972, col: 65, offset: 150507},
 											name: "InputLookupOption",
 										},
 									},
@@ -13020,35 +13020,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5014, col: 1, offset: 151996},
+			pos:  position{line: 5014, col: 1, offset: 151953},
 			expr: &actionExpr{
-				pos: position{line: 5014, col: 21, offset: 152016},
+				pos: position{line: 5014, col: 21, offset: 151973},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5014, col: 21, offset: 152016},
+					pos: position{line: 5014, col: 21, offset: 151973},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 21, offset: 152016},
+							pos:  position{line: 5014, col: 21, offset: 151973},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 26, offset: 152021},
+							pos:  position{line: 5014, col: 26, offset: 151978},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 42, offset: 152037},
+							pos:   position{line: 5014, col: 42, offset: 151994},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5014, col: 60, offset: 152055},
+								pos: position{line: 5014, col: 60, offset: 152012},
 								expr: &seqExpr{
-									pos: position{line: 5014, col: 61, offset: 152056},
+									pos: position{line: 5014, col: 61, offset: 152013},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5014, col: 61, offset: 152056},
+											pos:  position{line: 5014, col: 61, offset: 152013},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5014, col: 83, offset: 152078},
+											pos:  position{line: 5014, col: 83, offset: 152035},
 											name: "SPACE",
 										},
 									},
@@ -13056,20 +13056,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 91, offset: 152086},
+							pos:   position{line: 5014, col: 91, offset: 152043},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5014, col: 101, offset: 152096},
+								pos:  position{line: 5014, col: 101, offset: 152053},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 109, offset: 152104},
+							pos:   position{line: 5014, col: 109, offset: 152061},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5014, col: 121, offset: 152116},
+								pos: position{line: 5014, col: 121, offset: 152073},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5014, col: 122, offset: 152117},
+									pos:  position{line: 5014, col: 122, offset: 152074},
 									name: "WhereClause",
 								},
 							},
@@ -13080,15 +13080,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5036, col: 1, offset: 152767},
+			pos:  position{line: 5036, col: 1, offset: 152724},
 			expr: &actionExpr{
-				pos: position{line: 5036, col: 24, offset: 152790},
+				pos: position{line: 5036, col: 24, offset: 152747},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5036, col: 24, offset: 152790},
+					pos:   position{line: 5036, col: 24, offset: 152747},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5036, col: 41, offset: 152807},
+						pos:  position{line: 5036, col: 41, offset: 152764},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13096,124 +13096,124 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5048, col: 1, offset: 153199},
+			pos:  position{line: 5048, col: 1, offset: 153156},
 			expr: &choiceExpr{
-				pos: position{line: 5048, col: 12, offset: 153210},
+				pos: position{line: 5048, col: 12, offset: 153167},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 12, offset: 153210},
+						pos:  position{line: 5048, col: 12, offset: 153167},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 24, offset: 153222},
+						pos:  position{line: 5048, col: 24, offset: 153179},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 36, offset: 153234},
+						pos:  position{line: 5048, col: 36, offset: 153191},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 49, offset: 153247},
+						pos:  position{line: 5048, col: 49, offset: 153204},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 61, offset: 153259},
+						pos:  position{line: 5048, col: 61, offset: 153216},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 81, offset: 153279},
+						pos:  position{line: 5048, col: 81, offset: 153236},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 92, offset: 153290},
+						pos:  position{line: 5048, col: 92, offset: 153247},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 112, offset: 153310},
+						pos:  position{line: 5048, col: 112, offset: 153267},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 123, offset: 153321},
+						pos:  position{line: 5048, col: 123, offset: 153278},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 134, offset: 153332},
+						pos:  position{line: 5048, col: 134, offset: 153289},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 144, offset: 153342},
+						pos:  position{line: 5048, col: 144, offset: 153299},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 154, offset: 153352},
+						pos:  position{line: 5048, col: 154, offset: 153309},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 165, offset: 153363},
+						pos:  position{line: 5048, col: 165, offset: 153320},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 178, offset: 153376},
+						pos:  position{line: 5048, col: 178, offset: 153333},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 194, offset: 153392},
+						pos:  position{line: 5048, col: 194, offset: 153349},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 212, offset: 153410},
+						pos:  position{line: 5048, col: 212, offset: 153367},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 224, offset: 153422},
+						pos:  position{line: 5048, col: 224, offset: 153379},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 235, offset: 153433},
+						pos:  position{line: 5048, col: 235, offset: 153390},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 248, offset: 153446},
+						pos:  position{line: 5048, col: 248, offset: 153403},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 260, offset: 153458},
+						pos:  position{line: 5048, col: 260, offset: 153415},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 273, offset: 153471},
+						pos:  position{line: 5048, col: 273, offset: 153428},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 288, offset: 153486},
+						pos:  position{line: 5048, col: 288, offset: 153443},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 301, offset: 153499},
+						pos:  position{line: 5048, col: 301, offset: 153456},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 318, offset: 153516},
+						pos:  position{line: 5048, col: 318, offset: 153473},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 328, offset: 153526},
+						pos:  position{line: 5048, col: 328, offset: 153483},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 346, offset: 153544},
+						pos:  position{line: 5048, col: 346, offset: 153501},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 361, offset: 153559},
+						pos:  position{line: 5048, col: 361, offset: 153516},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 376, offset: 153574},
+						pos:  position{line: 5048, col: 376, offset: 153531},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5048, col: 391, offset: 153589},
+						pos:  position{line: 5048, col: 391, offset: 153546},
 						name: "CMD_INPUTLOOKUP",
 					},
 				},
@@ -13221,18 +13221,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5049, col: 1, offset: 153606},
+			pos:  position{line: 5049, col: 1, offset: 153563},
 			expr: &seqExpr{
-				pos: position{line: 5049, col: 15, offset: 153620},
+				pos: position{line: 5049, col: 15, offset: 153577},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5049, col: 15, offset: 153620},
+						pos:        position{line: 5049, col: 15, offset: 153577},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5049, col: 24, offset: 153629},
+						pos:  position{line: 5049, col: 24, offset: 153586},
 						name: "SPACE",
 					},
 				},
@@ -13240,18 +13240,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5050, col: 1, offset: 153635},
+			pos:  position{line: 5050, col: 1, offset: 153592},
 			expr: &seqExpr{
-				pos: position{line: 5050, col: 14, offset: 153648},
+				pos: position{line: 5050, col: 14, offset: 153605},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5050, col: 14, offset: 153648},
+						pos:        position{line: 5050, col: 14, offset: 153605},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5050, col: 22, offset: 153656},
+						pos:  position{line: 5050, col: 22, offset: 153613},
 						name: "SPACE",
 					},
 				},
@@ -13259,18 +13259,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5051, col: 1, offset: 153662},
+			pos:  position{line: 5051, col: 1, offset: 153619},
 			expr: &seqExpr{
-				pos: position{line: 5051, col: 14, offset: 153675},
+				pos: position{line: 5051, col: 14, offset: 153632},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5051, col: 14, offset: 153675},
+						pos:        position{line: 5051, col: 14, offset: 153632},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 22, offset: 153683},
+						pos:  position{line: 5051, col: 22, offset: 153640},
 						name: "SPACE",
 					},
 				},
@@ -13278,18 +13278,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5052, col: 1, offset: 153689},
+			pos:  position{line: 5052, col: 1, offset: 153646},
 			expr: &seqExpr{
-				pos: position{line: 5052, col: 20, offset: 153708},
+				pos: position{line: 5052, col: 20, offset: 153665},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5052, col: 20, offset: 153708},
+						pos:        position{line: 5052, col: 20, offset: 153665},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5052, col: 34, offset: 153722},
+						pos:  position{line: 5052, col: 34, offset: 153679},
 						name: "SPACE",
 					},
 				},
@@ -13297,18 +13297,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5053, col: 1, offset: 153728},
+			pos:  position{line: 5053, col: 1, offset: 153685},
 			expr: &seqExpr{
-				pos: position{line: 5053, col: 15, offset: 153742},
+				pos: position{line: 5053, col: 15, offset: 153699},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5053, col: 15, offset: 153742},
+						pos:        position{line: 5053, col: 15, offset: 153699},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5053, col: 24, offset: 153751},
+						pos:  position{line: 5053, col: 24, offset: 153708},
 						name: "SPACE",
 					},
 				},
@@ -13316,18 +13316,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5054, col: 1, offset: 153757},
+			pos:  position{line: 5054, col: 1, offset: 153714},
 			expr: &seqExpr{
-				pos: position{line: 5054, col: 14, offset: 153770},
+				pos: position{line: 5054, col: 14, offset: 153727},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5054, col: 14, offset: 153770},
+						pos:        position{line: 5054, col: 14, offset: 153727},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5054, col: 22, offset: 153778},
+						pos:  position{line: 5054, col: 22, offset: 153735},
 						name: "SPACE",
 					},
 				},
@@ -13335,9 +13335,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5055, col: 1, offset: 153784},
+			pos:  position{line: 5055, col: 1, offset: 153741},
 			expr: &litMatcher{
-				pos:        position{line: 5055, col: 22, offset: 153805},
+				pos:        position{line: 5055, col: 22, offset: 153762},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13345,16 +13345,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5056, col: 1, offset: 153812},
+			pos:  position{line: 5056, col: 1, offset: 153769},
 			expr: &seqExpr{
-				pos: position{line: 5056, col: 13, offset: 153824},
+				pos: position{line: 5056, col: 13, offset: 153781},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5056, col: 13, offset: 153824},
+						pos:  position{line: 5056, col: 13, offset: 153781},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5056, col: 31, offset: 153842},
+						pos:  position{line: 5056, col: 31, offset: 153799},
 						name: "SPACE",
 					},
 				},
@@ -13362,9 +13362,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5057, col: 1, offset: 153848},
+			pos:  position{line: 5057, col: 1, offset: 153805},
 			expr: &litMatcher{
-				pos:        position{line: 5057, col: 22, offset: 153869},
+				pos:        position{line: 5057, col: 22, offset: 153826},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13372,16 +13372,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5058, col: 1, offset: 153876},
+			pos:  position{line: 5058, col: 1, offset: 153833},
 			expr: &seqExpr{
-				pos: position{line: 5058, col: 13, offset: 153888},
+				pos: position{line: 5058, col: 13, offset: 153845},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5058, col: 13, offset: 153888},
+						pos:  position{line: 5058, col: 13, offset: 153845},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5058, col: 31, offset: 153906},
+						pos:  position{line: 5058, col: 31, offset: 153863},
 						name: "SPACE",
 					},
 				},
@@ -13389,18 +13389,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5059, col: 1, offset: 153912},
+			pos:  position{line: 5059, col: 1, offset: 153869},
 			expr: &seqExpr{
-				pos: position{line: 5059, col: 13, offset: 153924},
+				pos: position{line: 5059, col: 13, offset: 153881},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5059, col: 13, offset: 153924},
+						pos:        position{line: 5059, col: 13, offset: 153881},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5059, col: 20, offset: 153931},
+						pos:  position{line: 5059, col: 20, offset: 153888},
 						name: "SPACE",
 					},
 				},
@@ -13408,18 +13408,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5060, col: 1, offset: 153937},
+			pos:  position{line: 5060, col: 1, offset: 153894},
 			expr: &seqExpr{
-				pos: position{line: 5060, col: 12, offset: 153948},
+				pos: position{line: 5060, col: 12, offset: 153905},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5060, col: 12, offset: 153948},
+						pos:        position{line: 5060, col: 12, offset: 153905},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5060, col: 18, offset: 153954},
+						pos:  position{line: 5060, col: 18, offset: 153911},
 						name: "SPACE",
 					},
 				},
@@ -13427,18 +13427,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5061, col: 1, offset: 153960},
+			pos:  position{line: 5061, col: 1, offset: 153917},
 			expr: &seqExpr{
-				pos: position{line: 5061, col: 13, offset: 153972},
+				pos: position{line: 5061, col: 13, offset: 153929},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5061, col: 13, offset: 153972},
+						pos:        position{line: 5061, col: 13, offset: 153929},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5061, col: 20, offset: 153979},
+						pos:  position{line: 5061, col: 20, offset: 153936},
 						name: "SPACE",
 					},
 				},
@@ -13446,9 +13446,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5062, col: 1, offset: 153985},
+			pos:  position{line: 5062, col: 1, offset: 153942},
 			expr: &litMatcher{
-				pos:        position{line: 5062, col: 12, offset: 153996},
+				pos:        position{line: 5062, col: 12, offset: 153953},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13456,9 +13456,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5063, col: 1, offset: 154002},
+			pos:  position{line: 5063, col: 1, offset: 153959},
 			expr: &litMatcher{
-				pos:        position{line: 5063, col: 13, offset: 154014},
+				pos:        position{line: 5063, col: 13, offset: 153971},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13466,18 +13466,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5064, col: 1, offset: 154021},
+			pos:  position{line: 5064, col: 1, offset: 153978},
 			expr: &seqExpr{
-				pos: position{line: 5064, col: 15, offset: 154035},
+				pos: position{line: 5064, col: 15, offset: 153992},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5064, col: 15, offset: 154035},
+						pos:        position{line: 5064, col: 15, offset: 153992},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5064, col: 24, offset: 154044},
+						pos:  position{line: 5064, col: 24, offset: 154001},
 						name: "SPACE",
 					},
 				},
@@ -13485,18 +13485,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5065, col: 1, offset: 154050},
+			pos:  position{line: 5065, col: 1, offset: 154007},
 			expr: &seqExpr{
-				pos: position{line: 5065, col: 18, offset: 154067},
+				pos: position{line: 5065, col: 18, offset: 154024},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5065, col: 18, offset: 154067},
+						pos:        position{line: 5065, col: 18, offset: 154024},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 30, offset: 154079},
+						pos:  position{line: 5065, col: 30, offset: 154036},
 						name: "SPACE",
 					},
 				},
@@ -13504,18 +13504,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5066, col: 1, offset: 154085},
+			pos:  position{line: 5066, col: 1, offset: 154042},
 			expr: &seqExpr{
-				pos: position{line: 5066, col: 12, offset: 154096},
+				pos: position{line: 5066, col: 12, offset: 154053},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5066, col: 12, offset: 154096},
+						pos:        position{line: 5066, col: 12, offset: 154053},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5066, col: 18, offset: 154102},
+						pos:  position{line: 5066, col: 18, offset: 154059},
 						name: "SPACE",
 					},
 				},
@@ -13523,9 +13523,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5067, col: 1, offset: 154108},
+			pos:  position{line: 5067, col: 1, offset: 154065},
 			expr: &litMatcher{
-				pos:        position{line: 5067, col: 13, offset: 154120},
+				pos:        position{line: 5067, col: 13, offset: 154077},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13533,18 +13533,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5068, col: 1, offset: 154127},
+			pos:  position{line: 5068, col: 1, offset: 154084},
 			expr: &seqExpr{
-				pos: position{line: 5068, col: 20, offset: 154146},
+				pos: position{line: 5068, col: 20, offset: 154103},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5068, col: 20, offset: 154146},
+						pos:        position{line: 5068, col: 20, offset: 154103},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5068, col: 34, offset: 154160},
+						pos:  position{line: 5068, col: 34, offset: 154117},
 						name: "SPACE",
 					},
 				},
@@ -13552,9 +13552,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5069, col: 1, offset: 154166},
+			pos:  position{line: 5069, col: 1, offset: 154123},
 			expr: &litMatcher{
-				pos:        position{line: 5069, col: 14, offset: 154179},
+				pos:        position{line: 5069, col: 14, offset: 154136},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13562,22 +13562,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5070, col: 1, offset: 154187},
+			pos:  position{line: 5070, col: 1, offset: 154144},
 			expr: &seqExpr{
-				pos: position{line: 5070, col: 21, offset: 154207},
+				pos: position{line: 5070, col: 21, offset: 154164},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5070, col: 21, offset: 154207},
+						pos:  position{line: 5070, col: 21, offset: 154164},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5070, col: 27, offset: 154213},
+						pos:        position{line: 5070, col: 27, offset: 154170},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5070, col: 36, offset: 154222},
+						pos:  position{line: 5070, col: 36, offset: 154179},
 						name: "SPACE",
 					},
 				},
@@ -13585,9 +13585,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5071, col: 1, offset: 154228},
+			pos:  position{line: 5071, col: 1, offset: 154185},
 			expr: &litMatcher{
-				pos:        position{line: 5071, col: 15, offset: 154242},
+				pos:        position{line: 5071, col: 15, offset: 154199},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -13595,9 +13595,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5072, col: 1, offset: 154251},
+			pos:  position{line: 5072, col: 1, offset: 154208},
 			expr: &litMatcher{
-				pos:        position{line: 5072, col: 14, offset: 154264},
+				pos:        position{line: 5072, col: 14, offset: 154221},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -13605,9 +13605,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5073, col: 1, offset: 154272},
+			pos:  position{line: 5073, col: 1, offset: 154229},
 			expr: &litMatcher{
-				pos:        position{line: 5073, col: 15, offset: 154286},
+				pos:        position{line: 5073, col: 15, offset: 154243},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -13615,9 +13615,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5074, col: 1, offset: 154295},
+			pos:  position{line: 5074, col: 1, offset: 154252},
 			expr: &litMatcher{
-				pos:        position{line: 5074, col: 17, offset: 154311},
+				pos:        position{line: 5074, col: 17, offset: 154268},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -13625,9 +13625,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5075, col: 1, offset: 154322},
+			pos:  position{line: 5075, col: 1, offset: 154279},
 			expr: &litMatcher{
-				pos:        position{line: 5075, col: 15, offset: 154336},
+				pos:        position{line: 5075, col: 15, offset: 154293},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -13635,9 +13635,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5076, col: 1, offset: 154345},
+			pos:  position{line: 5076, col: 1, offset: 154302},
 			expr: &litMatcher{
-				pos:        position{line: 5076, col: 19, offset: 154363},
+				pos:        position{line: 5076, col: 19, offset: 154320},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -13645,9 +13645,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5077, col: 1, offset: 154376},
+			pos:  position{line: 5077, col: 1, offset: 154333},
 			expr: &litMatcher{
-				pos:        position{line: 5077, col: 17, offset: 154392},
+				pos:        position{line: 5077, col: 17, offset: 154349},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -13655,9 +13655,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5078, col: 1, offset: 154403},
+			pos:  position{line: 5078, col: 1, offset: 154360},
 			expr: &litMatcher{
-				pos:        position{line: 5078, col: 17, offset: 154419},
+				pos:        position{line: 5078, col: 17, offset: 154376},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -13665,18 +13665,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5079, col: 1, offset: 154430},
+			pos:  position{line: 5079, col: 1, offset: 154387},
 			expr: &seqExpr{
-				pos: position{line: 5079, col: 20, offset: 154449},
+				pos: position{line: 5079, col: 20, offset: 154406},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5079, col: 20, offset: 154449},
+						pos:        position{line: 5079, col: 20, offset: 154406},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5079, col: 34, offset: 154463},
+						pos:  position{line: 5079, col: 34, offset: 154420},
 						name: "SPACE",
 					},
 				},
@@ -13684,27 +13684,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5080, col: 1, offset: 154469},
+			pos:  position{line: 5080, col: 1, offset: 154426},
 			expr: &seqExpr{
-				pos: position{line: 5080, col: 16, offset: 154484},
+				pos: position{line: 5080, col: 16, offset: 154441},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5080, col: 16, offset: 154484},
+						pos: position{line: 5080, col: 16, offset: 154441},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5080, col: 16, offset: 154484},
+							pos:  position{line: 5080, col: 16, offset: 154441},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 23, offset: 154491},
+						pos:        position{line: 5080, col: 23, offset: 154448},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5080, col: 27, offset: 154495},
+						pos: position{line: 5080, col: 27, offset: 154452},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5080, col: 27, offset: 154495},
+							pos:  position{line: 5080, col: 27, offset: 154452},
 							name: "SPACE",
 						},
 					},
@@ -13713,9 +13713,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5081, col: 1, offset: 154502},
+			pos:  position{line: 5081, col: 1, offset: 154459},
 			expr: &litMatcher{
-				pos:        position{line: 5081, col: 17, offset: 154518},
+				pos:        position{line: 5081, col: 17, offset: 154475},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -13723,115 +13723,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5084, col: 1, offset: 154633},
+			pos:  position{line: 5084, col: 1, offset: 154590},
 			expr: &choiceExpr{
-				pos: position{line: 5084, col: 16, offset: 154648},
+				pos: position{line: 5084, col: 16, offset: 154605},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5084, col: 16, offset: 154648},
+						pos:        position{line: 5084, col: 16, offset: 154605},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5084, col: 47, offset: 154679},
+						pos:        position{line: 5084, col: 47, offset: 154636},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5084, col: 55, offset: 154687},
+						pos:        position{line: 5084, col: 55, offset: 154644},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 16, offset: 154710},
+						pos:        position{line: 5085, col: 16, offset: 154667},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 26, offset: 154720},
+						pos:        position{line: 5085, col: 26, offset: 154677},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 34, offset: 154728},
+						pos:        position{line: 5085, col: 34, offset: 154685},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 42, offset: 154736},
+						pos:        position{line: 5085, col: 42, offset: 154693},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 50, offset: 154744},
+						pos:        position{line: 5085, col: 50, offset: 154701},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 58, offset: 154752},
+						pos:        position{line: 5085, col: 58, offset: 154709},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5085, col: 66, offset: 154760},
+						pos:        position{line: 5085, col: 66, offset: 154717},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 16, offset: 154782},
+						pos:        position{line: 5086, col: 16, offset: 154739},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 26, offset: 154792},
+						pos:        position{line: 5086, col: 26, offset: 154749},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 34, offset: 154800},
+						pos:        position{line: 5086, col: 34, offset: 154757},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 42, offset: 154808},
+						pos:        position{line: 5086, col: 42, offset: 154765},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 50, offset: 154816},
+						pos:        position{line: 5086, col: 50, offset: 154773},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 58, offset: 154824},
+						pos:        position{line: 5086, col: 58, offset: 154781},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 66, offset: 154832},
+						pos:        position{line: 5086, col: 66, offset: 154789},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5086, col: 74, offset: 154840},
+						pos:        position{line: 5086, col: 74, offset: 154797},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -13841,25 +13841,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5087, col: 1, offset: 154846},
+			pos:  position{line: 5087, col: 1, offset: 154803},
 			expr: &choiceExpr{
-				pos: position{line: 5087, col: 16, offset: 154861},
+				pos: position{line: 5087, col: 16, offset: 154818},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5087, col: 16, offset: 154861},
+						pos:        position{line: 5087, col: 16, offset: 154818},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5087, col: 30, offset: 154875},
+						pos:        position{line: 5087, col: 30, offset: 154832},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5087, col: 36, offset: 154881},
+						pos:        position{line: 5087, col: 36, offset: 154838},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -13869,18 +13869,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5091, col: 1, offset: 155037},
+			pos:  position{line: 5091, col: 1, offset: 154994},
 			expr: &seqExpr{
-				pos: position{line: 5091, col: 8, offset: 155044},
+				pos: position{line: 5091, col: 8, offset: 155001},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5091, col: 8, offset: 155044},
+						pos:        position{line: 5091, col: 8, offset: 155001},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5091, col: 14, offset: 155050},
+						pos:  position{line: 5091, col: 14, offset: 155007},
 						name: "SPACE",
 					},
 				},
@@ -13888,22 +13888,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5092, col: 1, offset: 155056},
+			pos:  position{line: 5092, col: 1, offset: 155013},
 			expr: &seqExpr{
-				pos: position{line: 5092, col: 7, offset: 155062},
+				pos: position{line: 5092, col: 7, offset: 155019},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5092, col: 7, offset: 155062},
+						pos:  position{line: 5092, col: 7, offset: 155019},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5092, col: 13, offset: 155068},
+						pos:        position{line: 5092, col: 13, offset: 155025},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5092, col: 18, offset: 155073},
+						pos:  position{line: 5092, col: 18, offset: 155030},
 						name: "SPACE",
 					},
 				},
@@ -13911,22 +13911,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5093, col: 1, offset: 155079},
+			pos:  position{line: 5093, col: 1, offset: 155036},
 			expr: &seqExpr{
-				pos: position{line: 5093, col: 8, offset: 155086},
+				pos: position{line: 5093, col: 8, offset: 155043},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 8, offset: 155086},
+						pos:  position{line: 5093, col: 8, offset: 155043},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5093, col: 14, offset: 155092},
+						pos:        position{line: 5093, col: 14, offset: 155049},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5093, col: 20, offset: 155098},
+						pos:  position{line: 5093, col: 20, offset: 155055},
 						name: "SPACE",
 					},
 				},
@@ -13934,22 +13934,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5094, col: 1, offset: 155104},
+			pos:  position{line: 5094, col: 1, offset: 155061},
 			expr: &seqExpr{
-				pos: position{line: 5094, col: 9, offset: 155112},
+				pos: position{line: 5094, col: 9, offset: 155069},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 9, offset: 155112},
+						pos:  position{line: 5094, col: 9, offset: 155069},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5094, col: 24, offset: 155127},
+						pos:        position{line: 5094, col: 24, offset: 155084},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5094, col: 28, offset: 155131},
+						pos:  position{line: 5094, col: 28, offset: 155088},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13957,22 +13957,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5095, col: 1, offset: 155146},
+			pos:  position{line: 5095, col: 1, offset: 155103},
 			expr: &seqExpr{
-				pos: position{line: 5095, col: 7, offset: 155152},
+				pos: position{line: 5095, col: 7, offset: 155109},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5095, col: 7, offset: 155152},
+						pos:  position{line: 5095, col: 7, offset: 155109},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5095, col: 13, offset: 155158},
+						pos:        position{line: 5095, col: 13, offset: 155115},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5095, col: 19, offset: 155164},
+						pos:  position{line: 5095, col: 19, offset: 155121},
 						name: "SPACE",
 					},
 				},
@@ -13980,22 +13980,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5096, col: 1, offset: 155190},
+			pos:  position{line: 5096, col: 1, offset: 155147},
 			expr: &seqExpr{
-				pos: position{line: 5096, col: 7, offset: 155196},
+				pos: position{line: 5096, col: 7, offset: 155153},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5096, col: 7, offset: 155196},
+						pos:  position{line: 5096, col: 7, offset: 155153},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5096, col: 13, offset: 155202},
+						pos:        position{line: 5096, col: 13, offset: 155159},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5096, col: 19, offset: 155208},
+						pos:  position{line: 5096, col: 19, offset: 155165},
 						name: "SPACE",
 					},
 				},
@@ -14003,22 +14003,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5098, col: 1, offset: 155235},
+			pos:  position{line: 5098, col: 1, offset: 155192},
 			expr: &seqExpr{
-				pos: position{line: 5098, col: 10, offset: 155244},
+				pos: position{line: 5098, col: 10, offset: 155201},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5098, col: 10, offset: 155244},
+						pos:  position{line: 5098, col: 10, offset: 155201},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5098, col: 25, offset: 155259},
+						pos:        position{line: 5098, col: 25, offset: 155216},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5098, col: 29, offset: 155263},
+						pos:  position{line: 5098, col: 29, offset: 155220},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14026,22 +14026,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5099, col: 1, offset: 155278},
+			pos:  position{line: 5099, col: 1, offset: 155235},
 			expr: &seqExpr{
-				pos: position{line: 5099, col: 10, offset: 155287},
+				pos: position{line: 5099, col: 10, offset: 155244},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5099, col: 10, offset: 155287},
+						pos:  position{line: 5099, col: 10, offset: 155244},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5099, col: 25, offset: 155302},
+						pos:        position{line: 5099, col: 25, offset: 155259},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5099, col: 29, offset: 155306},
+						pos:  position{line: 5099, col: 29, offset: 155263},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14049,9 +14049,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5100, col: 1, offset: 155321},
+			pos:  position{line: 5100, col: 1, offset: 155278},
 			expr: &litMatcher{
-				pos:        position{line: 5100, col: 10, offset: 155330},
+				pos:        position{line: 5100, col: 10, offset: 155287},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14059,18 +14059,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5101, col: 1, offset: 155334},
+			pos:  position{line: 5101, col: 1, offset: 155291},
 			expr: &seqExpr{
-				pos: position{line: 5101, col: 12, offset: 155345},
+				pos: position{line: 5101, col: 12, offset: 155302},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5101, col: 12, offset: 155345},
+						pos:        position{line: 5101, col: 12, offset: 155302},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5101, col: 16, offset: 155349},
+						pos:  position{line: 5101, col: 16, offset: 155306},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14078,16 +14078,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5102, col: 1, offset: 155364},
+			pos:  position{line: 5102, col: 1, offset: 155321},
 			expr: &seqExpr{
-				pos: position{line: 5102, col: 12, offset: 155375},
+				pos: position{line: 5102, col: 12, offset: 155332},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5102, col: 12, offset: 155375},
+						pos:  position{line: 5102, col: 12, offset: 155332},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5102, col: 27, offset: 155390},
+						pos:        position{line: 5102, col: 27, offset: 155347},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14097,40 +14097,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5104, col: 1, offset: 155395},
+			pos:  position{line: 5104, col: 1, offset: 155352},
 			expr: &notExpr{
-				pos: position{line: 5104, col: 8, offset: 155402},
+				pos: position{line: 5104, col: 8, offset: 155359},
 				expr: &anyMatcher{
-					line: 5104, col: 9, offset: 155403,
+					line: 5104, col: 9, offset: 155360,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5105, col: 1, offset: 155405},
+			pos:  position{line: 5105, col: 1, offset: 155362},
 			expr: &choiceExpr{
-				pos: position{line: 5105, col: 15, offset: 155419},
+				pos: position{line: 5105, col: 15, offset: 155376},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5105, col: 15, offset: 155419},
+						pos:        position{line: 5105, col: 15, offset: 155376},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5105, col: 21, offset: 155425},
+						pos:        position{line: 5105, col: 21, offset: 155382},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5105, col: 28, offset: 155432},
+						pos:        position{line: 5105, col: 28, offset: 155389},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5105, col: 35, offset: 155439},
+						pos:        position{line: 5105, col: 35, offset: 155396},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14140,37 +14140,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5106, col: 1, offset: 155444},
+			pos:  position{line: 5106, col: 1, offset: 155401},
 			expr: &choiceExpr{
-				pos: position{line: 5106, col: 10, offset: 155453},
+				pos: position{line: 5106, col: 10, offset: 155410},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5106, col: 11, offset: 155454},
+						pos: position{line: 5106, col: 11, offset: 155411},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5106, col: 11, offset: 155454},
+								pos: position{line: 5106, col: 11, offset: 155411},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5106, col: 11, offset: 155454},
+									pos:  position{line: 5106, col: 11, offset: 155411},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5106, col: 23, offset: 155466},
+								pos:  position{line: 5106, col: 23, offset: 155423},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5106, col: 31, offset: 155474},
+								pos: position{line: 5106, col: 31, offset: 155431},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5106, col: 31, offset: 155474},
+									pos:  position{line: 5106, col: 31, offset: 155431},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5106, col: 46, offset: 155489},
+						pos: position{line: 5106, col: 46, offset: 155446},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5106, col: 46, offset: 155489},
+							pos:  position{line: 5106, col: 46, offset: 155446},
 							name: "WHITESPACE",
 						},
 					},
@@ -14179,38 +14179,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5107, col: 1, offset: 155501},
+			pos:  position{line: 5107, col: 1, offset: 155458},
 			expr: &seqExpr{
-				pos: position{line: 5107, col: 12, offset: 155512},
+				pos: position{line: 5107, col: 12, offset: 155469},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5107, col: 12, offset: 155512},
+						pos:        position{line: 5107, col: 12, offset: 155469},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5107, col: 18, offset: 155518},
+						pos: position{line: 5107, col: 18, offset: 155475},
 						expr: &seqExpr{
-							pos: position{line: 5107, col: 19, offset: 155519},
+							pos: position{line: 5107, col: 19, offset: 155476},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5107, col: 19, offset: 155519},
+									pos: position{line: 5107, col: 19, offset: 155476},
 									expr: &litMatcher{
-										pos:        position{line: 5107, col: 21, offset: 155521},
+										pos:        position{line: 5107, col: 21, offset: 155478},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5107, col: 28, offset: 155528,
+									line: 5107, col: 28, offset: 155485,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5107, col: 32, offset: 155532},
+						pos:        position{line: 5107, col: 32, offset: 155489},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14220,16 +14220,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5108, col: 1, offset: 155538},
+			pos:  position{line: 5108, col: 1, offset: 155495},
 			expr: &choiceExpr{
-				pos: position{line: 5108, col: 20, offset: 155557},
+				pos: position{line: 5108, col: 20, offset: 155514},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5108, col: 20, offset: 155557},
+						pos:  position{line: 5108, col: 20, offset: 155514},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5108, col: 28, offset: 155565},
+						pos:        position{line: 5108, col: 28, offset: 155522},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14239,16 +14239,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5109, col: 1, offset: 155568},
+			pos:  position{line: 5109, col: 1, offset: 155525},
 			expr: &choiceExpr{
-				pos: position{line: 5109, col: 19, offset: 155586},
+				pos: position{line: 5109, col: 19, offset: 155543},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5109, col: 19, offset: 155586},
+						pos:  position{line: 5109, col: 19, offset: 155543},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5109, col: 27, offset: 155594},
+						pos:  position{line: 5109, col: 27, offset: 155551},
 						name: "SPACE",
 					},
 				},
@@ -18957,11 +18957,11 @@ func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (an
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:                     op.(string),
-			Field:                  key.(string),
-			Values:                 ssr.value,
-			OriginalValues:         ssr.originalValue,
-			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
+			Op:              op.(string),
+			Field:           key.(string),
+			Values:          ssr.value,
+			OriginalValues:  ssr.originalValue,
+			CaseInsensitive: ssr.caseInsensitive,
 		},
 	}
 	return node, nil
@@ -18978,11 +18978,11 @@ func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, erro
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:                     "=",
-			Field:                  "*",
-			Values:                 ssr.value,
-			OriginalValues:         ssr.originalValue,
-			ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
+			Op:              "=",
+			Field:           "*",
+			Values:          ssr.value,
+			OriginalValues:  ssr.originalValue,
+			CaseInsensitive: ssr.caseInsensitive,
 		},
 	}
 	return node, nil
@@ -18996,9 +18996,9 @@ func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
 
 func (c *current) onCaseSensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
-		value:                  value,
-		originalValue:          value,
-		valueIsCaseInSensitive: false,
+		value:           value,
+		originalValue:   value,
+		caseInsensitive: false,
 	}, nil
 }
 
@@ -19010,9 +19010,9 @@ func (p *parser) callonCaseSensitiveString1() (any, error) {
 
 func (c *current) onCaseInsensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
-		value:                  strings.ToLower(value.(string)),
-		originalValue:          value,
-		valueIsCaseInSensitive: true,
+		value:           strings.ToLower(value.(string)),
+		originalValue:   value,
+		caseInsensitive: true,
 	}, nil
 }
 

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -489,170 +489,175 @@ type FormatResultsRequestArguments struct {
 	formatResultExpr *structs.FormatResultsRequest
 }
 
+type StringSearchRequest struct {
+	value                interface{}
+	valueIsCaseSensitive bool
+}
+
 var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 479, col: 1, offset: 13632},
+			pos:  position{line: 484, col: 1, offset: 13715},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 10, offset: 13641},
+				pos: position{line: 484, col: 10, offset: 13724},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 479, col: 10, offset: 13641},
+						pos: position{line: 484, col: 10, offset: 13724},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 479, col: 10, offset: 13641},
+							pos: position{line: 484, col: 10, offset: 13724},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 479, col: 10, offset: 13641},
+									pos: position{line: 484, col: 10, offset: 13724},
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 10, offset: 13641},
+										pos:  position{line: 484, col: 10, offset: 13724},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 17, offset: 13648},
+									pos:   position{line: 484, col: 17, offset: 13731},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 32, offset: 13663},
+										pos:  position{line: 484, col: 32, offset: 13746},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 52, offset: 13683},
+									pos:   position{line: 484, col: 52, offset: 13766},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 479, col: 65, offset: 13696},
+										pos: position{line: 484, col: 65, offset: 13779},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 66, offset: 13697},
+											pos:  position{line: 484, col: 66, offset: 13780},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 479, col: 80, offset: 13711},
+									pos:   position{line: 484, col: 80, offset: 13794},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 479, col: 95, offset: 13726},
+										pos: position{line: 484, col: 95, offset: 13809},
 										expr: &ruleRefExpr{
-											pos:  position{line: 479, col: 96, offset: 13727},
+											pos:  position{line: 484, col: 96, offset: 13810},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 479, col: 119, offset: 13750},
+									pos: position{line: 484, col: 119, offset: 13833},
 									expr: &ruleRefExpr{
-										pos:  position{line: 479, col: 119, offset: 13750},
+										pos:  position{line: 484, col: 119, offset: 13833},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 479, col: 126, offset: 13757},
+									pos:  position{line: 484, col: 126, offset: 13840},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 541, col: 3, offset: 15601},
+						pos: position{line: 546, col: 3, offset: 15684},
 						run: (*parser).callonStart17,
 						expr: &seqExpr{
-							pos: position{line: 541, col: 3, offset: 15601},
+							pos: position{line: 546, col: 3, offset: 15684},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 541, col: 3, offset: 15601},
+									pos: position{line: 546, col: 3, offset: 15684},
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 3, offset: 15601},
+										pos:  position{line: 546, col: 3, offset: 15684},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 10, offset: 15608},
+									pos:  position{line: 546, col: 10, offset: 15691},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 15, offset: 15613},
+									pos:  position{line: 546, col: 15, offset: 15696},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 28, offset: 15626},
+									pos:  position{line: 546, col: 28, offset: 15709},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 34, offset: 15632},
+									pos:   position{line: 546, col: 34, offset: 15715},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 50, offset: 15648},
+										pos:  position{line: 546, col: 50, offset: 15731},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 541, col: 70, offset: 15668},
+									pos:   position{line: 546, col: 70, offset: 15751},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 541, col: 85, offset: 15683},
+										pos: position{line: 546, col: 85, offset: 15766},
 										expr: &ruleRefExpr{
-											pos:  position{line: 541, col: 86, offset: 15684},
+											pos:  position{line: 546, col: 86, offset: 15767},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 541, col: 109, offset: 15707},
+									pos: position{line: 546, col: 109, offset: 15790},
 									expr: &ruleRefExpr{
-										pos:  position{line: 541, col: 109, offset: 15707},
+										pos:  position{line: 546, col: 109, offset: 15790},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 541, col: 116, offset: 15714},
+									pos:  position{line: 546, col: 116, offset: 15797},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 3, offset: 16169},
+						pos: position{line: 564, col: 3, offset: 16252},
 						run: (*parser).callonStart32,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 3, offset: 16169},
+							pos: position{line: 564, col: 3, offset: 16252},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 3, offset: 16169},
+									pos: position{line: 564, col: 3, offset: 16252},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 3, offset: 16169},
+										pos:  position{line: 564, col: 3, offset: 16252},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 559, col: 10, offset: 16176},
+									pos:   position{line: 564, col: 10, offset: 16259},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 22, offset: 16188},
+										pos:  position{line: 564, col: 22, offset: 16271},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 559, col: 39, offset: 16205},
+									pos:   position{line: 564, col: 39, offset: 16288},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 559, col: 54, offset: 16220},
+										pos: position{line: 564, col: 54, offset: 16303},
 										expr: &ruleRefExpr{
-											pos:  position{line: 559, col: 55, offset: 16221},
+											pos:  position{line: 564, col: 55, offset: 16304},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 78, offset: 16244},
+									pos: position{line: 564, col: 78, offset: 16327},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 78, offset: 16244},
+										pos:  position{line: 564, col: 78, offset: 16327},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 559, col: 85, offset: 16251},
+									pos:  position{line: 564, col: 85, offset: 16334},
 									name: "EOF",
 								},
 							},
@@ -663,76 +668,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 573, col: 1, offset: 16544},
+			pos:  position{line: 578, col: 1, offset: 16627},
 			expr: &actionExpr{
-				pos: position{line: 573, col: 21, offset: 16564},
+				pos: position{line: 578, col: 21, offset: 16647},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 573, col: 21, offset: 16564},
+					pos: position{line: 578, col: 21, offset: 16647},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 573, col: 21, offset: 16564},
+							pos:        position{line: 578, col: 21, offset: 16647},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 573, col: 26, offset: 16569},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 573, col: 32, offset: 16575},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 573, col: 36, offset: 16579},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 573, col: 41, offset: 16584},
+							pos:        position{line: 578, col: 26, offset: 16652},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 573, col: 47, offset: 16590},
+							pos:        position{line: 578, col: 32, offset: 16658},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 573, col: 51, offset: 16594},
+							pos:        position{line: 578, col: 36, offset: 16662},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 573, col: 56, offset: 16599},
+							pos:        position{line: 578, col: 41, offset: 16667},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 578, col: 47, offset: 16673},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 578, col: 51, offset: 16677},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 573, col: 61, offset: 16604},
+							pos:        position{line: 578, col: 56, offset: 16682},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 573, col: 66, offset: 16609},
+							pos:        position{line: 578, col: 61, offset: 16687},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 578, col: 66, offset: 16692},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -744,15 +749,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 580, col: 1, offset: 16750},
+			pos:  position{line: 585, col: 1, offset: 16833},
 			expr: &actionExpr{
-				pos: position{line: 580, col: 31, offset: 16780},
+				pos: position{line: 585, col: 31, offset: 16863},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 580, col: 31, offset: 16780},
+					pos:   position{line: 585, col: 31, offset: 16863},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 580, col: 38, offset: 16787},
+						pos:  position{line: 585, col: 38, offset: 16870},
 						name: "IntegerAsString",
 					},
 				},
@@ -760,22 +765,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 598, col: 1, offset: 17426},
+			pos:  position{line: 603, col: 1, offset: 17509},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 26, offset: 17451},
+				pos: position{line: 603, col: 26, offset: 17534},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 598, col: 26, offset: 17451},
+					pos:   position{line: 603, col: 26, offset: 17534},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 598, col: 37, offset: 17462},
+						pos: position{line: 603, col: 37, offset: 17545},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 598, col: 37, offset: 17462},
+								pos:  position{line: 603, col: 37, offset: 17545},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 598, col: 53, offset: 17478},
+								pos:  position{line: 603, col: 53, offset: 17561},
 								name: "PartialTimestamp",
 							},
 						},
@@ -785,22 +790,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 607, col: 1, offset: 17735},
+			pos:  position{line: 612, col: 1, offset: 17818},
 			expr: &actionExpr{
-				pos: position{line: 607, col: 17, offset: 17751},
+				pos: position{line: 612, col: 17, offset: 17834},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 607, col: 17, offset: 17751},
+					pos:   position{line: 612, col: 17, offset: 17834},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 607, col: 31, offset: 17765},
+						pos: position{line: 612, col: 31, offset: 17848},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 607, col: 31, offset: 17765},
+								pos:  position{line: 612, col: 31, offset: 17848},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 607, col: 55, offset: 17789},
+								pos:  position{line: 612, col: 55, offset: 17872},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -810,28 +815,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 611, col: 1, offset: 17851},
+			pos:  position{line: 616, col: 1, offset: 17934},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 22, offset: 17872},
+				pos: position{line: 616, col: 22, offset: 17955},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 22, offset: 17872},
+					pos: position{line: 616, col: 22, offset: 17955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 611, col: 22, offset: 17872},
+							pos:        position{line: 616, col: 22, offset: 17955},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 611, col: 28, offset: 17878},
+							pos:  position{line: 616, col: 28, offset: 17961},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 34, offset: 17884},
+							pos:   position{line: 616, col: 34, offset: 17967},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 45, offset: 17895},
+								pos:  position{line: 616, col: 45, offset: 17978},
 								name: "GenTimestamp",
 							},
 						},
@@ -841,28 +846,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 620, col: 1, offset: 18085},
+			pos:  position{line: 625, col: 1, offset: 18168},
 			expr: &actionExpr{
-				pos: position{line: 620, col: 24, offset: 18108},
+				pos: position{line: 625, col: 24, offset: 18191},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 620, col: 24, offset: 18108},
+					pos: position{line: 625, col: 24, offset: 18191},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 620, col: 24, offset: 18108},
+							pos:        position{line: 625, col: 24, offset: 18191},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 620, col: 32, offset: 18116},
+							pos:  position{line: 625, col: 32, offset: 18199},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 620, col: 38, offset: 18122},
+							pos:   position{line: 625, col: 38, offset: 18205},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 620, col: 49, offset: 18133},
+								pos:  position{line: 625, col: 49, offset: 18216},
 								name: "GenTimestamp",
 							},
 						},
@@ -872,59 +877,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 629, col: 1, offset: 18327},
+			pos:  position{line: 634, col: 1, offset: 18410},
 			expr: &actionExpr{
-				pos: position{line: 629, col: 28, offset: 18354},
+				pos: position{line: 634, col: 28, offset: 18437},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 629, col: 28, offset: 18354},
+					pos: position{line: 634, col: 28, offset: 18437},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 629, col: 28, offset: 18354},
+							pos:        position{line: 634, col: 28, offset: 18437},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 629, col: 40, offset: 18366},
+							pos:  position{line: 634, col: 40, offset: 18449},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 46, offset: 18372},
+							pos:   position{line: 634, col: 46, offset: 18455},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 629, col: 53, offset: 18379},
+								pos:  position{line: 634, col: 53, offset: 18462},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 69, offset: 18395},
+							pos:   position{line: 634, col: 69, offset: 18478},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 629, col: 77, offset: 18403},
+								pos: position{line: 634, col: 77, offset: 18486},
 								expr: &choiceExpr{
-									pos: position{line: 629, col: 78, offset: 18404},
+									pos: position{line: 634, col: 78, offset: 18487},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 629, col: 78, offset: 18404},
+											pos:        position{line: 634, col: 78, offset: 18487},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 629, col: 84, offset: 18410},
+											pos:        position{line: 634, col: 84, offset: 18493},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 629, col: 90, offset: 18416},
+											pos:        position{line: 634, col: 90, offset: 18499},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 629, col: 96, offset: 18422},
+											pos:        position{line: 634, col: 96, offset: 18505},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -939,26 +944,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 670, col: 1, offset: 19569},
+			pos:  position{line: 675, col: 1, offset: 19652},
 			expr: &actionExpr{
-				pos: position{line: 670, col: 19, offset: 19587},
+				pos: position{line: 675, col: 19, offset: 19670},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 670, col: 19, offset: 19587},
+					pos:   position{line: 675, col: 19, offset: 19670},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 670, col: 35, offset: 19603},
+						pos: position{line: 675, col: 35, offset: 19686},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 670, col: 35, offset: 19603},
+								pos:  position{line: 675, col: 35, offset: 19686},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 670, col: 55, offset: 19623},
+								pos:  position{line: 675, col: 55, offset: 19706},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 670, col: 77, offset: 19645},
+								pos:  position{line: 675, col: 77, offset: 19728},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -968,35 +973,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 674, col: 1, offset: 19706},
+			pos:  position{line: 679, col: 1, offset: 19789},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 23, offset: 19728},
+				pos: position{line: 679, col: 23, offset: 19811},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 23, offset: 19728},
+					pos: position{line: 679, col: 23, offset: 19811},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 674, col: 23, offset: 19728},
+							pos:   position{line: 679, col: 23, offset: 19811},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 29, offset: 19734},
+								pos:  position{line: 679, col: 29, offset: 19817},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 44, offset: 19749},
+							pos:   position{line: 679, col: 44, offset: 19832},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 674, col: 49, offset: 19754},
+								pos: position{line: 679, col: 49, offset: 19837},
 								expr: &seqExpr{
-									pos: position{line: 674, col: 50, offset: 19755},
+									pos: position{line: 679, col: 50, offset: 19838},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 674, col: 50, offset: 19755},
+											pos:  position{line: 679, col: 50, offset: 19838},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 674, col: 56, offset: 19761},
+											pos:  position{line: 679, col: 56, offset: 19844},
 											name: "GenTimesOption",
 										},
 									},
@@ -1009,25 +1014,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 721, col: 1, offset: 21304},
+			pos:  position{line: 726, col: 1, offset: 21387},
 			expr: &actionExpr{
-				pos: position{line: 721, col: 23, offset: 21326},
+				pos: position{line: 726, col: 23, offset: 21409},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 721, col: 23, offset: 21326},
+					pos: position{line: 726, col: 23, offset: 21409},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 721, col: 23, offset: 21326},
+							pos: position{line: 726, col: 23, offset: 21409},
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 23, offset: 21326},
+								pos:  position{line: 726, col: 23, offset: 21409},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 721, col: 35, offset: 21338},
+							pos:   position{line: 726, col: 35, offset: 21421},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 721, col: 42, offset: 21345},
+								pos:  position{line: 726, col: 42, offset: 21428},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1037,32 +1042,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 725, col: 1, offset: 21386},
+			pos:  position{line: 730, col: 1, offset: 21469},
 			expr: &actionExpr{
-				pos: position{line: 725, col: 16, offset: 21401},
+				pos: position{line: 730, col: 16, offset: 21484},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 725, col: 16, offset: 21401},
+					pos: position{line: 730, col: 16, offset: 21484},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 725, col: 16, offset: 21401},
+							pos: position{line: 730, col: 16, offset: 21484},
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 18, offset: 21403},
+								pos:  position{line: 730, col: 18, offset: 21486},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 725, col: 26, offset: 21411},
+							pos: position{line: 730, col: 26, offset: 21494},
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 26, offset: 21411},
+								pos:  position{line: 730, col: 26, offset: 21494},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 725, col: 38, offset: 21423},
+							pos:   position{line: 730, col: 38, offset: 21506},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 725, col: 45, offset: 21430},
+								pos:  position{line: 730, col: 45, offset: 21513},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1072,33 +1077,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 729, col: 1, offset: 21471},
+			pos:  position{line: 734, col: 1, offset: 21554},
 			expr: &actionExpr{
-				pos: position{line: 729, col: 16, offset: 21486},
+				pos: position{line: 734, col: 16, offset: 21569},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 729, col: 16, offset: 21486},
+					pos: position{line: 734, col: 16, offset: 21569},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 729, col: 16, offset: 21486},
+							pos:  position{line: 734, col: 16, offset: 21569},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 729, col: 21, offset: 21491},
+							pos:   position{line: 734, col: 21, offset: 21574},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 729, col: 28, offset: 21498},
+								pos: position{line: 734, col: 28, offset: 21581},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 729, col: 28, offset: 21498},
+										pos:  position{line: 734, col: 28, offset: 21581},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 729, col: 42, offset: 21512},
+										pos:  position{line: 734, col: 42, offset: 21595},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 729, col: 55, offset: 21525},
+										pos:  position{line: 734, col: 55, offset: 21608},
 										name: "TimeModifiers",
 									},
 								},
@@ -1110,102 +1115,102 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 734, col: 1, offset: 21604},
+			pos:  position{line: 739, col: 1, offset: 21687},
 			expr: &actionExpr{
-				pos: position{line: 734, col: 25, offset: 21628},
+				pos: position{line: 739, col: 25, offset: 21711},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 734, col: 25, offset: 21628},
+					pos:   position{line: 739, col: 25, offset: 21711},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 734, col: 32, offset: 21635},
+						pos: position{line: 739, col: 32, offset: 21718},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 32, offset: 21635},
+								pos:  position{line: 739, col: 32, offset: 21718},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 51, offset: 21654},
+								pos:  position{line: 739, col: 51, offset: 21737},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 69, offset: 21672},
+								pos:  position{line: 739, col: 69, offset: 21755},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 81, offset: 21684},
+								pos:  position{line: 739, col: 81, offset: 21767},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 94, offset: 21697},
+								pos:  position{line: 739, col: 94, offset: 21780},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 106, offset: 21709},
+								pos:  position{line: 739, col: 106, offset: 21792},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 117, offset: 21720},
+								pos:  position{line: 739, col: 117, offset: 21803},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 134, offset: 21737},
+								pos:  position{line: 739, col: 134, offset: 21820},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 148, offset: 21751},
+								pos:  position{line: 739, col: 148, offset: 21834},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 165, offset: 21768},
+								pos:  position{line: 739, col: 165, offset: 21851},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 184, offset: 21787},
+								pos:  position{line: 739, col: 184, offset: 21870},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 197, offset: 21800},
+								pos:  position{line: 739, col: 197, offset: 21883},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 209, offset: 21812},
+								pos:  position{line: 739, col: 209, offset: 21895},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 227, offset: 21830},
+								pos:  position{line: 739, col: 227, offset: 21913},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 240, offset: 21843},
+								pos:  position{line: 739, col: 240, offset: 21926},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 254, offset: 21857},
+								pos:  position{line: 739, col: 254, offset: 21940},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 272, offset: 21875},
+								pos:  position{line: 739, col: 272, offset: 21958},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 284, offset: 21887},
+								pos:  position{line: 739, col: 284, offset: 21970},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 295, offset: 21898},
+								pos:  position{line: 739, col: 295, offset: 21981},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 314, offset: 21917},
+								pos:  position{line: 739, col: 314, offset: 22000},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 330, offset: 21933},
+								pos:  position{line: 739, col: 330, offset: 22016},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 734, col: 346, offset: 21949},
+								pos:  position{line: 739, col: 346, offset: 22032},
 								name: "InputLookupAggBlock",
 							},
 						},
@@ -1215,37 +1220,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 739, col: 1, offset: 22050},
+			pos:  position{line: 744, col: 1, offset: 22133},
 			expr: &actionExpr{
-				pos: position{line: 739, col: 21, offset: 22070},
+				pos: position{line: 744, col: 21, offset: 22153},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 739, col: 21, offset: 22070},
+					pos: position{line: 744, col: 21, offset: 22153},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 21, offset: 22070},
+							pos:  position{line: 744, col: 21, offset: 22153},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 26, offset: 22075},
+							pos:  position{line: 744, col: 26, offset: 22158},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 739, col: 37, offset: 22086},
+							pos:   position{line: 744, col: 37, offset: 22169},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 739, col: 40, offset: 22089},
+								pos: position{line: 744, col: 40, offset: 22172},
 								expr: &choiceExpr{
-									pos: position{line: 739, col: 41, offset: 22090},
+									pos: position{line: 744, col: 41, offset: 22173},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 739, col: 41, offset: 22090},
+											pos:        position{line: 744, col: 41, offset: 22173},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 739, col: 47, offset: 22096},
+											pos:        position{line: 744, col: 47, offset: 22179},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1255,14 +1260,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 739, col: 53, offset: 22102},
+							pos:  position{line: 744, col: 53, offset: 22185},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 739, col: 68, offset: 22117},
+							pos:   position{line: 744, col: 68, offset: 22200},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 739, col: 75, offset: 22124},
+								pos:  position{line: 744, col: 75, offset: 22207},
 								name: "FieldNameList",
 							},
 						},
@@ -1272,28 +1277,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 757, col: 1, offset: 22628},
+			pos:  position{line: 762, col: 1, offset: 22711},
 			expr: &actionExpr{
-				pos: position{line: 757, col: 26, offset: 22653},
+				pos: position{line: 762, col: 26, offset: 22736},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 757, col: 26, offset: 22653},
+					pos: position{line: 762, col: 26, offset: 22736},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 757, col: 26, offset: 22653},
+							pos:   position{line: 762, col: 26, offset: 22736},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 757, col: 31, offset: 22658},
+								pos:  position{line: 762, col: 31, offset: 22741},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 757, col: 47, offset: 22674},
+							pos:   position{line: 762, col: 47, offset: 22757},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 757, col: 56, offset: 22683},
+								pos: position{line: 762, col: 56, offset: 22766},
 								expr: &ruleRefExpr{
-									pos:  position{line: 757, col: 57, offset: 22684},
+									pos:  position{line: 762, col: 57, offset: 22767},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1304,36 +1309,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 803, col: 1, offset: 24179},
+			pos:  position{line: 808, col: 1, offset: 24262},
 			expr: &actionExpr{
-				pos: position{line: 803, col: 20, offset: 24198},
+				pos: position{line: 808, col: 20, offset: 24281},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 803, col: 20, offset: 24198},
+					pos: position{line: 808, col: 20, offset: 24281},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 20, offset: 24198},
+							pos:  position{line: 808, col: 20, offset: 24281},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 803, col: 25, offset: 24203},
+							pos:  position{line: 808, col: 25, offset: 24286},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 35, offset: 24213},
+							pos:   position{line: 808, col: 35, offset: 24296},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 803, col: 41, offset: 24219},
+								pos:  position{line: 808, col: 41, offset: 24302},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 803, col: 64, offset: 24242},
+							pos:   position{line: 808, col: 64, offset: 24325},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 803, col: 72, offset: 24250},
+								pos: position{line: 808, col: 72, offset: 24333},
 								expr: &ruleRefExpr{
-									pos:  position{line: 803, col: 73, offset: 24251},
+									pos:  position{line: 808, col: 73, offset: 24334},
 									name: "StatsOptions",
 								},
 							},
@@ -1344,17 +1349,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 817, col: 1, offset: 24584},
+			pos:  position{line: 822, col: 1, offset: 24667},
 			expr: &actionExpr{
-				pos: position{line: 817, col: 17, offset: 24600},
+				pos: position{line: 822, col: 17, offset: 24683},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 817, col: 17, offset: 24600},
+					pos:   position{line: 822, col: 17, offset: 24683},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 817, col: 24, offset: 24607},
+						pos: position{line: 822, col: 24, offset: 24690},
 						expr: &ruleRefExpr{
-							pos:  position{line: 817, col: 25, offset: 24608},
+							pos:  position{line: 822, col: 25, offset: 24691},
 							name: "StatsOption",
 						},
 					},
@@ -1363,45 +1368,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 855, col: 1, offset: 26049},
+			pos:  position{line: 860, col: 1, offset: 26132},
 			expr: &actionExpr{
-				pos: position{line: 855, col: 16, offset: 26064},
+				pos: position{line: 860, col: 16, offset: 26147},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 855, col: 16, offset: 26064},
+					pos: position{line: 860, col: 16, offset: 26147},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 16, offset: 26064},
+							pos:  position{line: 860, col: 16, offset: 26147},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 22, offset: 26070},
+							pos:   position{line: 860, col: 22, offset: 26153},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 855, col: 32, offset: 26080},
+								pos:  position{line: 860, col: 32, offset: 26163},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 855, col: 47, offset: 26095},
+							pos:  position{line: 860, col: 47, offset: 26178},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 855, col: 53, offset: 26101},
+							pos:   position{line: 860, col: 53, offset: 26184},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 855, col: 58, offset: 26106},
+								pos: position{line: 860, col: 58, offset: 26189},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 855, col: 58, offset: 26106},
+										pos:  position{line: 860, col: 58, offset: 26189},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 855, col: 76, offset: 26124},
+										pos:  position{line: 860, col: 76, offset: 26207},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 855, col: 94, offset: 26142},
+										pos:  position{line: 860, col: 94, offset: 26225},
 										name: "QuotedString",
 									},
 								},
@@ -1413,36 +1418,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 860, col: 1, offset: 26247},
+			pos:  position{line: 865, col: 1, offset: 26330},
 			expr: &actionExpr{
-				pos: position{line: 860, col: 19, offset: 26265},
+				pos: position{line: 865, col: 19, offset: 26348},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 860, col: 19, offset: 26265},
+					pos:   position{line: 865, col: 19, offset: 26348},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 860, col: 27, offset: 26273},
+						pos: position{line: 865, col: 27, offset: 26356},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 860, col: 27, offset: 26273},
+								pos:        position{line: 865, col: 27, offset: 26356},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 860, col: 38, offset: 26284},
+								pos:        position{line: 865, col: 38, offset: 26367},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 860, col: 58, offset: 26304},
+								pos:        position{line: 865, col: 58, offset: 26387},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 860, col: 68, offset: 26314},
+								pos:        position{line: 865, col: 68, offset: 26397},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1454,22 +1459,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 868, col: 1, offset: 26504},
+			pos:  position{line: 873, col: 1, offset: 26587},
 			expr: &actionExpr{
-				pos: position{line: 868, col: 17, offset: 26520},
+				pos: position{line: 873, col: 17, offset: 26603},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 868, col: 17, offset: 26520},
+					pos: position{line: 873, col: 17, offset: 26603},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 868, col: 17, offset: 26520},
+							pos:  position{line: 873, col: 17, offset: 26603},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 868, col: 20, offset: 26523},
+							pos:   position{line: 873, col: 20, offset: 26606},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 868, col: 27, offset: 26530},
+								pos:  position{line: 873, col: 27, offset: 26613},
 								name: "FieldNameList",
 							},
 						},
@@ -1479,28 +1484,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 880, col: 1, offset: 26880},
+			pos:  position{line: 885, col: 1, offset: 26963},
 			expr: &actionExpr{
-				pos: position{line: 880, col: 35, offset: 26914},
+				pos: position{line: 885, col: 35, offset: 26997},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 880, col: 35, offset: 26914},
+					pos: position{line: 885, col: 35, offset: 26997},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 880, col: 35, offset: 26914},
+							pos:        position{line: 885, col: 35, offset: 26997},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 880, col: 53, offset: 26932},
+							pos:  position{line: 885, col: 53, offset: 27015},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 880, col: 59, offset: 26938},
+							pos:   position{line: 885, col: 59, offset: 27021},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 880, col: 67, offset: 26946},
+								pos:  position{line: 885, col: 67, offset: 27029},
 								name: "Boolean",
 							},
 						},
@@ -1510,28 +1515,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 892, col: 1, offset: 27207},
+			pos:  position{line: 897, col: 1, offset: 27290},
 			expr: &actionExpr{
-				pos: position{line: 892, col: 29, offset: 27235},
+				pos: position{line: 897, col: 29, offset: 27318},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 892, col: 29, offset: 27235},
+					pos: position{line: 897, col: 29, offset: 27318},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 892, col: 29, offset: 27235},
+							pos:        position{line: 897, col: 29, offset: 27318},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 892, col: 39, offset: 27245},
+							pos:  position{line: 897, col: 39, offset: 27328},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 892, col: 45, offset: 27251},
+							pos:   position{line: 897, col: 45, offset: 27334},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 892, col: 53, offset: 27259},
+								pos:  position{line: 897, col: 53, offset: 27342},
 								name: "Boolean",
 							},
 						},
@@ -1541,28 +1546,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 904, col: 1, offset: 27506},
+			pos:  position{line: 909, col: 1, offset: 27589},
 			expr: &actionExpr{
-				pos: position{line: 904, col: 28, offset: 27533},
+				pos: position{line: 909, col: 28, offset: 27616},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 904, col: 28, offset: 27533},
+					pos: position{line: 909, col: 28, offset: 27616},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 904, col: 28, offset: 27533},
+							pos:        position{line: 909, col: 28, offset: 27616},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 904, col: 37, offset: 27542},
+							pos:  position{line: 909, col: 37, offset: 27625},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 904, col: 43, offset: 27548},
+							pos:   position{line: 909, col: 43, offset: 27631},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 904, col: 51, offset: 27556},
+								pos:  position{line: 909, col: 51, offset: 27639},
 								name: "Boolean",
 							},
 						},
@@ -1572,28 +1577,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 917, col: 1, offset: 27890},
+			pos:  position{line: 922, col: 1, offset: 27973},
 			expr: &actionExpr{
-				pos: position{line: 917, col: 28, offset: 27917},
+				pos: position{line: 922, col: 28, offset: 28000},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 917, col: 28, offset: 27917},
+					pos: position{line: 922, col: 28, offset: 28000},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 917, col: 28, offset: 27917},
+							pos:        position{line: 922, col: 28, offset: 28000},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 917, col: 37, offset: 27926},
+							pos:  position{line: 922, col: 37, offset: 28009},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 917, col: 43, offset: 27932},
+							pos:   position{line: 922, col: 43, offset: 28015},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 917, col: 51, offset: 27940},
+								pos:  position{line: 922, col: 51, offset: 28023},
 								name: "Boolean",
 							},
 						},
@@ -1603,28 +1608,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 930, col: 1, offset: 28274},
+			pos:  position{line: 935, col: 1, offset: 28357},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 28, offset: 28301},
+				pos: position{line: 935, col: 28, offset: 28384},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 930, col: 28, offset: 28301},
+					pos: position{line: 935, col: 28, offset: 28384},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 930, col: 28, offset: 28301},
+							pos:        position{line: 935, col: 28, offset: 28384},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 930, col: 37, offset: 28310},
+							pos:  position{line: 935, col: 37, offset: 28393},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 930, col: 43, offset: 28316},
+							pos:   position{line: 935, col: 43, offset: 28399},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 930, col: 54, offset: 28327},
+								pos:  position{line: 935, col: 54, offset: 28410},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1634,37 +1639,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 950, col: 1, offset: 28931},
+			pos:  position{line: 955, col: 1, offset: 29014},
 			expr: &actionExpr{
-				pos: position{line: 950, col: 33, offset: 28963},
+				pos: position{line: 955, col: 33, offset: 29046},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 950, col: 33, offset: 28963},
+					pos: position{line: 955, col: 33, offset: 29046},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 950, col: 33, offset: 28963},
+							pos:        position{line: 955, col: 33, offset: 29046},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 950, col: 48, offset: 28978},
+							pos:  position{line: 955, col: 48, offset: 29061},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 950, col: 54, offset: 28984},
+							pos:  position{line: 955, col: 54, offset: 29067},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 950, col: 62, offset: 28992},
+							pos:   position{line: 955, col: 62, offset: 29075},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 950, col: 71, offset: 29001},
+								pos:  position{line: 955, col: 71, offset: 29084},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 950, col: 80, offset: 29010},
+							pos:  position{line: 955, col: 80, offset: 29093},
 							name: "R_PAREN",
 						},
 					},
@@ -1673,37 +1678,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 962, col: 1, offset: 29280},
+			pos:  position{line: 967, col: 1, offset: 29363},
 			expr: &actionExpr{
-				pos: position{line: 962, col: 32, offset: 29311},
+				pos: position{line: 967, col: 32, offset: 29394},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 962, col: 32, offset: 29311},
+					pos: position{line: 967, col: 32, offset: 29394},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 962, col: 32, offset: 29311},
+							pos:        position{line: 967, col: 32, offset: 29394},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 46, offset: 29325},
+							pos:  position{line: 967, col: 46, offset: 29408},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 52, offset: 29331},
+							pos:  position{line: 967, col: 52, offset: 29414},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 962, col: 60, offset: 29339},
+							pos:   position{line: 967, col: 60, offset: 29422},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 962, col: 69, offset: 29348},
+								pos:  position{line: 967, col: 69, offset: 29431},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 962, col: 78, offset: 29357},
+							pos:  position{line: 967, col: 78, offset: 29440},
 							name: "R_PAREN",
 						},
 					},
@@ -1712,28 +1717,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 974, col: 1, offset: 29625},
+			pos:  position{line: 979, col: 1, offset: 29708},
 			expr: &actionExpr{
-				pos: position{line: 974, col: 32, offset: 29656},
+				pos: position{line: 979, col: 32, offset: 29739},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 974, col: 32, offset: 29656},
+					pos: position{line: 979, col: 32, offset: 29739},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 974, col: 32, offset: 29656},
+							pos:        position{line: 979, col: 32, offset: 29739},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 974, col: 46, offset: 29670},
+							pos:  position{line: 979, col: 46, offset: 29753},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 974, col: 52, offset: 29676},
+							pos:   position{line: 979, col: 52, offset: 29759},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 974, col: 63, offset: 29687},
+								pos:  position{line: 979, col: 63, offset: 29770},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1743,46 +1748,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 990, col: 1, offset: 30149},
+			pos:  position{line: 995, col: 1, offset: 30232},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 22, offset: 30170},
+				pos: position{line: 995, col: 22, offset: 30253},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 990, col: 22, offset: 30170},
+					pos:   position{line: 995, col: 22, offset: 30253},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 990, col: 32, offset: 30180},
+						pos: position{line: 995, col: 32, offset: 30263},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 32, offset: 30180},
+								pos:  position{line: 995, col: 32, offset: 30263},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 65, offset: 30213},
+								pos:  position{line: 995, col: 65, offset: 30296},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 92, offset: 30240},
+								pos:  position{line: 995, col: 92, offset: 30323},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 118, offset: 30266},
+								pos:  position{line: 995, col: 118, offset: 30349},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 144, offset: 30292},
+								pos:  position{line: 995, col: 144, offset: 30375},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 170, offset: 30318},
+								pos:  position{line: 995, col: 170, offset: 30401},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 201, offset: 30349},
+								pos:  position{line: 995, col: 201, offset: 30432},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 990, col: 231, offset: 30379},
+								pos:  position{line: 995, col: 231, offset: 30462},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1792,35 +1797,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 994, col: 1, offset: 30438},
+			pos:  position{line: 999, col: 1, offset: 30521},
 			expr: &actionExpr{
-				pos: position{line: 994, col: 26, offset: 30463},
+				pos: position{line: 999, col: 26, offset: 30546},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 994, col: 26, offset: 30463},
+					pos: position{line: 999, col: 26, offset: 30546},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 994, col: 26, offset: 30463},
+							pos:   position{line: 999, col: 26, offset: 30546},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 994, col: 32, offset: 30469},
+								pos:  position{line: 999, col: 32, offset: 30552},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 994, col: 50, offset: 30487},
+							pos:   position{line: 999, col: 50, offset: 30570},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 994, col: 55, offset: 30492},
+								pos: position{line: 999, col: 55, offset: 30575},
 								expr: &seqExpr{
-									pos: position{line: 994, col: 56, offset: 30493},
+									pos: position{line: 999, col: 56, offset: 30576},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 994, col: 56, offset: 30493},
+											pos:  position{line: 999, col: 56, offset: 30576},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 994, col: 62, offset: 30499},
+											pos:  position{line: 999, col: 62, offset: 30582},
 											name: "StreamStatsOption",
 										},
 									},
@@ -1833,41 +1838,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1053, col: 1, offset: 32688},
+			pos:  position{line: 1058, col: 1, offset: 32771},
 			expr: &choiceExpr{
-				pos: position{line: 1053, col: 21, offset: 32708},
+				pos: position{line: 1058, col: 21, offset: 32791},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1053, col: 21, offset: 32708},
+						pos: position{line: 1058, col: 21, offset: 32791},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1053, col: 21, offset: 32708},
+							pos: position{line: 1058, col: 21, offset: 32791},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 21, offset: 32708},
+									pos:  position{line: 1058, col: 21, offset: 32791},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 26, offset: 32713},
+									pos:  position{line: 1058, col: 26, offset: 32796},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1053, col: 42, offset: 32729},
+									pos:   position{line: 1058, col: 42, offset: 32812},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1053, col: 56, offset: 32743},
+										pos:  position{line: 1058, col: 56, offset: 32826},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1053, col: 79, offset: 32766},
+									pos:  position{line: 1058, col: 79, offset: 32849},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1053, col: 85, offset: 32772},
+									pos:   position{line: 1058, col: 85, offset: 32855},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1053, col: 91, offset: 32778},
+										pos:  position{line: 1058, col: 91, offset: 32861},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1875,24 +1880,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1060, col: 3, offset: 32957},
+						pos: position{line: 1065, col: 3, offset: 33040},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1060, col: 3, offset: 32957},
+							pos: position{line: 1065, col: 3, offset: 33040},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1060, col: 3, offset: 32957},
+									pos:  position{line: 1065, col: 3, offset: 33040},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1060, col: 8, offset: 32962},
+									pos:  position{line: 1065, col: 8, offset: 33045},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1060, col: 24, offset: 32978},
+									pos:   position{line: 1065, col: 24, offset: 33061},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1060, col: 30, offset: 32984},
+										pos:  position{line: 1065, col: 30, offset: 33067},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -1904,31 +1909,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1068, col: 1, offset: 33150},
+			pos:  position{line: 1073, col: 1, offset: 33233},
 			expr: &actionExpr{
-				pos: position{line: 1068, col: 15, offset: 33164},
+				pos: position{line: 1073, col: 15, offset: 33247},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1068, col: 15, offset: 33164},
+					pos: position{line: 1073, col: 15, offset: 33247},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1068, col: 15, offset: 33164},
+							pos:  position{line: 1073, col: 15, offset: 33247},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1068, col: 25, offset: 33174},
+							pos:   position{line: 1073, col: 25, offset: 33257},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1068, col: 34, offset: 33183},
+								pos: position{line: 1073, col: 34, offset: 33266},
 								expr: &seqExpr{
-									pos: position{line: 1068, col: 35, offset: 33184},
+									pos: position{line: 1073, col: 35, offset: 33267},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1068, col: 35, offset: 33184},
+											pos:  position{line: 1073, col: 35, offset: 33267},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1068, col: 45, offset: 33194},
+											pos:  position{line: 1073, col: 45, offset: 33277},
 											name: "EqualityOperator",
 										},
 									},
@@ -1936,10 +1941,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1068, col: 64, offset: 33213},
+							pos:   position{line: 1073, col: 64, offset: 33296},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1068, col: 68, offset: 33217},
+								pos:  position{line: 1073, col: 68, offset: 33300},
 								name: "QuotedString",
 							},
 						},
@@ -1949,44 +1954,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1096, col: 1, offset: 33796},
+			pos:  position{line: 1101, col: 1, offset: 33879},
 			expr: &actionExpr{
-				pos: position{line: 1096, col: 17, offset: 33812},
+				pos: position{line: 1101, col: 17, offset: 33895},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1096, col: 17, offset: 33812},
+					pos: position{line: 1101, col: 17, offset: 33895},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1096, col: 17, offset: 33812},
+							pos:   position{line: 1101, col: 17, offset: 33895},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1096, col: 23, offset: 33818},
+								pos:  position{line: 1101, col: 23, offset: 33901},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1096, col: 36, offset: 33831},
+							pos:   position{line: 1101, col: 36, offset: 33914},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1096, col: 41, offset: 33836},
+								pos: position{line: 1101, col: 41, offset: 33919},
 								expr: &seqExpr{
-									pos: position{line: 1096, col: 42, offset: 33837},
+									pos: position{line: 1101, col: 42, offset: 33920},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1096, col: 43, offset: 33838},
+											pos: position{line: 1101, col: 43, offset: 33921},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1096, col: 43, offset: 33838},
+													pos:  position{line: 1101, col: 43, offset: 33921},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1096, col: 49, offset: 33844},
+													pos:  position{line: 1101, col: 49, offset: 33927},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1096, col: 56, offset: 33851},
+											pos:  position{line: 1101, col: 56, offset: 33934},
 											name: "ClauseLevel3",
 										},
 									},
@@ -1999,35 +2004,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1114, col: 1, offset: 34228},
+			pos:  position{line: 1119, col: 1, offset: 34311},
 			expr: &actionExpr{
-				pos: position{line: 1114, col: 17, offset: 34244},
+				pos: position{line: 1119, col: 17, offset: 34327},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1114, col: 17, offset: 34244},
+					pos: position{line: 1119, col: 17, offset: 34327},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1114, col: 17, offset: 34244},
+							pos:   position{line: 1119, col: 17, offset: 34327},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1114, col: 23, offset: 34250},
+								pos:  position{line: 1119, col: 23, offset: 34333},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1114, col: 36, offset: 34263},
+							pos:   position{line: 1119, col: 36, offset: 34346},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1114, col: 41, offset: 34268},
+								pos: position{line: 1119, col: 41, offset: 34351},
 								expr: &seqExpr{
-									pos: position{line: 1114, col: 42, offset: 34269},
+									pos: position{line: 1119, col: 42, offset: 34352},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1114, col: 42, offset: 34269},
+											pos:  position{line: 1119, col: 42, offset: 34352},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1114, col: 45, offset: 34272},
+											pos:  position{line: 1119, col: 45, offset: 34355},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2040,32 +2045,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1132, col: 1, offset: 34637},
+			pos:  position{line: 1137, col: 1, offset: 34720},
 			expr: &choiceExpr{
-				pos: position{line: 1132, col: 17, offset: 34653},
+				pos: position{line: 1137, col: 17, offset: 34736},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1132, col: 17, offset: 34653},
+						pos: position{line: 1137, col: 17, offset: 34736},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1132, col: 17, offset: 34653},
+							pos: position{line: 1137, col: 17, offset: 34736},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1132, col: 17, offset: 34653},
+									pos:   position{line: 1137, col: 17, offset: 34736},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1132, col: 25, offset: 34661},
+										pos: position{line: 1137, col: 25, offset: 34744},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1132, col: 25, offset: 34661},
+											pos:  position{line: 1137, col: 25, offset: 34744},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1132, col: 30, offset: 34666},
+									pos:   position{line: 1137, col: 30, offset: 34749},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1132, col: 36, offset: 34672},
+										pos:  position{line: 1137, col: 36, offset: 34755},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2073,13 +2078,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1143, col: 5, offset: 34968},
+						pos: position{line: 1148, col: 5, offset: 35051},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1143, col: 5, offset: 34968},
+							pos:   position{line: 1148, col: 5, offset: 35051},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1143, col: 12, offset: 34975},
+								pos:  position{line: 1148, col: 12, offset: 35058},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2089,43 +2094,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1147, col: 1, offset: 35016},
+			pos:  position{line: 1152, col: 1, offset: 35099},
 			expr: &choiceExpr{
-				pos: position{line: 1147, col: 17, offset: 35032},
+				pos: position{line: 1152, col: 17, offset: 35115},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1147, col: 17, offset: 35032},
+						pos: position{line: 1152, col: 17, offset: 35115},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1147, col: 17, offset: 35032},
+							pos: position{line: 1152, col: 17, offset: 35115},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 17, offset: 35032},
+									pos:  position{line: 1152, col: 17, offset: 35115},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1147, col: 25, offset: 35040},
+									pos:   position{line: 1152, col: 25, offset: 35123},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1147, col: 32, offset: 35047},
+										pos:  position{line: 1152, col: 32, offset: 35130},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1147, col: 45, offset: 35060},
+									pos:  position{line: 1152, col: 45, offset: 35143},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1149, col: 5, offset: 35097},
+						pos: position{line: 1154, col: 5, offset: 35180},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1149, col: 5, offset: 35097},
+							pos:   position{line: 1154, col: 5, offset: 35180},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1149, col: 10, offset: 35102},
+								pos:  position{line: 1154, col: 10, offset: 35185},
 								name: "SearchTerm",
 							},
 						},
@@ -2135,26 +2140,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1155, col: 1, offset: 35260},
+			pos:  position{line: 1160, col: 1, offset: 35343},
 			expr: &actionExpr{
-				pos: position{line: 1155, col: 15, offset: 35274},
+				pos: position{line: 1160, col: 15, offset: 35357},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1155, col: 15, offset: 35274},
+					pos:   position{line: 1160, col: 15, offset: 35357},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1155, col: 21, offset: 35280},
+						pos: position{line: 1160, col: 21, offset: 35363},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1155, col: 21, offset: 35280},
+								pos:  position{line: 1160, col: 21, offset: 35363},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1155, col: 44, offset: 35303},
+								pos:  position{line: 1160, col: 44, offset: 35386},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1155, col: 68, offset: 35327},
+								pos:  position{line: 1160, col: 68, offset: 35410},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2164,36 +2169,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1160, col: 1, offset: 35468},
+			pos:  position{line: 1165, col: 1, offset: 35551},
 			expr: &actionExpr{
-				pos: position{line: 1160, col: 19, offset: 35486},
+				pos: position{line: 1165, col: 19, offset: 35569},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1160, col: 19, offset: 35486},
+					pos: position{line: 1165, col: 19, offset: 35569},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1160, col: 19, offset: 35486},
+							pos:  position{line: 1165, col: 19, offset: 35569},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1160, col: 24, offset: 35491},
+							pos:  position{line: 1165, col: 24, offset: 35574},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1160, col: 38, offset: 35505},
+							pos:   position{line: 1165, col: 38, offset: 35588},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1160, col: 45, offset: 35512},
+								pos:  position{line: 1165, col: 45, offset: 35595},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1160, col: 68, offset: 35535},
+							pos:   position{line: 1165, col: 68, offset: 35618},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1160, col: 78, offset: 35545},
+								pos: position{line: 1165, col: 78, offset: 35628},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1160, col: 79, offset: 35546},
+									pos:  position{line: 1165, col: 79, offset: 35629},
 									name: "LimitExpr",
 								},
 							},
@@ -2204,35 +2209,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1248, col: 1, offset: 38289},
+			pos:  position{line: 1253, col: 1, offset: 38372},
 			expr: &actionExpr{
-				pos: position{line: 1248, col: 27, offset: 38315},
+				pos: position{line: 1253, col: 27, offset: 38398},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1248, col: 27, offset: 38315},
+					pos: position{line: 1253, col: 27, offset: 38398},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1248, col: 27, offset: 38315},
+							pos:   position{line: 1253, col: 27, offset: 38398},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1248, col: 33, offset: 38321},
+								pos:  position{line: 1253, col: 33, offset: 38404},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1248, col: 51, offset: 38339},
+							pos:   position{line: 1253, col: 51, offset: 38422},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1248, col: 56, offset: 38344},
+								pos: position{line: 1253, col: 56, offset: 38427},
 								expr: &seqExpr{
-									pos: position{line: 1248, col: 57, offset: 38345},
+									pos: position{line: 1253, col: 57, offset: 38428},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1248, col: 57, offset: 38345},
+											pos:  position{line: 1253, col: 57, offset: 38428},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1248, col: 63, offset: 38351},
+											pos:  position{line: 1253, col: 63, offset: 38434},
 											name: "TimechartArgument",
 										},
 									},
@@ -2245,22 +2250,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1277, col: 1, offset: 39085},
+			pos:  position{line: 1282, col: 1, offset: 39168},
 			expr: &actionExpr{
-				pos: position{line: 1277, col: 22, offset: 39106},
+				pos: position{line: 1282, col: 22, offset: 39189},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1277, col: 22, offset: 39106},
+					pos:   position{line: 1282, col: 22, offset: 39189},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1277, col: 29, offset: 39113},
+						pos: position{line: 1282, col: 29, offset: 39196},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1277, col: 29, offset: 39113},
+								pos:  position{line: 1282, col: 29, offset: 39196},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1277, col: 45, offset: 39129},
+								pos:  position{line: 1282, col: 45, offset: 39212},
 								name: "TcOptions",
 							},
 						},
@@ -2270,28 +2275,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1281, col: 1, offset: 39167},
+			pos:  position{line: 1286, col: 1, offset: 39250},
 			expr: &actionExpr{
-				pos: position{line: 1281, col: 18, offset: 39184},
+				pos: position{line: 1286, col: 18, offset: 39267},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1281, col: 18, offset: 39184},
+					pos: position{line: 1286, col: 18, offset: 39267},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1281, col: 18, offset: 39184},
+							pos:   position{line: 1286, col: 18, offset: 39267},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1281, col: 23, offset: 39189},
+								pos:  position{line: 1286, col: 23, offset: 39272},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1281, col: 39, offset: 39205},
+							pos:   position{line: 1286, col: 39, offset: 39288},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1281, col: 53, offset: 39219},
+								pos: position{line: 1286, col: 53, offset: 39302},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1281, col: 53, offset: 39219},
+									pos:  position{line: 1286, col: 53, offset: 39302},
 									name: "SplitByClause",
 								},
 							},
@@ -2302,22 +2307,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1295, col: 1, offset: 39558},
+			pos:  position{line: 1300, col: 1, offset: 39641},
 			expr: &actionExpr{
-				pos: position{line: 1295, col: 18, offset: 39575},
+				pos: position{line: 1300, col: 18, offset: 39658},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1295, col: 18, offset: 39575},
+					pos: position{line: 1300, col: 18, offset: 39658},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1295, col: 18, offset: 39575},
+							pos:  position{line: 1300, col: 18, offset: 39658},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1295, col: 21, offset: 39578},
+							pos:   position{line: 1300, col: 21, offset: 39661},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1295, col: 27, offset: 39584},
+								pos:  position{line: 1300, col: 27, offset: 39667},
 								name: "FieldName",
 							},
 						},
@@ -2327,24 +2332,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1303, col: 1, offset: 39713},
+			pos:  position{line: 1308, col: 1, offset: 39796},
 			expr: &actionExpr{
-				pos: position{line: 1303, col: 14, offset: 39726},
+				pos: position{line: 1308, col: 14, offset: 39809},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1303, col: 14, offset: 39726},
+					pos:   position{line: 1308, col: 14, offset: 39809},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1303, col: 22, offset: 39734},
+						pos: position{line: 1308, col: 22, offset: 39817},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1303, col: 22, offset: 39734},
+								pos:  position{line: 1308, col: 22, offset: 39817},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1303, col: 35, offset: 39747},
+								pos: position{line: 1308, col: 35, offset: 39830},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1303, col: 36, offset: 39748},
+									pos:  position{line: 1308, col: 36, offset: 39831},
 									name: "TcOption",
 								},
 							},
@@ -2355,34 +2360,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1345, col: 1, offset: 41268},
+			pos:  position{line: 1350, col: 1, offset: 41351},
 			expr: &actionExpr{
-				pos: position{line: 1345, col: 13, offset: 41280},
+				pos: position{line: 1350, col: 13, offset: 41363},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1345, col: 13, offset: 41280},
+					pos: position{line: 1350, col: 13, offset: 41363},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1345, col: 13, offset: 41280},
+							pos:  position{line: 1350, col: 13, offset: 41363},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1345, col: 19, offset: 41286},
+							pos:   position{line: 1350, col: 19, offset: 41369},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1345, col: 31, offset: 41298},
+								pos:  position{line: 1350, col: 31, offset: 41381},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1345, col: 43, offset: 41310},
+							pos:  position{line: 1350, col: 43, offset: 41393},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1345, col: 49, offset: 41316},
+							pos:   position{line: 1350, col: 49, offset: 41399},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1345, col: 53, offset: 41320},
+								pos:  position{line: 1350, col: 53, offset: 41403},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2392,36 +2397,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1350, col: 1, offset: 41433},
+			pos:  position{line: 1355, col: 1, offset: 41516},
 			expr: &actionExpr{
-				pos: position{line: 1350, col: 16, offset: 41448},
+				pos: position{line: 1355, col: 16, offset: 41531},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1350, col: 16, offset: 41448},
+					pos:   position{line: 1355, col: 16, offset: 41531},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1350, col: 24, offset: 41456},
+						pos: position{line: 1355, col: 24, offset: 41539},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1350, col: 24, offset: 41456},
+								pos:        position{line: 1355, col: 24, offset: 41539},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1350, col: 36, offset: 41468},
+								pos:        position{line: 1355, col: 36, offset: 41551},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1350, col: 49, offset: 41481},
+								pos:        position{line: 1355, col: 49, offset: 41564},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1350, col: 61, offset: 41493},
+								pos:        position{line: 1355, col: 61, offset: 41576},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2433,50 +2438,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1358, col: 1, offset: 41689},
+			pos:  position{line: 1363, col: 1, offset: 41772},
 			expr: &actionExpr{
-				pos: position{line: 1358, col: 17, offset: 41705},
+				pos: position{line: 1363, col: 17, offset: 41788},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1358, col: 17, offset: 41705},
+					pos:   position{line: 1363, col: 17, offset: 41788},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1358, col: 27, offset: 41715},
+						pos: position{line: 1363, col: 27, offset: 41798},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 27, offset: 41715},
+								pos:  position{line: 1363, col: 27, offset: 41798},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 36, offset: 41724},
+								pos:  position{line: 1363, col: 36, offset: 41807},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 44, offset: 41732},
+								pos:  position{line: 1363, col: 44, offset: 41815},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 57, offset: 41745},
+								pos:  position{line: 1363, col: 57, offset: 41828},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 66, offset: 41754},
+								pos:  position{line: 1363, col: 66, offset: 41837},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 73, offset: 41761},
+								pos:  position{line: 1363, col: 73, offset: 41844},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 79, offset: 41767},
+								pos:  position{line: 1363, col: 79, offset: 41850},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 86, offset: 41774},
+								pos:  position{line: 1363, col: 86, offset: 41857},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1358, col: 96, offset: 41784},
+								pos:  position{line: 1363, col: 96, offset: 41867},
 								name: "Year",
 							},
 						},
@@ -2486,37 +2491,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1362, col: 1, offset: 41820},
+			pos:  position{line: 1367, col: 1, offset: 41903},
 			expr: &actionExpr{
-				pos: position{line: 1362, col: 21, offset: 41840},
+				pos: position{line: 1367, col: 21, offset: 41923},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1362, col: 21, offset: 41840},
+					pos: position{line: 1367, col: 21, offset: 41923},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1362, col: 21, offset: 41840},
+							pos:   position{line: 1367, col: 21, offset: 41923},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1362, col: 29, offset: 41848},
+								pos: position{line: 1367, col: 29, offset: 41931},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1362, col: 29, offset: 41848},
+										pos:  position{line: 1367, col: 29, offset: 41931},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1362, col: 45, offset: 41864},
+										pos:  position{line: 1367, col: 45, offset: 41947},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1362, col: 62, offset: 41881},
+							pos:   position{line: 1367, col: 62, offset: 41964},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1362, col: 72, offset: 41891},
+								pos: position{line: 1367, col: 72, offset: 41974},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1362, col: 73, offset: 41892},
+									pos:  position{line: 1367, col: 73, offset: 41975},
 									name: "AllTimeScale",
 								},
 							},
@@ -2527,28 +2532,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1421, col: 1, offset: 44574},
+			pos:  position{line: 1426, col: 1, offset: 44657},
 			expr: &actionExpr{
-				pos: position{line: 1421, col: 21, offset: 44594},
+				pos: position{line: 1426, col: 21, offset: 44677},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1421, col: 21, offset: 44594},
+					pos: position{line: 1426, col: 21, offset: 44677},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1421, col: 21, offset: 44594},
+							pos:        position{line: 1426, col: 21, offset: 44677},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1421, col: 31, offset: 44604},
+							pos:  position{line: 1426, col: 31, offset: 44687},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1421, col: 37, offset: 44610},
+							pos:   position{line: 1426, col: 37, offset: 44693},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1421, col: 48, offset: 44621},
+								pos:  position{line: 1426, col: 48, offset: 44704},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2558,28 +2563,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1432, col: 1, offset: 44862},
+			pos:  position{line: 1437, col: 1, offset: 44945},
 			expr: &actionExpr{
-				pos: position{line: 1432, col: 21, offset: 44882},
+				pos: position{line: 1437, col: 21, offset: 44965},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1432, col: 21, offset: 44882},
+					pos: position{line: 1437, col: 21, offset: 44965},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1432, col: 21, offset: 44882},
+							pos:        position{line: 1437, col: 21, offset: 44965},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1432, col: 28, offset: 44889},
+							pos:  position{line: 1437, col: 28, offset: 44972},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1432, col: 34, offset: 44895},
+							pos:   position{line: 1437, col: 34, offset: 44978},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1432, col: 43, offset: 44904},
+								pos:  position{line: 1437, col: 43, offset: 44987},
 								name: "IntegerAsString",
 							},
 						},
@@ -2589,31 +2594,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1453, col: 1, offset: 45483},
+			pos:  position{line: 1458, col: 1, offset: 45566},
 			expr: &choiceExpr{
-				pos: position{line: 1453, col: 23, offset: 45505},
+				pos: position{line: 1458, col: 23, offset: 45588},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1453, col: 23, offset: 45505},
+						pos: position{line: 1458, col: 23, offset: 45588},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1453, col: 23, offset: 45505},
+							pos: position{line: 1458, col: 23, offset: 45588},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1453, col: 23, offset: 45505},
+									pos:        position{line: 1458, col: 23, offset: 45588},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1453, col: 35, offset: 45517},
+									pos:  position{line: 1458, col: 35, offset: 45600},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1453, col: 41, offset: 45523},
+									pos:   position{line: 1458, col: 41, offset: 45606},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1453, col: 51, offset: 45533},
+										pos:  position{line: 1458, col: 51, offset: 45616},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2621,33 +2626,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1467, col: 3, offset: 45952},
+						pos: position{line: 1472, col: 3, offset: 46035},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1467, col: 3, offset: 45952},
+							pos: position{line: 1472, col: 3, offset: 46035},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1467, col: 3, offset: 45952},
+									pos:        position{line: 1472, col: 3, offset: 46035},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1467, col: 15, offset: 45964},
+									pos:  position{line: 1472, col: 15, offset: 46047},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1467, col: 21, offset: 45970},
+									pos:   position{line: 1472, col: 21, offset: 46053},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1467, col: 32, offset: 45981},
+										pos: position{line: 1472, col: 32, offset: 46064},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1467, col: 32, offset: 45981},
+												pos:  position{line: 1472, col: 32, offset: 46064},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1467, col: 52, offset: 46001},
+												pos:  position{line: 1472, col: 52, offset: 46084},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2661,35 +2666,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1487, col: 1, offset: 46470},
+			pos:  position{line: 1492, col: 1, offset: 46553},
 			expr: &actionExpr{
-				pos: position{line: 1487, col: 19, offset: 46488},
+				pos: position{line: 1492, col: 19, offset: 46571},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1487, col: 19, offset: 46488},
+					pos: position{line: 1492, col: 19, offset: 46571},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1487, col: 19, offset: 46488},
+							pos:        position{line: 1492, col: 19, offset: 46571},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1487, col: 27, offset: 46496},
+							pos:  position{line: 1492, col: 27, offset: 46579},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1487, col: 33, offset: 46502},
+							pos:   position{line: 1492, col: 33, offset: 46585},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1487, col: 41, offset: 46510},
+								pos: position{line: 1492, col: 41, offset: 46593},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1487, col: 41, offset: 46510},
+										pos:  position{line: 1492, col: 41, offset: 46593},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1487, col: 57, offset: 46526},
+										pos:  position{line: 1492, col: 57, offset: 46609},
 										name: "IntegerAsString",
 									},
 								},
@@ -2701,35 +2706,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1502, col: 1, offset: 46905},
+			pos:  position{line: 1507, col: 1, offset: 46988},
 			expr: &actionExpr{
-				pos: position{line: 1502, col: 17, offset: 46921},
+				pos: position{line: 1507, col: 17, offset: 47004},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1502, col: 17, offset: 46921},
+					pos: position{line: 1507, col: 17, offset: 47004},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1502, col: 17, offset: 46921},
+							pos:        position{line: 1507, col: 17, offset: 47004},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1502, col: 23, offset: 46927},
+							pos:  position{line: 1507, col: 23, offset: 47010},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1502, col: 29, offset: 46933},
+							pos:   position{line: 1507, col: 29, offset: 47016},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1502, col: 37, offset: 46941},
+								pos: position{line: 1507, col: 37, offset: 47024},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1502, col: 37, offset: 46941},
+										pos:  position{line: 1507, col: 37, offset: 47024},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1502, col: 53, offset: 46957},
+										pos:  position{line: 1507, col: 53, offset: 47040},
 										name: "IntegerAsString",
 									},
 								},
@@ -2741,40 +2746,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1517, col: 1, offset: 47328},
+			pos:  position{line: 1522, col: 1, offset: 47411},
 			expr: &choiceExpr{
-				pos: position{line: 1517, col: 18, offset: 47345},
+				pos: position{line: 1522, col: 18, offset: 47428},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1517, col: 18, offset: 47345},
+						pos: position{line: 1522, col: 18, offset: 47428},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1517, col: 18, offset: 47345},
+							pos: position{line: 1522, col: 18, offset: 47428},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1517, col: 18, offset: 47345},
+									pos:        position{line: 1522, col: 18, offset: 47428},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1517, col: 25, offset: 47352},
+									pos:  position{line: 1522, col: 25, offset: 47435},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1517, col: 31, offset: 47358},
+									pos:   position{line: 1522, col: 31, offset: 47441},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1517, col: 36, offset: 47363},
+										pos: position{line: 1522, col: 36, offset: 47446},
 										expr: &choiceExpr{
-											pos: position{line: 1517, col: 37, offset: 47364},
+											pos: position{line: 1522, col: 37, offset: 47447},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1517, col: 37, offset: 47364},
+													pos:  position{line: 1522, col: 37, offset: 47447},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1517, col: 53, offset: 47380},
+													pos:  position{line: 1522, col: 53, offset: 47463},
 													name: "IntegerAsString",
 												},
 											},
@@ -2782,25 +2787,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1517, col: 71, offset: 47398},
+									pos:        position{line: 1522, col: 71, offset: 47481},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1517, col: 77, offset: 47404},
+									pos:   position{line: 1522, col: 77, offset: 47487},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1517, col: 82, offset: 47409},
+										pos: position{line: 1522, col: 82, offset: 47492},
 										expr: &choiceExpr{
-											pos: position{line: 1517, col: 83, offset: 47410},
+											pos: position{line: 1522, col: 83, offset: 47493},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1517, col: 83, offset: 47410},
+													pos:  position{line: 1522, col: 83, offset: 47493},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1517, col: 99, offset: 47426},
+													pos:  position{line: 1522, col: 99, offset: 47509},
 													name: "IntegerAsString",
 												},
 											},
@@ -2811,26 +2816,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1560, col: 3, offset: 48862},
+						pos: position{line: 1565, col: 3, offset: 48945},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1560, col: 3, offset: 48862},
+							pos: position{line: 1565, col: 3, offset: 48945},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1560, col: 3, offset: 48862},
+									pos:        position{line: 1565, col: 3, offset: 48945},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1560, col: 10, offset: 48869},
+									pos:  position{line: 1565, col: 10, offset: 48952},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1560, col: 16, offset: 48875},
+									pos:   position{line: 1565, col: 16, offset: 48958},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1560, col: 24, offset: 48883},
+										pos:  position{line: 1565, col: 24, offset: 48966},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -2842,38 +2847,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1575, col: 1, offset: 49214},
+			pos:  position{line: 1580, col: 1, offset: 49297},
 			expr: &actionExpr{
-				pos: position{line: 1575, col: 17, offset: 49230},
+				pos: position{line: 1580, col: 17, offset: 49313},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1575, col: 17, offset: 49230},
+					pos:   position{line: 1580, col: 17, offset: 49313},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1575, col: 25, offset: 49238},
+						pos: position{line: 1580, col: 25, offset: 49321},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 25, offset: 49238},
+								pos:  position{line: 1580, col: 25, offset: 49321},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 46, offset: 49259},
+								pos:  position{line: 1580, col: 46, offset: 49342},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 65, offset: 49278},
+								pos:  position{line: 1580, col: 65, offset: 49361},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 84, offset: 49297},
+								pos:  position{line: 1580, col: 84, offset: 49380},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 101, offset: 49314},
+								pos:  position{line: 1580, col: 101, offset: 49397},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1575, col: 116, offset: 49329},
+								pos:  position{line: 1580, col: 116, offset: 49412},
 								name: "BinOptionSpan",
 							},
 						},
@@ -2883,35 +2888,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1579, col: 1, offset: 49372},
+			pos:  position{line: 1584, col: 1, offset: 49455},
 			expr: &actionExpr{
-				pos: position{line: 1579, col: 22, offset: 49393},
+				pos: position{line: 1584, col: 22, offset: 49476},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1579, col: 22, offset: 49393},
+					pos: position{line: 1584, col: 22, offset: 49476},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1579, col: 22, offset: 49393},
+							pos:   position{line: 1584, col: 22, offset: 49476},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1579, col: 29, offset: 49400},
+								pos:  position{line: 1584, col: 29, offset: 49483},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1579, col: 42, offset: 49413},
+							pos:   position{line: 1584, col: 42, offset: 49496},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1579, col: 48, offset: 49419},
+								pos: position{line: 1584, col: 48, offset: 49502},
 								expr: &seqExpr{
-									pos: position{line: 1579, col: 49, offset: 49420},
+									pos: position{line: 1584, col: 49, offset: 49503},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1579, col: 49, offset: 49420},
+											pos:  position{line: 1584, col: 49, offset: 49503},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1579, col: 55, offset: 49426},
+											pos:  position{line: 1584, col: 55, offset: 49509},
 											name: "BinCmdOption",
 										},
 									},
@@ -2924,51 +2929,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1625, col: 1, offset: 50910},
+			pos:  position{line: 1630, col: 1, offset: 50993},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 13, offset: 50922},
+				pos: position{line: 1630, col: 13, offset: 51005},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1625, col: 13, offset: 50922},
+						pos: position{line: 1630, col: 13, offset: 51005},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1625, col: 13, offset: 50922},
+							pos: position{line: 1630, col: 13, offset: 51005},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1625, col: 13, offset: 50922},
+									pos:  position{line: 1630, col: 13, offset: 51005},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1625, col: 18, offset: 50927},
+									pos:  position{line: 1630, col: 18, offset: 51010},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1625, col: 26, offset: 50935},
+									pos:   position{line: 1630, col: 26, offset: 51018},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1625, col: 40, offset: 50949},
+										pos:  position{line: 1630, col: 40, offset: 51032},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1625, col: 59, offset: 50968},
+									pos:  position{line: 1630, col: 59, offset: 51051},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1625, col: 65, offset: 50974},
+									pos:   position{line: 1630, col: 65, offset: 51057},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1625, col: 71, offset: 50980},
+										pos:  position{line: 1630, col: 71, offset: 51063},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1625, col: 81, offset: 50990},
+									pos:   position{line: 1630, col: 81, offset: 51073},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1625, col: 94, offset: 51003},
+										pos: position{line: 1630, col: 94, offset: 51086},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1625, col: 95, offset: 51004},
+											pos:  position{line: 1630, col: 95, offset: 51087},
 											name: "AsField",
 										},
 									},
@@ -2977,34 +2982,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1648, col: 3, offset: 51633},
+						pos: position{line: 1653, col: 3, offset: 51716},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1648, col: 3, offset: 51633},
+							pos: position{line: 1653, col: 3, offset: 51716},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1648, col: 3, offset: 51633},
+									pos:  position{line: 1653, col: 3, offset: 51716},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1648, col: 8, offset: 51638},
+									pos:  position{line: 1653, col: 8, offset: 51721},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1648, col: 16, offset: 51646},
+									pos:   position{line: 1653, col: 16, offset: 51729},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1648, col: 22, offset: 51652},
+										pos:  position{line: 1653, col: 22, offset: 51735},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1648, col: 32, offset: 51662},
+									pos:   position{line: 1653, col: 32, offset: 51745},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1648, col: 45, offset: 51675},
+										pos: position{line: 1653, col: 45, offset: 51758},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1648, col: 46, offset: 51676},
+											pos:  position{line: 1653, col: 46, offset: 51759},
 											name: "AsField",
 										},
 									},
@@ -3017,15 +3022,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1675, col: 1, offset: 52414},
+			pos:  position{line: 1680, col: 1, offset: 52497},
 			expr: &actionExpr{
-				pos: position{line: 1675, col: 15, offset: 52428},
+				pos: position{line: 1680, col: 15, offset: 52511},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1675, col: 15, offset: 52428},
+					pos:   position{line: 1680, col: 15, offset: 52511},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1675, col: 27, offset: 52440},
+						pos:  position{line: 1680, col: 27, offset: 52523},
 						name: "SpanOptions",
 					},
 				},
@@ -3033,26 +3038,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1683, col: 1, offset: 52665},
+			pos:  position{line: 1688, col: 1, offset: 52748},
 			expr: &actionExpr{
-				pos: position{line: 1683, col: 16, offset: 52680},
+				pos: position{line: 1688, col: 16, offset: 52763},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1683, col: 16, offset: 52680},
+					pos: position{line: 1688, col: 16, offset: 52763},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1683, col: 16, offset: 52680},
+							pos:  position{line: 1688, col: 16, offset: 52763},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1683, col: 25, offset: 52689},
+							pos:  position{line: 1688, col: 25, offset: 52772},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1683, col: 31, offset: 52695},
+							pos:   position{line: 1688, col: 31, offset: 52778},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1683, col: 42, offset: 52706},
+								pos:  position{line: 1688, col: 42, offset: 52789},
 								name: "SpanLength",
 							},
 						},
@@ -3062,26 +3067,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1690, col: 1, offset: 52852},
+			pos:  position{line: 1695, col: 1, offset: 52935},
 			expr: &actionExpr{
-				pos: position{line: 1690, col: 15, offset: 52866},
+				pos: position{line: 1695, col: 15, offset: 52949},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1690, col: 15, offset: 52866},
+					pos: position{line: 1695, col: 15, offset: 52949},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1690, col: 15, offset: 52866},
+							pos:   position{line: 1695, col: 15, offset: 52949},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1690, col: 24, offset: 52875},
+								pos:  position{line: 1695, col: 24, offset: 52958},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1690, col: 40, offset: 52891},
+							pos:   position{line: 1695, col: 40, offset: 52974},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1690, col: 50, offset: 52901},
+								pos:  position{line: 1695, col: 50, offset: 52984},
 								name: "AllTimeScale",
 							},
 						},
@@ -3091,43 +3096,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1707, col: 1, offset: 53447},
+			pos:  position{line: 1712, col: 1, offset: 53530},
 			expr: &actionExpr{
-				pos: position{line: 1707, col: 14, offset: 53460},
+				pos: position{line: 1712, col: 14, offset: 53543},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1707, col: 14, offset: 53460},
+					pos: position{line: 1712, col: 14, offset: 53543},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1707, col: 14, offset: 53460},
+							pos:  position{line: 1712, col: 14, offset: 53543},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1707, col: 20, offset: 53466},
+							pos:        position{line: 1712, col: 20, offset: 53549},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1707, col: 28, offset: 53474},
+							pos:  position{line: 1712, col: 28, offset: 53557},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1707, col: 34, offset: 53480},
+							pos:   position{line: 1712, col: 34, offset: 53563},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1707, col: 41, offset: 53487},
+								pos: position{line: 1712, col: 41, offset: 53570},
 								expr: &choiceExpr{
-									pos: position{line: 1707, col: 42, offset: 53488},
+									pos: position{line: 1712, col: 42, offset: 53571},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1707, col: 42, offset: 53488},
+											pos:        position{line: 1712, col: 42, offset: 53571},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1707, col: 50, offset: 53496},
+											pos:        position{line: 1712, col: 50, offset: 53579},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3137,14 +3142,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1707, col: 61, offset: 53507},
+							pos:  position{line: 1712, col: 61, offset: 53590},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1707, col: 76, offset: 53522},
+							pos:   position{line: 1712, col: 76, offset: 53605},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1707, col: 86, offset: 53532},
+								pos:  position{line: 1712, col: 86, offset: 53615},
 								name: "IntegerAsString",
 							},
 						},
@@ -3154,22 +3159,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1731, col: 1, offset: 54113},
+			pos:  position{line: 1736, col: 1, offset: 54196},
 			expr: &actionExpr{
-				pos: position{line: 1731, col: 19, offset: 54131},
+				pos: position{line: 1736, col: 19, offset: 54214},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1731, col: 19, offset: 54131},
+					pos: position{line: 1736, col: 19, offset: 54214},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1731, col: 19, offset: 54131},
+							pos:  position{line: 1736, col: 19, offset: 54214},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1731, col: 24, offset: 54136},
+							pos:   position{line: 1736, col: 24, offset: 54219},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1731, col: 38, offset: 54150},
+								pos:  position{line: 1736, col: 38, offset: 54233},
 								name: "StatisticExpr",
 							},
 						},
@@ -3179,76 +3184,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1764, col: 1, offset: 55128},
+			pos:  position{line: 1769, col: 1, offset: 55211},
 			expr: &actionExpr{
-				pos: position{line: 1764, col: 18, offset: 55145},
+				pos: position{line: 1769, col: 18, offset: 55228},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1764, col: 18, offset: 55145},
+					pos: position{line: 1769, col: 18, offset: 55228},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1764, col: 18, offset: 55145},
+							pos:   position{line: 1769, col: 18, offset: 55228},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1764, col: 23, offset: 55150},
+								pos: position{line: 1769, col: 23, offset: 55233},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1764, col: 23, offset: 55150},
+										pos:  position{line: 1769, col: 23, offset: 55233},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1764, col: 33, offset: 55160},
+										pos:  position{line: 1769, col: 33, offset: 55243},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1764, col: 43, offset: 55170},
+							pos:   position{line: 1769, col: 43, offset: 55253},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1764, col: 49, offset: 55176},
+								pos: position{line: 1769, col: 49, offset: 55259},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1764, col: 50, offset: 55177},
+									pos:  position{line: 1769, col: 50, offset: 55260},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1764, col: 67, offset: 55194},
+							pos:   position{line: 1769, col: 67, offset: 55277},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1764, col: 78, offset: 55205},
+								pos: position{line: 1769, col: 78, offset: 55288},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1764, col: 78, offset: 55205},
+										pos:  position{line: 1769, col: 78, offset: 55288},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1764, col: 84, offset: 55211},
+										pos:  position{line: 1769, col: 84, offset: 55294},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1764, col: 99, offset: 55226},
+							pos:   position{line: 1769, col: 99, offset: 55309},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1764, col: 108, offset: 55235},
+								pos: position{line: 1769, col: 108, offset: 55318},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1764, col: 109, offset: 55236},
+									pos:  position{line: 1769, col: 109, offset: 55319},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1764, col: 120, offset: 55247},
+							pos:   position{line: 1769, col: 120, offset: 55330},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1764, col: 128, offset: 55255},
+								pos: position{line: 1769, col: 128, offset: 55338},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1764, col: 129, offset: 55256},
+									pos:  position{line: 1769, col: 129, offset: 55339},
 									name: "StatisticOptions",
 								},
 							},
@@ -3259,25 +3264,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1806, col: 1, offset: 56341},
+			pos:  position{line: 1811, col: 1, offset: 56424},
 			expr: &choiceExpr{
-				pos: position{line: 1806, col: 19, offset: 56359},
+				pos: position{line: 1811, col: 19, offset: 56442},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1806, col: 19, offset: 56359},
+						pos: position{line: 1811, col: 19, offset: 56442},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1806, col: 19, offset: 56359},
+							pos: position{line: 1811, col: 19, offset: 56442},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 19, offset: 56359},
+									pos:  position{line: 1811, col: 19, offset: 56442},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1806, col: 25, offset: 56365},
+									pos:   position{line: 1811, col: 25, offset: 56448},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1806, col: 32, offset: 56372},
+										pos:  position{line: 1811, col: 32, offset: 56455},
 										name: "IntegerAsString",
 									},
 								},
@@ -3285,30 +3290,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1809, col: 3, offset: 56426},
+						pos: position{line: 1814, col: 3, offset: 56509},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1809, col: 3, offset: 56426},
+							pos: position{line: 1814, col: 3, offset: 56509},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1809, col: 3, offset: 56426},
+									pos:  position{line: 1814, col: 3, offset: 56509},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1809, col: 9, offset: 56432},
+									pos:        position{line: 1814, col: 9, offset: 56515},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1809, col: 17, offset: 56440},
+									pos:  position{line: 1814, col: 17, offset: 56523},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1809, col: 23, offset: 56446},
+									pos:   position{line: 1814, col: 23, offset: 56529},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1809, col: 30, offset: 56453},
+										pos:  position{line: 1814, col: 30, offset: 56536},
 										name: "IntegerAsString",
 									},
 								},
@@ -3320,17 +3325,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1814, col: 1, offset: 56551},
+			pos:  position{line: 1819, col: 1, offset: 56634},
 			expr: &actionExpr{
-				pos: position{line: 1814, col: 21, offset: 56571},
+				pos: position{line: 1819, col: 21, offset: 56654},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1814, col: 21, offset: 56571},
+					pos:   position{line: 1819, col: 21, offset: 56654},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1814, col: 28, offset: 56578},
+						pos: position{line: 1819, col: 28, offset: 56661},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1814, col: 29, offset: 56579},
+							pos:  position{line: 1819, col: 29, offset: 56662},
 							name: "StatisticOption",
 						},
 					},
@@ -3339,34 +3344,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1863, col: 1, offset: 58141},
+			pos:  position{line: 1868, col: 1, offset: 58224},
 			expr: &actionExpr{
-				pos: position{line: 1863, col: 20, offset: 58160},
+				pos: position{line: 1868, col: 20, offset: 58243},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1863, col: 20, offset: 58160},
+					pos: position{line: 1868, col: 20, offset: 58243},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1863, col: 20, offset: 58160},
+							pos:  position{line: 1868, col: 20, offset: 58243},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1863, col: 26, offset: 58166},
+							pos:   position{line: 1868, col: 26, offset: 58249},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1863, col: 36, offset: 58176},
+								pos:  position{line: 1868, col: 36, offset: 58259},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1863, col: 55, offset: 58195},
+							pos:  position{line: 1868, col: 55, offset: 58278},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1863, col: 61, offset: 58201},
+							pos:   position{line: 1868, col: 61, offset: 58284},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1863, col: 67, offset: 58207},
+								pos:  position{line: 1868, col: 67, offset: 58290},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3376,48 +3381,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1868, col: 1, offset: 58316},
+			pos:  position{line: 1873, col: 1, offset: 58399},
 			expr: &actionExpr{
-				pos: position{line: 1868, col: 23, offset: 58338},
+				pos: position{line: 1873, col: 23, offset: 58421},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1868, col: 23, offset: 58338},
+					pos:   position{line: 1873, col: 23, offset: 58421},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1868, col: 31, offset: 58346},
+						pos: position{line: 1873, col: 31, offset: 58429},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1868, col: 31, offset: 58346},
+								pos:        position{line: 1873, col: 31, offset: 58429},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1868, col: 46, offset: 58361},
+								pos:        position{line: 1873, col: 46, offset: 58444},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1868, col: 60, offset: 58375},
+								pos:        position{line: 1873, col: 60, offset: 58458},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1868, col: 73, offset: 58388},
+								pos:        position{line: 1873, col: 73, offset: 58471},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1868, col: 85, offset: 58400},
+								pos:        position{line: 1873, col: 85, offset: 58483},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1868, col: 102, offset: 58417},
+								pos:        position{line: 1873, col: 102, offset: 58500},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3429,25 +3434,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1876, col: 1, offset: 58604},
+			pos:  position{line: 1881, col: 1, offset: 58687},
 			expr: &choiceExpr{
-				pos: position{line: 1876, col: 13, offset: 58616},
+				pos: position{line: 1881, col: 13, offset: 58699},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1876, col: 13, offset: 58616},
+						pos: position{line: 1881, col: 13, offset: 58699},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1876, col: 13, offset: 58616},
+							pos: position{line: 1881, col: 13, offset: 58699},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1876, col: 13, offset: 58616},
+									pos:  position{line: 1881, col: 13, offset: 58699},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1876, col: 16, offset: 58619},
+									pos:   position{line: 1881, col: 16, offset: 58702},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1876, col: 26, offset: 58629},
+										pos:  position{line: 1881, col: 26, offset: 58712},
 										name: "FieldNameList",
 									},
 								},
@@ -3455,13 +3460,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1879, col: 3, offset: 58686},
+						pos: position{line: 1884, col: 3, offset: 58769},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1879, col: 3, offset: 58686},
+							pos:   position{line: 1884, col: 3, offset: 58769},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1879, col: 16, offset: 58699},
+								pos:  position{line: 1884, col: 16, offset: 58782},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3471,26 +3476,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1883, col: 1, offset: 58757},
+			pos:  position{line: 1888, col: 1, offset: 58840},
 			expr: &actionExpr{
-				pos: position{line: 1883, col: 15, offset: 58771},
+				pos: position{line: 1888, col: 15, offset: 58854},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1883, col: 15, offset: 58771},
+					pos: position{line: 1888, col: 15, offset: 58854},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1883, col: 15, offset: 58771},
+							pos:  position{line: 1888, col: 15, offset: 58854},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1883, col: 20, offset: 58776},
+							pos:  position{line: 1888, col: 20, offset: 58859},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1883, col: 30, offset: 58786},
+							pos:   position{line: 1888, col: 30, offset: 58869},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1883, col: 40, offset: 58796},
+								pos:  position{line: 1888, col: 40, offset: 58879},
 								name: "DedupExpr",
 							},
 						},
@@ -3500,27 +3505,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1903, col: 1, offset: 59364},
+			pos:  position{line: 1908, col: 1, offset: 59447},
 			expr: &actionExpr{
-				pos: position{line: 1903, col: 14, offset: 59377},
+				pos: position{line: 1908, col: 14, offset: 59460},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1903, col: 14, offset: 59377},
+					pos: position{line: 1908, col: 14, offset: 59460},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1903, col: 14, offset: 59377},
+							pos:   position{line: 1908, col: 14, offset: 59460},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1903, col: 23, offset: 59386},
+								pos: position{line: 1908, col: 23, offset: 59469},
 								expr: &seqExpr{
-									pos: position{line: 1903, col: 24, offset: 59387},
+									pos: position{line: 1908, col: 24, offset: 59470},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1903, col: 24, offset: 59387},
+											pos:  position{line: 1908, col: 24, offset: 59470},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1903, col: 30, offset: 59393},
+											pos:  position{line: 1908, col: 30, offset: 59476},
 											name: "IntegerAsString",
 										},
 									},
@@ -3528,45 +3533,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 48, offset: 59411},
+							pos:   position{line: 1908, col: 48, offset: 59494},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1903, col: 57, offset: 59420},
+								pos: position{line: 1908, col: 57, offset: 59503},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1903, col: 58, offset: 59421},
+									pos:  position{line: 1908, col: 58, offset: 59504},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 73, offset: 59436},
+							pos:   position{line: 1908, col: 73, offset: 59519},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1903, col: 83, offset: 59446},
+								pos: position{line: 1908, col: 83, offset: 59529},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1903, col: 84, offset: 59447},
+									pos:  position{line: 1908, col: 84, offset: 59530},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 101, offset: 59464},
+							pos:   position{line: 1908, col: 101, offset: 59547},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1903, col: 110, offset: 59473},
+								pos: position{line: 1908, col: 110, offset: 59556},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1903, col: 111, offset: 59474},
+									pos:  position{line: 1908, col: 111, offset: 59557},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1903, col: 126, offset: 59489},
+							pos:   position{line: 1908, col: 126, offset: 59572},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1903, col: 139, offset: 59502},
+								pos: position{line: 1908, col: 139, offset: 59585},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1903, col: 140, offset: 59503},
+									pos:  position{line: 1908, col: 140, offset: 59586},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3577,27 +3582,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 1960, col: 1, offset: 61241},
+			pos:  position{line: 1965, col: 1, offset: 61324},
 			expr: &actionExpr{
-				pos: position{line: 1960, col: 19, offset: 61259},
+				pos: position{line: 1965, col: 19, offset: 61342},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 1960, col: 19, offset: 61259},
+					pos: position{line: 1965, col: 19, offset: 61342},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1960, col: 19, offset: 61259},
+							pos: position{line: 1965, col: 19, offset: 61342},
 							expr: &litMatcher{
-								pos:        position{line: 1960, col: 21, offset: 61261},
+								pos:        position{line: 1965, col: 21, offset: 61344},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1960, col: 31, offset: 61271},
+							pos:   position{line: 1965, col: 31, offset: 61354},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1960, col: 37, offset: 61277},
+								pos:  position{line: 1965, col: 37, offset: 61360},
 								name: "FieldName",
 							},
 						},
@@ -3607,48 +3612,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 1966, col: 1, offset: 61416},
+			pos:  position{line: 1971, col: 1, offset: 61499},
 			expr: &actionExpr{
-				pos: position{line: 1966, col: 32, offset: 61447},
+				pos: position{line: 1971, col: 32, offset: 61530},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 1966, col: 32, offset: 61447},
+					pos: position{line: 1971, col: 32, offset: 61530},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1966, col: 32, offset: 61447},
+							pos:   position{line: 1971, col: 32, offset: 61530},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 38, offset: 61453},
+								pos:  position{line: 1971, col: 38, offset: 61536},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 1966, col: 48, offset: 61463},
+							pos: position{line: 1971, col: 48, offset: 61546},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1966, col: 50, offset: 61465},
+								pos:  position{line: 1971, col: 50, offset: 61548},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1966, col: 57, offset: 61472},
+							pos:   position{line: 1971, col: 57, offset: 61555},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1966, col: 62, offset: 61477},
+								pos: position{line: 1971, col: 62, offset: 61560},
 								expr: &seqExpr{
-									pos: position{line: 1966, col: 63, offset: 61478},
+									pos: position{line: 1971, col: 63, offset: 61561},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1966, col: 63, offset: 61478},
+											pos:  position{line: 1971, col: 63, offset: 61561},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1966, col: 69, offset: 61484},
+											pos:  position{line: 1971, col: 69, offset: 61567},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 1966, col: 79, offset: 61494},
+											pos: position{line: 1971, col: 79, offset: 61577},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1966, col: 81, offset: 61496},
+												pos:  position{line: 1971, col: 81, offset: 61579},
 												name: "EQUAL",
 											},
 										},
@@ -3662,45 +3667,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 1977, col: 1, offset: 61771},
+			pos:  position{line: 1982, col: 1, offset: 61854},
 			expr: &actionExpr{
-				pos: position{line: 1977, col: 19, offset: 61789},
+				pos: position{line: 1982, col: 19, offset: 61872},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 1977, col: 19, offset: 61789},
+					pos: position{line: 1982, col: 19, offset: 61872},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1977, col: 19, offset: 61789},
+							pos:  position{line: 1982, col: 19, offset: 61872},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1977, col: 25, offset: 61795},
+							pos:   position{line: 1982, col: 25, offset: 61878},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1977, col: 31, offset: 61801},
+								pos:  position{line: 1982, col: 31, offset: 61884},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1977, col: 46, offset: 61816},
+							pos:   position{line: 1982, col: 46, offset: 61899},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1977, col: 51, offset: 61821},
+								pos: position{line: 1982, col: 51, offset: 61904},
 								expr: &seqExpr{
-									pos: position{line: 1977, col: 52, offset: 61822},
+									pos: position{line: 1982, col: 52, offset: 61905},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1977, col: 52, offset: 61822},
+											pos:  position{line: 1982, col: 52, offset: 61905},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1977, col: 58, offset: 61828},
+											pos:  position{line: 1982, col: 58, offset: 61911},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 1977, col: 73, offset: 61843},
+											pos: position{line: 1982, col: 73, offset: 61926},
 											expr: &ruleRefExpr{
-												pos:  position{line: 1977, col: 74, offset: 61844},
+												pos:  position{line: 1982, col: 74, offset: 61927},
 												name: "EQUAL",
 											},
 										},
@@ -3714,17 +3719,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 1995, col: 1, offset: 62372},
+			pos:  position{line: 2000, col: 1, offset: 62455},
 			expr: &actionExpr{
-				pos: position{line: 1995, col: 17, offset: 62388},
+				pos: position{line: 2000, col: 17, offset: 62471},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1995, col: 17, offset: 62388},
+					pos:   position{line: 2000, col: 17, offset: 62471},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1995, col: 24, offset: 62395},
+						pos: position{line: 2000, col: 24, offset: 62478},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1995, col: 25, offset: 62396},
+							pos:  position{line: 2000, col: 25, offset: 62479},
 							name: "DedupOption",
 						},
 					},
@@ -3733,36 +3738,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2035, col: 1, offset: 63662},
+			pos:  position{line: 2040, col: 1, offset: 63745},
 			expr: &actionExpr{
-				pos: position{line: 2035, col: 16, offset: 63677},
+				pos: position{line: 2040, col: 16, offset: 63760},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2035, col: 16, offset: 63677},
+					pos: position{line: 2040, col: 16, offset: 63760},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2035, col: 16, offset: 63677},
+							pos:  position{line: 2040, col: 16, offset: 63760},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2035, col: 22, offset: 63683},
+							pos:   position{line: 2040, col: 22, offset: 63766},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2035, col: 32, offset: 63693},
+								pos:  position{line: 2040, col: 32, offset: 63776},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2035, col: 47, offset: 63708},
+							pos:        position{line: 2040, col: 47, offset: 63791},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2035, col: 51, offset: 63712},
+							pos:   position{line: 2040, col: 51, offset: 63795},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2035, col: 57, offset: 63718},
+								pos:  position{line: 2040, col: 57, offset: 63801},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3772,30 +3777,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2040, col: 1, offset: 63827},
+			pos:  position{line: 2045, col: 1, offset: 63910},
 			expr: &actionExpr{
-				pos: position{line: 2040, col: 19, offset: 63845},
+				pos: position{line: 2045, col: 19, offset: 63928},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2040, col: 19, offset: 63845},
+					pos:   position{line: 2045, col: 19, offset: 63928},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2040, col: 27, offset: 63853},
+						pos: position{line: 2045, col: 27, offset: 63936},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2040, col: 27, offset: 63853},
+								pos:        position{line: 2045, col: 27, offset: 63936},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2040, col: 43, offset: 63869},
+								pos:        position{line: 2045, col: 43, offset: 63952},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2040, col: 57, offset: 63883},
+								pos:        position{line: 2045, col: 57, offset: 63966},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3807,22 +3812,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2048, col: 1, offset: 64068},
+			pos:  position{line: 2053, col: 1, offset: 64151},
 			expr: &actionExpr{
-				pos: position{line: 2048, col: 22, offset: 64089},
+				pos: position{line: 2053, col: 22, offset: 64172},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2048, col: 22, offset: 64089},
+					pos: position{line: 2053, col: 22, offset: 64172},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2048, col: 22, offset: 64089},
+							pos:  position{line: 2053, col: 22, offset: 64172},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2048, col: 39, offset: 64106},
+							pos:   position{line: 2053, col: 39, offset: 64189},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2048, col: 53, offset: 64120},
+								pos:  position{line: 2053, col: 53, offset: 64203},
 								name: "SortElements",
 							},
 						},
@@ -3832,35 +3837,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2053, col: 1, offset: 64228},
+			pos:  position{line: 2058, col: 1, offset: 64311},
 			expr: &actionExpr{
-				pos: position{line: 2053, col: 17, offset: 64244},
+				pos: position{line: 2058, col: 17, offset: 64327},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2053, col: 17, offset: 64244},
+					pos: position{line: 2058, col: 17, offset: 64327},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2053, col: 17, offset: 64244},
+							pos:   position{line: 2058, col: 17, offset: 64327},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2053, col: 23, offset: 64250},
+								pos:  position{line: 2058, col: 23, offset: 64333},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2053, col: 41, offset: 64268},
+							pos:   position{line: 2058, col: 41, offset: 64351},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2053, col: 46, offset: 64273},
+								pos: position{line: 2058, col: 46, offset: 64356},
 								expr: &seqExpr{
-									pos: position{line: 2053, col: 47, offset: 64274},
+									pos: position{line: 2058, col: 47, offset: 64357},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2053, col: 47, offset: 64274},
+											pos:  position{line: 2058, col: 47, offset: 64357},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2053, col: 62, offset: 64289},
+											pos:  position{line: 2058, col: 62, offset: 64372},
 											name: "SingleSortElement",
 										},
 									},
@@ -3873,22 +3878,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2068, col: 1, offset: 64647},
+			pos:  position{line: 2073, col: 1, offset: 64730},
 			expr: &actionExpr{
-				pos: position{line: 2068, col: 22, offset: 64668},
+				pos: position{line: 2073, col: 22, offset: 64751},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2068, col: 22, offset: 64668},
+					pos:   position{line: 2073, col: 22, offset: 64751},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2068, col: 31, offset: 64677},
+						pos: position{line: 2073, col: 31, offset: 64760},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2068, col: 31, offset: 64677},
+								pos:  position{line: 2073, col: 31, offset: 64760},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2068, col: 59, offset: 64705},
+								pos:  position{line: 2073, col: 59, offset: 64788},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -3898,33 +3903,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2072, col: 1, offset: 64764},
+			pos:  position{line: 2077, col: 1, offset: 64847},
 			expr: &actionExpr{
-				pos: position{line: 2072, col: 33, offset: 64796},
+				pos: position{line: 2077, col: 33, offset: 64879},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2072, col: 33, offset: 64796},
+					pos: position{line: 2077, col: 33, offset: 64879},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2072, col: 33, offset: 64796},
+							pos:   position{line: 2077, col: 33, offset: 64879},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2072, col: 47, offset: 64810},
+								pos: position{line: 2077, col: 47, offset: 64893},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2072, col: 47, offset: 64810},
+										pos:        position{line: 2077, col: 47, offset: 64893},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2072, col: 53, offset: 64816},
+										pos:        position{line: 2077, col: 53, offset: 64899},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2072, col: 59, offset: 64822},
+										pos:        position{line: 2077, col: 59, offset: 64905},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3933,10 +3938,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 63, offset: 64826},
+							pos:   position{line: 2077, col: 63, offset: 64909},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 69, offset: 64832},
+								pos:  position{line: 2077, col: 69, offset: 64915},
 								name: "FieldName",
 							},
 						},
@@ -3946,33 +3951,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2087, col: 1, offset: 65107},
+			pos:  position{line: 2092, col: 1, offset: 65190},
 			expr: &actionExpr{
-				pos: position{line: 2087, col: 30, offset: 65136},
+				pos: position{line: 2092, col: 30, offset: 65219},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2087, col: 30, offset: 65136},
+					pos: position{line: 2092, col: 30, offset: 65219},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2087, col: 30, offset: 65136},
+							pos:   position{line: 2092, col: 30, offset: 65219},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2087, col: 44, offset: 65150},
+								pos: position{line: 2092, col: 44, offset: 65233},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2087, col: 44, offset: 65150},
+										pos:        position{line: 2092, col: 44, offset: 65233},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2087, col: 50, offset: 65156},
+										pos:        position{line: 2092, col: 50, offset: 65239},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2087, col: 56, offset: 65162},
+										pos:        position{line: 2092, col: 56, offset: 65245},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -3981,31 +3986,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2087, col: 60, offset: 65166},
+							pos:   position{line: 2092, col: 60, offset: 65249},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2087, col: 64, offset: 65170},
+								pos: position{line: 2092, col: 64, offset: 65253},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2087, col: 64, offset: 65170},
+										pos:        position{line: 2092, col: 64, offset: 65253},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2087, col: 73, offset: 65179},
+										pos:        position{line: 2092, col: 73, offset: 65262},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2087, col: 81, offset: 65187},
+										pos:        position{line: 2092, col: 81, offset: 65270},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2087, col: 88, offset: 65194},
+										pos:        position{line: 2092, col: 88, offset: 65277},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4014,19 +4019,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2087, col: 95, offset: 65201},
+							pos:  position{line: 2092, col: 95, offset: 65284},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2087, col: 103, offset: 65209},
+							pos:   position{line: 2092, col: 103, offset: 65292},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2087, col: 109, offset: 65215},
+								pos:  position{line: 2092, col: 109, offset: 65298},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2087, col: 119, offset: 65225},
+							pos:  position{line: 2092, col: 119, offset: 65308},
 							name: "R_PAREN",
 						},
 					},
@@ -4035,26 +4040,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2107, col: 1, offset: 65650},
+			pos:  position{line: 2112, col: 1, offset: 65733},
 			expr: &actionExpr{
-				pos: position{line: 2107, col: 16, offset: 65665},
+				pos: position{line: 2112, col: 16, offset: 65748},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2107, col: 16, offset: 65665},
+					pos: position{line: 2112, col: 16, offset: 65748},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2107, col: 16, offset: 65665},
+							pos:  position{line: 2112, col: 16, offset: 65748},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2107, col: 21, offset: 65670},
+							pos:  position{line: 2112, col: 21, offset: 65753},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2107, col: 32, offset: 65681},
+							pos:   position{line: 2112, col: 32, offset: 65764},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2107, col: 43, offset: 65692},
+								pos:  position{line: 2112, col: 43, offset: 65775},
 								name: "RenameExpr",
 							},
 						},
@@ -4064,33 +4069,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2123, col: 1, offset: 66067},
+			pos:  position{line: 2128, col: 1, offset: 66150},
 			expr: &choiceExpr{
-				pos: position{line: 2123, col: 15, offset: 66081},
+				pos: position{line: 2128, col: 15, offset: 66164},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2123, col: 15, offset: 66081},
+						pos: position{line: 2128, col: 15, offset: 66164},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2123, col: 15, offset: 66081},
+							pos: position{line: 2128, col: 15, offset: 66164},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2123, col: 15, offset: 66081},
+									pos:   position{line: 2128, col: 15, offset: 66164},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2123, col: 31, offset: 66097},
+										pos:  position{line: 2128, col: 31, offset: 66180},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2123, col: 45, offset: 66111},
+									pos:  position{line: 2128, col: 45, offset: 66194},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2123, col: 48, offset: 66114},
+									pos:   position{line: 2128, col: 48, offset: 66197},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2123, col: 59, offset: 66125},
+										pos:  position{line: 2128, col: 59, offset: 66208},
 										name: "QuotedString",
 									},
 								},
@@ -4098,28 +4103,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2134, col: 3, offset: 66444},
+						pos: position{line: 2139, col: 3, offset: 66527},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2134, col: 3, offset: 66444},
+							pos: position{line: 2139, col: 3, offset: 66527},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2134, col: 3, offset: 66444},
+									pos:   position{line: 2139, col: 3, offset: 66527},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2134, col: 19, offset: 66460},
+										pos:  position{line: 2139, col: 19, offset: 66543},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2134, col: 33, offset: 66474},
+									pos:  position{line: 2139, col: 33, offset: 66557},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2134, col: 36, offset: 66477},
+									pos:   position{line: 2139, col: 36, offset: 66560},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2134, col: 47, offset: 66488},
+										pos:  position{line: 2139, col: 47, offset: 66571},
 										name: "RenamePattern",
 									},
 								},
@@ -4131,48 +4136,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2156, col: 1, offset: 67054},
+			pos:  position{line: 2161, col: 1, offset: 67137},
 			expr: &actionExpr{
-				pos: position{line: 2156, col: 13, offset: 67066},
+				pos: position{line: 2161, col: 13, offset: 67149},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2156, col: 13, offset: 67066},
+					pos: position{line: 2161, col: 13, offset: 67149},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 13, offset: 67066},
+							pos:  position{line: 2161, col: 13, offset: 67149},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 18, offset: 67071},
+							pos:  position{line: 2161, col: 18, offset: 67154},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2156, col: 26, offset: 67079},
+							pos:        position{line: 2161, col: 26, offset: 67162},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 34, offset: 67087},
+							pos:  position{line: 2161, col: 34, offset: 67170},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 40, offset: 67093},
+							pos:   position{line: 2161, col: 40, offset: 67176},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 46, offset: 67099},
+								pos:  position{line: 2161, col: 46, offset: 67182},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2156, col: 62, offset: 67115},
+							pos:  position{line: 2161, col: 62, offset: 67198},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2156, col: 68, offset: 67121},
+							pos:   position{line: 2161, col: 68, offset: 67204},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2156, col: 72, offset: 67125},
+								pos:  position{line: 2161, col: 72, offset: 67208},
 								name: "QuotedString",
 							},
 						},
@@ -4182,37 +4187,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2184, col: 1, offset: 67828},
+			pos:  position{line: 2189, col: 1, offset: 67911},
 			expr: &actionExpr{
-				pos: position{line: 2184, col: 14, offset: 67841},
+				pos: position{line: 2189, col: 14, offset: 67924},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2184, col: 14, offset: 67841},
+					pos: position{line: 2189, col: 14, offset: 67924},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 14, offset: 67841},
+							pos:  position{line: 2189, col: 14, offset: 67924},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 19, offset: 67846},
+							pos:  position{line: 2189, col: 19, offset: 67929},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 28, offset: 67855},
+							pos:   position{line: 2189, col: 28, offset: 67938},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2184, col: 34, offset: 67861},
+								pos: position{line: 2189, col: 34, offset: 67944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2184, col: 35, offset: 67862},
+									pos:  position{line: 2189, col: 35, offset: 67945},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 47, offset: 67874},
+							pos:   position{line: 2189, col: 47, offset: 67957},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 58, offset: 67885},
+								pos:  position{line: 2189, col: 58, offset: 67968},
 								name: "SortElements",
 							},
 						},
@@ -4222,41 +4227,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2221, col: 1, offset: 68736},
+			pos:  position{line: 2226, col: 1, offset: 68819},
 			expr: &actionExpr{
-				pos: position{line: 2221, col: 14, offset: 68749},
+				pos: position{line: 2226, col: 14, offset: 68832},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2221, col: 14, offset: 68749},
+					pos: position{line: 2226, col: 14, offset: 68832},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2221, col: 14, offset: 68749},
+							pos: position{line: 2226, col: 14, offset: 68832},
 							expr: &seqExpr{
-								pos: position{line: 2221, col: 15, offset: 68750},
+								pos: position{line: 2226, col: 15, offset: 68833},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2221, col: 15, offset: 68750},
+										pos:        position{line: 2226, col: 15, offset: 68833},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2221, col: 23, offset: 68758},
+										pos:  position{line: 2226, col: 23, offset: 68841},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2221, col: 31, offset: 68766},
+							pos:   position{line: 2226, col: 31, offset: 68849},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2221, col: 40, offset: 68775},
+								pos:  position{line: 2226, col: 40, offset: 68858},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2221, col: 56, offset: 68791},
+							pos:  position{line: 2226, col: 56, offset: 68874},
 							name: "SPACE",
 						},
 					},
@@ -4265,43 +4270,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2235, col: 1, offset: 69090},
+			pos:  position{line: 2240, col: 1, offset: 69173},
 			expr: &actionExpr{
-				pos: position{line: 2235, col: 14, offset: 69103},
+				pos: position{line: 2240, col: 14, offset: 69186},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2235, col: 14, offset: 69103},
+					pos: position{line: 2240, col: 14, offset: 69186},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2235, col: 14, offset: 69103},
+							pos:  position{line: 2240, col: 14, offset: 69186},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2235, col: 19, offset: 69108},
+							pos:  position{line: 2240, col: 19, offset: 69191},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2235, col: 28, offset: 69117},
+							pos:   position{line: 2240, col: 28, offset: 69200},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2235, col: 34, offset: 69123},
+								pos:  position{line: 2240, col: 34, offset: 69206},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2235, col: 45, offset: 69134},
+							pos:   position{line: 2240, col: 45, offset: 69217},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2235, col: 50, offset: 69139},
+								pos: position{line: 2240, col: 50, offset: 69222},
 								expr: &seqExpr{
-									pos: position{line: 2235, col: 51, offset: 69140},
+									pos: position{line: 2240, col: 51, offset: 69223},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2235, col: 51, offset: 69140},
+											pos:  position{line: 2240, col: 51, offset: 69223},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2235, col: 57, offset: 69146},
+											pos:  position{line: 2240, col: 57, offset: 69229},
 											name: "SingleEval",
 										},
 									},
@@ -4314,30 +4319,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2262, col: 1, offset: 69947},
+			pos:  position{line: 2267, col: 1, offset: 70030},
 			expr: &actionExpr{
-				pos: position{line: 2262, col: 15, offset: 69961},
+				pos: position{line: 2267, col: 15, offset: 70044},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2262, col: 15, offset: 69961},
+					pos: position{line: 2267, col: 15, offset: 70044},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2262, col: 15, offset: 69961},
+							pos:   position{line: 2267, col: 15, offset: 70044},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2262, col: 21, offset: 69967},
+								pos:  position{line: 2267, col: 21, offset: 70050},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2262, col: 31, offset: 69977},
+							pos:  position{line: 2267, col: 31, offset: 70060},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2262, col: 37, offset: 69983},
+							pos:   position{line: 2267, col: 37, offset: 70066},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2262, col: 42, offset: 69988},
+								pos:  position{line: 2267, col: 42, offset: 70071},
 								name: "EvalExpression",
 							},
 						},
@@ -4347,15 +4352,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2275, col: 1, offset: 70389},
+			pos:  position{line: 2280, col: 1, offset: 70472},
 			expr: &actionExpr{
-				pos: position{line: 2275, col: 19, offset: 70407},
+				pos: position{line: 2280, col: 19, offset: 70490},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2275, col: 19, offset: 70407},
+					pos:   position{line: 2280, col: 19, offset: 70490},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2275, col: 25, offset: 70413},
+						pos:  position{line: 2280, col: 25, offset: 70496},
 						name: "ValueExpr",
 					},
 				},
@@ -4363,85 +4368,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2284, col: 1, offset: 70637},
+			pos:  position{line: 2289, col: 1, offset: 70720},
 			expr: &choiceExpr{
-				pos: position{line: 2284, col: 18, offset: 70654},
+				pos: position{line: 2289, col: 18, offset: 70737},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2284, col: 18, offset: 70654},
+						pos: position{line: 2289, col: 18, offset: 70737},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2284, col: 18, offset: 70654},
+							pos: position{line: 2289, col: 18, offset: 70737},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2284, col: 18, offset: 70654},
+									pos:        position{line: 2289, col: 18, offset: 70737},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 23, offset: 70659},
+									pos:  position{line: 2289, col: 23, offset: 70742},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2284, col: 31, offset: 70667},
+									pos:   position{line: 2289, col: 31, offset: 70750},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2284, col: 41, offset: 70677},
+										pos:  position{line: 2289, col: 41, offset: 70760},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 50, offset: 70686},
+									pos:  position{line: 2289, col: 50, offset: 70769},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2284, col: 56, offset: 70692},
+									pos:   position{line: 2289, col: 56, offset: 70775},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2284, col: 66, offset: 70702},
+										pos:  position{line: 2289, col: 66, offset: 70785},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 76, offset: 70712},
+									pos:  position{line: 2289, col: 76, offset: 70795},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2284, col: 82, offset: 70718},
+									pos:   position{line: 2289, col: 82, offset: 70801},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2284, col: 93, offset: 70729},
+										pos:  position{line: 2289, col: 93, offset: 70812},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2284, col: 103, offset: 70739},
+									pos:  position{line: 2289, col: 103, offset: 70822},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2295, col: 3, offset: 70990},
+						pos: position{line: 2300, col: 3, offset: 71073},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2295, col: 3, offset: 70990},
+							pos: position{line: 2300, col: 3, offset: 71073},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2295, col: 3, offset: 70990},
+									pos:   position{line: 2300, col: 3, offset: 71073},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2295, col: 11, offset: 70998},
+										pos: position{line: 2300, col: 11, offset: 71081},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2295, col: 11, offset: 70998},
+												pos:        position{line: 2300, col: 11, offset: 71081},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2295, col: 20, offset: 71007},
+												pos:        position{line: 2300, col: 20, offset: 71090},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4450,31 +4455,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2295, col: 32, offset: 71019},
+									pos:  position{line: 2300, col: 32, offset: 71102},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2295, col: 40, offset: 71027},
+									pos:   position{line: 2300, col: 40, offset: 71110},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2295, col: 45, offset: 71032},
+										pos:  position{line: 2300, col: 45, offset: 71115},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2295, col: 64, offset: 71051},
+									pos:   position{line: 2300, col: 64, offset: 71134},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2295, col: 69, offset: 71056},
+										pos: position{line: 2300, col: 69, offset: 71139},
 										expr: &seqExpr{
-											pos: position{line: 2295, col: 70, offset: 71057},
+											pos: position{line: 2300, col: 70, offset: 71140},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2295, col: 70, offset: 71057},
+													pos:  position{line: 2300, col: 70, offset: 71140},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2295, col: 76, offset: 71063},
+													pos:  position{line: 2300, col: 76, offset: 71146},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4482,50 +4487,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2295, col: 97, offset: 71084},
+									pos:  position{line: 2300, col: 97, offset: 71167},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2318, col: 3, offset: 71688},
+						pos: position{line: 2323, col: 3, offset: 71771},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2318, col: 3, offset: 71688},
+							pos: position{line: 2323, col: 3, offset: 71771},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2318, col: 3, offset: 71688},
+									pos:        position{line: 2323, col: 3, offset: 71771},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2318, col: 14, offset: 71699},
+									pos:  position{line: 2323, col: 14, offset: 71782},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2318, col: 22, offset: 71707},
+									pos:   position{line: 2323, col: 22, offset: 71790},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2318, col: 32, offset: 71717},
+										pos:  position{line: 2323, col: 32, offset: 71800},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2318, col: 42, offset: 71727},
+									pos:   position{line: 2323, col: 42, offset: 71810},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2318, col: 47, offset: 71732},
+										pos: position{line: 2323, col: 47, offset: 71815},
 										expr: &seqExpr{
-											pos: position{line: 2318, col: 48, offset: 71733},
+											pos: position{line: 2323, col: 48, offset: 71816},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2318, col: 48, offset: 71733},
+													pos:  position{line: 2323, col: 48, offset: 71816},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2318, col: 54, offset: 71739},
+													pos:  position{line: 2323, col: 54, offset: 71822},
 													name: "ValueExpr",
 												},
 											},
@@ -4533,73 +4538,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2318, col: 66, offset: 71751},
+									pos:  position{line: 2323, col: 66, offset: 71834},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2335, col: 3, offset: 72170},
+						pos: position{line: 2340, col: 3, offset: 72253},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2335, col: 3, offset: 72170},
+							pos: position{line: 2340, col: 3, offset: 72253},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2335, col: 3, offset: 72170},
+									pos:        position{line: 2340, col: 3, offset: 72253},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2335, col: 12, offset: 72179},
+									pos:  position{line: 2340, col: 12, offset: 72262},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2335, col: 20, offset: 72187},
+									pos:   position{line: 2340, col: 20, offset: 72270},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2335, col: 30, offset: 72197},
+										pos:  position{line: 2340, col: 30, offset: 72280},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2335, col: 40, offset: 72207},
+									pos:  position{line: 2340, col: 40, offset: 72290},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2335, col: 46, offset: 72213},
+									pos:   position{line: 2340, col: 46, offset: 72296},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2335, col: 57, offset: 72224},
+										pos:  position{line: 2340, col: 57, offset: 72307},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2335, col: 67, offset: 72234},
+									pos:  position{line: 2340, col: 67, offset: 72317},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2347, col: 3, offset: 72514},
+						pos: position{line: 2352, col: 3, offset: 72597},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2347, col: 3, offset: 72514},
+							pos: position{line: 2352, col: 3, offset: 72597},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2347, col: 3, offset: 72514},
+									pos:        position{line: 2352, col: 3, offset: 72597},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2347, col: 10, offset: 72521},
+									pos:  position{line: 2352, col: 10, offset: 72604},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2347, col: 18, offset: 72529},
+									pos:  position{line: 2352, col: 18, offset: 72612},
 									name: "R_PAREN",
 								},
 							},
@@ -4610,30 +4615,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2354, col: 1, offset: 72626},
+			pos:  position{line: 2359, col: 1, offset: 72709},
 			expr: &actionExpr{
-				pos: position{line: 2354, col: 23, offset: 72648},
+				pos: position{line: 2359, col: 23, offset: 72731},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2354, col: 23, offset: 72648},
+					pos: position{line: 2359, col: 23, offset: 72731},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2354, col: 23, offset: 72648},
+							pos:   position{line: 2359, col: 23, offset: 72731},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2354, col: 33, offset: 72658},
+								pos:  position{line: 2359, col: 33, offset: 72741},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2354, col: 42, offset: 72667},
+							pos:  position{line: 2359, col: 42, offset: 72750},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2354, col: 48, offset: 72673},
+							pos:   position{line: 2359, col: 48, offset: 72756},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2354, col: 54, offset: 72679},
+								pos:  position{line: 2359, col: 54, offset: 72762},
 								name: "ValueExpr",
 							},
 						},
@@ -4643,15 +4648,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2362, col: 1, offset: 72884},
+			pos:  position{line: 2367, col: 1, offset: 72967},
 			expr: &actionExpr{
-				pos: position{line: 2362, col: 26, offset: 72909},
+				pos: position{line: 2367, col: 26, offset: 72992},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2362, col: 26, offset: 72909},
+					pos:   position{line: 2367, col: 26, offset: 72992},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2362, col: 37, offset: 72920},
+						pos:  position{line: 2367, col: 37, offset: 73003},
 						name: "StringExpr",
 					},
 				},
@@ -4659,15 +4664,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2372, col: 1, offset: 73129},
+			pos:  position{line: 2377, col: 1, offset: 73212},
 			expr: &actionExpr{
-				pos: position{line: 2372, col: 30, offset: 73158},
+				pos: position{line: 2377, col: 30, offset: 73241},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2372, col: 30, offset: 73158},
+					pos:   position{line: 2377, col: 30, offset: 73241},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2372, col: 45, offset: 73173},
+						pos:  position{line: 2377, col: 45, offset: 73256},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4675,22 +4680,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2381, col: 1, offset: 73379},
+			pos:  position{line: 2386, col: 1, offset: 73462},
 			expr: &actionExpr{
-				pos: position{line: 2381, col: 27, offset: 73405},
+				pos: position{line: 2386, col: 27, offset: 73488},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2381, col: 27, offset: 73405},
+					pos:   position{line: 2386, col: 27, offset: 73488},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2381, col: 40, offset: 73418},
+						pos: position{line: 2386, col: 40, offset: 73501},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2381, col: 40, offset: 73418},
+								pos:  position{line: 2386, col: 40, offset: 73501},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2381, col: 68, offset: 73446},
+								pos:  position{line: 2386, col: 68, offset: 73529},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4700,135 +4705,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2385, col: 1, offset: 73523},
+			pos:  position{line: 2390, col: 1, offset: 73606},
 			expr: &choiceExpr{
-				pos: position{line: 2385, col: 19, offset: 73541},
+				pos: position{line: 2390, col: 19, offset: 73624},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2385, col: 19, offset: 73541},
+						pos: position{line: 2390, col: 19, offset: 73624},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2385, col: 20, offset: 73542},
+							pos: position{line: 2390, col: 20, offset: 73625},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2385, col: 20, offset: 73542},
+									pos:   position{line: 2390, col: 20, offset: 73625},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2385, col: 28, offset: 73550},
+										pos:        position{line: 2390, col: 28, offset: 73633},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2385, col: 37, offset: 73559},
+									pos:  position{line: 2390, col: 37, offset: 73642},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2385, col: 45, offset: 73567},
+									pos:   position{line: 2390, col: 45, offset: 73650},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2385, col: 56, offset: 73578},
+										pos:  position{line: 2390, col: 56, offset: 73661},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2385, col: 67, offset: 73589},
+									pos:  position{line: 2390, col: 67, offset: 73672},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2385, col: 73, offset: 73595},
+									pos:   position{line: 2390, col: 73, offset: 73678},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2385, col: 79, offset: 73601},
+										pos:  position{line: 2390, col: 79, offset: 73684},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2385, col: 90, offset: 73612},
+									pos:  position{line: 2390, col: 90, offset: 73695},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2397, col: 3, offset: 73973},
+						pos: position{line: 2402, col: 3, offset: 74056},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2397, col: 4, offset: 73974},
+							pos: position{line: 2402, col: 4, offset: 74057},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2397, col: 4, offset: 73974},
+									pos:   position{line: 2402, col: 4, offset: 74057},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2397, col: 12, offset: 73982},
+										pos:        position{line: 2402, col: 12, offset: 74065},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 23, offset: 73993},
+									pos:  position{line: 2402, col: 23, offset: 74076},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 31, offset: 74001},
+									pos:   position{line: 2402, col: 31, offset: 74084},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2397, col: 46, offset: 74016},
+										pos:  position{line: 2402, col: 46, offset: 74099},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 61, offset: 74031},
+									pos:  position{line: 2402, col: 61, offset: 74114},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 67, offset: 74037},
+									pos:   position{line: 2402, col: 67, offset: 74120},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2397, col: 78, offset: 74048},
+										pos:  position{line: 2402, col: 78, offset: 74131},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 90, offset: 74060},
+									pos:   position{line: 2402, col: 90, offset: 74143},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2397, col: 99, offset: 74069},
+										pos: position{line: 2402, col: 99, offset: 74152},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2397, col: 100, offset: 74070},
+											pos:  position{line: 2402, col: 100, offset: 74153},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 119, offset: 74089},
+									pos:  position{line: 2402, col: 119, offset: 74172},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2413, col: 3, offset: 74651},
+						pos: position{line: 2418, col: 3, offset: 74734},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2413, col: 4, offset: 74652},
+							pos: position{line: 2418, col: 4, offset: 74735},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2413, col: 4, offset: 74652},
+									pos:   position{line: 2418, col: 4, offset: 74735},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2413, col: 12, offset: 74660},
+										pos: position{line: 2418, col: 12, offset: 74743},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2413, col: 12, offset: 74660},
+												pos:        position{line: 2418, col: 12, offset: 74743},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2413, col: 24, offset: 74672},
+												pos:        position{line: 2418, col: 24, offset: 74755},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4837,222 +4842,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2413, col: 34, offset: 74682},
+									pos:  position{line: 2418, col: 34, offset: 74765},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2413, col: 42, offset: 74690},
+									pos:   position{line: 2418, col: 42, offset: 74773},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2413, col: 57, offset: 74705},
+										pos:  position{line: 2418, col: 57, offset: 74788},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2413, col: 72, offset: 74720},
+									pos:  position{line: 2418, col: 72, offset: 74803},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2425, col: 3, offset: 75068},
+						pos: position{line: 2430, col: 3, offset: 75151},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2425, col: 4, offset: 75069},
+							pos: position{line: 2430, col: 4, offset: 75152},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2425, col: 4, offset: 75069},
+									pos:   position{line: 2430, col: 4, offset: 75152},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2425, col: 12, offset: 75077},
+										pos:        position{line: 2430, col: 12, offset: 75160},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2425, col: 24, offset: 75089},
+									pos:  position{line: 2430, col: 24, offset: 75172},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2425, col: 32, offset: 75097},
+									pos:   position{line: 2430, col: 32, offset: 75180},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2425, col: 42, offset: 75107},
+										pos:  position{line: 2430, col: 42, offset: 75190},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2425, col: 51, offset: 75116},
+									pos:  position{line: 2430, col: 51, offset: 75199},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2438, col: 3, offset: 75463},
+						pos: position{line: 2443, col: 3, offset: 75546},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2438, col: 4, offset: 75464},
+							pos: position{line: 2443, col: 4, offset: 75547},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2438, col: 4, offset: 75464},
+									pos:   position{line: 2443, col: 4, offset: 75547},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2438, col: 12, offset: 75472},
+										pos:        position{line: 2443, col: 12, offset: 75555},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 21, offset: 75481},
+									pos:  position{line: 2443, col: 21, offset: 75564},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 29, offset: 75489},
+									pos:   position{line: 2443, col: 29, offset: 75572},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 44, offset: 75504},
+										pos:  position{line: 2443, col: 44, offset: 75587},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 59, offset: 75519},
+									pos:  position{line: 2443, col: 59, offset: 75602},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 65, offset: 75525},
+									pos:   position{line: 2443, col: 65, offset: 75608},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 70, offset: 75530},
+										pos:  position{line: 2443, col: 70, offset: 75613},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 80, offset: 75540},
+									pos:  position{line: 2443, col: 80, offset: 75623},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2451, col: 3, offset: 75962},
+						pos: position{line: 2456, col: 3, offset: 76045},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2451, col: 4, offset: 75963},
+							pos: position{line: 2456, col: 4, offset: 76046},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2451, col: 4, offset: 75963},
+									pos:   position{line: 2456, col: 4, offset: 76046},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2451, col: 12, offset: 75971},
+										pos:        position{line: 2456, col: 12, offset: 76054},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2451, col: 23, offset: 75982},
+									pos:  position{line: 2456, col: 23, offset: 76065},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2451, col: 31, offset: 75990},
+									pos:   position{line: 2456, col: 31, offset: 76073},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2451, col: 42, offset: 76001},
+										pos:  position{line: 2456, col: 42, offset: 76084},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2451, col: 54, offset: 76013},
+									pos:  position{line: 2456, col: 54, offset: 76096},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2451, col: 60, offset: 76019},
+									pos:   position{line: 2456, col: 60, offset: 76102},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2451, col: 69, offset: 76028},
+										pos:  position{line: 2456, col: 69, offset: 76111},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2451, col: 81, offset: 76040},
+									pos:  position{line: 2456, col: 81, offset: 76123},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2451, col: 87, offset: 76046},
+									pos:   position{line: 2456, col: 87, offset: 76129},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2451, col: 98, offset: 76057},
+										pos: position{line: 2456, col: 98, offset: 76140},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2451, col: 99, offset: 76058},
+											pos:  position{line: 2456, col: 99, offset: 76141},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2451, col: 112, offset: 76071},
+									pos:  position{line: 2456, col: 112, offset: 76154},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2464, col: 3, offset: 76522},
+						pos: position{line: 2469, col: 3, offset: 76605},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2464, col: 4, offset: 76523},
+							pos: position{line: 2469, col: 4, offset: 76606},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2464, col: 4, offset: 76523},
+									pos:   position{line: 2469, col: 4, offset: 76606},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2464, col: 12, offset: 76531},
+										pos:        position{line: 2469, col: 12, offset: 76614},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2464, col: 21, offset: 76540},
+									pos:  position{line: 2469, col: 21, offset: 76623},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2464, col: 29, offset: 76548},
+									pos:   position{line: 2469, col: 29, offset: 76631},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2464, col: 36, offset: 76555},
+										pos:  position{line: 2469, col: 36, offset: 76638},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2464, col: 51, offset: 76570},
+									pos:  position{line: 2469, col: 51, offset: 76653},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2464, col: 57, offset: 76576},
+									pos:   position{line: 2469, col: 57, offset: 76659},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2464, col: 65, offset: 76584},
+										pos:  position{line: 2469, col: 65, offset: 76667},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2464, col: 80, offset: 76599},
+									pos:   position{line: 2469, col: 80, offset: 76682},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2464, col: 85, offset: 76604},
+										pos: position{line: 2469, col: 85, offset: 76687},
 										expr: &seqExpr{
-											pos: position{line: 2464, col: 86, offset: 76605},
+											pos: position{line: 2469, col: 86, offset: 76688},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2464, col: 86, offset: 76605},
+													pos:  position{line: 2469, col: 86, offset: 76688},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2464, col: 92, offset: 76611},
+													pos:  position{line: 2469, col: 92, offset: 76694},
 													name: "StringExpr",
 												},
 											},
@@ -5060,63 +5065,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2464, col: 105, offset: 76624},
+									pos:  position{line: 2469, col: 105, offset: 76707},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2481, col: 3, offset: 77152},
+						pos: position{line: 2486, col: 3, offset: 77235},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2481, col: 4, offset: 77153},
+							pos: position{line: 2486, col: 4, offset: 77236},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2481, col: 4, offset: 77153},
+									pos:   position{line: 2486, col: 4, offset: 77236},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2481, col: 12, offset: 77161},
+										pos:        position{line: 2486, col: 12, offset: 77244},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2481, col: 32, offset: 77181},
+									pos:  position{line: 2486, col: 32, offset: 77264},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2481, col: 40, offset: 77189},
+									pos:   position{line: 2486, col: 40, offset: 77272},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2481, col: 55, offset: 77204},
+										pos:  position{line: 2486, col: 55, offset: 77287},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2481, col: 70, offset: 77219},
+									pos:   position{line: 2486, col: 70, offset: 77302},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2481, col: 75, offset: 77224},
+										pos: position{line: 2486, col: 75, offset: 77307},
 										expr: &seqExpr{
-											pos: position{line: 2481, col: 76, offset: 77225},
+											pos: position{line: 2486, col: 76, offset: 77308},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2481, col: 76, offset: 77225},
+													pos:  position{line: 2486, col: 76, offset: 77308},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2481, col: 83, offset: 77232},
+													pos: position{line: 2486, col: 83, offset: 77315},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2481, col: 83, offset: 77232},
+															pos:        position{line: 2486, col: 83, offset: 77315},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2481, col: 92, offset: 77241},
+															pos:        position{line: 2486, col: 92, offset: 77324},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5124,7 +5129,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2481, col: 101, offset: 77250},
+													pos:        position{line: 2486, col: 101, offset: 77333},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5134,54 +5139,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2481, col: 108, offset: 77257},
+									pos:  position{line: 2486, col: 108, offset: 77340},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2506, col: 3, offset: 77960},
+						pos: position{line: 2511, col: 3, offset: 78043},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2506, col: 4, offset: 77961},
+							pos: position{line: 2511, col: 4, offset: 78044},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2506, col: 4, offset: 77961},
+									pos:   position{line: 2511, col: 4, offset: 78044},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2506, col: 12, offset: 77969},
+										pos:        position{line: 2511, col: 12, offset: 78052},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2506, col: 24, offset: 77981},
+									pos:  position{line: 2511, col: 24, offset: 78064},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2506, col: 32, offset: 77989},
+									pos:   position{line: 2511, col: 32, offset: 78072},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2506, col: 41, offset: 77998},
+										pos:  position{line: 2511, col: 41, offset: 78081},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2506, col: 64, offset: 78021},
+									pos:   position{line: 2511, col: 64, offset: 78104},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2506, col: 69, offset: 78026},
+										pos: position{line: 2511, col: 69, offset: 78109},
 										expr: &seqExpr{
-											pos: position{line: 2506, col: 70, offset: 78027},
+											pos: position{line: 2511, col: 70, offset: 78110},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2506, col: 70, offset: 78027},
+													pos:  position{line: 2511, col: 70, offset: 78110},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2506, col: 76, offset: 78033},
+													pos:  position{line: 2511, col: 76, offset: 78116},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5189,57 +5194,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2506, col: 101, offset: 78058},
+									pos:  position{line: 2511, col: 101, offset: 78141},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2526, col: 3, offset: 78646},
+						pos: position{line: 2531, col: 3, offset: 78729},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2526, col: 3, offset: 78646},
+							pos: position{line: 2531, col: 3, offset: 78729},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2526, col: 3, offset: 78646},
+									pos:   position{line: 2531, col: 3, offset: 78729},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2526, col: 9, offset: 78652},
+										pos:  position{line: 2531, col: 9, offset: 78735},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2526, col: 25, offset: 78668},
+									pos: position{line: 2531, col: 25, offset: 78751},
 									expr: &choiceExpr{
-										pos: position{line: 2526, col: 27, offset: 78670},
+										pos: position{line: 2531, col: 27, offset: 78753},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 27, offset: 78670},
+												pos:  position{line: 2531, col: 27, offset: 78753},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 36, offset: 78679},
+												pos:  position{line: 2531, col: 36, offset: 78762},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 46, offset: 78689},
+												pos:  position{line: 2531, col: 46, offset: 78772},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 54, offset: 78697},
+												pos:  position{line: 2531, col: 54, offset: 78780},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 62, offset: 78705},
+												pos:  position{line: 2531, col: 62, offset: 78788},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2526, col: 70, offset: 78713},
+												pos:  position{line: 2531, col: 70, offset: 78796},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2526, col: 84, offset: 78727},
+												pos:        position{line: 2531, col: 84, offset: 78810},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5255,36 +5260,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2538, col: 1, offset: 79122},
+			pos:  position{line: 2543, col: 1, offset: 79205},
 			expr: &choiceExpr{
-				pos: position{line: 2538, col: 13, offset: 79134},
+				pos: position{line: 2543, col: 13, offset: 79217},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2538, col: 13, offset: 79134},
+						pos: position{line: 2543, col: 13, offset: 79217},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2538, col: 14, offset: 79135},
+							pos: position{line: 2543, col: 14, offset: 79218},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2538, col: 14, offset: 79135},
+									pos:   position{line: 2543, col: 14, offset: 79218},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2538, col: 22, offset: 79143},
+										pos: position{line: 2543, col: 22, offset: 79226},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2538, col: 22, offset: 79143},
+												pos:        position{line: 2543, col: 22, offset: 79226},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2538, col: 32, offset: 79153},
+												pos:        position{line: 2543, col: 32, offset: 79236},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2538, col: 42, offset: 79163},
+												pos:        position{line: 2543, col: 42, offset: 79246},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5293,44 +5298,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 55, offset: 79176},
+									pos:  position{line: 2543, col: 55, offset: 79259},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2538, col: 63, offset: 79184},
+									pos:   position{line: 2543, col: 63, offset: 79267},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2538, col: 74, offset: 79195},
+										pos:  position{line: 2543, col: 74, offset: 79278},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 85, offset: 79206},
+									pos:  position{line: 2543, col: 85, offset: 79289},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2550, col: 3, offset: 79520},
+						pos: position{line: 2555, col: 3, offset: 79603},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2550, col: 4, offset: 79521},
+							pos: position{line: 2555, col: 4, offset: 79604},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2550, col: 4, offset: 79521},
+									pos:   position{line: 2555, col: 4, offset: 79604},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2550, col: 12, offset: 79529},
+										pos: position{line: 2555, col: 12, offset: 79612},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2550, col: 12, offset: 79529},
+												pos:        position{line: 2555, col: 12, offset: 79612},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2550, col: 20, offset: 79537},
+												pos:        position{line: 2555, col: 20, offset: 79620},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5339,31 +5344,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2550, col: 27, offset: 79544},
+									pos:  position{line: 2555, col: 27, offset: 79627},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2550, col: 35, offset: 79552},
+									pos:   position{line: 2555, col: 35, offset: 79635},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2550, col: 44, offset: 79561},
+										pos:  position{line: 2555, col: 44, offset: 79644},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2550, col: 55, offset: 79572},
+									pos:   position{line: 2555, col: 55, offset: 79655},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2550, col: 60, offset: 79577},
+										pos: position{line: 2555, col: 60, offset: 79660},
 										expr: &seqExpr{
-											pos: position{line: 2550, col: 61, offset: 79578},
+											pos: position{line: 2555, col: 61, offset: 79661},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2550, col: 61, offset: 79578},
+													pos:  position{line: 2555, col: 61, offset: 79661},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2550, col: 67, offset: 79584},
+													pos:  position{line: 2555, col: 67, offset: 79667},
 													name: "StringExpr",
 												},
 											},
@@ -5371,195 +5376,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2550, col: 80, offset: 79597},
+									pos:  position{line: 2555, col: 80, offset: 79680},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2572, col: 3, offset: 80197},
+						pos: position{line: 2577, col: 3, offset: 80280},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2572, col: 4, offset: 80198},
+							pos: position{line: 2577, col: 4, offset: 80281},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2572, col: 4, offset: 80198},
+									pos:   position{line: 2577, col: 4, offset: 80281},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2572, col: 12, offset: 80206},
+										pos:        position{line: 2577, col: 12, offset: 80289},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2572, col: 23, offset: 80217},
+									pos:  position{line: 2577, col: 23, offset: 80300},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2572, col: 31, offset: 80225},
+									pos:   position{line: 2577, col: 31, offset: 80308},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2572, col: 46, offset: 80240},
+										pos:  position{line: 2577, col: 46, offset: 80323},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2572, col: 61, offset: 80255},
+									pos:  position{line: 2577, col: 61, offset: 80338},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2583, col: 3, offset: 80557},
+						pos: position{line: 2588, col: 3, offset: 80640},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2583, col: 4, offset: 80558},
+							pos: position{line: 2588, col: 4, offset: 80641},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2583, col: 4, offset: 80558},
+									pos:   position{line: 2588, col: 4, offset: 80641},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2583, col: 12, offset: 80566},
+										pos:        position{line: 2588, col: 12, offset: 80649},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2583, col: 22, offset: 80576},
+									pos:  position{line: 2588, col: 22, offset: 80659},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2583, col: 30, offset: 80584},
+									pos:   position{line: 2588, col: 30, offset: 80667},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2583, col: 45, offset: 80599},
+										pos:  position{line: 2588, col: 45, offset: 80682},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2583, col: 60, offset: 80614},
+									pos:  position{line: 2588, col: 60, offset: 80697},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2583, col: 66, offset: 80620},
+									pos:   position{line: 2588, col: 66, offset: 80703},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2583, col: 72, offset: 80626},
+										pos:  position{line: 2588, col: 72, offset: 80709},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2583, col: 83, offset: 80637},
+									pos:  position{line: 2588, col: 83, offset: 80720},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2595, col: 3, offset: 80987},
+						pos: position{line: 2600, col: 3, offset: 81070},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2595, col: 4, offset: 80988},
+							pos: position{line: 2600, col: 4, offset: 81071},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2595, col: 4, offset: 80988},
+									pos:   position{line: 2600, col: 4, offset: 81071},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2595, col: 12, offset: 80996},
+										pos:        position{line: 2600, col: 12, offset: 81079},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2595, col: 22, offset: 81006},
+									pos:  position{line: 2600, col: 22, offset: 81089},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2595, col: 30, offset: 81014},
+									pos:   position{line: 2600, col: 30, offset: 81097},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2595, col: 45, offset: 81029},
+										pos:  position{line: 2600, col: 45, offset: 81112},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2595, col: 60, offset: 81044},
+									pos:  position{line: 2600, col: 60, offset: 81127},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2595, col: 66, offset: 81050},
+									pos:   position{line: 2600, col: 66, offset: 81133},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2595, col: 79, offset: 81063},
+										pos:  position{line: 2600, col: 79, offset: 81146},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2595, col: 90, offset: 81074},
+									pos:  position{line: 2600, col: 90, offset: 81157},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2619, col: 3, offset: 81743},
+						pos: position{line: 2624, col: 3, offset: 81826},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2619, col: 4, offset: 81744},
+							pos: position{line: 2624, col: 4, offset: 81827},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2619, col: 4, offset: 81744},
+									pos:   position{line: 2624, col: 4, offset: 81827},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2619, col: 12, offset: 81752},
+										pos:        position{line: 2624, col: 12, offset: 81835},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 22, offset: 81762},
+									pos:  position{line: 2624, col: 22, offset: 81845},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 30, offset: 81770},
+									pos:   position{line: 2624, col: 30, offset: 81853},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2619, col: 41, offset: 81781},
+										pos:  position{line: 2624, col: 41, offset: 81864},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 52, offset: 81792},
+									pos:  position{line: 2624, col: 52, offset: 81875},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 58, offset: 81798},
+									pos:   position{line: 2624, col: 58, offset: 81881},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2619, col: 69, offset: 81809},
+										pos:  position{line: 2624, col: 69, offset: 81892},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 81, offset: 81821},
+									pos:   position{line: 2624, col: 81, offset: 81904},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2619, col: 93, offset: 81833},
+										pos: position{line: 2624, col: 93, offset: 81916},
 										expr: &seqExpr{
-											pos: position{line: 2619, col: 94, offset: 81834},
+											pos: position{line: 2624, col: 94, offset: 81917},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2619, col: 94, offset: 81834},
+													pos:  position{line: 2624, col: 94, offset: 81917},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2619, col: 100, offset: 81840},
+													pos:  position{line: 2624, col: 100, offset: 81923},
 													name: "NumericExpr",
 												},
 											},
@@ -5567,50 +5572,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 114, offset: 81854},
+									pos:  position{line: 2624, col: 114, offset: 81937},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2644, col: 3, offset: 82684},
+						pos: position{line: 2649, col: 3, offset: 82767},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2644, col: 3, offset: 82684},
+							pos: position{line: 2649, col: 3, offset: 82767},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2644, col: 3, offset: 82684},
+									pos:        position{line: 2649, col: 3, offset: 82767},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2644, col: 14, offset: 82695},
+									pos:  position{line: 2649, col: 14, offset: 82778},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2644, col: 22, offset: 82703},
+									pos:   position{line: 2649, col: 22, offset: 82786},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2644, col: 28, offset: 82709},
+										pos:  position{line: 2649, col: 28, offset: 82792},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2644, col: 38, offset: 82719},
+									pos:   position{line: 2649, col: 38, offset: 82802},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2644, col: 45, offset: 82726},
+										pos: position{line: 2649, col: 45, offset: 82809},
 										expr: &seqExpr{
-											pos: position{line: 2644, col: 46, offset: 82727},
+											pos: position{line: 2649, col: 46, offset: 82810},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2644, col: 46, offset: 82727},
+													pos:  position{line: 2649, col: 46, offset: 82810},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2644, col: 52, offset: 82733},
+													pos:  position{line: 2649, col: 52, offset: 82816},
 													name: "StringExpr",
 												},
 											},
@@ -5618,38 +5623,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2644, col: 65, offset: 82746},
+									pos:  position{line: 2649, col: 65, offset: 82829},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2657, col: 3, offset: 83114},
+						pos: position{line: 2662, col: 3, offset: 83197},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2657, col: 4, offset: 83115},
+							pos: position{line: 2662, col: 4, offset: 83198},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2657, col: 4, offset: 83115},
+									pos:   position{line: 2662, col: 4, offset: 83198},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2657, col: 12, offset: 83123},
+										pos: position{line: 2662, col: 12, offset: 83206},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2657, col: 12, offset: 83123},
+												pos:        position{line: 2662, col: 12, offset: 83206},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2657, col: 22, offset: 83133},
+												pos:        position{line: 2662, col: 22, offset: 83216},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2657, col: 32, offset: 83143},
+												pos:        position{line: 2662, col: 32, offset: 83226},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5658,223 +5663,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2657, col: 40, offset: 83151},
+									pos:  position{line: 2662, col: 40, offset: 83234},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2657, col: 48, offset: 83159},
+									pos:   position{line: 2662, col: 48, offset: 83242},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2657, col: 54, offset: 83165},
+										pos:  position{line: 2662, col: 54, offset: 83248},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2657, col: 66, offset: 83177},
+									pos:   position{line: 2662, col: 66, offset: 83260},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2657, col: 82, offset: 83193},
+										pos: position{line: 2662, col: 82, offset: 83276},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2657, col: 83, offset: 83194},
+											pos:  position{line: 2662, col: 83, offset: 83277},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2657, col: 101, offset: 83212},
+									pos:  position{line: 2662, col: 101, offset: 83295},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2676, col: 3, offset: 83652},
+						pos: position{line: 2681, col: 3, offset: 83735},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2676, col: 3, offset: 83652},
+							pos: position{line: 2681, col: 3, offset: 83735},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2676, col: 3, offset: 83652},
+									pos:        position{line: 2681, col: 3, offset: 83735},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2676, col: 11, offset: 83660},
+									pos:  position{line: 2681, col: 11, offset: 83743},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2676, col: 19, offset: 83668},
+									pos:   position{line: 2681, col: 19, offset: 83751},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2676, col: 30, offset: 83679},
+										pos:  position{line: 2681, col: 30, offset: 83762},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2676, col: 50, offset: 83699},
+									pos:  position{line: 2681, col: 50, offset: 83782},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2676, col: 56, offset: 83705},
+									pos:   position{line: 2681, col: 56, offset: 83788},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2676, col: 62, offset: 83711},
+										pos: position{line: 2681, col: 62, offset: 83794},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2676, col: 62, offset: 83711},
+												pos:  position{line: 2681, col: 62, offset: 83794},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2676, col: 81, offset: 83730},
+												pos:  position{line: 2681, col: 81, offset: 83813},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2676, col: 100, offset: 83749},
+									pos:  position{line: 2681, col: 100, offset: 83832},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2687, col: 3, offset: 84054},
+						pos: position{line: 2692, col: 3, offset: 84137},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2687, col: 3, offset: 84054},
+							pos: position{line: 2692, col: 3, offset: 84137},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2687, col: 3, offset: 84054},
+									pos:        position{line: 2692, col: 3, offset: 84137},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2687, col: 12, offset: 84063},
+									pos:  position{line: 2692, col: 12, offset: 84146},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2687, col: 20, offset: 84071},
+									pos:   position{line: 2692, col: 20, offset: 84154},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2687, col: 25, offset: 84076},
+										pos:  position{line: 2692, col: 25, offset: 84159},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2687, col: 36, offset: 84087},
+									pos:  position{line: 2692, col: 36, offset: 84170},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2687, col: 42, offset: 84093},
+									pos:   position{line: 2692, col: 42, offset: 84176},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2687, col: 45, offset: 84096},
+										pos:  position{line: 2692, col: 45, offset: 84179},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2687, col: 55, offset: 84106},
+									pos:  position{line: 2692, col: 55, offset: 84189},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2694, col: 3, offset: 84264},
+						pos: position{line: 2699, col: 3, offset: 84347},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2694, col: 3, offset: 84264},
+							pos: position{line: 2699, col: 3, offset: 84347},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2694, col: 3, offset: 84264},
+									pos:        position{line: 2699, col: 3, offset: 84347},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 21, offset: 84282},
+									pos:  position{line: 2699, col: 21, offset: 84365},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2694, col: 29, offset: 84290},
+									pos:   position{line: 2699, col: 29, offset: 84373},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2694, col: 33, offset: 84294},
+										pos:  position{line: 2699, col: 33, offset: 84377},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 43, offset: 84304},
+									pos:  position{line: 2699, col: 43, offset: 84387},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2694, col: 49, offset: 84310},
+									pos:   position{line: 2699, col: 49, offset: 84393},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2694, col: 53, offset: 84314},
+										pos:  position{line: 2699, col: 53, offset: 84397},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 66, offset: 84327},
+									pos:  position{line: 2699, col: 66, offset: 84410},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2694, col: 72, offset: 84333},
+									pos:   position{line: 2699, col: 72, offset: 84416},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2694, col: 78, offset: 84339},
+										pos:  position{line: 2699, col: 78, offset: 84422},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 91, offset: 84352},
+									pos:  position{line: 2699, col: 91, offset: 84435},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2705, col: 3, offset: 84660},
+						pos: position{line: 2710, col: 3, offset: 84743},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2705, col: 3, offset: 84660},
+							pos: position{line: 2710, col: 3, offset: 84743},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2705, col: 3, offset: 84660},
+									pos:        position{line: 2710, col: 3, offset: 84743},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2705, col: 12, offset: 84669},
+									pos:  position{line: 2710, col: 12, offset: 84752},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2705, col: 20, offset: 84677},
+									pos:   position{line: 2710, col: 20, offset: 84760},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2705, col: 27, offset: 84684},
+										pos:  position{line: 2710, col: 27, offset: 84767},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2705, col: 38, offset: 84695},
+									pos:   position{line: 2710, col: 38, offset: 84778},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2705, col: 43, offset: 84700},
+										pos: position{line: 2710, col: 43, offset: 84783},
 										expr: &seqExpr{
-											pos: position{line: 2705, col: 44, offset: 84701},
+											pos: position{line: 2710, col: 44, offset: 84784},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2705, col: 44, offset: 84701},
+													pos:  position{line: 2710, col: 44, offset: 84784},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2705, col: 50, offset: 84707},
+													pos:  position{line: 2710, col: 50, offset: 84790},
 													name: "StringExpr",
 												},
 											},
@@ -5882,47 +5887,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2705, col: 63, offset: 84720},
+									pos:  position{line: 2710, col: 63, offset: 84803},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2723, col: 3, offset: 85187},
+						pos: position{line: 2728, col: 3, offset: 85270},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2723, col: 3, offset: 85187},
+							pos: position{line: 2728, col: 3, offset: 85270},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2723, col: 3, offset: 85187},
+									pos:        position{line: 2728, col: 3, offset: 85270},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2723, col: 12, offset: 85196},
+									pos:  position{line: 2728, col: 12, offset: 85279},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2723, col: 20, offset: 85204},
+									pos:   position{line: 2728, col: 20, offset: 85287},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2723, col: 42, offset: 85226},
+										pos: position{line: 2728, col: 42, offset: 85309},
 										expr: &seqExpr{
-											pos: position{line: 2723, col: 43, offset: 85227},
+											pos: position{line: 2728, col: 43, offset: 85310},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2723, col: 44, offset: 85228},
+													pos: position{line: 2728, col: 44, offset: 85311},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2723, col: 44, offset: 85228},
+															pos:        position{line: 2728, col: 44, offset: 85311},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2723, col: 53, offset: 85237},
+															pos:        position{line: 2728, col: 53, offset: 85320},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5930,7 +5935,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2723, col: 62, offset: 85246},
+													pos:        position{line: 2728, col: 62, offset: 85329},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5940,56 +5945,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2723, col: 69, offset: 85253},
+									pos:  position{line: 2728, col: 69, offset: 85336},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2745, col: 3, offset: 85850},
+						pos: position{line: 2750, col: 3, offset: 85933},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2745, col: 3, offset: 85850},
+							pos: position{line: 2750, col: 3, offset: 85933},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2745, col: 3, offset: 85850},
+									pos:        position{line: 2750, col: 3, offset: 85933},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2745, col: 13, offset: 85860},
+									pos:  position{line: 2750, col: 13, offset: 85943},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 21, offset: 85868},
+									pos:   position{line: 2750, col: 21, offset: 85951},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2745, col: 27, offset: 85874},
+										pos:  position{line: 2750, col: 27, offset: 85957},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 43, offset: 85890},
+									pos:   position{line: 2750, col: 43, offset: 85973},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2745, col: 53, offset: 85900},
+										pos: position{line: 2750, col: 53, offset: 85983},
 										expr: &seqExpr{
-											pos: position{line: 2745, col: 54, offset: 85901},
+											pos: position{line: 2750, col: 54, offset: 85984},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 54, offset: 85901},
+													pos:  position{line: 2750, col: 54, offset: 85984},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2745, col: 60, offset: 85907},
+													pos:        position{line: 2750, col: 60, offset: 85990},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 73, offset: 85920},
+													pos:  position{line: 2750, col: 73, offset: 86003},
 													name: "FloatAsString",
 												},
 											},
@@ -5997,40 +6002,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 89, offset: 85936},
+									pos:   position{line: 2750, col: 89, offset: 86019},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2745, col: 95, offset: 85942},
+										pos: position{line: 2750, col: 95, offset: 86025},
 										expr: &seqExpr{
-											pos: position{line: 2745, col: 96, offset: 85943},
+											pos: position{line: 2750, col: 96, offset: 86026},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 96, offset: 85943},
+													pos:  position{line: 2750, col: 96, offset: 86026},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2745, col: 102, offset: 85949},
+													pos:        position{line: 2750, col: 102, offset: 86032},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2745, col: 112, offset: 85959},
+													pos: position{line: 2750, col: 112, offset: 86042},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2745, col: 112, offset: 85959},
+															pos:        position{line: 2750, col: 112, offset: 86042},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2745, col: 125, offset: 85972},
+															pos:        position{line: 2750, col: 125, offset: 86055},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2745, col: 137, offset: 85984},
+															pos:        position{line: 2750, col: 137, offset: 86067},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6042,25 +6047,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 151, offset: 85998},
+									pos:   position{line: 2750, col: 151, offset: 86081},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2745, col: 158, offset: 86005},
+										pos: position{line: 2750, col: 158, offset: 86088},
 										expr: &seqExpr{
-											pos: position{line: 2745, col: 159, offset: 86006},
+											pos: position{line: 2750, col: 159, offset: 86089},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 159, offset: 86006},
+													pos:  position{line: 2750, col: 159, offset: 86089},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2745, col: 165, offset: 86012},
+													pos:        position{line: 2750, col: 165, offset: 86095},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 175, offset: 86022},
+													pos:  position{line: 2750, col: 175, offset: 86105},
 													name: "QuotedString",
 												},
 											},
@@ -6068,213 +6073,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2745, col: 190, offset: 86037},
+									pos:  position{line: 2750, col: 190, offset: 86120},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2785, col: 3, offset: 87032},
+						pos: position{line: 2790, col: 3, offset: 87115},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2785, col: 3, offset: 87032},
+							pos: position{line: 2790, col: 3, offset: 87115},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2785, col: 3, offset: 87032},
+									pos:        position{line: 2790, col: 3, offset: 87115},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 15, offset: 87044},
+									pos:  position{line: 2790, col: 15, offset: 87127},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2785, col: 23, offset: 87052},
+									pos:   position{line: 2790, col: 23, offset: 87135},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2785, col: 30, offset: 87059},
+										pos: position{line: 2790, col: 30, offset: 87142},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2785, col: 31, offset: 87060},
+											pos:  position{line: 2790, col: 31, offset: 87143},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 44, offset: 87073},
+									pos:  position{line: 2790, col: 44, offset: 87156},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2796, col: 3, offset: 87264},
+						pos: position{line: 2801, col: 3, offset: 87347},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2796, col: 3, offset: 87264},
+							pos: position{line: 2801, col: 3, offset: 87347},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2796, col: 3, offset: 87264},
+									pos:        position{line: 2801, col: 3, offset: 87347},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2796, col: 12, offset: 87273},
+									pos:  position{line: 2801, col: 12, offset: 87356},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2796, col: 20, offset: 87281},
+									pos:   position{line: 2801, col: 20, offset: 87364},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2796, col: 30, offset: 87291},
+										pos:  position{line: 2801, col: 30, offset: 87374},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2796, col: 40, offset: 87301},
+									pos:  position{line: 2801, col: 40, offset: 87384},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2802, col: 3, offset: 87424},
+						pos: position{line: 2807, col: 3, offset: 87507},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2802, col: 3, offset: 87424},
+							pos: position{line: 2807, col: 3, offset: 87507},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2802, col: 3, offset: 87424},
+									pos:        position{line: 2807, col: 3, offset: 87507},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 13, offset: 87434},
+									pos:  position{line: 2807, col: 13, offset: 87517},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2802, col: 21, offset: 87442},
+									pos:   position{line: 2807, col: 21, offset: 87525},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2802, col: 25, offset: 87446},
+										pos:  position{line: 2807, col: 25, offset: 87529},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 35, offset: 87456},
+									pos:  position{line: 2807, col: 35, offset: 87539},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2802, col: 41, offset: 87462},
+									pos:   position{line: 2807, col: 41, offset: 87545},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2802, col: 47, offset: 87468},
+										pos:  position{line: 2807, col: 47, offset: 87551},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 58, offset: 87479},
+									pos:  position{line: 2807, col: 58, offset: 87562},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2802, col: 64, offset: 87485},
+									pos:   position{line: 2807, col: 64, offset: 87568},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2802, col: 76, offset: 87497},
+										pos:  position{line: 2807, col: 76, offset: 87580},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2802, col: 87, offset: 87508},
+									pos:  position{line: 2807, col: 87, offset: 87591},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2809, col: 3, offset: 87732},
+						pos: position{line: 2814, col: 3, offset: 87815},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2809, col: 3, offset: 87732},
+							pos: position{line: 2814, col: 3, offset: 87815},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2809, col: 3, offset: 87732},
+									pos:        position{line: 2814, col: 3, offset: 87815},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2809, col: 14, offset: 87743},
+									pos:  position{line: 2814, col: 14, offset: 87826},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2809, col: 22, offset: 87751},
+									pos:   position{line: 2814, col: 22, offset: 87834},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2809, col: 26, offset: 87755},
+										pos:  position{line: 2814, col: 26, offset: 87838},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2809, col: 36, offset: 87765},
+									pos:  position{line: 2814, col: 36, offset: 87848},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2809, col: 42, offset: 87771},
+									pos:   position{line: 2814, col: 42, offset: 87854},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2809, col: 49, offset: 87778},
+										pos:  position{line: 2814, col: 49, offset: 87861},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2809, col: 60, offset: 87789},
+									pos:  position{line: 2814, col: 60, offset: 87872},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2817, col: 3, offset: 87953},
+						pos: position{line: 2822, col: 3, offset: 88036},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2817, col: 3, offset: 87953},
+							pos: position{line: 2822, col: 3, offset: 88036},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2817, col: 3, offset: 87953},
+									pos:        position{line: 2822, col: 3, offset: 88036},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2817, col: 14, offset: 87964},
+									pos:  position{line: 2822, col: 14, offset: 88047},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2817, col: 22, offset: 87972},
+									pos:   position{line: 2822, col: 22, offset: 88055},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2817, col: 26, offset: 87976},
+										pos:  position{line: 2822, col: 26, offset: 88059},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2817, col: 36, offset: 87986},
+									pos:  position{line: 2822, col: 36, offset: 88069},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2817, col: 42, offset: 87992},
+									pos:   position{line: 2822, col: 42, offset: 88075},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2817, col: 49, offset: 87999},
+										pos:  position{line: 2822, col: 49, offset: 88082},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2817, col: 60, offset: 88010},
+									pos:  position{line: 2822, col: 60, offset: 88093},
 									name: "R_PAREN",
 								},
 							},
@@ -6285,15 +6290,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2825, col: 1, offset: 88172},
+			pos:  position{line: 2830, col: 1, offset: 88255},
 			expr: &actionExpr{
-				pos: position{line: 2825, col: 21, offset: 88192},
+				pos: position{line: 2830, col: 21, offset: 88275},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2825, col: 21, offset: 88192},
+					pos:   position{line: 2830, col: 21, offset: 88275},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2825, col: 25, offset: 88196},
+						pos:  position{line: 2830, col: 25, offset: 88279},
 						name: "QuotedString",
 					},
 				},
@@ -6301,15 +6306,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2832, col: 1, offset: 88323},
+			pos:  position{line: 2837, col: 1, offset: 88406},
 			expr: &actionExpr{
-				pos: position{line: 2832, col: 22, offset: 88344},
+				pos: position{line: 2837, col: 22, offset: 88427},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2832, col: 22, offset: 88344},
+					pos:   position{line: 2837, col: 22, offset: 88427},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2832, col: 26, offset: 88348},
+						pos:  position{line: 2837, col: 26, offset: 88431},
 						name: "UnquotedString",
 					},
 				},
@@ -6317,22 +6322,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2839, col: 1, offset: 88476},
+			pos:  position{line: 2844, col: 1, offset: 88559},
 			expr: &actionExpr{
-				pos: position{line: 2839, col: 20, offset: 88495},
+				pos: position{line: 2844, col: 20, offset: 88578},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2839, col: 20, offset: 88495},
+					pos: position{line: 2844, col: 20, offset: 88578},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2839, col: 20, offset: 88495},
+							pos:  position{line: 2844, col: 20, offset: 88578},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2839, col: 26, offset: 88501},
+							pos:   position{line: 2844, col: 26, offset: 88584},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2839, col: 38, offset: 88513},
+								pos:  position{line: 2844, col: 38, offset: 88596},
 								name: "String",
 							},
 						},
@@ -6342,20 +6347,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2845, col: 1, offset: 88698},
+			pos:  position{line: 2850, col: 1, offset: 88781},
 			expr: &choiceExpr{
-				pos: position{line: 2845, col: 20, offset: 88717},
+				pos: position{line: 2850, col: 20, offset: 88800},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2845, col: 20, offset: 88717},
+						pos: position{line: 2850, col: 20, offset: 88800},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2845, col: 20, offset: 88717},
+							pos: position{line: 2850, col: 20, offset: 88800},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 2845, col: 20, offset: 88717},
+									pos: position{line: 2850, col: 20, offset: 88800},
 									expr: &charClassMatcher{
-										pos:        position{line: 2845, col: 20, offset: 88717},
+										pos:        position{line: 2850, col: 20, offset: 88800},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -6364,9 +6369,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2845, col: 31, offset: 88728},
+									pos: position{line: 2850, col: 31, offset: 88811},
 									expr: &litMatcher{
-										pos:        position{line: 2845, col: 33, offset: 88730},
+										pos:        position{line: 2850, col: 33, offset: 88813},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6376,27 +6381,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2848, col: 3, offset: 88772},
+						pos: position{line: 2853, col: 3, offset: 88855},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 2848, col: 3, offset: 88772},
+							pos: position{line: 2853, col: 3, offset: 88855},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2848, col: 3, offset: 88772},
+									pos:        position{line: 2853, col: 3, offset: 88855},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2848, col: 7, offset: 88776},
+									pos:   position{line: 2853, col: 7, offset: 88859},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2848, col: 13, offset: 88782},
+										pos:  position{line: 2853, col: 13, offset: 88865},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2848, col: 23, offset: 88792},
+									pos:        position{line: 2853, col: 23, offset: 88875},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6409,26 +6414,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2853, col: 1, offset: 88860},
+			pos:  position{line: 2858, col: 1, offset: 88943},
 			expr: &actionExpr{
-				pos: position{line: 2853, col: 15, offset: 88874},
+				pos: position{line: 2858, col: 15, offset: 88957},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2853, col: 15, offset: 88874},
+					pos: position{line: 2858, col: 15, offset: 88957},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2853, col: 15, offset: 88874},
+							pos:  position{line: 2858, col: 15, offset: 88957},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2853, col: 20, offset: 88879},
+							pos:  position{line: 2858, col: 20, offset: 88962},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2853, col: 30, offset: 88889},
+							pos:   position{line: 2858, col: 30, offset: 88972},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2853, col: 40, offset: 88899},
+								pos:  position{line: 2858, col: 40, offset: 88982},
 								name: "BoolExpr",
 							},
 						},
@@ -6438,15 +6443,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2865, col: 1, offset: 89192},
+			pos:  position{line: 2870, col: 1, offset: 89275},
 			expr: &actionExpr{
-				pos: position{line: 2865, col: 13, offset: 89204},
+				pos: position{line: 2870, col: 13, offset: 89287},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2865, col: 13, offset: 89204},
+					pos:   position{line: 2870, col: 13, offset: 89287},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2865, col: 18, offset: 89209},
+						pos:  position{line: 2870, col: 18, offset: 89292},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6454,35 +6459,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2870, col: 1, offset: 89279},
+			pos:  position{line: 2875, col: 1, offset: 89362},
 			expr: &actionExpr{
-				pos: position{line: 2870, col: 19, offset: 89297},
+				pos: position{line: 2875, col: 19, offset: 89380},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2870, col: 19, offset: 89297},
+					pos: position{line: 2875, col: 19, offset: 89380},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2870, col: 19, offset: 89297},
+							pos:   position{line: 2875, col: 19, offset: 89380},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2870, col: 25, offset: 89303},
+								pos:  position{line: 2875, col: 25, offset: 89386},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2870, col: 40, offset: 89318},
+							pos:   position{line: 2875, col: 40, offset: 89401},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2870, col: 45, offset: 89323},
+								pos: position{line: 2875, col: 45, offset: 89406},
 								expr: &seqExpr{
-									pos: position{line: 2870, col: 46, offset: 89324},
+									pos: position{line: 2875, col: 46, offset: 89407},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2870, col: 46, offset: 89324},
+											pos:  position{line: 2875, col: 46, offset: 89407},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2870, col: 49, offset: 89327},
+											pos:  position{line: 2875, col: 49, offset: 89410},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6495,35 +6500,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 2890, col: 1, offset: 89765},
+			pos:  position{line: 2895, col: 1, offset: 89848},
 			expr: &actionExpr{
-				pos: position{line: 2890, col: 19, offset: 89783},
+				pos: position{line: 2895, col: 19, offset: 89866},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 2890, col: 19, offset: 89783},
+					pos: position{line: 2895, col: 19, offset: 89866},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2890, col: 19, offset: 89783},
+							pos:   position{line: 2895, col: 19, offset: 89866},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2890, col: 25, offset: 89789},
+								pos:  position{line: 2895, col: 25, offset: 89872},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2890, col: 40, offset: 89804},
+							pos:   position{line: 2895, col: 40, offset: 89887},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2890, col: 45, offset: 89809},
+								pos: position{line: 2895, col: 45, offset: 89892},
 								expr: &seqExpr{
-									pos: position{line: 2890, col: 46, offset: 89810},
+									pos: position{line: 2895, col: 46, offset: 89893},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2890, col: 46, offset: 89810},
+											pos:  position{line: 2895, col: 46, offset: 89893},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2890, col: 50, offset: 89814},
+											pos:  position{line: 2895, col: 50, offset: 89897},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6536,47 +6541,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 2910, col: 1, offset: 90253},
+			pos:  position{line: 2915, col: 1, offset: 90336},
 			expr: &choiceExpr{
-				pos: position{line: 2910, col: 19, offset: 90271},
+				pos: position{line: 2915, col: 19, offset: 90354},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2910, col: 19, offset: 90271},
+						pos: position{line: 2915, col: 19, offset: 90354},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 2910, col: 19, offset: 90271},
+							pos: position{line: 2915, col: 19, offset: 90354},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2910, col: 19, offset: 90271},
+									pos:  position{line: 2915, col: 19, offset: 90354},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2910, col: 23, offset: 90275},
+									pos:  position{line: 2915, col: 23, offset: 90358},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2910, col: 31, offset: 90283},
+									pos:   position{line: 2915, col: 31, offset: 90366},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2910, col: 37, offset: 90289},
+										pos:  position{line: 2915, col: 37, offset: 90372},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2910, col: 52, offset: 90304},
+									pos:  position{line: 2915, col: 52, offset: 90387},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2920, col: 3, offset: 90507},
+						pos: position{line: 2925, col: 3, offset: 90590},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 2920, col: 3, offset: 90507},
+							pos:   position{line: 2925, col: 3, offset: 90590},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2920, col: 9, offset: 90513},
+								pos:  position{line: 2925, col: 9, offset: 90596},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6586,50 +6591,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 2925, col: 1, offset: 90584},
+			pos:  position{line: 2930, col: 1, offset: 90667},
 			expr: &choiceExpr{
-				pos: position{line: 2925, col: 19, offset: 90602},
+				pos: position{line: 2930, col: 19, offset: 90685},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2925, col: 19, offset: 90602},
+						pos: position{line: 2930, col: 19, offset: 90685},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 2925, col: 19, offset: 90602},
+							pos: position{line: 2930, col: 19, offset: 90685},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2925, col: 19, offset: 90602},
+									pos:  position{line: 2930, col: 19, offset: 90685},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2925, col: 27, offset: 90610},
+									pos:   position{line: 2930, col: 27, offset: 90693},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2925, col: 33, offset: 90616},
+										pos:  position{line: 2930, col: 33, offset: 90699},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2925, col: 48, offset: 90631},
+									pos:  position{line: 2930, col: 48, offset: 90714},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2928, col: 3, offset: 90667},
+						pos: position{line: 2933, col: 3, offset: 90750},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 2928, col: 3, offset: 90667},
+							pos:   position{line: 2933, col: 3, offset: 90750},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 2928, col: 10, offset: 90674},
+								pos: position{line: 2933, col: 10, offset: 90757},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2928, col: 10, offset: 90674},
+										pos:  position{line: 2933, col: 10, offset: 90757},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2928, col: 31, offset: 90695},
+										pos:  position{line: 2933, col: 31, offset: 90778},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6641,60 +6646,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 2933, col: 1, offset: 90815},
+			pos:  position{line: 2938, col: 1, offset: 90898},
 			expr: &choiceExpr{
-				pos: position{line: 2933, col: 23, offset: 90837},
+				pos: position{line: 2938, col: 23, offset: 90920},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2933, col: 23, offset: 90837},
+						pos: position{line: 2938, col: 23, offset: 90920},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2933, col: 24, offset: 90838},
+							pos: position{line: 2938, col: 24, offset: 90921},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2933, col: 24, offset: 90838},
+									pos:   position{line: 2938, col: 24, offset: 90921},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 2933, col: 28, offset: 90842},
+										pos: position{line: 2938, col: 28, offset: 90925},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2933, col: 28, offset: 90842},
+												pos:        position{line: 2938, col: 28, offset: 90925},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 39, offset: 90853},
+												pos:        position{line: 2938, col: 39, offset: 90936},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 49, offset: 90863},
+												pos:        position{line: 2938, col: 49, offset: 90946},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 59, offset: 90873},
+												pos:        position{line: 2938, col: 59, offset: 90956},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 70, offset: 90884},
+												pos:        position{line: 2938, col: 70, offset: 90967},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 84, offset: 90898},
+												pos:        position{line: 2938, col: 84, offset: 90981},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2933, col: 94, offset: 90908},
+												pos:        position{line: 2938, col: 94, offset: 90991},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6703,56 +6708,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2933, col: 109, offset: 90923},
+									pos:  position{line: 2938, col: 109, offset: 91006},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2933, col: 117, offset: 90931},
+									pos:   position{line: 2938, col: 117, offset: 91014},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2933, col: 123, offset: 90937},
+										pos:  position{line: 2938, col: 123, offset: 91020},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2933, col: 133, offset: 90947},
+									pos:  position{line: 2938, col: 133, offset: 91030},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2963, col: 3, offset: 91818},
+						pos: position{line: 2968, col: 3, offset: 91901},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 2963, col: 3, offset: 91818},
+							pos: position{line: 2968, col: 3, offset: 91901},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2963, col: 3, offset: 91818},
+									pos:   position{line: 2968, col: 3, offset: 91901},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2963, col: 11, offset: 91826},
+										pos: position{line: 2968, col: 11, offset: 91909},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2963, col: 11, offset: 91826},
+												pos:        position{line: 2968, col: 11, offset: 91909},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2963, col: 20, offset: 91835},
+												pos:        position{line: 2968, col: 20, offset: 91918},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2963, col: 29, offset: 91844},
+												pos:        position{line: 2968, col: 29, offset: 91927},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2963, col: 39, offset: 91854},
+												pos:        position{line: 2968, col: 39, offset: 91937},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6761,86 +6766,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 52, offset: 91867},
+									pos:  position{line: 2968, col: 52, offset: 91950},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 60, offset: 91875},
+									pos:   position{line: 2968, col: 60, offset: 91958},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2963, col: 70, offset: 91885},
+										pos:  position{line: 2968, col: 70, offset: 91968},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 80, offset: 91895},
+									pos:  position{line: 2968, col: 80, offset: 91978},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 86, offset: 91901},
+									pos:   position{line: 2968, col: 86, offset: 91984},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2963, col: 97, offset: 91912},
+										pos:  position{line: 2968, col: 97, offset: 91995},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 107, offset: 91922},
+									pos:  position{line: 2968, col: 107, offset: 92005},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2976, col: 3, offset: 92292},
+						pos: position{line: 2981, col: 3, offset: 92375},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 2976, col: 3, offset: 92292},
+							pos: position{line: 2981, col: 3, offset: 92375},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2976, col: 3, offset: 92292},
+									pos:   position{line: 2981, col: 3, offset: 92375},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2976, col: 8, offset: 92297},
+										pos:  position{line: 2981, col: 8, offset: 92380},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2976, col: 18, offset: 92307},
+									pos:  position{line: 2981, col: 18, offset: 92390},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2976, col: 24, offset: 92313},
+									pos:        position{line: 2981, col: 24, offset: 92396},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2976, col: 29, offset: 92318},
+									pos:  position{line: 2981, col: 29, offset: 92401},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2976, col: 37, offset: 92326},
+									pos:   position{line: 2981, col: 37, offset: 92409},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2976, col: 50, offset: 92339},
+										pos:  position{line: 2981, col: 50, offset: 92422},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2976, col: 60, offset: 92349},
+									pos:   position{line: 2981, col: 60, offset: 92432},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2976, col: 65, offset: 92354},
+										pos: position{line: 2981, col: 65, offset: 92437},
 										expr: &seqExpr{
-											pos: position{line: 2976, col: 66, offset: 92355},
+											pos: position{line: 2981, col: 66, offset: 92438},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2976, col: 66, offset: 92355},
+													pos:  position{line: 2981, col: 66, offset: 92438},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2976, col: 72, offset: 92361},
+													pos:  position{line: 2981, col: 72, offset: 92444},
 													name: "ValueExpr",
 												},
 											},
@@ -6848,50 +6853,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2976, col: 84, offset: 92373},
+									pos:  position{line: 2981, col: 84, offset: 92456},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2995, col: 3, offset: 92924},
+						pos: position{line: 3000, col: 3, offset: 93007},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2995, col: 3, offset: 92924},
+							pos: position{line: 3000, col: 3, offset: 93007},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2995, col: 3, offset: 92924},
+									pos:        position{line: 3000, col: 3, offset: 93007},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2995, col: 8, offset: 92929},
+									pos:  position{line: 3000, col: 8, offset: 93012},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2995, col: 16, offset: 92937},
+									pos:   position{line: 3000, col: 16, offset: 93020},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2995, col: 29, offset: 92950},
+										pos:  position{line: 3000, col: 29, offset: 93033},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2995, col: 39, offset: 92960},
+									pos:   position{line: 3000, col: 39, offset: 93043},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2995, col: 44, offset: 92965},
+										pos: position{line: 3000, col: 44, offset: 93048},
 										expr: &seqExpr{
-											pos: position{line: 2995, col: 45, offset: 92966},
+											pos: position{line: 3000, col: 45, offset: 93049},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2995, col: 45, offset: 92966},
+													pos:  position{line: 3000, col: 45, offset: 93049},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2995, col: 51, offset: 92972},
+													pos:  position{line: 3000, col: 51, offset: 93055},
 													name: "ValueExpr",
 												},
 											},
@@ -6899,7 +6904,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2995, col: 63, offset: 92984},
+									pos:  position{line: 3000, col: 63, offset: 93067},
 									name: "R_PAREN",
 								},
 							},
@@ -6910,34 +6915,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3013, col: 1, offset: 93405},
+			pos:  position{line: 3018, col: 1, offset: 93488},
 			expr: &actionExpr{
-				pos: position{line: 3013, col: 23, offset: 93427},
+				pos: position{line: 3018, col: 23, offset: 93510},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3013, col: 23, offset: 93427},
+					pos: position{line: 3018, col: 23, offset: 93510},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3013, col: 23, offset: 93427},
+							pos:   position{line: 3018, col: 23, offset: 93510},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3013, col: 28, offset: 93432},
+								pos:  position{line: 3018, col: 28, offset: 93515},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3013, col: 38, offset: 93442},
+							pos:   position{line: 3018, col: 38, offset: 93525},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3013, col: 41, offset: 93445},
+								pos:  position{line: 3018, col: 41, offset: 93528},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3013, col: 62, offset: 93466},
+							pos:   position{line: 3018, col: 62, offset: 93549},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3013, col: 68, offset: 93472},
+								pos:  position{line: 3018, col: 68, offset: 93555},
 								name: "ValueExpr",
 							},
 						},
@@ -6947,129 +6952,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3031, col: 1, offset: 94066},
+			pos:  position{line: 3036, col: 1, offset: 94149},
 			expr: &choiceExpr{
-				pos: position{line: 3031, col: 14, offset: 94079},
+				pos: position{line: 3036, col: 14, offset: 94162},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3031, col: 14, offset: 94079},
+						pos: position{line: 3036, col: 14, offset: 94162},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3031, col: 14, offset: 94079},
+							pos:   position{line: 3036, col: 14, offset: 94162},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3031, col: 24, offset: 94089},
+								pos:  position{line: 3036, col: 24, offset: 94172},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3040, col: 3, offset: 94279},
+						pos: position{line: 3045, col: 3, offset: 94362},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3040, col: 3, offset: 94279},
+							pos: position{line: 3045, col: 3, offset: 94362},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3040, col: 3, offset: 94279},
+									pos:  position{line: 3045, col: 3, offset: 94362},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3040, col: 12, offset: 94288},
+									pos:   position{line: 3045, col: 12, offset: 94371},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3040, col: 22, offset: 94298},
+										pos:  position{line: 3045, col: 22, offset: 94381},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3040, col: 37, offset: 94313},
+									pos:  position{line: 3045, col: 37, offset: 94396},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3049, col: 3, offset: 94497},
+						pos: position{line: 3054, col: 3, offset: 94580},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3049, col: 3, offset: 94497},
+							pos:   position{line: 3054, col: 3, offset: 94580},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3049, col: 11, offset: 94505},
+								pos:  position{line: 3054, col: 11, offset: 94588},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3058, col: 3, offset: 94685},
+						pos: position{line: 3063, col: 3, offset: 94768},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3058, col: 3, offset: 94685},
+							pos:   position{line: 3063, col: 3, offset: 94768},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3058, col: 7, offset: 94689},
+								pos:  position{line: 3063, col: 7, offset: 94772},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3067, col: 3, offset: 94861},
+						pos: position{line: 3072, col: 3, offset: 94944},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3067, col: 3, offset: 94861},
+							pos: position{line: 3072, col: 3, offset: 94944},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3067, col: 3, offset: 94861},
+									pos:  position{line: 3072, col: 3, offset: 94944},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3067, col: 12, offset: 94870},
+									pos:   position{line: 3072, col: 12, offset: 94953},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3067, col: 16, offset: 94874},
+										pos:  position{line: 3072, col: 16, offset: 94957},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3067, col: 28, offset: 94886},
+									pos:  position{line: 3072, col: 28, offset: 94969},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3076, col: 3, offset: 95055},
+						pos: position{line: 3081, col: 3, offset: 95138},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3076, col: 3, offset: 95055},
+							pos: position{line: 3081, col: 3, offset: 95138},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3076, col: 3, offset: 95055},
+									pos:  position{line: 3081, col: 3, offset: 95138},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3076, col: 11, offset: 95063},
+									pos:   position{line: 3081, col: 11, offset: 95146},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3076, col: 19, offset: 95071},
+										pos:  position{line: 3081, col: 19, offset: 95154},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3076, col: 28, offset: 95080},
+									pos:  position{line: 3081, col: 28, offset: 95163},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3085, col: 3, offset: 95252},
+						pos: position{line: 3090, col: 3, offset: 95335},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3085, col: 3, offset: 95252},
+							pos:   position{line: 3090, col: 3, offset: 95335},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3085, col: 18, offset: 95267},
+								pos:  position{line: 3090, col: 18, offset: 95350},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7079,28 +7084,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3095, col: 1, offset: 95464},
+			pos:  position{line: 3100, col: 1, offset: 95547},
 			expr: &choiceExpr{
-				pos: position{line: 3095, col: 15, offset: 95478},
+				pos: position{line: 3100, col: 15, offset: 95561},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3095, col: 15, offset: 95478},
+						pos: position{line: 3100, col: 15, offset: 95561},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3095, col: 15, offset: 95478},
+							pos: position{line: 3100, col: 15, offset: 95561},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3095, col: 15, offset: 95478},
+									pos:   position{line: 3100, col: 15, offset: 95561},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3095, col: 20, offset: 95483},
+										pos:  position{line: 3100, col: 20, offset: 95566},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3095, col: 29, offset: 95492},
+									pos: position{line: 3100, col: 29, offset: 95575},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3095, col: 31, offset: 95494},
+										pos:  position{line: 3100, col: 31, offset: 95577},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7108,23 +7113,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3103, col: 3, offset: 95664},
+						pos: position{line: 3108, col: 3, offset: 95747},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3103, col: 3, offset: 95664},
+							pos: position{line: 3108, col: 3, offset: 95747},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3103, col: 3, offset: 95664},
+									pos:   position{line: 3108, col: 3, offset: 95747},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3103, col: 7, offset: 95668},
+										pos:  position{line: 3108, col: 7, offset: 95751},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3103, col: 20, offset: 95681},
+									pos: position{line: 3108, col: 20, offset: 95764},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3103, col: 22, offset: 95683},
+										pos:  position{line: 3108, col: 22, offset: 95766},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7132,50 +7137,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3111, col: 3, offset: 95848},
+						pos: position{line: 3116, col: 3, offset: 95931},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3111, col: 3, offset: 95848},
+							pos: position{line: 3116, col: 3, offset: 95931},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3111, col: 3, offset: 95848},
+									pos:   position{line: 3116, col: 3, offset: 95931},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3111, col: 9, offset: 95854},
+										pos:  position{line: 3116, col: 9, offset: 95937},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3111, col: 25, offset: 95870},
+									pos: position{line: 3116, col: 25, offset: 95953},
 									expr: &choiceExpr{
-										pos: position{line: 3111, col: 27, offset: 95872},
+										pos: position{line: 3116, col: 27, offset: 95955},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 27, offset: 95872},
+												pos:  position{line: 3116, col: 27, offset: 95955},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 36, offset: 95881},
+												pos:  position{line: 3116, col: 36, offset: 95964},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 46, offset: 95891},
+												pos:  position{line: 3116, col: 46, offset: 95974},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 54, offset: 95899},
+												pos:  position{line: 3116, col: 54, offset: 95982},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 62, offset: 95907},
+												pos:  position{line: 3116, col: 62, offset: 95990},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3111, col: 70, offset: 95915},
+												pos:  position{line: 3116, col: 70, offset: 95998},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3111, col: 84, offset: 95929},
+												pos:        position{line: 3116, col: 84, offset: 96012},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7187,13 +7192,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3119, col: 3, offset: 96079},
+						pos: position{line: 3124, col: 3, offset: 96162},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3119, col: 3, offset: 96079},
+							pos:   position{line: 3124, col: 3, offset: 96162},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3119, col: 10, offset: 96086},
+								pos:  position{line: 3124, col: 10, offset: 96169},
 								name: "ConcatExpr",
 							},
 						},
@@ -7203,35 +7208,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3129, col: 1, offset: 96292},
+			pos:  position{line: 3134, col: 1, offset: 96375},
 			expr: &actionExpr{
-				pos: position{line: 3129, col: 15, offset: 96306},
+				pos: position{line: 3134, col: 15, offset: 96389},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3129, col: 15, offset: 96306},
+					pos: position{line: 3134, col: 15, offset: 96389},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3129, col: 15, offset: 96306},
+							pos:   position{line: 3134, col: 15, offset: 96389},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3129, col: 21, offset: 96312},
+								pos:  position{line: 3134, col: 21, offset: 96395},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3129, col: 32, offset: 96323},
+							pos:   position{line: 3134, col: 32, offset: 96406},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3129, col: 37, offset: 96328},
+								pos: position{line: 3134, col: 37, offset: 96411},
 								expr: &seqExpr{
-									pos: position{line: 3129, col: 38, offset: 96329},
+									pos: position{line: 3134, col: 38, offset: 96412},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3129, col: 38, offset: 96329},
+											pos:  position{line: 3134, col: 38, offset: 96412},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3129, col: 50, offset: 96341},
+											pos:  position{line: 3134, col: 50, offset: 96424},
 											name: "ConcatAtom",
 										},
 									},
@@ -7239,28 +7244,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3129, col: 63, offset: 96354},
+							pos: position{line: 3134, col: 63, offset: 96437},
 							expr: &choiceExpr{
-								pos: position{line: 3129, col: 65, offset: 96356},
+								pos: position{line: 3134, col: 65, offset: 96439},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3129, col: 65, offset: 96356},
+										pos:  position{line: 3134, col: 65, offset: 96439},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3129, col: 74, offset: 96365},
+										pos:  position{line: 3134, col: 74, offset: 96448},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3129, col: 84, offset: 96375},
+										pos:  position{line: 3134, col: 84, offset: 96458},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3129, col: 92, offset: 96383},
+										pos:  position{line: 3134, col: 92, offset: 96466},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3129, col: 100, offset: 96391},
+										pos:        position{line: 3134, col: 100, offset: 96474},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7274,54 +7279,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3147, col: 1, offset: 96797},
+			pos:  position{line: 3152, col: 1, offset: 96880},
 			expr: &choiceExpr{
-				pos: position{line: 3147, col: 15, offset: 96811},
+				pos: position{line: 3152, col: 15, offset: 96894},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3147, col: 15, offset: 96811},
+						pos: position{line: 3152, col: 15, offset: 96894},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3147, col: 15, offset: 96811},
+							pos:   position{line: 3152, col: 15, offset: 96894},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3147, col: 20, offset: 96816},
+								pos:  position{line: 3152, col: 20, offset: 96899},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3156, col: 3, offset: 96980},
+						pos: position{line: 3161, col: 3, offset: 97063},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3156, col: 3, offset: 96980},
+							pos:   position{line: 3161, col: 3, offset: 97063},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3156, col: 7, offset: 96984},
+								pos:  position{line: 3161, col: 7, offset: 97067},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3164, col: 3, offset: 97123},
+						pos: position{line: 3169, col: 3, offset: 97206},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3164, col: 3, offset: 97123},
+							pos:   position{line: 3169, col: 3, offset: 97206},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3164, col: 10, offset: 97130},
+								pos:  position{line: 3169, col: 10, offset: 97213},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3172, col: 3, offset: 97269},
+						pos: position{line: 3177, col: 3, offset: 97352},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3172, col: 3, offset: 97269},
+							pos:   position{line: 3177, col: 3, offset: 97352},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3172, col: 9, offset: 97275},
+								pos:  position{line: 3177, col: 9, offset: 97358},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7331,32 +7336,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3182, col: 1, offset: 97444},
+			pos:  position{line: 3187, col: 1, offset: 97527},
 			expr: &actionExpr{
-				pos: position{line: 3182, col: 16, offset: 97459},
+				pos: position{line: 3187, col: 16, offset: 97542},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3182, col: 16, offset: 97459},
+					pos: position{line: 3187, col: 16, offset: 97542},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3182, col: 16, offset: 97459},
+							pos:   position{line: 3187, col: 16, offset: 97542},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3182, col: 21, offset: 97464},
+								pos:  position{line: 3187, col: 21, offset: 97547},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3182, col: 39, offset: 97482},
+							pos: position{line: 3187, col: 39, offset: 97565},
 							expr: &choiceExpr{
-								pos: position{line: 3182, col: 41, offset: 97484},
+								pos: position{line: 3187, col: 41, offset: 97567},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3182, col: 41, offset: 97484},
+										pos:  position{line: 3187, col: 41, offset: 97567},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3182, col: 55, offset: 97498},
+										pos:        position{line: 3187, col: 55, offset: 97581},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7370,44 +7375,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3187, col: 1, offset: 97563},
+			pos:  position{line: 3192, col: 1, offset: 97646},
 			expr: &actionExpr{
-				pos: position{line: 3187, col: 22, offset: 97584},
+				pos: position{line: 3192, col: 22, offset: 97667},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3187, col: 22, offset: 97584},
+					pos: position{line: 3192, col: 22, offset: 97667},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3187, col: 22, offset: 97584},
+							pos:   position{line: 3192, col: 22, offset: 97667},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3187, col: 28, offset: 97590},
+								pos:  position{line: 3192, col: 28, offset: 97673},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3187, col: 46, offset: 97608},
+							pos:   position{line: 3192, col: 46, offset: 97691},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3187, col: 51, offset: 97613},
+								pos: position{line: 3192, col: 51, offset: 97696},
 								expr: &seqExpr{
-									pos: position{line: 3187, col: 52, offset: 97614},
+									pos: position{line: 3192, col: 52, offset: 97697},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3187, col: 53, offset: 97615},
+											pos: position{line: 3192, col: 53, offset: 97698},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3187, col: 53, offset: 97615},
+													pos:  position{line: 3192, col: 53, offset: 97698},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3187, col: 62, offset: 97624},
+													pos:  position{line: 3192, col: 62, offset: 97707},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3187, col: 71, offset: 97633},
+											pos:  position{line: 3192, col: 71, offset: 97716},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7420,48 +7425,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3208, col: 1, offset: 98134},
+			pos:  position{line: 3213, col: 1, offset: 98217},
 			expr: &actionExpr{
-				pos: position{line: 3208, col: 22, offset: 98155},
+				pos: position{line: 3213, col: 22, offset: 98238},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3208, col: 22, offset: 98155},
+					pos: position{line: 3213, col: 22, offset: 98238},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3208, col: 22, offset: 98155},
+							pos:   position{line: 3213, col: 22, offset: 98238},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3208, col: 28, offset: 98161},
+								pos:  position{line: 3213, col: 28, offset: 98244},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3208, col: 46, offset: 98179},
+							pos:   position{line: 3213, col: 46, offset: 98262},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3208, col: 51, offset: 98184},
+								pos: position{line: 3213, col: 51, offset: 98267},
 								expr: &seqExpr{
-									pos: position{line: 3208, col: 52, offset: 98185},
+									pos: position{line: 3213, col: 52, offset: 98268},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3208, col: 53, offset: 98186},
+											pos: position{line: 3213, col: 53, offset: 98269},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3208, col: 53, offset: 98186},
+													pos:  position{line: 3213, col: 53, offset: 98269},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3208, col: 61, offset: 98194},
+													pos:  position{line: 3213, col: 61, offset: 98277},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3208, col: 69, offset: 98202},
+													pos:  position{line: 3213, col: 69, offset: 98285},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3208, col: 76, offset: 98209},
+											pos:  position{line: 3213, col: 76, offset: 98292},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7474,22 +7479,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3228, col: 1, offset: 98678},
+			pos:  position{line: 3233, col: 1, offset: 98761},
 			expr: &actionExpr{
-				pos: position{line: 3228, col: 21, offset: 98698},
+				pos: position{line: 3233, col: 21, offset: 98781},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3228, col: 21, offset: 98698},
+					pos: position{line: 3233, col: 21, offset: 98781},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3228, col: 21, offset: 98698},
+							pos:  position{line: 3233, col: 21, offset: 98781},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3228, col: 27, offset: 98704},
+							pos:   position{line: 3233, col: 27, offset: 98787},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3228, col: 32, offset: 98709},
+								pos:  position{line: 3233, col: 32, offset: 98792},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7499,67 +7504,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3238, col: 1, offset: 98953},
+			pos:  position{line: 3243, col: 1, offset: 99036},
 			expr: &choiceExpr{
-				pos: position{line: 3238, col: 22, offset: 98974},
+				pos: position{line: 3243, col: 22, offset: 99057},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3238, col: 22, offset: 98974},
+						pos: position{line: 3243, col: 22, offset: 99057},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3238, col: 22, offset: 98974},
+							pos: position{line: 3243, col: 22, offset: 99057},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3238, col: 22, offset: 98974},
+									pos:  position{line: 3243, col: 22, offset: 99057},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3238, col: 30, offset: 98982},
+									pos:   position{line: 3243, col: 30, offset: 99065},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3238, col: 35, offset: 98987},
+										pos:  position{line: 3243, col: 35, offset: 99070},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3238, col: 53, offset: 99005},
+									pos:  position{line: 3243, col: 53, offset: 99088},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3241, col: 3, offset: 99040},
+						pos: position{line: 3246, col: 3, offset: 99123},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3241, col: 3, offset: 99040},
+							pos:   position{line: 3246, col: 3, offset: 99123},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3241, col: 20, offset: 99057},
+								pos:  position{line: 3246, col: 20, offset: 99140},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3244, col: 3, offset: 99111},
+						pos: position{line: 3249, col: 3, offset: 99194},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3244, col: 3, offset: 99111},
+							pos:   position{line: 3249, col: 3, offset: 99194},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3244, col: 9, offset: 99117},
+								pos:  position{line: 3249, col: 9, offset: 99200},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3254, col: 3, offset: 99336},
+						pos: position{line: 3259, col: 3, offset: 99419},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3254, col: 3, offset: 99336},
+							pos:   position{line: 3259, col: 3, offset: 99419},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3254, col: 10, offset: 99343},
+								pos:  position{line: 3259, col: 10, offset: 99426},
 								name: "NumberAsString",
 							},
 						},
@@ -7569,144 +7574,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3267, col: 1, offset: 99721},
+			pos:  position{line: 3272, col: 1, offset: 99804},
 			expr: &choiceExpr{
-				pos: position{line: 3267, col: 20, offset: 99740},
+				pos: position{line: 3272, col: 20, offset: 99823},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3267, col: 20, offset: 99740},
+						pos: position{line: 3272, col: 20, offset: 99823},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3267, col: 21, offset: 99741},
+							pos: position{line: 3272, col: 21, offset: 99824},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3267, col: 21, offset: 99741},
+									pos:   position{line: 3272, col: 21, offset: 99824},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3267, col: 29, offset: 99749},
+										pos: position{line: 3272, col: 29, offset: 99832},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3267, col: 29, offset: 99749},
+												pos:        position{line: 3272, col: 29, offset: 99832},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 37, offset: 99757},
+												pos:        position{line: 3272, col: 37, offset: 99840},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 46, offset: 99766},
+												pos:        position{line: 3272, col: 46, offset: 99849},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 58, offset: 99778},
+												pos:        position{line: 3272, col: 58, offset: 99861},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 67, offset: 99787},
+												pos:        position{line: 3272, col: 67, offset: 99870},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 77, offset: 99797},
+												pos:        position{line: 3272, col: 77, offset: 99880},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 85, offset: 99805},
+												pos:        position{line: 3272, col: 85, offset: 99888},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 95, offset: 99815},
+												pos:        position{line: 3272, col: 95, offset: 99898},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 102, offset: 99822},
+												pos:        position{line: 3272, col: 102, offset: 99905},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 113, offset: 99833},
+												pos:        position{line: 3272, col: 113, offset: 99916},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 123, offset: 99843},
+												pos:        position{line: 3272, col: 123, offset: 99926},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 132, offset: 99852},
+												pos:        position{line: 3272, col: 132, offset: 99935},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 142, offset: 99862},
+												pos:        position{line: 3272, col: 142, offset: 99945},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 151, offset: 99871},
+												pos:        position{line: 3272, col: 151, offset: 99954},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 161, offset: 99881},
+												pos:        position{line: 3272, col: 161, offset: 99964},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 170, offset: 99890},
+												pos:        position{line: 3272, col: 170, offset: 99973},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 179, offset: 99899},
+												pos:        position{line: 3272, col: 179, offset: 99982},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 187, offset: 99907},
+												pos:        position{line: 3272, col: 187, offset: 99990},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 196, offset: 99916},
+												pos:        position{line: 3272, col: 196, offset: 99999},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 204, offset: 99924},
+												pos:        position{line: 3272, col: 204, offset: 100007},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3267, col: 213, offset: 99933},
+												pos:        position{line: 3272, col: 213, offset: 100016},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7715,102 +7720,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3267, col: 220, offset: 99940},
+									pos:  position{line: 3272, col: 220, offset: 100023},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3267, col: 228, offset: 99948},
+									pos:   position{line: 3272, col: 228, offset: 100031},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3267, col: 234, offset: 99954},
+										pos:  position{line: 3272, col: 234, offset: 100037},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3267, col: 253, offset: 99973},
+									pos:  position{line: 3272, col: 253, offset: 100056},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3287, col: 3, offset: 100485},
+						pos: position{line: 3292, col: 3, offset: 100568},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3287, col: 3, offset: 100485},
+							pos: position{line: 3292, col: 3, offset: 100568},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3287, col: 3, offset: 100485},
+									pos:   position{line: 3292, col: 3, offset: 100568},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3287, col: 13, offset: 100495},
+										pos:        position{line: 3292, col: 13, offset: 100578},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3287, col: 21, offset: 100503},
+									pos:  position{line: 3292, col: 21, offset: 100586},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3287, col: 29, offset: 100511},
+									pos:   position{line: 3292, col: 29, offset: 100594},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3287, col: 35, offset: 100517},
+										pos:  position{line: 3292, col: 35, offset: 100600},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3287, col: 54, offset: 100536},
+									pos:   position{line: 3292, col: 54, offset: 100619},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3287, col: 69, offset: 100551},
+										pos: position{line: 3292, col: 69, offset: 100634},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3287, col: 70, offset: 100552},
+											pos:  position{line: 3292, col: 70, offset: 100635},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3287, col: 89, offset: 100571},
+									pos:  position{line: 3292, col: 89, offset: 100654},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3308, col: 3, offset: 101189},
+						pos: position{line: 3313, col: 3, offset: 101272},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3308, col: 4, offset: 101190},
+							pos: position{line: 3313, col: 4, offset: 101273},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3308, col: 4, offset: 101190},
+									pos:   position{line: 3313, col: 4, offset: 101273},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3308, col: 12, offset: 101198},
+										pos: position{line: 3313, col: 12, offset: 101281},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3308, col: 12, offset: 101198},
+												pos:        position{line: 3313, col: 12, offset: 101281},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3308, col: 20, offset: 101206},
+												pos:        position{line: 3313, col: 20, offset: 101289},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3308, col: 27, offset: 101213},
+												pos:        position{line: 3313, col: 27, offset: 101296},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3308, col: 38, offset: 101224},
+												pos:        position{line: 3313, col: 38, offset: 101307},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7819,54 +7824,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3308, col: 46, offset: 101232},
+									pos:  position{line: 3313, col: 46, offset: 101315},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3308, col: 54, offset: 101240},
+									pos:  position{line: 3313, col: 54, offset: 101323},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3321, col: 3, offset: 101526},
+						pos: position{line: 3326, col: 3, offset: 101609},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3321, col: 3, offset: 101526},
+							pos: position{line: 3326, col: 3, offset: 101609},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3321, col: 3, offset: 101526},
+									pos:        position{line: 3326, col: 3, offset: 101609},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3321, col: 14, offset: 101537},
+									pos:  position{line: 3326, col: 14, offset: 101620},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3321, col: 22, offset: 101545},
+									pos:   position{line: 3326, col: 22, offset: 101628},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3321, col: 33, offset: 101556},
+										pos:  position{line: 3326, col: 33, offset: 101639},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3321, col: 44, offset: 101567},
+									pos:   position{line: 3326, col: 44, offset: 101650},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3321, col: 53, offset: 101576},
+										pos: position{line: 3326, col: 53, offset: 101659},
 										expr: &seqExpr{
-											pos: position{line: 3321, col: 54, offset: 101577},
+											pos: position{line: 3326, col: 54, offset: 101660},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3321, col: 54, offset: 101577},
+													pos:  position{line: 3326, col: 54, offset: 101660},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3321, col: 60, offset: 101583},
+													pos:  position{line: 3326, col: 60, offset: 101666},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -7874,73 +7879,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3321, col: 80, offset: 101603},
+									pos:  position{line: 3326, col: 80, offset: 101686},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3349, col: 3, offset: 102445},
+						pos: position{line: 3354, col: 3, offset: 102528},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3349, col: 3, offset: 102445},
+							pos: position{line: 3354, col: 3, offset: 102528},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3349, col: 3, offset: 102445},
+									pos:   position{line: 3354, col: 3, offset: 102528},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3349, col: 12, offset: 102454},
+										pos:        position{line: 3354, col: 12, offset: 102537},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3349, col: 18, offset: 102460},
+									pos:  position{line: 3354, col: 18, offset: 102543},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3349, col: 26, offset: 102468},
+									pos:   position{line: 3354, col: 26, offset: 102551},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3349, col: 31, offset: 102473},
+										pos:  position{line: 3354, col: 31, offset: 102556},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3349, col: 39, offset: 102481},
+									pos:  position{line: 3354, col: 39, offset: 102564},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3352, col: 3, offset: 102516},
+						pos: position{line: 3357, col: 3, offset: 102599},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3352, col: 4, offset: 102517},
+							pos: position{line: 3357, col: 4, offset: 102600},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3352, col: 4, offset: 102517},
+									pos:   position{line: 3357, col: 4, offset: 102600},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3352, col: 12, offset: 102525},
+										pos: position{line: 3357, col: 12, offset: 102608},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3352, col: 12, offset: 102525},
+												pos:        position{line: 3357, col: 12, offset: 102608},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3352, col: 20, offset: 102533},
+												pos:        position{line: 3357, col: 20, offset: 102616},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3352, col: 30, offset: 102543},
+												pos:        position{line: 3357, col: 30, offset: 102626},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -7949,128 +7954,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3352, col: 39, offset: 102552},
+									pos:  position{line: 3357, col: 39, offset: 102635},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3352, col: 47, offset: 102560},
+									pos:   position{line: 3357, col: 47, offset: 102643},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3352, col: 53, offset: 102566},
+										pos:  position{line: 3357, col: 53, offset: 102649},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3352, col: 72, offset: 102585},
+									pos:   position{line: 3357, col: 72, offset: 102668},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3352, col: 79, offset: 102592},
+										pos:  position{line: 3357, col: 79, offset: 102675},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3352, col: 97, offset: 102610},
+									pos:  position{line: 3357, col: 97, offset: 102693},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3382, col: 3, offset: 103449},
+						pos: position{line: 3387, col: 3, offset: 103532},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3382, col: 4, offset: 103450},
+							pos: position{line: 3387, col: 4, offset: 103533},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3382, col: 4, offset: 103450},
+									pos:   position{line: 3387, col: 4, offset: 103533},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3382, col: 11, offset: 103457},
+										pos:        position{line: 3387, col: 11, offset: 103540},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3382, col: 17, offset: 103463},
+									pos:  position{line: 3387, col: 17, offset: 103546},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3382, col: 25, offset: 103471},
+									pos:   position{line: 3387, col: 25, offset: 103554},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3382, col: 31, offset: 103477},
+										pos:  position{line: 3387, col: 31, offset: 103560},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3382, col: 50, offset: 103496},
+									pos:   position{line: 3387, col: 50, offset: 103579},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3382, col: 56, offset: 103502},
+										pos: position{line: 3387, col: 56, offset: 103585},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3382, col: 57, offset: 103503},
+											pos:  position{line: 3387, col: 57, offset: 103586},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3382, col: 76, offset: 103522},
+									pos:  position{line: 3387, col: 76, offset: 103605},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3411, col: 3, offset: 104295},
+						pos: position{line: 3416, col: 3, offset: 104378},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3411, col: 3, offset: 104295},
+							pos: position{line: 3416, col: 3, offset: 104378},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3411, col: 3, offset: 104295},
+									pos:   position{line: 3416, col: 3, offset: 104378},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3411, col: 11, offset: 104303},
+										pos:        position{line: 3416, col: 11, offset: 104386},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3411, col: 28, offset: 104320},
+									pos:  position{line: 3416, col: 28, offset: 104403},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3411, col: 36, offset: 104328},
+									pos:   position{line: 3416, col: 36, offset: 104411},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3411, col: 42, offset: 104334},
+										pos:  position{line: 3416, col: 42, offset: 104417},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3411, col: 61, offset: 104353},
+									pos:  position{line: 3416, col: 61, offset: 104436},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3411, col: 67, offset: 104359},
+									pos:  position{line: 3416, col: 67, offset: 104442},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3411, col: 73, offset: 104365},
+									pos:   position{line: 3416, col: 73, offset: 104448},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3411, col: 84, offset: 104376},
+										pos:  position{line: 3416, col: 84, offset: 104459},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3411, col: 120, offset: 104412},
+									pos:  position{line: 3416, col: 120, offset: 104495},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3411, col: 126, offset: 104418},
+									pos:  position{line: 3416, col: 126, offset: 104501},
 									name: "R_PAREN",
 								},
 							},
@@ -8081,28 +8086,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3428, col: 1, offset: 104947},
+			pos:  position{line: 3433, col: 1, offset: 105030},
 			expr: &choiceExpr{
-				pos: position{line: 3428, col: 12, offset: 104958},
+				pos: position{line: 3433, col: 12, offset: 105041},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3428, col: 12, offset: 104958},
+						pos: position{line: 3433, col: 12, offset: 105041},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3428, col: 12, offset: 104958},
+							pos: position{line: 3433, col: 12, offset: 105041},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3428, col: 12, offset: 104958},
+									pos:   position{line: 3433, col: 12, offset: 105041},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3428, col: 16, offset: 104962},
+										pos:  position{line: 3433, col: 16, offset: 105045},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3428, col: 29, offset: 104975},
+									pos: position{line: 3433, col: 29, offset: 105058},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3428, col: 31, offset: 104977},
+										pos:  position{line: 3433, col: 31, offset: 105060},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8110,50 +8115,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3444, col: 3, offset: 105338},
+						pos: position{line: 3449, col: 3, offset: 105421},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3444, col: 3, offset: 105338},
+							pos: position{line: 3449, col: 3, offset: 105421},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3444, col: 3, offset: 105338},
+									pos:   position{line: 3449, col: 3, offset: 105421},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3444, col: 9, offset: 105344},
+										pos:  position{line: 3449, col: 9, offset: 105427},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3444, col: 25, offset: 105360},
+									pos: position{line: 3449, col: 25, offset: 105443},
 									expr: &choiceExpr{
-										pos: position{line: 3444, col: 27, offset: 105362},
+										pos: position{line: 3449, col: 27, offset: 105445},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 27, offset: 105362},
+												pos:  position{line: 3449, col: 27, offset: 105445},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 36, offset: 105371},
+												pos:  position{line: 3449, col: 36, offset: 105454},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 46, offset: 105381},
+												pos:  position{line: 3449, col: 46, offset: 105464},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 54, offset: 105389},
+												pos:  position{line: 3449, col: 54, offset: 105472},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 62, offset: 105397},
+												pos:  position{line: 3449, col: 62, offset: 105480},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3444, col: 70, offset: 105405},
+												pos:  position{line: 3449, col: 70, offset: 105488},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3444, col: 84, offset: 105419},
+												pos:        position{line: 3449, col: 84, offset: 105502},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8169,28 +8174,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3461, col: 1, offset: 105770},
+			pos:  position{line: 3466, col: 1, offset: 105853},
 			expr: &actionExpr{
-				pos: position{line: 3461, col: 19, offset: 105788},
+				pos: position{line: 3466, col: 19, offset: 105871},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3461, col: 19, offset: 105788},
+					pos: position{line: 3466, col: 19, offset: 105871},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3461, col: 19, offset: 105788},
+							pos:        position{line: 3466, col: 19, offset: 105871},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3461, col: 26, offset: 105795},
+							pos:  position{line: 3466, col: 26, offset: 105878},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3461, col: 32, offset: 105801},
+							pos:   position{line: 3466, col: 32, offset: 105884},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3461, col: 40, offset: 105809},
+								pos:  position{line: 3466, col: 40, offset: 105892},
 								name: "Boolean",
 							},
 						},
@@ -8200,28 +8205,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3472, col: 1, offset: 105998},
+			pos:  position{line: 3477, col: 1, offset: 106081},
 			expr: &actionExpr{
-				pos: position{line: 3472, col: 23, offset: 106020},
+				pos: position{line: 3477, col: 23, offset: 106103},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3472, col: 23, offset: 106020},
+					pos: position{line: 3477, col: 23, offset: 106103},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3472, col: 23, offset: 106020},
+							pos:        position{line: 3477, col: 23, offset: 106103},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3472, col: 34, offset: 106031},
+							pos:  position{line: 3477, col: 34, offset: 106114},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3472, col: 40, offset: 106037},
+							pos:   position{line: 3477, col: 40, offset: 106120},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3472, col: 48, offset: 106045},
+								pos:  position{line: 3477, col: 48, offset: 106128},
 								name: "Boolean",
 							},
 						},
@@ -8231,28 +8236,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3483, col: 1, offset: 106242},
+			pos:  position{line: 3488, col: 1, offset: 106325},
 			expr: &actionExpr{
-				pos: position{line: 3483, col: 20, offset: 106261},
+				pos: position{line: 3488, col: 20, offset: 106344},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3483, col: 20, offset: 106261},
+					pos: position{line: 3488, col: 20, offset: 106344},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3483, col: 20, offset: 106261},
+							pos:        position{line: 3488, col: 20, offset: 106344},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3483, col: 28, offset: 106269},
+							pos:  position{line: 3488, col: 28, offset: 106352},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3483, col: 34, offset: 106275},
+							pos:   position{line: 3488, col: 34, offset: 106358},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3483, col: 43, offset: 106284},
+								pos:  position{line: 3488, col: 43, offset: 106367},
 								name: "IntegerAsString",
 							},
 						},
@@ -8262,15 +8267,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3498, col: 1, offset: 106646},
+			pos:  position{line: 3503, col: 1, offset: 106729},
 			expr: &actionExpr{
-				pos: position{line: 3498, col: 19, offset: 106664},
+				pos: position{line: 3503, col: 19, offset: 106747},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3498, col: 19, offset: 106664},
+					pos:   position{line: 3503, col: 19, offset: 106747},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3498, col: 28, offset: 106673},
+						pos:  position{line: 3503, col: 28, offset: 106756},
 						name: "BoolExpr",
 					},
 				},
@@ -8278,30 +8283,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3509, col: 1, offset: 106885},
+			pos:  position{line: 3514, col: 1, offset: 106968},
 			expr: &actionExpr{
-				pos: position{line: 3509, col: 15, offset: 106899},
+				pos: position{line: 3514, col: 15, offset: 106982},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3509, col: 15, offset: 106899},
+					pos:   position{line: 3514, col: 15, offset: 106982},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3509, col: 23, offset: 106907},
+						pos: position{line: 3514, col: 23, offset: 106990},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3509, col: 23, offset: 106907},
+								pos:  position{line: 3514, col: 23, offset: 106990},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3509, col: 44, offset: 106928},
+								pos:  position{line: 3514, col: 44, offset: 107011},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3509, col: 61, offset: 106945},
+								pos:  position{line: 3514, col: 61, offset: 107028},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3509, col: 79, offset: 106963},
+								pos:  position{line: 3514, col: 79, offset: 107046},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8311,35 +8316,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3513, col: 1, offset: 107007},
+			pos:  position{line: 3518, col: 1, offset: 107090},
 			expr: &actionExpr{
-				pos: position{line: 3513, col: 19, offset: 107025},
+				pos: position{line: 3518, col: 19, offset: 107108},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3513, col: 19, offset: 107025},
+					pos: position{line: 3518, col: 19, offset: 107108},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3513, col: 19, offset: 107025},
+							pos:   position{line: 3518, col: 19, offset: 107108},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3513, col: 26, offset: 107032},
+								pos:  position{line: 3518, col: 26, offset: 107115},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3513, col: 37, offset: 107043},
+							pos:   position{line: 3518, col: 37, offset: 107126},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3513, col: 43, offset: 107049},
+								pos: position{line: 3518, col: 43, offset: 107132},
 								expr: &seqExpr{
-									pos: position{line: 3513, col: 44, offset: 107050},
+									pos: position{line: 3518, col: 44, offset: 107133},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3513, col: 44, offset: 107050},
+											pos:  position{line: 3518, col: 44, offset: 107133},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3513, col: 50, offset: 107056},
+											pos:  position{line: 3518, col: 50, offset: 107139},
 											name: "HeadOption",
 										},
 									},
@@ -8352,29 +8357,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3575, col: 1, offset: 109103},
+			pos:  position{line: 3580, col: 1, offset: 109186},
 			expr: &choiceExpr{
-				pos: position{line: 3575, col: 14, offset: 109116},
+				pos: position{line: 3580, col: 14, offset: 109199},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3575, col: 14, offset: 109116},
+						pos: position{line: 3580, col: 14, offset: 109199},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3575, col: 14, offset: 109116},
+							pos: position{line: 3580, col: 14, offset: 109199},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3575, col: 14, offset: 109116},
+									pos:  position{line: 3580, col: 14, offset: 109199},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3575, col: 19, offset: 109121},
+									pos:  position{line: 3580, col: 19, offset: 109204},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3575, col: 28, offset: 109130},
+									pos:   position{line: 3580, col: 28, offset: 109213},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3575, col: 37, offset: 109139},
+										pos:  position{line: 3580, col: 37, offset: 109222},
 										name: "HeadOptionList",
 									},
 								},
@@ -8382,24 +8387,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3585, col: 3, offset: 109410},
+						pos: position{line: 3590, col: 3, offset: 109493},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3585, col: 3, offset: 109410},
+							pos: position{line: 3590, col: 3, offset: 109493},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3585, col: 3, offset: 109410},
+									pos:  position{line: 3590, col: 3, offset: 109493},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3585, col: 8, offset: 109415},
+									pos:  position{line: 3590, col: 8, offset: 109498},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3585, col: 17, offset: 109424},
+									pos:   position{line: 3590, col: 17, offset: 109507},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3585, col: 26, offset: 109433},
+										pos:  position{line: 3590, col: 26, offset: 109516},
 										name: "IntegerAsString",
 									},
 								},
@@ -8407,17 +8412,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3602, col: 3, offset: 109912},
+						pos: position{line: 3607, col: 3, offset: 109995},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3602, col: 3, offset: 109912},
+							pos: position{line: 3607, col: 3, offset: 109995},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3602, col: 3, offset: 109912},
+									pos:  position{line: 3607, col: 3, offset: 109995},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3602, col: 8, offset: 109917},
+									pos:  position{line: 3607, col: 8, offset: 110000},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8428,29 +8433,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3616, col: 1, offset: 110348},
+			pos:  position{line: 3621, col: 1, offset: 110431},
 			expr: &choiceExpr{
-				pos: position{line: 3616, col: 14, offset: 110361},
+				pos: position{line: 3621, col: 14, offset: 110444},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3616, col: 14, offset: 110361},
+						pos: position{line: 3621, col: 14, offset: 110444},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3616, col: 14, offset: 110361},
+							pos: position{line: 3621, col: 14, offset: 110444},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3616, col: 14, offset: 110361},
+									pos:  position{line: 3621, col: 14, offset: 110444},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3616, col: 19, offset: 110366},
+									pos:  position{line: 3621, col: 19, offset: 110449},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3616, col: 28, offset: 110375},
+									pos:   position{line: 3621, col: 28, offset: 110458},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3616, col: 37, offset: 110384},
+										pos:  position{line: 3621, col: 37, offset: 110467},
 										name: "IntegerAsString",
 									},
 								},
@@ -8458,17 +8463,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3636, col: 3, offset: 110933},
+						pos: position{line: 3641, col: 3, offset: 111016},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3636, col: 3, offset: 110933},
+							pos: position{line: 3641, col: 3, offset: 111016},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3636, col: 3, offset: 110933},
+									pos:  position{line: 3641, col: 3, offset: 111016},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3636, col: 8, offset: 110938},
+									pos:  position{line: 3641, col: 8, offset: 111021},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8479,44 +8484,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3656, col: 1, offset: 111531},
+			pos:  position{line: 3661, col: 1, offset: 111614},
 			expr: &actionExpr{
-				pos: position{line: 3656, col: 20, offset: 111550},
+				pos: position{line: 3661, col: 20, offset: 111633},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3656, col: 20, offset: 111550},
+					pos: position{line: 3661, col: 20, offset: 111633},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3656, col: 20, offset: 111550},
+							pos:   position{line: 3661, col: 20, offset: 111633},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3656, col: 26, offset: 111556},
+								pos:  position{line: 3661, col: 26, offset: 111639},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3656, col: 37, offset: 111567},
+							pos:   position{line: 3661, col: 37, offset: 111650},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3656, col: 42, offset: 111572},
+								pos: position{line: 3661, col: 42, offset: 111655},
 								expr: &seqExpr{
-									pos: position{line: 3656, col: 43, offset: 111573},
+									pos: position{line: 3661, col: 43, offset: 111656},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3656, col: 44, offset: 111574},
+											pos: position{line: 3661, col: 44, offset: 111657},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3656, col: 44, offset: 111574},
+													pos:  position{line: 3661, col: 44, offset: 111657},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3656, col: 52, offset: 111582},
+													pos:  position{line: 3661, col: 52, offset: 111665},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3656, col: 59, offset: 111589},
+											pos:  position{line: 3661, col: 59, offset: 111672},
 											name: "Aggregator",
 										},
 									},
@@ -8529,28 +8534,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3673, col: 1, offset: 112092},
+			pos:  position{line: 3678, col: 1, offset: 112175},
 			expr: &actionExpr{
-				pos: position{line: 3673, col: 15, offset: 112106},
+				pos: position{line: 3678, col: 15, offset: 112189},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3673, col: 15, offset: 112106},
+					pos: position{line: 3678, col: 15, offset: 112189},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3673, col: 15, offset: 112106},
+							pos:   position{line: 3678, col: 15, offset: 112189},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3673, col: 23, offset: 112114},
+								pos:  position{line: 3678, col: 23, offset: 112197},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3673, col: 35, offset: 112126},
+							pos:   position{line: 3678, col: 35, offset: 112209},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3673, col: 43, offset: 112134},
+								pos: position{line: 3678, col: 43, offset: 112217},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3673, col: 43, offset: 112134},
+									pos:  position{line: 3678, col: 43, offset: 112217},
 									name: "AsField",
 								},
 							},
@@ -8561,26 +8566,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3689, col: 1, offset: 112975},
+			pos:  position{line: 3694, col: 1, offset: 113058},
 			expr: &actionExpr{
-				pos: position{line: 3689, col: 16, offset: 112990},
+				pos: position{line: 3694, col: 16, offset: 113073},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3689, col: 16, offset: 112990},
+					pos:   position{line: 3694, col: 16, offset: 113073},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3689, col: 21, offset: 112995},
+						pos: position{line: 3694, col: 21, offset: 113078},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3689, col: 21, offset: 112995},
+								pos:  position{line: 3694, col: 21, offset: 113078},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3689, col: 32, offset: 113006},
+								pos:  position{line: 3694, col: 32, offset: 113089},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3689, col: 48, offset: 113022},
+								pos:  position{line: 3694, col: 48, offset: 113105},
 								name: "AggCommon",
 							},
 						},
@@ -8590,165 +8595,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3694, col: 1, offset: 113228},
+			pos:  position{line: 3699, col: 1, offset: 113311},
 			expr: &actionExpr{
-				pos: position{line: 3694, col: 18, offset: 113245},
+				pos: position{line: 3699, col: 18, offset: 113328},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3694, col: 19, offset: 113246},
+					pos: position{line: 3699, col: 19, offset: 113329},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3694, col: 19, offset: 113246},
+							pos:        position{line: 3699, col: 19, offset: 113329},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 30, offset: 113257},
+							pos:        position{line: 3699, col: 30, offset: 113340},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 39, offset: 113266},
+							pos:        position{line: 3699, col: 39, offset: 113349},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 47, offset: 113274},
+							pos:        position{line: 3699, col: 47, offset: 113357},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 57, offset: 113284},
+							pos:        position{line: 3699, col: 57, offset: 113367},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 65, offset: 113292},
+							pos:        position{line: 3699, col: 65, offset: 113375},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 76, offset: 113303},
+							pos:        position{line: 3699, col: 76, offset: 113386},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 86, offset: 113313},
+							pos:        position{line: 3699, col: 86, offset: 113396},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 95, offset: 113322},
+							pos:        position{line: 3699, col: 95, offset: 113405},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 105, offset: 113332},
+							pos:        position{line: 3699, col: 105, offset: 113415},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 114, offset: 113341},
+							pos:        position{line: 3699, col: 114, offset: 113424},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 122, offset: 113349},
+							pos:        position{line: 3699, col: 122, offset: 113432},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 133, offset: 113360},
+							pos:        position{line: 3699, col: 133, offset: 113443},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3694, col: 142, offset: 113369},
+							pos:        position{line: 3699, col: 142, offset: 113452},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 1, offset: 113378},
+							pos:        position{line: 3700, col: 1, offset: 113461},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 10, offset: 113387},
+							pos:        position{line: 3700, col: 10, offset: 113470},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 26, offset: 113403},
+							pos:        position{line: 3700, col: 26, offset: 113486},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 37, offset: 113414},
+							pos:        position{line: 3700, col: 37, offset: 113497},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 46, offset: 113423},
+							pos:        position{line: 3700, col: 46, offset: 113506},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 56, offset: 113433},
+							pos:        position{line: 3700, col: 56, offset: 113516},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 72, offset: 113449},
+							pos:        position{line: 3700, col: 72, offset: 113532},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 82, offset: 113459},
+							pos:        position{line: 3700, col: 82, offset: 113542},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 100, offset: 113477},
+							pos:        position{line: 3700, col: 100, offset: 113560},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 113, offset: 113490},
+							pos:        position{line: 3700, col: 113, offset: 113573},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 132, offset: 113509},
+							pos:        position{line: 3700, col: 132, offset: 113592},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3695, col: 139, offset: 113516},
+							pos:        position{line: 3700, col: 139, offset: 113599},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8759,27 +8764,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3699, col: 1, offset: 113559},
+			pos:  position{line: 3704, col: 1, offset: 113642},
 			expr: &actionExpr{
-				pos: position{line: 3699, col: 22, offset: 113580},
+				pos: position{line: 3704, col: 22, offset: 113663},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3699, col: 23, offset: 113581},
+					pos: position{line: 3704, col: 23, offset: 113664},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3699, col: 23, offset: 113581},
+							pos:        position{line: 3704, col: 23, offset: 113664},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 37, offset: 113595},
+							pos:        position{line: 3704, col: 37, offset: 113678},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3699, col: 51, offset: 113609},
+							pos:        position{line: 3704, col: 51, offset: 113692},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8790,29 +8795,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3703, col: 1, offset: 113653},
+			pos:  position{line: 3708, col: 1, offset: 113736},
 			expr: &actionExpr{
-				pos: position{line: 3703, col: 12, offset: 113664},
+				pos: position{line: 3708, col: 12, offset: 113747},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3703, col: 12, offset: 113664},
+					pos: position{line: 3708, col: 12, offset: 113747},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3703, col: 12, offset: 113664},
+							pos:  position{line: 3708, col: 12, offset: 113747},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3703, col: 15, offset: 113667},
+							pos:   position{line: 3708, col: 15, offset: 113750},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3703, col: 23, offset: 113675},
+								pos: position{line: 3708, col: 23, offset: 113758},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3703, col: 23, offset: 113675},
+										pos:  position{line: 3708, col: 23, offset: 113758},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3703, col: 35, offset: 113687},
+										pos:  position{line: 3708, col: 35, offset: 113770},
 										name: "String",
 									},
 								},
@@ -8824,27 +8829,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3717, col: 1, offset: 114016},
+			pos:  position{line: 3722, col: 1, offset: 114099},
 			expr: &choiceExpr{
-				pos: position{line: 3717, col: 13, offset: 114028},
+				pos: position{line: 3722, col: 13, offset: 114111},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3717, col: 13, offset: 114028},
+						pos: position{line: 3722, col: 13, offset: 114111},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3717, col: 13, offset: 114028},
+							pos: position{line: 3722, col: 13, offset: 114111},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3717, col: 14, offset: 114029},
+									pos: position{line: 3722, col: 14, offset: 114112},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3717, col: 14, offset: 114029},
+											pos:        position{line: 3722, col: 14, offset: 114112},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3717, col: 24, offset: 114039},
+											pos:        position{line: 3722, col: 24, offset: 114122},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8852,47 +8857,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3717, col: 29, offset: 114044},
+									pos:  position{line: 3722, col: 29, offset: 114127},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3717, col: 37, offset: 114052},
+									pos:        position{line: 3722, col: 37, offset: 114135},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3717, col: 44, offset: 114059},
+									pos:   position{line: 3722, col: 44, offset: 114142},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3717, col: 54, offset: 114069},
+										pos:  position{line: 3722, col: 54, offset: 114152},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3717, col: 64, offset: 114079},
+									pos:  position{line: 3722, col: 64, offset: 114162},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3727, col: 3, offset: 114307},
+						pos: position{line: 3732, col: 3, offset: 114390},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3727, col: 3, offset: 114307},
+							pos: position{line: 3732, col: 3, offset: 114390},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3727, col: 4, offset: 114308},
+									pos: position{line: 3732, col: 4, offset: 114391},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3727, col: 4, offset: 114308},
+											pos:        position{line: 3732, col: 4, offset: 114391},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3727, col: 14, offset: 114318},
+											pos:        position{line: 3732, col: 14, offset: 114401},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8900,38 +8905,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3727, col: 19, offset: 114323},
+									pos:  position{line: 3732, col: 19, offset: 114406},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3727, col: 27, offset: 114331},
+									pos:   position{line: 3732, col: 27, offset: 114414},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3727, col: 33, offset: 114337},
+										pos:  position{line: 3732, col: 33, offset: 114420},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3727, col: 43, offset: 114347},
+									pos:  position{line: 3732, col: 43, offset: 114430},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3734, col: 5, offset: 114498},
+						pos: position{line: 3739, col: 5, offset: 114581},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3734, col: 6, offset: 114499},
+							pos: position{line: 3739, col: 6, offset: 114582},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3734, col: 6, offset: 114499},
+									pos:        position{line: 3739, col: 6, offset: 114582},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3734, col: 16, offset: 114509},
+									pos:        position{line: 3739, col: 16, offset: 114592},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -8944,77 +8949,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3743, col: 1, offset: 114645},
+			pos:  position{line: 3748, col: 1, offset: 114728},
 			expr: &choiceExpr{
-				pos: position{line: 3743, col: 14, offset: 114658},
+				pos: position{line: 3748, col: 14, offset: 114741},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3743, col: 14, offset: 114658},
+						pos: position{line: 3748, col: 14, offset: 114741},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3743, col: 14, offset: 114658},
+							pos: position{line: 3748, col: 14, offset: 114741},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3743, col: 14, offset: 114658},
+									pos:   position{line: 3748, col: 14, offset: 114741},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3743, col: 22, offset: 114666},
+										pos:  position{line: 3748, col: 22, offset: 114749},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3743, col: 36, offset: 114680},
+									pos:  position{line: 3748, col: 36, offset: 114763},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3743, col: 44, offset: 114688},
+									pos:        position{line: 3748, col: 44, offset: 114771},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3743, col: 51, offset: 114695},
+									pos:   position{line: 3748, col: 51, offset: 114778},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3743, col: 61, offset: 114705},
+										pos:  position{line: 3748, col: 61, offset: 114788},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3743, col: 71, offset: 114715},
+									pos:  position{line: 3748, col: 71, offset: 114798},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3758, col: 3, offset: 115125},
+						pos: position{line: 3763, col: 3, offset: 115208},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3758, col: 3, offset: 115125},
+							pos: position{line: 3763, col: 3, offset: 115208},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3758, col: 3, offset: 115125},
+									pos:   position{line: 3763, col: 3, offset: 115208},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3758, col: 11, offset: 115133},
+										pos:  position{line: 3763, col: 11, offset: 115216},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3758, col: 25, offset: 115147},
+									pos:  position{line: 3763, col: 25, offset: 115230},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3758, col: 33, offset: 115155},
+									pos:   position{line: 3763, col: 33, offset: 115238},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3758, col: 39, offset: 115161},
+										pos:  position{line: 3763, col: 39, offset: 115244},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3758, col: 49, offset: 115171},
+									pos:  position{line: 3763, col: 49, offset: 115254},
 									name: "R_PAREN",
 								},
 							},
@@ -9025,22 +9030,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3772, col: 1, offset: 115503},
+			pos:  position{line: 3777, col: 1, offset: 115586},
 			expr: &actionExpr{
-				pos: position{line: 3772, col: 18, offset: 115520},
+				pos: position{line: 3777, col: 18, offset: 115603},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3772, col: 18, offset: 115520},
+					pos:   position{line: 3777, col: 18, offset: 115603},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3772, col: 26, offset: 115528},
+						pos: position{line: 3777, col: 26, offset: 115611},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3772, col: 26, offset: 115528},
+								pos:  position{line: 3777, col: 26, offset: 115611},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3772, col: 42, offset: 115544},
+								pos:  position{line: 3777, col: 42, offset: 115627},
 								name: "IntegerAsString",
 							},
 						},
@@ -9050,93 +9055,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3784, col: 1, offset: 115918},
+			pos:  position{line: 3789, col: 1, offset: 116001},
 			expr: &choiceExpr{
-				pos: position{line: 3784, col: 18, offset: 115935},
+				pos: position{line: 3789, col: 18, offset: 116018},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3784, col: 18, offset: 115935},
+						pos: position{line: 3789, col: 18, offset: 116018},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3784, col: 18, offset: 115935},
+							pos: position{line: 3789, col: 18, offset: 116018},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3784, col: 18, offset: 115935},
+									pos:   position{line: 3789, col: 18, offset: 116018},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3784, col: 26, offset: 115943},
+										pos:  position{line: 3789, col: 26, offset: 116026},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3784, col: 44, offset: 115961},
+									pos:   position{line: 3789, col: 44, offset: 116044},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3784, col: 58, offset: 115975},
+										pos:  position{line: 3789, col: 58, offset: 116058},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3784, col: 72, offset: 115989},
+									pos:  position{line: 3789, col: 72, offset: 116072},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3784, col: 80, offset: 115997},
+									pos:        position{line: 3789, col: 80, offset: 116080},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3784, col: 87, offset: 116004},
+									pos:   position{line: 3789, col: 87, offset: 116087},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3784, col: 97, offset: 116014},
+										pos:  position{line: 3789, col: 97, offset: 116097},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3784, col: 107, offset: 116024},
+									pos:  position{line: 3789, col: 107, offset: 116107},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3800, col: 3, offset: 116473},
+						pos: position{line: 3805, col: 3, offset: 116556},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3800, col: 3, offset: 116473},
+							pos: position{line: 3805, col: 3, offset: 116556},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3800, col: 3, offset: 116473},
+									pos:   position{line: 3805, col: 3, offset: 116556},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3800, col: 11, offset: 116481},
+										pos:  position{line: 3805, col: 11, offset: 116564},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3800, col: 29, offset: 116499},
+									pos:   position{line: 3805, col: 29, offset: 116582},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3800, col: 43, offset: 116513},
+										pos:  position{line: 3805, col: 43, offset: 116596},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3800, col: 57, offset: 116527},
+									pos:  position{line: 3805, col: 57, offset: 116610},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3800, col: 65, offset: 116535},
+									pos:   position{line: 3805, col: 65, offset: 116618},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3800, col: 71, offset: 116541},
+										pos:  position{line: 3805, col: 71, offset: 116624},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3800, col: 81, offset: 116551},
+									pos:  position{line: 3805, col: 81, offset: 116634},
 									name: "R_PAREN",
 								},
 							},
@@ -9147,22 +9152,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3816, col: 1, offset: 116923},
+			pos:  position{line: 3821, col: 1, offset: 117006},
 			expr: &actionExpr{
-				pos: position{line: 3816, col: 25, offset: 116947},
+				pos: position{line: 3821, col: 25, offset: 117030},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3816, col: 25, offset: 116947},
+					pos:   position{line: 3821, col: 25, offset: 117030},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3816, col: 39, offset: 116961},
+						pos: position{line: 3821, col: 39, offset: 117044},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3816, col: 39, offset: 116961},
+								pos:  position{line: 3821, col: 39, offset: 117044},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3816, col: 67, offset: 116989},
+								pos:  position{line: 3821, col: 67, offset: 117072},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9172,43 +9177,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3820, col: 1, offset: 117052},
+			pos:  position{line: 3825, col: 1, offset: 117135},
 			expr: &actionExpr{
-				pos: position{line: 3820, col: 30, offset: 117081},
+				pos: position{line: 3825, col: 30, offset: 117164},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3820, col: 30, offset: 117081},
+					pos: position{line: 3825, col: 30, offset: 117164},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3820, col: 30, offset: 117081},
+							pos:   position{line: 3825, col: 30, offset: 117164},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3820, col: 34, offset: 117085},
+								pos:  position{line: 3825, col: 34, offset: 117168},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3820, col: 44, offset: 117095},
+							pos:   position{line: 3825, col: 44, offset: 117178},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3820, col: 48, offset: 117099},
+								pos: position{line: 3825, col: 48, offset: 117182},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3820, col: 48, offset: 117099},
+										pos:  position{line: 3825, col: 48, offset: 117182},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3820, col: 67, offset: 117118},
+										pos:  position{line: 3825, col: 67, offset: 117201},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3820, col: 87, offset: 117138},
+							pos:   position{line: 3825, col: 87, offset: 117221},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3820, col: 93, offset: 117144},
+								pos:  position{line: 3825, col: 93, offset: 117227},
 								name: "Number",
 							},
 						},
@@ -9218,15 +9223,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3833, col: 1, offset: 117378},
+			pos:  position{line: 3838, col: 1, offset: 117461},
 			expr: &actionExpr{
-				pos: position{line: 3833, col: 32, offset: 117409},
+				pos: position{line: 3838, col: 32, offset: 117492},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3833, col: 32, offset: 117409},
+					pos:   position{line: 3838, col: 32, offset: 117492},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3833, col: 38, offset: 117415},
+						pos:  position{line: 3838, col: 38, offset: 117498},
 						name: "Number",
 					},
 				},
@@ -9234,34 +9239,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3846, col: 1, offset: 117632},
+			pos:  position{line: 3851, col: 1, offset: 117715},
 			expr: &actionExpr{
-				pos: position{line: 3846, col: 26, offset: 117657},
+				pos: position{line: 3851, col: 26, offset: 117740},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3846, col: 26, offset: 117657},
+					pos: position{line: 3851, col: 26, offset: 117740},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3846, col: 26, offset: 117657},
+							pos:   position{line: 3851, col: 26, offset: 117740},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3846, col: 30, offset: 117661},
+								pos:  position{line: 3851, col: 30, offset: 117744},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3846, col: 40, offset: 117671},
+							pos:   position{line: 3851, col: 40, offset: 117754},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3846, col: 43, offset: 117674},
+								pos:  position{line: 3851, col: 43, offset: 117757},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3846, col: 60, offset: 117691},
+							pos:   position{line: 3851, col: 60, offset: 117774},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3846, col: 66, offset: 117697},
+								pos:  position{line: 3851, col: 66, offset: 117780},
 								name: "Boolean",
 							},
 						},
@@ -9271,22 +9276,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3859, col: 1, offset: 117932},
+			pos:  position{line: 3864, col: 1, offset: 118015},
 			expr: &actionExpr{
-				pos: position{line: 3859, col: 25, offset: 117956},
+				pos: position{line: 3864, col: 25, offset: 118039},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3859, col: 25, offset: 117956},
+					pos:   position{line: 3864, col: 25, offset: 118039},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3859, col: 39, offset: 117970},
+						pos: position{line: 3864, col: 39, offset: 118053},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3859, col: 39, offset: 117970},
+								pos:  position{line: 3864, col: 39, offset: 118053},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3859, col: 67, offset: 117998},
+								pos:  position{line: 3864, col: 67, offset: 118081},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9296,35 +9301,44 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3863, col: 1, offset: 118061},
+			pos:  position{line: 3868, col: 1, offset: 118144},
 			expr: &actionExpr{
-				pos: position{line: 3863, col: 30, offset: 118090},
+				pos: position{line: 3868, col: 30, offset: 118173},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3863, col: 30, offset: 118090},
+					pos: position{line: 3868, col: 30, offset: 118173},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3863, col: 30, offset: 118090},
+							pos:   position{line: 3868, col: 30, offset: 118173},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3863, col: 34, offset: 118094},
+								pos:  position{line: 3868, col: 34, offset: 118177},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3863, col: 44, offset: 118104},
+							pos:   position{line: 3868, col: 44, offset: 118187},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3863, col: 47, offset: 118107},
+								pos:  position{line: 3868, col: 47, offset: 118190},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3863, col: 64, offset: 118124},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3863, col: 70, offset: 118130},
-								name: "String",
+							pos:   position{line: 3868, col: 64, offset: 118207},
+							label: "stringSearchReq",
+							expr: &choiceExpr{
+								pos: position{line: 3868, col: 81, offset: 118224},
+								alternatives: []any{
+									&ruleRefExpr{
+										pos:  position{line: 3868, col: 81, offset: 118224},
+										name: "CaseSensitiveString",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 3868, col: 103, offset: 118246},
+										name: "CaseInsensitiveString",
+									},
+								},
 							},
 						},
 					},
@@ -9333,15 +9347,75 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3875, col: 1, offset: 118363},
+			pos:  position{line: 3882, col: 1, offset: 118609},
 			expr: &actionExpr{
-				pos: position{line: 3875, col: 32, offset: 118394},
+				pos: position{line: 3882, col: 32, offset: 118640},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3875, col: 32, offset: 118394},
+					pos:   position{line: 3882, col: 32, offset: 118640},
+					label: "stringSearchReq",
+					expr: &choiceExpr{
+						pos: position{line: 3882, col: 49, offset: 118657},
+						alternatives: []any{
+							&ruleRefExpr{
+								pos:  position{line: 3882, col: 49, offset: 118657},
+								name: "CaseSensitiveString",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 3882, col: 71, offset: 118679},
+								name: "CaseInsensitiveString",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CaseSensitiveString",
+			pos:  position{line: 3896, col: 1, offset: 119025},
+			expr: &actionExpr{
+				pos: position{line: 3896, col: 24, offset: 119048},
+				run: (*parser).callonCaseSensitiveString1,
+				expr: &seqExpr{
+					pos: position{line: 3896, col: 24, offset: 119048},
+					exprs: []any{
+						&litMatcher{
+							pos:        position{line: 3896, col: 24, offset: 119048},
+							val:        "CASE",
+							ignoreCase: false,
+							want:       "\"CASE\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 3896, col: 31, offset: 119055},
+							name: "L_PAREN",
+						},
+						&labeledExpr{
+							pos:   position{line: 3896, col: 39, offset: 119063},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3896, col: 45, offset: 119069},
+								name: "String",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 3896, col: 52, offset: 119076},
+							name: "R_PAREN",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CaseInsensitiveString",
+			pos:  position{line: 3903, col: 1, offset: 119191},
+			expr: &actionExpr{
+				pos: position{line: 3903, col: 26, offset: 119216},
+				run: (*parser).callonCaseInsensitiveString1,
+				expr: &labeledExpr{
+					pos:   position{line: 3903, col: 26, offset: 119216},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3875, col: 38, offset: 118400},
+						pos:  position{line: 3903, col: 32, offset: 119222},
 						name: "String",
 					},
 				},
@@ -9349,35 +9423,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 3889, col: 1, offset: 118731},
+			pos:  position{line: 3912, col: 1, offset: 119478},
 			expr: &actionExpr{
-				pos: position{line: 3889, col: 18, offset: 118748},
+				pos: position{line: 3912, col: 18, offset: 119495},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 3889, col: 18, offset: 118748},
+					pos: position{line: 3912, col: 18, offset: 119495},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3889, col: 18, offset: 118748},
+							pos:   position{line: 3912, col: 18, offset: 119495},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3889, col: 24, offset: 118754},
+								pos:  position{line: 3912, col: 24, offset: 119501},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3889, col: 34, offset: 118764},
+							pos:   position{line: 3912, col: 34, offset: 119511},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3889, col: 39, offset: 118769},
+								pos: position{line: 3912, col: 39, offset: 119516},
 								expr: &seqExpr{
-									pos: position{line: 3889, col: 40, offset: 118770},
+									pos: position{line: 3912, col: 40, offset: 119517},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3889, col: 40, offset: 118770},
+											pos:  position{line: 3912, col: 40, offset: 119517},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3889, col: 46, offset: 118776},
+											pos:  position{line: 3912, col: 46, offset: 119523},
 											name: "FieldName",
 										},
 									},
@@ -9390,16 +9464,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 3906, col: 1, offset: 119271},
+			pos:  position{line: 3929, col: 1, offset: 120018},
 			expr: &choiceExpr{
-				pos: position{line: 3906, col: 18, offset: 119288},
+				pos: position{line: 3929, col: 18, offset: 120035},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 3906, col: 18, offset: 119288},
+						pos:  position{line: 3929, col: 18, offset: 120035},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 3906, col: 38, offset: 119308},
+						pos:  position{line: 3929, col: 38, offset: 120055},
 						name: "EarliestOnly",
 					},
 				},
@@ -9407,71 +9481,71 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 3908, col: 1, offset: 119322},
+			pos:  position{line: 3931, col: 1, offset: 120069},
 			expr: &actionExpr{
-				pos: position{line: 3908, col: 22, offset: 119343},
+				pos: position{line: 3931, col: 22, offset: 120090},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 3908, col: 22, offset: 119343},
+					pos: position{line: 3931, col: 22, offset: 120090},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3908, col: 22, offset: 119343},
+							pos:  position{line: 3931, col: 22, offset: 120090},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3908, col: 35, offset: 119356},
+							pos:  position{line: 3931, col: 35, offset: 120103},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3908, col: 41, offset: 119362},
+							pos:   position{line: 3931, col: 41, offset: 120109},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3908, col: 55, offset: 119376},
+								pos: position{line: 3931, col: 55, offset: 120123},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3908, col: 55, offset: 119376},
+										pos:  position{line: 3931, col: 55, offset: 120123},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3908, col: 75, offset: 119396},
+										pos:  position{line: 3931, col: 75, offset: 120143},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3908, col: 94, offset: 119415},
+							pos:  position{line: 3931, col: 94, offset: 120162},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3908, col: 100, offset: 119421},
+							pos:  position{line: 3931, col: 100, offset: 120168},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3908, col: 111, offset: 119432},
+							pos:  position{line: 3931, col: 111, offset: 120179},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3908, col: 117, offset: 119438},
+							pos:   position{line: 3931, col: 117, offset: 120185},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3908, col: 129, offset: 119450},
+								pos: position{line: 3931, col: 129, offset: 120197},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3908, col: 129, offset: 119450},
+										pos:  position{line: 3931, col: 129, offset: 120197},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3908, col: 149, offset: 119470},
+										pos:  position{line: 3931, col: 149, offset: 120217},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3908, col: 168, offset: 119489},
+							pos: position{line: 3931, col: 168, offset: 120236},
 							expr: &anyMatcher{
-								line: 3908, col: 169, offset: 119490,
+								line: 3931, col: 169, offset: 120237,
 							},
 						},
 					},
@@ -9480,42 +9554,42 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 3949, col: 1, offset: 120612},
+			pos:  position{line: 3972, col: 1, offset: 121359},
 			expr: &actionExpr{
-				pos: position{line: 3949, col: 17, offset: 120628},
+				pos: position{line: 3972, col: 17, offset: 121375},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 3949, col: 17, offset: 120628},
+					pos: position{line: 3972, col: 17, offset: 121375},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3949, col: 17, offset: 120628},
+							pos:  position{line: 3972, col: 17, offset: 121375},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3949, col: 30, offset: 120641},
+							pos:  position{line: 3972, col: 30, offset: 121388},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3949, col: 36, offset: 120647},
+							pos:   position{line: 3972, col: 36, offset: 121394},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3949, col: 50, offset: 120661},
+								pos: position{line: 3972, col: 50, offset: 121408},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3949, col: 50, offset: 120661},
+										pos:  position{line: 3972, col: 50, offset: 121408},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3949, col: 70, offset: 120681},
+										pos:  position{line: 3972, col: 70, offset: 121428},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3949, col: 89, offset: 120700},
+							pos: position{line: 3972, col: 89, offset: 121447},
 							expr: &anyMatcher{
-								line: 3949, col: 90, offset: 120701,
+								line: 3972, col: 90, offset: 121448,
 							},
 						},
 					},
@@ -9524,24 +9598,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 3977, col: 1, offset: 121392},
+			pos:  position{line: 4000, col: 1, offset: 122139},
 			expr: &actionExpr{
-				pos: position{line: 3977, col: 23, offset: 121414},
+				pos: position{line: 4000, col: 23, offset: 122161},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 3977, col: 23, offset: 121414},
+					pos: position{line: 4000, col: 23, offset: 122161},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 3977, col: 23, offset: 121414},
+							pos:        position{line: 4000, col: 23, offset: 122161},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 3977, col: 27, offset: 121418},
+							pos: position{line: 4000, col: 27, offset: 122165},
 							expr: &charClassMatcher{
-								pos:        position{line: 3977, col: 27, offset: 121418},
+								pos:        position{line: 4000, col: 27, offset: 122165},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9554,21 +9628,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 3981, col: 1, offset: 121461},
+			pos:  position{line: 4004, col: 1, offset: 122208},
 			expr: &actionExpr{
-				pos: position{line: 3981, col: 13, offset: 121473},
+				pos: position{line: 4004, col: 13, offset: 122220},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 3981, col: 14, offset: 121474},
+					pos: position{line: 4004, col: 14, offset: 122221},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3981, col: 14, offset: 121474},
+							pos:        position{line: 4004, col: 14, offset: 122221},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 3981, col: 17, offset: 121477},
+							pos:        position{line: 4004, col: 17, offset: 122224},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9580,15 +9654,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 3985, col: 1, offset: 121520},
+			pos:  position{line: 4008, col: 1, offset: 122267},
 			expr: &actionExpr{
-				pos: position{line: 3985, col: 16, offset: 121535},
+				pos: position{line: 4008, col: 16, offset: 122282},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 3985, col: 16, offset: 121535},
+					pos:   position{line: 4008, col: 16, offset: 122282},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3985, col: 26, offset: 121545},
+						pos:  position{line: 4008, col: 26, offset: 122292},
 						name: "AllTimeScale",
 					},
 				},
@@ -9596,31 +9670,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 3992, col: 1, offset: 121769},
+			pos:  position{line: 4015, col: 1, offset: 122516},
 			expr: &actionExpr{
-				pos: position{line: 3992, col: 9, offset: 121777},
+				pos: position{line: 4015, col: 9, offset: 122524},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 3992, col: 9, offset: 121777},
+					pos: position{line: 4015, col: 9, offset: 122524},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3992, col: 9, offset: 121777},
+							pos:        position{line: 4015, col: 9, offset: 122524},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 3992, col: 13, offset: 121781},
+							pos:   position{line: 4015, col: 13, offset: 122528},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 3992, col: 19, offset: 121787},
+								pos: position{line: 4015, col: 19, offset: 122534},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3992, col: 19, offset: 121787},
+										pos:  position{line: 4015, col: 19, offset: 122534},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3992, col: 30, offset: 121798},
+										pos:  position{line: 4015, col: 30, offset: 122545},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9632,26 +9706,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 3996, col: 1, offset: 121846},
+			pos:  position{line: 4019, col: 1, offset: 122593},
 			expr: &actionExpr{
-				pos: position{line: 3996, col: 11, offset: 121856},
+				pos: position{line: 4019, col: 11, offset: 122603},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 3996, col: 11, offset: 121856},
+					pos: position{line: 4019, col: 11, offset: 122603},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3996, col: 11, offset: 121856},
+							pos:   position{line: 4019, col: 11, offset: 122603},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3996, col: 16, offset: 121861},
+								pos:  position{line: 4019, col: 16, offset: 122608},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3996, col: 36, offset: 121881},
+							pos:   position{line: 4019, col: 36, offset: 122628},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3996, col: 43, offset: 121888},
+								pos:  position{line: 4019, col: 43, offset: 122635},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9661,44 +9735,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4024, col: 1, offset: 122626},
+			pos:  position{line: 4047, col: 1, offset: 123373},
 			expr: &actionExpr{
-				pos: position{line: 4024, col: 29, offset: 122654},
+				pos: position{line: 4047, col: 29, offset: 123401},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4024, col: 29, offset: 122654},
+					pos: position{line: 4047, col: 29, offset: 123401},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4024, col: 29, offset: 122654},
+							pos:   position{line: 4047, col: 29, offset: 123401},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4024, col: 36, offset: 122661},
+								pos: position{line: 4047, col: 36, offset: 123408},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4024, col: 36, offset: 122661},
+										pos:  position{line: 4047, col: 36, offset: 123408},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4024, col: 45, offset: 122670},
+										pos:  position{line: 4047, col: 45, offset: 123417},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4024, col: 51, offset: 122676},
+							pos:   position{line: 4047, col: 51, offset: 123423},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4024, col: 57, offset: 122682},
+								pos: position{line: 4047, col: 57, offset: 123429},
 								expr: &choiceExpr{
-									pos: position{line: 4024, col: 58, offset: 122683},
+									pos: position{line: 4047, col: 58, offset: 123430},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4024, col: 58, offset: 122683},
+											pos:  position{line: 4047, col: 58, offset: 123430},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4024, col: 67, offset: 122692},
+											pos:  position{line: 4047, col: 67, offset: 123439},
 											name: "Snap",
 										},
 									},
@@ -9711,29 +9785,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4071, col: 1, offset: 124124},
+			pos:  position{line: 4094, col: 1, offset: 124871},
 			expr: &actionExpr{
-				pos: position{line: 4071, col: 22, offset: 124145},
+				pos: position{line: 4094, col: 22, offset: 124892},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4071, col: 22, offset: 124145},
+					pos: position{line: 4094, col: 22, offset: 124892},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4071, col: 22, offset: 124145},
+							pos:   position{line: 4094, col: 22, offset: 124892},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4071, col: 34, offset: 124157},
+								pos: position{line: 4094, col: 34, offset: 124904},
 								expr: &choiceExpr{
-									pos: position{line: 4071, col: 35, offset: 124158},
+									pos: position{line: 4094, col: 35, offset: 124905},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4071, col: 35, offset: 124158},
+											pos:        position{line: 4094, col: 35, offset: 124905},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4071, col: 43, offset: 124166},
+											pos:        position{line: 4094, col: 43, offset: 124913},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9743,12 +9817,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4071, col: 49, offset: 124172},
+							pos:   position{line: 4094, col: 49, offset: 124919},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4071, col: 57, offset: 124180},
+								pos: position{line: 4094, col: 57, offset: 124927},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4071, col: 58, offset: 124181},
+									pos:  position{line: 4094, col: 58, offset: 124928},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9759,31 +9833,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4096, col: 1, offset: 124864},
+			pos:  position{line: 4119, col: 1, offset: 125611},
 			expr: &actionExpr{
-				pos: position{line: 4096, col: 39, offset: 124902},
+				pos: position{line: 4119, col: 39, offset: 125649},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4096, col: 39, offset: 124902},
+					pos: position{line: 4119, col: 39, offset: 125649},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4096, col: 39, offset: 124902},
+							pos:   position{line: 4119, col: 39, offset: 125649},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4096, col: 46, offset: 124909},
+								pos: position{line: 4119, col: 46, offset: 125656},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4096, col: 47, offset: 124910},
+									pos:  position{line: 4119, col: 47, offset: 125657},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4096, col: 56, offset: 124919},
+							pos:   position{line: 4119, col: 56, offset: 125666},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4096, col: 66, offset: 124929},
+								pos: position{line: 4119, col: 66, offset: 125676},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4096, col: 67, offset: 124930},
+									pos:  position{line: 4119, col: 67, offset: 125677},
 									name: "Snap",
 								},
 							},
@@ -9794,136 +9868,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4123, col: 1, offset: 125558},
+			pos:  position{line: 4146, col: 1, offset: 126305},
 			expr: &actionExpr{
-				pos: position{line: 4123, col: 18, offset: 125575},
+				pos: position{line: 4146, col: 18, offset: 126322},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4123, col: 18, offset: 125575},
+					pos: position{line: 4146, col: 18, offset: 126322},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 18, offset: 125575},
+							pos:        position{line: 4146, col: 18, offset: 126322},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 23, offset: 125580},
+							pos:        position{line: 4146, col: 23, offset: 126327},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4123, col: 29, offset: 125586},
+							pos:        position{line: 4146, col: 29, offset: 126333},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 33, offset: 125590},
+							pos:        position{line: 4146, col: 33, offset: 126337},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 38, offset: 125595},
+							pos:        position{line: 4146, col: 38, offset: 126342},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4123, col: 44, offset: 125601},
+							pos:        position{line: 4146, col: 44, offset: 126348},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 48, offset: 125605},
+							pos:        position{line: 4146, col: 48, offset: 126352},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 53, offset: 125610},
+							pos:        position{line: 4146, col: 53, offset: 126357},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 58, offset: 125615},
+							pos:        position{line: 4146, col: 58, offset: 126362},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 63, offset: 125620},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4123, col: 69, offset: 125626},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4123, col: 73, offset: 125630},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4123, col: 78, offset: 125635},
+							pos:        position{line: 4146, col: 63, offset: 126367},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4123, col: 84, offset: 125641},
+							pos:        position{line: 4146, col: 69, offset: 126373},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 88, offset: 125645},
+							pos:        position{line: 4146, col: 73, offset: 126377},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 93, offset: 125650},
+							pos:        position{line: 4146, col: 78, offset: 126382},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4123, col: 99, offset: 125656},
+							pos:        position{line: 4146, col: 84, offset: 126388},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 103, offset: 125660},
+							pos:        position{line: 4146, col: 88, offset: 126392},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4123, col: 108, offset: 125665},
+							pos:        position{line: 4146, col: 93, offset: 126397},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4146, col: 99, offset: 126403},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4146, col: 103, offset: 126407},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4146, col: 108, offset: 126412},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -9935,15 +10009,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4127, col: 1, offset: 125707},
+			pos:  position{line: 4150, col: 1, offset: 126454},
 			expr: &actionExpr{
-				pos: position{line: 4127, col: 22, offset: 125728},
+				pos: position{line: 4150, col: 22, offset: 126475},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4127, col: 22, offset: 125728},
+					pos:   position{line: 4150, col: 22, offset: 126475},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4127, col: 32, offset: 125738},
+						pos:  position{line: 4150, col: 32, offset: 126485},
 						name: "FullTimeStamp",
 					},
 				},
@@ -9951,15 +10025,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4137, col: 1, offset: 126146},
+			pos:  position{line: 4160, col: 1, offset: 126893},
 			expr: &actionExpr{
-				pos: position{line: 4137, col: 14, offset: 126159},
+				pos: position{line: 4160, col: 14, offset: 126906},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4137, col: 14, offset: 126159},
+					pos: position{line: 4160, col: 14, offset: 126906},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4137, col: 14, offset: 126159},
+							pos:        position{line: 4160, col: 14, offset: 126906},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -9967,9 +10041,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4137, col: 27, offset: 126172},
+							pos: position{line: 4160, col: 27, offset: 126919},
 							expr: &charClassMatcher{
-								pos:        position{line: 4137, col: 27, offset: 126172},
+								pos:        position{line: 4160, col: 27, offset: 126919},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -9983,15 +10057,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4141, col: 1, offset: 126225},
+			pos:  position{line: 4164, col: 1, offset: 126972},
 			expr: &actionExpr{
-				pos: position{line: 4141, col: 24, offset: 126248},
+				pos: position{line: 4164, col: 24, offset: 126995},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4141, col: 24, offset: 126248},
+					pos: position{line: 4164, col: 24, offset: 126995},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4141, col: 24, offset: 126248},
+							pos:        position{line: 4164, col: 24, offset: 126995},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -9999,9 +10073,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4141, col: 39, offset: 126263},
+							pos: position{line: 4164, col: 39, offset: 127010},
 							expr: &charClassMatcher{
-								pos:        position{line: 4141, col: 39, offset: 126263},
+								pos:        position{line: 4164, col: 39, offset: 127010},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10015,22 +10089,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4145, col: 1, offset: 126316},
+			pos:  position{line: 4168, col: 1, offset: 127063},
 			expr: &actionExpr{
-				pos: position{line: 4145, col: 11, offset: 126326},
+				pos: position{line: 4168, col: 11, offset: 127073},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4145, col: 11, offset: 126326},
+					pos:   position{line: 4168, col: 11, offset: 127073},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4145, col: 16, offset: 126331},
+						pos: position{line: 4168, col: 16, offset: 127078},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4145, col: 16, offset: 126331},
+								pos:  position{line: 4168, col: 16, offset: 127078},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4145, col: 31, offset: 126346},
+								pos:  position{line: 4168, col: 31, offset: 127093},
 								name: "UnquotedString",
 							},
 						},
@@ -10040,23 +10114,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4149, col: 1, offset: 126387},
+			pos:  position{line: 4172, col: 1, offset: 127134},
 			expr: &actionExpr{
-				pos: position{line: 4149, col: 17, offset: 126403},
+				pos: position{line: 4172, col: 17, offset: 127150},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4149, col: 17, offset: 126403},
+					pos: position{line: 4172, col: 17, offset: 127150},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4149, col: 17, offset: 126403},
+							pos:        position{line: 4172, col: 17, offset: 127150},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4149, col: 21, offset: 126407},
+							pos: position{line: 4172, col: 21, offset: 127154},
 							expr: &charClassMatcher{
-								pos:        position{line: 4149, col: 21, offset: 126407},
+								pos:        position{line: 4172, col: 21, offset: 127154},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10064,7 +10138,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4149, col: 27, offset: 126413},
+							pos:        position{line: 4172, col: 27, offset: 127160},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10075,48 +10149,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4154, col: 1, offset: 126524},
+			pos:  position{line: 4177, col: 1, offset: 127271},
 			expr: &actionExpr{
-				pos: position{line: 4154, col: 19, offset: 126542},
+				pos: position{line: 4177, col: 19, offset: 127289},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4154, col: 19, offset: 126542},
+					pos: position{line: 4177, col: 19, offset: 127289},
 					expr: &choiceExpr{
-						pos: position{line: 4154, col: 20, offset: 126543},
+						pos: position{line: 4177, col: 20, offset: 127290},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4154, col: 20, offset: 126543},
+								pos:        position{line: 4177, col: 20, offset: 127290},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4154, col: 27, offset: 126550},
+								pos: position{line: 4177, col: 27, offset: 127297},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4154, col: 27, offset: 126550},
+										pos: position{line: 4177, col: 27, offset: 127297},
 										expr: &choiceExpr{
-											pos: position{line: 4154, col: 29, offset: 126552},
+											pos: position{line: 4177, col: 29, offset: 127299},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4154, col: 29, offset: 126552},
+													pos:  position{line: 4177, col: 29, offset: 127299},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4154, col: 43, offset: 126566},
+													pos:        position{line: 4177, col: 43, offset: 127313},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4154, col: 49, offset: 126572},
+													pos:  position{line: 4177, col: 49, offset: 127319},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4154, col: 54, offset: 126577,
+										line: 4177, col: 54, offset: 127324,
 									},
 								},
 							},
@@ -10127,12 +10201,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4161, col: 1, offset: 126692},
+			pos:  position{line: 4184, col: 1, offset: 127439},
 			expr: &choiceExpr{
-				pos: position{line: 4161, col: 16, offset: 126707},
+				pos: position{line: 4184, col: 16, offset: 127454},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4161, col: 16, offset: 126707},
+						pos:        position{line: 4184, col: 16, offset: 127454},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10140,18 +10214,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4161, col: 37, offset: 126728},
+						pos: position{line: 4184, col: 37, offset: 127475},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4161, col: 37, offset: 126728},
+								pos:        position{line: 4184, col: 37, offset: 127475},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4161, col: 41, offset: 126732},
+								pos: position{line: 4184, col: 41, offset: 127479},
 								expr: &charClassMatcher{
-									pos:        position{line: 4161, col: 41, offset: 126732},
+									pos:        position{line: 4184, col: 41, offset: 127479},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10159,7 +10233,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4161, col: 48, offset: 126739},
+								pos:        position{line: 4184, col: 48, offset: 127486},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10171,46 +10245,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4163, col: 1, offset: 126745},
+			pos:  position{line: 4186, col: 1, offset: 127492},
 			expr: &actionExpr{
-				pos: position{line: 4163, col: 39, offset: 126783},
+				pos: position{line: 4186, col: 39, offset: 127530},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4163, col: 39, offset: 126783},
+					pos: position{line: 4186, col: 39, offset: 127530},
 					expr: &choiceExpr{
-						pos: position{line: 4163, col: 40, offset: 126784},
+						pos: position{line: 4186, col: 40, offset: 127531},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4163, col: 40, offset: 126784},
+								pos:  position{line: 4186, col: 40, offset: 127531},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4163, col: 54, offset: 126798},
+								pos: position{line: 4186, col: 54, offset: 127545},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4163, col: 54, offset: 126798},
+										pos: position{line: 4186, col: 54, offset: 127545},
 										expr: &choiceExpr{
-											pos: position{line: 4163, col: 56, offset: 126800},
+											pos: position{line: 4186, col: 56, offset: 127547},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4163, col: 56, offset: 126800},
+													pos:  position{line: 4186, col: 56, offset: 127547},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4163, col: 70, offset: 126814},
+													pos:        position{line: 4186, col: 70, offset: 127561},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4163, col: 76, offset: 126820},
+													pos:  position{line: 4186, col: 76, offset: 127567},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4163, col: 81, offset: 126825,
+										line: 4186, col: 81, offset: 127572,
 									},
 								},
 							},
@@ -10221,21 +10295,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4167, col: 1, offset: 126865},
+			pos:  position{line: 4190, col: 1, offset: 127612},
 			expr: &actionExpr{
-				pos: position{line: 4167, col: 12, offset: 126876},
+				pos: position{line: 4190, col: 12, offset: 127623},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4167, col: 13, offset: 126877},
+					pos: position{line: 4190, col: 13, offset: 127624},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4167, col: 13, offset: 126877},
+							pos:        position{line: 4190, col: 13, offset: 127624},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4167, col: 22, offset: 126886},
+							pos:        position{line: 4190, col: 22, offset: 127633},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10246,14 +10320,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4173, col: 1, offset: 127040},
+			pos:  position{line: 4196, col: 1, offset: 127787},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 18, offset: 127057},
+				pos: position{line: 4196, col: 18, offset: 127804},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4173, col: 18, offset: 127057},
+					pos: position{line: 4196, col: 18, offset: 127804},
 					expr: &charClassMatcher{
-						pos:        position{line: 4173, col: 18, offset: 127057},
+						pos:        position{line: 4196, col: 18, offset: 127804},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10265,15 +10339,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4177, col: 1, offset: 127108},
+			pos:  position{line: 4200, col: 1, offset: 127855},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 11, offset: 127118},
+				pos: position{line: 4200, col: 11, offset: 127865},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4177, col: 11, offset: 127118},
+					pos:   position{line: 4200, col: 11, offset: 127865},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4177, col: 18, offset: 127125},
+						pos:  position{line: 4200, col: 18, offset: 127872},
 						name: "NumberAsString",
 					},
 				},
@@ -10281,59 +10355,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4183, col: 1, offset: 127314},
+			pos:  position{line: 4206, col: 1, offset: 128061},
 			expr: &actionExpr{
-				pos: position{line: 4183, col: 19, offset: 127332},
+				pos: position{line: 4206, col: 19, offset: 128079},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4183, col: 19, offset: 127332},
+					pos: position{line: 4206, col: 19, offset: 128079},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4183, col: 19, offset: 127332},
+							pos:   position{line: 4206, col: 19, offset: 128079},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4183, col: 27, offset: 127340},
+								pos: position{line: 4206, col: 27, offset: 128087},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4183, col: 27, offset: 127340},
+										pos:  position{line: 4206, col: 27, offset: 128087},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4183, col: 43, offset: 127356},
+										pos:  position{line: 4206, col: 43, offset: 128103},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4183, col: 60, offset: 127373},
+							pos: position{line: 4206, col: 60, offset: 128120},
 							expr: &choiceExpr{
-								pos: position{line: 4183, col: 62, offset: 127375},
+								pos: position{line: 4206, col: 62, offset: 128122},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4183, col: 62, offset: 127375},
+										pos:  position{line: 4206, col: 62, offset: 128122},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4183, col: 70, offset: 127383},
+										pos:        position{line: 4206, col: 70, offset: 128130},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4183, col: 76, offset: 127389},
+										pos:        position{line: 4206, col: 76, offset: 128136},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4183, col: 82, offset: 127395},
+										pos:        position{line: 4206, col: 82, offset: 128142},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4183, col: 88, offset: 127401},
+										pos:  position{line: 4206, col: 88, offset: 128148},
 										name: "EOF",
 									},
 								},
@@ -10345,17 +10419,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4189, col: 1, offset: 127530},
+			pos:  position{line: 4212, col: 1, offset: 128277},
 			expr: &actionExpr{
-				pos: position{line: 4189, col: 18, offset: 127547},
+				pos: position{line: 4212, col: 18, offset: 128294},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4189, col: 18, offset: 127547},
+					pos: position{line: 4212, col: 18, offset: 128294},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4189, col: 18, offset: 127547},
+							pos: position{line: 4212, col: 18, offset: 128294},
 							expr: &charClassMatcher{
-								pos:        position{line: 4189, col: 18, offset: 127547},
+								pos:        position{line: 4212, col: 18, offset: 128294},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10363,9 +10437,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4189, col: 24, offset: 127553},
+							pos: position{line: 4212, col: 24, offset: 128300},
 							expr: &charClassMatcher{
-								pos:        position{line: 4189, col: 24, offset: 127553},
+								pos:        position{line: 4212, col: 24, offset: 128300},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10373,15 +10447,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4189, col: 31, offset: 127560},
+							pos:        position{line: 4212, col: 31, offset: 128307},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4189, col: 35, offset: 127564},
+							pos: position{line: 4212, col: 35, offset: 128311},
 							expr: &charClassMatcher{
-								pos:        position{line: 4189, col: 35, offset: 127564},
+								pos:        position{line: 4212, col: 35, offset: 128311},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10394,17 +10468,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4194, col: 1, offset: 127659},
+			pos:  position{line: 4217, col: 1, offset: 128406},
 			expr: &actionExpr{
-				pos: position{line: 4194, col: 20, offset: 127678},
+				pos: position{line: 4217, col: 20, offset: 128425},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4194, col: 20, offset: 127678},
+					pos: position{line: 4217, col: 20, offset: 128425},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4194, col: 20, offset: 127678},
+							pos: position{line: 4217, col: 20, offset: 128425},
 							expr: &charClassMatcher{
-								pos:        position{line: 4194, col: 20, offset: 127678},
+								pos:        position{line: 4217, col: 20, offset: 128425},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10412,9 +10486,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4194, col: 26, offset: 127684},
+							pos: position{line: 4217, col: 26, offset: 128431},
 							expr: &charClassMatcher{
-								pos:        position{line: 4194, col: 26, offset: 127684},
+								pos:        position{line: 4217, col: 26, offset: 128431},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10427,14 +10501,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4198, col: 1, offset: 127727},
+			pos:  position{line: 4221, col: 1, offset: 128474},
 			expr: &actionExpr{
-				pos: position{line: 4198, col: 28, offset: 127754},
+				pos: position{line: 4221, col: 28, offset: 128501},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4198, col: 28, offset: 127754},
+					pos: position{line: 4221, col: 28, offset: 128501},
 					expr: &charClassMatcher{
-						pos:        position{line: 4198, col: 28, offset: 127754},
+						pos:        position{line: 4221, col: 28, offset: 128501},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10445,15 +10519,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4202, col: 1, offset: 127797},
+			pos:  position{line: 4225, col: 1, offset: 128544},
 			expr: &actionExpr{
-				pos: position{line: 4202, col: 20, offset: 127816},
+				pos: position{line: 4225, col: 20, offset: 128563},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4202, col: 20, offset: 127816},
+					pos:   position{line: 4225, col: 20, offset: 128563},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4202, col: 27, offset: 127823},
+						pos:  position{line: 4225, col: 27, offset: 128570},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10461,31 +10535,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4210, col: 1, offset: 128070},
+			pos:  position{line: 4233, col: 1, offset: 128817},
 			expr: &actionExpr{
-				pos: position{line: 4210, col: 21, offset: 128090},
+				pos: position{line: 4233, col: 21, offset: 128837},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4210, col: 21, offset: 128090},
+					pos: position{line: 4233, col: 21, offset: 128837},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4210, col: 21, offset: 128090},
+							pos:  position{line: 4233, col: 21, offset: 128837},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4210, col: 36, offset: 128105},
+							pos:   position{line: 4233, col: 36, offset: 128852},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4210, col: 40, offset: 128109},
+								pos: position{line: 4233, col: 40, offset: 128856},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4210, col: 40, offset: 128109},
+										pos:        position{line: 4233, col: 40, offset: 128856},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4210, col: 46, offset: 128115},
+										pos:        position{line: 4233, col: 46, offset: 128862},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10494,7 +10568,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4210, col: 52, offset: 128121},
+							pos:  position{line: 4233, col: 52, offset: 128868},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10503,43 +10577,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4218, col: 1, offset: 128302},
+			pos:  position{line: 4241, col: 1, offset: 129049},
 			expr: &actionExpr{
-				pos: position{line: 4218, col: 23, offset: 128324},
+				pos: position{line: 4241, col: 23, offset: 129071},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4218, col: 23, offset: 128324},
+					pos: position{line: 4241, col: 23, offset: 129071},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4218, col: 23, offset: 128324},
+							pos:  position{line: 4241, col: 23, offset: 129071},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4218, col: 38, offset: 128339},
+							pos:   position{line: 4241, col: 38, offset: 129086},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4218, col: 42, offset: 128343},
+								pos: position{line: 4241, col: 42, offset: 129090},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4218, col: 42, offset: 128343},
+										pos:        position{line: 4241, col: 42, offset: 129090},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4218, col: 49, offset: 128350},
+										pos:        position{line: 4241, col: 49, offset: 129097},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4218, col: 55, offset: 128356},
+										pos:        position{line: 4241, col: 55, offset: 129103},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4218, col: 62, offset: 128363},
+										pos:        position{line: 4241, col: 62, offset: 129110},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10548,7 +10622,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4218, col: 67, offset: 128368},
+							pos:  position{line: 4241, col: 67, offset: 129115},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10557,30 +10631,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4226, col: 1, offset: 128551},
+			pos:  position{line: 4249, col: 1, offset: 129298},
 			expr: &choiceExpr{
-				pos: position{line: 4226, col: 25, offset: 128575},
+				pos: position{line: 4249, col: 25, offset: 129322},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4226, col: 25, offset: 128575},
+						pos: position{line: 4249, col: 25, offset: 129322},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4226, col: 25, offset: 128575},
+							pos:   position{line: 4249, col: 25, offset: 129322},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4226, col: 28, offset: 128578},
+								pos:  position{line: 4249, col: 28, offset: 129325},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4229, col: 3, offset: 128620},
+						pos: position{line: 4252, col: 3, offset: 129367},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4229, col: 3, offset: 128620},
+							pos:   position{line: 4252, col: 3, offset: 129367},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4229, col: 6, offset: 128623},
+								pos:  position{line: 4252, col: 6, offset: 129370},
 								name: "InequalityOperator",
 							},
 						},
@@ -10590,25 +10664,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4233, col: 1, offset: 128666},
+			pos:  position{line: 4256, col: 1, offset: 129413},
 			expr: &actionExpr{
-				pos: position{line: 4233, col: 11, offset: 128676},
+				pos: position{line: 4256, col: 11, offset: 129423},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4233, col: 11, offset: 128676},
+					pos: position{line: 4256, col: 11, offset: 129423},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 11, offset: 128676},
+							pos:  position{line: 4256, col: 11, offset: 129423},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4233, col: 26, offset: 128691},
+							pos:        position{line: 4256, col: 26, offset: 129438},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4233, col: 30, offset: 128695},
+							pos:  position{line: 4256, col: 30, offset: 129442},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10617,25 +10691,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4237, col: 1, offset: 128735},
+			pos:  position{line: 4260, col: 1, offset: 129482},
 			expr: &actionExpr{
-				pos: position{line: 4237, col: 12, offset: 128746},
+				pos: position{line: 4260, col: 12, offset: 129493},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4237, col: 12, offset: 128746},
+					pos: position{line: 4260, col: 12, offset: 129493},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4237, col: 12, offset: 128746},
+							pos:  position{line: 4260, col: 12, offset: 129493},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4237, col: 27, offset: 128761},
+							pos:        position{line: 4260, col: 27, offset: 129508},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4237, col: 31, offset: 128765},
+							pos:  position{line: 4260, col: 31, offset: 129512},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10644,25 +10718,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4241, col: 1, offset: 128805},
+			pos:  position{line: 4264, col: 1, offset: 129552},
 			expr: &actionExpr{
-				pos: position{line: 4241, col: 10, offset: 128814},
+				pos: position{line: 4264, col: 10, offset: 129561},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4241, col: 10, offset: 128814},
+					pos: position{line: 4264, col: 10, offset: 129561},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 10, offset: 128814},
+							pos:  position{line: 4264, col: 10, offset: 129561},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4241, col: 25, offset: 128829},
+							pos:        position{line: 4264, col: 25, offset: 129576},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4241, col: 29, offset: 128833},
+							pos:  position{line: 4264, col: 29, offset: 129580},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10671,25 +10745,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4245, col: 1, offset: 128873},
+			pos:  position{line: 4268, col: 1, offset: 129620},
 			expr: &actionExpr{
-				pos: position{line: 4245, col: 10, offset: 128882},
+				pos: position{line: 4268, col: 10, offset: 129629},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4245, col: 10, offset: 128882},
+					pos: position{line: 4268, col: 10, offset: 129629},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4245, col: 10, offset: 128882},
+							pos:  position{line: 4268, col: 10, offset: 129629},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4245, col: 25, offset: 128897},
+							pos:        position{line: 4268, col: 25, offset: 129644},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4245, col: 29, offset: 128901},
+							pos:  position{line: 4268, col: 29, offset: 129648},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10698,25 +10772,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4249, col: 1, offset: 128941},
+			pos:  position{line: 4272, col: 1, offset: 129688},
 			expr: &actionExpr{
-				pos: position{line: 4249, col: 10, offset: 128950},
+				pos: position{line: 4272, col: 10, offset: 129697},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4249, col: 10, offset: 128950},
+					pos: position{line: 4272, col: 10, offset: 129697},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4249, col: 10, offset: 128950},
+							pos:  position{line: 4272, col: 10, offset: 129697},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4249, col: 25, offset: 128965},
+							pos:        position{line: 4272, col: 25, offset: 129712},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4249, col: 29, offset: 128969},
+							pos:  position{line: 4272, col: 29, offset: 129716},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10725,39 +10799,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4254, col: 1, offset: 129033},
+			pos:  position{line: 4277, col: 1, offset: 129780},
 			expr: &actionExpr{
-				pos: position{line: 4254, col: 11, offset: 129043},
+				pos: position{line: 4277, col: 11, offset: 129790},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4254, col: 12, offset: 129044},
+					pos: position{line: 4277, col: 12, offset: 129791},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4254, col: 12, offset: 129044},
+							pos:        position{line: 4277, col: 12, offset: 129791},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4254, col: 24, offset: 129056},
+							pos:        position{line: 4277, col: 24, offset: 129803},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4254, col: 35, offset: 129067},
+							pos:        position{line: 4277, col: 35, offset: 129814},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4254, col: 44, offset: 129076},
+							pos:        position{line: 4277, col: 44, offset: 129823},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4254, col: 52, offset: 129084},
+							pos:        position{line: 4277, col: 52, offset: 129831},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10768,39 +10842,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4258, col: 1, offset: 129125},
+			pos:  position{line: 4281, col: 1, offset: 129872},
 			expr: &actionExpr{
-				pos: position{line: 4258, col: 11, offset: 129135},
+				pos: position{line: 4281, col: 11, offset: 129882},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4258, col: 12, offset: 129136},
+					pos: position{line: 4281, col: 12, offset: 129883},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4258, col: 12, offset: 129136},
+							pos:        position{line: 4281, col: 12, offset: 129883},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4258, col: 24, offset: 129148},
+							pos:        position{line: 4281, col: 24, offset: 129895},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4258, col: 35, offset: 129159},
+							pos:        position{line: 4281, col: 35, offset: 129906},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4258, col: 44, offset: 129168},
+							pos:        position{line: 4281, col: 44, offset: 129915},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4258, col: 52, offset: 129176},
+							pos:        position{line: 4281, col: 52, offset: 129923},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -10811,39 +10885,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4262, col: 1, offset: 129217},
+			pos:  position{line: 4285, col: 1, offset: 129964},
 			expr: &actionExpr{
-				pos: position{line: 4262, col: 9, offset: 129225},
+				pos: position{line: 4285, col: 9, offset: 129972},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4262, col: 10, offset: 129226},
+					pos: position{line: 4285, col: 10, offset: 129973},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4262, col: 10, offset: 129226},
+							pos:        position{line: 4285, col: 10, offset: 129973},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4262, col: 20, offset: 129236},
+							pos:        position{line: 4285, col: 20, offset: 129983},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4262, col: 29, offset: 129245},
+							pos:        position{line: 4285, col: 29, offset: 129992},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4262, col: 37, offset: 129253},
+							pos:        position{line: 4285, col: 37, offset: 130000},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4262, col: 44, offset: 129260},
+							pos:        position{line: 4285, col: 44, offset: 130007},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -10854,27 +10928,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4266, col: 1, offset: 129299},
+			pos:  position{line: 4289, col: 1, offset: 130046},
 			expr: &actionExpr{
-				pos: position{line: 4266, col: 8, offset: 129306},
+				pos: position{line: 4289, col: 8, offset: 130053},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4266, col: 9, offset: 129307},
+					pos: position{line: 4289, col: 9, offset: 130054},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4266, col: 9, offset: 129307},
+							pos:        position{line: 4289, col: 9, offset: 130054},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4266, col: 18, offset: 129316},
+							pos:        position{line: 4289, col: 18, offset: 130063},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4266, col: 26, offset: 129324},
+							pos:        position{line: 4289, col: 26, offset: 130071},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -10885,27 +10959,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4270, col: 1, offset: 129362},
+			pos:  position{line: 4293, col: 1, offset: 130109},
 			expr: &actionExpr{
-				pos: position{line: 4270, col: 9, offset: 129370},
+				pos: position{line: 4293, col: 9, offset: 130117},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4270, col: 10, offset: 129371},
+					pos: position{line: 4293, col: 10, offset: 130118},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4270, col: 10, offset: 129371},
+							pos:        position{line: 4293, col: 10, offset: 130118},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4270, col: 20, offset: 129381},
+							pos:        position{line: 4293, col: 20, offset: 130128},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4270, col: 29, offset: 129390},
+							pos:        position{line: 4293, col: 29, offset: 130137},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -10916,27 +10990,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4274, col: 1, offset: 129429},
+			pos:  position{line: 4297, col: 1, offset: 130176},
 			expr: &actionExpr{
-				pos: position{line: 4274, col: 10, offset: 129438},
+				pos: position{line: 4297, col: 10, offset: 130185},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4274, col: 11, offset: 129439},
+					pos: position{line: 4297, col: 11, offset: 130186},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4274, col: 11, offset: 129439},
+							pos:        position{line: 4297, col: 11, offset: 130186},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4274, col: 22, offset: 129450},
+							pos:        position{line: 4297, col: 22, offset: 130197},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4274, col: 32, offset: 129460},
+							pos:        position{line: 4297, col: 32, offset: 130207},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -10947,39 +11021,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4278, col: 1, offset: 129502},
+			pos:  position{line: 4301, col: 1, offset: 130249},
 			expr: &actionExpr{
-				pos: position{line: 4278, col: 12, offset: 129513},
+				pos: position{line: 4301, col: 12, offset: 130260},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4278, col: 13, offset: 129514},
+					pos: position{line: 4301, col: 13, offset: 130261},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4278, col: 13, offset: 129514},
+							pos:        position{line: 4301, col: 13, offset: 130261},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4278, col: 26, offset: 129527},
+							pos:        position{line: 4301, col: 26, offset: 130274},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4278, col: 38, offset: 129539},
+							pos:        position{line: 4301, col: 38, offset: 130286},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4278, col: 47, offset: 129548},
+							pos:        position{line: 4301, col: 47, offset: 130295},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4278, col: 55, offset: 129556},
+							pos:        position{line: 4301, col: 55, offset: 130303},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -10990,39 +11064,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4282, col: 1, offset: 129598},
+			pos:  position{line: 4305, col: 1, offset: 130345},
 			expr: &actionExpr{
-				pos: position{line: 4282, col: 9, offset: 129606},
+				pos: position{line: 4305, col: 9, offset: 130353},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4282, col: 10, offset: 129607},
+					pos: position{line: 4305, col: 10, offset: 130354},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4282, col: 10, offset: 129607},
+							pos:        position{line: 4305, col: 10, offset: 130354},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 20, offset: 129617},
+							pos:        position{line: 4305, col: 20, offset: 130364},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 29, offset: 129626},
+							pos:        position{line: 4305, col: 29, offset: 130373},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 37, offset: 129634},
+							pos:        position{line: 4305, col: 37, offset: 130381},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4282, col: 44, offset: 129641},
+							pos:        position{line: 4305, col: 44, offset: 130388},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11033,33 +11107,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4287, col: 1, offset: 129772},
+			pos:  position{line: 4310, col: 1, offset: 130519},
 			expr: &actionExpr{
-				pos: position{line: 4287, col: 15, offset: 129786},
+				pos: position{line: 4310, col: 15, offset: 130533},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4287, col: 16, offset: 129787},
+					pos: position{line: 4310, col: 16, offset: 130534},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4287, col: 16, offset: 129787},
+							pos:        position{line: 4310, col: 16, offset: 130534},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4287, col: 23, offset: 129794},
+							pos:        position{line: 4310, col: 23, offset: 130541},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4287, col: 30, offset: 129801},
+							pos:        position{line: 4310, col: 30, offset: 130548},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4287, col: 37, offset: 129808},
+							pos:        position{line: 4310, col: 37, offset: 130555},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11070,26 +11144,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4296, col: 1, offset: 130031},
+			pos:  position{line: 4319, col: 1, offset: 130778},
 			expr: &actionExpr{
-				pos: position{line: 4296, col: 21, offset: 130051},
+				pos: position{line: 4319, col: 21, offset: 130798},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4296, col: 21, offset: 130051},
+					pos: position{line: 4319, col: 21, offset: 130798},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4296, col: 21, offset: 130051},
+							pos:  position{line: 4319, col: 21, offset: 130798},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4296, col: 26, offset: 130056},
+							pos:  position{line: 4319, col: 26, offset: 130803},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4296, col: 42, offset: 130072},
+							pos:   position{line: 4319, col: 42, offset: 130819},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4296, col: 53, offset: 130083},
+								pos:  position{line: 4319, col: 53, offset: 130830},
 								name: "TransactionOptions",
 							},
 						},
@@ -11099,17 +11173,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4305, col: 1, offset: 130389},
+			pos:  position{line: 4328, col: 1, offset: 131136},
 			expr: &actionExpr{
-				pos: position{line: 4305, col: 23, offset: 130411},
+				pos: position{line: 4328, col: 23, offset: 131158},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4305, col: 23, offset: 130411},
+					pos:   position{line: 4328, col: 23, offset: 131158},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4305, col: 34, offset: 130422},
+						pos: position{line: 4328, col: 34, offset: 131169},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4305, col: 34, offset: 130422},
+							pos:  position{line: 4328, col: 34, offset: 131169},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11118,35 +11192,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4320, col: 1, offset: 130813},
+			pos:  position{line: 4343, col: 1, offset: 131560},
 			expr: &actionExpr{
-				pos: position{line: 4320, col: 37, offset: 130849},
+				pos: position{line: 4343, col: 37, offset: 131596},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4320, col: 37, offset: 130849},
+					pos: position{line: 4343, col: 37, offset: 131596},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4320, col: 37, offset: 130849},
+							pos:   position{line: 4343, col: 37, offset: 131596},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4320, col: 43, offset: 130855},
+								pos:  position{line: 4343, col: 43, offset: 131602},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4320, col: 71, offset: 130883},
+							pos:   position{line: 4343, col: 71, offset: 131630},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4320, col: 76, offset: 130888},
+								pos: position{line: 4343, col: 76, offset: 131635},
 								expr: &seqExpr{
-									pos: position{line: 4320, col: 77, offset: 130889},
+									pos: position{line: 4343, col: 77, offset: 131636},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4320, col: 77, offset: 130889},
+											pos:  position{line: 4343, col: 77, offset: 131636},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4320, col: 83, offset: 130895},
+											pos:  position{line: 4343, col: 83, offset: 131642},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11159,26 +11233,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4355, col: 1, offset: 131884},
+			pos:  position{line: 4378, col: 1, offset: 132631},
 			expr: &actionExpr{
-				pos: position{line: 4355, col: 32, offset: 131915},
+				pos: position{line: 4378, col: 32, offset: 132662},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4355, col: 32, offset: 131915},
+					pos:   position{line: 4378, col: 32, offset: 132662},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4355, col: 40, offset: 131923},
+						pos: position{line: 4378, col: 40, offset: 132670},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4355, col: 40, offset: 131923},
+								pos:  position{line: 4378, col: 40, offset: 132670},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4355, col: 77, offset: 131960},
+								pos:  position{line: 4378, col: 77, offset: 132707},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4355, col: 96, offset: 131979},
+								pos:  position{line: 4378, col: 96, offset: 132726},
 								name: "EndsWithOption",
 							},
 						},
@@ -11188,15 +11262,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4359, col: 1, offset: 132023},
+			pos:  position{line: 4382, col: 1, offset: 132770},
 			expr: &actionExpr{
-				pos: position{line: 4359, col: 39, offset: 132061},
+				pos: position{line: 4382, col: 39, offset: 132808},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4359, col: 39, offset: 132061},
+					pos:   position{line: 4382, col: 39, offset: 132808},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4359, col: 46, offset: 132068},
+						pos:  position{line: 4382, col: 46, offset: 132815},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11204,28 +11278,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4370, col: 1, offset: 132284},
+			pos:  position{line: 4393, col: 1, offset: 133031},
 			expr: &actionExpr{
-				pos: position{line: 4370, col: 21, offset: 132304},
+				pos: position{line: 4393, col: 21, offset: 133051},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4370, col: 21, offset: 132304},
+					pos: position{line: 4393, col: 21, offset: 133051},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4370, col: 21, offset: 132304},
+							pos:        position{line: 4393, col: 21, offset: 133051},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4370, col: 34, offset: 132317},
+							pos:  position{line: 4393, col: 34, offset: 133064},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4370, col: 40, offset: 132323},
+							pos:   position{line: 4393, col: 40, offset: 133070},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4370, col: 48, offset: 132331},
+								pos:  position{line: 4393, col: 48, offset: 133078},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11235,28 +11309,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4380, col: 1, offset: 132569},
+			pos:  position{line: 4403, col: 1, offset: 133316},
 			expr: &actionExpr{
-				pos: position{line: 4380, col: 19, offset: 132587},
+				pos: position{line: 4403, col: 19, offset: 133334},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4380, col: 19, offset: 132587},
+					pos: position{line: 4403, col: 19, offset: 133334},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4380, col: 19, offset: 132587},
+							pos:        position{line: 4403, col: 19, offset: 133334},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4380, col: 30, offset: 132598},
+							pos:  position{line: 4403, col: 30, offset: 133345},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4380, col: 36, offset: 132604},
+							pos:   position{line: 4403, col: 36, offset: 133351},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4380, col: 44, offset: 132612},
+								pos:  position{line: 4403, col: 44, offset: 133359},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11266,26 +11340,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4391, col: 1, offset: 132881},
+			pos:  position{line: 4414, col: 1, offset: 133628},
 			expr: &actionExpr{
-				pos: position{line: 4391, col: 28, offset: 132908},
+				pos: position{line: 4414, col: 28, offset: 133655},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4391, col: 28, offset: 132908},
+					pos:   position{line: 4414, col: 28, offset: 133655},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4391, col: 37, offset: 132917},
+						pos: position{line: 4414, col: 37, offset: 133664},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4391, col: 37, offset: 132917},
+								pos:  position{line: 4414, col: 37, offset: 133664},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4391, col: 63, offset: 132943},
+								pos:  position{line: 4414, col: 63, offset: 133690},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4391, col: 81, offset: 132961},
+								pos:  position{line: 4414, col: 81, offset: 133708},
 								name: "TransactionSearch",
 							},
 						},
@@ -11295,22 +11369,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4395, col: 1, offset: 133009},
+			pos:  position{line: 4418, col: 1, offset: 133756},
 			expr: &actionExpr{
-				pos: position{line: 4395, col: 28, offset: 133036},
+				pos: position{line: 4418, col: 28, offset: 133783},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4395, col: 28, offset: 133036},
+					pos:   position{line: 4418, col: 28, offset: 133783},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4395, col: 33, offset: 133041},
+						pos: position{line: 4418, col: 33, offset: 133788},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4395, col: 33, offset: 133041},
+								pos:  position{line: 4418, col: 33, offset: 133788},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4395, col: 64, offset: 133072},
+								pos:  position{line: 4418, col: 64, offset: 133819},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11320,29 +11394,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4399, col: 1, offset: 133132},
+			pos:  position{line: 4422, col: 1, offset: 133879},
 			expr: &actionExpr{
-				pos: position{line: 4399, col: 38, offset: 133169},
+				pos: position{line: 4422, col: 38, offset: 133916},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4399, col: 38, offset: 133169},
+					pos: position{line: 4422, col: 38, offset: 133916},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4399, col: 38, offset: 133169},
+							pos:        position{line: 4422, col: 38, offset: 133916},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4399, col: 42, offset: 133173},
+							pos:   position{line: 4422, col: 42, offset: 133920},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4399, col: 55, offset: 133186},
+								pos:  position{line: 4422, col: 55, offset: 133933},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4399, col: 68, offset: 133199},
+							pos:        position{line: 4422, col: 68, offset: 133946},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11353,23 +11427,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4407, col: 1, offset: 133338},
+			pos:  position{line: 4430, col: 1, offset: 134085},
 			expr: &actionExpr{
-				pos: position{line: 4407, col: 21, offset: 133358},
+				pos: position{line: 4430, col: 21, offset: 134105},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4407, col: 21, offset: 133358},
+					pos: position{line: 4430, col: 21, offset: 134105},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4407, col: 21, offset: 133358},
+							pos:        position{line: 4430, col: 21, offset: 134105},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4407, col: 25, offset: 133362},
+							pos: position{line: 4430, col: 25, offset: 134109},
 							expr: &charClassMatcher{
-								pos:        position{line: 4407, col: 25, offset: 133362},
+								pos:        position{line: 4430, col: 25, offset: 134109},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11377,7 +11451,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4407, col: 44, offset: 133381},
+							pos:        position{line: 4430, col: 44, offset: 134128},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11388,15 +11462,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4412, col: 1, offset: 133492},
+			pos:  position{line: 4435, col: 1, offset: 134239},
 			expr: &actionExpr{
-				pos: position{line: 4412, col: 33, offset: 133524},
+				pos: position{line: 4435, col: 33, offset: 134271},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4412, col: 33, offset: 133524},
+					pos:   position{line: 4435, col: 33, offset: 134271},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4412, col: 37, offset: 133528},
+						pos:  position{line: 4435, col: 37, offset: 134275},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11404,15 +11478,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4420, col: 1, offset: 133683},
+			pos:  position{line: 4443, col: 1, offset: 134430},
 			expr: &actionExpr{
-				pos: position{line: 4420, col: 22, offset: 133704},
+				pos: position{line: 4443, col: 22, offset: 134451},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4420, col: 22, offset: 133704},
+					pos:   position{line: 4443, col: 22, offset: 134451},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4420, col: 27, offset: 133709},
+						pos:  position{line: 4443, col: 27, offset: 134456},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11420,37 +11494,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4430, col: 1, offset: 133881},
+			pos:  position{line: 4453, col: 1, offset: 134628},
 			expr: &actionExpr{
-				pos: position{line: 4430, col: 20, offset: 133900},
+				pos: position{line: 4453, col: 20, offset: 134647},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4430, col: 20, offset: 133900},
+					pos: position{line: 4453, col: 20, offset: 134647},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4430, col: 20, offset: 133900},
+							pos:        position{line: 4453, col: 20, offset: 134647},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4430, col: 27, offset: 133907},
+							pos:  position{line: 4453, col: 27, offset: 134654},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4430, col: 42, offset: 133922},
+							pos:  position{line: 4453, col: 42, offset: 134669},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4430, col: 50, offset: 133930},
+							pos:   position{line: 4453, col: 50, offset: 134677},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4430, col: 60, offset: 133940},
+								pos:  position{line: 4453, col: 60, offset: 134687},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4430, col: 69, offset: 133949},
+							pos:  position{line: 4453, col: 69, offset: 134696},
 							name: "R_PAREN",
 						},
 					},
@@ -11459,22 +11533,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4440, col: 1, offset: 134252},
+			pos:  position{line: 4463, col: 1, offset: 134999},
 			expr: &actionExpr{
-				pos: position{line: 4440, col: 20, offset: 134271},
+				pos: position{line: 4463, col: 20, offset: 135018},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4440, col: 20, offset: 134271},
+					pos: position{line: 4463, col: 20, offset: 135018},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4440, col: 20, offset: 134271},
+							pos:  position{line: 4463, col: 20, offset: 135018},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4440, col: 25, offset: 134276},
+							pos:   position{line: 4463, col: 25, offset: 135023},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4440, col: 42, offset: 134293},
+								pos:  position{line: 4463, col: 42, offset: 135040},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11484,41 +11558,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4444, col: 1, offset: 134342},
+			pos:  position{line: 4467, col: 1, offset: 135089},
 			expr: &actionExpr{
-				pos: position{line: 4444, col: 16, offset: 134357},
+				pos: position{line: 4467, col: 16, offset: 135104},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4444, col: 16, offset: 134357},
+					pos: position{line: 4467, col: 16, offset: 135104},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4444, col: 16, offset: 134357},
+							pos:  position{line: 4467, col: 16, offset: 135104},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4444, col: 27, offset: 134368},
+							pos:  position{line: 4467, col: 27, offset: 135115},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4444, col: 33, offset: 134374},
+							pos:   position{line: 4467, col: 33, offset: 135121},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4444, col: 50, offset: 134391},
+								pos: position{line: 4467, col: 50, offset: 135138},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4444, col: 50, offset: 134391},
+									pos:  position{line: 4467, col: 50, offset: 135138},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4444, col: 70, offset: 134411},
+							pos:  position{line: 4467, col: 70, offset: 135158},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4444, col: 85, offset: 134426},
+							pos:   position{line: 4467, col: 85, offset: 135173},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4444, col: 91, offset: 134432},
+								pos:  position{line: 4467, col: 91, offset: 135179},
 								name: "FieldName",
 							},
 						},
@@ -11528,35 +11602,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4472, col: 1, offset: 135172},
+			pos:  position{line: 4495, col: 1, offset: 135919},
 			expr: &actionExpr{
-				pos: position{line: 4472, col: 23, offset: 135194},
+				pos: position{line: 4495, col: 23, offset: 135941},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4472, col: 23, offset: 135194},
+					pos: position{line: 4495, col: 23, offset: 135941},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4472, col: 23, offset: 135194},
+							pos:   position{line: 4495, col: 23, offset: 135941},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4472, col: 31, offset: 135202},
+								pos:  position{line: 4495, col: 31, offset: 135949},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4472, col: 46, offset: 135217},
+							pos:   position{line: 4495, col: 46, offset: 135964},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4472, col: 52, offset: 135223},
+								pos: position{line: 4495, col: 52, offset: 135970},
 								expr: &seqExpr{
-									pos: position{line: 4472, col: 53, offset: 135224},
+									pos: position{line: 4495, col: 53, offset: 135971},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4472, col: 53, offset: 135224},
+											pos:  position{line: 4495, col: 53, offset: 135971},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4472, col: 59, offset: 135230},
+											pos:  position{line: 4495, col: 59, offset: 135977},
 											name: "MVBlockOption",
 										},
 									},
@@ -11569,26 +11643,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4506, col: 1, offset: 136286},
+			pos:  position{line: 4529, col: 1, offset: 137033},
 			expr: &actionExpr{
-				pos: position{line: 4506, col: 18, offset: 136303},
+				pos: position{line: 4529, col: 18, offset: 137050},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4506, col: 18, offset: 136303},
+					pos:   position{line: 4529, col: 18, offset: 137050},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4506, col: 27, offset: 136312},
+						pos: position{line: 4529, col: 27, offset: 137059},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4506, col: 27, offset: 136312},
+								pos:  position{line: 4529, col: 27, offset: 137059},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4506, col: 41, offset: 136326},
+								pos:  position{line: 4529, col: 41, offset: 137073},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4506, col: 60, offset: 136345},
+								pos:  position{line: 4529, col: 60, offset: 137092},
 								name: "SetSvOption",
 							},
 						},
@@ -11598,22 +11672,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4510, col: 1, offset: 136386},
+			pos:  position{line: 4533, col: 1, offset: 137133},
 			expr: &actionExpr{
-				pos: position{line: 4510, col: 16, offset: 136401},
+				pos: position{line: 4533, col: 16, offset: 137148},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4510, col: 16, offset: 136401},
+					pos:   position{line: 4533, col: 16, offset: 137148},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4510, col: 28, offset: 136413},
+						pos: position{line: 4533, col: 28, offset: 137160},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4510, col: 28, offset: 136413},
+								pos:  position{line: 4533, col: 28, offset: 137160},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4510, col: 46, offset: 136431},
+								pos:  position{line: 4533, col: 46, offset: 137178},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11623,28 +11697,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4514, col: 1, offset: 136478},
+			pos:  position{line: 4537, col: 1, offset: 137225},
 			expr: &actionExpr{
-				pos: position{line: 4514, col: 20, offset: 136497},
+				pos: position{line: 4537, col: 20, offset: 137244},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4514, col: 20, offset: 136497},
+					pos: position{line: 4537, col: 20, offset: 137244},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4514, col: 20, offset: 136497},
+							pos:        position{line: 4537, col: 20, offset: 137244},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4514, col: 28, offset: 136505},
+							pos:  position{line: 4537, col: 28, offset: 137252},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4514, col: 34, offset: 136511},
+							pos:   position{line: 4537, col: 34, offset: 137258},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4514, col: 38, offset: 136515},
+								pos:  position{line: 4537, col: 38, offset: 137262},
 								name: "QuotedString",
 							},
 						},
@@ -11654,28 +11728,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4525, col: 1, offset: 136766},
+			pos:  position{line: 4548, col: 1, offset: 137513},
 			expr: &actionExpr{
-				pos: position{line: 4525, col: 19, offset: 136784},
+				pos: position{line: 4548, col: 19, offset: 137531},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4525, col: 19, offset: 136784},
+					pos: position{line: 4548, col: 19, offset: 137531},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4525, col: 19, offset: 136784},
+							pos:        position{line: 4548, col: 19, offset: 137531},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4525, col: 31, offset: 136796},
+							pos:  position{line: 4548, col: 31, offset: 137543},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4525, col: 37, offset: 136802},
+							pos:   position{line: 4548, col: 37, offset: 137549},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4525, col: 41, offset: 136806},
+								pos:  position{line: 4548, col: 41, offset: 137553},
 								name: "QuotedString",
 							},
 						},
@@ -11685,28 +11759,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4543, col: 1, offset: 137277},
+			pos:  position{line: 4566, col: 1, offset: 138024},
 			expr: &actionExpr{
-				pos: position{line: 4543, col: 21, offset: 137297},
+				pos: position{line: 4566, col: 21, offset: 138044},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4543, col: 21, offset: 137297},
+					pos: position{line: 4566, col: 21, offset: 138044},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4543, col: 21, offset: 137297},
+							pos:        position{line: 4566, col: 21, offset: 138044},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4543, col: 34, offset: 137310},
+							pos:  position{line: 4566, col: 34, offset: 138057},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4543, col: 40, offset: 137316},
+							pos:   position{line: 4566, col: 40, offset: 138063},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4543, col: 48, offset: 137324},
+								pos:  position{line: 4566, col: 48, offset: 138071},
 								name: "Boolean",
 							},
 						},
@@ -11716,28 +11790,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4555, col: 1, offset: 137564},
+			pos:  position{line: 4578, col: 1, offset: 138311},
 			expr: &actionExpr{
-				pos: position{line: 4555, col: 16, offset: 137579},
+				pos: position{line: 4578, col: 16, offset: 138326},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4555, col: 16, offset: 137579},
+					pos: position{line: 4578, col: 16, offset: 138326},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4555, col: 16, offset: 137579},
+							pos:        position{line: 4578, col: 16, offset: 138326},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4555, col: 24, offset: 137587},
+							pos:  position{line: 4578, col: 24, offset: 138334},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4555, col: 30, offset: 137593},
+							pos:   position{line: 4578, col: 30, offset: 138340},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4555, col: 38, offset: 137601},
+								pos:  position{line: 4578, col: 38, offset: 138348},
 								name: "Boolean",
 							},
 						},
@@ -11747,28 +11821,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4567, col: 1, offset: 137866},
+			pos:  position{line: 4590, col: 1, offset: 138613},
 			expr: &actionExpr{
-				pos: position{line: 4567, col: 15, offset: 137880},
+				pos: position{line: 4590, col: 15, offset: 138627},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4567, col: 15, offset: 137880},
+					pos: position{line: 4590, col: 15, offset: 138627},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4567, col: 15, offset: 137880},
+							pos:  position{line: 4590, col: 15, offset: 138627},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4567, col: 20, offset: 137885},
+							pos:  position{line: 4590, col: 20, offset: 138632},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4567, col: 30, offset: 137895},
+							pos:   position{line: 4590, col: 30, offset: 138642},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4567, col: 40, offset: 137905},
+								pos: position{line: 4590, col: 40, offset: 138652},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4567, col: 40, offset: 137905},
+									pos:  position{line: 4590, col: 40, offset: 138652},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -11779,39 +11853,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4574, col: 1, offset: 138031},
+			pos:  position{line: 4597, col: 1, offset: 138778},
 			expr: &actionExpr{
-				pos: position{line: 4574, col: 23, offset: 138053},
+				pos: position{line: 4597, col: 23, offset: 138800},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4574, col: 23, offset: 138053},
+					pos: position{line: 4597, col: 23, offset: 138800},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4574, col: 23, offset: 138053},
+							pos:  position{line: 4597, col: 23, offset: 138800},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4574, col: 29, offset: 138059},
+							pos:   position{line: 4597, col: 29, offset: 138806},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4574, col: 35, offset: 138065},
+								pos:  position{line: 4597, col: 35, offset: 138812},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4574, col: 49, offset: 138079},
+							pos:   position{line: 4597, col: 49, offset: 138826},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4574, col: 54, offset: 138084},
+								pos: position{line: 4597, col: 54, offset: 138831},
 								expr: &seqExpr{
-									pos: position{line: 4574, col: 55, offset: 138085},
+									pos: position{line: 4597, col: 55, offset: 138832},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4574, col: 55, offset: 138085},
+											pos:  position{line: 4597, col: 55, offset: 138832},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4574, col: 61, offset: 138091},
+											pos:  position{line: 4597, col: 61, offset: 138838},
 											name: "SPathArgument",
 										},
 									},
@@ -11824,26 +11898,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4606, col: 1, offset: 138984},
+			pos:  position{line: 4629, col: 1, offset: 139731},
 			expr: &actionExpr{
-				pos: position{line: 4606, col: 18, offset: 139001},
+				pos: position{line: 4629, col: 18, offset: 139748},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4606, col: 18, offset: 139001},
+					pos:   position{line: 4629, col: 18, offset: 139748},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4606, col: 23, offset: 139006},
+						pos: position{line: 4629, col: 23, offset: 139753},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4606, col: 23, offset: 139006},
+								pos:  position{line: 4629, col: 23, offset: 139753},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4606, col: 36, offset: 139019},
+								pos:  position{line: 4629, col: 36, offset: 139766},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4606, col: 50, offset: 139033},
+								pos:  position{line: 4629, col: 50, offset: 139780},
 								name: "PathField",
 							},
 						},
@@ -11853,28 +11927,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4610, col: 1, offset: 139069},
+			pos:  position{line: 4633, col: 1, offset: 139816},
 			expr: &actionExpr{
-				pos: position{line: 4610, col: 15, offset: 139083},
+				pos: position{line: 4633, col: 15, offset: 139830},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4610, col: 15, offset: 139083},
+					pos: position{line: 4633, col: 15, offset: 139830},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4610, col: 15, offset: 139083},
+							pos:        position{line: 4633, col: 15, offset: 139830},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4610, col: 23, offset: 139091},
+							pos:  position{line: 4633, col: 23, offset: 139838},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4610, col: 29, offset: 139097},
+							pos:   position{line: 4633, col: 29, offset: 139844},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4610, col: 35, offset: 139103},
+								pos:  position{line: 4633, col: 35, offset: 139850},
 								name: "FieldName",
 							},
 						},
@@ -11884,28 +11958,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4613, col: 1, offset: 139159},
+			pos:  position{line: 4636, col: 1, offset: 139906},
 			expr: &actionExpr{
-				pos: position{line: 4613, col: 16, offset: 139174},
+				pos: position{line: 4636, col: 16, offset: 139921},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4613, col: 16, offset: 139174},
+					pos: position{line: 4636, col: 16, offset: 139921},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4613, col: 16, offset: 139174},
+							pos:        position{line: 4636, col: 16, offset: 139921},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 25, offset: 139183},
+							pos:  position{line: 4636, col: 25, offset: 139930},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4613, col: 31, offset: 139189},
+							pos:   position{line: 4636, col: 31, offset: 139936},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4613, col: 37, offset: 139195},
+								pos:  position{line: 4636, col: 37, offset: 139942},
 								name: "FieldName",
 							},
 						},
@@ -11915,34 +11989,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4616, col: 1, offset: 139252},
+			pos:  position{line: 4639, col: 1, offset: 139999},
 			expr: &actionExpr{
-				pos: position{line: 4616, col: 14, offset: 139265},
+				pos: position{line: 4639, col: 14, offset: 140012},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4616, col: 15, offset: 139266},
+					pos: position{line: 4639, col: 15, offset: 140013},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4616, col: 15, offset: 139266},
+							pos: position{line: 4639, col: 15, offset: 140013},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4616, col: 15, offset: 139266},
+									pos:        position{line: 4639, col: 15, offset: 140013},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4616, col: 22, offset: 139273},
+									pos:  position{line: 4639, col: 22, offset: 140020},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4616, col: 28, offset: 139279},
+									pos:  position{line: 4639, col: 28, offset: 140026},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4616, col: 47, offset: 139298},
+							pos:  position{line: 4639, col: 47, offset: 140045},
 							name: "SPathFieldString",
 						},
 					},
@@ -11951,16 +12025,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4628, col: 1, offset: 139710},
+			pos:  position{line: 4651, col: 1, offset: 140457},
 			expr: &choiceExpr{
-				pos: position{line: 4628, col: 21, offset: 139730},
+				pos: position{line: 4651, col: 21, offset: 140477},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4628, col: 21, offset: 139730},
+						pos:  position{line: 4651, col: 21, offset: 140477},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4628, col: 36, offset: 139745},
+						pos:  position{line: 4651, col: 36, offset: 140492},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -11968,28 +12042,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4631, col: 1, offset: 139818},
+			pos:  position{line: 4654, col: 1, offset: 140565},
 			expr: &actionExpr{
-				pos: position{line: 4631, col: 16, offset: 139833},
+				pos: position{line: 4654, col: 16, offset: 140580},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4631, col: 16, offset: 139833},
+					pos: position{line: 4654, col: 16, offset: 140580},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4631, col: 16, offset: 139833},
+							pos:  position{line: 4654, col: 16, offset: 140580},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4631, col: 21, offset: 139838},
+							pos:  position{line: 4654, col: 21, offset: 140585},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4631, col: 32, offset: 139849},
+							pos:   position{line: 4654, col: 32, offset: 140596},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4631, col: 46, offset: 139863},
+								pos: position{line: 4654, col: 46, offset: 140610},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4631, col: 46, offset: 139863},
+									pos:  position{line: 4654, col: 46, offset: 140610},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12000,39 +12074,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4653, col: 1, offset: 140472},
+			pos:  position{line: 4676, col: 1, offset: 141219},
 			expr: &actionExpr{
-				pos: position{line: 4653, col: 24, offset: 140495},
+				pos: position{line: 4676, col: 24, offset: 141242},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4653, col: 24, offset: 140495},
+					pos: position{line: 4676, col: 24, offset: 141242},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4653, col: 24, offset: 140495},
+							pos:  position{line: 4676, col: 24, offset: 141242},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4653, col: 30, offset: 140501},
+							pos:   position{line: 4676, col: 30, offset: 141248},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4653, col: 37, offset: 140508},
+								pos:  position{line: 4676, col: 37, offset: 141255},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4653, col: 52, offset: 140523},
+							pos:   position{line: 4676, col: 52, offset: 141270},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4653, col: 57, offset: 140528},
+								pos: position{line: 4676, col: 57, offset: 141275},
 								expr: &seqExpr{
-									pos: position{line: 4653, col: 58, offset: 140529},
+									pos: position{line: 4676, col: 58, offset: 141276},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4653, col: 58, offset: 140529},
+											pos:  position{line: 4676, col: 58, offset: 141276},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4653, col: 64, offset: 140535},
+											pos:  position{line: 4676, col: 64, offset: 141282},
 											name: "FormatArgument",
 										},
 									},
@@ -12045,30 +12119,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4687, col: 1, offset: 141724},
+			pos:  position{line: 4710, col: 1, offset: 142471},
 			expr: &actionExpr{
-				pos: position{line: 4687, col: 19, offset: 141742},
+				pos: position{line: 4710, col: 19, offset: 142489},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4687, col: 19, offset: 141742},
+					pos:   position{line: 4710, col: 19, offset: 142489},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4687, col: 28, offset: 141751},
+						pos: position{line: 4710, col: 28, offset: 142498},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4687, col: 28, offset: 141751},
+								pos:  position{line: 4710, col: 28, offset: 142498},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4687, col: 46, offset: 141769},
+								pos:  position{line: 4710, col: 46, offset: 142516},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4687, col: 65, offset: 141788},
+								pos:  position{line: 4710, col: 65, offset: 142535},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4687, col: 82, offset: 141805},
+								pos:  position{line: 4710, col: 82, offset: 142552},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12078,28 +12152,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4691, col: 1, offset: 141855},
+			pos:  position{line: 4714, col: 1, offset: 142602},
 			expr: &actionExpr{
-				pos: position{line: 4691, col: 20, offset: 141874},
+				pos: position{line: 4714, col: 20, offset: 142621},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4691, col: 20, offset: 141874},
+					pos: position{line: 4714, col: 20, offset: 142621},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4691, col: 20, offset: 141874},
+							pos:        position{line: 4714, col: 20, offset: 142621},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4691, col: 28, offset: 141882},
+							pos:  position{line: 4714, col: 28, offset: 142629},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4691, col: 34, offset: 141888},
+							pos:   position{line: 4714, col: 34, offset: 142635},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4691, col: 38, offset: 141892},
+								pos:  position{line: 4714, col: 38, offset: 142639},
 								name: "QuotedString",
 							},
 						},
@@ -12109,28 +12183,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4700, col: 1, offset: 142104},
+			pos:  position{line: 4723, col: 1, offset: 142851},
 			expr: &actionExpr{
-				pos: position{line: 4700, col: 21, offset: 142124},
+				pos: position{line: 4723, col: 21, offset: 142871},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4700, col: 21, offset: 142124},
+					pos: position{line: 4723, col: 21, offset: 142871},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4700, col: 21, offset: 142124},
+							pos:        position{line: 4723, col: 21, offset: 142871},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4700, col: 34, offset: 142137},
+							pos:  position{line: 4723, col: 34, offset: 142884},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4700, col: 40, offset: 142143},
+							pos:   position{line: 4723, col: 40, offset: 142890},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4700, col: 47, offset: 142150},
+								pos:  position{line: 4723, col: 47, offset: 142897},
 								name: "IntegerAsString",
 							},
 						},
@@ -12140,28 +12214,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4713, col: 1, offset: 142556},
+			pos:  position{line: 4736, col: 1, offset: 143303},
 			expr: &actionExpr{
-				pos: position{line: 4713, col: 19, offset: 142574},
+				pos: position{line: 4736, col: 19, offset: 143321},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4713, col: 19, offset: 142574},
+					pos: position{line: 4736, col: 19, offset: 143321},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4713, col: 19, offset: 142574},
+							pos:        position{line: 4736, col: 19, offset: 143321},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4713, col: 30, offset: 142585},
+							pos:  position{line: 4736, col: 30, offset: 143332},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4713, col: 36, offset: 142591},
+							pos:   position{line: 4736, col: 36, offset: 143338},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4713, col: 40, offset: 142595},
+								pos:  position{line: 4736, col: 40, offset: 143342},
 								name: "QuotedString",
 							},
 						},
@@ -12171,78 +12245,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4722, col: 1, offset: 142810},
+			pos:  position{line: 4745, col: 1, offset: 143557},
 			expr: &actionExpr{
-				pos: position{line: 4722, col: 24, offset: 142833},
+				pos: position{line: 4745, col: 24, offset: 143580},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4722, col: 24, offset: 142833},
+					pos: position{line: 4745, col: 24, offset: 143580},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4722, col: 24, offset: 142833},
+							pos:   position{line: 4745, col: 24, offset: 143580},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 34, offset: 142843},
+								pos:  position{line: 4745, col: 34, offset: 143590},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4722, col: 47, offset: 142856},
+							pos:  position{line: 4745, col: 47, offset: 143603},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4722, col: 53, offset: 142862},
+							pos:   position{line: 4745, col: 53, offset: 143609},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 63, offset: 142872},
+								pos:  position{line: 4745, col: 63, offset: 143619},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4722, col: 76, offset: 142885},
+							pos:  position{line: 4745, col: 76, offset: 143632},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4722, col: 82, offset: 142891},
+							pos:   position{line: 4745, col: 82, offset: 143638},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 95, offset: 142904},
+								pos:  position{line: 4745, col: 95, offset: 143651},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4722, col: 108, offset: 142917},
+							pos:  position{line: 4745, col: 108, offset: 143664},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4722, col: 114, offset: 142923},
+							pos:   position{line: 4745, col: 114, offset: 143670},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 121, offset: 142930},
+								pos:  position{line: 4745, col: 121, offset: 143677},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4722, col: 134, offset: 142943},
+							pos:  position{line: 4745, col: 134, offset: 143690},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4722, col: 140, offset: 142949},
+							pos:   position{line: 4745, col: 140, offset: 143696},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 153, offset: 142962},
+								pos:  position{line: 4745, col: 153, offset: 143709},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4722, col: 166, offset: 142975},
+							pos:  position{line: 4745, col: 166, offset: 143722},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4722, col: 172, offset: 142981},
+							pos:   position{line: 4745, col: 172, offset: 143728},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4722, col: 179, offset: 142988},
+								pos:  position{line: 4745, col: 179, offset: 143735},
 								name: "QuotedString",
 							},
 						},
@@ -12252,28 +12326,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4740, col: 1, offset: 143564},
+			pos:  position{line: 4763, col: 1, offset: 144311},
 			expr: &actionExpr{
-				pos: position{line: 4740, col: 20, offset: 143583},
+				pos: position{line: 4763, col: 20, offset: 144330},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4740, col: 20, offset: 143583},
+					pos: position{line: 4763, col: 20, offset: 144330},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4740, col: 20, offset: 143583},
+							pos:  position{line: 4763, col: 20, offset: 144330},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4740, col: 25, offset: 143588},
+							pos:  position{line: 4763, col: 25, offset: 144335},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4740, col: 40, offset: 143603},
+							pos:   position{line: 4763, col: 40, offset: 144350},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4740, col: 55, offset: 143618},
+								pos: position{line: 4763, col: 55, offset: 144365},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4740, col: 55, offset: 143618},
+									pos:  position{line: 4763, col: 55, offset: 144365},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12284,42 +12358,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4747, col: 1, offset: 143771},
+			pos:  position{line: 4770, col: 1, offset: 144518},
 			expr: &actionExpr{
-				pos: position{line: 4747, col: 28, offset: 143798},
+				pos: position{line: 4770, col: 28, offset: 144545},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4747, col: 28, offset: 143798},
+					pos: position{line: 4770, col: 28, offset: 144545},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4747, col: 28, offset: 143798},
+							pos:  position{line: 4770, col: 28, offset: 144545},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4747, col: 34, offset: 143804},
+							pos:   position{line: 4770, col: 34, offset: 144551},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4747, col: 40, offset: 143810},
+								pos: position{line: 4770, col: 40, offset: 144557},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4747, col: 40, offset: 143810},
+									pos:  position{line: 4770, col: 40, offset: 144557},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4747, col: 60, offset: 143830},
+							pos:   position{line: 4770, col: 60, offset: 144577},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4747, col: 65, offset: 143835},
+								pos: position{line: 4770, col: 65, offset: 144582},
 								expr: &seqExpr{
-									pos: position{line: 4747, col: 66, offset: 143836},
+									pos: position{line: 4770, col: 66, offset: 144583},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4747, col: 66, offset: 143836},
+											pos:  position{line: 4770, col: 66, offset: 144583},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4747, col: 72, offset: 143842},
+											pos:  position{line: 4770, col: 72, offset: 144589},
 											name: "EventCountArgument",
 										},
 									},
@@ -12332,30 +12406,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4803, col: 1, offset: 145719},
+			pos:  position{line: 4826, col: 1, offset: 146466},
 			expr: &actionExpr{
-				pos: position{line: 4803, col: 23, offset: 145741},
+				pos: position{line: 4826, col: 23, offset: 146488},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4803, col: 23, offset: 145741},
+					pos:   position{line: 4826, col: 23, offset: 146488},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4803, col: 28, offset: 145746},
+						pos: position{line: 4826, col: 28, offset: 146493},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4803, col: 28, offset: 145746},
+								pos:  position{line: 4826, col: 28, offset: 146493},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4803, col: 41, offset: 145759},
+								pos:  position{line: 4826, col: 41, offset: 146506},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4803, col: 58, offset: 145776},
+								pos:  position{line: 4826, col: 58, offset: 146523},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4803, col: 76, offset: 145794},
+								pos:  position{line: 4826, col: 76, offset: 146541},
 								name: "ListVixField",
 							},
 						},
@@ -12365,28 +12439,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4807, col: 1, offset: 145833},
+			pos:  position{line: 4830, col: 1, offset: 146580},
 			expr: &actionExpr{
-				pos: position{line: 4807, col: 15, offset: 145847},
+				pos: position{line: 4830, col: 15, offset: 146594},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4807, col: 15, offset: 145847},
+					pos: position{line: 4830, col: 15, offset: 146594},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4807, col: 15, offset: 145847},
+							pos:        position{line: 4830, col: 15, offset: 146594},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4807, col: 23, offset: 145855},
+							pos:  position{line: 4830, col: 23, offset: 146602},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4807, col: 29, offset: 145861},
+							pos:   position{line: 4830, col: 29, offset: 146608},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4807, col: 35, offset: 145867},
+								pos:  position{line: 4830, col: 35, offset: 146614},
 								name: "IndexName",
 							},
 						},
@@ -12396,28 +12470,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4810, col: 1, offset: 145923},
+			pos:  position{line: 4833, col: 1, offset: 146670},
 			expr: &actionExpr{
-				pos: position{line: 4810, col: 19, offset: 145941},
+				pos: position{line: 4833, col: 19, offset: 146688},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4810, col: 19, offset: 145941},
+					pos: position{line: 4833, col: 19, offset: 146688},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4810, col: 19, offset: 145941},
+							pos:        position{line: 4833, col: 19, offset: 146688},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4810, col: 31, offset: 145953},
+							pos:  position{line: 4833, col: 31, offset: 146700},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4810, col: 37, offset: 145959},
+							pos:   position{line: 4833, col: 37, offset: 146706},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4810, col: 43, offset: 145965},
+								pos:  position{line: 4833, col: 43, offset: 146712},
 								name: "Boolean",
 							},
 						},
@@ -12427,28 +12501,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4813, col: 1, offset: 146041},
+			pos:  position{line: 4836, col: 1, offset: 146788},
 			expr: &actionExpr{
-				pos: position{line: 4813, col: 20, offset: 146060},
+				pos: position{line: 4836, col: 20, offset: 146807},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4813, col: 20, offset: 146060},
+					pos: position{line: 4836, col: 20, offset: 146807},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4813, col: 20, offset: 146060},
+							pos:        position{line: 4836, col: 20, offset: 146807},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4813, col: 34, offset: 146074},
+							pos:  position{line: 4836, col: 34, offset: 146821},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4813, col: 40, offset: 146080},
+							pos:   position{line: 4836, col: 40, offset: 146827},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4813, col: 46, offset: 146086},
+								pos:  position{line: 4836, col: 46, offset: 146833},
 								name: "Boolean",
 							},
 						},
@@ -12458,28 +12532,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4816, col: 1, offset: 146164},
+			pos:  position{line: 4839, col: 1, offset: 146911},
 			expr: &actionExpr{
-				pos: position{line: 4816, col: 17, offset: 146180},
+				pos: position{line: 4839, col: 17, offset: 146927},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4816, col: 17, offset: 146180},
+					pos: position{line: 4839, col: 17, offset: 146927},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4816, col: 17, offset: 146180},
+							pos:        position{line: 4839, col: 17, offset: 146927},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4816, col: 28, offset: 146191},
+							pos:  position{line: 4839, col: 28, offset: 146938},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4816, col: 34, offset: 146197},
+							pos:   position{line: 4839, col: 34, offset: 146944},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4816, col: 40, offset: 146203},
+								pos:  position{line: 4839, col: 40, offset: 146950},
 								name: "Boolean",
 							},
 						},
@@ -12489,24 +12563,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4820, col: 1, offset: 146279},
+			pos:  position{line: 4843, col: 1, offset: 147026},
 			expr: &actionExpr{
-				pos: position{line: 4820, col: 14, offset: 146292},
+				pos: position{line: 4843, col: 14, offset: 147039},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4820, col: 14, offset: 146292},
+					pos: position{line: 4843, col: 14, offset: 147039},
 					expr: &seqExpr{
-						pos: position{line: 4820, col: 15, offset: 146293},
+						pos: position{line: 4843, col: 15, offset: 147040},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4820, col: 15, offset: 146293},
+								pos: position{line: 4843, col: 15, offset: 147040},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4820, col: 16, offset: 146294},
+									pos:  position{line: 4843, col: 16, offset: 147041},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4820, col: 22, offset: 146300,
+								line: 4843, col: 22, offset: 147047,
 							},
 						},
 					},
@@ -12515,39 +12589,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4825, col: 1, offset: 146373},
+			pos:  position{line: 4848, col: 1, offset: 147120},
 			expr: &actionExpr{
-				pos: position{line: 4825, col: 18, offset: 146390},
+				pos: position{line: 4848, col: 18, offset: 147137},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4825, col: 18, offset: 146390},
+					pos: position{line: 4848, col: 18, offset: 147137},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4825, col: 18, offset: 146390},
+							pos:  position{line: 4848, col: 18, offset: 147137},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4825, col: 23, offset: 146395},
+							pos:  position{line: 4848, col: 23, offset: 147142},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4825, col: 36, offset: 146408},
+							pos:   position{line: 4848, col: 36, offset: 147155},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4825, col: 49, offset: 146421},
+								pos: position{line: 4848, col: 49, offset: 147168},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4825, col: 49, offset: 146421},
+									pos:  position{line: 4848, col: 49, offset: 147168},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4825, col: 70, offset: 146442},
+							pos:   position{line: 4848, col: 70, offset: 147189},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4825, col: 77, offset: 146449},
+								pos: position{line: 4848, col: 77, offset: 147196},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4825, col: 77, offset: 146449},
+									pos:  position{line: 4848, col: 77, offset: 147196},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12558,32 +12632,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4854, col: 1, offset: 147176},
+			pos:  position{line: 4877, col: 1, offset: 147923},
 			expr: &actionExpr{
-				pos: position{line: 4854, col: 24, offset: 147199},
+				pos: position{line: 4877, col: 24, offset: 147946},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4854, col: 24, offset: 147199},
+					pos: position{line: 4877, col: 24, offset: 147946},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4854, col: 24, offset: 147199},
+							pos:  position{line: 4877, col: 24, offset: 147946},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4854, col: 30, offset: 147205},
+							pos:        position{line: 4877, col: 30, offset: 147952},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4854, col: 38, offset: 147213},
+							pos:  position{line: 4877, col: 38, offset: 147960},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4854, col: 44, offset: 147219},
+							pos:   position{line: 4877, col: 44, offset: 147966},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4854, col: 48, offset: 147223},
+								pos:  position{line: 4877, col: 48, offset: 147970},
 								name: "String",
 							},
 						},
@@ -12593,22 +12667,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 4858, col: 1, offset: 147269},
+			pos:  position{line: 4881, col: 1, offset: 148016},
 			expr: &actionExpr{
-				pos: position{line: 4858, col: 22, offset: 147290},
+				pos: position{line: 4881, col: 22, offset: 148037},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 4858, col: 22, offset: 147290},
+					pos: position{line: 4881, col: 22, offset: 148037},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4858, col: 22, offset: 147290},
+							pos:  position{line: 4881, col: 22, offset: 148037},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4858, col: 28, offset: 147296},
+							pos:   position{line: 4881, col: 28, offset: 148043},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4858, col: 38, offset: 147306},
+								pos:  position{line: 4881, col: 38, offset: 148053},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12618,36 +12692,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 4862, col: 1, offset: 147365},
+			pos:  position{line: 4885, col: 1, offset: 148112},
 			expr: &actionExpr{
-				pos: position{line: 4862, col: 18, offset: 147382},
+				pos: position{line: 4885, col: 18, offset: 148129},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4862, col: 18, offset: 147382},
+					pos: position{line: 4885, col: 18, offset: 148129},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4862, col: 18, offset: 147382},
+							pos:  position{line: 4885, col: 18, offset: 148129},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4862, col: 23, offset: 147387},
+							pos:  position{line: 4885, col: 23, offset: 148134},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 4862, col: 36, offset: 147400},
+							pos:   position{line: 4885, col: 36, offset: 148147},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4862, col: 42, offset: 147406},
+								pos:  position{line: 4885, col: 42, offset: 148153},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4862, col: 56, offset: 147420},
+							pos:   position{line: 4885, col: 56, offset: 148167},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4862, col: 62, offset: 147426},
+								pos: position{line: 4885, col: 62, offset: 148173},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4862, col: 62, offset: 147426},
+									pos:  position{line: 4885, col: 62, offset: 148173},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12658,22 +12732,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 4892, col: 1, offset: 148160},
+			pos:  position{line: 4915, col: 1, offset: 148907},
 			expr: &actionExpr{
-				pos: position{line: 4892, col: 18, offset: 148177},
+				pos: position{line: 4915, col: 18, offset: 148924},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 4892, col: 18, offset: 148177},
+					pos: position{line: 4915, col: 18, offset: 148924},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4892, col: 18, offset: 148177},
+							pos:  position{line: 4915, col: 18, offset: 148924},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4892, col: 24, offset: 148183},
+							pos:   position{line: 4915, col: 24, offset: 148930},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4892, col: 34, offset: 148193},
+								pos:  position{line: 4915, col: 34, offset: 148940},
 								name: "FieldName",
 							},
 						},
@@ -12683,32 +12757,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 4896, col: 1, offset: 148234},
+			pos:  position{line: 4919, col: 1, offset: 148981},
 			expr: &actionExpr{
-				pos: position{line: 4896, col: 18, offset: 148251},
+				pos: position{line: 4919, col: 18, offset: 148998},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4896, col: 18, offset: 148251},
+					pos: position{line: 4919, col: 18, offset: 148998},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4896, col: 18, offset: 148251},
+							pos:  position{line: 4919, col: 18, offset: 148998},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4896, col: 24, offset: 148257},
+							pos:        position{line: 4919, col: 24, offset: 149004},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4896, col: 32, offset: 148265},
+							pos:  position{line: 4919, col: 32, offset: 149012},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4896, col: 38, offset: 148271},
+							pos:   position{line: 4919, col: 38, offset: 149018},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4896, col: 47, offset: 148280},
+								pos:  position{line: 4919, col: 47, offset: 149027},
 								name: "IntegerAsString",
 							},
 						},
@@ -12718,26 +12792,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 4900, col: 1, offset: 148326},
+			pos:  position{line: 4923, col: 1, offset: 149073},
 			expr: &actionExpr{
-				pos: position{line: 4900, col: 16, offset: 148341},
+				pos: position{line: 4923, col: 16, offset: 149088},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 4900, col: 16, offset: 148341},
+					pos: position{line: 4923, col: 16, offset: 149088},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4900, col: 16, offset: 148341},
+							pos:  position{line: 4923, col: 16, offset: 149088},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4900, col: 22, offset: 148347},
+							pos:  position{line: 4923, col: 22, offset: 149094},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4900, col: 32, offset: 148357},
+							pos:   position{line: 4923, col: 32, offset: 149104},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4900, col: 42, offset: 148367},
+								pos:  position{line: 4923, col: 42, offset: 149114},
 								name: "BoolExpr",
 							},
 						},
@@ -12747,28 +12821,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 4904, col: 1, offset: 148427},
+			pos:  position{line: 4927, col: 1, offset: 149174},
 			expr: &actionExpr{
-				pos: position{line: 4904, col: 28, offset: 148454},
+				pos: position{line: 4927, col: 28, offset: 149201},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 4904, col: 28, offset: 148454},
+					pos: position{line: 4927, col: 28, offset: 149201},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4904, col: 28, offset: 148454},
+							pos:        position{line: 4927, col: 28, offset: 149201},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 37, offset: 148463},
+							pos:  position{line: 4927, col: 37, offset: 149210},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 43, offset: 148469},
+							pos:   position{line: 4927, col: 43, offset: 149216},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 51, offset: 148477},
+								pos:  position{line: 4927, col: 51, offset: 149224},
 								name: "Boolean",
 							},
 						},
@@ -12778,28 +12852,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 4913, col: 1, offset: 148661},
+			pos:  position{line: 4936, col: 1, offset: 149408},
 			expr: &actionExpr{
-				pos: position{line: 4913, col: 28, offset: 148688},
+				pos: position{line: 4936, col: 28, offset: 149435},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 4913, col: 28, offset: 148688},
+					pos: position{line: 4936, col: 28, offset: 149435},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4913, col: 28, offset: 148688},
+							pos:        position{line: 4936, col: 28, offset: 149435},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4913, col: 37, offset: 148697},
+							pos:  position{line: 4936, col: 37, offset: 149444},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4913, col: 43, offset: 148703},
+							pos:   position{line: 4936, col: 43, offset: 149450},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4913, col: 51, offset: 148711},
+								pos:  position{line: 4936, col: 51, offset: 149458},
 								name: "Boolean",
 							},
 						},
@@ -12809,28 +12883,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 4922, col: 1, offset: 148895},
+			pos:  position{line: 4945, col: 1, offset: 149642},
 			expr: &actionExpr{
-				pos: position{line: 4922, col: 27, offset: 148921},
+				pos: position{line: 4945, col: 27, offset: 149668},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 4922, col: 27, offset: 148921},
+					pos: position{line: 4945, col: 27, offset: 149668},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4922, col: 27, offset: 148921},
+							pos:        position{line: 4945, col: 27, offset: 149668},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4922, col: 35, offset: 148929},
+							pos:  position{line: 4945, col: 35, offset: 149676},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4922, col: 41, offset: 148935},
+							pos:   position{line: 4945, col: 41, offset: 149682},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4922, col: 48, offset: 148942},
+								pos:  position{line: 4945, col: 48, offset: 149689},
 								name: "PositiveInteger",
 							},
 						},
@@ -12840,28 +12914,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 4931, col: 1, offset: 149133},
+			pos:  position{line: 4954, col: 1, offset: 149880},
 			expr: &actionExpr{
-				pos: position{line: 4931, col: 25, offset: 149157},
+				pos: position{line: 4954, col: 25, offset: 149904},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 4931, col: 25, offset: 149157},
+					pos: position{line: 4954, col: 25, offset: 149904},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4931, col: 25, offset: 149157},
+							pos:        position{line: 4954, col: 25, offset: 149904},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4931, col: 31, offset: 149163},
+							pos:  position{line: 4954, col: 31, offset: 149910},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4931, col: 37, offset: 149169},
+							pos:   position{line: 4954, col: 37, offset: 149916},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4931, col: 44, offset: 149176},
+								pos:  position{line: 4954, col: 44, offset: 149923},
 								name: "PositiveInteger",
 							},
 						},
@@ -12871,30 +12945,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 4940, col: 1, offset: 149363},
+			pos:  position{line: 4963, col: 1, offset: 150110},
 			expr: &actionExpr{
-				pos: position{line: 4940, col: 22, offset: 149384},
+				pos: position{line: 4963, col: 22, offset: 150131},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4940, col: 22, offset: 149384},
+					pos:   position{line: 4963, col: 22, offset: 150131},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 4940, col: 41, offset: 149403},
+						pos: position{line: 4963, col: 41, offset: 150150},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4940, col: 41, offset: 149403},
+								pos:  position{line: 4963, col: 41, offset: 150150},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4940, col: 67, offset: 149429},
+								pos:  position{line: 4963, col: 67, offset: 150176},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4940, col: 93, offset: 149455},
+								pos:  position{line: 4963, col: 93, offset: 150202},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4940, col: 118, offset: 149480},
+								pos:  position{line: 4963, col: 118, offset: 150227},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -12904,35 +12978,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 4944, col: 1, offset: 149541},
+			pos:  position{line: 4967, col: 1, offset: 150288},
 			expr: &actionExpr{
-				pos: position{line: 4944, col: 26, offset: 149566},
+				pos: position{line: 4967, col: 26, offset: 150313},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4944, col: 26, offset: 149566},
+					pos: position{line: 4967, col: 26, offset: 150313},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4944, col: 26, offset: 149566},
+							pos:   position{line: 4967, col: 26, offset: 150313},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4944, col: 34, offset: 149574},
+								pos:  position{line: 4967, col: 34, offset: 150321},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4944, col: 53, offset: 149593},
+							pos:   position{line: 4967, col: 53, offset: 150340},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4944, col: 58, offset: 149598},
+								pos: position{line: 4967, col: 58, offset: 150345},
 								expr: &seqExpr{
-									pos: position{line: 4944, col: 59, offset: 149599},
+									pos: position{line: 4967, col: 59, offset: 150346},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4944, col: 59, offset: 149599},
+											pos:  position{line: 4967, col: 59, offset: 150346},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4944, col: 65, offset: 149605},
+											pos:  position{line: 4967, col: 65, offset: 150352},
 											name: "InputLookupOption",
 										},
 									},
@@ -12945,35 +13019,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 4986, col: 1, offset: 151051},
+			pos:  position{line: 5009, col: 1, offset: 151798},
 			expr: &actionExpr{
-				pos: position{line: 4986, col: 21, offset: 151071},
+				pos: position{line: 5009, col: 21, offset: 151818},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4986, col: 21, offset: 151071},
+					pos: position{line: 5009, col: 21, offset: 151818},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4986, col: 21, offset: 151071},
+							pos:  position{line: 5009, col: 21, offset: 151818},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4986, col: 26, offset: 151076},
+							pos:  position{line: 5009, col: 26, offset: 151823},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 4986, col: 42, offset: 151092},
+							pos:   position{line: 5009, col: 42, offset: 151839},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4986, col: 60, offset: 151110},
+								pos: position{line: 5009, col: 60, offset: 151857},
 								expr: &seqExpr{
-									pos: position{line: 4986, col: 61, offset: 151111},
+									pos: position{line: 5009, col: 61, offset: 151858},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4986, col: 61, offset: 151111},
+											pos:  position{line: 5009, col: 61, offset: 151858},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4986, col: 83, offset: 151133},
+											pos:  position{line: 5009, col: 83, offset: 151880},
 											name: "SPACE",
 										},
 									},
@@ -12981,20 +13055,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4986, col: 91, offset: 151141},
+							pos:   position{line: 5009, col: 91, offset: 151888},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4986, col: 101, offset: 151151},
+								pos:  position{line: 5009, col: 101, offset: 151898},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4986, col: 109, offset: 151159},
+							pos:   position{line: 5009, col: 109, offset: 151906},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4986, col: 121, offset: 151171},
+								pos: position{line: 5009, col: 121, offset: 151918},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4986, col: 122, offset: 151172},
+									pos:  position{line: 5009, col: 122, offset: 151919},
 									name: "WhereClause",
 								},
 							},
@@ -13005,15 +13079,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5008, col: 1, offset: 151822},
+			pos:  position{line: 5031, col: 1, offset: 152569},
 			expr: &actionExpr{
-				pos: position{line: 5008, col: 24, offset: 151845},
+				pos: position{line: 5031, col: 24, offset: 152592},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5008, col: 24, offset: 151845},
+					pos:   position{line: 5031, col: 24, offset: 152592},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5008, col: 41, offset: 151862},
+						pos:  position{line: 5031, col: 41, offset: 152609},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13021,124 +13095,124 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5020, col: 1, offset: 152254},
+			pos:  position{line: 5043, col: 1, offset: 153001},
 			expr: &choiceExpr{
-				pos: position{line: 5020, col: 12, offset: 152265},
+				pos: position{line: 5043, col: 12, offset: 153012},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 12, offset: 152265},
+						pos:  position{line: 5043, col: 12, offset: 153012},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 24, offset: 152277},
+						pos:  position{line: 5043, col: 24, offset: 153024},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 36, offset: 152289},
+						pos:  position{line: 5043, col: 36, offset: 153036},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 49, offset: 152302},
+						pos:  position{line: 5043, col: 49, offset: 153049},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 61, offset: 152314},
+						pos:  position{line: 5043, col: 61, offset: 153061},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 81, offset: 152334},
+						pos:  position{line: 5043, col: 81, offset: 153081},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 92, offset: 152345},
+						pos:  position{line: 5043, col: 92, offset: 153092},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 112, offset: 152365},
+						pos:  position{line: 5043, col: 112, offset: 153112},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 123, offset: 152376},
+						pos:  position{line: 5043, col: 123, offset: 153123},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 134, offset: 152387},
+						pos:  position{line: 5043, col: 134, offset: 153134},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 144, offset: 152397},
+						pos:  position{line: 5043, col: 144, offset: 153144},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 154, offset: 152407},
+						pos:  position{line: 5043, col: 154, offset: 153154},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 165, offset: 152418},
+						pos:  position{line: 5043, col: 165, offset: 153165},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 178, offset: 152431},
+						pos:  position{line: 5043, col: 178, offset: 153178},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 194, offset: 152447},
+						pos:  position{line: 5043, col: 194, offset: 153194},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 212, offset: 152465},
+						pos:  position{line: 5043, col: 212, offset: 153212},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 224, offset: 152477},
+						pos:  position{line: 5043, col: 224, offset: 153224},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 235, offset: 152488},
+						pos:  position{line: 5043, col: 235, offset: 153235},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 248, offset: 152501},
+						pos:  position{line: 5043, col: 248, offset: 153248},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 260, offset: 152513},
+						pos:  position{line: 5043, col: 260, offset: 153260},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 273, offset: 152526},
+						pos:  position{line: 5043, col: 273, offset: 153273},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 288, offset: 152541},
+						pos:  position{line: 5043, col: 288, offset: 153288},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 301, offset: 152554},
+						pos:  position{line: 5043, col: 301, offset: 153301},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 318, offset: 152571},
+						pos:  position{line: 5043, col: 318, offset: 153318},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 328, offset: 152581},
+						pos:  position{line: 5043, col: 328, offset: 153328},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 346, offset: 152599},
+						pos:  position{line: 5043, col: 346, offset: 153346},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 361, offset: 152614},
+						pos:  position{line: 5043, col: 361, offset: 153361},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 376, offset: 152629},
+						pos:  position{line: 5043, col: 376, offset: 153376},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5020, col: 391, offset: 152644},
+						pos:  position{line: 5043, col: 391, offset: 153391},
 						name: "CMD_INPUTLOOKUP",
 					},
 				},
@@ -13146,18 +13220,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5021, col: 1, offset: 152661},
+			pos:  position{line: 5044, col: 1, offset: 153408},
 			expr: &seqExpr{
-				pos: position{line: 5021, col: 15, offset: 152675},
+				pos: position{line: 5044, col: 15, offset: 153422},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5021, col: 15, offset: 152675},
+						pos:        position{line: 5044, col: 15, offset: 153422},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5021, col: 24, offset: 152684},
+						pos:  position{line: 5044, col: 24, offset: 153431},
 						name: "SPACE",
 					},
 				},
@@ -13165,18 +13239,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5022, col: 1, offset: 152690},
+			pos:  position{line: 5045, col: 1, offset: 153437},
 			expr: &seqExpr{
-				pos: position{line: 5022, col: 14, offset: 152703},
+				pos: position{line: 5045, col: 14, offset: 153450},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5022, col: 14, offset: 152703},
+						pos:        position{line: 5045, col: 14, offset: 153450},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5022, col: 22, offset: 152711},
+						pos:  position{line: 5045, col: 22, offset: 153458},
 						name: "SPACE",
 					},
 				},
@@ -13184,18 +13258,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5023, col: 1, offset: 152717},
+			pos:  position{line: 5046, col: 1, offset: 153464},
 			expr: &seqExpr{
-				pos: position{line: 5023, col: 14, offset: 152730},
+				pos: position{line: 5046, col: 14, offset: 153477},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5023, col: 14, offset: 152730},
+						pos:        position{line: 5046, col: 14, offset: 153477},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5023, col: 22, offset: 152738},
+						pos:  position{line: 5046, col: 22, offset: 153485},
 						name: "SPACE",
 					},
 				},
@@ -13203,18 +13277,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5024, col: 1, offset: 152744},
+			pos:  position{line: 5047, col: 1, offset: 153491},
 			expr: &seqExpr{
-				pos: position{line: 5024, col: 20, offset: 152763},
+				pos: position{line: 5047, col: 20, offset: 153510},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5024, col: 20, offset: 152763},
+						pos:        position{line: 5047, col: 20, offset: 153510},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5024, col: 34, offset: 152777},
+						pos:  position{line: 5047, col: 34, offset: 153524},
 						name: "SPACE",
 					},
 				},
@@ -13222,18 +13296,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5025, col: 1, offset: 152783},
+			pos:  position{line: 5048, col: 1, offset: 153530},
 			expr: &seqExpr{
-				pos: position{line: 5025, col: 15, offset: 152797},
+				pos: position{line: 5048, col: 15, offset: 153544},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5025, col: 15, offset: 152797},
+						pos:        position{line: 5048, col: 15, offset: 153544},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5025, col: 24, offset: 152806},
+						pos:  position{line: 5048, col: 24, offset: 153553},
 						name: "SPACE",
 					},
 				},
@@ -13241,18 +13315,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5026, col: 1, offset: 152812},
+			pos:  position{line: 5049, col: 1, offset: 153559},
 			expr: &seqExpr{
-				pos: position{line: 5026, col: 14, offset: 152825},
+				pos: position{line: 5049, col: 14, offset: 153572},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5026, col: 14, offset: 152825},
+						pos:        position{line: 5049, col: 14, offset: 153572},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5026, col: 22, offset: 152833},
+						pos:  position{line: 5049, col: 22, offset: 153580},
 						name: "SPACE",
 					},
 				},
@@ -13260,9 +13334,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5027, col: 1, offset: 152839},
+			pos:  position{line: 5050, col: 1, offset: 153586},
 			expr: &litMatcher{
-				pos:        position{line: 5027, col: 22, offset: 152860},
+				pos:        position{line: 5050, col: 22, offset: 153607},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13270,16 +13344,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5028, col: 1, offset: 152867},
+			pos:  position{line: 5051, col: 1, offset: 153614},
 			expr: &seqExpr{
-				pos: position{line: 5028, col: 13, offset: 152879},
+				pos: position{line: 5051, col: 13, offset: 153626},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5028, col: 13, offset: 152879},
+						pos:  position{line: 5051, col: 13, offset: 153626},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5028, col: 31, offset: 152897},
+						pos:  position{line: 5051, col: 31, offset: 153644},
 						name: "SPACE",
 					},
 				},
@@ -13287,9 +13361,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5029, col: 1, offset: 152903},
+			pos:  position{line: 5052, col: 1, offset: 153650},
 			expr: &litMatcher{
-				pos:        position{line: 5029, col: 22, offset: 152924},
+				pos:        position{line: 5052, col: 22, offset: 153671},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13297,16 +13371,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5030, col: 1, offset: 152931},
+			pos:  position{line: 5053, col: 1, offset: 153678},
 			expr: &seqExpr{
-				pos: position{line: 5030, col: 13, offset: 152943},
+				pos: position{line: 5053, col: 13, offset: 153690},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5030, col: 13, offset: 152943},
+						pos:  position{line: 5053, col: 13, offset: 153690},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5030, col: 31, offset: 152961},
+						pos:  position{line: 5053, col: 31, offset: 153708},
 						name: "SPACE",
 					},
 				},
@@ -13314,18 +13388,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5031, col: 1, offset: 152967},
+			pos:  position{line: 5054, col: 1, offset: 153714},
 			expr: &seqExpr{
-				pos: position{line: 5031, col: 13, offset: 152979},
+				pos: position{line: 5054, col: 13, offset: 153726},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5031, col: 13, offset: 152979},
+						pos:        position{line: 5054, col: 13, offset: 153726},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5031, col: 20, offset: 152986},
+						pos:  position{line: 5054, col: 20, offset: 153733},
 						name: "SPACE",
 					},
 				},
@@ -13333,18 +13407,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5032, col: 1, offset: 152992},
+			pos:  position{line: 5055, col: 1, offset: 153739},
 			expr: &seqExpr{
-				pos: position{line: 5032, col: 12, offset: 153003},
+				pos: position{line: 5055, col: 12, offset: 153750},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5032, col: 12, offset: 153003},
+						pos:        position{line: 5055, col: 12, offset: 153750},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5032, col: 18, offset: 153009},
+						pos:  position{line: 5055, col: 18, offset: 153756},
 						name: "SPACE",
 					},
 				},
@@ -13352,18 +13426,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5033, col: 1, offset: 153015},
+			pos:  position{line: 5056, col: 1, offset: 153762},
 			expr: &seqExpr{
-				pos: position{line: 5033, col: 13, offset: 153027},
+				pos: position{line: 5056, col: 13, offset: 153774},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5033, col: 13, offset: 153027},
+						pos:        position{line: 5056, col: 13, offset: 153774},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5033, col: 20, offset: 153034},
+						pos:  position{line: 5056, col: 20, offset: 153781},
 						name: "SPACE",
 					},
 				},
@@ -13371,9 +13445,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5034, col: 1, offset: 153040},
+			pos:  position{line: 5057, col: 1, offset: 153787},
 			expr: &litMatcher{
-				pos:        position{line: 5034, col: 12, offset: 153051},
+				pos:        position{line: 5057, col: 12, offset: 153798},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13381,9 +13455,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5035, col: 1, offset: 153057},
+			pos:  position{line: 5058, col: 1, offset: 153804},
 			expr: &litMatcher{
-				pos:        position{line: 5035, col: 13, offset: 153069},
+				pos:        position{line: 5058, col: 13, offset: 153816},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13391,18 +13465,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5036, col: 1, offset: 153076},
+			pos:  position{line: 5059, col: 1, offset: 153823},
 			expr: &seqExpr{
-				pos: position{line: 5036, col: 15, offset: 153090},
+				pos: position{line: 5059, col: 15, offset: 153837},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5036, col: 15, offset: 153090},
+						pos:        position{line: 5059, col: 15, offset: 153837},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5036, col: 24, offset: 153099},
+						pos:  position{line: 5059, col: 24, offset: 153846},
 						name: "SPACE",
 					},
 				},
@@ -13410,18 +13484,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5037, col: 1, offset: 153105},
+			pos:  position{line: 5060, col: 1, offset: 153852},
 			expr: &seqExpr{
-				pos: position{line: 5037, col: 18, offset: 153122},
+				pos: position{line: 5060, col: 18, offset: 153869},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5037, col: 18, offset: 153122},
+						pos:        position{line: 5060, col: 18, offset: 153869},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5037, col: 30, offset: 153134},
+						pos:  position{line: 5060, col: 30, offset: 153881},
 						name: "SPACE",
 					},
 				},
@@ -13429,18 +13503,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5038, col: 1, offset: 153140},
+			pos:  position{line: 5061, col: 1, offset: 153887},
 			expr: &seqExpr{
-				pos: position{line: 5038, col: 12, offset: 153151},
+				pos: position{line: 5061, col: 12, offset: 153898},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5038, col: 12, offset: 153151},
+						pos:        position{line: 5061, col: 12, offset: 153898},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5038, col: 18, offset: 153157},
+						pos:  position{line: 5061, col: 18, offset: 153904},
 						name: "SPACE",
 					},
 				},
@@ -13448,9 +13522,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5039, col: 1, offset: 153163},
+			pos:  position{line: 5062, col: 1, offset: 153910},
 			expr: &litMatcher{
-				pos:        position{line: 5039, col: 13, offset: 153175},
+				pos:        position{line: 5062, col: 13, offset: 153922},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13458,18 +13532,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5040, col: 1, offset: 153182},
+			pos:  position{line: 5063, col: 1, offset: 153929},
 			expr: &seqExpr{
-				pos: position{line: 5040, col: 20, offset: 153201},
+				pos: position{line: 5063, col: 20, offset: 153948},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5040, col: 20, offset: 153201},
+						pos:        position{line: 5063, col: 20, offset: 153948},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5040, col: 34, offset: 153215},
+						pos:  position{line: 5063, col: 34, offset: 153962},
 						name: "SPACE",
 					},
 				},
@@ -13477,9 +13551,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5041, col: 1, offset: 153221},
+			pos:  position{line: 5064, col: 1, offset: 153968},
 			expr: &litMatcher{
-				pos:        position{line: 5041, col: 14, offset: 153234},
+				pos:        position{line: 5064, col: 14, offset: 153981},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13487,22 +13561,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5042, col: 1, offset: 153242},
+			pos:  position{line: 5065, col: 1, offset: 153989},
 			expr: &seqExpr{
-				pos: position{line: 5042, col: 21, offset: 153262},
+				pos: position{line: 5065, col: 21, offset: 154009},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5042, col: 21, offset: 153262},
+						pos:  position{line: 5065, col: 21, offset: 154009},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5042, col: 27, offset: 153268},
+						pos:        position{line: 5065, col: 27, offset: 154015},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5042, col: 36, offset: 153277},
+						pos:  position{line: 5065, col: 36, offset: 154024},
 						name: "SPACE",
 					},
 				},
@@ -13510,9 +13584,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5043, col: 1, offset: 153283},
+			pos:  position{line: 5066, col: 1, offset: 154030},
 			expr: &litMatcher{
-				pos:        position{line: 5043, col: 15, offset: 153297},
+				pos:        position{line: 5066, col: 15, offset: 154044},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -13520,9 +13594,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5044, col: 1, offset: 153306},
+			pos:  position{line: 5067, col: 1, offset: 154053},
 			expr: &litMatcher{
-				pos:        position{line: 5044, col: 14, offset: 153319},
+				pos:        position{line: 5067, col: 14, offset: 154066},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -13530,9 +13604,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5045, col: 1, offset: 153327},
+			pos:  position{line: 5068, col: 1, offset: 154074},
 			expr: &litMatcher{
-				pos:        position{line: 5045, col: 15, offset: 153341},
+				pos:        position{line: 5068, col: 15, offset: 154088},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -13540,9 +13614,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5046, col: 1, offset: 153350},
+			pos:  position{line: 5069, col: 1, offset: 154097},
 			expr: &litMatcher{
-				pos:        position{line: 5046, col: 17, offset: 153366},
+				pos:        position{line: 5069, col: 17, offset: 154113},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -13550,9 +13624,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5047, col: 1, offset: 153377},
+			pos:  position{line: 5070, col: 1, offset: 154124},
 			expr: &litMatcher{
-				pos:        position{line: 5047, col: 15, offset: 153391},
+				pos:        position{line: 5070, col: 15, offset: 154138},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -13560,9 +13634,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5048, col: 1, offset: 153400},
+			pos:  position{line: 5071, col: 1, offset: 154147},
 			expr: &litMatcher{
-				pos:        position{line: 5048, col: 19, offset: 153418},
+				pos:        position{line: 5071, col: 19, offset: 154165},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -13570,9 +13644,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5049, col: 1, offset: 153431},
+			pos:  position{line: 5072, col: 1, offset: 154178},
 			expr: &litMatcher{
-				pos:        position{line: 5049, col: 17, offset: 153447},
+				pos:        position{line: 5072, col: 17, offset: 154194},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -13580,9 +13654,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5050, col: 1, offset: 153458},
+			pos:  position{line: 5073, col: 1, offset: 154205},
 			expr: &litMatcher{
-				pos:        position{line: 5050, col: 17, offset: 153474},
+				pos:        position{line: 5073, col: 17, offset: 154221},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -13590,18 +13664,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5051, col: 1, offset: 153485},
+			pos:  position{line: 5074, col: 1, offset: 154232},
 			expr: &seqExpr{
-				pos: position{line: 5051, col: 20, offset: 153504},
+				pos: position{line: 5074, col: 20, offset: 154251},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5051, col: 20, offset: 153504},
+						pos:        position{line: 5074, col: 20, offset: 154251},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5051, col: 34, offset: 153518},
+						pos:  position{line: 5074, col: 34, offset: 154265},
 						name: "SPACE",
 					},
 				},
@@ -13609,27 +13683,27 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5052, col: 1, offset: 153524},
+			pos:  position{line: 5075, col: 1, offset: 154271},
 			expr: &seqExpr{
-				pos: position{line: 5052, col: 16, offset: 153539},
+				pos: position{line: 5075, col: 16, offset: 154286},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5052, col: 16, offset: 153539},
+						pos: position{line: 5075, col: 16, offset: 154286},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5052, col: 16, offset: 153539},
+							pos:  position{line: 5075, col: 16, offset: 154286},
 							name: "SPACE",
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5052, col: 23, offset: 153546},
+						pos:        position{line: 5075, col: 23, offset: 154293},
 						val:        ".",
 						ignoreCase: false,
 						want:       "\".\"",
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5052, col: 27, offset: 153550},
+						pos: position{line: 5075, col: 27, offset: 154297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5052, col: 27, offset: 153550},
+							pos:  position{line: 5075, col: 27, offset: 154297},
 							name: "SPACE",
 						},
 					},
@@ -13638,9 +13712,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5053, col: 1, offset: 153557},
+			pos:  position{line: 5076, col: 1, offset: 154304},
 			expr: &litMatcher{
-				pos:        position{line: 5053, col: 17, offset: 153573},
+				pos:        position{line: 5076, col: 17, offset: 154320},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -13648,115 +13722,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5056, col: 1, offset: 153688},
+			pos:  position{line: 5079, col: 1, offset: 154435},
 			expr: &choiceExpr{
-				pos: position{line: 5056, col: 16, offset: 153703},
+				pos: position{line: 5079, col: 16, offset: 154450},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5056, col: 16, offset: 153703},
+						pos:        position{line: 5079, col: 16, offset: 154450},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5056, col: 47, offset: 153734},
+						pos:        position{line: 5079, col: 47, offset: 154481},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5056, col: 55, offset: 153742},
+						pos:        position{line: 5079, col: 55, offset: 154489},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 16, offset: 153765},
+						pos:        position{line: 5080, col: 16, offset: 154512},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 26, offset: 153775},
+						pos:        position{line: 5080, col: 26, offset: 154522},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 34, offset: 153783},
+						pos:        position{line: 5080, col: 34, offset: 154530},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 42, offset: 153791},
+						pos:        position{line: 5080, col: 42, offset: 154538},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 50, offset: 153799},
+						pos:        position{line: 5080, col: 50, offset: 154546},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 58, offset: 153807},
+						pos:        position{line: 5080, col: 58, offset: 154554},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5057, col: 66, offset: 153815},
+						pos:        position{line: 5080, col: 66, offset: 154562},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 16, offset: 153837},
+						pos:        position{line: 5081, col: 16, offset: 154584},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 26, offset: 153847},
+						pos:        position{line: 5081, col: 26, offset: 154594},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 34, offset: 153855},
+						pos:        position{line: 5081, col: 34, offset: 154602},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 42, offset: 153863},
+						pos:        position{line: 5081, col: 42, offset: 154610},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 50, offset: 153871},
+						pos:        position{line: 5081, col: 50, offset: 154618},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 58, offset: 153879},
+						pos:        position{line: 5081, col: 58, offset: 154626},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 66, offset: 153887},
+						pos:        position{line: 5081, col: 66, offset: 154634},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5058, col: 74, offset: 153895},
+						pos:        position{line: 5081, col: 74, offset: 154642},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -13766,25 +13840,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5059, col: 1, offset: 153901},
+			pos:  position{line: 5082, col: 1, offset: 154648},
 			expr: &choiceExpr{
-				pos: position{line: 5059, col: 16, offset: 153916},
+				pos: position{line: 5082, col: 16, offset: 154663},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5059, col: 16, offset: 153916},
+						pos:        position{line: 5082, col: 16, offset: 154663},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5059, col: 30, offset: 153930},
+						pos:        position{line: 5082, col: 30, offset: 154677},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5059, col: 36, offset: 153936},
+						pos:        position{line: 5082, col: 36, offset: 154683},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -13794,18 +13868,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5063, col: 1, offset: 154092},
+			pos:  position{line: 5086, col: 1, offset: 154839},
 			expr: &seqExpr{
-				pos: position{line: 5063, col: 8, offset: 154099},
+				pos: position{line: 5086, col: 8, offset: 154846},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5063, col: 8, offset: 154099},
+						pos:        position{line: 5086, col: 8, offset: 154846},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5063, col: 14, offset: 154105},
+						pos:  position{line: 5086, col: 14, offset: 154852},
 						name: "SPACE",
 					},
 				},
@@ -13813,22 +13887,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5064, col: 1, offset: 154111},
+			pos:  position{line: 5087, col: 1, offset: 154858},
 			expr: &seqExpr{
-				pos: position{line: 5064, col: 7, offset: 154117},
+				pos: position{line: 5087, col: 7, offset: 154864},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5064, col: 7, offset: 154117},
+						pos:  position{line: 5087, col: 7, offset: 154864},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5064, col: 13, offset: 154123},
+						pos:        position{line: 5087, col: 13, offset: 154870},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5064, col: 18, offset: 154128},
+						pos:  position{line: 5087, col: 18, offset: 154875},
 						name: "SPACE",
 					},
 				},
@@ -13836,22 +13910,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5065, col: 1, offset: 154134},
+			pos:  position{line: 5088, col: 1, offset: 154881},
 			expr: &seqExpr{
-				pos: position{line: 5065, col: 8, offset: 154141},
+				pos: position{line: 5088, col: 8, offset: 154888},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 8, offset: 154141},
+						pos:  position{line: 5088, col: 8, offset: 154888},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5065, col: 14, offset: 154147},
+						pos:        position{line: 5088, col: 14, offset: 154894},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5065, col: 20, offset: 154153},
+						pos:  position{line: 5088, col: 20, offset: 154900},
 						name: "SPACE",
 					},
 				},
@@ -13859,22 +13933,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5066, col: 1, offset: 154159},
+			pos:  position{line: 5089, col: 1, offset: 154906},
 			expr: &seqExpr{
-				pos: position{line: 5066, col: 9, offset: 154167},
+				pos: position{line: 5089, col: 9, offset: 154914},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5066, col: 9, offset: 154167},
+						pos:  position{line: 5089, col: 9, offset: 154914},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5066, col: 24, offset: 154182},
+						pos:        position{line: 5089, col: 24, offset: 154929},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5066, col: 28, offset: 154186},
+						pos:  position{line: 5089, col: 28, offset: 154933},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13882,22 +13956,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5067, col: 1, offset: 154201},
+			pos:  position{line: 5090, col: 1, offset: 154948},
 			expr: &seqExpr{
-				pos: position{line: 5067, col: 7, offset: 154207},
+				pos: position{line: 5090, col: 7, offset: 154954},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5067, col: 7, offset: 154207},
+						pos:  position{line: 5090, col: 7, offset: 154954},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5067, col: 13, offset: 154213},
+						pos:        position{line: 5090, col: 13, offset: 154960},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5067, col: 19, offset: 154219},
+						pos:  position{line: 5090, col: 19, offset: 154966},
 						name: "SPACE",
 					},
 				},
@@ -13905,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5068, col: 1, offset: 154245},
+			pos:  position{line: 5091, col: 1, offset: 154992},
 			expr: &seqExpr{
-				pos: position{line: 5068, col: 7, offset: 154251},
+				pos: position{line: 5091, col: 7, offset: 154998},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5068, col: 7, offset: 154251},
+						pos:  position{line: 5091, col: 7, offset: 154998},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5068, col: 13, offset: 154257},
+						pos:        position{line: 5091, col: 13, offset: 155004},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5068, col: 19, offset: 154263},
+						pos:  position{line: 5091, col: 19, offset: 155010},
 						name: "SPACE",
 					},
 				},
@@ -13928,22 +14002,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5070, col: 1, offset: 154290},
+			pos:  position{line: 5093, col: 1, offset: 155037},
 			expr: &seqExpr{
-				pos: position{line: 5070, col: 10, offset: 154299},
+				pos: position{line: 5093, col: 10, offset: 155046},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5070, col: 10, offset: 154299},
+						pos:  position{line: 5093, col: 10, offset: 155046},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5070, col: 25, offset: 154314},
+						pos:        position{line: 5093, col: 25, offset: 155061},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5070, col: 29, offset: 154318},
+						pos:  position{line: 5093, col: 29, offset: 155065},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13951,22 +14025,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5071, col: 1, offset: 154333},
+			pos:  position{line: 5094, col: 1, offset: 155080},
 			expr: &seqExpr{
-				pos: position{line: 5071, col: 10, offset: 154342},
+				pos: position{line: 5094, col: 10, offset: 155089},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5071, col: 10, offset: 154342},
+						pos:  position{line: 5094, col: 10, offset: 155089},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5071, col: 25, offset: 154357},
+						pos:        position{line: 5094, col: 25, offset: 155104},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5071, col: 29, offset: 154361},
+						pos:  position{line: 5094, col: 29, offset: 155108},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -13974,9 +14048,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5072, col: 1, offset: 154376},
+			pos:  position{line: 5095, col: 1, offset: 155123},
 			expr: &litMatcher{
-				pos:        position{line: 5072, col: 10, offset: 154385},
+				pos:        position{line: 5095, col: 10, offset: 155132},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -13984,18 +14058,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5073, col: 1, offset: 154389},
+			pos:  position{line: 5096, col: 1, offset: 155136},
 			expr: &seqExpr{
-				pos: position{line: 5073, col: 12, offset: 154400},
+				pos: position{line: 5096, col: 12, offset: 155147},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5073, col: 12, offset: 154400},
+						pos:        position{line: 5096, col: 12, offset: 155147},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5073, col: 16, offset: 154404},
+						pos:  position{line: 5096, col: 16, offset: 155151},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14003,16 +14077,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5074, col: 1, offset: 154419},
+			pos:  position{line: 5097, col: 1, offset: 155166},
 			expr: &seqExpr{
-				pos: position{line: 5074, col: 12, offset: 154430},
+				pos: position{line: 5097, col: 12, offset: 155177},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5074, col: 12, offset: 154430},
+						pos:  position{line: 5097, col: 12, offset: 155177},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5074, col: 27, offset: 154445},
+						pos:        position{line: 5097, col: 27, offset: 155192},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14022,40 +14096,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5076, col: 1, offset: 154450},
+			pos:  position{line: 5099, col: 1, offset: 155197},
 			expr: &notExpr{
-				pos: position{line: 5076, col: 8, offset: 154457},
+				pos: position{line: 5099, col: 8, offset: 155204},
 				expr: &anyMatcher{
-					line: 5076, col: 9, offset: 154458,
+					line: 5099, col: 9, offset: 155205,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5077, col: 1, offset: 154460},
+			pos:  position{line: 5100, col: 1, offset: 155207},
 			expr: &choiceExpr{
-				pos: position{line: 5077, col: 15, offset: 154474},
+				pos: position{line: 5100, col: 15, offset: 155221},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5077, col: 15, offset: 154474},
+						pos:        position{line: 5100, col: 15, offset: 155221},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5077, col: 21, offset: 154480},
+						pos:        position{line: 5100, col: 21, offset: 155227},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5077, col: 28, offset: 154487},
+						pos:        position{line: 5100, col: 28, offset: 155234},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5077, col: 35, offset: 154494},
+						pos:        position{line: 5100, col: 35, offset: 155241},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14065,37 +14139,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5078, col: 1, offset: 154499},
+			pos:  position{line: 5101, col: 1, offset: 155246},
 			expr: &choiceExpr{
-				pos: position{line: 5078, col: 10, offset: 154508},
+				pos: position{line: 5101, col: 10, offset: 155255},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5078, col: 11, offset: 154509},
+						pos: position{line: 5101, col: 11, offset: 155256},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5078, col: 11, offset: 154509},
+								pos: position{line: 5101, col: 11, offset: 155256},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5078, col: 11, offset: 154509},
+									pos:  position{line: 5101, col: 11, offset: 155256},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5078, col: 23, offset: 154521},
+								pos:  position{line: 5101, col: 23, offset: 155268},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5078, col: 31, offset: 154529},
+								pos: position{line: 5101, col: 31, offset: 155276},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5078, col: 31, offset: 154529},
+									pos:  position{line: 5101, col: 31, offset: 155276},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5078, col: 46, offset: 154544},
+						pos: position{line: 5101, col: 46, offset: 155291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5078, col: 46, offset: 154544},
+							pos:  position{line: 5101, col: 46, offset: 155291},
 							name: "WHITESPACE",
 						},
 					},
@@ -14104,38 +14178,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5079, col: 1, offset: 154556},
+			pos:  position{line: 5102, col: 1, offset: 155303},
 			expr: &seqExpr{
-				pos: position{line: 5079, col: 12, offset: 154567},
+				pos: position{line: 5102, col: 12, offset: 155314},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5079, col: 12, offset: 154567},
+						pos:        position{line: 5102, col: 12, offset: 155314},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5079, col: 18, offset: 154573},
+						pos: position{line: 5102, col: 18, offset: 155320},
 						expr: &seqExpr{
-							pos: position{line: 5079, col: 19, offset: 154574},
+							pos: position{line: 5102, col: 19, offset: 155321},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5079, col: 19, offset: 154574},
+									pos: position{line: 5102, col: 19, offset: 155321},
 									expr: &litMatcher{
-										pos:        position{line: 5079, col: 21, offset: 154576},
+										pos:        position{line: 5102, col: 21, offset: 155323},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5079, col: 28, offset: 154583,
+									line: 5102, col: 28, offset: 155330,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5079, col: 32, offset: 154587},
+						pos:        position{line: 5102, col: 32, offset: 155334},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14145,16 +14219,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5080, col: 1, offset: 154593},
+			pos:  position{line: 5103, col: 1, offset: 155340},
 			expr: &choiceExpr{
-				pos: position{line: 5080, col: 20, offset: 154612},
+				pos: position{line: 5103, col: 20, offset: 155359},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5080, col: 20, offset: 154612},
+						pos:  position{line: 5103, col: 20, offset: 155359},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5080, col: 28, offset: 154620},
+						pos:        position{line: 5103, col: 28, offset: 155367},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14164,16 +14238,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5081, col: 1, offset: 154623},
+			pos:  position{line: 5104, col: 1, offset: 155370},
 			expr: &choiceExpr{
-				pos: position{line: 5081, col: 19, offset: 154641},
+				pos: position{line: 5104, col: 19, offset: 155388},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5081, col: 19, offset: 154641},
+						pos:  position{line: 5104, col: 19, offset: 155388},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5081, col: 27, offset: 154649},
+						pos:  position{line: 5104, col: 27, offset: 155396},
 						name: "SPACE",
 					},
 				},
@@ -18877,13 +18951,15 @@ func (p *parser) callonFieldWithStringValue1() (any, error) {
 	return p.cur.onFieldWithStringValue1(stack["keyValuePair"])
 }
 
-func (c *current) onNamedFieldWithStringValue1(key, op, value any) (any, error) {
+func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (any, error) {
+	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:     op.(string),
-			Field:  key.(string),
-			Values: value,
+			Op:                   op.(string),
+			Field:                key.(string),
+			Values:               ssr.value,
+			ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
 		},
 	}
 	return node, nil
@@ -18892,16 +18968,18 @@ func (c *current) onNamedFieldWithStringValue1(key, op, value any) (any, error) 
 func (p *parser) callonNamedFieldWithStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNamedFieldWithStringValue1(stack["key"], stack["op"], stack["value"])
+	return p.cur.onNamedFieldWithStringValue1(stack["key"], stack["op"], stack["stringSearchReq"])
 }
 
-func (c *current) onUnnamedFieldWithStringValue1(value any) (any, error) {
+func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, error) {
+	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
-			Op:     "=",
-			Field:  "*",
-			Values: value,
+			Op:                   "=",
+			Field:                "*",
+			Values:               ssr.value,
+			ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
 		},
 	}
 	return node, nil
@@ -18910,7 +18988,33 @@ func (c *current) onUnnamedFieldWithStringValue1(value any) (any, error) {
 func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onUnnamedFieldWithStringValue1(stack["value"])
+	return p.cur.onUnnamedFieldWithStringValue1(stack["stringSearchReq"])
+}
+
+func (c *current) onCaseSensitiveString1(value any) (any, error) {
+	return &StringSearchRequest{
+		value:                value,
+		valueIsCaseSensitive: true,
+	}, nil
+}
+
+func (p *parser) callonCaseSensitiveString1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCaseSensitiveString1(stack["value"])
+}
+
+func (c *current) onCaseInsensitiveString1(value any) (any, error) {
+	return &StringSearchRequest{
+		value:                strings.ToLower(value.(string)),
+		valueIsCaseSensitive: false,
+	}, nil
+}
+
+func (p *parser) callonCaseInsensitiveString1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCaseInsensitiveString1(stack["value"])
 }
 
 func (c *current) onFieldNameList1(first, rest any) (any, error) {

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -474,6 +474,11 @@ type FormatResultsRequestArguments struct {
     formatResultExpr *structs.FormatResultsRequest
 }
 
+type StringSearchRequest struct {
+	value interface{}
+	valueIsCaseSensitive bool
+}
+
 }
 
 Start <- SPACE? initialSearch:(InitialSearchBlock) filterBlocks:(FilterBlock)* queryAggBlocks:(QueryAggergatorBlock)* SPACE? EOF {
@@ -3860,28 +3865,46 @@ FieldWithStringValue <- keyValuePair:(NamedFieldWithStringValue / UnnamedFieldWi
     return keyValuePair, nil
 }
 
-NamedFieldWithStringValue <- key:FieldName op:EqualityOperator value:String {
+NamedFieldWithStringValue <- key:FieldName op:EqualityOperator stringSearchReq:(CaseSensitiveString / CaseInsensitiveString) {
+    ssr := stringSearchReq.(*StringSearchRequest)
     node := &ast.Node{
         NodeType: ast.NodeTerminal,
         Comparison:ast.Comparison{
             Op: op.(string),
             Field: key.(string),
-            Values: value,
+            Values: ssr.value,
+            ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
         },
     }
     return node, nil
 }
 
-UnnamedFieldWithStringValue <- value:String {
+UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsensitiveString) {
+    ssr := stringSearchReq.(*StringSearchRequest)
     node := &ast.Node{
         NodeType: ast.NodeTerminal,
         Comparison:ast.Comparison{
             Op: "=",
             Field: "*",
-            Values: value,
+            Values: ssr.value,
+            ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
         },
     }
     return node, nil
+}
+
+CaseSensitiveString <- "CASE" L_PAREN value:String R_PAREN {
+    return &StringSearchRequest{
+        value: value,
+        valueIsCaseSensitive: true,
+    }, nil
+}
+
+CaseInsensitiveString <- value:String {
+    return &StringSearchRequest{
+        value: strings.ToLower(value.(string)),
+        valueIsCaseSensitive: false,
+    }, nil
 }
 
 // Parses one or more FieldNames separated by a comma and space.

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -475,9 +475,9 @@ type FormatResultsRequestArguments struct {
 }
 
 type StringSearchRequest struct {
-	value interface{}
+    value interface{}
     originalValue interface{}
-	valueIsCaseInSensitive bool
+    caseInsensitive bool
 }
 
 }
@@ -3875,7 +3875,7 @@ NamedFieldWithStringValue <- key:FieldName op:EqualityOperator stringSearchReq:(
             Field: key.(string),
             Values: ssr.value,
             OriginalValues: ssr.originalValue,
-            ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
+            CaseInsensitive: ssr.caseInsensitive,
         },
     }
     return node, nil
@@ -3890,7 +3890,7 @@ UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsens
             Field: "*",
             Values: ssr.value,
             OriginalValues: ssr.originalValue,
-            ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
+            CaseInsensitive: ssr.caseInsensitive,
         },
     }
     return node, nil
@@ -3900,7 +3900,7 @@ CaseSensitiveString <- "CASE" L_PAREN value:String R_PAREN {
     return &StringSearchRequest{
         value: value,
         originalValue: value,
-        valueIsCaseInSensitive: false,
+        caseInsensitive: false,
     }, nil
 }
 
@@ -3908,7 +3908,7 @@ CaseInsensitiveString <- value:String {
     return &StringSearchRequest{
         value: strings.ToLower(value.(string)),
         originalValue: value,
-        valueIsCaseInSensitive: true,
+        caseInsensitive: true,
     }, nil
 }
 

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -476,7 +476,7 @@ type FormatResultsRequestArguments struct {
 
 type StringSearchRequest struct {
 	value interface{}
-	valueIsCaseSensitive bool
+	valueIsCaseInSensitive bool
 }
 
 }
@@ -3873,7 +3873,7 @@ NamedFieldWithStringValue <- key:FieldName op:EqualityOperator stringSearchReq:(
             Op: op.(string),
             Field: key.(string),
             Values: ssr.value,
-            ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
+            ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
         },
     }
     return node, nil
@@ -3887,7 +3887,7 @@ UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsens
             Op: "=",
             Field: "*",
             Values: ssr.value,
-            ValueIsCaseSensitive: ssr.valueIsCaseSensitive,
+            ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
         },
     }
     return node, nil
@@ -3896,14 +3896,14 @@ UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsens
 CaseSensitiveString <- "CASE" L_PAREN value:String R_PAREN {
     return &StringSearchRequest{
         value: value,
-        valueIsCaseSensitive: true,
+        valueIsCaseInSensitive: false,
     }, nil
 }
 
 CaseInsensitiveString <- value:String {
     return &StringSearchRequest{
         value: strings.ToLower(value.(string)),
-        valueIsCaseSensitive: false,
+        valueIsCaseInSensitive: true,
     }, nil
 }
 

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -476,6 +476,7 @@ type FormatResultsRequestArguments struct {
 
 type StringSearchRequest struct {
 	value interface{}
+    originalValue interface{}
 	valueIsCaseInSensitive bool
 }
 
@@ -3873,6 +3874,7 @@ NamedFieldWithStringValue <- key:FieldName op:EqualityOperator stringSearchReq:(
             Op: op.(string),
             Field: key.(string),
             Values: ssr.value,
+            OriginalValues: ssr.originalValue,
             ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
         },
     }
@@ -3887,6 +3889,7 @@ UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsens
             Op: "=",
             Field: "*",
             Values: ssr.value,
+            OriginalValues: ssr.originalValue,
             ValueIsCaseInSensitive: ssr.valueIsCaseInSensitive,
         },
     }
@@ -3896,6 +3899,7 @@ UnnamedFieldWithStringValue <- stringSearchReq:(CaseSensitiveString / CaseInsens
 CaseSensitiveString <- "CASE" L_PAREN value:String R_PAREN {
     return &StringSearchRequest{
         value: value,
+        originalValue: value,
         valueIsCaseInSensitive: false,
     }, nil
 }
@@ -3903,6 +3907,7 @@ CaseSensitiveString <- "CASE" L_PAREN value:String R_PAREN {
 CaseInsensitiveString <- value:String {
     return &StringSearchRequest{
         value: strings.ToLower(value.(string)),
+        originalValue: value,
         valueIsCaseInSensitive: true,
     }, nil
 }

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -126,7 +126,7 @@ func Test_searchQuotedStringMinorBreakers(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
 	assert.Equal(t, filterNode.Comparison.Values, `"abc./\\:=@#$%-_DEF"`)
-	assert.False(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.False(t, filterNode.Comparison.CaseInsensitive)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)
@@ -191,7 +191,7 @@ func Test_searchUnquotedStringMinorBreakers(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
 	assert.Equal(t, filterNode.Comparison.Values, strings.ToLower(`"abc./\\:=@#$%-_DEF"`))
-	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.True(t, filterNode.Comparison.CaseInsensitive)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)
@@ -1264,7 +1264,7 @@ func Test_searchQuotedWildcard(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Values, `"t*day"`)
 	assert.Equal(t, filterNode.Comparison.OriginalValues, `"T*day"`)
-	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.True(t, filterNode.Comparison.CaseInsensitive)
 
 	astNode := &structs.ASTNode{}
 	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
@@ -1289,7 +1289,7 @@ func Test_searchUnquotedWildcard(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Values, `"t*day"`)
 	assert.Equal(t, filterNode.Comparison.OriginalValues, `"T*day"`)
-	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.True(t, filterNode.Comparison.CaseInsensitive)
 
 	astNode := &structs.ASTNode{}
 	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
@@ -2220,7 +2220,7 @@ func Test_aggHasEvalFuncWithoutGroupBy(t *testing.T) {
 	assert.Equal(t, "=", filterNode.Comparison.Op)
 	assert.Equal(t, "\"boston\"", filterNode.Comparison.Values)
 	assert.Equal(t, `"Boston"`, filterNode.Comparison.OriginalValues)
-	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.True(t, filterNode.Comparison.CaseInsensitive)
 
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	assert.NotNil(t, pipeCommands)
@@ -2580,7 +2580,7 @@ func Test_commentInsideQuotes(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Field, "A")
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Values, "\"Hello, ```this is not commented out``` world!\"")
-	assert.False(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.False(t, filterNode.Comparison.CaseInsensitive)
 
 	astNode := &structs.ASTNode{}
 	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
@@ -10141,7 +10141,7 @@ func performCommon_aggEval_Constant_Field(t *testing.T, measureFunc utils.Aggreg
 	assert.Equal(t, "=", filterNode.Comparison.Op)
 	assert.Equal(t, "\"boston\"", filterNode.Comparison.Values)
 	assert.Equal(t, "\"Boston\"", filterNode.Comparison.OriginalValues)
-	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
+	assert.True(t, filterNode.Comparison.CaseInsensitive)
 
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	assert.NotNil(t, pipeCommands)

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -190,11 +190,12 @@ func Test_searchUnquotedStringMinorBreakers(t *testing.T) {
 	assert.NotNil(t, filterNode)
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
-	assert.Equal(t, filterNode.Comparison.Values, `"abc./\\:=@#$%-_DEF"`)
+	assert.Equal(t, filterNode.Comparison.Values, strings.ToLower(`"abc./\\:=@#$%-_DEF"`))
+	assert.Equal(t, filterNode.Comparison.ValueIsCaseInSensitive, true)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)
-	assert.Equal(t, []byte(`abc./\\:=@#$%-_DEF`), matchFilter.MatchPhrase)
+	assert.Equal(t, []byte("abc./\\\\:=@#$%-_def"), matchFilter.MatchPhrase)
 }
 
 func Test_searchUnquotedStringMajorBreakerAtStart(t *testing.T) {

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -126,7 +126,7 @@ func Test_searchQuotedStringMinorBreakers(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
 	assert.Equal(t, filterNode.Comparison.Values, `"abc./\\:=@#$%-_DEF"`)
-	assert.Equal(t, filterNode.Comparison.ValueIsCaseSensitive, true)
+	assert.Equal(t, filterNode.Comparison.ValueIsCaseInSensitive, false)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -54,7 +54,7 @@ func parseWithoutError(t *testing.T, query string) (*structs.ASTNode, *structs.Q
 
 func extractMatchFilter(t *testing.T, node *ast.Node) *structs.MatchFilter {
 	astNode := &structs.ASTNode{}
-	err := pipesearch.SearchQueryToASTnode(node, astNode, 0)
+	err := pipesearch.SearchQueryToASTnode(node, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition)
 
@@ -71,7 +71,7 @@ func extractMatchFilter(t *testing.T, node *ast.Node) *structs.MatchFilter {
 
 func extractExpressionFilter(t *testing.T, node *ast.Node) *structs.ExpressionFilter {
 	astNode := &structs.ASTNode{}
-	err := pipesearch.SearchQueryToASTnode(node, astNode, 0)
+	err := pipesearch.SearchQueryToASTnode(node, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition)
 
@@ -126,7 +126,7 @@ func Test_searchQuotedStringMinorBreakers(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
 	assert.Equal(t, filterNode.Comparison.Values, `"abc./\\:=@#$%-_DEF"`)
-	assert.Equal(t, filterNode.Comparison.ValueIsCaseInSensitive, false)
+	assert.False(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)
@@ -191,7 +191,7 @@ func Test_searchUnquotedStringMinorBreakers(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Field, "*")
 	assert.Equal(t, filterNode.Comparison.Values, strings.ToLower(`"abc./\\:=@#$%-_DEF"`))
-	assert.Equal(t, filterNode.Comparison.ValueIsCaseInSensitive, true)
+	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	matchFilter := extractMatchFilter(t, filterNode)
 	assert.Equal(t, structs.MATCH_PHRASE, matchFilter.MatchType)
@@ -644,7 +644,7 @@ func Test_searchSimpleAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("1000"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -682,7 +682,7 @@ func Test_searchChainedAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -719,7 +719,7 @@ func Test_searchSimpleOR(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("1000"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.OrFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.OrFilterCondition.FilterCriteria, 2)
@@ -757,7 +757,7 @@ func Test_searchChainedOR(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.OrFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.OrFilterCondition.FilterCriteria, 1)
@@ -801,7 +801,7 @@ func Test_searchANDThenOR(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -845,7 +845,7 @@ func Test_searchORThenAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -905,7 +905,7 @@ func Test_searchParenthesesToChangePrecedence(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.OrFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.OrFilterCondition.FilterCriteria, 1)
@@ -942,7 +942,7 @@ func Test_searchImplicitAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("1000"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -980,7 +980,7 @@ func Test_searchChainedImplicitAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1023,7 +1023,7 @@ func Test_searchMixedImplicitAndExplicitAND(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1055,7 +1055,7 @@ func Test_searchSimpleNOTEquals(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1079,7 +1079,7 @@ func Test_searchSimpleNOTNotEquals(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1103,7 +1103,7 @@ func Test_searchSimpleNOTLessThan(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1127,7 +1127,7 @@ func Test_searchSimpleNOTGreaterThan(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1151,7 +1151,7 @@ func Test_searchSimpleNOTLessThanOrEqual(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1175,7 +1175,7 @@ func Test_searchSimpleNOTGreaterThanOrEqual(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1199,7 +1199,7 @@ func Test_searchCancelingNots(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("200"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1235,7 +1235,7 @@ func Test_searchCompoundNOT(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Comparison.Values, json.Number("10"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 1)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1262,16 +1262,18 @@ func Test_searchQuotedWildcard(t *testing.T) {
 	assert.Equal(t, filterNode.NodeType, ast.NodeTerminal)
 	assert.Equal(t, filterNode.Comparison.Field, "day")
 	assert.Equal(t, filterNode.Comparison.Op, "=")
-	assert.Equal(t, filterNode.Comparison.Values, `"T*day"`)
+	assert.Equal(t, filterNode.Comparison.Values, `"t*day"`)
+	assert.Equal(t, filterNode.Comparison.OriginalValues, `"T*day"`)
+	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
 	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.LeftInput.Expression.LeftInput.ColumnName, "day")
 	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.FilterOperator, utils.Equals)
-	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.RightInput.Expression.LeftInput.ColumnValue.StringVal, "T*day")
+	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.RightInput.Expression.LeftInput.ColumnValue.StringVal, "t*day")
 }
 
 func Test_searchUnquotedWildcard(t *testing.T) {
@@ -1285,16 +1287,18 @@ func Test_searchUnquotedWildcard(t *testing.T) {
 	assert.Equal(t, filterNode.NodeType, ast.NodeTerminal)
 	assert.Equal(t, filterNode.Comparison.Field, "day")
 	assert.Equal(t, filterNode.Comparison.Op, "=")
-	assert.Equal(t, filterNode.Comparison.Values, `"T*day"`)
+	assert.Equal(t, filterNode.Comparison.Values, `"t*day"`)
+	assert.Equal(t, filterNode.Comparison.OriginalValues, `"T*day"`)
+	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
 	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.LeftInput.Expression.LeftInput.ColumnName, "day")
 	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.FilterOperator, utils.Equals)
-	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.RightInput.Expression.LeftInput.ColumnValue.StringVal, "T*day")
+	assert.Equal(t, astNode.AndFilterCondition.FilterCriteria[0].ExpressionFilter.RightInput.Expression.LeftInput.ColumnValue.StringVal, "t*day")
 }
 
 func Test_searchNumberedWildcardBecomesString(t *testing.T) {
@@ -1311,7 +1315,7 @@ func Test_searchNumberedWildcardBecomesString(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, `"50*"`)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1341,7 +1345,7 @@ func Test_chainedSearch(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("2"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -1386,7 +1390,7 @@ func Test_manyChainedSearch(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Right.Comparison.Values, json.Number("4"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1445,7 +1449,7 @@ func Test_manyChainedSearchOptionalPipeSpacing(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Right.Comparison.Values, json.Number("4"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1516,7 +1520,7 @@ func Test_manyChainedCompoundSearch(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Right.Comparison.Values, json.Number("6"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1594,7 +1598,7 @@ func Test_searchBlockWithoutUsingSearchKeyword(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Right.Comparison.Values, json.Number("6"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 1)
@@ -1648,7 +1652,7 @@ func Test_regexSingleColumnEquals(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.ValueIsRegex, true)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -1686,7 +1690,7 @@ func Test_regexSingleColumnNotEquals(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.ValueIsRegex, true)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -1731,7 +1735,7 @@ func Test_regexAnyColumn(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.ValueIsRegex, true)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -2214,7 +2218,9 @@ func Test_aggHasEvalFuncWithoutGroupBy(t *testing.T) {
 	assert.Equal(t, ast.NodeTerminal, filterNode.NodeType)
 	assert.Equal(t, "city", filterNode.Comparison.Field)
 	assert.Equal(t, "=", filterNode.Comparison.Op)
-	assert.Equal(t, "\"Boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, "\"boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, `"Boston"`, filterNode.Comparison.OriginalValues)
+	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	assert.NotNil(t, pipeCommands)
@@ -2451,7 +2457,7 @@ func Test_commentAtStart(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("1"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 0)
@@ -2481,7 +2487,7 @@ func Test_commentInMiddle(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.OrFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.OrFilterCondition.NestedNodes, 0)
@@ -2507,7 +2513,7 @@ func Test_commentAtEnd(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("1"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 0)
@@ -2530,7 +2536,7 @@ func Test_commentContainingQuotes(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("1"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 0)
@@ -2553,7 +2559,7 @@ func Test_commentContainingBackticks(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Values, json.Number("1"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 0)
@@ -2564,7 +2570,7 @@ func Test_commentContainingBackticks(t *testing.T) {
 }
 
 func Test_commentInsideQuotes(t *testing.T) {
-	query := []byte("A=\"Hello, ```this is not commented out``` world!\"")
+	query := []byte("A=CASE(\"Hello, ```this is not commented out``` world!\")")
 	res, err := spl.Parse("", query)
 	assert.Nil(t, err)
 	filterNode := res.(ast.QueryStruct).SearchFilter
@@ -2574,9 +2580,10 @@ func Test_commentInsideQuotes(t *testing.T) {
 	assert.Equal(t, filterNode.Comparison.Field, "A")
 	assert.Equal(t, filterNode.Comparison.Op, "=")
 	assert.Equal(t, filterNode.Comparison.Values, "\"Hello, ```this is not commented out``` world!\"")
+	assert.False(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.NestedNodes, 0)
@@ -5403,7 +5410,7 @@ func Test_evalWithMultipleSpaces2(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Right.Comparison.Values, json.Number("3"))
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.OrFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.OrFilterCondition.FilterCriteria, 1)
@@ -5446,7 +5453,7 @@ func Test_multilineQuery(t *testing.T) {
 	assert.Equal(t, filterNode.Right.Comparison.ValueIsRegex, true)
 
 	astNode := &structs.ASTNode{}
-	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0)
+	err = pipesearch.SearchQueryToASTnode(filterNode, astNode, 0, false)
 	assert.Nil(t, err)
 	assert.NotNil(t, astNode.AndFilterCondition.FilterCriteria)
 	assert.Len(t, astNode.AndFilterCondition.FilterCriteria, 2)
@@ -7005,7 +7012,7 @@ func Test_TransactionRequestWithFilterStringExpr(t *testing.T) {
 		assert.NotNil(t, filterNode)
 
 		astNode, aggregator, err := pipesearch.ParseQuery(string(query), 0, "Splunk QL")
-		assert.Nil(t, err)
+		assert.Nil(t, err, "ind=%v, Failed for query: %s", ind, query)
 		assert.NotNil(t, astNode)
 		assert.NotNil(t, aggregator)
 		assert.NotNil(t, aggregator.TransactionArguments)
@@ -7013,8 +7020,8 @@ func Test_TransactionRequestWithFilterStringExpr(t *testing.T) {
 		transactionRequest := aggregator.TransactionArguments
 		assert.Equal(t, structs.TransactionType, aggregator.PipeCommandType)
 		assert.Equal(t, results[ind].Fields, transactionRequest.Fields)
-		assert.Equal(t, results[ind].StartsWith, transactionRequest.StartsWith)
-		assert.Equal(t, results[ind].EndsWith, transactionRequest.EndsWith)
+		assert.Equal(t, results[ind].StartsWith, transactionRequest.StartsWith, "ind=%v, Failed for query: %s", ind, query)
+		assert.Equal(t, results[ind].EndsWith, transactionRequest.EndsWith, "ind=%v, Failed for query: %s", ind, query)
 	}
 }
 

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10083,7 +10083,8 @@ func performCommon_aggEval_BoolExpr(t *testing.T, measureFunc utils.AggregateFun
 	assert.Equal(t, ast.NodeTerminal, filterNode.NodeType)
 	assert.Equal(t, "city", filterNode.Comparison.Field)
 	assert.Equal(t, "=", filterNode.Comparison.Op)
-	assert.Equal(t, "\"Boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, "\"Boston\"", filterNode.Comparison.OriginalValues)
+	assert.Equal(t, `"boston"`, filterNode.Comparison.Values)
 
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	assert.NotNil(t, pipeCommands)
@@ -10138,7 +10139,9 @@ func performCommon_aggEval_Constant_Field(t *testing.T, measureFunc utils.Aggreg
 	assert.Equal(t, ast.NodeTerminal, filterNode.NodeType)
 	assert.Equal(t, "city", filterNode.Comparison.Field)
 	assert.Equal(t, "=", filterNode.Comparison.Op)
-	assert.Equal(t, "\"Boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, "\"boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, "\"Boston\"", filterNode.Comparison.OriginalValues)
+	assert.True(t, filterNode.Comparison.ValueIsCaseInSensitive)
 
 	pipeCommands := res.(ast.QueryStruct).PipeCommands
 	assert.NotNil(t, pipeCommands)
@@ -10910,7 +10913,7 @@ func Test_InputLookup_6(t *testing.T) {
 	assert.Equal(t, ast.NodeTerminal, filterNode.NodeType)
 	assert.Equal(t, "city", filterNode.Comparison.Field)
 	assert.Equal(t, "=", filterNode.Comparison.Op)
-	assert.Equal(t, "\"Boston\"", filterNode.Comparison.Values)
+	assert.Equal(t, "\"boston\"", filterNode.Comparison.Values)
 
 	astNode, aggregator, err := pipesearch.ParseQuery(query, 0, "Splunk QL")
 

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -265,9 +265,9 @@ func parseSingleCondition(expr sqlparser.Expr, astNode *structs.ASTNode, qid uin
 		case string:
 			val = strings.ReplaceAll(val, "'", "")
 			val = strings.ReplaceAll(val, "\"", "")
-			criteria, err = ast.ProcessSingleFilter(columnName, val, clause[1], false, true, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, val, val, clause[1], false, true, qid)
 		default:
-			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), clause[1], false, true, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), json.Number(literal), clause[1], false, true, qid)
 		}
 
 		if err != nil {

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -265,9 +265,9 @@ func parseSingleCondition(expr sqlparser.Expr, astNode *structs.ASTNode, qid uin
 		case string:
 			val = strings.ReplaceAll(val, "'", "")
 			val = strings.ReplaceAll(val, "\"", "")
-			criteria, err = ast.ProcessSingleFilter(columnName, val, val, clause[1], false, true, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, val, val, clause[1], false, true, false, qid)
 		default:
-			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), json.Number(literal), clause[1], false, true, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), json.Number(literal), clause[1], false, true, false, qid)
 		}
 
 		if err != nil {

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -265,9 +265,9 @@ func parseSingleCondition(expr sqlparser.Expr, astNode *structs.ASTNode, qid uin
 		case string:
 			val = strings.ReplaceAll(val, "'", "")
 			val = strings.ReplaceAll(val, "\"", "")
-			criteria, err = ast.ProcessSingleFilter(columnName, val, clause[1], false, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, val, clause[1], false, true, qid)
 		default:
-			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), clause[1], false, qid)
+			criteria, err = ast.ProcessSingleFilter(columnName, json.Number(literal), clause[1], false, true, qid)
 		}
 
 		if err != nil {

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -119,6 +119,7 @@ type Comparison struct {
 	Op                     string
 	Field                  string
 	Values                 interface{}
+	OriginalValues         interface{}
 	ValueIsRegex           bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
 	ValueIsCaseInSensitive bool // True if Values is case insensitive. False if Values is case sensitive.
 }

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -116,12 +116,12 @@ type TimeModifiers struct {
 
 // Comparison is an individual comparison operation on a terminal node
 type Comparison struct {
-	Op                     string
-	Field                  string
-	Values                 interface{}
-	OriginalValues         interface{}
-	ValueIsRegex           bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
-	ValueIsCaseInSensitive bool // True if Values is case insensitive. False if Values is case sensitive.
+	Op              string
+	Field           string
+	Values          interface{}
+	OriginalValues  interface{}
+	ValueIsRegex    bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
+	CaseInsensitive bool
 }
 
 func (c *Comparison) isMatchAll() bool {

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -116,11 +116,11 @@ type TimeModifiers struct {
 
 // Comparison is an individual comparison operation on a terminal node
 type Comparison struct {
-	Op                   string
-	Field                string
-	Values               interface{}
-	ValueIsRegex         bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
-	ValueIsCaseSensitive bool // True if Values is case sensitive. False if Values is case insensitive.
+	Op                     string
+	Field                  string
+	Values                 interface{}
+	ValueIsRegex           bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
+	ValueIsCaseInSensitive bool // True if Values is case insensitive. False if Values is case sensitive.
 }
 
 func (c *Comparison) isMatchAll() bool {

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -116,10 +116,11 @@ type TimeModifiers struct {
 
 // Comparison is an individual comparison operation on a terminal node
 type Comparison struct {
-	Op           string
-	Field        string
-	Values       interface{}
-	ValueIsRegex bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
+	Op                   string
+	Field                string
+	Values               interface{}
+	ValueIsRegex         bool // True if Values is a regex string. False if Values is a wildcarded string or anything else.
+	ValueIsCaseSensitive bool // True if Values is case sensitive. False if Values is case insensitive.
 }
 
 func (c *Comparison) isMatchAll() bool {

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -117,7 +117,7 @@ type Configuration struct {
 	AnalyticsEnabledConverted  bool
 	AgileAggsEnabled           string `yaml:"agileAggsEnabled"` // should we read/write AgileAggsTrees?
 	AgileAggsEnabledConverted  bool
-	DualCaseCheck              string `yaml:"dualCaseCheck"` // should we check for dual case in the query? This is to support the old data that does not have case-insensitive search support
+	DualCaseCheck              string `yaml:"dualCaseCheck"` // This is to support the old data that does not have case-insensitive search support. TODO: Remove this after 2 months from now: Aug 21st, 2024.
 	DualCaseCheckConverted     bool
 	QueryHostname              string         `yaml:"queryHostname"` // hostname of the query server. i.e. if DNS is https://cloud.siglens.com, this should be cloud.siglens.com
 	IngestUrl                  string         `yaml:"ingestUrl"`     // full address of the ingest server, including scheme and port, e.g. https://ingest.siglens.com:8080

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -117,6 +117,8 @@ type Configuration struct {
 	AnalyticsEnabledConverted  bool
 	AgileAggsEnabled           string `yaml:"agileAggsEnabled"` // should we read/write AgileAggsTrees?
 	AgileAggsEnabledConverted  bool
+	DualCaseCheck              string `yaml:"dualCaseCheck"` // should we check for dual case in the query? This is to support the old data that does not have case-insensitive search support
+	DualCaseCheckConverted     bool
 	QueryHostname              string         `yaml:"queryHostname"` // hostname of the query server. i.e. if DNS is https://cloud.siglens.com, this should be cloud.siglens.com
 	IngestUrl                  string         `yaml:"ingestUrl"`     // full address of the ingest server, including scheme and port, e.g. https://ingest.siglens.com:8080
 	S3                         S3Config       `yaml:"s3"`            // s3 related config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -252,6 +252,10 @@ func IsAggregationsEnabled() bool {
 	return runningConfig.AgileAggsEnabledConverted
 }
 
+func IsDualCaseCheckEnabled() bool {
+	return runningConfig.DualCaseCheckConverted
+}
+
 func SetAggregationsFlag(enabled bool) {
 	runningConfig.AgileAggsEnabledConverted = enabled
 	runningConfig.AgileAggsEnabled = strconv.FormatBool(enabled)
@@ -495,6 +499,8 @@ func GetTestConfig(dataPath string) common.Configuration {
 		AnalyticsEnabledConverted:  false,
 		AgileAggsEnabled:           "true",
 		AgileAggsEnabledConverted:  true,
+		DualCaseCheck:              "false",
+		DualCaseCheckConverted:     false,
 		QueryHostname:              "",
 		Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
 		TLS:                        common.TLSConfig{Enabled: false, CertificatePath: "", PrivateKeyPath: ""},
@@ -630,6 +636,17 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 		config.AgileAggsEnabled = "true"
 	}
 	config.AgileAggsEnabledConverted = AgileAggsEnabled
+
+	if len(config.DualCaseCheck) <= 0 {
+		config.DualCaseCheck = "false"
+	}
+	dualCaseCheck, err := strconv.ParseBool(config.DualCaseCheck)
+	if err != nil {
+		log.Errorf("ExtractConfigData: failed to parse DualCaseCheck flag. Defaulting to false. Error: %v", err)
+		dualCaseCheck = false
+		config.DualCaseCheck = "false"
+	}
+	config.DualCaseCheckConverted = dualCaseCheck
 
 	if len(config.DataPath) <= 0 {
 		config.DataPath = "data/"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -112,6 +112,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				AnalyticsEnabledConverted:  false,
 				AgileAggsEnabled:           "false",
 				AgileAggsEnabledConverted:  false,
+				DualCaseCheck:              "false",
+				DualCaseCheckConverted:     false,
 				SafeServerStart:            true,
 				Log:                        common.LogConfig{LogPrefix: "./pkg/ingestor/httpserver/", LogFileRotationSizeMB: 100, CompressLogFile: false},
 				Tracing:                    common.TracingConfig{Endpoint: "http://localhost:4317", ServiceName: "siglens", SamplingPercentage: 100},
@@ -146,6 +148,7 @@ func Test_ExtractConfigData(t *testing.T) {
  S3IngestBufferSize: 1000
  MaxParallelS3IngestBuffers: 10
  PQSEnabled: F
+ dualCaseCheck: true
  analyticsEnabled: bad string
  AgileAggsEnabled: bad string
  tracing:
@@ -184,6 +187,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				QueryHostname:              "localhost:9000",
 				PQSEnabled:                 "true",
 				PQSEnabledConverted:        true,
+				DualCaseCheck:              "true",
+				DualCaseCheckConverted:     true,
 				AnalyticsEnabled:           "true",
 				AnalyticsEnabledConverted:  true,
 				AgileAggsEnabled:           "true",
@@ -266,6 +271,8 @@ a: b
 				AnalyticsEnabledConverted:  true,
 				AgileAggsEnabled:           "true",
 				AgileAggsEnabledConverted:  true,
+				DualCaseCheck:              "false",
+				DualCaseCheckConverted:     false,
 				Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
 				Tracing:                    common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
 			},

--- a/pkg/querytracker/snhasher.go
+++ b/pkg/querytracker/snhasher.go
@@ -118,7 +118,7 @@ func getHashForSearchQuery(sq *structs.SearchQuery) uint64 {
 		getHashForMatchFilter(sq.MatchFilter),
 		sq.SearchType,
 		getHashForQueryInfo(sq.QueryInfo),
-		sq.FilterIsCaseInSensitive)
+		sq.FilterIsCaseInsensitive)
 	return xxhash.Sum64String(val)
 }
 

--- a/pkg/querytracker/snhasher.go
+++ b/pkg/querytracker/snhasher.go
@@ -113,11 +113,12 @@ func getHashForSearchQuery(sq *structs.SearchQuery) uint64 {
 		return 0
 	}
 
-	val := fmt.Sprintf("%v:%v:%v:%v",
+	val := fmt.Sprintf("%v:%v:%v:%v:%v",
 		getHashForSearchExpression(sq.ExpressionFilter),
 		getHashForMatchFilter(sq.MatchFilter),
 		sq.SearchType,
-		getHashForQueryInfo(sq.QueryInfo))
+		getHashForQueryInfo(sq.QueryInfo),
+		sq.FilterIsCaseInSensitive)
 	return xxhash.Sum64String(val)
 }
 

--- a/pkg/querytracker/snhasher_test.go
+++ b/pkg/querytracker/snhasher_test.go
@@ -48,7 +48,7 @@ func Test_HashSearchNode(t *testing.T) {
 	}
 
 	hid1 := GetHashForQuery(sNode)
-	expected := "11481340929163441556" // pre-computed hashid to compare against for above query
+	expected := "15281968501864336114" // pre-computed hashid to compare against for above query
 	assert.Equal(t, expected, hid1, "hid1=%v, not equal to expected=%v", hid1, expected)
 
 	hid2 := GetHashForQuery(sNode)

--- a/pkg/segment/query/metadata/blockmeta.go
+++ b/pkg/segment/query/metadata/blockmeta.go
@@ -78,10 +78,10 @@ func convertBlocksToSearchRequest(blocksForFile map[uint16]map[string]bool, file
 // TODO: function is getting to big and has many args, needs to be refactored
 // Returns all search requests,  number of blocks checked, number of blocks passed, error
 func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
-	blockTracker *structs.BlockTracker, bloomKeys map[string]bool, bloomOp utils.LogicalOperator,
+	blockTracker *structs.BlockTracker, bloomKeys map[string]bool, originalBloomKeys map[string]string, bloomOp utils.LogicalOperator,
 	rangeFilter map[string]string, rangeOp utils.FilterOperator, isRange bool, wildCardValue bool,
 	currQuery *structs.SearchQuery, colsToCheck map[string]bool, wildcardCol bool,
-	qid uint64, isQueryPersistent bool, pqid string) (*structs.SegmentSearchRequest, uint64, uint64, error) {
+	qid uint64, isQueryPersistent bool, pqid string, dualCaseCheckEnabled bool) (*structs.SegmentSearchRequest, uint64, uint64, error) {
 
 	isMatchAll := currQuery.IsMatchAll()
 
@@ -154,9 +154,9 @@ func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
 				}
 				if !wildCardValue && !negateMatch {
 					if wildcardCol {
-						doBloomCheckAllCol(segMicroIndex, blockToCheck, bloomKeys, bloomOp, timeFilteredBlocks)
+						doBloomCheckAllCol(segMicroIndex, blockToCheck, bloomKeys, originalBloomKeys, bloomOp, timeFilteredBlocks, dualCaseCheckEnabled)
 					} else {
-						doBloomCheckForCol(segMicroIndex, blockToCheck, bloomKeys, bloomOp, timeFilteredBlocks, colsToCheck)
+						doBloomCheckForCol(segMicroIndex, blockToCheck, bloomKeys, originalBloomKeys, bloomOp, timeFilteredBlocks, colsToCheck, dualCaseCheckEnabled)
 					}
 				}
 			}
@@ -243,8 +243,10 @@ func doRangeCheckForCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, r
 	}
 }
 
-func doBloomCheckForCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, bloomKeys map[string]bool,
-	bloomOp utils.LogicalOperator, timeFilteredBlocks map[uint16]map[string]bool, colsToCheck map[string]bool) {
+func doBloomCheckForCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, bloomKeys map[string]bool, originalBloomKeys map[string]string,
+	bloomOp utils.LogicalOperator, timeFilteredBlocks map[uint16]map[string]bool, colsToCheck map[string]bool, dualCaseEnabled bool) {
+
+	checkInOriginalKeys := dualCaseEnabled && len(originalBloomKeys) > 0
 
 	var matchedNeedleInBlock = true
 	for entry := range bloomKeys {
@@ -258,6 +260,12 @@ func doBloomCheckForCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, b
 				continue
 			}
 			needleExists = colCMI.Bf.TestString(entry)
+			if !needleExists && checkInOriginalKeys {
+				originalEntry, ok := originalBloomKeys[entry]
+				if ok {
+					needleExists = colCMI.Bf.TestString(originalEntry)
+				}
+			}
 			if needleExists {
 				timeFilteredBlocks[blockToCheck][colName] = true
 				break
@@ -277,8 +285,10 @@ func doBloomCheckForCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, b
 	}
 }
 
-func doBloomCheckAllCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, bloomKeys map[string]bool,
-	bloomOp utils.LogicalOperator, timeFilteredBlocks map[uint16]map[string]bool) {
+func doBloomCheckAllCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, bloomKeys map[string]bool, originalBloomKeys map[string]string,
+	bloomOp utils.LogicalOperator, timeFilteredBlocks map[uint16]map[string]bool, dualCaseCheckEnabled bool) {
+
+	checkInOriginalKeys := dualCaseCheckEnabled && len(originalBloomKeys) > 0
 
 	var matchedNeedleInBlock = true
 	var allEntriesMissing bool = false
@@ -293,7 +303,15 @@ func doBloomCheckAllCol(segMicroIndex *SegmentMicroIndex, blockToCheck uint16, b
 				if cmi.CmiType != utils.CMI_BLOOM_INDEX[0] {
 					continue
 				}
-				if cmi.Bf.TestString(entry) {
+				entryExists := cmi.Bf.TestString(entry)
+				if !entryExists && checkInOriginalKeys {
+					originalEntry, ok := originalBloomKeys[entry]
+					if ok {
+						entryExists = cmi.Bf.TestString(originalEntry)
+					}
+				}
+
+				if entryExists {
 					timeFilteredBlocks[blockToCheck][cname] = true
 					atleastOneFound = true
 				}

--- a/pkg/segment/query/metadata/unrotatedmeta.go
+++ b/pkg/segment/query/metadata/unrotatedmeta.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/query/summary"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -68,7 +69,7 @@ func createSearchRequestForUnrotated(fileName string, tableName string,
 // filters unrotated blocks based on search conditions
 // returns the final search request, total blocks, sum of filtered blocks, and any errors
 func CheckMicroIndicesForUnrotated(currQuery *structs.SearchQuery, lookupTimeRange *dtu.TimeRange, indexNames []string,
-	allBlocksToSearch map[string]map[string]*structs.BlockTracker, bloomWords map[string]bool, bloomOp utils.LogicalOperator, rangeFilter map[string]string,
+	allBlocksToSearch map[string]map[string]*structs.BlockTracker, bloomWords map[string]bool, originalBloomWords map[string]string, bloomOp utils.LogicalOperator, rangeFilter map[string]string,
 	rangeOp utils.FilterOperator, isRange bool, wildcardValue bool, qid uint64) (map[string]*structs.SegmentSearchRequest, uint64, uint64, error) {
 
 	writer.UnrotatedInfoLock.RLock()
@@ -79,6 +80,8 @@ func CheckMicroIndicesForUnrotated(currQuery *structs.SearchQuery, lookupTimeRan
 	var wg sync.WaitGroup
 	totalUnrotatedBlocks := uint64(0)
 	totalFilteredBlocks := uint64(0)
+
+	dualCaseCheckEnabled := config.IsDualCaseCheckEnabled()
 
 	for _, rawSearchKeys := range allBlocksToSearch {
 		for segKey, blkTracker := range rawSearchKeys {
@@ -92,7 +95,7 @@ func CheckMicroIndicesForUnrotated(currQuery *structs.SearchQuery, lookupTimeRan
 				defer wg.Done()
 
 				filteredBlocks, maxBlocks, numFiltered, err := store.DoCMICheckForUnrotated(currQuery, lookupTimeRange,
-					blkT, bloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildcardValue, qid)
+					blkT, bloomWords, originalBloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildcardValue, qid, dualCaseCheckEnabled)
 				atomic.AddUint64(&totalUnrotatedBlocks, maxBlocks)
 				atomic.AddUint64(&totalFilteredBlocks, numFiltered)
 				if err != nil {
@@ -172,9 +175,9 @@ func extractUnrotatedSSRFromCondition(condition *structs.SearchCondition, op seg
 
 		for _, query := range condition.SearchQueries {
 			rangeFilter, rangeOp, isRange := query.ExtractRangeFilterFromQuery(qid)
-			bloomWords, wildcardBloom, bloomOp := query.GetAllBlockBloomKeysToSearch()
+			bloomWords, originalBloomWords, wildcardBloom, bloomOp := query.GetAllBlockBloomKeysToSearch()
 			res, totalUnrotatedBlocks, filteredUnrotatedBlocks, err := CheckMicroIndicesForUnrotated(query, timeRange, indexNames,
-				rawSearchKeys, bloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildcardBloom, qid)
+				rawSearchKeys, bloomWords, originalBloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildcardBloom, qid)
 
 			if err != nil {
 				log.Errorf("qid=%d, extractUnrotatedSSRFromCondition: an error occurred while checking unrotated data %+v", qid, err)

--- a/pkg/segment/query/metadatafilter_test.go
+++ b/pkg/segment/query/metadatafilter_test.go
@@ -93,7 +93,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 	_, _, isRange := baseQuery.ExtractRangeFilterFromQuery(1)
 	assert.False(t, isRange)
 
-	blockbloomKeywords, wildcard, blockOp := baseQuery.GetAllBlockBloomKeysToSearch()
+	blockbloomKeywords, _, wildcard, blockOp := baseQuery.GetAllBlockBloomKeysToSearch()
 	assert.False(t, wildcard)
 
 	assert.Len(t, blockbloomKeywords, 1)
@@ -106,7 +106,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		blkTracker, err := qsr.GetMicroIndexFilter()
 		assert.NoError(t, err, "no error should occur when getting block tracker")
 		searchRequests, checkedBlocks, matchedBlocks, errs := getAllSearchRequestsFromCmi(baseQuery, tRange, blkTracker,
-			blockbloomKeywords, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
+			blockbloomKeywords, nil, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
 		assert.Len(t, errs, 0)
 		assert.Len(t, searchRequests, 1, "one file at a time")
 		assert.Equal(t, uint64(numBlocks), checkedBlocks, "checkedBlocks blocks is not as expected")
@@ -131,7 +131,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		},
 		SearchType: SimpleExpression,
 	}
-	blockbloomKeywords, wildcard, blockOp = fileNameQuery.GetAllBlockBloomKeysToSearch()
+	blockbloomKeywords, _, wildcard, blockOp = fileNameQuery.GetAllBlockBloomKeysToSearch()
 	assert.False(t, wildcard)
 	assert.Len(t, blockbloomKeywords, 1)
 	assert.Equal(t, blockOp, utils.And)
@@ -143,7 +143,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		blkTracker, err := qsr.GetMicroIndexFilter()
 		assert.NoError(t, err, "no error should occur when getting block tracker")
 		searchRequests, checkedBlocks, matchedBlocks, errs := getAllSearchRequestsFromCmi(fileNameQuery, tRange, blkTracker,
-			blockbloomKeywords, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
+			blockbloomKeywords, nil, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
 		assert.Len(t, errs, 0)
 		assert.Equal(t, uint64(numBlocks), checkedBlocks, "all blocks will be checked")
 		if qsr.segKey == randomFile {
@@ -172,7 +172,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 	qsrs = ConvertSegKeysToQueryRequests(qInfo, allFiles)
 	keysToRawSearch, _, _ = FilterSegKeysToQueryResults(qInfo, qsrs)
 
-	blockbloomKeywords, wildcard, blockOp = batchQuery.GetAllBlockBloomKeysToSearch()
+	blockbloomKeywords, _, wildcard, blockOp = batchQuery.GetAllBlockBloomKeysToSearch()
 	assert.False(t, wildcard)
 	assert.Len(t, blockbloomKeywords, 1)
 	assert.Equal(t, blockOp, utils.And)
@@ -185,7 +185,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		blkTracker, err := qsr.GetMicroIndexFilter()
 		assert.NoError(t, err, "no error should occur when getting block tracker")
 		searchRequests, checkedBlocks, matchedBlocks, errs := getAllSearchRequestsFromCmi(batchQuery, tRange, blkTracker,
-			blockbloomKeywords, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
+			blockbloomKeywords, nil, blockOp, nil, rangeOp, false, wildcard, 0, true, qsr.pqid)
 		assert.Len(t, errs, 0)
 		assert.Len(t, searchRequests, 1, "process single request at a time")
 		assert.Equal(t, uint64(numBlocks), checkedBlocks, "each file will should have a single matching block")
@@ -206,7 +206,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 	}
 
 	// changing col name has no effect on block bloom keys
-	blockbloomKeywords, wildcardValue, blockOp := batchWildcardQuery.GetAllBlockBloomKeysToSearch()
+	blockbloomKeywords, nil, wildcardValue, blockOp := batchWildcardQuery.GetAllBlockBloomKeysToSearch()
 	assert.False(t, wildcardValue)
 	assert.Len(t, blockbloomKeywords, 1)
 	assert.Equal(t, blockOp, utils.And)
@@ -219,7 +219,7 @@ func testBloomFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		blkTracker, err := qsr.GetMicroIndexFilter()
 		assert.NoError(t, err, "no error should occur when getting block tracker")
 		searchRequests, checkedBlocks, matchedBlocks, errs := getAllSearchRequestsFromCmi(batchWildcardQuery, tRange, blkTracker,
-			blockbloomKeywords, blockOp, nil, rangeOp, false, wildcardValue, 0, true, qsr.pqid)
+			blockbloomKeywords, nil, blockOp, nil, rangeOp, false, wildcardValue, 0, true, qsr.pqid)
 		assert.Len(t, errs, 0)
 		assert.Len(t, searchRequests, 1, "one file at a time key7=batch-1")
 		assert.Equal(t, uint64(numBlocks), checkedBlocks, "each file will should have a single matching block")
@@ -266,7 +266,7 @@ func testRangeFilter(t *testing.T, numBlocks int, numEntriesInBlock int, fileCou
 		blkTracker, err := qsr.GetMicroIndexFilter()
 		assert.NoError(t, err, "no error should occur when getting block tracker")
 		finalRangeRequests, totalChecked, passedBlocks, errs := getAllSearchRequestsFromCmi(rangeQuery, tRange, blkTracker,
-			nil, utils.And, rangeFilter, rangeOp, true, false, 0, true, qsr.pqid)
+			nil, nil, utils.And, rangeFilter, rangeOp, true, false, 0, true, qsr.pqid)
 		assert.Len(t, errs, 0)
 		assert.Equal(t, uint64(numBlocks), totalChecked)
 		assert.Equal(t, uint64(1), passedBlocks, "one block in each file matches")

--- a/pkg/segment/query/microindexcheck.go
+++ b/pkg/segment/query/microindexcheck.go
@@ -49,24 +49,24 @@ func MicroIndexCheck(currQuery *SearchQuery, filesToSearch map[string]map[string
 	indexNames []string, querySummary *summary.QuerySummary, qid uint64, isQueryPersistent bool, pqid string) (map[string]*SegmentSearchRequest, error) {
 
 	rangeFilter, rangeOp, isRange := currQuery.ExtractRangeFilterFromQuery(qid)
-	bloomWords, wildcardBloom, bloomOp := currQuery.GetAllBlockBloomKeysToSearch()
+	bloomWords, originalBloomWords, wildcardBloom, bloomOp := currQuery.GetAllBlockBloomKeysToSearch()
 
 	finalFilteredRequest, blocksChecked, blockCount := filterViaMicroIndices(currQuery, indexNames, timeRange,
-		filesToSearch, bloomWords, bloomOp, rangeFilter, rangeOp, wildcardBloom, isRange, qid, isQueryPersistent, pqid)
+		filesToSearch, bloomWords, originalBloomWords, bloomOp, rangeFilter, rangeOp, wildcardBloom, isRange, qid, isQueryPersistent, pqid)
 	querySummary.UpdateCMIResults(blocksChecked, blockCount)
 	return finalFilteredRequest, nil
 }
 
 // returns final SSRs, count of total blocks checked, count of blocks that passed
 func filterViaMicroIndices(currQuery *structs.SearchQuery, indexNames []string, timeRange *dtu.TimeRange,
-	filesToSearch map[string]map[string]*BlockTracker, bloomWords map[string]bool, bloomOp LogicalOperator,
+	filesToSearch map[string]map[string]*BlockTracker, bloomWords map[string]bool, originalBloomWords map[string]string, bloomOp LogicalOperator,
 	rangeFilter map[string]string, rangeOp utils.FilterOperator, wildCardValue bool,
 	isRange bool, qid uint64, isQueryPersistent bool, pqid string) (map[string]*SegmentSearchRequest, uint64, uint64) {
 
 	finalResults := make(map[string]*SegmentSearchRequest)
 
 	serResults, totalBlocks, finalBlockCount, errors := getAllSearchRequestsFromCmi(currQuery, timeRange,
-		filesToSearch, bloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildCardValue, qid, isQueryPersistent, pqid)
+		filesToSearch, bloomWords, originalBloomWords, bloomOp, rangeFilter, rangeOp, isRange, wildCardValue, qid, isQueryPersistent, pqid)
 
 	if len(errors) > 0 {
 		for _, err := range errors {
@@ -82,7 +82,7 @@ func filterViaMicroIndices(currQuery *structs.SearchQuery, indexNames []string, 
 
 // returns a list of search request, max possible number of blocks, num blocks to be searched, error
 func getAllSearchRequestsFromCmi(currQuery *structs.SearchQuery, timeRange *dtu.TimeRange,
-	segkeysToCheck map[string]map[string]*BlockTracker, bloomKeys map[string]bool, bloomOp utils.LogicalOperator,
+	segkeysToCheck map[string]map[string]*BlockTracker, bloomKeys map[string]bool, originalBloomKeys map[string]string, bloomOp utils.LogicalOperator,
 	rangeFilter map[string]string, rangeOp utils.FilterOperator, isRange bool, wildCardValue bool,
 	qid uint64, isQueryPersistent bool, pqid string) ([]*structs.SegmentSearchRequest, uint64, uint64, []error) {
 
@@ -97,6 +97,8 @@ func getAllSearchRequestsFromCmi(currQuery *structs.SearchQuery, timeRange *dtu.
 	searchRequestResults := make(chan *structs.SegmentSearchRequest, sizeChannel)
 	searchRequestErrors := make(chan error, sizeChannel)
 
+	dualCaseCheckEnabled := config.IsDualCaseCheckEnabled()
+
 	colsToCheck, wildcardColQuery := currQuery.GetAllColumnsInQuery()
 	delete(colsToCheck, config.GetTimeStampKey()) // timestamp should not be checked in cmi
 	var blockWG sync.WaitGroup
@@ -105,8 +107,8 @@ func getAllSearchRequestsFromCmi(currQuery *structs.SearchQuery, timeRange *dtu.
 			blockWG.Add(1)
 			go func(key, indName string, blkT *BlockTracker) {
 				defer blockWG.Done()
-				finalReq, totalBlockCount, filteredBlockCount, err := metadata.RunCmiCheck(key, indName, timeRange, blkT, bloomKeys, bloomOp,
-					rangeFilter, rangeOp, isRange, wildCardValue, currQuery, colsToCheck, wildcardColQuery, qid, isQueryPersistent, pqid)
+				finalReq, totalBlockCount, filteredBlockCount, err := metadata.RunCmiCheck(key, indName, timeRange, blkT, bloomKeys, originalBloomKeys, bloomOp,
+					rangeFilter, rangeOp, isRange, wildCardValue, currQuery, colsToCheck, wildcardColQuery, qid, isQueryPersistent, pqid, dualCaseCheckEnabled)
 				if err != nil {
 					log.Errorf("qid=%d, getAllSearchRequestsFromCmi: Failed to get search request from cmi: %+v", qid, err)
 					searchRequestErrors <- err

--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -39,7 +39,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper, isCaseSensitive bool) (bool, error) {
+	bsh *structs.BlockSearchHelper, isCaseInSensitive bool) (bool, error) {
 	var compiledRegex *regexp.Regexp
 	var err error
 
@@ -56,7 +56,7 @@ func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.Mat
 	}
 
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseSensitive)
+		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseInSensitive)
 		if err != nil {
 			return false, err
 		}
@@ -82,7 +82,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
-	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper, isCaseSensitive bool) (bool, error) {
+	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper, isCaseInSensitive bool) (bool, error) {
 
 	if qValDte == nil {
 		return false, nil
@@ -94,7 +94,7 @@ func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *util
 
 	dte := &utils.DtypeEnclosure{}
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseSensitive)
+		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseInSensitive)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -39,7 +39,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper) (bool, error) {
+	bsh *structs.BlockSearchHelper, isCaseSensitive bool) (bool, error) {
 	var compiledRegex *regexp.Regexp
 	var err error
 
@@ -56,7 +56,7 @@ func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.Mat
 	}
 
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex)
+		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseSensitive)
 		if err != nil {
 			return false, err
 		}
@@ -82,7 +82,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
-	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper) (bool, error) {
+	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper, isCaseSensitive bool) (bool, error) {
 
 	if qValDte == nil {
 		return false, nil
@@ -94,7 +94,7 @@ func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *util
 
 	dte := &utils.DtypeEnclosure{}
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte)
+		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseSensitive)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -39,7 +39,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper, isCaseInSensitive bool) (bool, error) {
+	bsh *structs.BlockSearchHelper, isCaseInsensitive bool) (bool, error) {
 	var compiledRegex *regexp.Regexp
 	var err error
 
@@ -56,7 +56,7 @@ func (sfr *SegmentFileReader) ApplySearchToMatchFilterDictCsg(match *structs.Mat
 	}
 
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseInSensitive)
+		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseInsensitive)
 		if err != nil {
 			return false, err
 		}
@@ -82,7 +82,7 @@ returns:
 	err
 */
 func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
-	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper, isCaseInSensitive bool) (bool, error) {
+	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper, isCaseInsensitive bool) (bool, error) {
 
 	if qValDte == nil {
 		return false, nil
@@ -94,7 +94,7 @@ func (sfr *SegmentFileReader) ApplySearchToExpressionFilterDictCsg(qValDte *util
 
 	dte := &utils.DtypeEnclosure{}
 	for dwordIdx, dWord := range sfr.deTlv {
-		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseInSensitive)
+		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseInsensitive)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -369,19 +369,19 @@ func (mcsr *MultiColSegmentReader) GetDictEncCvalsFromColFile(results map[uint16
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper, cname string, isCaseInSensitive bool) (bool, error) {
+	bsh *structs.BlockSearchHelper, cname string, isCaseInsensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
 		return false, errors.New("could not find sfr for cname")
 	}
 
-	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh, isCaseInSensitive)
+	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh, isCaseInsensitive)
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
 	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper,
-	cname string, isCaseInSensitive bool) (bool, error) {
+	cname string, isCaseInsensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
@@ -389,7 +389,7 @@ func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte 
 	}
 
 	return mcsr.allFileReaders[keyIndex].ApplySearchToExpressionFilterDictCsg(qValDte,
-		fop, isRegexSearch, bsh, isCaseInSensitive)
+		fop, isRegexSearch, bsh, isCaseInsensitive)
 }
 
 func (mcsr *MultiColSegmentReader) IsColPresent(cname string) bool {

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -369,19 +369,19 @@ func (mcsr *MultiColSegmentReader) GetDictEncCvalsFromColFile(results map[uint16
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper, cname string, isCaseSensitive bool) (bool, error) {
+	bsh *structs.BlockSearchHelper, cname string, isCaseInSensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
 		return false, errors.New("could not find sfr for cname")
 	}
 
-	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh, isCaseSensitive)
+	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh, isCaseInSensitive)
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
 	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper,
-	cname string, isCaseSensitive bool) (bool, error) {
+	cname string, isCaseInSensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
@@ -389,7 +389,7 @@ func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte 
 	}
 
 	return mcsr.allFileReaders[keyIndex].ApplySearchToExpressionFilterDictCsg(qValDte,
-		fop, isRegexSearch, bsh, isCaseSensitive)
+		fop, isRegexSearch, bsh, isCaseInSensitive)
 }
 
 func (mcsr *MultiColSegmentReader) IsColPresent(cname string) bool {

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -369,19 +369,19 @@ func (mcsr *MultiColSegmentReader) GetDictEncCvalsFromColFile(results map[uint16
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToMatchFilterDictCsg(match *structs.MatchFilter,
-	bsh *structs.BlockSearchHelper, cname string) (bool, error) {
+	bsh *structs.BlockSearchHelper, cname string, isCaseSensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
 		return false, errors.New("could not find sfr for cname")
 	}
 
-	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh)
+	return mcsr.allFileReaders[keyIndex].ApplySearchToMatchFilterDictCsg(match, bsh, isCaseSensitive)
 }
 
 func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte *utils.DtypeEnclosure,
 	fop utils.FilterOperator, isRegexSearch bool, bsh *structs.BlockSearchHelper,
-	cname string) (bool, error) {
+	cname string, isCaseSensitive bool) (bool, error) {
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
@@ -389,7 +389,7 @@ func (mcsr *MultiColSegmentReader) ApplySearchToExpressionFilterDictCsg(qValDte 
 	}
 
 	return mcsr.allFileReaders[keyIndex].ApplySearchToExpressionFilterDictCsg(qValDte,
-		fop, isRegexSearch, bsh)
+		fop, isRegexSearch, bsh, isCaseSensitive)
 }
 
 func (mcsr *MultiColSegmentReader) IsColPresent(cname string) bool {

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -63,7 +63,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInSensitive)
+		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInsensitive)
 	case MatchWordsAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -76,7 +76,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInSensitive)
+			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInsensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -92,14 +92,14 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInSensitive)
+		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInsensitive)
 	case RegexExpression:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
 		if err != nil {
 			log.Debugf("ApplyColumnarSearchQuery: failed to read column %v rec from column file. qid=%v, err: %v", query.QueryInfo.ColName, qid, err)
 			return false, nil
 		}
-		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInSensitive)
+		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInsensitive)
 	case RegexExpressionAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -112,7 +112,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInSensitive)
+			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInsensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -135,7 +135,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInSensitive)
+			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInsensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -151,7 +151,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, Equals, true, holderDte, query.FilterIsCaseInSensitive)
+		return writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, Equals, true, holderDte, query.FilterIsCaseInsensitive)
 	case MatchDictArrayAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -164,7 +164,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, query.ExpressionFilter.FilterOp, true, holderDte, query.FilterIsCaseInSensitive)
+			retVal, _ := writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, query.ExpressionFilter.FilterOp, true, holderDte, query.FilterIsCaseInsensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -210,7 +210,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			return true, dictEncColNames, nil
 		}
 
-		found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInSensitive)
+		found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInsensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: matchwords dict search failed, err=%v", err)
 			return false, dictEncColNames, err
@@ -230,7 +230,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			}
 
 			dictEncColNames[cname] = true
-			found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, cname, sq.FilterIsCaseInSensitive)
+			found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, cname, sq.FilterIsCaseInsensitive)
 			if err != nil {
 				continue
 			}
@@ -254,7 +254,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 		}
 
 		found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-			sq.ExpressionFilter.FilterOp, regex, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInSensitive)
+			sq.ExpressionFilter.FilterOp, regex, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInsensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: simpleexp/wildrexp dict search failed, err=%v", err)
 			return false, dictEncColNames, err
@@ -275,7 +275,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 
 			dictEncColNames[cname] = true
 			found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-				sq.ExpressionFilter.FilterOp, true, bsh, cname, sq.FilterIsCaseInSensitive)
+				sq.ExpressionFilter.FilterOp, true, bsh, cname, sq.FilterIsCaseInsensitive)
 			if err != nil {
 				continue
 			}
@@ -299,7 +299,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 
 			dictEncColNames[cname] = true
 			found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-				sq.ExpressionFilter.FilterOp, false, bsh, cname, sq.FilterIsCaseInSensitive)
+				sq.ExpressionFilter.FilterOp, false, bsh, cname, sq.FilterIsCaseInsensitive)
 			if err != nil {
 				continue
 			}

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -63,7 +63,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseSensitive)
+		return writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInSensitive)
 	case MatchWordsAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -76,7 +76,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseSensitive)
+			retVal, _ := writer.ApplySearchToMatchFilterRawCsg(query.MatchFilter, rawColVal, compiledRegex, query.FilterIsCaseInSensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -92,14 +92,14 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseSensitive)
+		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInSensitive)
 	case RegexExpression:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
 		if err != nil {
 			log.Debugf("ApplyColumnarSearchQuery: failed to read column %v rec from column file. qid=%v, err: %v", query.QueryInfo.ColName, qid, err)
 			return false, nil
 		}
-		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseSensitive)
+		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInSensitive)
 	case RegexExpressionAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -112,7 +112,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseSensitive)
+			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, true, holderDte, query.FilterIsCaseInSensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -135,7 +135,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseSensitive)
+			retVal, _ := writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte, query.FilterIsCaseInSensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -151,7 +151,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		if err != nil {
 			return false, err
 		}
-		return writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, Equals, true, holderDte, query.FilterIsCaseSensitive)
+		return writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, Equals, true, holderDte, query.FilterIsCaseInSensitive)
 	case MatchDictArrayAllColumns:
 		var atleastOneNonError bool
 		var finalErr error
@@ -164,7 +164,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			} else {
 				atleastOneNonError = true
 			}
-			retVal, _ := writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, query.ExpressionFilter.FilterOp, true, holderDte, query.FilterIsCaseSensitive)
+			retVal, _ := writer.ApplySearchToDictArrayFilter(query.QueryInfo.KValDte, query.QueryInfo.QValDte, rawColVal, query.ExpressionFilter.FilterOp, true, holderDte, query.FilterIsCaseInSensitive)
 			if retVal {
 				multiColReader.IncrementColumnUsageByIdx(colKeyIndex)
 				return true, nil
@@ -210,7 +210,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			return true, dictEncColNames, nil
 		}
 
-		found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseSensitive)
+		found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInSensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: matchwords dict search failed, err=%v", err)
 			return false, dictEncColNames, err
@@ -230,7 +230,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			}
 
 			dictEncColNames[cname] = true
-			found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, cname, sq.FilterIsCaseSensitive)
+			found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, cname, sq.FilterIsCaseInSensitive)
 			if err != nil {
 				continue
 			}
@@ -254,7 +254,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 		}
 
 		found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-			sq.ExpressionFilter.FilterOp, regex, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseSensitive)
+			sq.ExpressionFilter.FilterOp, regex, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInSensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: simpleexp/wildrexp dict search failed, err=%v", err)
 			return false, dictEncColNames, err
@@ -275,7 +275,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 
 			dictEncColNames[cname] = true
 			found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-				sq.ExpressionFilter.FilterOp, true, bsh, cname, sq.FilterIsCaseSensitive)
+				sq.ExpressionFilter.FilterOp, true, bsh, cname, sq.FilterIsCaseInSensitive)
 			if err != nil {
 				continue
 			}
@@ -299,7 +299,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 
 			dictEncColNames[cname] = true
 			found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
-				sq.ExpressionFilter.FilterOp, false, bsh, cname, sq.FilterIsCaseSensitive)
+				sq.ExpressionFilter.FilterOp, false, bsh, cname, sq.FilterIsCaseInSensitive)
 			if err != nil {
 				continue
 			}

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -75,7 +75,7 @@ func RawSearchSegmentFileWrapper(req *structs.SegmentSearchRequest, parallelismP
 		return
 	}
 	defer numConcurrentRawSearch.Release(1)
-	searchMemory := req.GetMaxSearchMemorySize(searchNode, parallelismPerFile, PQMR_INITIAL_SIZE)
+	searchMemory := req.GetMaxSearchMemorySize(parallelismPerFile, PQMR_INITIAL_SIZE)
 	err = limit.RequestSearchMemory(searchMemory)
 	if err != nil {
 		log.Errorf("qid=%d, Failed to acquire memory from global pool for search! Error: %v", qid, err)
@@ -629,7 +629,7 @@ func AggsFastPathWrapper(req *structs.SegmentSearchRequest, parallelismPerFile i
 		return
 	}
 	defer numConcurrentRawSearch.Release(1)
-	searchMemory := req.GetMaxSearchMemorySize(searchNode, parallelismPerFile, PQMR_INITIAL_SIZE)
+	searchMemory := req.GetMaxSearchMemorySize(parallelismPerFile, PQMR_INITIAL_SIZE)
 	err = limit.RequestSearchMemory(searchMemory)
 	if err != nil {
 		log.Errorf("qid=%d, Failed to acquire memory from global pool for search! Error: %v", qid, err)

--- a/pkg/segment/structs/expressionstructs.go
+++ b/pkg/segment/structs/expressionstructs.go
@@ -25,8 +25,9 @@ import (
 // only one field will be non-nil
 // literal can either be a string or a json.Number
 type ExpressionInput struct {
-	ColumnValue *DtypeEnclosure // column value: "0", "abc", "abcd*", "0.213"
-	ColumnName  string          // column name for expression: "col1", "col2", ... "colN"
+	ColumnValue         *DtypeEnclosure // column value: "0", "abc", "abcd*", "0.213". This value will be normalized to Lower Case if the search is case insensitive.
+	OriginalColumnValue *DtypeEnclosure // original column value. Similar to Column Value, but is only created when dualCaseCheck is enabled and the search is case insensitive
+	ColumnName          string          // column name for expression: "col1", "col2", ... "colN"
 }
 
 // expressions are used for SegReaders to parse and search segment files

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -91,8 +91,9 @@ type ExpressionFilter struct {
 
 // Top level filter criteria condition that define either a MatchFilter or ExpressionFilter. Only one will be defined, never both
 type FilterCriteria struct {
-	MatchFilter      *MatchFilter      // match filter to check multiple words in a column
-	ExpressionFilter *ExpressionFilter // expression filter to check a single expression in a column
+	MatchFilter           *MatchFilter      // match filter to check multiple words in a column
+	ExpressionFilter      *ExpressionFilter // expression filter to check a single expression in a column
+	FilterIsCaseSensitive bool              // if the filter is case sensitive
 }
 
 // A condition struct defines the FilterConditions and ASTNodes that exist as a part of a single condition

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -66,15 +66,17 @@ const (
 // MatchFilter searches for all words in matchWords in the column matchColumn
 // The matchOperator defines if all or any of the matchWords need to be present
 type MatchFilter struct {
-	MatchColumn    string                 // column to search for
-	MatchWords     [][]byte               // all words to search for
-	MatchOperator  utils.LogicalOperator  // how to combine matchWords
-	MatchPhrase    []byte                 //whole string to search for in case of MatchPhrase query
-	MatchDictArray *MatchDictArrayRequest //array to search for in case of jaeger query
-	MatchType      MatchFilterType
-	NegateMatch    bool
-	RegexpString   string // Do not manually set this. Use SetRegexp(). This is only public to allow for GOB encoding MatchFilter.
-	regexp         *regexp.Regexp
+	MatchColumn         string                 // column to search for
+	MatchWords          [][]byte               // all words to search for. The values will be normalized to Lower case if the query is case insensitive
+	MatchWordsOriginal  [][]byte               // all original words to search for. Will be set only if dualcasecheck is enabled and query is case insensitive.
+	MatchOperator       utils.LogicalOperator  // how to combine matchWords
+	MatchPhrase         []byte                 //whole string to search for in case of MatchPhrase query. The value will be normalized to Lower case if the query is case insensitive
+	MatchPhraseOriginal []byte                 //original string to search for in case of MatchPhrase query. Will be set only if dualcasecheck is enabled and query is case insensitive.
+	MatchDictArray      *MatchDictArrayRequest //array to search for in case of jaeger query
+	MatchType           MatchFilterType
+	NegateMatch         bool
+	RegexpString        string // Do not manually set this. Use SetRegexp(). This is only public to allow for GOB encoding MatchFilter.
+	regexp              *regexp.Regexp
 }
 
 type MatchDictArrayRequest struct {

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -91,9 +91,9 @@ type ExpressionFilter struct {
 
 // Top level filter criteria condition that define either a MatchFilter or ExpressionFilter. Only one will be defined, never both
 type FilterCriteria struct {
-	MatchFilter           *MatchFilter      // match filter to check multiple words in a column
-	ExpressionFilter      *ExpressionFilter // expression filter to check a single expression in a column
-	FilterIsCaseSensitive bool              // if the filter is case sensitive
+	MatchFilter             *MatchFilter      // match filter to check multiple words in a column
+	ExpressionFilter        *ExpressionFilter // expression filter to check a single expression in a column
+	FilterIsCaseInSensitive bool              // if the filter is case sensitive
 }
 
 // A condition struct defines the FilterConditions and ASTNodes that exist as a part of a single condition

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -95,7 +95,7 @@ type ExpressionFilter struct {
 type FilterCriteria struct {
 	MatchFilter             *MatchFilter      // match filter to check multiple words in a column
 	ExpressionFilter        *ExpressionFilter // expression filter to check a single expression in a column
-	FilterIsCaseInSensitive bool              // if the filter is case sensitive
+	FilterIsCaseInsensitive bool              // if the filter is case sensitive
 }
 
 // A condition struct defines the FilterConditions and ASTNodes that exist as a part of a single condition

--- a/pkg/segment/structs/searchnodestructs.go
+++ b/pkg/segment/structs/searchnodestructs.go
@@ -54,10 +54,11 @@ const (
 // A Search query is either an expression or match filter
 // Never will both be defined
 type SearchQuery struct {
-	ExpressionFilter *SearchExpression
-	MatchFilter      *MatchFilter
-	SearchType       SearchQueryType // type of query
-	QueryInfo        *QueryInfo      // query info
+	ExpressionFilter      *SearchExpression
+	MatchFilter           *MatchFilter
+	SearchType            SearchQueryType // type of query
+	QueryInfo             *QueryInfo      // query info
+	FilterIsCaseSensitive bool            // whether the filter is case sensitive
 }
 
 type QueryInfo struct {

--- a/pkg/segment/structs/searchnodestructs.go
+++ b/pkg/segment/structs/searchnodestructs.go
@@ -54,11 +54,11 @@ const (
 // A Search query is either an expression or match filter
 // Never will both be defined
 type SearchQuery struct {
-	ExpressionFilter      *SearchExpression
-	MatchFilter           *MatchFilter
-	SearchType            SearchQueryType // type of query
-	QueryInfo             *QueryInfo      // query info
-	FilterIsCaseSensitive bool            // whether the filter is case sensitive
+	ExpressionFilter        *SearchExpression
+	MatchFilter             *MatchFilter
+	SearchType              SearchQueryType // type of query
+	QueryInfo               *QueryInfo      // query info
+	FilterIsCaseInSensitive bool            // whether the filter is case sensitive
 }
 
 type QueryInfo struct {

--- a/pkg/segment/structs/searchnodestructs.go
+++ b/pkg/segment/structs/searchnodestructs.go
@@ -312,17 +312,18 @@ func GetAllColumnsFromCondition(cond *SearchCondition) (map[string]bool, bool) {
 // returns map[string]bool, bool, LogicalOperator
 // map is all non-wildcard block bloom keys, bool is if any keyword contained a wildcard, LogicalOperator
 // is if any/all of map keys need to exist
-func (query *SearchQuery) GetAllBlockBloomKeysToSearch() (map[string]bool, bool, LogicalOperator) {
+func (query *SearchQuery) GetAllBlockBloomKeysToSearch() (map[string]bool, map[string]string, bool, LogicalOperator) {
+	dualCaseCheckEnabled := config.IsDualCaseCheckEnabled()
 
 	if query.MatchFilter != nil {
-		matchKeys, wildcardExists, matchOp := query.MatchFilter.GetAllBlockBloomKeysToSearch()
-		return matchKeys, wildcardExists, matchOp
+		matchKeys, originalMatchKeys, wildcardExists, matchOp := query.MatchFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInSensitive)
+		return matchKeys, originalMatchKeys, wildcardExists, matchOp
 	} else {
-		blockBloomKeys, wildcardExists, err := query.ExpressionFilter.GetAllBlockBloomKeysToSearch()
+		blockBloomKeys, originalBlockBloomKeys, wildcardExists, err := query.ExpressionFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInSensitive)
 		if err != nil {
-			return make(map[string]bool), false, And
+			return make(map[string]bool), make(map[string]string), false, And
 		}
-		return blockBloomKeys, wildcardExists, And
+		return blockBloomKeys, originalBlockBloomKeys, wildcardExists, And
 	}
 }
 

--- a/pkg/segment/structs/searchnodestructs.go
+++ b/pkg/segment/structs/searchnodestructs.go
@@ -58,7 +58,7 @@ type SearchQuery struct {
 	MatchFilter             *MatchFilter
 	SearchType              SearchQueryType // type of query
 	QueryInfo               *QueryInfo      // query info
-	FilterIsCaseInSensitive bool            // whether the filter is case sensitive
+	FilterIsCaseInsensitive bool            // whether the filter is case sensitive
 }
 
 type QueryInfo struct {
@@ -316,10 +316,10 @@ func (query *SearchQuery) GetAllBlockBloomKeysToSearch() (map[string]bool, map[s
 	dualCaseCheckEnabled := config.IsDualCaseCheckEnabled()
 
 	if query.MatchFilter != nil {
-		matchKeys, originalMatchKeys, wildcardExists, matchOp := query.MatchFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInSensitive)
+		matchKeys, originalMatchKeys, wildcardExists, matchOp := query.MatchFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInsensitive)
 		return matchKeys, originalMatchKeys, wildcardExists, matchOp
 	} else {
-		blockBloomKeys, originalBlockBloomKeys, wildcardExists, err := query.ExpressionFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInSensitive)
+		blockBloomKeys, originalBlockBloomKeys, wildcardExists, err := query.ExpressionFilter.GetAllBlockBloomKeysToSearch(dualCaseCheckEnabled, query.FilterIsCaseInsensitive)
 		if err != nil {
 			return make(map[string]bool), make(map[string]string), false, And
 		}

--- a/pkg/segment/structs/segsearchstructs.go
+++ b/pkg/segment/structs/segsearchstructs.go
@@ -141,7 +141,7 @@ type CmiContainer struct {
 
 // even if only one block will be searched and parallelism=10, we will spawn 10 buffers, although 9 wont be used
 // TODO: more accurate block summaries and colmeta sizing
-func (ssr *SegmentSearchRequest) GetMaxSearchMemorySize(sNode *SearchNode, parallelismPerFile int64, bitsetMinSize uint16) uint64 {
+func (ssr *SegmentSearchRequest) GetMaxSearchMemorySize(parallelismPerFile int64, bitsetMinSize uint16) uint64 {
 
 	// bitset size worst case is min(15000*num blocks, total record count)
 	var totalBits uint64
@@ -327,11 +327,12 @@ func getSearchInputFromFilterInput(filter *FilterInput, qid uint64) *SearchExpre
 }
 
 func GetSearchQueryFromFilterCriteria(criteria *FilterCriteria, qid uint64) *SearchQuery {
+	var sq *SearchQuery
 
 	if criteria.MatchFilter != nil {
-		return extractSearchQueryFromMatchFilter(criteria.MatchFilter)
+		sq = extractSearchQueryFromMatchFilter(criteria.MatchFilter)
 	} else {
-		sq := extractSearchQueryFromExpressionFilter(criteria.ExpressionFilter, qid)
+		sq = extractSearchQueryFromExpressionFilter(criteria.ExpressionFilter, qid)
 
 		var colVal *DtypeEnclosure
 		if sq.ExpressionFilter.LeftSearchInput.ColumnValue != nil {
@@ -343,8 +344,9 @@ func GetSearchQueryFromFilterCriteria(criteria *FilterCriteria, qid uint64) *Sea
 		if colVal != nil && colVal.Dtype == SS_DT_STRING && colVal.StringVal == "*" {
 			sq.SearchType = MatchAll
 		}
-		return sq
 	}
+	sq.FilterIsCaseSensitive = criteria.FilterIsCaseSensitive
+	return sq
 }
 
 func extractSearchQueryFromMatchFilter(match *MatchFilter) *SearchQuery {

--- a/pkg/segment/structs/segsearchstructs.go
+++ b/pkg/segment/structs/segsearchstructs.go
@@ -345,7 +345,7 @@ func GetSearchQueryFromFilterCriteria(criteria *FilterCriteria, qid uint64) *Sea
 			sq.SearchType = MatchAll
 		}
 	}
-	sq.FilterIsCaseSensitive = criteria.FilterIsCaseSensitive
+	sq.FilterIsCaseInSensitive = criteria.FilterIsCaseInSensitive
 	return sq
 }
 

--- a/pkg/segment/structs/segsearchstructs_test.go
+++ b/pkg/segment/structs/segsearchstructs_test.go
@@ -31,7 +31,7 @@ func Test_getSearchInputFromFilter(t *testing.T) {
 		SubtreeResult: "literal1",
 	}
 
-	search := getSearchInputFromFilterInput(simpleFilter, 0)
+	search := getSearchInputFromFilterInput(simpleFilter, false, 0)
 	log.Info(search)
 	assert.Equal(t, search.ColumnValue.StringVal, "literal1")
 
@@ -45,7 +45,7 @@ func Test_getSearchInputFromFilter(t *testing.T) {
 		Expression: exp,
 	}
 
-	search = getSearchInputFromFilterInput(expressionColumnFilter, 0)
+	search = getSearchInputFromFilterInput(expressionColumnFilter, false, 0)
 	log.Info(search)
 	assert.Nil(t, search.ColumnValue)
 	assert.Equal(t, 1, len(search.getAllColumnsInSearch()))
@@ -66,7 +66,7 @@ func Test_getSearchInputFromFilter(t *testing.T) {
 	expressionComplexFilter := &FilterInput{
 		Expression: exp,
 	}
-	search = getSearchInputFromFilterInput(expressionComplexFilter, 0)
+	search = getSearchInputFromFilterInput(expressionComplexFilter, false, 0)
 	assert.Nil(t, search.ColumnValue)
 	assert.Equal(t, 0, len(search.ColumnName))
 	assert.Equal(t, 2, len(search.getAllColumnsInSearch()))

--- a/pkg/segment/structs/segsearchstructs_test.go
+++ b/pkg/segment/structs/segsearchstructs_test.go
@@ -100,7 +100,7 @@ func Test_extractBlockBloomTokens(t *testing.T) {
 			RightSearchInput: rightInput,
 		},
 	}
-	allKeys, wildcard, op := query.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op := query.GetAllBlockBloomKeysToSearch()
 	assert.Len(t, allKeys, 1, "only 1 key")
 	_, ok := allKeys["1"]
 	assert.True(t, ok, "value exists")
@@ -108,7 +108,7 @@ func Test_extractBlockBloomTokens(t *testing.T) {
 	assert.Equal(t, And, op)
 
 	query.ExpressionFilter.LeftSearchInput = leftLiteralInput
-	allKeys, wildcard, op = query.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op = query.GetAllBlockBloomKeysToSearch()
 	assert.Len(t, allKeys, 1, "only 1 key")
 	_, ok = allKeys["abc"]
 	assert.True(t, ok, "abc key exists")
@@ -116,7 +116,7 @@ func Test_extractBlockBloomTokens(t *testing.T) {
 	assert.Equal(t, And, op)
 
 	query.ExpressionFilter.LeftSearchInput = leftWildCardInput
-	allKeys, wildcard, op = query.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op = query.GetAllBlockBloomKeysToSearch()
 	assert.Len(t, allKeys, 0, "no keys")
 	_, ok = allKeys["abc*"]
 	assert.False(t, ok, "abc* should not exist bc of wildcard")
@@ -130,7 +130,7 @@ func Test_extractBlockBloomTokens(t *testing.T) {
 			MatchOperator: Or,
 		},
 	}
-	allKeys, wildcard, op = matchTest.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op = matchTest.GetAllBlockBloomKeysToSearch()
 	assert.True(t, wildcard)
 	assert.Len(t, allKeys, 2, "2 keys")
 	_, ok = allKeys["a"]
@@ -153,7 +153,7 @@ func Test_GetAllBlockBloomKeysToSearch_MatchPhrase(t *testing.T) {
 		MatchType:     MATCH_PHRASE,
 	}
 
-	allKeys, wildcard, op := matchFilterNoWildcard.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op := matchFilterNoWildcard.GetAllBlockBloomKeysToSearch(false, false)
 	assert.Equal(t, 1, len(allKeys))
 	_, ok := allKeys["foo bar"]
 	assert.True(t, ok)
@@ -168,7 +168,7 @@ func Test_GetAllBlockBloomKeysToSearch_MatchPhrase(t *testing.T) {
 		MatchType:     MATCH_PHRASE,
 	}
 
-	allKeys, wildcard, op = matchFilterWithWildcard.GetAllBlockBloomKeysToSearch()
+	allKeys, _, wildcard, op = matchFilterWithWildcard.GetAllBlockBloomKeysToSearch(false, false)
 	assert.Equal(t, 0, len(allKeys))
 	assert.True(t, wildcard)
 	assert.Equal(t, And, op)

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -65,7 +65,7 @@ const WIP_SIZE = 2_000_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size
-const BLOCK_BLOOM_SIZE = 100 // the default should be on the smaller side. Let dynamic bloom sizing fix the optimal one
+const BLOCK_BLOOM_SIZE = 200 // the default should be on the smaller side. Let dynamic bloom sizing fix the optimal one
 const BLOCK_RI_MAP_SIZE = 100
 
 var MAX_BYTES_METRICS_BLOCK uint64 = 1e+8         // 100MB

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -165,6 +165,29 @@ func CreateDtypeEnclosure(inVal interface{}, qid uint64) (*DtypeEnclosure, error
 	return &dte, nil
 }
 
+func (dte *DtypeEnclosure) UpdateTheRegexp(caseInsensitive bool) {
+	if dte == nil {
+		return
+	}
+
+	if dte.Dtype != SS_DT_STRING {
+		return
+	}
+
+	if strings.Contains(dte.StringVal, "*") {
+		rawRegex := dtu.ReplaceWildcardStarWithRegex(dte.StringVal)
+		if caseInsensitive {
+			rawRegex = "(?i)" + rawRegex
+		}
+
+		compiledRegex, err := regexp.Compile(rawRegex)
+		if err != nil {
+			log.Errorf("UpdateTheRegexp: Failed to compile regex for %s. This may cause search failures. Err: %v", rawRegex, err)
+		}
+		dte.SetRegexp(compiledRegex)
+	}
+}
+
 func enclosureFromJsonNumber(num json.Number, dte *DtypeEnclosure) {
 
 	numstr := string(num)

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -165,7 +165,7 @@ func CreateDtypeEnclosure(inVal interface{}, qid uint64) (*DtypeEnclosure, error
 	return &dte, nil
 }
 
-func (dte *DtypeEnclosure) UpdateTheRegexp(caseInsensitive bool) {
+func (dte *DtypeEnclosure) UpdateRegexp(caseInsensitive bool) {
 	if dte == nil {
 		return
 	}
@@ -182,7 +182,7 @@ func (dte *DtypeEnclosure) UpdateTheRegexp(caseInsensitive bool) {
 
 		compiledRegex, err := regexp.Compile(rawRegex)
 		if err != nil {
-			log.Errorf("UpdateTheRegexp: Failed to compile regex for %s. This may cause search failures. Err: %v", rawRegex, err)
+			log.Errorf("UpdateRegexp: Failed to compile regex for %s. This may cause search failures. Err: %v", rawRegex, err)
 		}
 		dte.SetRegexp(compiledRegex)
 	}

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -18,6 +18,7 @@
 package writer
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -488,7 +489,7 @@ func (ss *SegStore) encodeSingleString(key string, valStr string, maxIdx uint32,
 
 	if bi != nil {
 		bi.uniqueWordCount += addToBlockBloom(bi.Bf, valBytes)
-		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strings.ToLower(value)))
+		bi.uniqueWordCount += addToBlockBloom(bi.Bf, bytes.ToLower(valBytes))
 	}
 	if !ss.skipDe {
 		checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -25,6 +25,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -358,6 +359,8 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte, maxIdx u
 			if bi != nil {
 				bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(keyName))
 				bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(keyVal))
+				bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strings.ToLower(keyName)))
+				bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strings.ToLower(keyVal)))
 			}
 			stats.AddSegStatsStr(ss.AllSst, keyName, keyVal, ss.wipBlock.bb, nil, false, false)
 			if colWip.cbufidx > maxIdx {
@@ -466,6 +469,7 @@ func (ss *SegStore) encodeSingleString(key string, value string, maxIdx uint32,
 
 	if bi != nil {
 		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(value))
+		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strings.ToLower(value)))
 	}
 	if !ss.skipDe {
 		checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum)

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -32,7 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRegex *regexp.Regexp, isCaseInSensitive bool) (bool, error) {
+func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRegex *regexp.Regexp, isCaseInsensitive bool) (bool, error) {
 	var err error
 
 	if len(match.MatchWords) == 0 {
@@ -75,11 +75,11 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 				// if the search is case insensitive, then the compiled regex should already be case insensitive regex
 				foundQword = compiledRegex.Match(asciiBytes)
 			} else {
-				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase, isCaseInSensitive)
+				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase, isCaseInsensitive)
 			}
 		} else {
 			for _, qword := range match.MatchWords {
-				foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseInSensitive)
+				foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseInsensitive)
 				if !foundQword {
 					break
 				}
@@ -91,7 +91,7 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 	if match.MatchOperator == Or {
 		var foundQword bool
 		for _, qword := range match.MatchWords {
-			foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseInSensitive)
+			foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseInsensitive)
 			if foundQword {
 				return true, nil
 			}
@@ -103,7 +103,7 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 }
 
 func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byte, fop FilterOperator, isRegexSearch bool,
-	holderDte *DtypeEnclosure, isCaseInSensitive bool) (bool, error) {
+	holderDte *DtypeEnclosure, isCaseInsensitive bool) (bool, error) {
 	if qValDte == nil {
 		return false, nil
 	}
@@ -120,7 +120,7 @@ func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byt
 			strlen := utils.BytesToUint16LittleEndian(rec[idx : idx+2])
 			idx += 2
 			if int(strlen) == len(col) {
-				keyEquals = utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[idx:idx+strlen], col)
+				keyEquals = utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[idx:idx+strlen], col)
 			}
 			idx += strlen
 			if !keyEquals {
@@ -146,23 +146,23 @@ func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byt
 				// one byte for type & two for reclen
 				strlen := utils.BytesToUint16LittleEndian(rec[idx+1 : idx+3])
 				idx += 3
-				valEquals = utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
+				valEquals = utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
 				idx += strlen
 			case VALTYPE_ENC_BOOL[0]:
 				// valEquals, err = fopOnBool(rec[idx:], qValDte, fop)
 				strlen := utils.BytesToUint16LittleEndian(rec[idx+1 : idx+3])
 				idx += 3
-				valEquals = utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
+				valEquals = utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
 				idx += strlen
 			case VALTYPE_ENC_INT64[0]:
 				strlen := utils.BytesToUint16LittleEndian(rec[idx+1 : idx+3])
 				idx += 3
-				valEquals = utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
+				valEquals = utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
 				idx += strlen
 			case VALTYPE_ENC_FLOAT64[0]:
 				strlen := utils.BytesToUint16LittleEndian(rec[idx+1 : idx+3])
 				idx += 3
-				valEquals = utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
+				valEquals = utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[idx:idx+strlen], qValDte.StringValBytes)
 				idx += strlen
 			default:
 				log.Errorf("ApplySearchToDictArrayFilter:SS_DT_ARRAY_DICT unknown type=%v\n", rec[idx])
@@ -178,11 +178,11 @@ func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byt
 }
 
 func ApplySearchToExpressionFilterSimpleCsg(qValDte *DtypeEnclosure, fop FilterOperator,
-	col []byte, isRegexSearch bool, holderDte *DtypeEnclosure, isCaseInSensitive bool) (bool, error) {
+	col []byte, isRegexSearch bool, holderDte *DtypeEnclosure, isCaseInsensitive bool) (bool, error) {
 
 	holderDte.Reset()
 
-	return filterOpOnDataType(col, qValDte, fop, isRegexSearch, holderDte, isCaseInSensitive)
+	return filterOpOnDataType(col, qValDte, fop, isRegexSearch, holderDte, isCaseInsensitive)
 }
 
 func isValTypeEncANumber(valTypeEnc byte) bool {
@@ -196,7 +196,7 @@ func isValTypeEncANumber(valTypeEnc byte) bool {
 }
 
 func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
-	isRegexSearch bool, recDte *DtypeEnclosure, isCaseInSensitive bool) (bool, error) {
+	isRegexSearch bool, recDte *DtypeEnclosure, isCaseInsensitive bool) (bool, error) {
 
 	if qValDte == nil {
 		return false, nil
@@ -221,7 +221,7 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 
 			return false, nil
 		}
-		return fopOnString(rec, qValDte, fop, isRegexSearch, isCaseInSensitive)
+		return fopOnString(rec, qValDte, fop, isRegexSearch, isCaseInsensitive)
 	case SS_DT_BOOL:
 		if len(rec) == 0 {
 			if fop == Equals {
@@ -288,7 +288,7 @@ func filterOpOnRecNumberEncType(rec []byte, qValDte *DtypeEnclosure, fop FilterO
 
 // If the search is a regex search and case insensitive, then the compiled regex should already be case insensitive regex
 func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
-	isRegexSearch bool, isCaseInSensitive bool) (bool, error) {
+	isRegexSearch bool, isCaseInsensitive bool) (bool, error) {
 
 	const sOff int = 3
 	if len(rec) < sOff {
@@ -307,7 +307,7 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 		if len(rec[sOff:]) != len(qValDte.StringVal) {
 			return false, nil
 		}
-		return utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[sOff:], qValDte.StringValBytes), nil
+		return utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[sOff:], qValDte.StringValBytes), nil
 	case NotEquals:
 		if isRegexSearch {
 			regexp := qValDte.GetRegexp()
@@ -316,7 +316,7 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 			}
 			return !regexp.Match(rec[sOff:]), nil
 		}
-		return !utils.PerformBytesEqualityCheck(isCaseInSensitive, rec[sOff:], qValDte.StringValBytes), nil
+		return !utils.PerformBytesEqualityCheck(isCaseInsensitive, rec[sOff:], qValDte.StringValBytes), nil
 	}
 	return false, nil
 }

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -73,6 +73,7 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 			}
 
 			if compiledRegex != nil {
+				asciiBytes = utils.NormalizeSearchBytes(isCaseInSensitive, asciiBytes)
 				foundQword = compiledRegex.Match(asciiBytes)
 			} else {
 				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase, isCaseInSensitive)
@@ -302,7 +303,8 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 			if regexp == nil {
 				return false, errors.New("qValDte had nil regexp compilation")
 			}
-			return regexp.Match(rec[sOff:]), nil
+			searchBytes := utils.NormalizeSearchBytes(isCaseInSensitive, rec[sOff:])
+			return regexp.Match(searchBytes), nil
 		}
 		if len(rec[sOff:]) != len(qValDte.StringVal) {
 			return false, nil
@@ -315,7 +317,8 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 			if regexp == nil {
 				return false, errors.New("qValDte had nil regexp compilation")
 			}
-			return !regexp.Match(rec[sOff:]), nil
+			searchBytes := utils.NormalizeSearchBytes(isCaseInSensitive, rec[sOff:])
+			return !regexp.Match(searchBytes), nil
 		}
 		searchBytes := utils.NormalizeSearchBytes(isCaseInSensitive, rec[sOff:])
 		return !bytes.Equal(searchBytes, qValDte.StringValBytes), nil

--- a/pkg/segment/writer/rawchecker.go
+++ b/pkg/segment/writer/rawchecker.go
@@ -33,7 +33,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRegex *regexp.Regexp) (bool, error) {
+func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRegex *regexp.Regexp, isCaseSensitive bool) (bool, error) {
 	var err error
 
 	if len(match.MatchWords) == 0 {
@@ -75,11 +75,11 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 			if compiledRegex != nil {
 				foundQword = compiledRegex.Match(asciiBytes)
 			} else {
-				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase)
+				foundQword = utils.IsSubWordPresent(asciiBytes, match.MatchPhrase, isCaseSensitive)
 			}
 		} else {
 			for _, qword := range match.MatchWords {
-				foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword))
+				foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseSensitive)
 				if !foundQword {
 					break
 				}
@@ -91,7 +91,7 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 	if match.MatchOperator == Or {
 		var foundQword bool
 		for _, qword := range match.MatchWords {
-			foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword))
+			foundQword = utils.IsSubWordPresent(asciiBytes, []byte(qword), isCaseSensitive)
 			if foundQword {
 				return true, nil
 			}
@@ -103,7 +103,7 @@ func ApplySearchToMatchFilterRawCsg(match *MatchFilter, col []byte, compiledRege
 }
 
 func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byte, fop FilterOperator, isRegexSearch bool,
-	holderDte *DtypeEnclosure) (bool, error) {
+	holderDte *DtypeEnclosure, isCaseSensitive bool) (bool, error) {
 	if qValDte == nil {
 		return false, nil
 	}
@@ -111,6 +111,7 @@ func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byt
 	if len(rec) == 0 || rec[0] != VALTYPE_DICT_ARRAY[0] {
 		return false, nil
 	} else if rec[0] == VALTYPE_DICT_ARRAY[0] {
+		rec = utils.NormalizeSearchBytes(isCaseSensitive, rec)
 		//loop over the dict arrray till we reach the end
 		totalLen := utils.BytesToInt16LittleEndian(rec[1:])
 		idx := uint16(3)
@@ -178,11 +179,11 @@ func ApplySearchToDictArrayFilter(col []byte, qValDte *DtypeEnclosure, rec []byt
 }
 
 func ApplySearchToExpressionFilterSimpleCsg(qValDte *DtypeEnclosure, fop FilterOperator,
-	col []byte, isRegexSearch bool, holderDte *DtypeEnclosure) (bool, error) {
+	col []byte, isRegexSearch bool, holderDte *DtypeEnclosure, isCaseSensitive bool) (bool, error) {
 
 	holderDte.Reset()
 
-	return filterOpOnDataType(col, qValDte, fop, isRegexSearch, holderDte)
+	return filterOpOnDataType(col, qValDte, fop, isRegexSearch, holderDte, isCaseSensitive)
 }
 
 func isValTypeEncANumber(valTypeEnc byte) bool {
@@ -196,7 +197,7 @@ func isValTypeEncANumber(valTypeEnc byte) bool {
 }
 
 func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
-	isRegexSearch bool, recDte *DtypeEnclosure) (bool, error) {
+	isRegexSearch bool, recDte *DtypeEnclosure, isCaseSensitive bool) (bool, error) {
 
 	if qValDte == nil {
 		return false, nil
@@ -221,7 +222,7 @@ func filterOpOnDataType(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 
 			return false, nil
 		}
-		return fopOnString(rec, qValDte, fop, isRegexSearch)
+		return fopOnString(rec, qValDte, fop, isRegexSearch, isCaseSensitive)
 	case SS_DT_BOOL:
 		if len(rec) == 0 {
 			if fop == Equals {
@@ -287,7 +288,7 @@ func filterOpOnRecNumberEncType(rec []byte, qValDte *DtypeEnclosure, fop FilterO
 }
 
 func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
-	isRegexSearch bool) (bool, error) {
+	isRegexSearch bool, isCaseSensitive bool) (bool, error) {
 
 	const sOff int = 3
 	if len(rec) < sOff {
@@ -306,7 +307,8 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 		if len(rec[sOff:]) != len(qValDte.StringVal) {
 			return false, nil
 		}
-		return bytes.Equal(rec[sOff:], qValDte.StringValBytes), nil
+		searchBytes := utils.NormalizeSearchBytes(isCaseSensitive, rec[sOff:])
+		return bytes.Equal(searchBytes, qValDte.StringValBytes), nil
 	case NotEquals:
 		if isRegexSearch {
 			regexp := qValDte.GetRegexp()
@@ -315,7 +317,8 @@ func fopOnString(rec []byte, qValDte *DtypeEnclosure, fop FilterOperator,
 			}
 			return !regexp.Match(rec[sOff:]), nil
 		}
-		return !bytes.Equal(rec[sOff:], qValDte.StringValBytes), nil
+		searchBytes := utils.NormalizeSearchBytes(isCaseSensitive, rec[sOff:])
+		return !bytes.Equal(searchBytes, qValDte.StringValBytes), nil
 	}
 	return false, nil
 }

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -78,7 +78,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 
 		var found bool
 		for _, colWip := range colWips {
-			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil)
+			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil, false)
 			assert.Nil(t, err)
 			found = result
 			if found {
@@ -95,7 +95,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
+		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for val2 in column-a worked")
@@ -106,7 +106,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for val2 in column-d worked (should not be found)")
@@ -117,7 +117,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for two values in column-a worked (should not be found)")
@@ -128,7 +128,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for multiple values in column-a worked (all should be found)")
@@ -192,7 +192,7 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		qValDte, _ = CreateDtypeEnclosure("haystack", 0)
 		qValDte.AddStringAsByteSlice()
 		var eOff uint16 = 3 + utils.BytesToUint16LittleEndian(colWips["cstr"].cbuf[1:3]) // 2 bytes stored for string type
-		result, err := ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cstr"].cbuf[:eOff], false, holderDte)
+		result, err := ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cstr"].cbuf[:eOff], false, holderDte, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		qValDte.Reset()
@@ -200,7 +200,7 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		t.Logf("doing equals search for haystack for col that is not string")
 		qValDte, _ = CreateDtypeEnclosure("haystack", 0)
 		qValDte.AddStringAsByteSlice()
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte, false)
 		assert.Equal(t, false, result)
 		qValDte.Reset()
 
@@ -208,13 +208,13 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		t.Logf("doing equals search for float ")
 		t.Logf("cbuf:%s", string(colWips["cfloat"].cbuf[:]))
 		qValDte, _ = CreateDtypeEnclosure(-2345.35, 0)
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte, false)
 		assert.Equal(t, true, result)
 		qValDte.Reset()
 
 		t.Logf("doing equals search for unsigned ")
 		qValDte, _ = CreateDtypeEnclosure(2345, 0)
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cunsigned"].cbuf[:], false, holderDte)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cunsigned"].cbuf[:], false, holderDte, false)
 		assert.Equal(t, true, result)
 		qValDte.Reset()
 	}

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -114,7 +114,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, sQuery.FilterIsCaseSensitive)
+		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, sQuery.FilterIsCaseInSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply match words search", log.ErrorLevel, err)
 			return false
@@ -125,7 +125,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, sQuery.FilterIsCaseSensitive)
+			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, sQuery.FilterIsCaseInSensitive)
 			if retVal {
 				return true
 			}
@@ -136,7 +136,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseSensitive)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply simple expression search", log.ErrorLevel, err)
 			return false
@@ -147,7 +147,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseSensitive)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on RegexExpression", log.ErrorLevel, err)
 			return false
@@ -158,7 +158,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseSensitive)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInSensitive)
 			if retVal {
 				return true
 			}
@@ -169,7 +169,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseSensitive)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInSensitive)
 			if retVal {
 				return true
 			}
@@ -180,7 +180,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte, sQuery.FilterIsCaseSensitive)
+		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte, sQuery.FilterIsCaseInSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on MatchDictArraySingleColumn", log.ErrorLevel, err)
 			return false
@@ -191,7 +191,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte, sQuery.FilterIsCaseSensitive)
+			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte, sQuery.FilterIsCaseInSensitive)
 			if retVal {
 				return true
 			}

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -114,7 +114,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil)
+		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, sQuery.FilterIsCaseSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply match words search", log.ErrorLevel, err)
 			return false
@@ -125,7 +125,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil)
+			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, sQuery.FilterIsCaseSensitive)
 			if retVal {
 				return true
 			}
@@ -136,7 +136,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply simple expression search", log.ErrorLevel, err)
 			return false
@@ -147,7 +147,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on RegexExpression", log.ErrorLevel, err)
 			return false
@@ -158,7 +158,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseSensitive)
 			if retVal {
 				return true
 			}
@@ -169,7 +169,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseSensitive)
 			if retVal {
 				return true
 			}
@@ -180,7 +180,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte)
+		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte, sQuery.FilterIsCaseSensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on MatchDictArraySingleColumn", log.ErrorLevel, err)
 			return false
@@ -191,7 +191,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte)
+			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte, sQuery.FilterIsCaseSensitive)
 			if retVal {
 				return true
 			}

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -114,7 +114,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, sQuery.FilterIsCaseInSensitive)
+		retVal, err := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, rawVal.getLastRecord(), nil, sQuery.FilterIsCaseInsensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply match words search", log.ErrorLevel, err)
 			return false
@@ -125,7 +125,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, sQuery.FilterIsCaseInSensitive)
+			retVal, _ := ApplySearchToMatchFilterRawCsg(sQuery.MatchFilter, colVal.getLastRecord(), nil, sQuery.FilterIsCaseInsensitive)
 			if retVal {
 				return true
 			}
@@ -136,7 +136,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInSensitive)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInsensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply simple expression search", log.ErrorLevel, err)
 			return false
@@ -147,7 +147,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInSensitive)
+		retVal, err := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, rawVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInsensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on RegexExpression", log.ErrorLevel, err)
 			return false
@@ -158,7 +158,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInSensitive)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), true, holderDte, sQuery.FilterIsCaseInsensitive)
 			if retVal {
 				return true
 			}
@@ -169,7 +169,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInSensitive)
+			retVal, _ := ApplySearchToExpressionFilterSimpleCsg(sQuery.QueryInfo.QValDte, sQuery.ExpressionFilter.FilterOp, colVal.getLastRecord(), false, holderDte, sQuery.FilterIsCaseInsensitive)
 			if retVal {
 				return true
 			}
@@ -180,7 +180,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 		if !ok {
 			return false
 		}
-		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte, sQuery.FilterIsCaseInSensitive)
+		retVal, err := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, rawVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, true, holderDte, sQuery.FilterIsCaseInsensitive)
 		if err != nil {
 			segStore.StoreSegmentError("applySearchSingleQuery: failed to apply wildcard expression search on MatchDictArraySingleColumn", log.ErrorLevel, err)
 			return false
@@ -191,7 +191,7 @@ func applySearchSingleQuery(colWips map[string]*ColWip, sQuery *structs.SearchQu
 			if cname == tsKey {
 				continue
 			}
-			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte, sQuery.FilterIsCaseInSensitive)
+			retVal, _ := ApplySearchToDictArrayFilter([]byte(sQuery.QueryInfo.ColName), sQuery.QueryInfo.QValDte, colVal.getLastRecord(), sQuery.ExpressionFilter.FilterOp, false, holderDte, sQuery.FilterIsCaseInsensitive)
 			if retVal {
 				return true
 			}

--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -308,9 +308,9 @@ func (ri *RangeIndex) copyRangeIndex() *RangeIndex {
 // does CMI check on unrotated segment info for inputted request. Assumes UnrotatedInfoLock has been acquired
 // returns the final blocks to search, total unrotated blocks, num filtered blocks, and errors if any
 func (usi *UnrotatedSegmentInfo) DoCMICheckForUnrotated(currQuery *structs.SearchQuery, tRange *dtu.TimeRange,
-	blkTracker *structs.BlockTracker, bloomWords map[string]bool, bloomOp segutils.LogicalOperator, rangeFilter map[string]string,
+	blkTracker *structs.BlockTracker, bloomWords map[string]bool, originalBloomWords map[string]string, bloomOp segutils.LogicalOperator, rangeFilter map[string]string,
 	rangeOp segutils.FilterOperator, isRange bool, wildcardValue bool,
-	qid uint64) (map[uint16]map[string]bool, uint64, uint64, error) {
+	qid uint64, dualCaseCheckEnabled bool) (map[uint16]map[string]bool, uint64, uint64, error) {
 
 	timeFilteredBlocks := metautils.FilterBlocksByTime(usi.blockSummaries, blkTracker, tRange)
 	totalPossibleBlocks := uint64(len(usi.blockSummaries))
@@ -327,7 +327,7 @@ func (usi *UnrotatedSegmentInfo) DoCMICheckForUnrotated(currQuery *structs.Searc
 	if isRange {
 		err = usi.doRangeCheckForCols(timeFilteredBlocks, rangeFilter, rangeOp, colsToCheck, qid)
 	} else if !wildcardValue {
-		err = usi.doBloomCheckForCols(timeFilteredBlocks, bloomWords, bloomOp, colsToCheck, qid)
+		err = usi.doBloomCheckForCols(timeFilteredBlocks, bloomWords, originalBloomWords, bloomOp, colsToCheck, qid, dualCaseCheckEnabled)
 	}
 
 	numFinalBlocks := uint64(len(timeFilteredBlocks))
@@ -378,12 +378,15 @@ func (usi *UnrotatedSegmentInfo) doRangeCheckForCols(timeFilteredBlocks map[uint
 }
 
 func (usi *UnrotatedSegmentInfo) doBloomCheckForCols(timeFilteredBlocks map[uint16]map[string]bool,
-	bloomKeys map[string]bool, bloomOp segutils.LogicalOperator,
-	colsToCheck map[string]bool, qid uint64) error {
+	bloomKeys map[string]bool, originalBloomKeys map[string]string, bloomOp segutils.LogicalOperator,
+	colsToCheck map[string]bool, qid uint64, dualCaseCheckEnabled bool) error {
 
 	if !usi.isCmiLoaded {
 		return nil
 	}
+
+	checkInOriginalKeys := dualCaseCheckEnabled && len(originalBloomKeys) > 0
+
 	numUnrotatedBlks := uint16(len(usi.unrotatedBlockCmis))
 	for blkNum := range timeFilteredBlocks {
 		if blkNum > numUnrotatedBlks {
@@ -405,6 +408,12 @@ func (usi *UnrotatedSegmentInfo) doBloomCheckForCols(timeFilteredBlocks map[uint
 					continue
 				}
 				needleExists := cmi.Bf.TestString(entry)
+				if !needleExists && checkInOriginalKeys {
+					originalEntry, ok := originalBloomKeys[entry]
+					if ok {
+						needleExists = cmi.Bf.TestString(originalEntry)
+					}
+				}
 				if needleExists {
 					atLeastOneFound = true
 					timeFilteredBlocks[blkNum][col] = true

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -220,8 +220,8 @@ func BytesCaseInsensitiveEqual(a, b []byte) bool {
 	return true
 }
 
-func PerformBytesEqualityCheck(isCaseInSensitive bool, a, b []byte) bool {
-	if isCaseInSensitive {
+func PerformBytesEqualityCheck(isCaseInsensitive bool, a, b []byte) bool {
+	if isCaseInsensitive {
 		return BytesCaseInsensitiveEqual(a, b)
 	}
 	return bytes.Equal(a, b)

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -208,13 +208,20 @@ func UnsafeByteSliceToString(haystack []byte) string {
 	return *(*string)(unsafe.Pointer(&haystack))
 }
 
+func isAlpha(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+}
+
 func BytesCaseInsensitiveEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if a[i] != b[i] && a[i] != b[i]^32 {
-			return false
+		if a[i] != b[i] {
+			// Check if both are alphabetic characters and differ only by case
+			if !isAlpha(a[i]) || !isAlpha(b[i]) || a[i]^32 != b[i] {
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -208,9 +208,9 @@ func UnsafeByteSliceToString(haystack []byte) string {
 	return *(*string)(unsafe.Pointer(&haystack))
 }
 
-func NormalizeSearchBytes(isCaseSensitive bool, valueBytes []byte) []byte {
-	if isCaseSensitive {
-		return valueBytes
+func NormalizeSearchBytes(isCaseInSensitive bool, valueBytes []byte) []byte {
+	if isCaseInSensitive {
+		return bytes.ToLower(valueBytes)
 	}
-	return bytes.ToLower(valueBytes)
+	return valueBytes
 }

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -208,13 +208,6 @@ func UnsafeByteSliceToString(haystack []byte) string {
 	return *(*string)(unsafe.Pointer(&haystack))
 }
 
-func NormalizeSearchBytes(isCaseInSensitive bool, valueBytes []byte) []byte {
-	if isCaseInSensitive {
-		return bytes.ToLower(valueBytes)
-	}
-	return valueBytes
-}
-
 func BytesCaseInsensitiveEqual(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -207,3 +207,10 @@ func SearchStr(needle string, haystack []string) bool {
 func UnsafeByteSliceToString(haystack []byte) string {
 	return *(*string)(unsafe.Pointer(&haystack))
 }
+
+func NormalizeSearchBytes(isCaseSensitive bool, valueBytes []byte) []byte {
+	if isCaseSensitive {
+		return valueBytes
+	}
+	return bytes.ToLower(valueBytes)
+}

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -214,3 +214,22 @@ func NormalizeSearchBytes(isCaseInSensitive bool, valueBytes []byte) []byte {
 	}
 	return valueBytes
 }
+
+func BytesCaseInsensitiveEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] && a[i] != b[i]^32 {
+			return false
+		}
+	}
+	return true
+}
+
+func PerformBytesEqualityCheck(isCaseInSensitive bool, a, b []byte) bool {
+	if isCaseInSensitive {
+		return BytesCaseInsensitiveEqual(a, b)
+	}
+	return bytes.Equal(a, b)
+}

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -107,7 +107,7 @@ func HashString(x string) string {
 }
 
 // we are assumung that needleLen and haystackLen are both non zero
-func IsSubWordPresent(haystack []byte, needle []byte, isCaseInSensitive bool) bool {
+func IsSubWordPresent(haystack []byte, needle []byte, isCaseInsensitive bool) bool {
 	needleLen := len(needle)
 	haystackLen := len(haystack)
 
@@ -118,7 +118,7 @@ func IsSubWordPresent(haystack []byte, needle []byte, isCaseInSensitive bool) bo
 	for i := 0; i <= haystackLen-needleLen; i++ {
 		haystackSlice := haystack[i : i+needleLen]
 
-		if PerformBytesEqualityCheck(isCaseInSensitive, haystackSlice, needle) {
+		if PerformBytesEqualityCheck(isCaseInsensitive, haystackSlice, needle) {
 			// haystack[i:i+needleLen-1] was matched
 			// we need to check if haystack[i - 1] is a whitespace and if haystack[i + needleLen] is a whitespace
 			if (i == 0 || haystack[i-1] == single_whitespace[0]) && (i+needleLen == haystackLen || haystack[i+needleLen] == single_whitespace[0]) {

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -107,7 +107,7 @@ func HashString(x string) string {
 }
 
 // we are assumung that needleLen and haystackLen are both non zero
-func IsSubWordPresent(haystack []byte, needle []byte, isCaseSensitive bool) bool {
+func IsSubWordPresent(haystack []byte, needle []byte, isCaseInSensitive bool) bool {
 	needleLen := len(needle)
 	haystackLen := len(haystack)
 
@@ -115,7 +115,7 @@ func IsSubWordPresent(haystack []byte, needle []byte, isCaseSensitive bool) bool
 		return false
 	}
 
-	haystack = NormalizeSearchBytes(isCaseSensitive, haystack)
+	haystack = NormalizeSearchBytes(isCaseInSensitive, haystack)
 
 	if needleLen == haystackLen {
 		return bytes.Equal(needle, haystack)

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -107,13 +107,17 @@ func HashString(x string) string {
 }
 
 // we are assumung that needleLen and haystackLen are both non zero
-func IsSubWordPresent(haystack []byte, needle []byte) bool {
+func IsSubWordPresent(haystack []byte, needle []byte, isCaseSensitive bool) bool {
 	needleLen := len(needle)
 	haystackLen := len(haystack)
 
 	if needleLen > haystackLen {
 		return false
-	} else if needleLen == haystackLen {
+	}
+
+	haystack = NormalizeSearchBytes(isCaseSensitive, haystack)
+
+	if needleLen == haystackLen {
 		return bytes.Equal(needle, haystack)
 	}
 

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -115,29 +115,14 @@ func IsSubWordPresent(haystack []byte, needle []byte, isCaseInSensitive bool) bo
 		return false
 	}
 
-	haystack = NormalizeSearchBytes(isCaseInSensitive, haystack)
+	for i := 0; i <= haystackLen-needleLen; i++ {
+		haystackSlice := haystack[i : i+needleLen]
 
-	if needleLen == haystackLen {
-		return bytes.Equal(needle, haystack)
-	}
-
-	for i := 0; i < haystackLen-needleLen+1; i += 1 {
-		if haystack[i] == needle[0] {
-			for j := needleLen - 1; j >= 1; j -= 1 {
-				if haystack[i+j] != needle[j] {
-					break
-				}
-				if j == 1 {
-					// haystack[i:i+needleLen-1] was matched
-					// we need to check if haystack[i - 1] is a whitespace and if haystack[i + needleLen] is a whitespace
-					if i-1 >= 0 && haystack[i-1] != single_whitespace[0] {
-						break
-					}
-					if i+needleLen < haystackLen && haystack[i+needleLen] != single_whitespace[0] {
-						break
-					}
-					return true
-				}
+		if PerformBytesEqualityCheck(isCaseInSensitive, haystackSlice, needle) {
+			// haystack[i:i+needleLen-1] was matched
+			// we need to check if haystack[i - 1] is a whitespace and if haystack[i + needleLen] is a whitespace
+			if (i == 0 || haystack[i-1] == single_whitespace[0]) && (i+needleLen == haystackLen || haystack[i+needleLen] == single_whitespace[0]) {
+				return true
 			}
 		}
 	}

--- a/pkg/utils/segutils_test.go
+++ b/pkg/utils/segutils_test.go
@@ -192,7 +192,7 @@ func Test_IsSubWordPresent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsSubWordPresent(tt.args.haystack, tt.args.needle); got != tt.want {
+			if got := IsSubWordPresent(tt.args.haystack, tt.args.needle, false); got != tt.want {
 				t.Errorf("IsSubWordPresent() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
# Description
- Adds support for case-insensitive search. Add the original string and lower case converted string to bloom and then during search the search by default will convert the given user query to lower case search unless it is done through `CASE(<string>)`.
- Also enabled the code to have backward compatibility with the old data that might not have lower case values in the bloom.
   - Users can enable this by setting `dualCaseCheck: true` in the config file.
   - To do this I have maintained the original string that is given in the query and this string will be used to check for entry in the bloom
   -  And the original string will only be maintained given that the `dualCaseCheck` is enabled and the query do not have a `CASE`.
- When I first implemented the case insensitive search without supporting backward compatible, I have directly converted the search value to lower case at the parser level and when supporting backward compatible came into picture, I thought that I can do the lower case conversion at `GetAllBlockBloomKeysToSearch` and not do the conversion at the parser like I did now. 
     - But it seemed like we are calling this per Block and also except when the search is case sensitive we need to do the lower case conversion and modifying `DtypeEnclosure` for column values multiple times. Plus if a `SearchExpression` has a `complexRelationExpression` we won't be converting that into Lower Case.
    - And also it made sense that assuming at some point in future we might not need this backward compatible considering the retention, there will be this overhead of normalizing the case.  So I felt that properly assigning the search value (either lower case or original string if CASE) would be better. 

# Testing
- All the test cases pass 
- I have also tested this by ingesting data on `develop` => so no lower case values in bloom. Then checkout to the current branch and enabled `dualCaseCheck` and run the queries to make sure that I am searching for all the values.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
