### PR TITLE
Use read lock to get segstore

### DIFF
--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1313,7 +1313,7 @@ func createMockTsRollupWipBlock(t *testing.T, segkey string) *WipBlock {
 		cnames[cidx] = currCol
 	}
 	sId := "ts-rollup"
-	segstore, err := getSegStore(sId, "test", 0)
+	segstore, err := getOrCreateSegStore(sId, "test", 0)
 	if err != nil {
 		log.Errorf("createMockTsRollupWipBlock, getSegstore err=%v", err)
 		return nil

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -147,7 +147,7 @@ func TestRecordEncodeDecode(t *testing.T) {
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
 		sId := fmt.Sprintf("test-%d", i)
-		segstore, err := getSegStore(sId, "test", 0)
+		segstore, err := getOrCreateSegStore(sId, "test", 0)
 		if err != nil {
 			log.Errorf("AddEntryToInMemBuf, getSegstore err=%v", err)
 			t.Errorf("failed to get segstore! %v", err)
@@ -259,7 +259,7 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
 		sId := fmt.Sprintf("test-%d", i)
-		segstore, err := getSegStore(sId, "test", 0)
+		segstore, err := getOrCreateSegStore(sId, "test", 0)
 		if err != nil {
 			log.Errorf("AddEntryToInMemBuf, getSegstore err=%v", err)
 			t.Errorf("failed to get segstore! %v", err)
@@ -552,7 +552,7 @@ func Test_SegStoreAllColumnsRecLen(t *testing.T) {
 
 	cTime := uint64(time.Now().UnixMilli())
 	sId := fmt.Sprintf("test-%d", cTime)
-	segstore, err := getSegStore(sId, "test", 0)
+	segstore, err := getOrCreateSegStore(sId, "test", 0)
 	if err != nil {
 		log.Errorf("AddEntryToInMemBuf, getSegstore err=%v", err)
 		t.Errorf("failed to get segstore! %v", err)

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -62,7 +62,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 	for i, test := range cases {
 		cTime := uint64(time.Now().UnixMilli())
 		sId := fmt.Sprintf("test-a-%d", i)
-		segstore, err := getSegStore(sId, "test", 0)
+		segstore, err := getOrCreateSegStore(sId, "test", 0)
 		if err != nil {
 			log.Errorf("AddEntryToInMemBuf, getSegstore err=%v", err)
 			t.Errorf("failed to get segstore! %v", err)

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -310,7 +310,7 @@ func AddEntryToInMemBuf(streamid string, indexName string, flush bool,
 	signalType SIGNAL_TYPE, orgid uint64, rid uint64, cnameCacheByteHashToStr map[uint64]string,
 	jsParsingStackbuf []byte, pleArray []*ParsedLogEvent) error {
 
-	segstore, err := getSegStore(streamid, indexName, orgid)
+	segstore, err := getOrCreateSegStore(streamid, indexName, orgid)
 	if err != nil {
 		log.Errorf("AddEntryToInMemBuf, getSegstore err=%v", err)
 		return err
@@ -671,7 +671,7 @@ func InitColWip(segKey string, colName string) *ColWip {
 // varint stores length of Record , it would occupy 1-9 bytes
 // The first bit of each byte of varint specifies whether there are follow on bytes
 // rest 7 bits are used to store the number
-func getSegStore(streamid string, table string, orgId uint64) (*SegStore, error) {
+func getOrCreateSegStore(streamid string, table string, orgId uint64) (*SegStore, error) {
 
 	allSegStoresLock.Lock()
 	defer allSegStoresLock.Unlock()

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -683,8 +683,8 @@ func getOrCreateSegStore(streamid string, table string, orgId uint64) (*SegStore
 }
 
 func getSegStore(streamid string) *SegStore {
-	allSegStoresLock.Lock()
-	defer allSegStoresLock.Unlock()
+	allSegStoresLock.RLock()
+	defer allSegStoresLock.RUnlock()
 
 	segstore, present := allSegStores[streamid]
 	if !present {


### PR DESCRIPTION
# Description
This PR reduces some unnecessary locking. Theres a `RWMutex` used to control access to a map of all unrotated segstores. Previously, when getting or creating a segstore, we would always acquire the write lock; now we generally acquire the read lock, but still acquire the write lock if necessary.

# Testing
## Correctness
Manually tested an ingestion with ~20 threads and indexes, and there wasn't any panic like "concurrent map read and write"

## Performance
Ran ingestion like this:
```
go run main.go ingest esbulk -n 20 -g dynamic-user -d http://localhost:8081/elastic -p 23 -t 5_000_000 -i bidx -b 1000
```
and then pprof:
```
go tool pprof http://localhost:5122/debug/pprof/block
```

Before, locking in `getSegStore()` was blocking for 3.31 seconds. Now, `getOrCreateSegstore()` (it was renamed) only blocks for 0.00525 seconds. Also, ingestion on my local machine increased from 242 MB/s to 248 MB/s

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
