### PR TITLE
add more restrictive lock during creation of segstore

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -49,8 +49,8 @@ import (
 // proportion of available to allocate for specific uses
 const MICRO_IDX_MEM_PERCENT = 35 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
 const SSM_MEM_PERCENT = 20
-const MICRO_IDX_CHECK_MEM_PERCENT = 5 // percent allocated for runtime checking & loading of cmis
-const RAW_SEARCH_MEM_PERCENT = 38     // minimum percent allocated for segsearch
+const MICRO_IDX_CHECK_MEM_PERCENT = 28 // percent allocated for runtime checking & loading of cmis
+const RAW_SEARCH_MEM_PERCENT = 15     // minimum percent allocated for segsearch
 const METRICS_MEMORY_MEM_PERCENT = 2
 
 // percent allocated for segmentsearchmeta (blocksummaries, blocklen/off)

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -50,7 +50,7 @@ import (
 const MICRO_IDX_MEM_PERCENT = 35 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
 const SSM_MEM_PERCENT = 20
 const MICRO_IDX_CHECK_MEM_PERCENT = 28 // percent allocated for runtime checking & loading of cmis
-const RAW_SEARCH_MEM_PERCENT = 15     // minimum percent allocated for segsearch
+const RAW_SEARCH_MEM_PERCENT = 15      // minimum percent allocated for segsearch
 const METRICS_MEMORY_MEM_PERCENT = 2
 
 // percent allocated for segmentsearchmeta (blocksummaries, blocklen/off)

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -47,9 +47,9 @@ import (
 
 // GLOBAL Defs
 // proportion of available to allocate for specific uses
-const MICRO_IDX_MEM_PERCENT = 35 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
+const MICRO_IDX_MEM_PERCENT = 15 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
 const SSM_MEM_PERCENT = 20
-const MICRO_IDX_CHECK_MEM_PERCENT = 28 // percent allocated for runtime checking & loading of cmis
+const MICRO_IDX_CHECK_MEM_PERCENT = 48 // percent allocated for runtime checking & loading of cmis
 const RAW_SEARCH_MEM_PERCENT = 15      // minimum percent allocated for segsearch
 const METRICS_MEMORY_MEM_PERCENT = 2
 


### PR DESCRIPTION
# Description
When multiple threads call `AddEntry` function, they each call  `getOrCreateSegStore` and multiple of them could be waiting for lock , one of them succeeds, creates a the NewSegStore, and then others try to do the same thing. The original thread writes the the bulk batch it received in its segstore. But that segstore get's overwritten in the map with the latter threads, thereby causing loss of data. 
This more restrictive lock fixes that.



Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
