### PR TITLE
Use number union for node.AggValues

### DIFF
--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -433,7 +433,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 			agIdx := idx                           // set to the start of aggValue for this node's data
 			agIdx += uint32(measResIndices[j]) * 9 // jump to the AgValue for this meas's index
 
-			wvInt64, wvFloat64, dtype = utils.ConvertBytes(buf[agIdx : agIdx+9])
+			wvInt64, wvFloat64, dtype = utils.ConvertBytesToNumber(buf[agIdx : agIdx+9])
 
 			// remainder will give us MeasFnIdx
 			fn := writer.IdxToAgFn[measResIndices[j]%writer.TotalMeasFns]

--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -347,6 +347,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 
 	var wvInt64 int64
 	var wvFloat64 float64
+	var dtype utils.SS_DTYPE
 	idx := uint32(0)
 
 	// level
@@ -432,18 +433,7 @@ func (str *AgileTreeReader) decodeNodeDetailsJit(buf []byte, numAggValues int,
 			agIdx := idx                           // set to the start of aggValue for this node's data
 			agIdx += uint32(measResIndices[j]) * 9 // jump to the AgValue for this meas's index
 
-			dtype := utils.SS_DTYPE(buf[agIdx])
-			agIdx += 1
-
-			switch dtype {
-			case utils.SS_DT_UNSIGNED_NUM, utils.SS_DT_SIGNED_NUM:
-				wvInt64 = toputils.BytesToInt64LittleEndian(buf[agIdx : agIdx+8])
-			case utils.SS_DT_FLOAT:
-				wvFloat64 = toputils.BytesToFloat64LittleEndian(buf[agIdx : agIdx+8])
-			case utils.SS_DT_BACKFILL:
-			default:
-				return fmt.Errorf("AgileTreeReader.decodeNodeDetailsJit: unsupported Dtype: %v", dtype)
-			}
+			wvInt64, wvFloat64, dtype = utils.ConvertBytes(buf[agIdx : agIdx+9])
 
 			// remainder will give us MeasFnIdx
 			fn := writer.IdxToAgFn[measResIndices[j]%writer.TotalMeasFns]

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/siglens/siglens/pkg/utils"
+)
+
+type numberType = byte
+
+const (
+	invalidType numberType = iota
+	int64Type
+	float64Type
+	backfillType
+)
+
+type Number struct {
+	bytes [9]byte // 8 bytes for the number; last byte for the type
+}
+
+func (n *Number) SetInt64(i int64) {
+	utils.Int64ToBytesLittleEndianInplace(i, n.bytes[:8])
+	n.bytes[8] = int64Type
+}
+
+func (n *Number) SetFloat64(f float64) {
+	utils.Float64ToBytesLittleEndianInplace(f, n.bytes[:8])
+	n.bytes[8] = float64Type
+}
+
+func (n *Number) Int64() (int64, error) {
+
+	if n.bytes[8] == backfillType {
+		return 0, nil
+	}
+
+	if n.bytes[8] != int64Type {
+		return 0, fmt.Errorf("Not a int64, t: %v", n.bytes[8])
+	}
+
+	return utils.BytesToInt64LittleEndian(n.bytes[:8]), nil
+}
+
+func (n *Number) Float64() (float64, error) {
+
+	if n.bytes[8] == backfillType {
+		return 0, nil
+	}
+
+	if n.bytes[8] != float64Type {
+		return 0, fmt.Errorf("Not a float64, t: %v", n.bytes[8])
+	}
+
+	return utils.BytesToFloat64LittleEndian(n.bytes[:8]), nil
+}
+
+func (n *Number) ConvertToFloat64() error {
+
+	if n.bytes[8] == backfillType {
+		return nil
+	}
+
+	if n.bytes[8] == int64Type {
+		ni, err := n.Int64()
+		if err != nil {
+			return err
+		}
+		n.SetFloat64(float64(ni))
+		return nil
+	}
+
+	if n.bytes[8] != float64Type {
+		return fmt.Errorf("Not a float64, t: %v", n.bytes[8])
+	}
+	return nil
+}
+
+func (n *Number) ConvertToInt64() error {
+
+	if n.bytes[8] == backfillType {
+		return nil
+	}
+
+	if n.bytes[8] == float64Type {
+		nf, err := n.Float64()
+		if err != nil {
+			return err
+		}
+		n.SetInt64(int64(nf))
+		return nil
+	}
+
+	if n.bytes[8] != int64Type {
+		return fmt.Errorf("Not a int64, t: %v", n.bytes[8])
+	}
+	return nil
+}
+
+func (n *Number) Reset() {
+	n.bytes[8] = invalidType
+}
+
+func (n *Number) Type() numberType {
+	return n.bytes[8]
+}
+
+func (n *Number) CopyToBuffer(buf []byte) {
+	copy(buf, n.bytes[:])
+}
+
+func (n *Number) ReduceFast(other *Number, fun AggregateFunctions) error {
+
+	if n.Type() == invalidType {
+		copy(n.bytes[:], other.bytes[:])
+		return nil
+	} else if other.Type() == invalidType {
+		return nil
+	} else if other.Type() == backfillType {
+		return nil
+	} else if n.Type() == backfillType {
+		copy(n.bytes[:], other.bytes[:])
+		return nil
+	}
+
+	// If I am float and other is int then Convert other to float
+	if n.Type() == float64Type || other.Type() == int64Type {
+		err := other.ConvertToFloat64()
+		if err != nil {
+			return err
+		}
+	}
+
+	// If I am int and other is float then Convert me to float
+	if n.Type() == int64Type || other.Type() == float64Type {
+		err := n.ConvertToFloat64()
+		if err != nil {
+			return err
+		}
+	}
+
+	switch n.Type() {
+	case int64Type:
+		ni, err := n.Int64()
+		if err != nil {
+			return err
+		}
+		oi, err := other.Int64()
+		if err != nil {
+			return err
+		}
+		switch fun {
+		case Sum:
+			n.SetInt64(ni + oi)
+		case Min:
+			n.SetInt64(MinInt64(ni, oi))
+		case Max:
+			n.SetInt64(MaxInt64(ni, oi))
+		case Count:
+			n.SetInt64(ni + oi)
+		default:
+			return fmt.Errorf("ReduceFast: unsupported reduce function: %v", fun)
+		}
+	case float64Type:
+		nf, err := n.Float64()
+		if err != nil {
+			return err
+		}
+		of, err := other.Float64()
+		if err != nil {
+			return err
+		}
+		switch fun {
+		case Sum:
+			n.SetFloat64(nf + of)
+		case Min:
+			n.SetFloat64(math.Min(nf, of))
+		case Max:
+			n.SetFloat64(math.Max(nf, of))
+		case Count:
+			n.SetFloat64(nf + of)
+		default:
+			return fmt.Errorf("ReduceFast: unsupported reduce function: %v", fun)
+		}
+	default:
+		return fmt.Errorf("ReduceFast: unexpected Type: %v", n.Type())
+	}
+
+	return nil
+}

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -37,6 +37,14 @@ type Number struct {
 	bytes [9]byte // 8 bytes for the number; last byte for the type
 }
 
