### PR TITLE
fix bug with resizing of slices

### DIFF
--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -546,18 +546,12 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 		defer fileutils.GLOBAL_FD_LIMITER.Release(numOpenFDs)
 
 		//readjust workBufComp size based on num of columns in this wip
-		sizeNeeded := len(segstore.wipBlock.colWips) - len(segstore.workBufForCompression)
-		if sizeNeeded > 0 {
-			segstore.workBufForCompression = toputils.ResizeSlice(segstore.workBufForCompression,
-				sizeNeeded)
-			// now make each of these bufs of atleast WIP_SIZE
-			for i := 0; i < len(segstore.workBufForCompression); i++ {
-				bsizeNeeded := utils.WIP_SIZE - len(segstore.workBufForCompression[i])
-				if bsizeNeeded > 0 {
-					segstore.workBufForCompression[i] = toputils.ResizeSlice(segstore.workBufForCompression[i],
-						bsizeNeeded)
-				}
-			}
+		segstore.workBufForCompression = toputils.ResizeSlice(segstore.workBufForCompression,
+			len(segstore.wipBlock.colWips))
+		// now make each of these bufs of atleast WIP_SIZE
+		for i := 0; i < len(segstore.workBufForCompression); i++ {
+			segstore.workBufForCompression[i] = toputils.ResizeSlice(segstore.workBufForCompression[i],
+				utils.WIP_SIZE)
 		}
 
 		if config.IsAggregationsEnabled() {


### PR DESCRIPTION
# Description

`AppendWIP..` would crash if the num of columns changed between each wip, because we were incorrectly resizing slice.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
