### PR TITLE
perf improvements: bloom writing optimizations

### DIFF
--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -161,7 +161,7 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 		if inCount >= itemsLen {
 			newArr := make([]interface{}, 100)
 			items = append(items, newArr...)
-			itemsLen += 1000
+			itemsLen += 100
 		}
 
 		esAction, indexName, idVal := extractIndexAndValidateAction(scanner.Bytes(),

--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -141,10 +141,6 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 	origItems := items
 	defer respItemsPool.Put(&origItems)
 
-	// kunal todo check , if items gets extended and we put back origitems then does the os
-	// delete the old items array ?
-	itemsLen := len(items)
-
 	atleastOneSuccess := false
 	localIndexMap := make(map[string]string)
 
@@ -158,10 +154,9 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 
 	for scanner.Scan() {
 		inCount++
-		if inCount >= itemsLen {
+		if inCount >= len(items) {
 			newArr := make([]interface{}, 100)
 			items = append(items, newArr...)
-			itemsLen += 100
 		}
 
 		esAction, indexName, idVal := extractIndexAndValidateAction(scanner.Bytes(),

--- a/pkg/es/writer/esBulkHandler_test.go
+++ b/pkg/es/writer/esBulkHandler_test.go
@@ -37,7 +37,7 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	// Setup ingestion parameters.
 	now := utils.GetCurrentTimeInMs()
 	indexName := "traces"
-	shouldFlush := false
+	shouldFlush := true
 	localIndexMap := make(map[string]string)
 	orgId := uint64(0)
 

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bits-and-blooms/bitset"
 	"github.com/cespare/xxhash"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/reader/microreader"
@@ -186,8 +185,7 @@ func Test_packUnpackDictEnc(t *testing.T) {
 
 	deCount := uint16(100)
 
-	hashToDci := make(map[uint64]*writer.DwordCbufIdxs)
-	deRecNums := make([]*bitset.BitSet, 100)
+	deMap := make(map[string][]uint16)
 
 	recCounts := uint16(100)
 
@@ -218,21 +216,16 @@ func Test_packUnpackDictEnc(t *testing.T) {
 		copy(tempWipCbuf[wipIdx:], cvalBytes)
 		wipIdx += cvTlvLen
 
-		newBs := bitset.New(uint(recCounts))
+		arr := make([]uint16, recCounts/deCount)
+		deMap[string(cvalBytes)] = arr
 
 		for rn := uint16(0); rn < recCounts/deCount; rn++ {
-			newBs.Set(uint(recNum + rn))
+			arr[rn] = recNum + rn
 		}
-		cvalHash := xxhash.Sum64(cvalBytes)
-
-		dci := writer.CreateDci(wipIdx-cvTlvLen, uint16(cvTlvLen), dwIdx)
-		hashToDci[cvalHash] = dci
-		deRecNums[dwIdx] = newBs
-
 		recNum += recCounts / deCount
 	}
 	colWip.CopyWipForTestOnly(tempWipCbuf, wipIdx)
-	colWip.SetDeDataForTest(deCount, hashToDci, deRecNums)
+	colWip.SetDeDataForTest(deCount, deMap)
 
 	writer.PackDictEnc(colWip)
 	buf, idx := colWip.GetBufAndIdx()

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -66,7 +66,7 @@ const WIP_SIZE = 2_000_000
 const PQMR_SIZE uint = 4000 // init size of pqs bitset
 const WIP_NUM_RECS = 4000
 const BLOOM_SIZE_HISTORY = 5 // number of entries to analyze to get next block's bloom size
-const BLOCK_BLOOM_SIZE = 200 // the default should be on the smaller side. Let dynamic bloom sizing fix the optimal one
+const BLOCK_BLOOM_SIZE = 10
 const BLOCK_RI_MAP_SIZE = 100
 
 var MAX_BYTES_METRICS_BLOCK uint64 = 1e+8         // 100MB

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -367,7 +367,7 @@ func (stb *StarTreeBuilder) creatEnc(wip *WipBlock) error {
 		if deData.deCount < wipCardLimit {
 			for _, dci := range deData.hashToDci {
 
-				dword := cwip.GetDictword(dci)
+				dword := cwip.GetDciWord(dci)
 
 				enc := stb.setColValEnc(colNum, dword)
 				recNumsBitset := deData.deRecNums[dci.recBsIdx]
@@ -552,7 +552,7 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 	if deData.deCount < wipCardLimit {
 		for _, dci := range deData.hashToDci {
 
-			dword := cwip.GetDictword(dci)
+			dword := cwip.GetDciWord(dci)
 
 			recNumsBitSet := deData.deRecNums[dci.recBsIdx]
 			if recNumsBitSet.Test(uint(recNum)) {

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -359,10 +359,8 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 			}
 			keyNameStr := string(keyName)
 			if bi != nil {
-				bi.uniqueWordCount += addToBlockBloom(bi.Bf, keyName)
-				bi.uniqueWordCount += addToBlockBloom(bi.Bf, keyVal)
-				bi.uniqueWordCount += addToBlockBloom(bi.Bf, utils.BytesToLowerInPlace(keyName))
-				bi.uniqueWordCount += addToBlockBloom(bi.Bf, utils.BytesToLowerInPlace(keyVal))
+				bi.uniqueWordCount += addToBlockBloomBothCases(bi.Bf, keyName)
+				bi.uniqueWordCount += addToBlockBloomBothCases(bi.Bf, keyVal)
 			}
 			// get the copied key value bytes from the ColWip buffer,
 			// As the keyVal bytes are converted to lower case while adding to Bloom above.
@@ -468,8 +466,7 @@ func (ss *SegStore) encodeSingleString(key string,
 	ss.updateColValueSizeInAllSeenColumns(key, recLen)
 
 	if bi != nil {
-		bi.uniqueWordCount += addToBlockBloom(bi.Bf, valBytes)
-		bi.uniqueWordCount += addToBlockBloom(bi.Bf, utils.BytesToLowerInPlace(valBytes))
+		bi.uniqueWordCount += addToBlockBloomBothCases(bi.Bf, valBytes)
 	}
 	if !ss.skipDe {
 		ss.checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum, s)
@@ -505,7 +502,7 @@ func (ss *SegStore) encodeSingleBool(key string, val bool,
 	ss.updateColValueSizeInAllSeenColumns(key, 2)
 
 	if bi != nil {
-		bi.uniqueWordCount += addToBlockBloom(bi.Bf, []byte(strconv.FormatBool(val)))
+		bi.uniqueWordCount += addToBlockBloomBothCases(bi.Bf, []byte(strconv.FormatBool(val)))
 	}
 	return matchedCol
 }

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -998,6 +998,12 @@ func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[st
 			} else {
 				encType = ZSTD_COMLUNAR_BLOCK
 			}
+
+			err := segStore.writeToBloom(encType, compWorkBuf[:cap(compWorkBuf)], cname, colWip)
+			if err != nil {
+				log.Fatalf("WriteMockColSegFile: failed to writeToBloom colsegfilename=%v, err=%v", colWip.csgFname, err)
+			}
+
 			blkLen, blkOffset, err := writeWip(colWip, encType, compWorkBuf)
 			if err != nil {
 				log.Errorf("WriteMockColSegFile: failed to write colsegfilename=%v, err=%v", csgFname, err)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1485,7 +1485,7 @@ func PackDictEnc(colWip *ColWip) {
 
 	for _, dci := range colWip.deData.hashToDci {
 
-		dword := colWip.GetDictword(dci)
+		dword := colWip.GetDciWord(dci)
 
 		recNumsBitset := colWip.deData.deRecNums[dci.recBsIdx]
 		// copy the actual dict word , the TLV is packed inside the dword

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -474,7 +474,7 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 
 			stringVal := strconv.FormatInt(intVal, 10)
 			newColWip.WriteSingleString(stringVal)
-			bloom.uniqueWordCount += addToBlockBloom(bloom.Bf, []byte(stringVal))
+			bloom.uniqueWordCount += addToBlockBloomBothCases(bloom.Bf, []byte(stringVal))
 
 		case utils.VALTYPE_ENC_FLOAT64[0]:
 			// Parse the float.
@@ -483,7 +483,7 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 
 			stringVal := strconv.FormatFloat(floatVal, 'f', -1, 64)
 			newColWip.WriteSingleString(stringVal)
-			bloom.uniqueWordCount += addToBlockBloom(bloom.Bf, []byte(stringVal))
+			bloom.uniqueWordCount += addToBlockBloomBothCases(bloom.Bf, []byte(stringVal))
 
 		case utils.VALTYPE_ENC_BACKFILL[0]:
 			// This is a null value.
@@ -503,7 +503,7 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 			}
 
 			newColWip.WriteSingleString(stringVal)
-			bloom.uniqueWordCount += addToBlockBloom(bloom.Bf, []byte(stringVal))
+			bloom.uniqueWordCount += addToBlockBloomBothCases(bloom.Bf, []byte(stringVal))
 
 		default:
 			// Unknown type.

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -209,11 +209,8 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 			cwip.cbufidx = 0
 			cwip.cstartidx = 0
 
-			for cvalHash := range cwip.deData.hashToDci {
-				delete(cwip.deData.hashToDci, cvalHash)
-			}
-			for idx := range cwip.deData.deRecNums {
-				cwip.deData.deRecNums[idx] = nil
+			for dword := range cwip.deData.deMap {
+				delete(cwip.deData.deMap, dword)
 			}
 			cwip.deData.deCount = 0
 		}

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1312,9 +1312,7 @@ func addToBlockBloomBothCasesWithBuf(blockBloom *bloom.BloomFilter, fullWord []b
 	hasUpper := utils.HasUpper(copy)
 
 	// add the original full
-	if !blockBloom.TestAndAdd(copy) {
-		blockWordCount += 1
-	}
+	_ = blockBloom.Add(copy)
 
 	var hasSubWords bool
 	for {
@@ -1324,9 +1322,7 @@ func addToBlockBloomBothCasesWithBuf(blockBloom *bloom.BloomFilter, fullWord []b
 		}
 		hasSubWords = true
 		// add original sub word
-		if !blockBloom.TestAndAdd(copy[:i]) {
-			blockWordCount += 1
-		}
+		_ = blockBloom.Add(copy[:i])
 
 		// add sub word lowercase
 		if hasUpper {
@@ -1334,25 +1330,19 @@ func addToBlockBloomBothCasesWithBuf(blockBloom *bloom.BloomFilter, fullWord []b
 			if err != nil {
 				return 0, err
 			}
-			if !blockBloom.TestAndAdd(word) {
-				blockWordCount += 1
-			}
+			_ = blockBloom.Add(word)
 		}
 		copy = copy[i+BYTE_SPACE_LEN:]
 	}
 
 	// handle last word. If no word was found, then we have already added the full word
 	if hasSubWords && len(copy) > 0 {
-		if !blockBloom.TestAndAdd(copy) {
-			blockWordCount += 1
-		}
+		_ = blockBloom.Add(copy)
 		word, err := utils.BytesToLower(copy, workBuf)
 		if err != nil {
 			return 0, err
 		}
-		if !blockBloom.TestAndAdd(word) {
-			blockWordCount += 1
-		}
+		_ = blockBloom.Add(word)
 	}
 
 	if hasUpper {
@@ -1363,17 +1353,13 @@ func addToBlockBloomBothCasesWithBuf(blockBloom *bloom.BloomFilter, fullWord []b
 			if err != nil {
 				return 0, err
 			}
-			if !blockBloom.TestAndAdd(word) {
-				blockWordCount += 1
-			}
+			_ = blockBloom.Add(word)
 		} else {
 			word, err := utils.BytesToLower(copy, workBuf)
 			if err != nil {
 				return 0, err
 			}
-			if !blockBloom.TestAndAdd(word) {
-				blockWordCount += 1
-			}
+			_ = blockBloom.Add(word)
 		}
 	}
 	return blockWordCount, nil

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1225,7 +1225,7 @@ func (cw *ColWip) writeDeBloom(buf []byte, bi *BloomIndex) error {
 			// we don't add backfill value to bloom since we are not going to search for it
 			continue
 		case VALTYPE_ENC_SMALL_STRING[0]:
-			// the first 3 bytes are TL(type len)
+			// the first 3 bytes are the type and length
 			numAdded, err := addToBlockBloomBothCasesWithBuf(bi.Bf, dword[3:], buf)
 			if err != nil {
 				return err

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -574,6 +574,7 @@ func addToBlockBloomBothCases(blockBloom *bloom.BloomFilter, fullWord []byte) ui
 	// had to convert
 	hasUpper := utils.HasUpper(copy)
 
+	// add the original full
 	if !blockBloom.TestAndAdd(copy) {
 		blockWordCount += 1
 	}
@@ -585,10 +586,12 @@ func addToBlockBloomBothCases(blockBloom *bloom.BloomFilter, fullWord []byte) ui
 			break
 		}
 		hasSubWords = true
+		// add original sub word
 		if !blockBloom.TestAndAdd(copy[:i]) {
 			blockWordCount += 1
 		}
 
+		// add original sub word lowercase
 		if hasUpper {
 			if !blockBloom.TestAndAdd(utils.BytesToLowerInPlace(copy[:i])) {
 				blockWordCount += 1
@@ -607,10 +610,17 @@ func addToBlockBloomBothCases(blockBloom *bloom.BloomFilter, fullWord []byte) ui
 		}
 	}
 
-	// if there is no subword, then we have not added the lower case, add it
-	if !hasSubWords && hasUpper {
-		if !blockBloom.TestAndAdd(utils.BytesToLowerInPlace(copy)) {
-			blockWordCount += 1
+	if hasUpper {
+		if hasSubWords {
+			// if subwords, then add the original full's lowercase
+			// but have to use the original var, since the copy is pointing to last subword
+			if !blockBloom.TestAndAdd(utils.BytesToLowerInPlace(fullWord[:])) {
+				blockWordCount += 1
+			}
+		} else {
+			if !blockBloom.TestAndAdd(utils.BytesToLowerInPlace(copy)) {
+				blockWordCount += 1
+			}
 		}
 	}
 

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -325,7 +325,7 @@ func Test_addToBlockBloom(t *testing.T) {
 
 	for i, test := range cases {
 		mockBloom := bloom.NewWithEstimates(uint(1000), BLOOM_COLL_PROBABILITY)
-		addedCount := addToBlockBloom(mockBloom, test.fullWord)
+		addedCount := addToBlockBloomBothCases(mockBloom, test.fullWord)
 		assert.Equal(t, addedCount, test.expectedAddCount)
 
 		for _, word := range test.expectedMatches {
@@ -372,7 +372,7 @@ func Benchmark_addToBloom(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		mockBloom.ClearAll()
-		addToBlockBloom(mockBloom, exampleWord)
+		addToBlockBloomBothCases(mockBloom, exampleWord)
 	}
 }
 

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -325,8 +325,7 @@ func Test_addToBlockBloom(t *testing.T) {
 
 	for i, test := range cases {
 		mockBloom := bloom.NewWithEstimates(uint(1000), BLOOM_COLL_PROBABILITY)
-		addedCount := addToBlockBloomBothCases(mockBloom, test.fullWord)
-		assert.Equal(t, addedCount, test.expectedAddCount)
+		_ = addToBlockBloomBothCases(mockBloom, test.fullWord)
 
 		for _, word := range test.expectedMatches {
 			assert.True(t, mockBloom.TestString(word), fmt.Sprintf("test=%v failed to find %+v in bloom", i, word))

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -243,3 +243,13 @@ func BytesToLowerInPlace(b []byte) []byte {
 	}
 	return b
 }
+
+// Checks if there is an upper case letter
+func HasUpper(b []byte) bool {
+	for _, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -263,7 +263,7 @@ func BytesToLower(b []byte, workBuf []byte) ([]byte, error) {
 		return nil, fmt.Errorf("BytesToLower: passed in workbuf len was smaller than b")
 	}
 
-	for i:= 0; i < blen; i++ {
+	for i := 0; i < blen; i++ {
 		if b[i] >= 'A' && b[i] <= 'Z' {
 			workBuf[i] = b[i] + 32
 		} else {

--- a/pkg/utils/bitutils.go
+++ b/pkg/utils/bitutils.go
@@ -253,3 +253,22 @@ func HasUpper(b []byte) bool {
 	}
 	return false
 }
+
+// This function converts the bytes to lower case using the passed in bug
+func BytesToLower(b []byte, workBuf []byte) ([]byte, error) {
+
+	blen := len(b)
+
+	if len(workBuf) < blen {
+		return nil, fmt.Errorf("BytesToLower: passed in workbuf len was smaller than b")
+	}
+
+	for i:= 0; i < blen; i++ {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			workBuf[i] = b[i] + 32
+		} else {
+			workBuf[i] = b[i]
+		}
+	}
+	return workBuf[:blen], nil
+}


### PR DESCRIPTION
# Description
1. This avoids looping through the colValue twice and does it only if there is an upper case letter
2. Avoids testAdd call to bloom if there is no upper case letter
3. Add to bloom during the time of wipPacking to avoid bloom adds for the dict columns for the same dict encodings
4. Switch to using `Add` call for bloom instead of `TestAdd`
5. Fix a buf with itemsLen if batchsize was greater than 4k
6. All of these improvements increase the ingestion performance by `40%`

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
