### PR TITLE
fix: fixes issue with arithmetic operation on metrics without filters

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -19,6 +19,7 @@ package promql
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -773,6 +774,87 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v4(t *testing.T) {
 	for seriesId, tsMap := range mResult.Results {
 		for ts, val := range tsMap {
 			assert.Equal(t, expectedResults[seriesId][ts], val, "At timestamp %d", ts)
+		}
+	}
+}
+
+// Many to Many
+func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v5(t *testing.T) {
+	endTime := uint32(time.Now().Unix())
+	startTime := endTime - 86400 // 1 day
+
+	myId := uint64(0)
+
+	// Test: query1 - query2 * query3 + query2
+	query := "node_cpu_seconds_total - node_memory_MemTotal_bytes * node_disk_reads_completed_total + node_memory_MemTotal_bytes"
+
+	mQueryReqs, _, queryArithmetic, err := ConvertPromQLToMetricsQuery(query, startTime, endTime, myId)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(mQueryReqs))
+	assert.Equal(t, 1, len(queryArithmetic))
+
+	queryResMap1 := make(map[string]map[uint32]float64)
+	queryResMap1["node_cpu_seconds_total{tk1:v1,tk2:v2"] = map[uint32]float64{
+		1: 100.0,
+		2: 200.0,
+	}
+
+	queryResMap1["node_cpu_seconds_total{tk3:v1,tk4:v2"] = map[uint32]float64{
+		1: 1000.0,
+		2: 2000.0,
+	}
+
+	queryResult1 := &mresults.MetricsResult{
+		MetricName: "node_cpu_seconds_total",
+		Results:    queryResMap1,
+	}
+
+	queryResMap2 := make(map[string]map[uint32]float64)
+	queryResMap2["node_memory_MemTotal_bytes{tk1:v1,tk2:v2"] = map[uint32]float64{
+		1: 1000.0,
+		2: 2000.0,
+	}
+	queryResMap2["node_memory_MemTotal_bytes{tk4:v1,tk5:v2"] = map[uint32]float64{
+		1: 1000.0,
+		2: 2000.0,
+	}
+	queryResult2 := &mresults.MetricsResult{
+		MetricName: "node_memory_MemTotal_bytes",
+		Results:    queryResMap2,
+	}
+
+	queryResMap3 := make(map[string]map[uint32]float64)
+	queryResMap3["node_disk_reads_completed_total{tk1:v1,tk2:v2"] = map[uint32]float64{
+		1: 10.0,
+		2: 20.0,
+	}
+	queryResMap3["node_disk_reads_completed_total{tk4:v1,tk5:v2"] = map[uint32]float64{
+		1: 10.0,
+		2: 20.0,
+	}
+	queryResult3 := &mresults.MetricsResult{
+		MetricName: "node_disk_reads_completed_total",
+		Results:    queryResMap3,
+	}
+
+	queryResultsMap := make(map[uint64]*mresults.MetricsResult)
+	queryResultsMap[xxhash.Sum64String("node_cpu_seconds_total")] = queryResult1
+	queryResultsMap[xxhash.Sum64String("node_memory_MemTotal_bytes")] = queryResult2
+	queryResultsMap[xxhash.Sum64String("node_disk_reads_completed_total")] = queryResult3
+
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	assert.NotNil(t, mResult)
+	assert.Equal(t, 1, len(mResult.Results))
+	fmt.Println(mResult.Results)
+
+	expectedResults := map[uint32]float64{
+		1: 100.0 - (1000.0 * 10.0) + 1000.0,
+		2: 200.0 - (2000.0 * 20.0) + 2000.0,
+	}
+
+	for _, tsMap := range mResult.Results {
+		for ts, val := range tsMap {
+			assert.Equal(t, expectedResults[ts], val, "At timestamp %d", ts)
 		}
 	}
 }

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -1179,7 +1179,7 @@ func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap
 
 	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], map[uint64]*mresults.MetricsResult{
 		1: metricsResults,
-	}, false)
+	}, nil)
 	assert.Nil(t, err)
 	assert.Len(t, res, 1)
 	for _, resMap := range res {
@@ -1404,7 +1404,7 @@ func initialize_Multiple_Metric_Results(t *testing.T, initialEntries1 map[uint32
 }
 
 func test_GetResults_LogicalAndVectorMatchingOps(t *testing.T, initialEntries1 map[uint32]float64, initialEntries2 map[uint32]float64, labelStrs1 []string, labelStrs2 []string, ansMap map[string]map[uint32]float64, queryOps []structs.QueryArithmetic, downsampler structs.Downsampler, aggregator structs.Aggregation) {
-	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], initialize_Multiple_Metric_Results(t, initialEntries1, initialEntries2, labelStrs1, labelStrs2, queryOps, downsampler, aggregator), false)
+	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], initialize_Multiple_Metric_Results(t, initialEntries1, initialEntries2, labelStrs1, labelStrs2, queryOps, downsampler, aggregator), nil)
 	assert.Nil(t, err)
 	validateResults(t, res, ansMap)
 }


### PR DESCRIPTION
# Description
- This fixes the issue where there are multiple series on both of the metric queries in a formula

# Testing
- Added a new unit test case

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