+func (n *Number) SetInvalidType() {
+	n.bytes[8] = invalidType
+}
+
+func (n *Number) SetBackfillType() {
+	n.bytes[8] = backfillType
+}
+
 func (n *Number) SetInt64(i int64) {
 	utils.Int64ToBytesLittleEndianInplace(i, n.bytes[:8])
 	n.bytes[8] = int64Type

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -633,39 +633,40 @@ func (nte *NumTypeEnclosure) Reset() {
 	nte.FloatVal = 0
 }
 
-func (cval *CValueEnclosure) ToNumber() (*Number, error) {
-	if cval == nil {
-		return nil, fmt.Errorf("ToNumber: cval is nil")
-	}
+func (cval *CValueEnclosure) ToNumber(number *Number) error {
 
-	number := &Number{}
+	number.SetInvalidType()
+	if cval == nil {
+		return fmt.Errorf("ToNumber: cval is nil")
+	}
 
 	switch cval.Dtype {
 	case SS_DT_FLOAT:
 		val, ok := cval.CVal.(float64)
 		if !ok {
-			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+			return fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
 		}
 		number.SetFloat64(val)
 	case SS_DT_SIGNED_NUM:
 		val, ok := cval.CVal.(int64)
 		if !ok {
-			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+			return fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
 		}
 		number.SetInt64(int64(val))
 	case SS_DT_UNSIGNED_NUM:
 		val, ok := cval.CVal.(int64)
 		if !ok {
-			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+			return fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
 		}
 		number.SetInt64(val)
 	case SS_DT_BACKFILL:
-		return number, nil
+		number.SetBackfillType()
+		return nil
 	default:
-		return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+		return fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
 	}
 
-	return number, nil
+	return nil
 }
 
 func (cval *CValueEnclosure) ToNumType(res *NumTypeEnclosure) error {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -633,6 +633,41 @@ func (nte *NumTypeEnclosure) Reset() {
 	nte.FloatVal = 0
 }
 
+func (cval *CValueEnclosure) ToNumber() (*Number, error) {
+	if cval == nil {
+		return nil, fmt.Errorf("ToNumber: cval is nil")
+	}
+
+	number := &Number{}
+
+	switch cval.Dtype {
+	case SS_DT_FLOAT:
+		val, ok := cval.CVal.(float64)
+		if !ok {
+			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+		}
+		number.SetFloat64(val)
+	case SS_DT_SIGNED_NUM:
+		val, ok := cval.CVal.(int64)
+		if !ok {
+			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+		}
+		number.SetInt64(int64(val))
+	case SS_DT_UNSIGNED_NUM:
+		val, ok := cval.CVal.(int64)
+		if !ok {
+			return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+		}
+		number.SetInt64(val)
+	case SS_DT_BACKFILL:
+		return number, nil
+	default:
+		return nil, fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
+	}
+
+	return number, nil
+}
+
 func (cval *CValueEnclosure) ToNumType(res *NumTypeEnclosure) error {
 	if cval == nil {
 		return fmt.Errorf("ToNumType: cval is nil")

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -60,13 +60,11 @@ func AgFnToIdx(fn utils.AggregateFunctions) int {
 	return MeasFnCountIdx
 }
 
-var one = utils.NumTypeEnclosure{Ntype: utils.SS_DT_UNSIGNED_NUM, IntgrVal: int64(1)}
-
 type Node struct {
 	myKey     uint32
 	parent    *Node
 	children  map[uint32]*Node
-	aggValues []*utils.NumTypeEnclosure
+	aggValues []*utils.Number
 }
 
 type StarTreeBuilder struct {
@@ -233,7 +231,7 @@ func (stb *StarTreeBuilder) Aggregate(cur *Node) error {
 		cur.aggValues = toputils.ResizeSlice(cur.aggValues, lenAggValues)
 		if len(cur.aggValues) > aggValuesLen {
 			for i := aggValuesLen; i < len(cur.aggValues); i++ {
-				cur.aggValues[i] = &utils.NumTypeEnclosure{}
+				cur.aggValues[i] = &utils.Number{}
 			}
 		}
 	}
@@ -254,37 +252,25 @@ func (stb *StarTreeBuilder) Aggregate(cur *Node) error {
 		for mcNum := range stb.mColNames {
 			midx := mcNum * TotalMeasFns
 			agidx := midx + MeasFnMinIdx
-			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx].Ntype,
-				child.aggValues[agidx].IntgrVal,
-				child.aggValues[agidx].FloatVal,
-				utils.Min)
+			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx], utils.Min)
 			if err != nil {
 				log.Errorf("Aggregate: error in aggregating min err:%v", err)
 				return err
 			}
 			agidx = midx + MeasFnMaxIdx
-			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx].Ntype,
-				child.aggValues[agidx].IntgrVal,
-				child.aggValues[agidx].FloatVal,
-				utils.Max)
+			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx], utils.Max)
 			if err != nil {
 				log.Errorf("Aggregate: error in aggregating max err:%v", err)
 				return err
 			}
 			agidx = midx + MeasFnSumIdx
