### PR TITLE
Check rotated files when unrotated are absent

### DIFF
--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -40,8 +40,10 @@ import (
 // record identifiers is segfilename + blockNum + recordNum
 // If esResponse is false, _id and _type will not be added to any record
 func GetRecordsFromSegment(segKey string, vTable string, blkRecIndexes map[uint16]map[uint16]uint64,
-	tsKey string, esQuery bool, qid uint64, aggs *structs.QueryAggregators, colsIndexMap map[string]int,
-	allColsInAggs map[string]struct{}, nodeRes *structs.NodeResult, consistentCValLen map[string]uint32) (map[string]map[string]interface{}, map[string]bool, error) {
+	tsKey string, esQuery bool, qid uint64, aggs *structs.QueryAggregators,
+	colsIndexMap map[string]int, allColsInAggs map[string]struct{}, nodeRes *structs.NodeResult,
+	consistentCValLen map[string]uint32) (map[string]map[string]interface{}, map[string]bool, error) {
+
 	records, columns, err := getRecordsFromSegmentHelper(segKey, vTable, blkRecIndexes, tsKey, esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
 	if err != nil {
 		// This may have failed because we're using the unrotated key, but the
@@ -59,12 +61,15 @@ func GetRecordsFromSegment(segKey string, vTable string, blkRecIndexes map[uint1
 }
 
 func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map[uint16]map[uint16]uint64,
-	tsKey string, esQuery bool, qid uint64, aggs *structs.QueryAggregators, colsIndexMap map[string]int,
-	allColsInAggs map[string]struct{}, nodeRes *structs.NodeResult, consistentCValLen map[string]uint32) (map[string]map[string]interface{}, map[string]bool, error) {
+	tsKey string, esQuery bool, qid uint64, aggs *structs.QueryAggregators,
+	colsIndexMap map[string]int, allColsInAggs map[string]struct{}, nodeRes *structs.NodeResult,
+	consistentCValLen map[string]uint32) (map[string]map[string]interface{}, map[string]bool, error) {
+
 	var err error
 	segKey, err = checkRecentlyRotatedKey(segKey)
 	if err != nil {
-		log.Errorf("qid=%d GetRecordsFromSegment failed to get recently rotated information for key %s table %s. err %+v", qid, segKey, vTable, err)
+		log.Errorf("qid=%d GetRecordsFromSegment failed to get recently rotated information for key %s table %s. err %+v",
+			qid, segKey, vTable, err)
 	}
 	var allCols map[string]bool
 	var exists bool

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -44,13 +44,14 @@ func GetRecordsFromSegment(segKey string, vTable string, blkRecIndexes map[uint1
 	colsIndexMap map[string]int, allColsInAggs map[string]struct{}, nodeRes *structs.NodeResult,
 	consistentCValLen map[string]uint32) (map[string]map[string]interface{}, map[string]bool, error) {
 
-	records, columns, err := getRecordsFromSegmentHelper(segKey, vTable, blkRecIndexes, tsKey, esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
+	records, columns, err := getRecordsFromSegmentHelper(segKey, vTable, blkRecIndexes, tsKey,
+		esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
 	if err != nil {
 		// This may have failed because we're using the unrotated key, but the
 		// data has since been rotated. Try with the rotated key.
 		rotatedKey := writer.GetRotatedVersion(segKey)
-		records, columns, err = getRecordsFromSegmentHelper(rotatedKey, vTable, blkRecIndexes, tsKey, esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
-
+		records, columns, err = getRecordsFromSegmentHelper(rotatedKey, vTable, blkRecIndexes, tsKey,
+			esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
 		if err != nil {
 			log.Errorf("GetRecordsFromSegment: failed to get records for segkey=%v, err=%v", rotatedKey, err)
 			return nil, nil, err
@@ -68,7 +69,7 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	var err error
 	segKey, err = checkRecentlyRotatedKey(segKey)
 	if err != nil {
-		log.Errorf("qid=%d GetRecordsFromSegment failed to get recently rotated information for key %s table %s. err %+v",
+		log.Errorf("qid=%d getRecordsFromSegmentHelper failed to get recently rotated information for key %s table %s. err %+v",
 			qid, segKey, vTable, err)
 	}
 	var allCols map[string]bool
@@ -77,7 +78,7 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	if !exists {
 		allCols, exists = metadata.CheckAndGetColsForSegKey(segKey, vTable)
 		if !exists {
-			log.Errorf("GetRecordsFromSegment: failed to get column for key: %s, table %s", segKey, vTable)
+			log.Errorf("getRecordsFromSegmentHelper: failed to get column for key: %s, table %s", segKey, vTable)
 			return nil, allCols, errors.New("failed to get column names for segkey in rotated and unrotated files")
 		}
 	}
@@ -93,7 +94,7 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	numOpenFds := int64(len(allCols))
 	err = fileutils.GLOBAL_FD_LIMITER.TryAcquireWithBackoff(numOpenFds, 10, fmt.Sprintf("GetRecordsFromSegment.qid=%d", qid))
 	if err != nil {
-		log.Errorf("qid=%d GetRecordsFromSegment failed to acquire lock for opening %+v file descriptors. err %+v", qid, numOpenFds, err)
+		log.Errorf("qid=%d getRecordsFromSegmentHelper failed to acquire lock for opening %+v file descriptors. err %+v", qid, numOpenFds, err)
 		return nil, map[string]bool{}, err
 	}
 	defer fileutils.GLOBAL_FD_LIMITER.Release(numOpenFds)
@@ -107,21 +108,21 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	}
 	err = blob.BulkDownloadSegmentBlob(bulkDownloadFiles, true)
 	if err != nil {
-		log.Errorf("qid=%d, GetRecordsFromSegment failed to download col file. err=%v", qid, err)
+		log.Errorf("qid=%d, getRecordsFromSegmentHelper failed to download col file. err=%v", qid, err)
 		return nil, map[string]bool{}, err
 	}
 
 	defer func() {
 		err = blob.SetSegSetFilesAsNotInUse(allFiles)
 		if err != nil {
-			log.Errorf("qid=%d, GetRecordsFromSegment failed to set segset files as not in use. err=%v", qid, err)
+			log.Errorf("qid=%d, getRecordsFromSegmentHelper failed to set segset files as not in use. err=%v", qid, err)
 		}
 	}()
 
 	for ssFile := range bulkDownloadFiles {
 		fd, err := os.Open(ssFile)
 		if err != nil {
-			log.Errorf("qid=%d, GetRecordsFromSegment failed to open col file. Tried to open file=%v, err=%v", qid, ssFile, err)
+			log.Errorf("qid=%d, getRecordsFromSegmentHelper failed to open col file. Tried to open file=%v, err=%v", qid, ssFile, err)
 			return nil, map[string]bool{}, err
 		}
 		defer fd.Close()
@@ -131,13 +132,13 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	if writer.IsSegKeyUnrotated(segKey) {
 		blockMetadata, err = writer.GetBlockSearchInfoForKey(segKey)
 		if err != nil {
-			log.Errorf("qid=%d GetRecordsFromSegment failed to get block search info for unrotated key %s table %s", qid, segKey, vTable)
+			log.Errorf("qid=%d getRecordsFromSegmentHelper failed to get block search info for unrotated key %s table %s", qid, segKey, vTable)
 			return nil, map[string]bool{}, err
 		}
 	} else {
 		blockMetadata, err = metadata.GetBlockSearchInfoForKey(segKey)
 		if err != nil {
-			log.Errorf("GetRecordsFromSegment: failed to get blocksearchinfo for segkey=%v, err=%v", segKey, err)
+			log.Errorf("getRecordsFromSegmentHelper: failed to get blocksearchinfo for segkey=%v, err=%v", segKey, err)
 			return nil, map[string]bool{}, err
 		}
 	}
@@ -146,22 +147,21 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	if writer.IsSegKeyUnrotated(segKey) {
 		blockSum, err = writer.GetBlockSummaryForKey(segKey)
 		if err != nil {
-			log.Errorf("qid=%d GetRecordsFromSegment failed to get block search info for unrotated key %s table %s", qid, segKey, vTable)
+			log.Errorf("qid=%d getRecordsFromSegmentHelper failed to get block search info for unrotated key %s table %s", qid, segKey, vTable)
 			return nil, map[string]bool{}, err
 		}
 	} else {
 		blockSum, err = metadata.GetBlockSummariesForKey(segKey)
 		if err != nil {
-			log.Errorf("GetRecordsFromSegment: failed to get blocksearchinfo for segkey=%v, err=%v", segKey, err)
+			log.Errorf("getRecordsFromSegmentHelper: failed to get blocksearchinfo for segkey=%v, err=%v", segKey, err)
 			return nil, map[string]bool{}, err
 		}
 	}
 
 	result := make(map[string]map[string]interface{})
-
 	sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, allCols, blockMetadata, blockSum, 1, consistentCValLen, qid)
 	if err != nil {
-		log.Errorf("GetRecordsFromSegment: failed to initialize shared readers for segkey=%v, err=%v", segKey, err)
+		log.Errorf("getRecordsFromSegmentHelper: failed to initialize shared readers for segkey=%v, err=%v", segKey, err)
 		return nil, map[string]bool{}, err
 	}
 	defer sharedReader.Close()

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -46,7 +46,7 @@ func GetRecordsFromSegment(segKey string, vTable string, blkRecIndexes map[uint1
 	if err != nil {
 		// This may have failed because we're using the unrotated key, but the
 		// data has since been rotated. Try with the rotated key.
-		rotatedKey := writer.GetRotatedSegKey(segKey)
+		rotatedKey := writer.GetRotatedVersion(segKey)
 		records, columns, err = getRecordsFromSegmentHelper(rotatedKey, vTable, blkRecIndexes, tsKey, esQuery, qid, aggs, colsIndexMap, allColsInAggs, nodeRes, consistentCValLen)
 
 		if err != nil {

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/cespare/xxhash"
 	"github.com/siglens/siglens/pkg/blob"
@@ -192,10 +191,8 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool, block
 		if err != nil {
 			// This segment may have been recently rotated; try reading the
 			// rotated segment file.
-			rotatedFName := strings.Replace(fName, "/active/", "/final/", 1)
+			rotatedFName := writer.GetRotatedVersion(fName)
 			currFd, err = os.OpenFile(rotatedFName, os.O_RDONLY, 0644)
-
-			log.Errorf("andrew failed to open a file, but final err=%v", err)
 			if err != nil {
 				log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to open file %s for columns %s. Error: %v.",
 					qid, rotatedFName, colName, err)

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/cespare/xxhash"
 	"github.com/siglens/siglens/pkg/blob"
@@ -189,9 +190,17 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool, block
 		fName := fName
 		currFd, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 		if err != nil {
-			log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to open file %s for columns %s. Error: %v.",
-				qid, fName, colName, err)
-			continue
+			// This segment may have been recently rotated; try reading the
+			// rotated segment file.
+			rotatedFName := strings.Replace(fName, "/active/", "/final/", 1)
+			currFd, err = os.OpenFile(rotatedFName, os.O_RDONLY, 0644)
+
+			log.Errorf("andrew failed to open a file, but final err=%v", err)
+			if err != nil {
+				log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to open file %s for columns %s. Error: %v.",
+					qid, rotatedFName, colName, err)
+				continue
+			}
 		}
 		sharedReader.allFDs[colName] = currFd
 		allInUseSegSetFiles = append(allInUseSegSetFiles, fName)

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -771,11 +771,13 @@ func getFinalBaseSegDirFromActive(activeBaseSegDir string) (string, error) {
 		return "", err
 	}
 
-	return strings.Replace(activeBaseSegDir, "/active/", "/final/", 1), nil
+	return GetRotatedVersion(activeBaseSegDir), nil
 }
 
-// Take a valid segKey (rotated or unrotated), and return the rotated version.
-func GetRotatedSegKey(segKey string) string {
+// Take a string that is based on a rotated/unrotated segkey (e.g., just a
+// segkey, or a filename that contains a segkey), and return the rotated
+// version of that string.
+func GetRotatedVersion(segKey string) string {
 	return strings.Replace(segKey, "/active/", "/final/", 1)
 }
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -774,6 +774,11 @@ func getFinalBaseSegDirFromActive(activeBaseSegDir string) (string, error) {
 	return strings.Replace(activeBaseSegDir, "/active/", "/final/", 1), nil
 }
 
+// Take a valid segKey (rotated or unrotated), and return the rotated version.
+func GetRotatedSegKey(segKey string) string {
+	return strings.Replace(segKey, "/active/", "/final/", 1)
+}
+
 func updateRangeIndex(key string, rangeIndexPtr map[string]*structs.Numbers, numType SS_IntUintFloatTypes, intVal int64,
 	uintVal uint64, fltVal float64) {
 	switch numType {

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -127,6 +127,15 @@ func Test_getFinalBaseSegDirFromActive(t *testing.T) {
 	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/final/"+virtualTableName+"/"+streamid+"/1/", finalBasedir)
 }
 
+func Test_GetRotatedVersion(t *testing.T) {
+	unrotatedSegKey := "data/test.abc/active/ind-0/0-0-17399183820399492381/4/4"
+	rotatedVersion := GetRotatedVersion(unrotatedSegKey)
+	assert.Equal(t, "data/test.abc/final/ind-0/0-0-17399183820399492381/4/4", rotatedVersion)
+
+	doubleRotatedVersion := GetRotatedVersion(rotatedVersion)
+	assert.Equal(t, "data/test.abc/final/ind-0/0-0-17399183820399492381/4/4", doubleRotatedVersion)
+}
+
 func Test_ReplaceSingleSegMeta(t *testing.T) {
 	config.InitializeDefaultConfig(t.TempDir())
 	initSmr()


### PR DESCRIPTION
# Description
There's a concurrency bug that sometimes happens:
1. We get a query, and find the segments that match it; one of the unrotated segments match it
2. Concurrently, we receive more data, and rotate the segment that matched it
3. We continue processing the query, and try to read from the files where data is stored. But the segment got rotated, so it's in the `.../final/...` directory instead of the `.../active/...` directory. We log and return an error for that segment.

This PR fixes the issue by looking in `/final/` if we got an error looking in `/active/`

# Testing
Mostly manual testing. I decreased the size of segments via `maxSegFileSize: 200000000` in my server.yaml. I also added a 5-second sleep just above this line: https://github.com/siglens/siglens/blob/develop/pkg/segment/reader/record/recordreader.go#L138. Then I continually ingested data, ran the query `*`, and ingested more data so the segment would rotate before my sleep finished. Without this PR, I saw errors like:
```
InitSharedMultiColumnReaders: failed to open file data/sigsingle.nZgMjB6N9wZZUPAkyh6DdL/active/ind-0/0-0-16142326282426453201/290/290_7976178037195605558.csg for columns weekday. Error: open data/sigsingle.nZgMjB6N9wZZUPAkyh6DdL/active/ind-0/0-0-16142326282426453201/290/290_7976178037195605558.csg: no such file or directory. 
```
With this PR, those errors don't show up because we check `final` before logging the error, and the `final` finals are present

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
