### PR TITLE
Bump Version to 0.2.36d

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -73,7 +73,7 @@ jobs:
           continue-on-error: true
           with:
               context: tools/sigclient
-              file: Dockerfile
+              file: tool/sigclient/Dockerfile
               push: true
               tags: siglens/sigclient:latest
   sigscalr-release-assets:

--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -385,7 +385,7 @@ func startQueryServer(serverAddr string) {
 					return emptyHtmlContent
 				},
 				"CSSVersion": func() string {
-					return "0.2.35"
+					return "0.2.36d"
 				},
 			})
 			textTemplate := texttemplate.New("other")

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -21,4 +21,4 @@
 
 package config
 
-const SigLensVersion = "0.2.35"
+const SigLensVersion = "0.2.36d"


### PR DESCRIPTION
# Description
- Bump version to 0.2.36d
- This also includes a change to SigClient-docker job in `publish-prod-images.yml` file. Pointing to the correct dockerfile.