-			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx].Ntype,
-				child.aggValues[agidx].IntgrVal,
-				child.aggValues[agidx].FloatVal,
-				utils.Sum)
+			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx], utils.Sum)
 			if err != nil {
 				log.Errorf("Aggregate: error in aggregating sum err:%v", err)
 				return err
 			}
 			agidx = midx + MeasFnCountIdx
-			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx].Ntype,
-				child.aggValues[agidx].IntgrVal,
-				child.aggValues[agidx].FloatVal,
-				utils.Count)
+			err = cur.aggValues[agidx].ReduceFast(child.aggValues[agidx], utils.Count)
 			if err != nil {
 				log.Errorf("Aggregate: error in aggregating count err:%v", err)
 				return err
@@ -363,9 +349,7 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 	lenAggValues := len(stb.mColNames) * TotalMeasFns
 	measCidx := make([]uint32, len(stb.mColNames))
 
-	nte := &utils.NumTypeEnclosure{
-		Ntype: utils.SS_INVALID,
-	}
+	num := &utils.Number{}
 
 	for recNum := uint16(0); recNum < numRecs; recNum += 1 {
 		for colNum := range stb.groupByKeys {
@@ -381,14 +365,14 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 					mcName, err)
 				continue
 			}
-			err = cVal.ToNumType(nte)
+			num, err = cVal.ToNumber()
 			if err != nil {
 				log.Errorf("buildTreeStructure: Could not convert cval: %v for cname: %v, err: %v",
 					cVal, mcName, err)
 				continue
 			}
 
-			err = stb.addMeasures(nte, lenAggValues, midx, node)
+			err = stb.addMeasures(num, lenAggValues, midx, node)
 			if err != nil {
 				log.Errorf("buildTreeStructure: Could not add measure for cname: %v", mcName)
 				return err
@@ -398,14 +382,14 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 	return nil
 }
 
-func (stb *StarTreeBuilder) addMeasures(val *utils.NumTypeEnclosure,
+func (stb *StarTreeBuilder) addMeasures(val *utils.Number,
 	lenAggValues int, midx int, node *Node) error {
 
 	sizeNeeded := lenAggValues - len(node.aggValues)
 	if sizeNeeded > 0 {
-		newArr := make([]*utils.NumTypeEnclosure, sizeNeeded)
+		newArr := make([]*utils.Number, sizeNeeded)
 		for i := 0; i < sizeNeeded; i++ {
-			newArr[i] = &utils.NumTypeEnclosure{}
+			newArr[i] = &utils.Number{}
 		}
 		node.aggValues = append(node.aggValues, newArr...)
 	}
@@ -413,39 +397,30 @@ func (stb *StarTreeBuilder) addMeasures(val *utils.NumTypeEnclosure,
 	var err error
 	// always calculate all meas Fns
 	agvidx := midx + MeasFnMinIdx
-	err = node.aggValues[agvidx].ReduceFast(val.Ntype,
-		val.IntgrVal,
-		val.FloatVal,
-		utils.Min)
+	err = node.aggValues[agvidx].ReduceFast(val, utils.Min)
 	if err != nil {
 		log.Errorf("addMeasures: error in min err:%v", err)
 		return err
 	}
 	agvidx = midx + MeasFnMaxIdx
-	err = node.aggValues[agvidx].ReduceFast(val.Ntype,
-		val.IntgrVal,
-		val.FloatVal,
-		utils.Max)
+	err = node.aggValues[agvidx].ReduceFast(val, utils.Max)
 	if err != nil {
 		log.Errorf("addMeasures: error in max err:%v", err)
 		return err
 	}
 	agvidx = midx + MeasFnSumIdx
-	err = node.aggValues[agvidx].ReduceFast(val.Ntype,
-		val.IntgrVal,
-		val.FloatVal,
-		utils.Sum)
+	err = node.aggValues[agvidx].ReduceFast(val, utils.Sum)
 	if err != nil {
 		log.Errorf("addMeasures: error in sum err:%v", err)
 		return err
 	}
 
+	one := &utils.Number{}
+	one.SetInt64(1)
+
 	agvidx = midx + MeasFnCountIdx
 	// for count we always use 1 instead of val
-	err = node.aggValues[agvidx].ReduceFast(one.Ntype,
-		one.IntgrVal,
-		one.FloatVal,
-		utils.Count)
+	err = node.aggValues[agvidx].ReduceFast(one, utils.Count)
 	if err != nil {
 		log.Errorf("addMeasures: error in count err:%v", err)
 		return err

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -365,7 +365,7 @@ func (stb *StarTreeBuilder) buildTreeStructure(wip *WipBlock) error {
 					mcName, err)
 				continue
 			}
-			num, err = cVal.ToNumber()
+			err = cVal.ToNumber(num)
 			if err != nil {
 				log.Errorf("buildTreeStructure: Could not convert cval: %v for cname: %v, err: %v",
 					cVal, mcName, err)

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -254,21 +254,9 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 			log.Errorf("encodeNodeDetails: ancestor is not the root, level: %v, nodeKey: %+v", level, n.myKey)
 		}
 
-		for agIdx, e := range n.aggValues {
-			copy(stb.buf[idx:], []byte{uint8(e.Ntype)})
-			idx += 1
-
-			switch e.Ntype {
-			case SS_DT_UNSIGNED_NUM, SS_DT_SIGNED_NUM:
-				utils.Int64ToBytesLittleEndianInplace(e.IntgrVal, stb.buf[idx:])
-			case SS_DT_FLOAT:
-				utils.Float64ToBytesLittleEndianInplace(e.FloatVal, stb.buf[idx:])
-			case SS_DT_BACKFILL: // even for backfill we will have empty bytes in to keep things uniform
-			default:
-				return 0, fmt.Errorf("encodeNodeDetails: unsupported Dtype: %v, agIdx: %v, nodeKey: %+v, e: %+v",
-					e.Ntype, agIdx, n.myKey, e)
-			}
-			idx += 8
+		for _, e := range n.aggValues {
+			e.CopyToBuffer(stb.buf[idx:])
+			idx += 9
 		}
 	}
 	_, err := strLevFd.WriteAt(stb.buf[:idx], strLevFileOff)

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -293,10 +293,12 @@ func TestStarTree(t *testing.T) {
 
 		// first TotalMeasFns will be for col "e"
 		agSumIdx := 1*(TotalMeasFns) + MeasFnSumIdx
-		assert.Equal(t, root.aggValues[agSumIdx].IntgrVal,
+		iv, err := root.aggValues[agSumIdx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, iv,
 			int64(34),
 			fmt.Sprintf("expected sum of 34 for sum of column f; got %d",
-				root.aggValues[agSumIdx].IntgrVal))
+				iv))
 
 	}
 	fName := fmt.Sprintf("%v.strl", ss.SegmentKey)
@@ -390,10 +392,12 @@ func TestStarTreeMedium(t *testing.T) {
 
 		// first TotalMeasFns will be for col "e"
 		agSumIdx := 1*(TotalMeasFns) + MeasFnSumIdx
-		assert.Equal(t, root.aggValues[agSumIdx].IntgrVal,
+		iv, err := root.aggValues[agSumIdx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, iv,
 			int64(34*1000),
 			fmt.Sprintf("expected sum of 340000 for sum of column f; got %d",
-				root.aggValues[agSumIdx].IntgrVal))
+				iv))
 	}
 	fName := fmt.Sprintf("%v.strl", ss.SegmentKey)
 	_ = os.RemoveAll(fName)
@@ -487,10 +491,13 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 
 		// first TotalMeasFns will be for col "e"
 		agSumIdx := 1*(TotalMeasFns) + MeasFnSumIdx
-		assert.Equal(t, root.aggValues[agSumIdx].IntgrVal,
+		iv, err := root.aggValues[agSumIdx].Int64()
+		assert.NoError(t, err)
+
+		assert.Equal(t, iv,
 			int64(1700),
 			fmt.Sprintf("expected sum of 3400 for sum of column f; got %d",
-				root.aggValues[agSumIdx].IntgrVal))
+				iv))
 
 	}
 	fName := fmt.Sprintf("%v.strl", ss.SegmentKey)
