### PR TITLE
Fix: Mismatch of aggValues in agileTree

### DIFF
--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -364,6 +364,7 @@ func (ss *SegStore) doLogEventFilling(ple *ParsedLogEvent, tsKey *string) (bool,
 				colRis[cname] = ri
 			}
 
+			startIdx := colWip.cbufidx
 			copy(colWip.cbuf[colWip.cbufidx:], ple.allCvalsTypeLen[i][0:9])
 			colWip.cbufidx += 9
 
@@ -402,6 +403,9 @@ func (ss *SegStore) doLogEventFilling(ple *ParsedLogEvent, tsKey *string) (bool,
 			updateRangeIndex(cname, ri.Ranges, numType, intVal, uintVal, floatVal)
 			addSegStatsNums(segstats, cname, numType, intVal, uintVal, floatVal, asciiBytesBuf.Bytes())
 			ss.updateColValueSizeInAllSeenColumns(cname, 9)
+			if !ss.skipDe {
+				ss.checkAddDictEnc(colWip, colWip.cbuf[startIdx:colWip.cbufidx], ss.wipBlock.blockSummary.RecCount, startIdx, false)
+			}
 		default:
 			return false, utils.TeeErrorf("doLogEventFilling: unknown ctype: %v", ctype)
 		}


### PR DESCRIPTION
# Description
Summarize the change.
- Initialize the aggValues during the creation of node to prevent inconsistencies and scenarios where sometimes measureVal is not found for a record is [missing](https://github.com/siglens/siglens/blob/4daa08c5309ddb937783c149bbb4764ca3633c07/pkg/segment/writer/agiletree.go#L636).
- Added checks to report errors during agileTree creation
- We were not encoding numerical values because of which this issue happened and there was a mismatch.

Stack trace

```
panic: runtime error: index out of range [0] with length 0

goroutine 541 [running]:
github.com/siglens/siglens/pkg/segment/writer.(*StarTreeBuilder).Aggregate(0xc030d56000, 0xc038c40d00)
	/usr/app/pkg/segment/writer/agiletree.go:384 +0x5bf
github.com/siglens/siglens/pkg/segment/writer.(*StarTreeBuilder).Aggregate(0xc030d56000, 0xc038c20240)
	/usr/app/pkg/segment/writer/agiletree.go:368 +0x1b6
github.com/siglens/siglens/pkg/segment/writer.(*StarTreeBuilder).Aggregate(0xc030d56000, 0xc030d72840)
```

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

- After this fix, ran ingestion with same pqueries info on playground and verified.
- Also re-tested dropping of columns to make sure everything is working fine.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
