### PR TITLE
avoid string conversion during jp.ParseString and use bytes all along

### DIFF
--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -54,10 +54,6 @@ const CREATE_TOP_STR string = "create"
 const UPDATE_TOP_STR string = "update"
 const INDEX_UNDER_STR string = "_index"
 
-// How much stack space to allocate for unescaping JSON strings; if a string longer
-// than this needs to be escaped, it will result in a heap allocation
-const unescapeStackBufSize = 64
-
 var resp_status_201 map[string]interface{}
 
 func init() {
@@ -133,7 +129,7 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
 	// stack-allocated array for allocation-free unescaping of small strings
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	for scanner.Scan() {
 		inCount++

--- a/pkg/es/writer/esBulkHandler_test.go
+++ b/pkg/es/writer/esBulkHandler_test.go
@@ -43,11 +43,13 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	flush := func() {
 		jsonBytes := []byte(`{"hello": "world"}`)
 		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), true,
-			localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr)
+			localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr,
+			jsParsingStackbuf[:])
 		assert.Nil(t, err)
 	}
 
@@ -65,7 +67,7 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	}
 
 	for _, jsonBytes := range jsons {
-		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr)
+		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.Nil(t, err)
 	}
 	flush()
@@ -84,7 +86,7 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	}
 
 	for _, jsonBytes := range jsons {
-		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr)
+		err := ProcessIndexRequest(jsonBytes, now, indexName, uint64(len(jsonBytes)), shouldFlush, localIndexMap, orgId, 0, idxToStreamIdCache, cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.Nil(t, err)
 	}
 	flush()

--- a/pkg/integrations/loki/loki.go
+++ b/pkg/integrations/loki/loki.go
@@ -59,8 +59,6 @@ const (
 	HOUR_IN_MS         = 3_600_000
 )
 
