### PR TITLE
Fix flaky test for chained time modifiers that fails on sundays

### DIFF
--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10566,9 +10566,6 @@ func Test_ParseRelativeTimeModifier_Chained_2(t *testing.T) {
 	assert.Equal(t, expectedLatestTime, actualLatestTime)
 }
 
-/*
-   This test is flaky, it fails on weekend boundary days, disabling it for now
-
 func Test_ParseRelativeTimeModifier_Chained_3(t *testing.T) {
 	query := `* | earliest=@w1-7d+9h latest=@w1-7d+17h`
 	_, err := spl.Parse("", []byte(query))
@@ -10582,12 +10579,16 @@ func Test_ParseRelativeTimeModifier_Chained_3(t *testing.T) {
 	// Get the current time in the local time zone
 	now := time.Now().In(time.Local)
 
+	daysToSubtract := int(now.Weekday())
+	if daysToSubtract == 0 { // Check if it's Sunday
+		daysToSubtract = 7
+	}
 	// Calculate the expected earliest time: last week's Monday at 9 AM
-	lastMonday9AM := time.Date(now.Year(), now.Month(), now.Day()-int(now.Weekday())-7+int(time.Monday), 9, 0, 0, 0, time.Local)
+	lastMonday9AM := time.Date(now.Year(), now.Month(), now.Day()-daysToSubtract-7+int(time.Monday), 9, 0, 0, 0, now.Location())
 	expectedEarliestTime := lastMonday9AM
 
 	// Calculate the expected latest time: last week's Monday at 5 PM
-	lastMonday5PM := time.Date(now.Year(), now.Month(), now.Day()-int(now.Weekday())-7+int(time.Monday), 17, 0, 0, 0, time.Local)
+	lastMonday5PM := time.Date(now.Year(), now.Month(), now.Day()-daysToSubtract-7+int(time.Monday), 17, 0, 0, 0, now.Location())
 	expectedLatestTime := lastMonday5PM
 
 	// Convert the actual times from Unix milliseconds to local time
@@ -10598,8 +10599,6 @@ func Test_ParseRelativeTimeModifier_Chained_3(t *testing.T) {
 	assert.Equal(t, expectedEarliestTime, actualEarliestTime)
 	assert.Equal(t, expectedLatestTime, actualLatestTime)
 }
-
-*/
 
 func Test_ParseRelativeTimeModifier_Chained_4(t *testing.T) {
 	query := `* | earliest=-26h@h latest=-2h@h`


### PR DESCRIPTION
# Description
The issue was that the code didn't handle Sundays correctly, which caused it to calculate the wrong date. Instead of finding the Monday from the previous week, it returned the Monday of the current week when run on a Sunday. This happened because the code didn't account for the fact that `time.Weekday()` gives 0 for Sunday. To fix this, I  added a check to see if the current day is Sunday, and if it is, we subtract an additional 7 days. This ensures that the date always goes back two weeks to the correct Monday, matching what the SPL query `@w1-7d` is supposed to do.

# Testing
- Tested that the fix correctly handles Sundays by returning the Monday from two weeks prior, as expected
- Tested the logic across all days of the week to ensure it correctly identifies the Monday of the previous week.
- Tested during both the first 12 hours and the last 12 hours of each day to confirm consistent results.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
