### PR TITLE
Optimize Flushing of Bloom

### DIFF
--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1092,12 +1092,6 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 		return 0
 	}
 
-	err = bffd.Sync()
-	if err != nil {
-		log.Errorf("flushBloomIndex: failed to sync correct bloom size fname=%v, err=%v", fname, err)
-		return 0
-	}
-
 	if len(bi.HistoricalCount) == 0 {
 		bi.HistoricalCount = make([]uint32, 0)
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1077,7 +1077,7 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 		return 0
 	}
 
-	bffd, err = os.OpenFile(fname, os.O_WRONLY|os.O_CREATE, 0644)
+	bffd, err = os.OpenFile(fname, os.O_WRONLY, 0644)
 	if err != nil {
 		log.Errorf("flushBloomIndex: open failed fname=%v for writing the bloom size, err=%v", fname, err)
 		return 0
@@ -1090,7 +1090,7 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 		return 0
 	}
 
-	_, err = bffd.Write(toputils.Uint32ToBytesLittleEndian(bytesWritten-4))
+	_, err = bffd.Write(toputils.Uint32ToBytesLittleEndian(bytesWritten - 4))
 	if err != nil {
 		log.Errorf("flushBloomIndex: failed to write bloom size to fname=%v, err=%v", fname, err)
 		return 0

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1051,7 +1051,7 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 
 	// copy the blockNum
 	if _, err = bffd.Write(toputils.Uint16ToBytesLittleEndian(ss.numBlocks)); err != nil {
-		log.Errorf("flushBloomIndex: bloomsize write failed fname=%v, err=%v", fname, err)
+		log.Errorf("flushBloomIndex: block num write failed fname=%v, err=%v", fname, err)
 		return 0
 	}
 	bytesWritten += utils.LEN_BLKNUM_CMI_SIZE
@@ -1070,12 +1070,6 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 		return 0
 	}
 	bytesWritten += uint32(bloomSize)
-
-	err = bffd.Sync()
-	if err != nil {
-		log.Errorf("flushBloomIndex: bloom data sync failed fname=%v, err=%v", fname, err)
-		return 0
-	}
 
 	err = bffd.Close()
 	if err != nil {
@@ -1104,7 +1098,7 @@ func (ss *SegStore) flushBloomIndex(cname string, bi *BloomIndex) uint64 {
 
 	err = bffd.Sync()
 	if err != nil {
-		log.Errorf("flushBloomIndex: data length sync failed fname=%v, err=%v", fname, err)
+		log.Errorf("flushBloomIndex: data sync failed fname=%v, err=%v", fname, err)
 		return 0
 	}
 


### PR DESCRIPTION
# Description
Summarize the change.
Optimize writing of bytesWritten by first writing dummy data and then overwritting it with the correct size.
This prevents writing the bloom twice.

Tested on a sample 20M records 1 index 10 segment test for [Benchmark_agileTreeIngest](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/benchmark_test.go#L379).

Before
Total Memory used: 166.44MB
Memory used by allocation of bufio writer: 25 MB
Memory used by `bi.Bf.WriteTo(bufWriter)`: 96 MB

After
Total Memory used: 46.43MB
Memory used by additional os.Open: 1 MB

We noticed a sudden drop from 166 MB to 46 MB of memory usage. It would be even more efficient for large data sizes.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
