### PR TITLE
increase segfile size to avoid too fast rotations

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -495,7 +495,7 @@ func GetTestConfig(dataPath string) common.Configuration {
 		S3:                          common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
 		RetentionHours:              24 * 90,
 		TimeStampKey:                "timestamp",
-		MaxSegFileSize:              1_073_741_824,
+		MaxSegFileSize:              4_294_967_296,
 		LicenseKeyPath:              "./",
 		ESVersion:                   "",
 		Debug:                       false,
@@ -723,7 +723,7 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 		config.LicenseKeyPath = "./"
 	}
 	if config.MaxSegFileSize <= 0 {
-		config.MaxSegFileSize = 1_073_741_824
+		config.MaxSegFileSize = 4_294_967_296
 	}
 	if len(config.ESVersion) <= 0 {
 		config.ESVersion = "6.8.20"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -261,7 +261,7 @@ a: b
 				S3:                          common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
 				RetentionHours:              15 * 24,
 				TimeStampKey:                "timestamp",
-				MaxSegFileSize:              1_073_741_824,
+				MaxSegFileSize:              4_294_967_296,
 				LicenseKeyPath:              "./",
 				ESVersion:                   "6.8.20",
 				DataDiskThresholdPercent:    85,

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -134,6 +134,7 @@ var VALTYPE_ENC_INT64 = []byte{0x10}
 var VALTYPE_ENC_FLOAT64 = []byte{0x11}
 var VALTYPE_ENC_LARGE_STRING = []byte{0x12}
 var VALTYPE_ENC_BACKFILL = []byte{0x13}
+var STR_VALTYPE_ENC_BACKFILL = string([]byte{0x13})
 var VALTYPE_DICT_ARRAY = []byte{0x14}
 var VALTYPE_RAW_JSON = []byte{0x15}
 
@@ -176,7 +177,7 @@ const (
 const STALE_RECENTLY_ROTATED_ENTRY_MS = 60_000             // one minute
 const SEGMENT_ROTATE_DURATION_SECONDS = 15 * 60            // 15 mins
 var UPLOAD_INGESTNODE_DIR = time.Duration(1 * time.Minute) // one minute
-const SEGMENT_ROTATE_SLEEP_DURATION_SECONDS = 60           // 1 min
+const SEGMENT_ROTATE_SLEEP_DURATION_SECONDS = 120
 
 var QUERY_EARLY_EXIT_LIMIT = uint64(10_000)
 var QUERY_MAX_BUCKETS = uint64(10_000)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -44,6 +44,7 @@ import (
 )
 
 var wipCardLimit uint16 = 501
+
 const MaxDeEntries = 1002 // this should be atleast 2x of wipCardLimit
 
 const FPARM_INT64 = int64(0)
@@ -589,6 +590,7 @@ func initMicroIndices(key string, valType SS_DTYPE, colBlooms map[string]*BloomI
 func (ss *SegStore) backFillPastRecords(key string, valType SS_DTYPE, recNum uint16, colBlooms map[string]*BloomIndex,
 	colRis map[string]*RangeIndex, colWip *ColWip) uint32 {
 
+	initMicroIndices(key, valType, colBlooms, colRis)
 	packedLen := uint32(0)
 
 	recArr := make([]uint16, recNum)


### PR DESCRIPTION
# Description
Summarize the change.
1. Increase segfile size to avoid too fast rotations on high load
2. Decrease dict card limit for perf reasons when hihg card columns were present, we were doing too many string conversion on each new wip to check if we have exceeded card limit and allocating a rec array for each unique value

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
