### PR TITLE
Cleanup the startup sequence

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -271,24 +271,14 @@ func StartSiglensServer(nodeType commonconfig.DeploymentType, nodeID string) err
 		return err
 	}
 
+	querytracker.InitQT()
+	fileutils.InitLogFiles()
+
 	siglensStartupLog := fmt.Sprintf("----- Siglens server type %s starting up ----- \n", nodeType)
 	if config.GetLogPrefix() != "" {
 		StdOutLogger.Infof(siglensStartupLog)
 	}
 	log.Infof(siglensStartupLog)
-	if queryNode {
-		err := usq.InitUsq()
-		if err != nil {
-			log.Errorf("error in init UserSavedQueries: %v", err)
-			return err
-		}
-
-		err = dashboards.InitDashboards()
-		if err != nil {
-			log.Errorf("error in init Dashboards: %v", err)
-			return err
-		}
-	}
 
 	if hook := hooks.GlobalHooks.StartSiglensExtrasHook; hook != nil {
 		err := hook(nodeID)
@@ -305,12 +295,11 @@ func StartSiglensServer(nodeType commonconfig.DeploymentType, nodeID string) err
 	}
 
 	instrumentation.InitMetrics()
-	querytracker.InitQT()
 
-	fileutils.InitLogFiles()
 	go tracinghandler.MonitorSpansHealth()
 	go tracinghandler.DependencyGraphThread()
 	go entryHandler.MonitorDiskUsage()
+
 	return nil
 }
 


### PR DESCRIPTION
# Description
Summarize the change.
Cleans up the startup sequence for siglens server.
Ports should be opened at last, that are `startIngestServer`, `startQueryServer` and `InitMetrics`

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
After this change started a server, ingested data and queried.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
