### PR TITLE
Backend API to show column count on My Org

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -321,6 +321,7 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 	allVTableCounts := segwriter.GetVTableCountsForAll(myid, allSegMetas)
 
 	allIndexCols := make(map[string]map[string]struct{})
+	totalCols := make(map[string]struct{})
 
 	// Create a map to store segment counts per index
 	segmentCounts := make(map[string]int)
@@ -340,6 +341,7 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 		}
 		for col := range segMeta.ColumnNames {
 			allIndexCols[indexName][col] = struct{}{}
+			totalCols[col] = struct{}{}
 		}
 	}
 
@@ -375,13 +377,6 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 		}
 
 		stats.IndexToStats[indexName] = indexStats
-	}
-
-	totalCols := make(map[string]struct{})
-	for _, indexCols := range allIndexCols {
-		for col := range indexCols {
-			totalCols[col] = struct{}{}
-		}
 	}
 
 	return stats, totalEventCount, totalBytes, totalOnDiskBytes, uint64(len(totalCols))

--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -86,8 +86,8 @@ func ProcessClusterStatsHandler(ctx *fasthttp.RequestCtx, myid uint64) {
 
 	httpResp.IngestionStats["Metrics Incoming Volume"] = convertBytesToGB(float64(metricsIncomingBytes))
 
-	httpResp.IngestionStats["Event Count"] = humanize.Comma(int64(logsColumnCount))
-	httpResp.IngestionStats["Segment Count"] = humanize.Comma(int64(logsColumnCount))
+	httpResp.IngestionStats["Event Count"] = humanize.Comma(int64(logsEventCount))
+	httpResp.IngestionStats["Column Count"] = humanize.Comma(int64(logsColumnCount))
 
 	httpResp.IngestionStats["Log Storage Used"] = convertBytesToGB(logsOnDiskBytes)
 	httpResp.IngestionStats["Metrics Storage Used"] = convertBytesToGB(float64(metricsOnDiskBytes + metricsInMemBytes))
@@ -158,8 +158,8 @@ func convertDataToSlice(allIndexStats utils.AllIndexesStats, volumeField, countF
 		nextVal[index] = make(map[string]interface{})
 		nextVal[index][volumeField] = convertBytesToGB(float64(indexStats.NumBytesIngested))
 		nextVal[index][countField] = humanize.Comma(int64(indexStats.NumRecords))
-		// nextVal[index][segmentCountField] = humanize.Comma(int64(indexStats.NumSegments))
-		nextVal[index][segmentCountField] = humanize.Comma(int64(indexStats.NumColumns))
+		nextVal[index][segmentCountField] = humanize.Comma(int64(indexStats.NumSegments))
+		nextVal[index][columnCountField] = humanize.Comma(int64(indexStats.NumColumns))
 
 		retVal = append(retVal, nextVal)
 	}

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -313,7 +313,7 @@ func processSearchRequest(searchRequestBody *structs.SearchRequestBody, myid uin
 func MonitorSpansHealth() {
 	time.Sleep(1 * time.Minute) // Wait for initial traces ingest first
 	for {
-		_, traceIndexCount, _, _ := health.GetTraceStatsForAllSegments(0)
+		_, traceIndexCount, _, _, _ := health.GetTraceStatsForAllSegments(0)
 		if traceIndexCount > 0 {
 			ProcessRedTracesIngest()
 		}
@@ -503,7 +503,7 @@ func DependencyGraphThread() {
 
 		time.Sleep(sleepDuration)
 
-		_, traceIndexCount, _, _ := health.GetTraceStatsForAllSegments(0)
+		_, traceIndexCount, _, _, _ := health.GetTraceStatsForAllSegments(0)
 		if traceIndexCount > 0 {
 			// Calculate startEpoch and endEpoch for the last hour
 			endEpoch := time.Now().UnixMilli()

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -378,6 +378,7 @@ type IndexStats struct {
 	NumBytesIngested uint64
 	NumRecords       uint64
 	NumSegments      uint64
+	NumColumns       uint64
 }
 
 type ClusterStatsResponseInfo struct {


### PR DESCRIPTION
# Description
Summarize the change.
Created a Backend API to show column count on My Org.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Checked the network response to validate it.
```
{
    "ingestionStats": {
        "Column Count": "33",
        "Event Count": "100,000",
        "Incoming Volume": "0.101 GB",
        "Log Incoming Volume": "0.101 GB",
        "Log Storage Used": "0.024 GB",
        "Logs Storage Saved": 76.60865500384506,
        "Metrics Incoming Volume": "0.000 GB",
        "Metrics Storage Saved": 0,
        "Metrics Storage Used": "0.000 GB"
    },
...
    "indexStats": [
        {
            "ind-0": {
                "columnCount": "33",
                "eventCount": "10,000",
                "ingestVolume": "0.010 GB",
                "segmentCount": "1"
            }
        },
        {
            "ind-1": {
                "columnCount": "33",
                "eventCount": "10,000",
                "ingestVolume": "0.010 GB",
                "segmentCount": "1"
            }
        }
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
