### PR TITLE
Numeric dict encoded values logging error

### DIFF
--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -283,7 +283,7 @@ func readAllRawRecords(orderedRecNums []uint16, blockIdx uint16, segReader *segr
 			var cValEnc utils.CValueEnclosure
 
 			err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockIdx, recNum,
-				qid, isTsCol, &cValEnc)
+				qid, isTsCol, &cValEnc, nodeRes)
 			if err != nil {
 				nodeRes.StoreGlobalSearchError(fmt.Sprintf("extractSortVals: Failed to extract value for column %v", cname), log.ErrorLevel, err)
 			} else {

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -266,9 +266,7 @@ func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(colKeyIndex int, 
 	}
 
 	if colKeyIndex == -1 || colKeyIndex >= mcsr.maxColIdx {
-		// Debug to avoid log flood for when the column does not exist
-		log.Debugf("MultiColSegmentReader.ReadRawRecordFromColumnFile: failed to find colKeyIndex %v in multi col reader. All cols: %+v", colKeyIndex, mcsr.allColsReverseIndex)
-		return nil, nil
+		return nil, fmt.Errorf("MultiColSegmentReader.ReadRawRecordFromColumnFile: failed to find colKeyIndex %v in multi col reader. All cols: %+v", colKeyIndex, mcsr.allColsReverseIndex)
 	}
 
 	return mcsr.allFileReaders[colKeyIndex].ReadRecordFromBlock(blockNum, recordNum)
@@ -337,9 +335,7 @@ func (mcsr *MultiColSegmentReader) IsBlkDictEncoded(cname string,
 
 	keyIndex, ok := mcsr.allColsReverseIndex[cname]
 	if !ok {
-		// Debug to avoid log flood for when the column does not exist
-		log.Debugf("MultiColSegmentReader.IsBlkDictEncoded: failed to find column %s in multi col reader. All cols: %+v", cname, mcsr.allColsReverseIndex)
-		return false, errors.New("column not found in MultipleColumnSegmentReader")
+		return false, fmt.Errorf("MultiColSegmentReader.IsBlkDictEncoded: failed to find column %s in multi col reader. All cols: %+v", cname, mcsr.allColsReverseIndex)
 	}
 
 	return mcsr.allFileReaders[keyIndex].IsBlkDictEncoded(blkNum)

--- a/pkg/segment/reader/segread/multicolreader_test.go
+++ b/pkg/segment/reader/segread/multicolreader_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/siglens/siglens/pkg/config"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
 	log "github.com/sirupsen/logrus"
@@ -65,7 +66,7 @@ func Test_multiSegReader(t *testing.T) {
 
 	err = multiReader.ValidateAndReadBlock(colsToReadIndices, 0)
 	assert.Nil(t, err)
-
+	nodeRes := &structs.NodeResult{}
 	for colName := range cols {
 		if colName == config.GetTimeStampKey() {
 			continue
@@ -77,11 +78,11 @@ func Test_multiSegReader(t *testing.T) {
 
 		// correct block, incorrect recordNum
 		err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock), 0,
-			false, &cValEnc)
+			false, &cValEnc, nodeRes)
 		assert.NotNil(t, err)
 
 		err = multiReader.ExtractValueFromColumnFile(cKeyidx, 0, uint16(numEntriesInBlock-3), 0,
-			false, &cValEnc)
+			false, &cValEnc, nodeRes)
 		assert.Nil(t, err)
 		assert.NotNil(t, cValEnc)
 		log.Infof("ExtractValueFromColumnFile: %+v for column %s", cValEnc, colName)

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 
 	"github.com/siglens/siglens/pkg/segment/reader/segread"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	. "github.com/siglens/siglens/pkg/segment/structs"
 	. "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
@@ -51,7 +52,7 @@ func GetRequiredColsForSearchQuery(multiColReader *segread.MultiColSegmentReader
 func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiColSegmentReader,
 	blockNum uint16, recordNum uint16, holderDte *DtypeEnclosure, qid uint64,
 	searchReq *SegmentSearchRequest, cmiPassedNonDictColKeyIndices map[int]struct{},
-	queryInfoColKeyIndex int, compiledRegex *regexp.Regexp) (bool, error) {
+	queryInfoColKeyIndex int, compiledRegex *regexp.Regexp, nodeRes *structs.NodeResult) (bool, error) {
 
 	switch query.SearchType {
 	case MatchAll:
@@ -59,7 +60,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		return true, nil
 	case MatchWords:
 		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex,
-			blockNum, recordNum, qid, false)
+			blockNum, recordNum, qid, false, nodeRes)
 		if err != nil {
 			return false, err
 		}
@@ -69,7 +70,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		var finalErr error
 		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 			if err != nil {
 				finalErr = err
 				continue
@@ -88,13 +89,13 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			return false, finalErr
 		}
 	case SimpleExpression:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 		if err != nil {
 			return false, err
 		}
 		return writer.ApplySearchToExpressionFilterSimpleCsg(query.QueryInfo.QValDte, query.ExpressionFilter.FilterOp, rawColVal, false, holderDte)
 	case RegexExpression:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 		if err != nil {
 			log.Debugf("ApplyColumnarSearchQuery: failed to read column %v rec from column file. qid=%v, err: %v", query.QueryInfo.ColName, qid, err)
 			return false, nil
@@ -105,7 +106,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		var finalErr error
 		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 			if err != nil {
 				finalErr = err
 				continue
@@ -128,7 +129,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		var finalErr error
 		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 			if err != nil {
 				finalErr = err
 				continue
@@ -147,7 +148,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 			return false, finalErr
 		}
 	case MatchDictArraySingleColumn:
-		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false)
+		rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(queryInfoColKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 		if err != nil {
 			return false, err
 		}
@@ -157,7 +158,7 @@ func ApplyColumnarSearchQuery(query *SearchQuery, multiColReader *segread.MultiC
 		var finalErr error
 		for colKeyIndex := range cmiPassedNonDictColKeyIndices {
 
-			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false)
+			rawColVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recordNum, qid, false, nodeRes)
 			if err != nil {
 				finalErr = err
 				continue

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -231,7 +231,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			if recIT.ShouldProcessRecord(i) {
 				matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
 					qid, searchReq, cmiPassedNonDictColKeyIndices,
-					queryInfoColKeyIndex, compiledRegex)
+					queryInfoColKeyIndex, compiledRegex, nodeRes)
 				if err != nil {
 					nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to ApplyColumnarSearchQuery", log.ErrorLevel, err)
 					break

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -160,7 +160,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 	doRecLevelSearch, deCnames, err := applyColumnarSearchUsingDictEnc(query, multiColReader, blockNum, qid,
 		recIT, blockHelper, searchReq, cmiPassedCnames)
 	if err != nil {
-		allSearchResults.AddError(err)
+		nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to applyColumnarSearchUsingDictEnc", log.ErrorLevel, err)
 		// we still continue, since the reclevel may not yield an error
 	}
 

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -263,7 +263,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			// Get timechart's group by col val, each different val will be a bucket inside each time range bucket
 			if byFieldCnameKeyIdx != -1 {
 				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(byFieldCnameKeyIdx,
-					blockNum, recNum, qid, isTsCol)
+					blockNum, recNum, qid, isTsCol, nodeRes)
 				if err != nil {
 					nodeRes.StoreGlobalSearchError(fmt.Sprintf("addRecordToAggregations: Failed to get key for column %v", byField), log.ErrorLevel, err)
 				} else {
@@ -306,7 +306,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 					len(groupbyColKeyIndices)*utils.MAX_RECORD_SIZE)
 			}
 			for _, colKeyIndex := range groupbyColKeyIndices {
-				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false)
+				rawVal, err := multiColReader.ReadRawRecordFromColumnFile(colKeyIndex, blockNum, recNum, qid, false, nodeRes)
 				if err != nil {
 					nodeRes.StoreGlobalSearchError(fmt.Sprintf("addRecordToAggregations: Failed to get key for column %v", colKeyIndex), log.ErrorLevel, err)
 					copy(aggsKeyWorkingBuf[aggsKeyBufIdx:], utils.VALTYPE_ENC_BACKFILL)
@@ -320,7 +320,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 
 		for colKeyIdx, indices := range measureColKeyIdxAndIndices {
 			err := multiColReader.ExtractValueFromColumnFile(colKeyIdx, blockNum, recNum,
-				qid, false, &retCVal)
+				qid, false, &retCVal, nodeRes)
 			if err != nil {
 				nodeRes.StoreGlobalSearchError(fmt.Sprintf("addRecordToAggregations: Failed to extract measure value from colKeyIdx %v", colKeyIdx), log.ErrorLevel, err)
 
@@ -875,7 +875,7 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 		for _, recNum := range sortedMatchedRecs {
 			for colKeyIdx, cname := range nonDeColsKeyIndices {
 				err := multiReader.ExtractValueFromColumnFile(colKeyIdx, blockStatus.BlockNum,
-					recNum, qid, false, &cValEnc)
+					recNum, qid, false, &cValEnc, nodeRes)
 				if err != nil {
 					nodeRes.StoreGlobalSearchError(fmt.Sprintf("segmentStatsWorker: Failed to extract value for cname %+v", cname), log.ErrorLevel, err)
 					continue

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -570,7 +570,7 @@ func extractSortVals(aggs *structs.QueryAggregators, multiColReader *segread.Mul
 
 	var colVal utils.CValueEnclosure
 	err = multiColReader.ExtractValueFromColumnFile(aggsSortColKeyIdx, blkNum, recNum,
-		qid, false, &colVal)
+		qid, false, &colVal, nodeRes)
 	if err != nil {
 		nodeRes.StoreGlobalSearchError(fmt.Sprintf("extractSortVals: Failed to extract value for column %v", aggs.Sort.ColName), log.ErrorLevel, err)
 		invalidAggsCol = true


### PR DESCRIPTION
# Description
Summarize the change.
For queries like `app_name=Bracecould | stats min(http_status)`, `http_status` which is a numeric dict encoded value was being treated as nonDeCol. Over [here](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/search/searchaggs.go#L988) there are no checks for int64 and float64 type values which also can be dict [encoded](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/reader/segread/segreader.go#L427). Added numeric stats accumulation similar to how its done over [here](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/search/searchaggs.go#L906).

Also, added global logger for [this](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/reader/segread/multicolreader.go#L270) log flood.

P.S.: We are returning nil error in case of a column not found due to which the test failed in the previous commit. I am now logging that column not found error in the given method. Due to this edge case, the PR got a little larger. Sorry!

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
