### PR TITLE
Compiled Regex is not persisted for PQS due to unexported field

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -522,9 +522,9 @@ type DtypeEnclosure struct {
 	SignedVal      int64
 	FloatVal       float64
 	StringVal      string
-	StringValBytes []byte         // byte slice representation of StringVal
-	StringSliceVal []string       // used for array dict
-	RexpCompiled   *regexp.Regexp //  should be unexported in future to allow for gob encoding
+	StringValBytes []byte   // byte slice representation of StringVal
+	StringSliceVal []string // used for array dict
+	RexpCompiled   *regexp.Regexp
 }
 
 func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -524,7 +524,7 @@ type DtypeEnclosure struct {
 	StringVal      string
 	StringValBytes []byte         // byte slice representation of StringVal
 	StringSliceVal []string       // used for array dict
-	rexpCompiled   *regexp.Regexp //  should be unexported to allow for gob encoding
+	RexpCompiled   *regexp.Regexp //  should be unexported in future to allow for gob encoding
 }
 
 func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {
@@ -539,7 +539,7 @@ func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {
 		}
 	}
 
-	hasRegexp := dte.rexpCompiled != nil
+	hasRegexp := dte.RexpCompiled != nil
 	err := encoder.Encode(hasRegexp)
 	if err != nil {
 		log.Errorf("DtypeEnclosure.GobEncode: error encoding hasRegexp: %v", err)
@@ -547,9 +547,9 @@ func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {
 	}
 
 	if hasRegexp {
-		err := encoder.Encode(dte.rexpCompiled.String())
+		err := encoder.Encode(dte.RexpCompiled.String())
 		if err != nil {
-			log.Errorf("DtypeEnclosure.GobEncode: error encoding rexpCompiled: %v", err)
+			log.Errorf("DtypeEnclosure.GobEncode: error encoding RexpCompiled: %v", err)
 			return nil, err
 		}
 	}
@@ -584,7 +584,7 @@ func (dte *DtypeEnclosure) GobDecode(data []byte) error {
 			return err
 		}
 
-		dte.rexpCompiled, err = regexp.Compile(rexp)
+		dte.RexpCompiled, err = regexp.Compile(rexp)
 		if err != nil {
 			log.Errorf("DtypeEnclosure.GobDecode: error compiling rexp %v: %v", rexp, err)
 			return err
@@ -595,11 +595,11 @@ func (dte *DtypeEnclosure) GobDecode(data []byte) error {
 }
 
 func (dte *DtypeEnclosure) SetRegexp(exp *regexp.Regexp) {
-	dte.rexpCompiled = exp
+	dte.RexpCompiled = exp
 }
 
 func (dte *DtypeEnclosure) GetRegexp() *regexp.Regexp {
-	return dte.rexpCompiled
+	return dte.RexpCompiled
 }
 
 // used for numeric calcs and promotions
@@ -704,7 +704,7 @@ func (dte *DtypeEnclosure) Reset() {
 	dte.SignedVal = 0
 	dte.FloatVal = 0
 	dte.StringVal = ""
-	dte.rexpCompiled = nil
+	dte.RexpCompiled = nil
 }
 
 func (dte *DtypeEnclosure) IsFullWildcard() bool {
@@ -713,7 +713,7 @@ func (dte *DtypeEnclosure) IsFullWildcard() bool {
 		if dte.StringVal == "*" {
 			return true
 		}
-		return dte.rexpCompiled != nil && dte.rexpCompiled.String() == ".*"
+		return dte.RexpCompiled != nil && dte.RexpCompiled.String() == ".*"
 	default:
 		return false
 	}


### PR DESCRIPTION
# Description
Summarize the change.
Currently, we are just marshaling the PQS data and writing it to the file. We are not encoding it before writing.
Unexported fields are not marshaled and so compiled regex was not written to disk. Upon reading the PQS info, we were getting `nil` compiled regex due to which all regex based PQS queries were failing during ingest with error. 

`
time="2024-08-24 21:40:30" level=error msg="SegmentKey: data/sigsingle.NAxq42aiGpFefVVpoAEuYJ/active/bidx-7/0-0-10969000109510147866/999/999, applySearchSingleQuery: failed to apply wildcard expression search on RegexExpression, Count: 22942336, ExtraInfo: qValDte had nil regexp compilation"
`

For now, have made the field exported. In future, when we plan to encode and write to disk we can revert this change.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Insert data
- Run these queries 
```
* | hobby=Act*
"* | search app_name=""W*""  | fields app_name, batch | head 2"
"search app_name=Hyena* | fields gender, http_method, http_status | transaction gender http_method startswith=http_status=301  endswith=(http_status=404 OR http_status=500) | head 2"
"search app_name=Hyena* | fields app_name, app_version, gender, http_method, http_status | transaction gender http_method startswith=http_status=301  endswith=(http_status=404 OR http_status=500)"
```
- Let the data be rotated. Check the pqsinfo.bin
- Ingest some more data. Verify that errors are not present.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
