### PR TITLE
Numeric dict encoded values

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -987,6 +987,10 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 				switch val := rawVal.(type) {
 				case string:
 					stats.AddSegStatsStr(lStats, colName, val, bb, aggColUsage, hasValuesFunc, hasListFunc)
+				case int64:
+					stats.AddSegStatsNums(lStats, colName, utils.SS_INT64, val, 0, 0, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc)
+				case float64:
+					stats.AddSegStatsNums(lStats, colName, utils.SS_FLOAT64, 0, 0, val, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc)
 				default:
 					// This means the column is not dict encoded. So add it to the return value
 					retVal[colName] = true


### PR DESCRIPTION
# Description
Summarize the change.
For queries like `app_name=Bracecould | stats min(http_status)`, `http_status` which is a numeric dict encoded value was being treated as nonDeCol. Over [here](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/search/searchaggs.go#L988) there are no checks for int64 and float64 type values which also can be dict [encoded](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/reader/segread/segreader.go#L427). Added numeric stats accumulation similar to how its done over [here](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/pkg/segment/search/searchaggs.go#L906).

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
