### PR TITLE
Symlink active to final dir on rotation

### DIFF
--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -573,7 +573,7 @@ func Test_SegStoreAllColumnsRecLen(t *testing.T) {
 		assertTheColRecSize(t, segstore, expectedColSizeAfterIdx, idx)
 	}
 
-	err = CleanupUnrotatedSegment(segstore, sId, true)
+	err = CleanupUnrotatedSegment(segstore, sId, true, true)
 	assert.Nil(t, err)
 }
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -794,7 +794,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 
 		allColsSizes := segstore.getAllColsSizes()
 
-		err = symlinkRelativePaths(activeBasedir, finalBasedir)
+		err = toputils.SymlinkRelativePaths(activeBasedir, finalBasedir)
 		if err != nil {
 			log.Errorf("checkAndRotateColFiles: failed to symlink %v to %v; err=%v",
 				activeBasedir, finalBasedir, err)
@@ -837,30 +837,6 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 			log.Errorf("checkAndRotateColFiles: failed to upload ingest node dir , err=%v", err)
 		}
 	}
-	return nil
-}
-
-func symlinkRelativePaths(oldPath string, newPath string) error {
-	absOldPath, err := filepath.Abs(oldPath)
-	if err != nil {
-		log.Errorf("symlinkRelativePaths: failed to get absolute path for oldPath %v; err=%v",
-			oldPath, err)
-		return err
-	}
-
-	absNewPath, err := filepath.Abs(newPath)
-	if err != nil {
-		log.Errorf("symlinkRelativePaths: failed to get absolute path for newPath %v; err=%v",
-			newPath, err)
-		return err
-	}
-
-	err = os.Symlink(absOldPath, absNewPath)
-	if err != nil {
-		log.Errorf("symlinkRelativePaths: failed to symlink %v to %v; err=%v", absOldPath, absNewPath, err)
-		return err
-	}
-
 	return nil
 }
 

--- a/pkg/utils/fileutils.go
+++ b/pkg/utils/fileutils.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func SymlinkRelativePaths(oldPath string, newPath string) error {
+	absOldPath, err := filepath.Abs(oldPath)
+	if err != nil {
+		log.Errorf("symlinkRelativePaths: failed to get absolute path for oldPath %v; err=%v",
+			oldPath, err)
+		return err
+	}
+
+	absNewPath, err := filepath.Abs(newPath)
+	if err != nil {
+		log.Errorf("symlinkRelativePaths: failed to get absolute path for newPath %v; err=%v",
+			newPath, err)
+		return err
+	}
+
+	err = os.Symlink(absOldPath, absNewPath)
+	if err != nil {
+		log.Errorf("symlinkRelativePaths: failed to symlink %v to %v; err=%v", absOldPath, absNewPath, err)
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description
Instead of moving the `active` directory to `final` on segment rotation, make a symlink. Occasionally, moving the directory causes query problems because when we start the query the segment data is in `active` but by the time we're actually fetching the data it's been moved to `final`. 

# Testing
Manual testing for continuous ingestion with continuous query, and restarting siglens and verifying the data can still be queried.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
