### PR TITLE
mem fixes: dedata, sync pools for cbuf, items, tree traversal, atree file size chunk writing

### DIFF
--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -139,6 +139,8 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 	items := *respItemsPool.Get().(*[]interface{})
 	// if we end up extending items, then save the orig pointer, so that we can put it back
 	origItems := items
+	defer respItemsPool.Put(&origItems)
+
 	// kunal todo check , if items gets extended and we put back origitems then does the os
 	// delete the old items array ?
 	itemsLen := len(items)
@@ -248,7 +250,6 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 	response["errors"] = overallError
 	response["items"] = items[0:inCount]
 
-	respItemsPool.Put(&origItems)
 	if atleastOneSuccess {
 		return processedCount, response, nil
 	} else {

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -181,7 +181,8 @@ func Benchmark_readColumnarFile(b *testing.B) {
 
 func Test_packUnpackDictEnc(t *testing.T) {
 
-	colWip := &writer.ColWip{}
+	cname := "muycname"
+	colWip := writer.InitColWip("mysegkey", cname)
 
 	deCount := uint16(100)
 
@@ -193,7 +194,6 @@ func Test_packUnpackDictEnc(t *testing.T) {
 	allBlockSummaries := make([]*structs.BlockSummary, 1)
 	allBlockSummaries[0] = &structs.BlockSummary{RecCount: recCounts}
 
-	cname := "muycname"
 	sfr := &SegmentFileReader{
 		blockSummaries: allBlockSummaries,
 		deTlv:          make([][]byte, 0),

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -65,7 +65,7 @@ const WIP_SIZE = 2_000_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size
-const BLOCK_BLOOM_SIZE = 20_000
+const BLOCK_BLOOM_SIZE = 100 // the default should be on the smaller side. Let dynamic bloom sizing fix the optimal one
 const BLOCK_RI_MAP_SIZE = 100
 
 var MAX_BYTES_METRICS_BLOCK uint64 = 1e+8         // 100MB

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -62,6 +62,12 @@ const MULTINODE_SSM_MEM_PERCENT = 20
 
 // if you change this size, adjust the block bloom size
 const WIP_SIZE = 2_000_000
+
+// Max recs that could fit in a wip is 20k,
+// if only 1 dict word then 20k *2 bytes for recnum + wordlen
+// if  2 dict word then (20k/2 *2 bytes for recnum)*2 words + wordlen
+// basically we need max of 20k * 2 bytes for recnum + some buffer
+const WIP_DE_PACKING_SIZE = 100_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -65,7 +65,7 @@ const WIP_SIZE = 2_000_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size
-const BLOCK_BLOOM_SIZE = 100 // the default should be on the smaller side. Let dynamic bloom sizing fix the optimal one
+const BLOCK_BLOOM_SIZE = 20_000
 const BLOCK_RI_MAP_SIZE = 100
 
 var MAX_BYTES_METRICS_BLOCK uint64 = 1e+8         // 100MB

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -67,7 +67,7 @@ const WIP_SIZE = 2_000_000
 // if only 1 dict word then 20k *2 bytes for recnum + wordlen
 // if  2 dict word then (20k/2 *2 bytes for recnum)*2 words + wordlen
 // basically we need max of 20k * 2 bytes for recnum + some buffer
-const WIP_DE_PACKING_SIZE = 100_000
+const WIP_DE_PACKING_SIZE = 200_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -230,6 +230,13 @@ func MaxInt64(a1 int64, b1 int64) int64 {
 	return a1
 }
 
+func MaxUint32(a1 uint32, b1 uint32) uint32 {
+	if a1 < b1 {
+		return b1
+	}
+	return a1
+}
+
 func MaxUint16(a1 uint16, b1 uint16) uint16 {
 	if a1 < b1 {
 		return b1

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -58,9 +58,8 @@ type StarTreeBuilder struct {
 	wipRecNumToColEnc [][]uint32          //maintain working buffer per wipBlock
 	buf               []byte
 	// array to keep reusing for tree traversal. [level][*Node Array]
-	treeTravNodePts   [][]*Node
+	treeTravNodePtrs [][]*Node
 }
-
 
 // its ok for this to be int, since this will be used as an index in arrays
 const (
@@ -93,7 +92,7 @@ func GetSTB() *STBHolder {
 			STBHolderPool[i] = &STBHolder{
 				stbPtr: &StarTreeBuilder{
 					// 1 extra for the root level
-					treeTravNodePts: make([][]*Node, querytracker.MAX_NUM_GROUPBY_COLS+1)},
+					treeTravNodePtrs: make([][]*Node, querytracker.MAX_NUM_GROUPBY_COLS+1)},
 			}
 		}
 

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -367,10 +367,7 @@ func (stb *StarTreeBuilder) creatEnc(wip *WipBlock) error {
 		if deData.deCount < wipCardLimit {
 			for _, dci := range deData.hashToDci {
 
-				s := dci.sIdx
-				wl := uint32(dci.wlen)
-
-				dword := cwip.cbuf[s : s+wl]
+				dword := cwip.GetDictword(dci)
 
 				enc := stb.setColValEnc(colNum, dword)
 				recNumsBitset := deData.deRecNums[dci.recBsIdx]
@@ -555,10 +552,7 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 	if deData.deCount < wipCardLimit {
 		for _, dci := range deData.hashToDci {
 
-			s := dci.sIdx
-			wl := uint32(dci.wlen)
-
-			dword := cwip.cbuf[s : s+wl]
+			dword := cwip.GetDictword(dci)
 
 			recNumsBitSet := deData.deRecNums[dci.recBsIdx]
 			if recNumsBitSet.Test(uint(recNum)) {

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -225,9 +225,9 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 		numNodesNeeded += len(n.children)
 	}
 
-	stb.treeTravNodePts[level] = utils.ResizeSlice(stb.treeTravNodePts[level], numNodesNeeded)
+	stb.treeTravNodePtrs[level] = utils.ResizeSlice(stb.treeTravNodePtrs[level], numNodesNeeded)
 
-	nextLevelNodes := stb.treeTravNodePts[level][:numNodesNeeded]
+	nextLevelNodes := stb.treeTravNodePtrs[level][:numNodesNeeded]
 	nlIdx := 0
 
 	clBufIdx := uint32(0) // cur level buf idx for intermediary writes

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -225,7 +225,9 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 		numNodesNeeded += len(n.children)
 	}
 
-	nextLevelNodes := make([]*Node, numNodesNeeded)
+	stb.treeTravNodePts[level] = utils.ResizeSlice(stb.treeTravNodePts[level], numNodesNeeded)
+
+	nextLevelNodes := stb.treeTravNodePts[level][:numNodesNeeded]
 	nlIdx := 0
 
 	clBufIdx := uint32(0) // cur level buf idx for intermediary writes

--- a/pkg/segment/writer/agiletreewriter.go
+++ b/pkg/segment/writer/agiletreewriter.go
@@ -27,6 +27,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// write in 128k chunks so we avoid accumulating too much in stb.buf
+const ATREE_FD_CHUNK_SIZE = 128_000
+
 func (stb *StarTreeBuilder) encodeDictEnc(colName string, colNum uint16,
 	writer *bufio.Writer) (uint32, error) {
 
@@ -267,8 +270,7 @@ func (stb *StarTreeBuilder) encodeNodeDetails(strLevFd *os.File, curLevNodes []*
 			clBufIdx += 9
 		}
 
-		// write in 128k chunks so we avoid accumulating too much in stb.buf
-		if clBufIdx >= 128_000 {
+		if clBufIdx >= ATREE_FD_CHUNK_SIZE {
 			_, err := strLevFd.WriteAt(stb.buf[:clBufIdx], strLevFileOff)
 			if err != nil {
 				log.Errorf("encodeNodeDetails: nnd write failed, level: %v fname=%v, err=%v", level, strLevFd.Name(), err)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1487,10 +1487,7 @@ func PackDictEnc(colWip *ColWip) {
 
 	for _, dci := range colWip.deData.hashToDci {
 
-		s := dci.sIdx
-		wl := uint32(dci.wlen)
-
-		dword := colWip.cbuf[s : s+wl]
+		dword := colWip.GetDictword(dci)
 
 		recNumsBitset := colWip.deData.deRecNums[dci.recBsIdx]
 		// copy the actual dict word , the TLV is packed inside the dword

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -73,18 +73,17 @@ const FPARM_FLOAT64 = float64(0)
 func (ss *SegStore) EncodeColumns(rawData []byte, recordTime uint64, tsKey *string,
 	signalType segutils.SIGNAL_TYPE,
 	cnameCacheByteHashToStr map[uint64]string,
-	jsParsingStackbuf []byte) (uint32, bool, error) {
+	jsParsingStackbuf []byte) (bool, error) {
 
-	var maxIdx uint32 = 0
 	var matchedCol = false
 
 	ss.encodeTime(recordTime, tsKey)
 	var err error
-	maxIdx, matchedCol, err = ss.encodeRawJsonObject("", rawData, maxIdx, tsKey, matchedCol,
+	matchedCol, err = ss.encodeRawJsonObject("", rawData, tsKey, matchedCol,
 		signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
 	if err != nil {
 		log.Errorf("Failed to encode json object! err: %+v", err)
-		return maxIdx, matchedCol, err
+		return matchedCol, err
 	}
 
 	for colName, foundCol := range ss.wipBlock.columnsInBlock {
@@ -106,12 +105,12 @@ func (ss *SegStore) EncodeColumns(rawData []byte, recordTime uint64, tsKey *stri
 			colWip.cbufidx-1)
 	}
 
-	return maxIdx, matchedCol, nil
+	return matchedCol, nil
 }
 
-func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, maxIdx uint32, tsKey *string,
+func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, tsKey *string,
 	matchedCol bool, signalType segutils.SIGNAL_TYPE,
-	cnameCacheByteHashToStr map[uint64]string, jsParsingStackbuf []byte) (uint32, bool, error) {
+	cnameCacheByteHashToStr map[uint64]string, jsParsingStackbuf []byte) (bool, error) {
 
 	handler := func(key []byte, value []byte, valueType jp.ValueType, off int) error {
 		// Maybe push some state onto a stack here?
@@ -132,7 +131,7 @@ func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, maxIdx uint
 		}
 		switch valueType {
 		case jp.Object:
-			maxIdx, matchedCol, err = ss.encodeRawJsonObject(finalKey, value, maxIdx, tsKey,
+			matchedCol, err = ss.encodeRawJsonObject(finalKey, value, tsKey,
 				matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
 			if err != nil {
 				return fmt.Errorf("encodeRawJsonObject: obj currKey: %v, err: %v", currKey, err)
@@ -140,9 +139,9 @@ func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, maxIdx uint
 		case jp.Array:
 			if signalType == SIGNAL_JAEGER_TRACES {
 
-				maxIdx, matchedCol, err = ss.encodeRawJsonArray(finalKey, value, maxIdx, tsKey, matchedCol, signalType)
+				matchedCol, err = ss.encodeRawJsonArray(finalKey, value, tsKey, matchedCol, signalType)
 			} else {
-				maxIdx, matchedCol, err = ss.encodeNonJaegerRawJsonArray(finalKey, value, maxIdx, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
+				matchedCol, err = ss.encodeNonJaegerRawJsonArray(finalKey, value, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
 			}
 			if err != nil {
 				return fmt.Errorf("encodeRawJsonObject: arr currKey: %v, err: %v", currKey, err)
@@ -155,11 +154,7 @@ func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, maxIdx uint
 					currKey, err)
 			}
 
-			maxIdx, matchedCol, err = ss.encodeSingleString(finalKey, maxIdx, tsKey, matchedCol,
-				valUnescaped)
-			if err != nil {
-				return fmt.Errorf("encodeRawJsonObject: singstr currKey: %v, err: %v", currKey, err)
-			}
+			matchedCol = ss.encodeSingleString(finalKey, tsKey, matchedCol, valUnescaped)
 		case jp.Number:
 			numVal, err := jp.ParseInt(value)
 			if err != nil {
@@ -167,59 +162,53 @@ func (ss *SegStore) encodeRawJsonObject(currKey string, data []byte, maxIdx uint
 				if err != nil {
 					return fmt.Errorf("encodeRawJsonObject: flt currKey: %v, err: %v", currKey, err)
 				}
-				maxIdx, matchedCol, _ = ss.encodeSingleNumber(finalKey, fltVal, maxIdx, tsKey,
+				matchedCol = ss.encodeSingleNumber(finalKey, fltVal, tsKey,
 					matchedCol, value)
 				return nil
 			}
-			maxIdx, matchedCol, _ = ss.encodeSingleNumber(finalKey, numVal, maxIdx, tsKey,
+			matchedCol = ss.encodeSingleNumber(finalKey, numVal, tsKey,
 				matchedCol, value)
 		case jp.Boolean:
 			boolVal, err := jp.ParseBoolean(value)
 			if err != nil {
 				return fmt.Errorf("encodeRawJsonObject: bool currKey: %v, err: %v", currKey, err)
 			}
-			maxIdx, matchedCol, err = ss.encodeSingleBool(finalKey, boolVal, maxIdx, tsKey, matchedCol)
-			if err != nil {
-				return fmt.Errorf("encodeRawJsonObject: singbool currKey: %v, err: %v", currKey, err)
-			}
+			matchedCol = ss.encodeSingleBool(finalKey, boolVal, tsKey, matchedCol)
 		case jp.Null:
-			maxIdx, matchedCol, err = ss.encodeSingleNull(finalKey, maxIdx, tsKey, matchedCol)
-			if err != nil {
-				return fmt.Errorf("encodeRawJsonObject: singnull currKey: %v, err: %v", currKey, err)
-			}
+			matchedCol = ss.encodeSingleNull(finalKey, tsKey, matchedCol)
 		default:
 			return fmt.Errorf("currKey: %v, received unknown type of %+s", currKey, valueType)
 		}
 		return nil
 	}
 	err := jp.ObjectEach(data, handler)
-	return maxIdx, matchedCol, err
+	return matchedCol, err
 }
 
-func (ss *SegStore) encodeRawJsonArray(currKey string, data []byte, maxIdx uint32, tsKey *string,
-	matchedCol bool, signalType segutils.SIGNAL_TYPE) (uint32, bool, error) {
+func (ss *SegStore) encodeRawJsonArray(currKey string, data []byte, tsKey *string,
+	matchedCol bool, signalType segutils.SIGNAL_TYPE) (bool, error) {
 	var encErr error
 	if signalType == SIGNAL_JAEGER_TRACES {
 		if currKey != "references" && currKey != "logs" {
-			maxIdx, matchedCol, encErr = ss.encodeSingleDictArray(currKey, data, maxIdx, tsKey, matchedCol, signalType)
+			matchedCol, encErr = ss.encodeSingleDictArray(currKey, data, tsKey, matchedCol, signalType)
 			if encErr != nil {
 				log.Infof("encodeRawJsonArray error %s", encErr)
-				return maxIdx, matchedCol, encErr
+				return matchedCol, encErr
 			}
 		} else {
-			maxIdx, matchedCol, encErr = ss.encodeSingleRawBuffer(currKey, data, maxIdx, tsKey, matchedCol, signalType)
+			matchedCol, encErr = ss.encodeSingleRawBuffer(currKey, data, tsKey, matchedCol, signalType)
 			if encErr != nil {
-				return maxIdx, matchedCol, encErr
+				return matchedCol, encErr
 			}
 		}
 	}
-	return maxIdx, matchedCol, nil
+	return matchedCol, nil
 }
 
-func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, maxIdx uint32, tsKey *string,
+func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, tsKey *string,
 	matchedCol bool, signalType segutils.SIGNAL_TYPE,
 	cnameCacheByteHashToStr map[uint64]string,
-	jsParsingStackbuf []byte) (uint32, bool, error) {
+	jsParsingStackbuf []byte) (bool, error) {
 
 	i := 0
 	var finalErr error
@@ -234,13 +223,13 @@ func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, max
 		i++
 		switch valueType {
 		case jp.Object:
-			maxIdx, matchedCol, encErr = ss.encodeRawJsonObject(finalKey, value, maxIdx, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
+			matchedCol, encErr = ss.encodeRawJsonObject(finalKey, value, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
 			if encErr != nil {
 				finalErr = encErr
 				return
 			}
 		case jp.Array:
-			maxIdx, matchedCol, encErr = ss.encodeNonJaegerRawJsonArray(finalKey, value, maxIdx, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
+			matchedCol, encErr = ss.encodeNonJaegerRawJsonArray(finalKey, value, tsKey, matchedCol, signalType, cnameCacheByteHashToStr, jsParsingStackbuf)
 			if encErr != nil {
 				finalErr = encErr
 				return
@@ -252,11 +241,7 @@ func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, max
 				finalErr = encErr
 				return
 			}
-			maxIdx, matchedCol, encErr = ss.encodeSingleString(finalKey, maxIdx, tsKey, matchedCol, valUnescaped)
-			if encErr != nil {
-				finalErr = encErr
-				return
-			}
+			matchedCol = ss.encodeSingleString(finalKey, tsKey, matchedCol, valUnescaped)
 		case jp.Number:
 			numVal, encErr := jp.ParseInt(value)
 			if encErr != nil {
@@ -265,11 +250,11 @@ func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, max
 					finalErr = encErr
 					return
 				}
-				maxIdx, matchedCol, _ = ss.encodeSingleNumber(finalKey, fltVal, maxIdx, tsKey,
+				matchedCol = ss.encodeSingleNumber(finalKey, fltVal, tsKey,
 					matchedCol, value)
 				return
 			}
-			maxIdx, matchedCol, _ = ss.encodeSingleNumber(finalKey, numVal, maxIdx, tsKey,
+			matchedCol = ss.encodeSingleNumber(finalKey, numVal, tsKey,
 				matchedCol, value)
 		case jp.Boolean:
 			boolVal, encErr := jp.ParseBoolean(value)
@@ -277,17 +262,9 @@ func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, max
 				finalErr = encErr
 				return
 			}
-			maxIdx, matchedCol, encErr = ss.encodeSingleBool(finalKey, boolVal, maxIdx, tsKey, matchedCol)
-			if encErr != nil {
-				finalErr = encErr
-				return
-			}
+			matchedCol = ss.encodeSingleBool(finalKey, boolVal, tsKey, matchedCol)
 		case jp.Null:
-			maxIdx, matchedCol, encErr = ss.encodeSingleNull(finalKey, maxIdx, tsKey, matchedCol)
-			if encErr != nil {
-				finalErr = encErr
-				return
-			}
+			matchedCol = ss.encodeSingleNull(finalKey, tsKey, matchedCol)
 		default:
 			finalErr = fmt.Errorf("received unknown type of %+s", valueType)
 			return
@@ -296,13 +273,13 @@ func (ss *SegStore) encodeNonJaegerRawJsonArray(currKey string, data []byte, max
 	if aErr != nil {
 		finalErr = aErr
 	}
-	return maxIdx, matchedCol, finalErr
+	return matchedCol, finalErr
 }
 
-func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte, maxIdx uint32,
-	tsKey *string, matchedCol bool, signalType segutils.SIGNAL_TYPE) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
+	tsKey *string, matchedCol bool, signalType segutils.SIGNAL_TYPE) (bool, error) {
 	if arraykey == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol, nil
 	}
 	var finalErr error
 	var colWip *ColWip
@@ -385,9 +362,6 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte, maxIdx u
 				bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(keyVal))
 			}
 			addSegStatsStrIngestion(ss.AllSst, keyName, []byte(keyVal))
-			if colWip.cbufidx > maxIdx {
-				maxIdx = colWip.cbufidx
-			}
 		default:
 			finalErr = fmt.Errorf("encodeSingleDictArray : received unknown type of %+s", valueType)
 			return
@@ -398,7 +372,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte, maxIdx u
 		finalErr = aErr
 	}
 	ss.updateColValueSizeInAllSeenColumns(arraykey, uint32(colWip.cbufidx-s))
-	return maxIdx, matchedCol, finalErr
+	return matchedCol, finalErr
 }
 
 func getNestedDictEntries(data []byte) (string, string, string, error) {
@@ -427,10 +401,10 @@ func getNestedDictEntries(data []byte) (string, string, string, error) {
 
 }
 
-func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte, maxIdx uint32,
-	tsKey *string, matchedCol bool, signalType segutils.SIGNAL_TYPE) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte,
+	tsKey *string, matchedCol bool, signalType segutils.SIGNAL_TYPE) (bool, error) {
 	if key == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol, nil
 	}
 	var colWip *ColWip
 	colWip, _, matchedCol = ss.initAndBackFillColumn(key, SS_DT_STRING, matchedCol)
@@ -457,16 +431,13 @@ func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte, maxIdx uint3
 	colWip.cbufidx += uint32(n)
 	ss.updateColValueSizeInAllSeenColumns(key, uint32(3+n))
 
-	if colWip.cbufidx > maxIdx {
-		maxIdx = colWip.cbufidx
-	}
-	return maxIdx, matchedCol, nil
+	return matchedCol, nil
 }
 
-func (ss *SegStore) encodeSingleString(key string, maxIdx uint32,
-	tsKey *string, matchedCol bool, valBytes []byte) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleString(key string,
+	tsKey *string, matchedCol bool, valBytes []byte) bool {
 	if key == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol
 	}
 	var colWip *ColWip
 	var recNum uint16
@@ -496,16 +467,13 @@ func (ss *SegStore) encodeSingleString(key string, maxIdx uint32,
 		ss.checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum, s)
 	}
 	addSegStatsStrIngestion(ss.AllSst, key, valBytes)
-	if colWip.cbufidx > maxIdx {
-		maxIdx = colWip.cbufidx
-	}
-	return maxIdx, matchedCol, nil
+	return matchedCol
 }
 
-func (ss *SegStore) encodeSingleBool(key string, val bool, maxIdx uint32,
-	tsKey *string, matchedCol bool) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleBool(key string, val bool,
+	tsKey *string, matchedCol bool) bool {
 	if key == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol
 	}
 	var colWip *ColWip
 	colBlooms := ss.wipBlock.columnBlooms
@@ -530,32 +498,26 @@ func (ss *SegStore) encodeSingleBool(key string, val bool, maxIdx uint32,
 	if bi != nil {
 		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strconv.FormatBool(val)))
 	}
-	if colWip.cbufidx > maxIdx {
-		maxIdx = colWip.cbufidx
-	}
-	return maxIdx, matchedCol, nil
+	return matchedCol
 }
 
-func (ss *SegStore) encodeSingleNull(key string, maxIdx uint32,
-	tsKey *string, matchedCol bool) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleNull(key string,
+	tsKey *string, matchedCol bool) bool {
 	if key == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol
 	}
 	var colWip *ColWip
 	colWip, _, matchedCol = ss.initAndBackFillColumn(key, SS_DT_BACKFILL, matchedCol)
 	copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_ENC_BACKFILL[:])
 	colWip.cbufidx += 1
 	ss.updateColValueSizeInAllSeenColumns(key, 1)
-	if colWip.cbufidx > maxIdx {
-		maxIdx = colWip.cbufidx
-	}
-	return maxIdx, matchedCol, nil
+	return matchedCol
 }
 
-func (ss *SegStore) encodeSingleNumber(key string, value interface{}, maxIdx uint32,
-	tsKey *string, matchedCol bool, valBytes []byte) (uint32, bool, error) {
+func (ss *SegStore) encodeSingleNumber(key string, value interface{},
+	tsKey *string, matchedCol bool, valBytes []byte) bool {
 	if key == *tsKey {
-		return maxIdx, matchedCol, nil
+		return matchedCol
 	}
 	var colWip *ColWip
 	var recNum uint16
@@ -580,10 +542,7 @@ func (ss *SegStore) encodeSingleNumber(key string, value interface{}, maxIdx uin
 	colWip.cbufidx += retLen
 	ss.updateColValueSizeInAllSeenColumns(key, retLen)
 
-	if colWip.cbufidx > maxIdx {
-		maxIdx = colWip.cbufidx
-	}
-	return maxIdx, matchedCol, nil
+	return matchedCol
 }
 
 func (ss *SegStore) initAndBackFillColumn(key string, valType SS_DTYPE,
@@ -1024,7 +983,7 @@ func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[st
 
 			timestp := uint64(i) + 1 // dont start with 0 as timestamp
 			raw, _ := json.Marshal(entry)
-			_, _, err := segStore.EncodeColumns(raw, timestp, &tsKey, SIGNAL_EVENTS,
+			_, err := segStore.EncodeColumns(raw, timestp, &tsKey, SIGNAL_EVENTS,
 				cnameCacheByteHashToStr, jsParsingStackbuf[:])
 			if err != nil {
 				log.Errorf("WriteMockColSegFile: error packing entry: %s", err)
@@ -1155,7 +1114,7 @@ func WriteMockTraceFile(segkey string, numBlocks int, entryCount int) ([]map[str
 
 		entry := entries[0].entry
 		timestp := uint64(2) + 1 // dont start with 0 as timestamp
-		_, _, err := segStore.EncodeColumns(entry, timestp, &tsKey, SIGNAL_JAEGER_TRACES,
+		_, err := segStore.EncodeColumns(entry, timestp, &tsKey, SIGNAL_JAEGER_TRACES,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		if err != nil {
 			log.Errorf("WriteMockTraceFile: error packing entry: %s", err)
@@ -1382,7 +1341,7 @@ func createMockTsRollupWipBlock(t *testing.T, segkey string) *WipBlock {
 		record_json[cnames[0]] = "value1"
 		record_json[cnames[1]] = json.Number(fmt.Sprint(i))
 		rawJson, _ := json.Marshal(record_json)
-		_, _, err := segstore.EncodeColumns(rawJson, runningTs, &tsKey, SIGNAL_EVENTS,
+		_, err := segstore.EncodeColumns(rawJson, runningTs, &tsKey, SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		if err != nil {
 			log.Errorf("Error:WriteMockColSegFile: error packing entry: %s", err)

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -153,13 +153,10 @@ func TestRecordEncodeDecode(t *testing.T) {
 			t.Errorf("failed to get segstore! %v", err)
 		}
 		tsKey := config.GetTimeStampKey()
-		maxIdx, _, err := segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
+		_, err = segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 
-		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
-
 		assert.Nil(t, err)
-		assert.GreaterOrEqual(t, maxIdx, uint32(0))
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
 			var val CValueEnclosure
@@ -268,13 +265,10 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 			t.Errorf("failed to get segstore! %v", err)
 		}
 		tsKey := config.GetTimeStampKey()
-		maxIdx, _, err := segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_JAEGER_TRACES,
+		_, err = segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_JAEGER_TRACES,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 
-		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
-
 		assert.Nil(t, err)
-		assert.GreaterOrEqual(t, maxIdx, uint32(0))
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
 			var val CValueEnclosure

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -68,7 +68,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			t.Errorf("failed to get segstore! %v", err)
 		}
 		tsKey := config.GetTimeStampKey()
-		_, _, err = segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
+		_, err = segstore.EncodeColumns(test.input, cTime, &tsKey, SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.Nil(t, err)
 
@@ -186,12 +186,10 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		segstore.numBlocks = 0
 
 		ts := config.GetTimeStampKey()
-		maxIdx, _, err := segstore.EncodeColumns(test.input, 1234, &ts, SIGNAL_EVENTS,
+		_, err := segstore.EncodeColumns(test.input, 1234, &ts, SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
-		t.Logf("encoded len: %v, origlen=%v", maxIdx, len(test.input))
 
 		assert.Nil(t, err)
-		assert.Greater(t, maxIdx, uint32(0))
 
 		var holderDte *DtypeEnclosure = &DtypeEnclosure{}
 		var qValDte *DtypeEnclosure

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -186,11 +186,8 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 			cwip.cbufidx = 0
 			cwip.cstartidx = 0
 
-			for dword := range cwip.deData.deToRecnumIdx {
-				delete(cwip.deData.deToRecnumIdx, dword)
-			}
-			for cvalHash := range cwip.deData.deHashToRecnumIdx {
-				delete(cwip.deData.deHashToRecnumIdx, cvalHash)
+			for cvalHash := range cwip.deData.hashToDci {
+				delete(cwip.deData.hashToDci, cvalHash)
 			}
 			for idx := range cwip.deData.deRecNums {
 				cwip.deData.deRecNums[idx] = nil
@@ -533,6 +530,10 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 			}
 		}
 
+		if config.IsAggregationsEnabled() {
+			segstore.computeStarTree()
+		}
+
 		compBufIdx := 0
 		for colName, colInfo := range segstore.wipBlock.colWips {
 			if colInfo.cbufidx > 0 {
@@ -583,9 +584,6 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 				}(colName, colInfo, segstore.workBufForCompression[compBufIdx])
 				compBufIdx++
 			}
-		}
-		if config.IsAggregationsEnabled() {
-			segstore.computeStarTree()
 		}
 
 		allColsToFlush.Wait()

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -201,8 +201,12 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 
 	for _, bi := range segstore.wipBlock.columnBlooms {
 		bi.uniqueWordCount = 0
-		blockBloomElementCount := getBlockBloomSize(bi)
-		bi.Bf = bloom.NewWithEstimates(uint(blockBloomElementCount), utils.BLOOM_COLL_PROBABILITY)
+		if bi.Bf == nil {
+			bi.Bf = bloom.NewWithEstimates(uint(utils.BLOCK_BLOOM_SIZE),
+				utils.BLOOM_COLL_PROBABILITY)
+		} else {
+			bi.Bf.ClearAll()
+		}
 	}
 
 	for k := range segstore.wipBlock.columnRangeIndexes {

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -201,12 +201,8 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 
 	for _, bi := range segstore.wipBlock.columnBlooms {
 		bi.uniqueWordCount = 0
-		if bi.Bf == nil {
-			bi.Bf = bloom.NewWithEstimates(uint(utils.BLOCK_BLOOM_SIZE),
-				utils.BLOOM_COLL_PROBABILITY)
-		} else {
-			bi.Bf.ClearAll()
-		}
+		blockBloomElementCount := getBlockBloomSize(bi)
+		bi.Bf = bloom.NewWithEstimates(uint(blockBloomElementCount), utils.BLOOM_COLL_PROBABILITY)
 	}
 
 	for k := range segstore.wipBlock.columnRangeIndexes {

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1179,3 +1179,10 @@ func CreateDci(sIdx uint32, wlen uint16, recBsIdx uint16) *DwordCbufIdxs {
 	}
 	return dci
 }
+
+func (cw *ColWip) GetDictword(dci *DwordCbufIdxs) []byte {
+
+	s := dci.sIdx
+	wl := uint32(dci.wlen)
+	return cw.cbuf[s : s+wl]
+}

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -265,11 +265,13 @@ func TestStarTree(t *testing.T) {
 		raw, err := json.Marshal(record_json)
 		assert.NoError(t, err)
 
-		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
+		_, err = ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
-		ss.wipBlock.maxIdx = maxIdx
+		for _, cwip := range ss.wipBlock.colWips {
+			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+		}
 		ss.wipBlock.blockSummary.RecCount += 1
 	}
 
@@ -364,11 +366,13 @@ func TestStarTreeMedium(t *testing.T) {
 		raw, err := json.Marshal(record_json)
 		assert.NoError(t, err)
 
-		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
+		_, err = ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
-		ss.wipBlock.maxIdx = maxIdx
+		for _, cwip := range ss.wipBlock.colWips {
+			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+		}
 		ss.wipBlock.blockSummary.RecCount += 1
 	}
 
@@ -463,11 +467,13 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 		raw, err := json.Marshal(record_json)
 		assert.NoError(t, err)
 
-		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
+		_, err = ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
-		ss.wipBlock.maxIdx = maxIdx
+		for _, cwip := range ss.wipBlock.colWips {
+			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+		}
 		ss.wipBlock.blockSummary.RecCount += 1
 		ss.RecordCount++
 	}
@@ -564,11 +570,14 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 		raw, err := json.Marshal(record_json)
 		assert.NoError(t, err)
 
-		maxIdx, _, err := ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
+		_, err = ss.EncodeColumns(raw, uint64(i), &tsKey, utils.SIGNAL_EVENTS,
 			cnameCacheByteHashToStr, jsParsingStackbuf[:])
 		assert.NoError(t, err)
 
-		ss.wipBlock.maxIdx = maxIdx
+		for _, cwip := range ss.wipBlock.colWips {
+			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+		}
+
 		ss.wipBlock.blockSummary.RecCount += 1
 	}
 

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -281,7 +281,8 @@ func TestStarTree(t *testing.T) {
 		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
-	var builder StarTreeBuilder
+	builder := GetSTB().stbPtr
+
 	for trial := 0; trial < 10; trial += 1 {
 		builder.ResetSegTree(groupByCols, mColNames, gcWorkBuf)
 		err := builder.ComputeStarTree(&ss.wipBlock)
@@ -379,7 +380,7 @@ func TestStarTreeMedium(t *testing.T) {
 		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
-	var builder StarTreeBuilder
+	builder := GetSTB().stbPtr
 
 	for trial := 0; trial < 10; trial += 1 {
 		builder.ResetSegTree(groupByCols[:], mColNames, gcWorkBuf)
@@ -479,7 +480,8 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
-	var builder StarTreeBuilder
+	builder := GetSTB().stbPtr
+
 	for trial := 0; trial < 10; trial += 1 {
 		builder.ResetSegTree(groupByCols[:], mColNames, gcWorkBuf)
 		err := builder.ComputeStarTree(&ss.wipBlock)
@@ -578,7 +580,7 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 		gcWorkBuf[colNum] = make([]string, MaxAgileTreeNodeCountForAlloc)
 	}
 
-	var builder StarTreeBuilder
+	builder := GetSTB().stbPtr
 
 	for trial := 0; trial < 1; trial += 1 {
 		builder.ResetSegTree(groupByCols[:], mColNames, gcWorkBuf)


### PR DESCRIPTION
# Description

1. Use sync pools for colWip.cbuf and avoid reallocs of 2 MB per wip
2. Reuse buf for indexname parsing
3. Use sync pool for items array while doing json parsing for es bulk index requests
4. Encode and write atree in 128k chunks and avoid one large write and reduced mem usage
5. Use pre-allocated array for agile tree traversal
6. Simplify `deData` and reduce the num of maps used, and reduce mem consumption
7. simplify json parsing code and remove unused return variables of encodeXXType
8. do maxIdx calculation once after all columns have been parsed.

These changes brings down the memory consumption by more than `40%`  

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
