### PR TITLE
Remove test data even when tests panic

### DIFF
--- a/pkg/segment/segexecution_test.go
+++ b/pkg/segment/segexecution_test.go
@@ -1473,6 +1473,8 @@ func getMyIds() []uint64 {
 }
 
 func Test_Query(t *testing.T) {
+	t.Cleanup(func() { os.RemoveAll("data/") })
+
 	config.InitializeDefaultConfig(t.TempDir())
 	_ = localstorage.InitLocalStorage()
 	limit.InitMemoryLimiter()
@@ -1501,11 +1503,11 @@ func Test_Query(t *testing.T) {
 	asyncQueryTest(t, numBuffers, numEntriesForBuffer, fileCount)
 
 	groupByQueryTestsForAsteriskQueries(t, numBuffers, numEntriesForBuffer, fileCount)
-
-	os.RemoveAll("data/")
 }
 
 func Test_Scroll(t *testing.T) {
+	t.Cleanup(func() { os.RemoveAll("data/") })
+
 	config.InitializeDefaultConfig(t.TempDir())
 	limit.InitMemoryLimiter()
 	_ = localstorage.InitLocalStorage()
@@ -1520,10 +1522,11 @@ func Test_Scroll(t *testing.T) {
 	metadata.InitMockColumnarMetadataStore("data/", fileCount, numBuffers, numEntriesForBuffer)
 	testESScroll(t, numBuffers, numEntriesForBuffer, fileCount)
 	testPipesearchScroll(t, numBuffers, numEntriesForBuffer, fileCount)
-	os.RemoveAll("data/")
 }
 
 func Test_unrotatedQuery(t *testing.T) {
+	t.Cleanup(func() { os.RemoveAll(config.GetDataPath()) })
+
 	config.InitializeTestingConfig(t.TempDir())
 	config.SetDataPath("unrotatedtest/")
 	limit.InitMemoryLimiter()
@@ -1655,14 +1658,14 @@ func Test_unrotatedQuery(t *testing.T) {
 	result = ExecuteQuery(simpleNode, aggs, uint64(numBatch*numRec*2), qc)
 	assert.Equal(t, backfillExpectecd, result.TotalResults.TotalCount)
 	assert.Equal(t, Equals, result.TotalResults.Op)
-	os.RemoveAll(config.GetDataPath())
 }
 
 func Test_EncodeDecodeBlockSummary(t *testing.T) {
+	dir := "data/"
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
 	batchSize := 10
 	entryCount := 10
-	dir := "data/"
 	err := os.MkdirAll(dir, os.FileMode(0755))
 	_ = localstorage.InitLocalStorage()
 
@@ -1676,7 +1679,6 @@ func Test_EncodeDecodeBlockSummary(t *testing.T) {
 	writer.WriteMockBlockSummary(blockSumFile, blockSummaries, allBmhInMem)
 	blockSums, readAllBmh, _, err := microreader.ReadBlockSummaries(blockSumFile, []byte{})
 	if err != nil {
-		os.RemoveAll(dir)
 		log.Fatal(err)
 	}
 
@@ -1691,7 +1693,6 @@ func Test_EncodeDecodeBlockSummary(t *testing.T) {
 		assert.Equal(t, uint32(30), readAllBmh[uint16(i)].ColumnBlockLen["key1"])
 		assert.Equal(t, int64(i*30), readAllBmh[uint16(i)].ColumnBlockOffset["key1"])
 	}
-	os.RemoveAll(dir)
 }
 
 func Benchmark_agileTreeQueryReader(t *testing.B) {


### PR DESCRIPTION
# Description
Unmerged changes in a different branch caused some tests to panic. This inhibited the cleanup logic, so then during development when you switch back to a branch like develop where the tests should pass, they were still failing because there were leftover files. This PR fixes this issue by using `t.Cleanup()` to ensure the cleanup logic happens even in the case of panics (see https://go.dev/play/p/I4UaAb5Fd8Z)

# Testing
The leftover data was in `pkg/segment/data`. After running `make test` again with these changes, the tests still panicked (as I was on a feature branch that has issues), but `pkg/segment/data` got cleaned up correctly. Then switching back to develop and running `make test`, the tests all passed (as expected)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
