### PR TITLE
StarTreeBuilderPool for managing STBs

### DIFF
--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -20,12 +20,18 @@ package writer
 import (
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/siglens/siglens/pkg/segment/utils"
 	toputils "github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
+
+const MaxConcurrentAgileTrees = 5
+
+var currentAgileTreeCount int
+var atreeCounterLock sync.Mutex = sync.Mutex{}
 
 type StarTree struct {
 	Root *Node

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -46,13 +46,12 @@ var STBHolderPool [MaxConcurrentAgileTrees]*STBHolder
 
 type STBHolder struct {
 	stbPtr            *StarTreeBuilder
-	segStore          *SegStore
 	currentlyInUse    bool
 	lastUsedTimestamp time.Time
 	myIdx             uint16
 }
 
-func (ss *SegStore) GetSTB() *STBHolder {
+func GetSTB() *STBHolder {
 	atreeCounterLock.Lock()
 	defer atreeCounterLock.Unlock()
 	if currentAgileTreeCount == MaxConcurrentAgileTrees {
@@ -65,7 +64,6 @@ func (ss *SegStore) GetSTB() *STBHolder {
 			STBHolderPool[i].stbPtr = &StarTreeBuilder{}
 			STBHolderPool[i].currentlyInUse = true
 			STBHolderPool[i].lastUsedTimestamp = time.Now()
-			STBHolderPool[i].segStore = ss
 			STBHolderPool[i].myIdx = uint16(i)
 			currentAgileTreeCount++
 
@@ -90,7 +88,6 @@ func (stbHolder *STBHolder) ReleaseSTB() {
 
 	currentAgileTreeCount--
 	stbHolder.currentlyInUse = false
-	stbHolder.segStore = nil
 }
 
 var IdxToAgFn []utils.AggregateFunctions = []utils.AggregateFunctions{

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -48,7 +48,6 @@ type STBHolder struct {
 	stbPtr            *StarTreeBuilder
 	currentlyInUse    bool
 	lastUsedTimestamp time.Time
-	myIdx             uint16
 }
 
 func GetSTB() *STBHolder {
@@ -60,14 +59,9 @@ func GetSTB() *STBHolder {
 
 	for i := 0; i < MaxConcurrentAgileTrees; i++ {
 		if STBHolderPool[i] == nil {
-			STBHolderPool[i] = &STBHolder{}
-			STBHolderPool[i].stbPtr = &StarTreeBuilder{}
-			STBHolderPool[i].currentlyInUse = true
-			STBHolderPool[i].lastUsedTimestamp = time.Now()
-			STBHolderPool[i].myIdx = uint16(i)
-			currentAgileTreeCount++
-
-			return STBHolderPool[i]
+			STBHolderPool[i] = &STBHolder{
+				stbPtr: &StarTreeBuilder{},
+			}
 		}
 
 		if !STBHolderPool[i].currentlyInUse {

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -59,7 +59,7 @@ type STBHolder struct {
 func GetSTB() *STBHolder {
 	atreeCounterLock.Lock()
 	defer atreeCounterLock.Unlock()
-	if currentAgileTreeCount == MaxConcurrentAgileTrees {
+	if currentAgileTreeCount >= MaxConcurrentAgileTrees {
 		return nil
 	}
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -274,7 +274,6 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 	segstore.numBlocks = 0
 	segstore.timeCreated = time.Now()
 	if segstore.stbHolder != nil {
-		log.Infof("resetSegStore: Release STB due to reset")
 		segstore.stbHolder.ReleaseSTB()
 		segstore.stbHolder = nil
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -258,7 +258,7 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 	segstore.numBlocks = 0
 	segstore.timeCreated = time.Now()
 	if segstore.stbHolder != nil {
-		log.Infof("resetSegStore: Release STB due to reset: %v\n", segstore.stbHolder.myIdx)
+		log.Infof("resetSegStore: Release STB due to reset")
 		segstore.stbHolder.ReleaseSTB()
 		segstore.stbHolder = nil
 	}
@@ -689,9 +689,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 		if config.IsAggregationsEnabled() && segstore.stbHolder != nil {
 			nc := segstore.stbHolder.stbPtr.GetNodeCount()
 			cnc := segstore.stbHolder.stbPtr.GetEachColNodeCount()
-			log.Infof("checkAndRotateColFiles: stree node count: %v , Each Col NodeCount: %v Release STB due to rotation: %v\n",
-				nc, cnc, segstore.stbHolder.myIdx)
-
+			log.Infof("checkAndRotateColFiles:  Release STB, stree node count: %v , Each Col NodeCount: %v", nc, cnc)
 			segstore.stbHolder.ReleaseSTB()
 			segstore.stbHolder = nil
 		}
@@ -907,8 +905,8 @@ func (segstore *SegStore) computeStarTree() {
 		if found {
 			// todo when we implement dropping of columns from atree,
 			// drop the column here and remove the dropping of segtree
-			log.Errorf("computeStarTree: Release STB %v found cname: %v with high card: %v, blockNum: %v",
-				segstore.stbHolder.myIdx, cname, cardinality, segstore.numBlocks)
+			log.Errorf("computeStarTree: Release STB, found cname: %v with high card: %v, blockNum: %v",
+				cname, cardinality, segstore.numBlocks)
 
 			segstore.stbHolder.stbPtr.DropSegTree(segstore.stbDictEncWorkBuf)
 			segstore.stbHolder.ReleaseSTB()
@@ -920,7 +918,7 @@ func (segstore *SegStore) computeStarTree() {
 	err := segstore.stbHolder.stbPtr.ComputeStarTree(&segstore.wipBlock)
 
 	if err != nil {
-		log.Errorf("computeStarTree: Release STB %v, Failed to compute star tree: %v", segstore.stbHolder.myIdx, err)
+		log.Errorf("computeStarTree: Release STB, Failed to compute star tree: %v", err)
 		segstore.stbHolder.ReleaseSTB()
 		segstore.stbHolder = nil
 		return

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -876,7 +876,7 @@ func (segstore *SegStore) computeStarTree() {
 			return
 		}
 
-		segstore.stbHolder = segstore.GetSTB()
+		segstore.stbHolder = GetSTB()
 		if segstore.stbHolder == nil {
 			log.Infof("computeStarTree: Failed to get STB")
 			return


### PR DESCRIPTION
# Description
Summarize the change.
Created an STBHolderPool to get and release StarTreeBuilder for memory management.
In future PR, we will release memory based on specific timeouts.
Also, `usingSegTree` variable is not needed as this could be checked directly via stbHolder.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Manually ran multiple segment ingest and monitored logs to check the allocation of stbHolders to segStore.
Also, tested the same using the [Benchmark_agileTreeIngest](https://github.com/siglens/siglens/blob/ed6891239e65e973446a5f0783b75e32d911242b/benchmark_test.go#L379).

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
