### PR TITLE
In place NTE conversion and pre-alloc node ptrs

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -633,32 +633,29 @@ func (nte *NumTypeEnclosure) Reset() {
 	nte.FloatVal = 0
 }
 
-func (cval *CValueEnclosure) ToNumType() (*NumTypeEnclosure, error) {
+func (cval *CValueEnclosure) ToNumType(res *NumTypeEnclosure) error {
 	if cval == nil {
-		return nil, fmt.Errorf("ToNumType: cval is nil")
+		return fmt.Errorf("ToNumType: cval is nil")
 	}
 	switch cval.Dtype {
 	case SS_DT_FLOAT:
-		return &NumTypeEnclosure{
-			Ntype:    SS_DT_FLOAT,
-			FloatVal: cval.CVal.(float64),
-		}, nil
+		res.Ntype = SS_DT_FLOAT
+		res.FloatVal = cval.CVal.(float64)
+		return nil
 	case SS_DT_SIGNED_NUM:
-		return &NumTypeEnclosure{
-			Ntype:    SS_DT_SIGNED_NUM,
-			IntgrVal: cval.CVal.(int64),
-		}, nil
+		res.Ntype = SS_DT_SIGNED_NUM
+		res.IntgrVal = cval.CVal.(int64)
+		return nil
 	case SS_DT_UNSIGNED_NUM:
-		return &NumTypeEnclosure{
-			Ntype:    SS_DT_SIGNED_NUM,
-			IntgrVal: int64(cval.CVal.(uint64)),
-		}, nil
+		res.Ntype = SS_DT_UNSIGNED_NUM
+		res.IntgrVal = int64(cval.CVal.(uint64))
+		return nil
 	case SS_DT_BACKFILL:
-		return &NumTypeEnclosure{
-			Ntype: SS_DT_BACKFILL,
-		}, nil
+		res.Ntype = SS_DT_BACKFILL
+		res.Ntype = SS_DT_BACKFILL
+		return nil
 	default:
-		return nil, fmt.Errorf("ToNumType: unexpected Ntype: %v", cval.Dtype)
+		return fmt.Errorf("ToNumType: unexpected Ntype: %v", cval.Dtype)
 	}
 }
 

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -360,6 +360,10 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 	lenAggValues := len(stb.mColNames) * TotalMeasFns
 	measCidx := make([]uint32, len(stb.mColNames))
 
+	nte := &utils.NumTypeEnclosure{
+		Ntype: utils.SS_INVALID,
+	}
+
 	for recNum := uint16(0); recNum < numRecs; recNum += 1 {
 		for colNum := range stb.groupByKeys {
 			curColValues[colNum] = stb.wipRecNumToColEnc[colNum][recNum]
@@ -374,7 +378,7 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 					mcName, err)
 				continue
 			}
-			nte, err := cVal.ToNumType()
+			err = cVal.ToNumType(nte)
 			if err != nil {
 				log.Errorf("buildTreeStructure: Could not convert cval: %v for cname: %v, err: %v",
 					cVal, mcName, err)

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -203,7 +203,7 @@ func (stb *StarTreeBuilder) newNode() *Node {
 	// and after that if the nodePool count exceeds then we can do the
 	// one by one extension
 	stbNodePoolLen := len(stb.nodePool)
-	stb.nodePool = toputils.ResizeSlice(stb.nodePool, MaxAgileTreeNodeCount)
+	stb.nodePool = toputils.ResizeSlice(stb.nodePool, MaxAgileTreeNodeCountForAlloc)
 	if len(stb.nodePool) > stbNodePoolLen {
 		for i := stbNodePoolLen; i < len(stb.nodePool); i++ {
 			stb.nodePool[i] = &Node{}
@@ -377,7 +377,7 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 			nte, err := cVal.ToNumType()
 			if err != nil {
 				log.Errorf("buildTreeStructure: Could not convert cval: %v for cname: %v, err: %v",
-					mcName, cVal, err)
+					cVal, mcName, err)
 				continue
 			}
 

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -216,12 +216,19 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 	copy(stb.buf[idx:], utils.Uint32ToBytesLittleEndian(uint32(len(curLevNodes))))
 	idx += 4
 
-	nextLevelNodes := []*Node{}
+	numNodesNeeded := 0
+	for _, n := range curLevNodes {
+		numNodesNeeded += len(n.children)
+	}
+
+	nextLevelNodes := make([]*Node, numNodesNeeded)
+	nlIdx := 0
 	for _, n := range curLevNodes {
 
 		// save nextlevel children
 		for _, child := range n.children {
-			nextLevelNodes = append(nextLevelNodes, child)
+			nextLevelNodes[nlIdx] = child
+			nlIdx++
 		}
 		// encode curr nodes details
 

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/siglens/siglens/pkg/config"
 	. "github.com/siglens/siglens/pkg/segment/structs"
 	. "github.com/siglens/siglens/pkg/segment/utils"
-	bbp "github.com/valyala/bytebufferpool"
 )
 
 func TestBlockSumEncodeDecode(t *testing.T) {
@@ -449,10 +448,8 @@ func Test_addSegStatsStr(t *testing.T) {
 	sst := make(map[string]*SegStats)
 	numRecs := uint64(2000)
 
-	bb := bbp.Get()
-
 	for i := uint64(0); i < numRecs; i++ {
-		addSegStatsStr(sst, cname, fmt.Sprintf("%v", i), bb)
+		addSegStatsStrIngestion(sst, cname, []byte(fmt.Sprintf("%v", i)))
 	}
 
 	assert.Equal(t, numRecs, sst[cname].Count)

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -54,6 +54,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const MaxAgileTreeNodeCountForAlloc = 8_066_000 // for atree to do allocations
+// For Last wip we do not know how many nodes this wip will add, hence we
+// leave a room for one wip's worth of recs.
 const MaxAgileTreeNodeCount = 8_000_000
 const colWipsSizeLimit = 2000 // We shouldn't exceed this during normal usage.
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -54,9 +54,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const MaxAgileTreeNodeCountForAlloc = 8_066_000 // for atree to do allocations
 // For Last wip we do not know how many nodes this wip will add, hence we
 // leave a room for one wip's worth of recs.
+const MaxAgileTreeNodeCountForAlloc = 8_066_000 // for atree to do allocations
 const MaxAgileTreeNodeCount = 8_000_000
 const colWipsSizeLimit = 2000 // We shouldn't exceed this during normal usage.
 

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -277,7 +277,7 @@ func TestStarTree(t *testing.T) {
 
 	gcWorkBuf := make([][]string, len(groupByCols))
 	for colNum := 0; colNum < len(groupByCols); colNum++ {
-		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCount)
+		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
 	var builder StarTreeBuilder
@@ -372,7 +372,7 @@ func TestStarTreeMedium(t *testing.T) {
 
 	gcWorkBuf := make([][]string, len(groupByCols))
 	for colNum := 0; colNum < len(groupByCols); colNum++ {
-		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCount)
+		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
 	var builder StarTreeBuilder
@@ -469,7 +469,7 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 
 	gcWorkBuf := make([][]string, len(groupByCols))
 	for colNum := 0; colNum < len(groupByCols); colNum++ {
-		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCount)
+		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
 	var builder StarTreeBuilder
@@ -564,7 +564,7 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 
 	gcWorkBuf := make([][]string, len(groupByCols))
 	for colNum := 0; colNum < len(groupByCols); colNum++ {
-		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCount)
+		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
 	var builder StarTreeBuilder


### PR DESCRIPTION
# Description
1. Use in in place conversions for NumTypeEnclosures
2. pre-alloc pointer array for node.children

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
