### PR TITLE
fix: Building and Pushing of SigClient image to DockerHub

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -72,10 +72,10 @@ jobs:
           uses: docker/build-push-action@v3
           continue-on-error: true
           with:
-              context: .
-              file: tools/sigclient/Dockerfile
+              context: tools/sigclient
+              file: Dockerfile
               push: true
-              tags: sigclient/sigclient:latest
+              tags: siglens/sigclient:latest
   sigscalr-release-assets:
       runs-on: ubuntu-latest
       environment: build-environment

--- a/tools/sigclient/Dockerfile
+++ b/tools/sigclient/Dockerfile
@@ -5,7 +5,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-WORKDIR /usr/app/tools/sigclient
+WORKDIR /usr/app
 RUN go build -o sigclient main.go
 
 CMD ["./sigclient"]

--- a/tools/sigclient/Dockerfile
+++ b/tools/sigclient/Dockerfile
@@ -8,4 +8,4 @@ COPY . .
 WORKDIR /usr/app
 RUN go build -o sigclient main.go
 
-CMD ["./sigclient"]
+ENTRYPOINT ["./sigclient"]


### PR DESCRIPTION
# Description
- There is an issue with building of docker image for SigClient. We were copying the `go.mod` and `go.sum` files of SigLens instead of SigClient and then copying everything of SigLens and in the docker switching the worker directory to `tools/SigClient` and then we are building the image. 
- Even though the above one works we are needlessly copying the whole siglens and running `go mod` for SigLens.
- Also there is an issue with pushing of SigClient image, the existing [job fails at pushing of SigClient image](https://github.com/siglens/siglens/actions/runs/10744047913/job/29800103071#step:4:227) (not sure why it says the job is successful)
- So I have updated these two configs

# Testing
- I have tested that the docker is being built successfully, but I have not verified the Github Actions flow.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
