### PR TITLE
fix missing lock and de pack buf panics

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -503,12 +503,17 @@ func DependencyGraphThread() {
 
 		time.Sleep(sleepDuration)
 
-		// Calculate startEpoch and endEpoch for the last hour
-		endEpoch := time.Now().UnixMilli()
-		startEpoch := time.Now().Add(-time.Hour).UnixMilli()
+		_, traceIndexCount, _, _ := health.GetTraceStatsForAllSegments(0)
+		if traceIndexCount > 0 {
+			// Calculate startEpoch and endEpoch for the last hour
+			endEpoch := time.Now().UnixMilli()
+			startEpoch := time.Now().Add(-time.Hour).UnixMilli()
 
-		depMatrix := MakeTracesDependancyGraph(startEpoch, endEpoch)
-		writeDependencyMatrix(depMatrix)
+			depMatrix := MakeTracesDependancyGraph(startEpoch, endEpoch)
+			if len(depMatrix) > 0 {
+				writeDependencyMatrix(depMatrix)
+			}
+		}
 	}
 }
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -63,11 +63,6 @@ const MULTINODE_SSM_MEM_PERCENT = 20
 // if you change this size, adjust the block bloom size
 const WIP_SIZE = 2_000_000
 
-// Max recs that could fit in a wip is 20k,
-// if only 1 dict word then 20k *2 bytes for recnum + wordlen
-// if  2 dict word then (20k/2 *2 bytes for recnum)*2 words + wordlen
-// basically we need max of 20k * 2 bytes for recnum + some buffer
-const WIP_DE_PACKING_SIZE = 200_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1489,7 +1489,9 @@ func SetCardinalityLimit(val uint16) {
 func PackDictEnc(colWip *ColWip) {
 
 	localIdx := 0
-	// reuse the existing cbuf
+	colWip.dePackingBuf = *wipCbufPool.Get().(*[]byte)
+	defer wipCbufPool.Put(&colWip.dePackingBuf)
+
 	// copy num of dict words
 	copy(colWip.dePackingBuf[localIdx:], utils.Uint16ToBytesLittleEndian(colWip.deData.deCount))
 	localIdx += 2

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1489,8 +1489,6 @@ func SetCardinalityLimit(val uint16) {
 func PackDictEnc(colWip *ColWip) {
 
 	localIdx := 0
-	colWip.dePackingBuf = *wipCbufPool.Get().(*[]byte)
-	defer wipCbufPool.Put(&colWip.dePackingBuf)
 
 	// copy num of dict words
 	copy(colWip.dePackingBuf[localIdx:], utils.Uint16ToBytesLittleEndian(colWip.deData.deCount))

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1438,8 +1438,8 @@ func (ss *SegStore) FlushSegStats() error {
 		tsKey := config.GetTimeStampKey()
 		for cname, cwip := range ss.wipBlock.colWips {
 			if cwip.cbufidx > 0 {
-				log.Infof("FlushSegStats: sst nil but cname: %v, cwip.cbufidx: %v", cname,
-					cwip.cbufidx)
+				log.Infof("FlushSegStats: sst nil but cname: %v, cwip.cbufidx: %v, segkey: %v",
+					cname, cwip.cbufidx, ss.SegmentKey)
 				if cname != tsKey {
 					found += 1
 				}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1436,6 +1436,9 @@ func (ss *SegStore) FlushSegStats() error {
 	if len(ss.AllSst) <= 0 {
 		found := 0
 		tsKey := config.GetTimeStampKey()
+		// Flush is called once one of the cbufidx is >0, but if we find no columns
+		// with cbufidx > 0 other than timestamp column, only then declare this as an error
+		// else we won't create a sst file
 		for cname, cwip := range ss.wipBlock.colWips {
 			if cwip.cbufidx > 0 {
 				log.Infof("FlushSegStats: sst nil but cname: %v, cwip.cbufidx: %v, segkey: %v",
@@ -1445,9 +1448,6 @@ func (ss *SegStore) FlushSegStats() error {
 				}
 			}
 		}
-		// Flush is called only one of the cbufidx is >0, but if we find no columns
-		// with cbufidx > 0 other than timestamp column, only then declare this as an error
-		// else we won;t create a sst file
 		if found == 0 {
 			log.Errorf("FlushSegStats: no segstats to flush, found: %v cwips with data", found)
 			return errors.New("FlushSegStats: no segstats to flush")

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -202,6 +202,7 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 
 		for _, cwip := range segstore.wipBlock.colWips {
 			wipCbufPool.Put(&cwip.cbuf)
+			wipCbufPool.Put(&cwip.dePackingBuf)
 		}
 		segstore.wipBlock.colWips = make(map[string]*ColWip)
 	} else {
@@ -306,6 +307,7 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 
 	for _, cwip := range segstore.wipBlock.colWips {
 		wipCbufPool.Put(&cwip.cbuf)
+		wipCbufPool.Put(&cwip.dePackingBuf)
 	}
 
 	segstore.wipBlock.colWips = make(map[string]*ColWip)
@@ -441,6 +443,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 	// Conversion succeeded, so replace the column with the new one.
 	wipBlock.colWips[colName] = newColWip
 	wipCbufPool.Put(&oldColWip.cbuf)
+	wipCbufPool.Put(&oldColWip.dePackingBuf)
 	delete(wipBlock.columnBlooms, colName)
 	return true
 }
@@ -511,6 +514,7 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 	// Replace the old column.
 	wipBlock.colWips[colName] = newColWip
 	wipCbufPool.Put(&oldColWip.cbuf)
+	wipCbufPool.Put(&oldColWip.dePackingBuf)
 	delete(wipBlock.columnRangeIndexes, colName)
 }
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -181,8 +181,10 @@ func GetInMemorySize() uint64 {
 
 	totalSize := uint64(0)
 	for _, s := range allSegStores {
+		s.Lock.Lock()
 		totalSize += s.wipBlock.getSize()
 		totalSize += s.GetSegStorePQMatchSize()
+		s.Lock.Unlock()
 	}
 
 	totalSize += metrics.GetTotalEncodedSize()

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -465,12 +465,14 @@ func InitColWip(segKey string, colName string) *ColWip {
 	}
 
 	cbuf := *wipCbufPool.Get().(*[]byte)
+	dePack := *wipCbufPool.Get().(*[]byte)
 
 	return &ColWip{
-		csgFname: fmt.Sprintf("%v_%v.csg", segKey, xxhash.Sum64String(colName)),
-		deData:   &deData,
-		dciPool:  dciPool,
-		cbuf:     cbuf,
+		csgFname:     fmt.Sprintf("%v_%v.csg", segKey, xxhash.Sum64String(colName)),
+		deData:       &deData,
+		dciPool:      dciPool,
+		cbuf:         cbuf,
+		dePackingBuf: dePack,
 	}
 }
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -114,7 +114,7 @@ type ColWip struct {
 	cbuf         []byte // in progress bytes
 	csgFname     string // file name of csg file
 	deData       *DeData
-	dePackingBuf [WIP_DE_PACKING_SIZE]byte
+	dePackingBuf []byte
 	dciPool      []*DwordCbufIdxs
 }
 


### PR DESCRIPTION
# Description

1. concurrent map read/write was causing a panic during ingestion. Added missing segstore.lock
2. Don't create dependency graph if traces count is 0
3. Use cbufpool for de packing instead of a const size of 200k (fixes a panic in some scenarios)


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
