### PR TITLE
Do not run tracing related queries if trace index count is 0

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -42,6 +42,12 @@ import (
 
 var excludedInternalIndices = [...]string{"traces", "red-traces", "service-dependency"}
 
+// GetTraceStatsForAllSegments retrieves all trace-related statistics.
+func GetTraceStatsForAllSegments(myid uint64) (utils.AllIndexesStats, int64, float64, float64) {
+	allSegMetas := writer.ReadAllSegmetas()
+	return GetTracesStats(myid, allSegMetas)
+}
+
 func ProcessClusterStatsHandler(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	var httpResp utils.ClusterStatsResponseInfo

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -30,6 +30,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	pipesearch "github.com/siglens/siglens/pkg/ast/pipesearch"
 	"github.com/siglens/siglens/pkg/es/writer"
+	"github.com/siglens/siglens/pkg/health"
 	"github.com/siglens/siglens/pkg/segment/tracing/structs"
 	"github.com/siglens/siglens/pkg/segment/tracing/utils"
 	"github.com/siglens/siglens/pkg/usageStats"
@@ -312,7 +313,10 @@ func processSearchRequest(searchRequestBody *structs.SearchRequestBody, myid uin
 func MonitorSpansHealth() {
 	time.Sleep(1 * time.Minute) // Wait for initial traces ingest first
 	for {
-		ProcessRedTracesIngest()
+		_, traceIndexCount, _, _ := health.GetTraceStatsForAllSegments(0)
+		if traceIndexCount > 0 {
+			ProcessRedTracesIngest()
+		}
 		time.Sleep(5 * time.Minute)
 	}
 }


### PR DESCRIPTION
# Description
Do not run tracing related queries if trace index count is 0.
This code uses 0 as `myID` since there is no way to retrieve the orgID from the caller in `startup.go` ([link](https://github.com/venkateshamatam/siglens/blob/29e9253627d4a58870d4df31f19f5a24cede6c39/cmd/startup/startup.go#L291)) and the current implementation uses 0 as myID ([link](https://github.com/venkateshamatam/siglens/blob/29e9253627d4a58870d4df31f19f5a24cede6c39/pkg/segment/tracing/handler/tracehandler.go#L356))
# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
