### PR TITLE
Bug fix: aggregations do not work after fields

### DIFF
--- a/cicd/ingest.csv
+++ b/cicd/ingest.csv
@@ -400,3 +400,8 @@ NOT invalidColumn=123,now-1d,now,*,total,eq,100000,Splunk QL
 "app_name=Grayeye | stats list(eval(if(http_status > 300, 100, ""abc""))) as list",now-1d,now,*,group:list:*,eq,[100],Splunk QL
 "app_name=Grayeye | stats list(eval(if(http_method = ""GET"", ""HEAD"", http_method))) as list",now-1d,now,*,group:list:*,eq,[HEAD],Splunk QL
 "app_name=Grayeye | sort http_status | stats list(eval(if(http_method = ""GET"", ""HEAD"", http_method))) as list",now-1d,now,*,group:list:*,eq,[HEAD],Splunk QL
+"app_name=Bracecould | fields latency | stats avg(latency) as field",now-1d,now,*,field,eq,"7,030,508.166",Splunk QL
+"app_name=Bracecould | fields latency | stats values(latency) as field",now-1d,now,*,field,eq,[6269746 7330203 8469275 892120 9552581 9669124],Splunk QL
+"app_name=Bracecould | fields latency | stats count as field",now-1d,now,*,field,eq,[6],Splunk QL
+
+

--- a/cicd/restart.csv
+++ b/cicd/restart.csv
@@ -379,4 +379,7 @@ NOT invalidColumn=123,now-1d,now,*,total,eq,100000,Splunk QL
 "app_name=Grayeye | stats list(eval(if(http_method = ""GET"", ""HEAD"", http_method))) as list",now-1d,now,*,group:list:*,eq,[HEAD],Splunk QL
 "app_name=Bracecould | sort http_status | stats values(eval(http_status+10)) as values",now-1d,now,*,group:values:*,eq,"[311 312 410 510]",Splunk QL
 "app_name=Grayeye | sort http_status | stats list(eval(if(http_method = ""GET"", ""HEAD"", http_method))) as list",now-1d,now,*,group:list:*,eq,[HEAD],Splunk QL
+"app_name=Bracecould | fields latency | stats avg(latency) as field",now-1d,now,*,field,eq,"7,030,508.166",Splunk QL
+"app_name=Bracecould | fields latency | stats values(latency) as field",now-1d,now,*,field,eq,[6269746 7330203 8469275 892120 9552581 9669124],Splunk QL
+"app_name=Bracecould | fields latency | stats count as field",now-1d,now,*,field,eq,[6],Splunk QL
 

