### PR TITLE
use bitset for storing recnums for dictEnc columns

### DIFF
--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -322,10 +322,13 @@ func (stb *StarTreeBuilder) creatEnc(wip *WipBlock) error {
 		deData := cwip.deData
 		if deData.deCount < wipCardLimit {
 			for rawKey, recIdx := range deData.deToRecnumIdx {
-				indices := deData.deRecNums[recIdx]
 				enc := stb.setColValEnc(colNum, rawKey)
-				for _, recNum := range indices {
-					stb.wipRecNumToColEnc[colNum][recNum] = enc
+
+				recNumsBitset := deData.deRecNums[recIdx]
+				for recNum := uint16(0); recNum < uint16(recNumsBitset.Len()); recNum++ {
+					if recNumsBitset.Test(uint(recNum)) {
+						stb.wipRecNumToColEnc[colNum][recNum] = enc
+					}
 				}
 			}
 			continue // done with this dict encoded column
@@ -520,8 +523,8 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 	deData := cwip.deData
 	if deData.deCount < wipCardLimit {
 		for dword, recsIdx := range deData.deToRecnumIdx {
-			recNumsArr := deData.deRecNums[recsIdx]
-			if toputils.BinarySearchUint16(recNum, recNumsArr) {
+			recNumsBitSet := deData.deRecNums[recsIdx]
+			if recNumsBitSet.Test(uint(recNum)) {
 				var mcVal utils.CValueEnclosure
 				_, err := GetCvalFromRec([]byte(dword)[0:], 0, &mcVal)
 				if err != nil {

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -102,7 +102,7 @@ func (ss *SegStore) EncodeColumns(rawData []byte, recordTime uint64, tsKey *stri
 		colWip.cbufidx += 1
 		ss.updateColValueSizeInAllSeenColumns(colName, 1)
 		// also do backfill dictEnc for this recnum
-		checkAddDictEnc(colWip, VALTYPE_ENC_BACKFILL[:], ss.wipBlock.blockSummary.RecCount)
+		ss.checkAddDictEnc(colWip, VALTYPE_ENC_BACKFILL[:], ss.wipBlock.blockSummary.RecCount)
 	}
 
 	return maxIdx, matchedCol, nil
@@ -486,7 +486,7 @@ func (ss *SegStore) encodeSingleString(key string, valStr string, maxIdx uint32,
 		bi.uniqueWordCount += addToBlockBloom(bi.Bf, valBytes)
 	}
 	if !ss.skipDe {
-		checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum)
+		ss.checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum)
 	}
 	addSegStatsStrIngestion(ss.AllSst, key, valBytes)
 	if colWip.cbufidx > maxIdx {
@@ -555,7 +555,7 @@ func (ss *SegStore) encodeSingleNumber(key string, value interface{}, maxIdx uin
 	colWip, recNum, matchedCol = ss.initAndBackFillColumn(key, value, matchedCol)
 	colRis := ss.wipBlock.columnRangeIndexes
 	segstats := ss.AllSst
-	retLen := encSingleNumber(key, value, colWip.cbuf[:], colWip.cbufidx, colRis, recNum, segstats,
+	retLen := ss.encSingleNumber(key, value, colWip.cbuf[:], colWip.cbufidx, colRis, recNum, segstats,
 		ss.wipBlock.bb, colWip, valBytes)
 	colWip.cbufidx += retLen
 	ss.updateColValueSizeInAllSeenColumns(key, retLen)
@@ -582,7 +582,7 @@ func (ss *SegStore) initAndBackFillColumn(key string, value interface{}, matched
 	if !ok {
 		if recNum != 0 {
 			log.Debugf("EncodeColumns: newColumn=%v showed up in the middle, backfilling it now", key)
-			backFillPastRecords(key, value, recNum, colBlooms, colRis, colWip)
+			ss.backFillPastRecords(key, value, recNum, colBlooms, colRis, colWip)
 		}
 	}
 	allColsInBlock[key] = true
@@ -616,29 +616,30 @@ func initMicroIndices(key string, val interface{}, colBlooms map[string]*BloomIn
 	}
 }
 
-func backFillPastRecords(key string, val interface{}, recNum uint16, colBlooms map[string]*BloomIndex,
+func (ss *SegStore) backFillPastRecords(key string, val interface{}, recNum uint16,
+	colBlooms map[string]*BloomIndex,
 	colRis map[string]*RangeIndex, colWip *ColWip) uint32 {
 	initMicroIndices(key, val, colBlooms, colRis)
 	packedLen := uint32(0)
 
-	recArr := make([]uint16, recNum)
-	for i := uint16(0); i < recNum; i++ {
+	bs := ss.GetNewBitset(uint(recNum))
+	for i := uint(0); i < uint(recNum); i++ {
 		// only the type will be saved when we are backfilling
 		copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_ENC_BACKFILL[:])
 		colWip.cbufidx += 1
 		packedLen += 1
-		recArr[i] = i
+		bs.Set(i)
 	}
 	// we will also init dictEnc for backfilled recnums
 	colWip.deData.deToRecnumIdx[string(VALTYPE_ENC_BACKFILL[:])] = colWip.deData.deCount
 	colWip.deData.deHashToRecnumIdx[xxhash.Sum64(VALTYPE_ENC_BACKFILL[:])] = colWip.deData.deCount
-	colWip.deData.deRecNums[colWip.deData.deCount] = recArr
+	colWip.deData.deRecNums[colWip.deData.deCount] = bs
 	colWip.deData.deCount++
 
 	return packedLen
 }
 
-func encSingleNumber(key string, val interface{}, wipbuf []byte, idx uint32,
+func (ss *SegStore) encSingleNumber(key string, val interface{}, wipbuf []byte, idx uint32,
 	colRis map[string]*RangeIndex, wRecNum uint16,
 	segstats map[string]*SegStats, bb *bbp.ByteBuffer, colWip *ColWip,
 	valBytes []byte) uint32 {
@@ -656,7 +657,7 @@ func encSingleNumber(key string, val interface{}, wipbuf []byte, idx uint32,
 			valBytes)
 		valSize := encJsonNumber(key, SS_FLOAT64, FPARM_INT64, FPARM_UINT64, cval, wipbuf[:],
 			idx, ri.Ranges)
-		checkAddDictEnc(colWip, wipbuf[idx:idx+valSize], wRecNum)
+		ss.checkAddDictEnc(colWip, wipbuf[idx:idx+valSize], wRecNum)
 		return valSize
 	case int64:
 		addSegStatsNums(segstats, key, SS_INT64, cval, FPARM_UINT64, FPARM_FLOAT64,
@@ -664,7 +665,7 @@ func encSingleNumber(key string, val interface{}, wipbuf []byte, idx uint32,
 
 		valSize := encJsonNumber(key, SS_INT64, cval, FPARM_UINT64, FPARM_FLOAT64, wipbuf[:],
 			idx, ri.Ranges)
-		checkAddDictEnc(colWip, wipbuf[idx:idx+valSize], wRecNum)
+		ss.checkAddDictEnc(colWip, wipbuf[idx:idx+valSize], wRecNum)
 		return valSize
 
 	default:
@@ -1395,23 +1396,21 @@ func WriteMockBlockSummary(file string, blockSums []*BlockSummary,
 	}
 }
 
-func checkAddDictEnc(colWip *ColWip, cval []byte, recNum uint16) {
+func (ss *SegStore) checkAddDictEnc(colWip *ColWip, cval []byte, recNum uint16) {
 	if colWip.deData.deCount < wipCardLimit {
 		cvalHash := xxhash.Sum64(cval)
 		recsIdx, ok := colWip.deData.deHashToRecnumIdx[cvalHash]
 		if !ok {
-			recs := make([]uint16, 0)
+			// start bitset with len of the last RecNum*2
+			bs := ss.GetNewBitset(uint(recNum) * 2)
 			deData := colWip.deData
-
-			deData.deToRecnumIdx[string(cval)] = colWip.deData.deCount
-			deData.deHashToRecnumIdx[cvalHash] = colWip.deData.deCount
-			deData.deRecNums[colWip.deData.deCount] = recs
 			recsIdx = deData.deCount
+			deData.deToRecnumIdx[string(cval)] = recsIdx
+			deData.deHashToRecnumIdx[cvalHash] = recsIdx
+			deData.deRecNums[recsIdx] = bs
 			deData.deCount++
 		}
-		colWip.deData.deRecNums[recsIdx] = append(colWip.deData.deRecNums[recsIdx], recNum)
-		// todo we optimize this code, by pre-allocing a fixed length of recs, keep an idx, then add it to recs
-		// advantages: 1) we avoid extending the array. 2) we avoid inserting in the map on every rec
+		colWip.deData.deRecNums[recsIdx].Set(uint(recNum))
 	}
 }
 
@@ -1438,20 +1437,22 @@ func PackDictEnc(colWip *ColWip) {
 
 	for dword, recIdx := range colWip.deData.deToRecnumIdx {
 
-		recNumsArr := colWip.deData.deRecNums[recIdx]
+		recNumsBitset := colWip.deData.deRecNums[recIdx]
 		// copy the actual dict word , the TLV is packed inside the dword
 		copy(colWip.cbuf[colWip.cbufidx:], []byte(dword))
 		colWip.cbufidx += uint32(len(dword))
 
-		// copy num of records
-		numRecs := uint16(len(recNumsArr))
+		// copy num of records, by finding how many bits are set
+		numRecs := uint16(recNumsBitset.Count())
 		copy(colWip.cbuf[colWip.cbufidx:], utils.Uint16ToBytesLittleEndian(numRecs))
 		colWip.cbufidx += 2
 
-		for i := uint16(0); i < numRecs; i++ {
-			// copy the recNum
-			copy(colWip.cbuf[colWip.cbufidx:], utils.Uint16ToBytesLittleEndian(recNumsArr[i]))
-			colWip.cbufidx += 2
+		for i := uint16(0); i < uint16(recNumsBitset.Len()); i++ {
+			if recNumsBitset.Test(uint(i)) {
+				// copy the recNum
+				copy(colWip.cbuf[colWip.cbufidx:], utils.Uint16ToBytesLittleEndian(i))
+				colWip.cbufidx += 2
+			}
 		}
 	}
 }

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -63,6 +63,8 @@ const colWipsSizeLimit = 2000 // We shouldn't exceed this during normal usage.
 
 const MaxConcurrentAgileTrees = 5
 
+const BS_INITIAL_SIZE = uint32(1000)
+
 var currentAgileTreeCount int
 var atreeCounterLock sync.Mutex = sync.Mutex{}
 
@@ -130,7 +132,7 @@ func NewSegStore(orgId uint64) *SegStore {
 
 func (ss *SegStore) GetNewBitset(bsSize uint) *bitset.BitSet {
 	if ss.bsPoolCurrIdx >= ss.bsPoolCount {
-		newCount := uint32(1000)
+		newCount := BS_INITIAL_SIZE
 		ss.bsPool = toputils.ResizeSlice(ss.bsPool, int(newCount+ss.bsPoolCount))
 		for i := uint32(0); i < newCount; i++ {
 			newBs := bitset.New(bsSize)

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -101,7 +101,6 @@ type SegStore struct {
 	SegmentErrors      map[string]*structs.SearchErrorInfo
 	bsPool             []*bitset.BitSet
 	bsPoolCurrIdx      uint32
-	bsPoolCount        uint32
 }
 
 // helper struct to keep track of persistent queries and columns that need to be searched
@@ -131,14 +130,14 @@ func NewSegStore(orgId uint64) *SegStore {
 }
 
 func (ss *SegStore) GetNewBitset(bsSize uint) *bitset.BitSet {
-	if ss.bsPoolCurrIdx >= ss.bsPoolCount {
+	lastKnownLen := uint32(len(ss.bsPool))
+	if ss.bsPoolCurrIdx >= lastKnownLen {
 		newCount := BS_INITIAL_SIZE
-		ss.bsPool = toputils.ResizeSlice(ss.bsPool, int(newCount+ss.bsPoolCount))
+		ss.bsPool = toputils.ResizeSlice(ss.bsPool, int(newCount+lastKnownLen))
 		for i := uint32(0); i < newCount; i++ {
 			newBs := bitset.New(bsSize)
-			ss.bsPool[ss.bsPoolCount+i] = newBs
+			ss.bsPool[lastKnownLen+i] = newBs
 		}
-		ss.bsPoolCount += newCount
 	}
 	retVal := ss.bsPool[ss.bsPoolCurrIdx]
 	retVal.ClearAll()

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bits-and-blooms/bitset"
 	"github.com/cespare/xxhash"
 	"github.com/klauspost/compress/zstd"
 	"github.com/siglens/siglens/pkg/blob"
@@ -86,8 +87,9 @@ type SegfileRotateInfo struct {
 type DeData struct {
 	deToRecnumIdx     map[string]uint16 // [dictWordKey] => index to recNums Array
 	deHashToRecnumIdx map[uint64]uint16 // [hash(dictWordKey)] => index to recNums Array
-	deRecNums         [][]uint16        // [De idx] ==> recNums that match this de
-	deCount           uint16            // keeps track of cardinality count for this COL_WIP
+	// kunal todo , we could potentially just use uint32 indexes here that could point to the pool
+	deRecNums []*bitset.BitSet // [De idx] ==> BitSet of recNums that match this de
+	deCount   uint16           // keeps track of cardinality count for this COL_WIP
 }
 
 type ColWip struct {
@@ -432,7 +434,7 @@ func InitColWip(segKey string, colName string) *ColWip {
 
 	deData := DeData{deToRecnumIdx: make(map[string]uint16),
 		deHashToRecnumIdx: make(map[uint64]uint16),
-		deRecNums:         make([][]uint16, MaxDeEntries),
+		deRecNums:         make([]*bitset.BitSet, MaxDeEntries),
 		deCount:           0,
 	}
 
@@ -946,8 +948,8 @@ func (cw *ColWip) GetBufAndIdx() ([]byte, uint32) {
 	return cw.cbuf[0:cw.cbufidx], cw.cbufidx
 }
 
-func (cw *ColWip) SetDeData(deCount uint16, deToRecnumIdx map[string]uint16,
-	deHashToRecnumIdx map[uint64]uint16, deRecNums [][]uint16) {
+func (cw *ColWip) SetDeDataForTest(deCount uint16, deToRecnumIdx map[string]uint16,
+	deHashToRecnumIdx map[uint64]uint16, deRecNums []*bitset.BitSet) {
 
 	deData := DeData{deToRecnumIdx: deToRecnumIdx,
 		deHashToRecnumIdx: deHashToRecnumIdx,


### PR DESCRIPTION
# Description
1. Switch `recNums` for dictEnc columns from array to bitset
2. This saves about `3.1 GB` of mem  (about `6%`) on a `1 index, 10 segment, 3.2 million recs/seg` test 

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
