### PR TITLE
Bump Version to 0.2.35d

### DIFF
--- a/RELEASE_README.md
+++ b/RELEASE_README.md
@@ -9,15 +9,15 @@ SigLens executable should support: `linux/arm64, linux/amd64, darwin/arm64, and 
 ## SigLens Release Steps
 
 1. The version number in `develop` will have a suffix, for example: “0.1.29d”.
-2. When you are ready to do a release, remove the “d” suffix in the version number `SigLensVersion` located in `pkg/config/version.go` and create a pull request to merge these changes into `develop`. After merging, `develop` will now have the updated version number without the "d" suffix, for example: “0.1.29”.
-***This step is critical. Failure to increment this number will lead to failure in creating a GitHub release.***
+2. When you are ready to do a release, remove the “d” suffix in the version number `SigLensVersion` located in `pkg/config/version.go`. ***This step is critical. Failure to increment this number will lead to failure in creating a GitHub release.***
 3. Update the `CSSVersion` function in the `startQueryServer` function (located in the `startup.go` file) to return the new version number. This ensures proper cache busting for CSS files.
-4. Add detailed release notes in the pull request describing the changes, enhancements, and bug fixes in this release.
-5. Merge develop to `main` using Create a Merge Commit. Do NOT Squash and Merge.
-6. GitHub Actions will take care of the following builds:
+4. Create a pull request to merge these changes into `develop`. After merging, `develop` will now have the updated version number without the "d" suffix, for example: “0.1.29”.
+5. Add detailed release notes in the pull request describing the changes, enhancements, and bug fixes in this release.
+6. Merge develop to `main` using Create a Merge Commit. Do NOT Squash and Merge.
+7. GitHub Actions will take care of the following builds:
    1. siglens docker image
       - `linux/amd64, linux/arm64`
       - The docker image build uses buildx to create an image index & the corresponding builds
-7. Once the release completes, increment the version number in `develop`. The version in the `develop` branch should include a suffix, for example: "0.1.30d" for differentiation.
+8. Once the release completes, increment the version number and CSS version number in `develop`. The version in the `develop` branch should include a suffix, for example: "0.1.30d" for differentiation.
 
 Note: The main branch will never have the "d" suffix in the version number. The "d" suffix is only for the develop branch to indicate a development version.

--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -383,7 +383,7 @@ func startQueryServer(serverAddr string) {
 					return emptyHtmlContent
 				},
 				"CSSVersion": func() string {
-					return "0.2.34"
+					return "0.2.35d"
 				},
 			})
 			textTemplate := texttemplate.New("other")

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -21,4 +21,4 @@
 
 package config
 
-const SigLensVersion = "0.2.34"
+const SigLensVersion = "0.2.35d"


### PR DESCRIPTION
# Description
- Bumps the version to `0.2.35d`
- Also includes an update to the `Release_read_me` file.