--- a/pkg/segment/aggregations/evalaggs.go
+++ b/pkg/segment/aggregations/evalaggs.go
@@ -675,20 +675,20 @@ func ComputeAggEvalForCardinality(measureAgg *structs.MeasureAggregator, sstMap 
 func ComputeAggEvalForValues(measureAgg *structs.MeasureAggregator, sstMap map[string]*structs.SegStats, measureResults map[string]utils.CValueEnclosure, runningEvalStats map[string]interface{}) error {
 	fields := measureAgg.ValueColRequest.GetFields()
 
-	var strSet map[string]struct{}
+	var valueSet map[string]struct{}
 	_, ok := runningEvalStats[measureAgg.String()]
 	if !ok {
-		strSet = make(map[string]struct{}, 0)
-		runningEvalStats[measureAgg.String()] = strSet
+		valueSet = make(map[string]struct{}, 0)
+		runningEvalStats[measureAgg.String()] = valueSet
 	} else {
-		strSet, ok = runningEvalStats[measureAgg.String()].(map[string]struct{})
+		valueSet, ok = runningEvalStats[measureAgg.String()].(map[string]struct{})
 		if !ok {
 			return fmt.Errorf("ComputeAggEvalForValues: can not convert strSet for measureAgg: %v", measureAgg.String())
 		}
 	}
 
 	if len(fields) == 0 {
-		_, err := PerformAggEvalForCardinality(measureAgg, strSet, nil)
+		_, err := PerformAggEvalForCardinality(measureAgg, valueSet, nil)
 		if err != nil {
 			return fmt.Errorf("ComputeAggEvalForValues: Error while performing eval agg for values, err: %v", err)
 		}
@@ -706,7 +706,7 @@ func ComputeAggEvalForValues(measureAgg *structs.MeasureAggregator, sstMap map[s
 				return fmt.Errorf("ComputeAggEvalForValues: Error while populating fieldToValue from sstMap, err: %v", err)
 			}
 
-			_, err = PerformAggEvalForCardinality(measureAgg, strSet, fieldToValue)
+			_, err = PerformAggEvalForCardinality(measureAgg, valueSet, fieldToValue)
 			if err != nil {
 				return fmt.Errorf("ComputeAggEvalForValues: Error while performing eval agg for values, err: %v", err)
 			}
@@ -714,12 +714,12 @@ func ComputeAggEvalForValues(measureAgg *structs.MeasureAggregator, sstMap map[s
 	}
 
 	uniqueStrings := make([]string, 0)
-	for str := range strSet {
+	for str := range valueSet {
 		uniqueStrings = append(uniqueStrings, str)
 	}
 	sort.Strings(uniqueStrings)
 
-	runningEvalStats[measureAgg.String()] = strSet
+	runningEvalStats[measureAgg.String()] = valueSet
 
 	measureResults[measureAgg.String()] = utils.CValueEnclosure{
 		Dtype: utils.SS_DT_STRING_SLICE,
@@ -731,15 +731,13 @@ func ComputeAggEvalForValues(measureAgg *structs.MeasureAggregator, sstMap map[s
 
 func ComputeAggEvalForList(measureAgg *structs.MeasureAggregator, sstMap map[string]*structs.SegStats, measureResults map[string]utils.CValueEnclosure, runningEvalStats map[string]interface{}) error {
 	fields := measureAgg.ValueColRequest.GetFields()
-	finalList := []string{}
-
-	var strList []string
+	var finalList []string
 	_, ok := runningEvalStats[measureAgg.String()]
 	if !ok {
-		strList = make([]string, 0)
-		runningEvalStats[measureAgg.String()] = strList
+		finalList = make([]string, 0)
+		runningEvalStats[measureAgg.String()] = finalList
 	} else {
-		strList, ok = runningEvalStats[measureAgg.String()].([]string)
+		finalList, ok = runningEvalStats[measureAgg.String()].([]string)
 		if !ok {
 			return fmt.Errorf("ComputeAggEvalForList: can not convert to list for measureAgg: %v", measureAgg.String())
 		}
@@ -747,7 +745,7 @@ func ComputeAggEvalForList(measureAgg *structs.MeasureAggregator, sstMap map[str
 
 	if len(fields) == 0 {
 		fieldToValue := make(map[string]utils.CValueEnclosure)
-		list, err := PerformAggEvalForList(measureAgg, strList, fieldToValue)
+		list, err := PerformAggEvalForList(measureAgg, finalList, fieldToValue)
 		if err != nil {
 			return fmt.Errorf("ComputeAggEvalForList: Error while performing eval agg for list, err: %v", err)
 		}
@@ -765,15 +763,13 @@ func ComputeAggEvalForList(measureAgg *structs.MeasureAggregator, sstMap map[str
 				return fmt.Errorf("ComputeAggEvalForList: Error while populating fieldToValue from sstMap, err: %v", err)
 			}
 
-			list, err := PerformAggEvalForList(measureAgg, strList, fieldToValue)
+			list, err := PerformAggEvalForList(measureAgg, finalList, fieldToValue)
 			if err != nil {
 				return fmt.Errorf("ComputeAggEvalForList: Error while performing eval agg for list, err: %v", err)
 			}
-			finalList = append(finalList, list...)
+			finalList = list
 		}
 	}
-
-	runningEvalStats[measureAgg.String()] = finalList
 
 	// limit the list to MAX_SPL_LIST_SIZE
 	if len(finalList) > utils.MAX_SPL_LIST_SIZE {
@@ -783,6 +779,7 @@ func ComputeAggEvalForList(measureAgg *structs.MeasureAggregator, sstMap map[str
 		Dtype: utils.SS_DT_STRING_SLICE,
 		CVal:  finalList,
 	}
+	runningEvalStats[measureAgg.String()] = finalList
 	return nil
 }
 

--- a/pkg/segment/aggregations/evalaggs_test.go
+++ b/pkg/segment/aggregations/evalaggs_test.go
@@ -14,7 +14,7 @@ func getDummyMeasureAggregator() *structs.MeasureAggregator {
 		MeasureCol:      "vals",
 		MeasureFunc:     utils.Sum,
 		StrEnc:          "vals",
-		ValueColRequest: nil,
+		ValueColRequest: getDummyNumericValueExpr("vals"),
 	}
 }
 
@@ -66,56 +66,324 @@ func getDummySegStats() *structs.SegStats {
 	}
 }
 
-func TestComputeAggEvalForList(t *testing.T) {
-	dummyMeasureAggr := getDummyMeasureAggregator()
-	tests := []struct {
-		name             string
-		measureAgg       *structs.MeasureAggregator
-		sstMap           map[string]*structs.SegStats
-		measureResults   map[string]utils.CValueEnclosure
-		runningEvalStats map[string]interface{}
-		expectedError    error
-	}{
-		{
-			name:           "runningEvalStats contains measureAgg.String() but cannot be converted to []string",
-			measureAgg:     dummyMeasureAggr,
-			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
-			measureResults: make(map[string]utils.CValueEnclosure),
-			runningEvalStats: map[string]interface{}{
-				"someKey": 123, // Invalid type
-			},
-			expectedError: fmt.Errorf("ComputeAggEvalForList: can not convert to list for measureAgg: %v", "someKey"),
-		},
-		{
-			name:           "fields is empty",
-			measureAgg:     dummyMeasureAggr,
-			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
-			measureResults: make(map[string]utils.CValueEnclosure),
-			runningEvalStats: map[string]interface{}{
-				"someKey": []string{},
-			},
-			expectedError: nil,
-		},
-		{
-			name:           "fields is not empty but sstMap does not contain the required key",
-			measureAgg:     dummyMeasureAggr,
-			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
-			measureResults: make(map[string]utils.CValueEnclosure),
-			runningEvalStats: map[string]interface{}{
-				"someKey": []string{},
-			},
-			expectedError: fmt.Errorf("ComputeAggEvalForList: sstMap did not have segstats for field %v, measureAgg: %v", "someField", "someKey"),
-		},
+func getDummyNumericValueExpr(fieldName string) *structs.ValueExpr {
+	leftExpr := &structs.NumericExpr{
+		NumericExprMode: 2,
+		IsTerminal:      true,
+		ValueIsField:    true,
+		Value:           fieldName,
+		Op:              "",
+		Left:            nil,
+		Right:           nil,
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ComputeAggEvalForList(tt.measureAgg, tt.sstMap, tt.measureResults, tt.runningEvalStats)
-			if tt.expectedError != nil {
-				assert.EqualError(t, err, tt.expectedError.Error())
-			} else {
-				assert.NoError(t, err)
-			}
-		})
+	rightExpr := &structs.NumericExpr{
+		NumericExprMode: 0,
+		IsTerminal:      true,
+		ValueIsField:    false,
+		Value:           "2",
+		Op:              "",
+		Left:            nil,
+		Right:           nil,
 	}
+
+	expr := &structs.NumericExpr{
+		NumericExprMode: 4,
+		IsTerminal:      false,
+		ValueIsField:    false,
+		Value:           "",
+		Op:              "/",
+		Left:            leftExpr,
+		Right:           rightExpr,
+	}
+
+	return &structs.ValueExpr{
+		NumericExpr:   expr,
+		ValueExprMode: 0,
+	}
+}
+
+func getDummyNumericValueExprWithoutField() *structs.ValueExpr {
+	expr := &structs.NumericExpr{
+		NumericExprMode: 0,
+		IsTerminal:      true,
+		ValueIsField:    false,
+		Value:           "100",
+		Op:              "",
+		Left:            nil,
+		Right:           nil,
+	}
+
+	return &structs.ValueExpr{
+		NumericExpr:   expr,
+		ValueExprMode: 0,
+	}
+}
+
+func TestComputeAggEvalForList_InvalidRunningEvalStatsConversion(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": 123, // Invalid type
+	}
+	sstMap := map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+
+	expectedError := fmt.Errorf("ComputeAggEvalForList: can not convert to list for measureAgg: %v", "vals")
+
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.EqualError(t, err, expectedError.Error())
+}
+
+func TestComputeAggEvalForList_EmptyFields(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	dummyMeasureAggr.ValueColRequest = getDummyNumericValueExprWithoutField()
+	sstMap := map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+}
+
+func TestComputeAggEvalForList_MissingSSTMapKey(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	sstMap := map[string]*structs.SegStats{"otherKey": getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+
+	expectedError := fmt.Errorf("ComputeAggEvalForList: sstMap did not have segstats for field %v, measureAgg: %v", "vals", "vals")
+
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.EqualError(t, err, expectedError.Error())
+}
+
+func TestComputeAggEvalForList_CorrectInputsWithoutField(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	dummyMeasureAggr.ValueColRequest = getDummyNumericValueExprWithoutField()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+	expected := []string{"100"}
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 1")
+	assert.Equal(t, 1, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 1")
+	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
+}
+
+func TestComputeAggEvalForList_CorrectInputsWithField(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+	expected := []string{"0.5", "2", "5"}
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 3")
+	assert.Equal(t, 3, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 3")
+	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
+}
+
+func TestComputeAggEvalForList_largeLists(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	list := make([]*utils.CValueEnclosure, utils.MAX_SPL_LIST_SIZE+100)
+
+	for i := range list {
+		list[i] = &utils.CValueEnclosure{
+			CVal:  1.0,
+			Dtype: utils.SS_DT_FLOAT,
+		}
+	}
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	sstMap["vals"].Records = list
+	measureResults := make(map[string]utils.CValueEnclosure)
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	assert.Equal(t, utils.MAX_SPL_LIST_SIZE, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be MAX_SPL_LIST_SIZE")
+	assert.Equal(t, utils.MAX_SPL_LIST_SIZE, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be MAX_SPL_LIST_SIZE")
+}
+
+func TestComputeAggEvalForList_TestUpdateWithMultipleEvals(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := make(map[string]utils.CValueEnclosure)
+	expected := []string{"0.5", "2", "5"}
+	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 3")
+	assert.Equal(t, 3, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 3")
+	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
+
+	expected = []string{"0.5", "2", "5", "0.5", "2", "5"}
+	measureResults = make(map[string]utils.CValueEnclosure)
+	err = ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 6")
+	assert.Equal(t, 6, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 6")
+	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
+
+}
+
+// Test cases
+func TestComputeAggEvalForValues_NoFields(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+	measureAgg.ValueColRequest = getDummyNumericValueExprWithoutField()
+
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+
+	result, ok := measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+}
+
+func TestComputeAggEvalForValues_MissingSSTMapKey(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"other": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sstMap did not have segstats")
+}
+
+func TestComputeAggEvalForValues_InvalidStrSetConversion(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": []string{},
+	}
+
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "can not convert strSet")
+}
+
+func TestComputeAggEvalForValues_WithFieldsAndValidData(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	expected := []string{"0.5", "2", "5"}
+	result, ok := measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok := result.CVal.([]string)
+	assert.True(t, ok)
+	assert.Equal(t, expected, uniqueStrings)
+}
+
+func TestComputeAggEvalForValues_WithoutFieldsAndValidData(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+	measureAgg.ValueColRequest = getDummyNumericValueExprWithoutField()
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	expected := []string{"100"}
+	result, ok := measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok := result.CVal.([]string)
+	assert.True(t, ok)
+	assert.Equal(t, expected, uniqueStrings)
+}
+
+func TestComputeAggEvalForValues_UpdateWithMultipleEvals(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	expected := []string{"0.5", "2", "5"}
+	result, ok := measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok := result.CVal.([]string)
+	assert.True(t, ok)
+	assert.Equal(t, expected, uniqueStrings)
+
+	err = ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	result, ok = measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok = result.CVal.([]string)
+	assert.True(t, ok)
+	// expected remains the same
+	assert.Equal(t, expected, uniqueStrings)
+}
+
+func TestComputeAggEvalForValues_UpdateWithMultipleEvalsWithoutField(t *testing.T) {
+	measureAgg := getDummyMeasureAggregator()
+	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}
+	measureResults := map[string]utils.CValueEnclosure{}
+	runningEvalStats := map[string]interface{}{
+		"vals": map[string]struct{}{},
+	}
+	measureAgg.ValueColRequest = getDummyNumericValueExprWithoutField()
+	err := ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	expected := []string{"100"}
+	result, ok := measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok := result.CVal.([]string)
+	assert.True(t, ok)
+	assert.Equal(t, expected, uniqueStrings)
+
+	err = ComputeAggEvalForValues(measureAgg, sstMap, measureResults, runningEvalStats)
+	assert.NoError(t, err)
+	result, ok = measureResults[measureAgg.String()]
+	assert.True(t, ok)
+	assert.Equal(t, utils.SS_DT_STRING_SLICE, result.Dtype)
+
+	uniqueStrings, ok = result.CVal.([]string)
+	assert.True(t, ok)
+	// expected remains the same
+	assert.Equal(t, expected, uniqueStrings)
 }

--- a/pkg/segment/aggregations/evalaggs_test.go
+++ b/pkg/segment/aggregations/evalaggs_test.go
@@ -68,7 +68,7 @@ func getDummySegStats() *structs.SegStats {
 
 func getDummyNumericValueExpr(fieldName string) *structs.ValueExpr {
 	leftExpr := &structs.NumericExpr{
-		NumericExprMode: 2,
+		NumericExprMode: structs.NEMNumberField,
 		IsTerminal:      true,
 		ValueIsField:    true,
 		Value:           fieldName,
@@ -78,7 +78,7 @@ func getDummyNumericValueExpr(fieldName string) *structs.ValueExpr {
 	}
 
 	rightExpr := &structs.NumericExpr{
-		NumericExprMode: 0,
+		NumericExprMode: structs.NEMNumber,
 		IsTerminal:      true,
 		ValueIsField:    false,
 		Value:           "2",
@@ -88,7 +88,7 @@ func getDummyNumericValueExpr(fieldName string) *structs.ValueExpr {
 	}
 
 	expr := &structs.NumericExpr{
-		NumericExprMode: 4,
+		NumericExprMode: structs.NEMNumericExpr,
 		IsTerminal:      false,
 		ValueIsField:    false,
 		Value:           "",
@@ -99,13 +99,13 @@ func getDummyNumericValueExpr(fieldName string) *structs.ValueExpr {
 
 	return &structs.ValueExpr{
 		NumericExpr:   expr,
-		ValueExprMode: 0,
+		ValueExprMode: structs.VEMNumericExpr,
 	}
 }
 
 func getDummyNumericValueExprWithoutField() *structs.ValueExpr {
 	expr := &structs.NumericExpr{
-		NumericExprMode: 0,
+		NumericExprMode: structs.NEMNumber,
 		IsTerminal:      true,
 		ValueIsField:    false,
 		Value:           "100",
@@ -116,14 +116,14 @@ func getDummyNumericValueExprWithoutField() *structs.ValueExpr {
 
 	return &structs.ValueExpr{
 		NumericExpr:   expr,
-		ValueExprMode: 0,
+		ValueExprMode: structs.VEMNumericExpr,
 	}
 }
 
 func TestComputeAggEvalForList_InvalidRunningEvalStatsConversion(t *testing.T) {
 	dummyMeasureAggr := getDummyMeasureAggregator()
 	runningEvalStats := map[string]interface{}{
-		"vals": 123, // Invalid type
+		"vals": 123, // Invalid type, cannot convert to a list.
 	}
 	sstMap := map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()}
 	measureResults := make(map[string]utils.CValueEnclosure)
@@ -242,7 +242,6 @@ func TestComputeAggEvalForList_TestUpdateWithMultipleEvals(t *testing.T) {
 
 }
 
-// Test cases
 func TestComputeAggEvalForValues_NoFields(t *testing.T) {
 	measureAgg := getDummyMeasureAggregator()
 	sstMap := map[string]*structs.SegStats{"vals": getDummySegStats()}

--- a/pkg/segment/aggregations/evalaggs_test.go
+++ b/pkg/segment/aggregations/evalaggs_test.go
@@ -1,0 +1,121 @@
+package aggregations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func getDummyMeasureAggregator() *structs.MeasureAggregator {
+	return &structs.MeasureAggregator{
+		MeasureCol:      "vals",
+		MeasureFunc:     utils.Sum,
+		StrEnc:          "vals",
+		ValueColRequest: nil,
+	}
+}
+
+func getDummySegStats() *structs.SegStats {
+	return &structs.SegStats{
+		IsNumeric: true,
+		Count:     3,
+		Hll:       nil,
+		NumStats: &structs.NumericStats{
+			Min: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				IntgrVal: 1,
+				FloatVal: 1.0,
+			},
+			Max: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				IntgrVal: 10,
+				FloatVal: 10.0,
+			},
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				IntgrVal: 15,
+				FloatVal: 15.0,
+			},
+			Dtype: utils.SS_DT_FLOAT,
+		},
+		StringStats: &structs.StringStats{
+			StrSet: map[string]struct{}{
+				"1":  {},
+				"4":  {},
+				"10": {},
+			},
+			StrList: []string{"1", "4", "10"},
+		},
+		Records: []*utils.CValueEnclosure{
+			{
+				CVal:  1.0,
+				Dtype: utils.SS_DT_FLOAT,
+			},
+			{
+				CVal:  4.0,
+				Dtype: utils.SS_DT_FLOAT,
+			},
+			{
+				CVal:  10.0,
+				Dtype: utils.SS_DT_FLOAT,
+			},
+		},
+	}
+}
+
+func TestComputeAggEvalForList(t *testing.T) {
+	dummyMeasureAggr := getDummyMeasureAggregator()
+	tests := []struct {
+		name             string
+		measureAgg       *structs.MeasureAggregator
+		sstMap           map[string]*structs.SegStats
+		measureResults   map[string]utils.CValueEnclosure
+		runningEvalStats map[string]interface{}
+		expectedError    error
+	}{
+		{
+			name:           "runningEvalStats contains measureAgg.String() but cannot be converted to []string",
+			measureAgg:     dummyMeasureAggr,
+			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
+			measureResults: make(map[string]utils.CValueEnclosure),
+			runningEvalStats: map[string]interface{}{
+				"someKey": 123, // Invalid type
+			},
+			expectedError: fmt.Errorf("ComputeAggEvalForList: can not convert to list for measureAgg: %v", "someKey"),
+		},
+		{
+			name:           "fields is empty",
+			measureAgg:     dummyMeasureAggr,
+			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
+			measureResults: make(map[string]utils.CValueEnclosure),
+			runningEvalStats: map[string]interface{}{
+				"someKey": []string{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:           "fields is not empty but sstMap does not contain the required key",
+			measureAgg:     dummyMeasureAggr,
+			sstMap:         map[string]*structs.SegStats{dummyMeasureAggr.MeasureCol: getDummySegStats()},
+			measureResults: make(map[string]utils.CValueEnclosure),
+			runningEvalStats: map[string]interface{}{
+				"someKey": []string{},
+			},
+			expectedError: fmt.Errorf("ComputeAggEvalForList: sstMap did not have segstats for field %v, measureAgg: %v", "someField", "someKey"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ComputeAggEvalForList(tt.measureAgg, tt.sstMap, tt.measureResults, tt.runningEvalStats)
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -200,7 +200,6 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 	var resultRecMap map[string]bool
 
 	hasQueryAggergatorBlock := aggs.HasQueryAggergatorBlockInChain()
-	// perform stat aggs if they are present in chain
 	hasStatsAggregator := aggs.IsStatsAggPresentInChain()
 	transactionArgsExist := aggs.HasTransactionArgumentsInChain()
 	recsAggRecords := make([]map[string]interface{}, 0)

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -200,6 +200,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 	var resultRecMap map[string]bool
 
 	hasQueryAggergatorBlock := aggs.HasQueryAggergatorBlockInChain()
+	hasStatsAggregator := aggs.IsStatsAggPresentInChain()
 	transactionArgsExist := aggs.HasTransactionArgumentsInChain()
 	recsAggRecords := make([]map[string]interface{}, 0)
 
@@ -230,7 +231,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 
 		nodeRes.ColumnsOrder = colsIndexMap
 
-		if hasQueryAggergatorBlock || transactionArgsExist {
+		if hasQueryAggergatorBlock || transactionArgsExist || hasStatsAggregator {
 
 			numTotalSegments, _, resultCount, rawSearchFinished, err := query.GetQuerySearchStateForQid(qid)
 			if err != nil {

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -200,6 +200,7 @@ func GetJsonFromAllRrc(allrrc []*utils.RecordResultContainer, esResponse bool, q
 	var resultRecMap map[string]bool
 
 	hasQueryAggergatorBlock := aggs.HasQueryAggergatorBlockInChain()
+	// perform stat aggs if they are present in chain
 	hasStatsAggregator := aggs.IsStatsAggPresentInChain()
 	transactionArgsExist := aggs.HasTransactionArgumentsInChain()
 	recsAggRecords := make([]map[string]interface{}, 0)

--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -492,8 +492,11 @@ func GetSegAvg(runningSegStat *structs.SegStats, currSegStat *structs.SegStats) 
 
 	// Update running segment statistics
 	runningSegStat.Count += currSegStat.Count
-	runningSegStat.NumStats.Sum.ReduceFast(currSegStat.NumStats.Sum.Ntype, currSegStat.NumStats.Sum.IntgrVal, currSegStat.NumStats.Sum.FloatVal, utils.Sum)
-
+	err := runningSegStat.NumStats.Sum.ReduceFast(currSegStat.NumStats.Sum.Ntype, currSegStat.NumStats.Sum.IntgrVal, currSegStat.NumStats.Sum.FloatVal, utils.Sum)
+	if err != nil {
+		log.Errorf("GetSegAvg: error in reducing sum, err: %+v", err)
+		return &rSst, err
+	}
 	// Calculate and return the average
 	avg, err := getAverage(runningSegStat.NumStats.Sum, runningSegStat.Count)
 	rSst.FloatVal = avg

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -405,8 +405,8 @@ func TestGetAverage_IntegerSum(t *testing.T) {
 	count := uint64(4)
 
 	expected := 5.0
-	result := getAverage(sum, count)
-
+	result, err := getAverage(sum, count)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -418,8 +418,8 @@ func TestGetAverage_FloatSum(t *testing.T) {
 	count := uint64(4)
 
 	expected := 5.0
-	result := getAverage(sum, count)
-
+	result, err := getAverage(sum, count)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
 
@@ -430,90 +430,17 @@ func TestGetAverage_ZeroCount(t *testing.T) {
 	}
 	count := uint64(0)
 
-	// Handle division by zero if your function has specific behavior, otherwise expect NaN
-	expected := 0.0
-	result := getAverage(sum, count)
-
-	assert.Equal(t, expected, result)
+	_, err := getAverage(sum, count)
+	assert.Error(t, err)
 }
 
-func TestAccumulateSum_BothInteger(t *testing.T) {
-	runningSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_SIGNED_NUM,
-		IntgrVal: 10,
-	}
-	currSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_SIGNED_NUM,
-		IntgrVal: 20,
-	}
-
-	expected := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_SIGNED_NUM,
-		IntgrVal: 30,
-	}
-
-	result := accumulateSum(runningSum, currSum)
-
-	assert.Equal(t, expected, result)
-}
-
-func TestAccumulateSum_RunningIntegerCurrentFloat(t *testing.T) {
-	runningSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_SIGNED_NUM,
-		IntgrVal: 10,
-	}
-	currSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
+func TestGetAverage_InvalidType(t *testing.T) {
+	sum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_STRING,
 		FloatVal: 20.0,
 	}
+	count := uint64(4)
 
-	expected := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 30.0,
-		IntgrVal: 10,
-	}
-
-	result := accumulateSum(runningSum, currSum)
-
-	assert.Equal(t, expected, result)
-}
-
-func TestAccumulateSum_RunningFloatCurrentInteger(t *testing.T) {
-	runningSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 10.0,
-	}
-	currSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_SIGNED_NUM,
-		IntgrVal: 20,
-	}
-
-	expected := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 30.0,
-	}
-
-	result := accumulateSum(runningSum, currSum)
-
-	assert.Equal(t, expected, result)
-}
-
-func TestAccumulateSum_BothFloat(t *testing.T) {
-	runningSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 10.0,
-	}
-	currSum := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 20.0,
-	}
-
-	expected := utils.NumTypeEnclosure{
-		Ntype:    utils.SS_DT_FLOAT,
-		FloatVal: 30.0,
-	}
-
-	result := accumulateSum(runningSum, currSum)
-
-	assert.Equal(t, expected, result)
+	_, err := getAverage(sum, count)
+	assert.Error(t, err)
 }

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -190,3 +190,209 @@ func TestGetSegList(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSegAvg_CurrSegStatIsNil(t *testing.T) {
+	runningSegStat := &structs.SegStats{}
+	currSegStat := (*structs.SegStats)(nil)
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		IntgrVal: 0,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.Error(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_CurrSegStatIsNonNumeric(t *testing.T) {
+	runningSegStat := &structs.SegStats{}
+	currSegStat := &structs.SegStats{
+		IsNumeric: false,
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		IntgrVal: 0,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.Error(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_FirstSegmentWithIntegerStats(t *testing.T) {
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_SIGNED_NUM,
+				IntgrVal: 20,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	result, err := GetSegAvg(nil, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_FirstSegmentWithFloatStats(t *testing.T) {
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				FloatVal: 20.0,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	result, err := GetSegAvg(nil, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_RunningSegmentIntAndCurrentSegmentFloat(t *testing.T) {
+	runningSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     3,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_SIGNED_NUM,
+				IntgrVal: 30,
+			},
+		},
+	}
+
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				FloatVal: 20.0,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_RunningAndCurrentSegmentWithFloatStats(t *testing.T) {
+	runningSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				FloatVal: 20.0,
+			},
+		},
+	}
+
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				FloatVal: 10.0,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 7.5,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_RunningSegmentFloatAndCurrentSegmentInt(t *testing.T) {
+	runningSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_FLOAT,
+				FloatVal: 20.0,
+			},
+		},
+	}
+
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_SIGNED_NUM,
+				IntgrVal: 10,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 7.5,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestGetSegAvg_BothSegmentsWithIntStats(t *testing.T) {
+	runningSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     3,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_SIGNED_NUM,
+				IntgrVal: 30,
+			},
+		},
+	}
+
+	currSegStat := &structs.SegStats{
+		IsNumeric: true,
+		Count:     2,
+		NumStats: &structs.NumericStats{
+			Sum: utils.NumTypeEnclosure{
+				Ntype:    utils.SS_DT_SIGNED_NUM,
+				IntgrVal: 20,
+			},
+		},
+	}
+
+	expected := &utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	result, err := GetSegAvg(runningSegStat, currSegStat)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -396,3 +396,124 @@ func TestGetSegAvg_BothSegmentsWithIntStats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
+
+func TestGetAverage_IntegerSum(t *testing.T) {
+	sum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 20,
+	}
+	count := uint64(4)
+
+	expected := 5.0
+	result := getAverage(sum, count)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestGetAverage_FloatSum(t *testing.T) {
+	sum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 20.0,
+	}
+	count := uint64(4)
+
+	expected := 5.0
+	result := getAverage(sum, count)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestGetAverage_ZeroCount(t *testing.T) {
+	sum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 20.0,
+	}
+	count := uint64(0)
+
+	// Handle division by zero if your function has specific behavior, otherwise expect NaN
+	expected := 0.0
+	result := getAverage(sum, count)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestAccumulateSum_BothInteger(t *testing.T) {
+	runningSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 10,
+	}
+	currSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 20,
+	}
+
+	expected := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 30,
+	}
+
+	result := accumulateSum(runningSum, currSum)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestAccumulateSum_RunningIntegerCurrentFloat(t *testing.T) {
+	runningSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 10,
+	}
+	currSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 20.0,
+	}
+
+	expected := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 30.0,
+		IntgrVal: 10,
+	}
+
+	result := accumulateSum(runningSum, currSum)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestAccumulateSum_RunningFloatCurrentInteger(t *testing.T) {
+	runningSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	currSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_SIGNED_NUM,
+		IntgrVal: 20,
+	}
+
+	expected := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 30.0,
+	}
+
+	result := accumulateSum(runningSum, currSum)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestAccumulateSum_BothFloat(t *testing.T) {
+	runningSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 10.0,
+	}
+	currSum := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 20.0,
+	}
+
+	expected := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 30.0,
+	}
+
+	result := accumulateSum(runningSum, currSum)
+
+	assert.Equal(t, expected, result)
+}

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -110,7 +110,7 @@ func TestGetSegList(t *testing.T) {
 			runningSegStat: nil,
 			currSegStat:    nil,
 			expectedRes:    &utils.CValueEnclosure{Dtype: utils.SS_DT_STRING_SLICE, CVal: []string{}},
-			expectedErr:    errors.New("GetSegList: currSegStat does not contain string list"),
+			expectedErr:    errors.New("GetSegList: currSegStat does not contain string list <nil>"),
 		},
 		{
 			name:           "runningSegStat is nil, currSegStat has small list",

--- a/pkg/segment/reader/segread/segstatsreader_test.go
+++ b/pkg/segment/reader/segread/segstatsreader_test.go
@@ -110,7 +110,7 @@ func TestGetSegList(t *testing.T) {
 			runningSegStat: nil,
 			currSegStat:    nil,
 			expectedRes:    &utils.CValueEnclosure{Dtype: utils.SS_DT_STRING_SLICE, CVal: []string{}},
-			expectedErr:    errors.New("GetSegList: currSegStat is nil"),
+			expectedErr:    errors.New("GetSegList: currSegStat does not contain string list"),
 		},
 		{
 			name:           "runningSegStat is nil, currSegStat has small list",

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -327,8 +327,6 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 			sstResult, err = segread.GetSegAvg(sr.runningSegStat[idx], currSst)
 		case utils.Values:
 			// If value has to be evaluated use corresponding compute agg eval
-			strSet := make(map[string]struct{})
-			if sr.runningSegStat.
 			if measureAgg.ValueColRequest != nil {
 				err := aggregations.ComputeAggEvalForValues(measureAgg, sstMap, sr.segStatsResults.measureResults, sr.runningEvalStats)
 				if err != nil {

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -344,10 +344,8 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 				return err
 			}
 
-			// Store the result in measureResults
 			sr.segStatsResults.measureResults[measureAgg.String()] = *res
 
-			// Update the running segment stats if necessary
 			if sr.runningSegStat[idx] == nil {
 				sr.runningSegStat[idx] = currSst
 			}

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -351,17 +351,22 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 					strSet[str] = struct{}{}
 				}
 			}
+
 			if sr.runningSegStat[idx] != nil {
-
-				for str := range sr.runningSegStat[idx].StringStats.StrSet {
-					strSet[str] = struct{}{}
+				if sr.runningSegStat[idx].StringStats == nil {
+					sr.runningSegStat[idx].StringStats = &structs.StringStats{
+						StrSet: strSet,
+					}
+				} else {
+					for str := range sr.runningSegStat[idx].StringStats.StrSet {
+						strSet[str] = struct{}{}
+					}
+					sr.runningSegStat[idx].StringStats.StrSet = strSet
 				}
-
-				sr.runningSegStat[idx].StringStats.StrSet = strSet
+			} else {
+				sr.runningSegStat[idx] = currSst
 			}
-
 			sr.runningEvalStats[measureAgg.String()] = strSet
-
 			uniqueStrings := make([]string, 0)
 			for str := range strSet {
 				uniqueStrings = append(uniqueStrings, str)

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -352,6 +352,7 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 				}
 			}
 
+			// update running stats
 			if sr.runningSegStat[idx] != nil {
 				if sr.runningSegStat[idx].StringStats == nil {
 					sr.runningSegStat[idx].StringStats = &structs.StringStats{


### PR DESCRIPTION
# Description
Fixes stat aggregators being ignored are fields in a query.
Fixes values and average stat aggregators giving inconsistent results after fields.


Fixes #885 (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

app_name=Bracecould | fields latency | stats avg(latency) as avg
app_name=Bracecould | fields latency | stats values(latency) as values
app_name=Bracecould | fields latency | stats count 
app_name=Bracecould | fields latency | stats min(latency)
app_name=Bracecould | fields latency | stats max(latency)
app_name=Bracecould | fields latency | stats sum(latency)
app_name=Bracecould | fields latency | stats list(latency)
app_name=Bracecould | fields latency | stats range(latency)

In all queries the result should be the same without fields in query.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
