### PR TITLE
continue with query flow even on HLL error

### DIFF
--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -135,7 +135,6 @@ func readSingleSst(fdata []byte, qid uint64) (*structs.SegStats, error) {
 		err := sst.CreateHllFromBytes(fdata[idx : idx+hllSize])
 		if err != nil {
 			log.Errorf("qid=%d, readSingleSst: unable to create Hll from raw bytes. sst err: %v", qid, err)
-			return nil, err
 		}
 	}
 

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -437,10 +437,7 @@ func (sr *SearchResults) MergeRemoteRRCResults(rrcs []*utils.RecordResultContain
 }
 
 func (sr *SearchResults) AddSegmentStats(remoteStatsJSON *RemoteStatsJSON) error {
-	remoteStats, err := remoteStatsJSON.ToRemoteStats()
-	if err != nil {
-		return fmt.Errorf("Error while converting RemoteStatsJSON to RemoteStats, qid=%v, err: %v", sr.qid, err)
-	}
+	remoteStats := remoteStatsJSON.ToRemoteStats()
 
 	return sr.MergeSegmentStats(sr.sAggs.MeasureOperations, *remoteStats)
 }
@@ -1133,8 +1130,7 @@ func (rs *RemoteStats) RemoteStatsToJSON() (*RemoteStatsJSON, error) {
 	return remoteStatsJson, nil
 }
 
-func (rj *RemoteStatsJSON) ToRemoteStats() (*RemoteStats, error) {
-	var err error
+func (rj *RemoteStatsJSON) ToRemoteStats() *RemoteStats {
 	remoteStats := &RemoteStats{
 		EvalStats: rj.EvalStats,
 	}
@@ -1143,11 +1139,8 @@ func (rj *RemoteStatsJSON) ToRemoteStats() (*RemoteStats, error) {
 		if segStatJSON == nil {
 			continue
 		}
-		remoteStats.SegStats[idx], err = segStatJSON.ToStats()
-		if err != nil {
-			return nil, err
-		}
+		remoteStats.SegStats[idx] = segStatJSON.ToStats()
 	}
 
-	return remoteStats, nil
+	return remoteStats
 }

--- a/pkg/segment/results/segresults/segresults_test.go
+++ b/pkg/segment/results/segresults/segresults_test.go
@@ -99,8 +99,7 @@ func Test_Remote_Stats(t *testing.T) {
 	assert.Equal(t, remoteStats.SegStats[0].StringStats, remoteStatsJson.SegStats[0].StringStats)
 	assert.Equal(t, expectedHllBytes, remoteStatsJson.SegStats[0].RawHll)
 
-	decodedRemoteStats, err := remoteStatsJson.ToRemoteStats()
-	assert.Nil(t, err)
+	decodedRemoteStats := remoteStatsJson.ToRemoteStats()
 	assert.NotNil(t, decodedRemoteStats)
 
 	assert.Equal(t, remoteStats, decodedRemoteStats)

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -546,7 +546,6 @@ func (ss *SegStats) Init(rawSegStatJson []byte) error {
 	err = ss.CreateHllFromBytes(segStatJson.RawHll)
 	if err != nil {
 		log.Errorf("SegStats.Init: Failed to create new segmentio Hll from raw bytes. error: %v data: %v", err, string(segStatJson.RawHll))
-		return err
 	}
 	ss.NumStats = segStatJson.NumStats
 	return nil
@@ -627,7 +626,7 @@ func (ss *SegStats) GetHllDataSize() int {
 	return size
 }
 
-func (ssj *SegStatsJSON) ToStats() (*SegStats, error) {
+func (ssj *SegStatsJSON) ToStats() *SegStats {
 	ss := &SegStats{}
 	ss.IsNumeric = ssj.IsNumeric
 	ss.Count = ssj.Count
@@ -635,12 +634,11 @@ func (ssj *SegStatsJSON) ToStats() (*SegStats, error) {
 		err := ss.CreateHllFromBytes(ssj.RawHll)
 		if err != nil {
 			log.Errorf("SegStatsJSON.ToStats: Failed to unmarshal hll error: %v data: %v", err, string(ssj.RawHll))
-			return nil, err
 		}
 	}
 	ss.NumStats = ssj.NumStats
 	ss.StringStats = ssj.StringStats
-	return ss, nil
+	return ss
 }
 
 // convert SegStats to SegStatsJSON

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -800,8 +800,7 @@ func Test_EncodeDecodeSegStats(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, segStatsJson)
 
-		recoveredSegStats, err := segStatsJson.ToStats()
-		assert.NoError(t, err)
+		recoveredSegStats := segStatsJson.ToStats()
 		assert.NotNil(t, recoveredSegStats)
 
 		assert.Equal(t, originalSegStats, recoveredSegStats)


### PR DESCRIPTION
# Description
- If there is an error while extracting the HLL from the raw bytes, we will log the error but will not stop the query execution flow.
- The `stats cardinality` query flow is not changed.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
