### PR TITLE
memory optimizations: create getnumfromrec and move the compWokrBuf from wip to segstore

### DIFF
--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -916,6 +916,7 @@ func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[st
 	cnameCacheByteHashToStr := make(map[uint64]string)
 	var jsParsingStackbuf [64]byte
 
+	compWorkBuf := make([]byte, WIP_SIZE)
 	tsKey := config.GetTimeStampKey()
 	allCols := make(map[string]uint32)
 	// set up entries
@@ -983,7 +984,7 @@ func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[st
 			} else {
 				encType = ZSTD_COMLUNAR_BLOCK
 			}
-			blkLen, blkOffset, err := writeWip(colWip, encType)
+			blkLen, blkOffset, err := writeWip(colWip, encType, compWorkBuf)
 			if err != nil {
 				log.Errorf("WriteMockColSegFile: failed to write colsegfilename=%v, err=%v", csgFname, err)
 			}
@@ -1021,6 +1022,8 @@ func WriteMockTraceFile(segkey string, numBlocks int, entryCount int) ([]map[str
 
 	cnameCacheByteHashToStr := make(map[uint64]string)
 	var jsParsingStackbuf [64]byte
+
+	compWorkBuf := make([]byte, WIP_SIZE)
 
 	tsKey := config.GetTimeStampKey()
 	allCols := make(map[string]uint32)
@@ -1111,7 +1114,7 @@ func WriteMockTraceFile(segkey string, numBlocks int, entryCount int) ([]map[str
 			} else {
 				encType = ZSTD_COMLUNAR_BLOCK
 			}
-			blkLen, blkOffset, err := writeWip(colWip, encType)
+			blkLen, blkOffset, err := writeWip(colWip, encType, compWorkBuf)
 			if err != nil {
 				log.Errorf("WriteMockTraceFile: failed to write tracer filename=%v, err=%v", csgFname, err)
 			}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -94,7 +94,7 @@ type SegStore struct {
 	SegmentErrors         map[string]*structs.SearchErrorInfo
 	bsPool                []*bitset.BitSet
 	bsPoolCurrIdx         uint32
-	workBufForCompression [][]byte
+	workBufForCompression [][]byte // A work buf for each column
 }
 
 // helper struct to keep track of persistent queries and columns that need to be searched


### PR DESCRIPTION
# Description
1. Create a new method that converts from rec bytes directly to `Number` type instead of the intermediary Cval
2. Move the `workBufForComp` from ColWip to segstore so that it does not get cleared out on every segment rotation.

memory Savings:
1. Saves about `80 MB` per segment
2. Saves about `60 MB` per segment


# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
