### PR TITLE
Migrate to Segmentio Hll from axiom Hll

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/siglens/siglens
 go 1.19
 
 require (
-	github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a
 	github.com/bits-and-blooms/bitset v1.2.0
 	github.com/bits-and-blooms/bloom/v3 v3.0.1
 	github.com/brianvoe/gofakeit/v6 v6.21.0
@@ -62,6 +61,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
@@ -75,7 +75,6 @@ require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -100,6 +99,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/go-co-op/gocron v1.31.1
 	github.com/prometheus/common v0.46.0
+	github.com/segmentio/go-hll v1.0.1
 	github.com/slack-go/slack v0.12.2
 	golang.org/x/net v0.23.0 // indirect
 	gorm.io/driver/sqlite v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/aws/aws-sdk-go v1.50.0 h1:HBtrLeO+QyDKnc3t1+5DR1RxodOHCGr8ZcrHudpv7jI=
-github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a h1:eqjiAL3qooftPm8b9C1GsSSRcmlw7iOva8vdBTmV2PY=
-github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 h1:6df1vn4bBlDDo4tARvBm7l6KA9iVMnE3NWizDeWSrps=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -38,8 +36,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
-github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
-github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fasthttp/router v1.4.1 h1:3xPUO+hy/HAkgGDSd5sX5w18cyGDIFbC7vip8KwPDk8=
@@ -93,7 +89,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYp
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
-github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -140,6 +135,9 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2D
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -170,6 +168,8 @@ github.com/segmentio/analytics-go/v3 v3.2.1 h1:G+f90zxtc1p9G+WigVyTR0xNfOghOGs/P
 github.com/segmentio/analytics-go/v3 v3.2.1/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
 github.com/segmentio/backo-go v1.0.0 h1:kbOAtGJY2DqOR0jfRkYEorx/b18RgtepGtY3+Cpe6qA=
 github.com/segmentio/backo-go v1.0.0/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
+github.com/segmentio/go-hll v1.0.1 h1:ph2Dy18eNdzzT6H2UsEacnWvDnHY6fbsmAnqDWNJeoQ=
+github.com/segmentio/go-hll v1.0.1/go.mod h1:cJhmOoNwstKKd+IWBWRlctKkitBI8XHjw9NgyE27Xdk=
 github.com/shirou/gopsutil/v3 v3.24.1 h1:R3t6ondCEvmARp3wxODhXMTLC/klMa87h2PHUw5m7QI=
 github.com/shirou/gopsutil/v3 v3.24.1/go.mod h1:UU7a2MSBQa+kW1uuDq8DeEBS8kmrnQwsv2b5O513rwU=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=

--- a/pkg/segment/aggregations/streamstats.go
+++ b/pkg/segment/aggregations/streamstats.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash"
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -173,10 +173,10 @@ func PerformNoWindowStreamStatsOnSingleFunc(ssOption *structs.StreamStatsOptions
 	case utils.Cardinality:
 		strValue := fmt.Sprintf("%v", colValue.CVal)
 		if ssResults.CardinalityHLL == nil {
-			ssResults.CardinalityHLL = hyperloglog.New()
+			ssResults.CardinalityHLL = structs.CreateNewSegmentioHll()
 		}
-		ssResults.CardinalityHLL.Insert([]byte(strValue))
-		ssResults.CurrResult.CVal = float64(ssResults.CardinalityHLL.Estimate())
+		ssResults.CardinalityHLL.AddRaw(xxhash.Sum64String(strValue))
+		ssResults.CurrResult.CVal = float64(ssResults.CardinalityHLL.Cardinality())
 	case utils.Values:
 		strValue := fmt.Sprintf("%v", colValue.CVal)
 		if ssResults.ValuesMap == nil {

--- a/pkg/segment/aggregations/streamstats.go
+++ b/pkg/segment/aggregations/streamstats.go
@@ -173,7 +173,7 @@ func PerformNoWindowStreamStatsOnSingleFunc(ssOption *structs.StreamStatsOptions
 	case utils.Cardinality:
 		strValue := fmt.Sprintf("%v", colValue.CVal)
 		if ssResults.CardinalityHLL == nil {
-			ssResults.CardinalityHLL = structs.CreateNewSegmentioHll()
+			ssResults.CardinalityHLL = structs.CreateNewHll()
 		}
 		ssResults.CardinalityHLL.AddRaw(xxhash.Sum64String(strValue))
 		ssResults.CurrResult.CVal = float64(ssResults.CardinalityHLL.Cardinality())

--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -90,7 +90,8 @@ func readSingleSst(fdata []byte, qid uint64) (*structs.SegStats, error) {
 
 	idx := uint16(0)
 
-	// read version, currently ignored
+	// read version
+	version := fdata[idx]
 	idx++
 
 	// read isNumeric
@@ -104,10 +105,12 @@ func readSingleSst(fdata []byte, qid uint64) (*structs.SegStats, error) {
 	hllSize := toputils.BytesToUint16LittleEndian(fdata[idx : idx+2])
 	idx += 2
 
-	err := sst.CreateHllFromBytes(fdata[idx:idx+hllSize], false)
-	if err != nil {
-		log.Errorf("qid=%d, readSingleSst: unable to create Hll from raw bytes. sst err: %v", qid, err)
-		return nil, err
+	if version == utils.VERSION_SEGSTATS[0] {
+		err := sst.CreateHllFromBytes(fdata[idx : idx+hllSize])
+		if err != nil {
+			log.Errorf("qid=%d, readSingleSst: unable to create Hll from raw bytes. sst err: %v", qid, err)
+			return nil, err
+		}
 	}
 	idx += hllSize
 

--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -401,7 +401,7 @@ func GetSegCardinality(runningSegStat *structs.SegStats,
 		return &res, nil
 	}
 
-	err := runningSegStat.SegHll.StrictUnion(*currSegStat.SegHll)
+	err := runningSegStat.Hll.StrictUnion(*currSegStat.Hll)
 	if err != nil {
 		log.Errorf("GetSegCardinality: error in Hll.Merge, err: %+v", err)
 		return nil, err

--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -105,12 +105,18 @@ func readSingleSst(fdata []byte, qid uint64) (*structs.SegStats, error) {
 	hllSize := toputils.BytesToUint16LittleEndian(fdata[idx : idx+2])
 	idx += 2
 
-	if version == utils.VERSION_SEGSTATS[0] {
+	switch version {
+	case utils.VERSION_SEGSTATS[0]:
 		err := sst.CreateHllFromBytes(fdata[idx : idx+hllSize])
 		if err != nil {
 			log.Errorf("qid=%d, readSingleSst: unable to create Hll from raw bytes. sst err: %v", qid, err)
 			return nil, err
 		}
+	case 1:
+		log.Infof("qid=%d, readSingleSst: ignoring Hll (old version)", qid)
+	default:
+		log.Errorf("qid=%d, readSingleSst: unknown version: %v", qid, version)
+		return nil, errors.New("readSingleSst: unknown version")
 	}
 	idx += hllSize
 

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -49,8 +49,7 @@ func Test_sstReadWrite(t *testing.T) {
 		Count:     2345,
 		NumStats:  &myNums,
 	}
-	err := inSst.CreateNewHll()
-	assert.Nil(t, err)
+	inSst.CreateNewHll()
 
 	for i := 0; i < 3200; i++ {
 		inSst.InsertIntoHll([]byte(fmt.Sprintf("mystr:%v", i)))
@@ -65,7 +64,7 @@ func Test_sstReadWrite(t *testing.T) {
 	ss.SegmentKey = "segkey-1"
 	ss.AllSst = allSst
 
-	err = ss.FlushSegStats()
+	err := ss.FlushSegStats()
 	assert.Nil(t, err)
 
 	allSstMap, err := ReadSegStats("segkey-1", 123)

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -530,7 +530,7 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 	bucketNum := 0
 	results := make([]*structs.BucketResult, len(gb.AllRunningBuckets))
-	tmLimitResult.Hll = structs.CreateNewSegmentioHll()
+	tmLimitResult.Hll = structs.CreateNewHll()
 	tmLimitResult.StrSet = make(map[string]struct{}, 0)
 	tmLimitResult.ValIsInLimit = aggregations.CheckGroupByColValsAgainstLimit(timechart, gb.GroupByColValCnt, tmLimitResult.GroupValScoreMap, req.MeasureOperations)
 	for key, idx := range gb.StringBucketIdx {
@@ -947,7 +947,7 @@ func (rb *RunningBucketResultsJSON) Convert() (*RunningBucketResults, error) {
 				log.Errorf("RunningBucketResultsJSON.Convert: failed to decode hllString, err: %v", err)
 				return nil, err
 			}
-			hll, err := structs.CreateSegmentioHllFromBytes(hllBytes)
+			hll, err := structs.CreateHllFromBytes(hllBytes)
 			if err != nil {
 				log.Errorf("RunningBucketResultsJSON.Convert: failed to unmarshal hllBytes, err: %v", err)
 				return nil, err

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/axiomhq/hyperloglog"
+	"github.com/segmentio/go-hll"
 	"github.com/siglens/siglens/pkg/segment/aggregations"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -530,7 +530,7 @@ func (gb *GroupByBuckets) ConvertToAggregationResult(req *structs.GroupByRequest
 
 	bucketNum := 0
 	results := make([]*structs.BucketResult, len(gb.AllRunningBuckets))
-	tmLimitResult.Hll = hyperloglog.New14()
+	tmLimitResult.Hll = structs.CreateNewSegmentioHll()
 	tmLimitResult.StrSet = make(map[string]struct{}, 0)
 	tmLimitResult.ValIsInLimit = aggregations.CheckGroupByColValsAgainstLimit(timechart, gb.GroupByColValCnt, tmLimitResult.GroupValScoreMap, req.MeasureOperations)
 	for key, idx := range gb.StringBucketIdx {
@@ -605,7 +605,7 @@ func (gb *GroupByBuckets) AddResultToStatRes(req *structs.GroupByRequest, bucket
 			}
 		}
 
-		var hllToMerge *hyperloglog.Sketch
+		var hllToMerge *hll.Hll
 		var strSetToMerge map[string]struct{}
 		var eVal utils.CValueEnclosure
 		switch mInfo.MeasureFunc {
@@ -733,7 +733,7 @@ func (gb *GroupByBuckets) AddResultToStatRes(req *structs.GroupByRequest, bucket
 				}
 				eVal = utils.CValueEnclosure{CVal: uint64(len(strSet)), Dtype: utils.SS_DT_UNSIGNED_NUM}
 			} else {
-				finalVal := runningStats[valIdx].hll.Estimate()
+				finalVal := runningStats[valIdx].hll.Cardinality()
 				eVal = utils.CValueEnclosure{CVal: finalVal, Dtype: utils.SS_DT_UNSIGNED_NUM}
 				hllToMerge = runningStats[valIdx].hll
 			}
@@ -846,11 +846,7 @@ func (gb *GroupByBuckets) ConvertToJson() (*GroupByBucketsJSON, error) {
 		retVals := make([]interface{}, 0, len(bucket.currStats))
 		for idx, rs := range bucket.runningStats {
 			if bucket.currStats[idx].MeasureFunc == utils.Cardinality {
-				encoded, err := rs.hll.MarshalBinary()
-				if err != nil {
-					log.Errorf("GroupByBuckets.ConvertToJson: failed to marshal hll, err: %v", err)
-					return nil, err
-				}
+				encoded := rs.hll.ToBytes()
 				retVals = append(retVals, encoded)
 			} else {
 				retVals = append(retVals, rs.rawVal.CVal)
@@ -876,11 +872,7 @@ func (tb *TimeBuckets) ConvertToJson() (*TimeBucketsJSON, error) {
 		retVals := make([]interface{}, 0, len(bucket.currStats))
 		for idx, rs := range bucket.runningStats {
 			if bucket.currStats[idx].MeasureFunc == utils.Cardinality {
-				encoded, err := rs.hll.MarshalBinary()
-				if err != nil {
-					log.Errorf("TimeBuckets.ConvertToJson: failed to marshal hll, err: %v", err)
-					return nil, err
-				}
+				encoded := rs.hll.ToBytes()
 				retVals = append(retVals, encoded)
 			} else {
 				retVals = append(retVals, rs.rawVal.CVal)
@@ -945,7 +937,6 @@ func (rb *RunningBucketResultsJSON) Convert() (*RunningBucketResults, error) {
 	currRunningStats := make([]runningStats, 0, len(rb.RunningStats))
 	for statsIdx, rs := range rb.RunningStats {
 		if rb.CurrStats[statsIdx].MeasureFunc == utils.Cardinality {
-			hll := hyperloglog.New()
 			hllString, ok := rs.(string)
 			if !ok {
 				log.Errorf("RunningBucketResultsJSON.Convert: failed to convert hll to string, hll: %+v of type %T", rs, rs)
@@ -956,7 +947,7 @@ func (rb *RunningBucketResultsJSON) Convert() (*RunningBucketResults, error) {
 				log.Errorf("RunningBucketResultsJSON.Convert: failed to decode hllString, err: %v", err)
 				return nil, err
 			}
-			err = hll.UnmarshalBinary(hllBytes)
+			hll, err := structs.CreateSegmentioHllFromBytes(hllBytes)
 			if err != nil {
 				log.Errorf("RunningBucketResultsJSON.Convert: failed to unmarshal hllBytes, err: %v", err)
 				return nil, err

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -963,10 +963,7 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 							Count:     0,
 							Records:   make([]*utils.CValueEnclosure, 0),
 						}
-						err := stats.CreateNewHll()
-						if err != nil {
-							log.Errorf("qid=%d, segmentStatsWorker failed to create new hll for col %s", qid, colName)
-						}
+						stats.CreateNewHll()
 
 						lStats[colName] = stats
 					}

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -582,7 +582,7 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 			sstMap[mOp.MeasureCol] = &structs.SegStats{
 				IsNumeric:   dtypeVal.IsNumeric(),
 				Count:       1,
-				SegHll:      nil,
+				Hll:         nil,
 				NumStats:    &structs.NumericStats{Min: *nTypeEnclosure, Max: *nTypeEnclosure, Sum: *nTypeEnclosure, Dtype: dtypeVal.Dtype},
 				StringStats: nil,
 				Records:     nil,

--- a/pkg/segment/search/segsearch_test.go
+++ b/pkg/segment/search/segsearch_test.go
@@ -417,8 +417,8 @@ func testAggsQuery(t *testing.T, numEntriesForBuffer int, searchReq *structs.Seg
 	key0Block0Stats := block0["key0"]
 	assert.False(t, key0Block0Stats.IsNumeric)
 	assert.Equal(t, key0Block0Stats.Count, uint64(numEntriesForBuffer))
-	assert.GreaterOrEqual(t, key0Block0Stats.Hll.Estimate(), uint64(0))
-	assert.LessOrEqual(t, key0Block0Stats.Hll.Estimate(), uint64(2), "key0 always has same value")
+	assert.GreaterOrEqual(t, key0Block0Stats.GetHllCardinality(), uint64(0))
+	assert.LessOrEqual(t, key0Block0Stats.GetHllCardinality(), uint64(2), "key0 always has same value")
 
 	key6Block0Stats := block0["key6"]
 	assert.True(t, key6Block0Stats.IsNumeric)

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -32,8 +32,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/axiomhq/hyperloglog"
 	"github.com/dustin/go-humanize"
+	"github.com/segmentio/go-hll"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
@@ -314,7 +314,7 @@ type Cluster struct {
 type TMLimitResult struct {
 	ValIsInLimit     map[string]bool
 	GroupValScoreMap map[string]*utils.CValueEnclosure
-	Hll              *hyperloglog.Sketch
+	Hll              *hll.Hll
 	StrSet           map[string]struct{}
 	OtherCValArr     []*utils.CValueEnclosure
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -523,7 +523,7 @@ func (ss *SegStats) Init(rawSegStatJson []byte) error {
 	}
 	ss.IsNumeric = segStatJson.IsNumeric
 	ss.Count = segStatJson.Count
-	err = ss.CreateHllFromBytes(segStatJson.RawHll, true)
+	err = ss.CreateHllFromBytes(segStatJson.RawHll)
 	if err != nil {
 		log.Errorf("SegStats.Init: Failed to create new segmentio Hll from raw bytes. error: %v data: %v", err, string(segStatJson.RawHll))
 		return err
@@ -552,9 +552,7 @@ func CreateHllFromBytes(rawHll []byte) (*hll.Hll, error) {
 	return &hll, nil
 }
 
-// Create new segmentio Hll from the raw bytes.
-// If creatNew is true, it will create a new Hll, if failed to create from raw bytes
-func (ss *SegStats) CreateHllFromBytes(rawHll []byte, creatNew bool) error {
+func (ss *SegStats) CreateHllFromBytes(rawHll []byte) error {
 	hll, err := CreateHllFromBytes(rawHll)
 	if err != nil {
 		return err
@@ -596,7 +594,7 @@ func (ssj *SegStatsJSON) ToStats() (*SegStats, error) {
 	ss := &SegStats{}
 	ss.IsNumeric = ssj.IsNumeric
 	ss.Count = ssj.Count
-	err := ss.CreateHllFromBytes(ssj.RawHll, false)
+	err := ss.CreateHllFromBytes(ssj.RawHll)
 	if err != nil {
 		log.Errorf("SegStatsJSON.ToStats: Failed to unmarshal hll error: %v data: %v", err, string(ssj.RawHll))
 		return nil, err

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -20,7 +20,6 @@ package structs
 import (
 	"testing"
 
-	"github.com/axiomhq/hyperloglog"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -773,7 +772,6 @@ func Test_EncodeDecodeSegStats(t *testing.T) {
 				},
 				Dtype: utils.SS_DT_SIGNED_NUM,
 			},
-			Hll:         hyperloglog.New16(),
 			StringStats: nil,
 			Records:     nil,
 		},
@@ -781,7 +779,6 @@ func Test_EncodeDecodeSegStats(t *testing.T) {
 			IsNumeric: false,
 			Count:     42,
 			NumStats:  nil,
-			Hll:       hyperloglog.New16(),
 			StringStats: &StringStats{
 				StrSet: map[string]struct{}{
 					"str1": {},
@@ -797,6 +794,9 @@ func Test_EncodeDecodeSegStats(t *testing.T) {
 	}
 
 	for _, originalSegStats := range segStatsList {
+		err := originalSegStats.CreateNewHll()
+		assert.NoError(t, err)
+
 		segStatsJson, err := originalSegStats.ToJSON()
 		assert.NoError(t, err)
 		assert.NotNil(t, segStatsJson)
@@ -814,7 +814,6 @@ func Test_EqualsIsDeepEquals(t *testing.T) {
 		IsNumeric: false,
 		Count:     42,
 		NumStats:  nil,
-		Hll:       hyperloglog.New16(),
 		StringStats: &StringStats{
 			StrSet: map[string]struct{}{
 				"str1": {},
@@ -832,7 +831,6 @@ func Test_EqualsIsDeepEquals(t *testing.T) {
 		IsNumeric: false,
 		Count:     42,
 		NumStats:  nil,
-		Hll:       hyperloglog.New16(),
 		StringStats: &StringStats{
 			StrSet: map[string]struct{}{
 				"str1": {},
@@ -845,6 +843,12 @@ func Test_EqualsIsDeepEquals(t *testing.T) {
 		},
 		Records: nil,
 	}
+
+	err := segStat1.CreateNewHll()
+	assert.NoError(t, err)
+
+	err = segStat2.CreateNewHll()
+	assert.NoError(t, err)
 
 	assert.Equal(t, segStat1, segStat2)
 

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -794,8 +794,7 @@ func Test_EncodeDecodeSegStats(t *testing.T) {
 	}
 
 	for _, originalSegStats := range segStatsList {
-		err := originalSegStats.CreateNewHll()
-		assert.NoError(t, err)
+		originalSegStats.CreateNewHll()
 
 		segStatsJson, err := originalSegStats.ToJSON()
 		assert.NoError(t, err)
@@ -844,11 +843,9 @@ func Test_EqualsIsDeepEquals(t *testing.T) {
 		Records: nil,
 	}
 
-	err := segStat1.CreateNewHll()
-	assert.NoError(t, err)
+	segStat1.CreateNewHll()
 
-	err = segStat2.CreateNewHll()
-	assert.NoError(t, err)
+	segStat2.CreateNewHll()
 
 	assert.Equal(t, segStat1, segStat2)
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -141,6 +141,8 @@ var VERSION_TSOFILE = []byte{0x01}
 var VERSION_TSGFILE = []byte{0x01}
 var VERSION_MBLOCKSUMMARY = []byte{0x01}
 
+var VERSION_SEGSTATS = []byte{2}
+
 const INCONSISTENT_CVAL_SIZE uint32 = math.MaxUint32
 
 type SS_DTYPE uint8

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1465,10 +1465,7 @@ func addSegStatsStrIngestion(segstats map[string]*SegStats, cname string, valByt
 			IsNumeric: false,
 			Count:     0,
 		}
-		err := stats.CreateNewHll()
-		if err != nil {
-			log.Errorf("addSegStatsStrIngestion: error creating hll: %s", err)
-		}
+		stats.CreateNewHll()
 
 		segstats[cname] = stats
 	}
@@ -1503,10 +1500,7 @@ func addSegStatsNums(segstats map[string]*SegStats, cname string,
 			Count:     0,
 			NumStats:  numStats,
 		}
-		err := stats.CreateNewHll()
-		if err != nil {
-			log.Errorf("addSegStatsNums: error creating hll: %s", err)
-		}
+		stats.CreateNewHll()
 		segstats[cname] = stats
 	}
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1444,7 +1444,7 @@ func writeSstToBuf(sst *structs.SegStats, buf []byte) (uint16, error) {
 	idx := uint16(0)
 
 	// version
-	copy(buf[idx:], []byte{1})
+	copy(buf[idx:], utils.VERSION_SEGSTATS)
 	idx++
 
 	// isNumeric

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -809,7 +809,7 @@ func (segstore *SegStore) isAnyAtreeColAboveCardLimit() (string, bool, uint64) {
 			return cname, true, 0
 		}
 
-		colCardinalityEstimate := segstore.AllSst[cname].Hll.Estimate()
+		colCardinalityEstimate := segstore.AllSst[cname].GetHllCardinality()
 		if colCardinalityEstimate > uint64(wipCardLimit) {
 			return cname, true, colCardinalityEstimate
 		}
@@ -841,7 +841,7 @@ func (segstore *SegStore) initStarTreeCols() ([]string, []string) {
 			continue
 		}
 
-		colCardinalityEstimate := segstore.AllSst[cname].Hll.Estimate()
+		colCardinalityEstimate := segstore.AllSst[cname].GetHllCardinality()
 
 		if colCardinalityEstimate > uint64(wipCardLimit) {
 			continue
@@ -1455,11 +1455,7 @@ func writeSstToBuf(sst *structs.SegStats, buf []byte) (uint16, error) {
 	copy(buf[idx:], toputils.Uint64ToBytesLittleEndian(sst.Count))
 	idx += 8
 
-	hllData, err := sst.Hll.MarshalBinary()
-	if err != nil {
-		log.Errorf("writeSstToBuf: HLL marshal failed err=%v", err)
-		return idx, err
-	}
+	hllData := sst.GetHllBytes()
 
 	// HLL_Size
 	copy(buf[idx:], toputils.Uint16ToBytesLittleEndian(uint16(len(hllData))))

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/siglens/siglens/pkg/segment/structs"
 	. "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
-	log "github.com/sirupsen/logrus"
 
 	bbp "github.com/valyala/bytebufferpool"
 )
@@ -52,10 +51,7 @@ func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 			NumStats:  numStats,
 			Records:   make([]*CValueEnclosure, 0),
 		}
-		err := stats.CreateNewHll()
-		if err != nil {
-			log.Errorf("AddSegStatsNums: Error creating new HLL: %v", err)
-		}
+		stats.CreateNewHll()
 		segstats[cname] = stats
 	}
 
@@ -94,10 +90,7 @@ func AddSegStatsCount(segstats map[string]*SegStats, cname string,
 			Count:     0,
 			NumStats:  numStats,
 		}
-		err := stats.CreateNewHll()
-		if err != nil {
-			log.Errorf("AddSegStatsCount: Error creating new HLL: %v", err)
-		}
+		stats.CreateNewHll()
 		segstats[cname] = stats
 	}
 	stats.Count += count
@@ -241,10 +234,7 @@ func AddSegStatsStr(segstats map[string]*SegStats, cname string, strVal string,
 			Count:     0,
 			Records:   make([]*CValueEnclosure, 0),
 		}
-		err := stats.CreateNewHll()
-		if err != nil {
-			log.Errorf("AddSegStatsStr: Error creating new HLL: %v", err)
-		}
+		stats.CreateNewHll()
 
 		segstats[cname] = stats
 	}


### PR DESCRIPTION
# Description
- Migrates to Segmentio Hll from Axiom Hll.
- Segmentio Hll requires some default settings to be set and it will throw an error if the settings are invalid. For that we are using the defined settings instead of default.
- But from the query side for timechart and stats cardinality, we will try to create the Hll with same settings if failed, it will be return the default hll. 

# Testing
- All Unit tests passed

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