-const unescapeStackBufSize = 64
-
 func parseLabels(labelsString string) map[string]string {
 	labelsString = strings.Trim(labelsString, "{}")
 	labelPairs := strings.Split(labelsString, ", ")
@@ -233,7 +231,7 @@ func ProcessLokiLogsPromtailIngestRequest(ctx *fasthttp.RequestCtx, myid uint64)
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	for _, stream := range streams {
 		labels := stream["labels"].(string)
@@ -340,7 +338,7 @@ func ProcessLokiApiIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	for _, stream := range logData.Streams {
 		allIngestData := make(map[string]interface{})

--- a/pkg/integrations/splunk/splunk.go
+++ b/pkg/integrations/splunk/splunk.go
@@ -31,8 +31,6 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const unescapeStackBufSize = 64
-
 func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	if hook := hooks.GlobalHooks.OverrideIngestRequestHook; hook != nil {
 		alreadyHandled := hook(ctx, myid, grpc.INGEST_FUNC_SPLUNK, false)
@@ -102,7 +100,7 @@ func handleSingleRecord(record map[string]interface{}, myid uint64) (error, int)
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	localIndexMap := make(map[string]string)
 	err = writer.ProcessIndexRequest(recordAsBytes, tsNow, indexNameIn, uint64(len(recordAsString)), false, localIndexMap, myid, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr,

--- a/pkg/integrations/splunk/splunk.go
+++ b/pkg/integrations/splunk/splunk.go
@@ -31,6 +31,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const unescapeStackBufSize = 64
+
 func ProcessSplunkHecIngestRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	if hook := hooks.GlobalHooks.OverrideIngestRequestHook; hook != nil {
 		alreadyHandled := hook(ctx, myid, grpc.INGEST_FUNC_SPLUNK, false)
@@ -100,9 +102,11 @@ func handleSingleRecord(record map[string]interface{}, myid uint64) (error, int)
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [unescapeStackBufSize]byte
 
 	localIndexMap := make(map[string]string)
-	err = writer.ProcessIndexRequest(recordAsBytes, tsNow, indexNameIn, uint64(len(recordAsString)), false, localIndexMap, myid, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr)
+	err = writer.ProcessIndexRequest(recordAsBytes, tsNow, indexNameIn, uint64(len(recordAsString)), false, localIndexMap, myid, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr,
+		jsParsingStackbuf[:])
 	if err != nil {
 		return fmt.Errorf("Failed to add entry to in mem buffer"), fasthttp.StatusServiceUnavailable
 	}

--- a/pkg/otlp/otlp.go
+++ b/pkg/otlp/otlp.go
@@ -39,8 +39,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const unescapeStackBufSize = 64
-
 func ProcessTraceIngest(ctx *fasthttp.RequestCtx) {
 	if hook := hooks.GlobalHooks.OverrideIngestRequestHook; hook != nil {
 		alreadyHandled := hook(ctx, 0 /* TODO */, grpc.INGEST_FUNC_OTLP_TRACES, false)
@@ -90,7 +88,7 @@ func ProcessTraceIngest(ctx *fasthttp.RequestCtx) {
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	// Go through the request data and ingest each of the spans.
 	numSpans := 0       // The total number of spans sent in this request.

--- a/pkg/sampledataset/sampledataset.go
+++ b/pkg/sampledataset/sampledataset.go
@@ -32,6 +32,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const unescapeStackBufSize = 64
+
 func generateESBody(recs int, actionLine string, rdr Generator,
 	bb *bytebufferpool.ByteBuffer) ([]byte, error) {
 
@@ -100,13 +102,14 @@ func ProcessSyntheicDataRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	idxToStreamIdCache := make(map[string]string)
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [unescapeStackBufSize]byte
 
 	responsebody := make(map[string]interface{})
 	for scanner.Scan() {
 		scanner.Scan()
 		rawJson := scanner.Bytes()
 		numBytes := len(rawJson)
-		err = writer.ProcessIndexRequest(rawJson, tsNow, "test-data", uint64(numBytes), false, localIndexMap, myid, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr)
+		err = writer.ProcessIndexRequest(rawJson, tsNow, "test-data", uint64(numBytes), false, localIndexMap, myid, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		if err != nil {
 			utils.SendError(ctx, "Failed to ingest data", "", err)
 			return

--- a/pkg/sampledataset/sampledataset.go
+++ b/pkg/sampledataset/sampledataset.go
@@ -32,8 +32,6 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const unescapeStackBufSize = 64
-
 func generateESBody(recs int, actionLine string, rdr Generator,
 	bb *bytebufferpool.ByteBuffer) ([]byte, error) {
 
@@ -102,7 +100,7 @@ func ProcessSyntheicDataRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	idxToStreamIdCache := make(map[string]string)
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [utils.UnescapeStackBufSize]byte
 
 	responsebody := make(map[string]interface{})
 	for scanner.Scan() {

--- a/pkg/segment/segexecution_test.go
+++ b/pkg/segment/segexecution_test.go
@@ -1539,6 +1539,7 @@ func Test_unrotatedQuery(t *testing.T) {
 	writer.SetCardinalityLimit(0)
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for batch := 0; batch < numBatch; batch++ {
 		for rec := 0; rec < numRec; rec++ {
@@ -1556,7 +1557,7 @@ func Test_unrotatedQuery(t *testing.T) {
 			rawJson, err := json.Marshal(record)
 			assert.Nil(t, err)
 			err = writer.AddEntryToInMemBuf("test1", rawJson, uint64(rec)+1, "test", 10, false,
-				SIGNAL_EVENTS, 0, 0, cnameCacheByteHashToStr)
+				SIGNAL_EVENTS, 0, 0, cnameCacheByteHashToStr, jsParsingStackbuf[:])
 			assert.Nil(t, err)
 		}
 

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -40,8 +40,6 @@ import (
 
 const OneHourInMs = 60 * 60 * 1000
 
-const unescapeStackBufSize = 64
-
 func ProcessSearchTracesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	searchRequestBody, readJSON, err := ParseAndValidateRequestBody(ctx)
 	if err != nil {
@@ -338,7 +336,7 @@ func ProcessRedTracesIngest() {
 	spans := make([]*structs.Span, 0)
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [putils.UnescapeStackBufSize]byte
 
 	for {
 		ctx := &fasthttp.RequestCtx{}
@@ -577,7 +575,7 @@ func writeDependencyMatrix(dependencyMatrix map[string]map[string]int) {
 
 	idxToStreamIdCache := make(map[string]string)
 	cnameCacheByteHashToStr := make(map[uint64]string)
-	var jsParsingStackbuf [unescapeStackBufSize]byte
+	var jsParsingStackbuf [putils.UnescapeStackBufSize]byte
 
 	// Ingest
 	err = writer.ProcessIndexRequest(dependencyMatrixJSON, now, indexName, lenJsonData, shouldFlush, localIndexMap, orgId, 0 /* TODO */, idxToStreamIdCache, cnameCacheByteHashToStr,

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -142,6 +142,7 @@ func TestRecordEncodeDecode(t *testing.T) {
 			)},
 	}
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
@@ -153,7 +154,7 @@ func TestRecordEncodeDecode(t *testing.T) {
 		}
 		tsKey := config.GetTimeStampKey()
 		maxIdx, _, err := segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 
 		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
 
@@ -256,6 +257,7 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 	}
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
@@ -267,7 +269,7 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 		}
 		tsKey := config.GetTimeStampKey()
 		maxIdx, _, err := segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_JAEGER_TRACES,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 
 		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
 
@@ -563,10 +565,11 @@ func Test_SegStoreAllColumnsRecLen(t *testing.T) {
 	}
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for idx, record := range records {
 		err := segstore.WritePackedRecord(record.input, cTime, SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.Nil(t, err, "failed to write packed record %v", idx)
 
 		assert.Equal(t, idx+1, segstore.RecordCount, "idx=%v", idx)

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -57,6 +57,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 	}
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
@@ -68,7 +69,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 		}
 		tsKey := config.GetTimeStampKey()
 		_, _, err = segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.Nil(t, err)
 
 		colWips := allSegStores[sId].wipBlock.colWips
@@ -157,6 +158,7 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 	}
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for _, test := range cases {
 		allCols := make(map[string]uint32)
@@ -185,7 +187,7 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 
 		ts := config.GetTimeStampKey()
 		maxIdx, _, err := segstore.EncodeColumns(test.input, 1234, &ts, SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
 
 		assert.Nil(t, err)

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -995,7 +995,8 @@ func (wipBlock *WipBlock) adjustEarliestLatestTimes(ts_millis uint64) {
 }
 
 func (segstore *SegStore) WritePackedRecord(rawJson []byte, ts_millis uint64,
-	signalType utils.SIGNAL_TYPE, cnameCacheByteHashToStr map[uint64]string) error {
+	signalType utils.SIGNAL_TYPE, cnameCacheByteHashToStr map[uint64]string,
+	jsParsingStackbuf []byte) error {
 
 	var maxIdx uint32
 	var err error
@@ -1003,7 +1004,7 @@ func (segstore *SegStore) WritePackedRecord(rawJson []byte, ts_millis uint64,
 	tsKey := config.GetTimeStampKey()
 	if signalType == utils.SIGNAL_EVENTS || signalType == utils.SIGNAL_JAEGER_TRACES {
 		maxIdx, matchedPCols, err = segstore.EncodeColumns(rawJson, ts_millis, &tsKey, signalType,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf)
 		if err != nil {
 			log.Errorf("WritePackedRecord: Failed to encode record=%+v", string(rawJson))
 			return err

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -248,6 +248,7 @@ func TestStarTree(t *testing.T) {
 	ss.numBlocks = 0
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	tsKey := config.GetTimeStampKey()
 	for i, test := range cases {
@@ -265,7 +266,7 @@ func TestStarTree(t *testing.T) {
 		assert.NoError(t, err)
 
 		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
 		ss.wipBlock.maxIdx = maxIdx
@@ -344,6 +345,7 @@ func TestStarTreeMedium(t *testing.T) {
 	tsKey := config.GetTimeStampKey()
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range currCases {
 
@@ -360,7 +362,7 @@ func TestStarTreeMedium(t *testing.T) {
 		assert.NoError(t, err)
 
 		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
 		ss.wipBlock.maxIdx = maxIdx
@@ -440,6 +442,7 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 	tsKey := config.GetTimeStampKey()
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range currCases {
 
@@ -456,7 +459,7 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 		assert.NoError(t, err)
 
 		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
 		ss.wipBlock.maxIdx = maxIdx
@@ -536,6 +539,7 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 	tsKey := config.GetTimeStampKey()
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for i, test := range currCases {
 
@@ -552,7 +556,7 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 		assert.NoError(t, err)
 
 		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
-			cnameCacheByteHashToStr)
+			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
 		ss.wipBlock.maxIdx = maxIdx

--- a/pkg/segment/writer/unrotatedquery_test.go
+++ b/pkg/segment/writer/unrotatedquery_test.go
@@ -65,6 +65,7 @@ func Test_writePQSFiles(t *testing.T) {
 	querytracker.UpdateQTUsage([]string{"test"}, node, nil, "batch=batch-0")
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
+	var jsParsingStackbuf [64]byte
 
 	for batch := 0; batch < numBatch; batch++ {
 		for rec := 0; rec < numRec; rec++ {
@@ -80,7 +81,7 @@ func Test_writePQSFiles(t *testing.T) {
 				streamid := fmt.Sprintf("stream-%d", stremNum)
 				raw, _ := json.Marshal(record)
 				err := AddEntryToInMemBuf(streamid, raw, uint64(rec), "test", 10, false,
-					utils.SIGNAL_EVENTS, 0, 0, cnameCacheByteHashToStr)
+					utils.SIGNAL_EVENTS, 0, 0, cnameCacheByteHashToStr, jsParsingStackbuf[:])
 				assert.Nil(t, err)
 			}
 		}

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -27,6 +27,8 @@ import (
 	"github.com/rogpeppe/fastuuid"
 )
 
+const UnescapeStackBufSize = 64
+
 var UUID_GENERATOR *fastuuid.Generator
 
 var MAX_SHARDS = int(1)


### PR DESCRIPTION
# Description

The call to `jp.ParseString()` was using up `19 GB` during a `1 index, 10 segments` test. The call inside this function was doing `string(retVal)` where retVal was `[]byte`. All this function was doing was unescaping the incoming bytes and converting the result into string. We don't necessarily need the string and work around by just using the bytes. So switched this processing logic to only do the unescaping and returning the resultant byte array as is. 

This resulted in savings of about `13 GB` or so


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
