### PR TITLE
Add util to estimate runtime size of struct

### DIFF
--- a/pkg/utils/debugutils.go
+++ b/pkg/utils/debugutils.go
@@ -18,6 +18,8 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -91,4 +93,17 @@ func SigDebugExit(computeExtraMessage func() string) {
 func extractFuncName(funcName string) string {
 	funcNameSplit := strings.Split(funcName, ".")
 	return funcNameSplit[len(funcNameSplit)-1]
+}
+
+// Useful for estimating runtime size of structs.
+func GetGobSize(v interface{}) int {
+	var buffer bytes.Buffer
+	encoder := gob.NewEncoder(&buffer)
+
+	err := encoder.Encode(v)
+	if err != nil {
+		return 0
+	}
+
+	return buffer.Len()
 }


### PR DESCRIPTION
# Description
This adds a util that can be helpful during development to estimate how much memory a struct is consuming at runtime.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
