### PR TITLE
Fix stats count for MatchAllQuery

### DIFF
--- a/pkg/segment/query/metadata/metadata.go
+++ b/pkg/segment/query/metadata/metadata.go
@@ -557,6 +557,7 @@ func FilterSegmentsByTime(timeRange *dtu.TimeRange, indexNames []string, orgid u
 						EndEpochMs:   smi.LatestEpochMS,
 					},
 					ConsistentCValLenMap: smi.GetAllColumnsRecSize(),
+					TotalRecords:         smi.GetRecordCount(),
 				}
 				timePassed++
 			}

--- a/pkg/segment/query/metadata/segmentmicroindex.go
+++ b/pkg/segment/query/metadata/segmentmicroindex.go
@@ -281,3 +281,7 @@ func (sm *SegmentMicroIndex) GetAllColumnsRecSize() map[string]uint32 {
 	}
 	return retVal
 }
+
+func (sm *SegmentMicroIndex) GetRecordCount() uint32 {
+	return uint32(sm.SegMeta.RecordCount)
+}

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -801,6 +801,9 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 				allSegFileResults.AddError(err)
 				continue
 			}
+			sstMap["*"] = &structs.SegStats{
+				Count: uint64(segReq.TotalRecords),
+			}
 		} else {
 			// run through micro index check for block tracker & generate SSR
 			blocksToRawSearch, err := segReq.GetMicroIndexFilter()
@@ -1066,6 +1069,7 @@ func FilterAggSegKeysToQueryResults(qInfo *QueryInformation, allPossibleKeys map
 				segKeyTsRange:        segTimeCs.TimeRange,
 				tableName:            tableName,
 				ConsistentCValLenMap: segTimeCs.ConsistentCValLenMap,
+				TotalRecords:         segTimeCs.TotalRecords,
 			}
 
 			qReq.sType = segType
@@ -1111,6 +1115,7 @@ func ConvertSegKeysToQueryRequests(qInfo *QueryInformation, allPossibleKeys map[
 				segKeyTsRange:        segTimeCs.TimeRange,
 				tableName:            tableName,
 				ConsistentCValLenMap: segTimeCs.ConsistentCValLenMap,
+				TotalRecords:         segTimeCs.TotalRecords,
 			}
 			allSegRequests = append(allSegRequests, qReq)
 		}

--- a/pkg/segment/query/segqueryhelpers.go
+++ b/pkg/segment/query/segqueryhelpers.go
@@ -59,6 +59,7 @@ type QuerySegmentRequest struct {
 	blkTracker           *structs.BlockTracker
 	HasMatchedRrc        bool
 	ConsistentCValLenMap map[string]uint32
+	TotalRecords         uint32
 }
 
 func (qi *QueryInformation) GetSearchNode() *structs.SearchNode {

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -248,12 +248,8 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 		aggOp := measureAgg.MeasureFunc
 		aggCol := measureAgg.MeasureCol
 
-		if aggOp == utils.Count && aggCol == "*" {
-			// Choose the first column.
-			for key := range sstMap {
-				aggCol = key
-				break
-			}
+		if aggOp != utils.Count && aggCol == "*" {
+			return fmt.Errorf("UpdateSegmentStats: aggOp: %v cannot be applied with *, qid=%v", aggOp, sr.qid)
 		}
 		currSst, ok := sstMap[aggCol]
 		if !ok && measureAgg.ValueColRequest == nil {

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -132,6 +132,7 @@ type BlockTracker struct {
 type SegmentByTimeAndColSizes struct {
 	TimeRange            *dtu.TimeRange
 	ConsistentCValLenMap map[string]uint32
+	TotalRecords         uint32
 }
 
 func InitTableInfo(rawRequest string, orgid uint64, es bool) *TableInfo {

--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -546,7 +546,8 @@ func FilterUnrotatedSegmentsInQuery(timeRange *dtu.TimeRange, indexNames []strin
 			retVal[usi.TableName] = make(map[string]*structs.SegmentByTimeAndColSizes)
 		}
 		retVal[usi.TableName][segKey] = &structs.SegmentByTimeAndColSizes{
-			TimeRange: usi.tsRange,
+			TimeRange:    usi.tsRange,
+			TotalRecords: uint32(usi.RecordCount),
 		}
 		totalCount++
 	}


### PR DESCRIPTION
# Description
Summarize the change.
In the case of matchAllQuery like `* | stats count` we were just picking up a random column from the sstMap and then using that count. If records have NULL values, the count would vary based on the column picked (Note: Map iteration order is not deterministic).
Find the total records in the segment from microIndices and then pass that on to the SegmentQueryRequest. Use this value to get the count.

Showing the message explicitly because, often it is confusing for people to apply operators with `*` which is only supported for count.

`request_id=* | stats count` was giving correct results because we are [populating](https://github.com/siglens/siglens/blob/523968fba532486e00054b05e924757b25cdb7db/pkg/segment/search/searchaggs.go#L958) sstMap for `*` because for raw search for `count` with `*`.

After this fix `* | stats count` should also return same result as above.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Insert dummy data with NULL values in the column and then query.
Moreover, tested by ingesting esbulk across multiple segments.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