@@ -584,24 +591,32 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 
 		// first TotalMeasFns will be for col "e"
 		agidx := 1*(TotalMeasFns) + MeasFnSumIdx
-		assert.Equal(t, int64(17*100), root.aggValues[agidx].IntgrVal,
+		iv, err := root.aggValues[agidx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(17*100), iv,
 			fmt.Sprintf("expected 17000 for sum of column f; got %d",
-				root.aggValues[agidx].IntgrVal))
+				iv))
 
 		agidx = 1*(TotalMeasFns) + MeasFnMinIdx
-		assert.Equal(t, int64(2), root.aggValues[agidx].IntgrVal,
+		iv, err = root.aggValues[agidx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(2), iv,
 			fmt.Sprintf("expected 2 for min of column f; got %d",
-				root.aggValues[agidx].IntgrVal))
+				iv))
 
 		agidx = 1*(TotalMeasFns) + MeasFnMaxIdx
-		assert.Equal(t, int64(4), root.aggValues[agidx].IntgrVal,
+		iv, err = root.aggValues[agidx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(4), iv,
 			fmt.Sprintf("expected 4 for max of column f; got %d",
-				root.aggValues[agidx].IntgrVal))
+				iv))
 
 		agidx = 1*(TotalMeasFns) + MeasFnCountIdx
-		assert.Equal(t, int64(800), root.aggValues[agidx].IntgrVal,
+		iv, err = root.aggValues[agidx].Int64()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(800), iv,
 			fmt.Sprintf("expected 800 for count of column f; got %d",
-				root.aggValues[agidx].IntgrVal))
+				iv))
 
 	}
 	fName := fmt.Sprintf("%v.strl", ss.SegmentKey)


### PR DESCRIPTION
# Description
Switch from using `CvalEnclosure (interface)` to a number union type.
This saves about `1.5 GB` per agile tree

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
