### PR TITLE
Merge active and final data directories

### DIFF
--- a/pkg/blob/local/localstorage.go
+++ b/pkg/blob/local/localstorage.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siglens/siglens/pkg/blob/ssutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -128,7 +129,7 @@ func AddSegSetFileToLocal(fName string, segSetData *structs.SegSetData) {
 	segSetKeysLock.Lock()
 	defer segSetKeysLock.Unlock()
 
-	if strings.Contains(fName, "/active/") {
+	if !utils.IsFileForRotatedSegment(fName) {
 		return
 	}
 	if _, exists := segSetKeys[fName]; !exists {
@@ -149,7 +150,7 @@ func SetBlobAsInUse(fName string) error {
 	segSetKeysLock.Lock()
 	defer segSetKeysLock.Unlock()
 
-	if strings.Contains(fName, "/active/") {
+	if !utils.IsFileForRotatedSegment(fName) {
 		return nil
 	}
 	if _, exists := segSetKeys[fName]; exists {
@@ -178,10 +179,10 @@ func IsFilePresentOnLocal(fName string) bool {
 func DeleteLocal(fName string) error {
 	segSetKeysLock.Lock()
 	defer segSetKeysLock.Unlock()
-	if strings.Contains(fName, "/active/") {
-		log.Debugf("DeleteLocal: Not deleting segset from active dir %v", fName)
+	if !utils.IsFileForRotatedSegment(fName) {
+		log.Debugf("DeleteLocal: Not deleting segset from unrotated dir %v", fName)
 		delete(segSetKeys, fName)
-		return fmt.Errorf("not deleting segset from active dir %v", fName)
+		return fmt.Errorf("not deleting segset from unrotated dir %v", fName)
 	}
 	if _, exists := segSetKeys[fName]; exists && fName != "" {
 		deleteLocalFile(fName)
@@ -248,7 +249,7 @@ Returns an error if SetSetData does not exist in SegSetKeys
 func SetBlobAsNotInUse(segSetFile string) error {
 	segSetKeysLock.Lock()
 	defer segSetKeysLock.Unlock()
-	if strings.Contains(segSetFile, "/active/") {
+	if !utils.IsFileForRotatedSegment(segSetFile) {
 		return nil
 	}
 	if _, exists := segSetKeys[segSetFile]; exists {

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -43,6 +43,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
+	toputils "github.com/siglens/siglens/pkg/utils"
 	"github.com/siglens/siglens/pkg/utils/semaphore"
 	log "github.com/sirupsen/logrus"
 )
@@ -283,7 +284,7 @@ func shouldBackFillPQMR(searchNode *structs.SearchNode, searchReq *structs.Segme
 }
 
 func writePqmrFilesWrapper(segmentSearchRecords *SegmentSearchStatus, searchReq *structs.SegmentSearchRequest, qid uint64, pqid string) {
-	if strings.Contains(searchReq.SegmentKey, "/active/") {
+	if !toputils.IsSegmentRotated(searchReq.SegmentKey) {
 		return
 	}
 	if strings.Contains(searchReq.SegmentKey, config.GetHostID()) {

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1128,25 +1128,12 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		return err
 	}
 
-	// Check if final directory already exists
-	if _, err := os.Stat(finalDir); err == nil {
-		log.Infof("rotateSegment: final directory %s already exists, skipping rename operation", finalDir)
-		return nil
-
-	}
-
-	// Check if source directory exists
-	if _, err := os.Stat(ms.metricsKeyBase); os.IsNotExist(err) {
-		log.Infof("rotateSegment: source directory %s does not exist, skipping rename operation", ms.metricsKeyBase)
-		return nil
-	}
-
-	// Rename metricsKeyBase to finalDir
-	err = os.Rename(path.Dir(ms.metricsKeyBase), finalDir)
+	err = toputils.WriteValidityFile(ms.metricsKeyBase)
 	if err != nil {
-		log.Errorf("rotateSegment: failed to rename %s to %s for orgid=%v, Error %+v", ms.metricsKeyBase, finalDir, ms.Orgid, err)
+		log.Errorf("rotateSegment: failed to write validity file for %s, orgid=%v, Error %+v", ms.metricsKeyBase, ms.Orgid, err)
 		return err
 	}
+
 	log.Infof("rotating segment of size %v that created %v metrics blocks to %+v", ms.totalEncodedSize, ms.currBlockNum+1, finalDir)
 	if !forceRotate {
 		nextSuffix, err := suffix.GetNextSuffix(ms.Mid, "ts")

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -356,8 +356,8 @@ func getBaseMetricsKey(suffix uint64, mId string) (string, error) {
 /*
 Returns <<dataDir>>/<<hostname>>/final/<<mid>>/suffix
 */
-// TODO: delete this function
 func getFinalMetricsDir(mId string, suffix uint64) string {
+	// TODO: use filepath.Join
 	var sb strings.Builder
 	sb.WriteString(config.GetRunningConfig().DataPath)
 	sb.WriteString(config.GetHostID())

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -339,13 +339,14 @@ func InitMetricsSegment(orgid uint64, mId string) (*MetricsSegment, error) {
 }
 
 /*
-Returns <<dataDir>>/<<hostname>>/active/ts/<<mid>>/{suffix}/suffix
+Returns <<dataDir>>/<<hostname>>/final/ts/<<mid>>/{suffix}/suffix
 */
 func getBaseMetricsKey(suffix uint64, mId string) (string, error) {
+	// TODO: use filepath.Join
 	var sb strings.Builder
 	sb.WriteString(config.GetDataPath())
 	sb.WriteString(config.GetHostID())
-	sb.WriteString("/active/ts/")
+	sb.WriteString("/final/ts/")
 	sb.WriteString(mId + "/")
 	sb.WriteString(strconv.FormatUint(suffix, 10) + "/")
 	basedir := sb.String()
@@ -355,6 +356,7 @@ func getBaseMetricsKey(suffix uint64, mId string) (string, error) {
 /*
 Returns <<dataDir>>/<<hostname>>/final/<<mid>>/suffix
 */
+// TODO: delete this function
 func getFinalMetricsDir(mId string, suffix uint64) string {
 	var sb strings.Builder
 	sb.WriteString(config.GetRunningConfig().DataPath)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1018,6 +1018,11 @@ func WriteMockColSegFile(segkey string, numBlocks int, entryCount int) ([]map[st
 		allColsSizes[cname] = &ColSizeInfo{CmiSize: cmiSize, CsgSize: csgSize}
 	}
 
+	err := utils.WriteValidityFile(segkey)
+	if err != nil {
+		panic(fmt.Sprintf("WriteMockColSegFile: failed to write segment validity file; err=%v", err))
+	}
+
 	return allBlockBlooms, allBlockSummaries, allBlockRangeIdx, mapCol, allBlockOffsets, allColsSizes
 }
 

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -573,7 +573,7 @@ func Test_SegStoreAllColumnsRecLen(t *testing.T) {
 		assertTheColRecSize(t, segstore, expectedColSizeAfterIdx, idx)
 	}
 
-	err = CleanupUnrotatedSegment(segstore, sId, true)
+	err = CleanupUnrotatedSegment(segstore, sId, true, true)
 	assert.Nil(t, err)
 }
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -273,7 +273,7 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 	}
 	segstore.suffix = nextSuffix
 
-	basedir := getActiveBaseSegDir(streamid, virtualTableName, nextSuffix)
+	basedir := getBaseSegDir(streamid, virtualTableName, nextSuffix)
 	err = os.MkdirAll(basedir, 0764)
 	if err != nil {
 		log.Errorf("resetSegStore : Could not mkdir basedir=%v,  %v", basedir, err)
@@ -761,26 +761,10 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 			segstore.stbHolder = nil
 		}
 
-		activeBasedir := segstore.segbaseDir
-		finalBasedir, err := getFinalBaseSegDirFromActive(activeBasedir)
-		if err != nil {
-			log.Errorf("checkAndRotateColFiles: failed to get finalBasedir from activeBasedir=%v; err=%v", activeBasedir, err)
-			return err
-		}
-
-		finalSegmentKey := fmt.Sprintf("%s%d", finalBasedir, segstore.suffix)
-
-		log.Infof("Rotating segId=%v RecCount: %v, OnDiskBytes=%v, numBlocks=%v, finalSegKey=%v orgId=%v, forceRotate:%v, onTimeRotate: %v, onTreeRotate: %v",
+		log.Infof("Rotating segId=%v RecCount: %v, OnDiskBytes=%v, numBlocks=%v, orgId=%v, forceRotate:%v, onTimeRotate: %v, onTreeRotate: %v",
 			segstore.SegmentKey, segstore.RecordCount, segstore.OnDiskBytes, segstore.numBlocks,
-			finalSegmentKey, segstore.OrgId, forceRotate, onTimeRotate, onTreeRotate)
+			segstore.OrgId, forceRotate, onTimeRotate, onTreeRotate)
 
-		// make sure the parent dir of final exists, the two path calls are because getFinal.. func
-		// returns a '/' at the end
-		err = os.MkdirAll(path.Dir(path.Dir(finalBasedir)), 0764)
-		if err != nil {
-			log.Errorf("checkAndRotateColFiles: failed to mkdir finalBasedir=%v; err=%v", finalBasedir, err)
-			return err
-		}
 		// delete pqmr files if empty and add to empty PQS
 		for pqid, hasMatchedAnyRecordInWip := range segstore.pqNonEmptyResults {
 			if !hasMatchedAnyRecordInWip {
@@ -794,14 +778,15 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 
 		allColsSizes := segstore.getAllColsSizes()
 
-		// move the whole dir in one shot
-		err = os.Rename(activeBasedir, finalBasedir)
+		_, err := os.Create(filepath.Join(segstore.segbaseDir, toputils.SegmentValidityFname))
 		if err != nil {
-			log.Errorf("checkAndRotateColFiles: failed to mv active to final, err=%v", err)
+			log.Errorf("checkAndRotateColFiles: failed to create segment validity file for segkey=%v; err=%v",
+				segstore.SegmentKey, err)
 			return err
 		}
+
 		// Upload segment files to s3
-		filesToUpload := fileutils.GetAllFilesInDirectory(finalBasedir)
+		filesToUpload := fileutils.GetAllFilesInDirectory(segstore.segbaseDir)
 
 		err = blob.UploadSegmentFiles(filesToUpload)
 		if err != nil {
@@ -813,9 +798,9 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 			allPqids[pqid] = true
 		}
 
-		var segmeta = structs.SegMeta{SegmentKey: finalSegmentKey, EarliestEpochMS: segstore.earliest_millis,
+		var segmeta = structs.SegMeta{SegmentKey: segstore.SegmentKey, EarliestEpochMS: segstore.earliest_millis,
 			LatestEpochMS: segstore.latest_millis, VirtualTableName: segstore.VirtualTableName,
-			RecordCount: segstore.RecordCount, SegbaseDir: finalBasedir,
+			RecordCount: segstore.RecordCount, SegbaseDir: segstore.segbaseDir,
 			BytesReceivedCount: segstore.BytesReceivedCount, OnDiskBytes: segstore.OnDiskBytes,
 			ColumnNames: allColsSizes, AllPQIDs: allPqids, NumBlocks: segstore.numBlocks, OrgId: segstore.OrgId}
 
@@ -823,11 +808,11 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 		if hook := hooks.GlobalHooks.AfterSegmentRotation; hook != nil {
 			err := hook(&segmeta)
 			if err != nil {
-				log.Errorf("checkAndRotateColFiles: AfterSegmentRotation hook failed for segKey=%v, err=%v", finalSegmentKey, err)
+				log.Errorf("checkAndRotateColFiles: AfterSegmentRotation hook failed for segKey=%v, err=%v", segstore.SegmentKey, err)
 			}
 		}
 
-		updateRecentlyRotatedSegmentFiles(segstore.SegmentKey, finalSegmentKey)
+		updateRecentlyRotatedSegmentFiles(segstore.SegmentKey)
 		metadata.AddSegMetaToMetadata(&segmeta)
 
 		// upload ingest node dir to s3
@@ -836,7 +821,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 			log.Errorf("checkAndRotateColFiles: failed to upload ingest node dir , err=%v", err)
 		}
 
-		err = CleanupUnrotatedSegment(segstore, streamid, !forceRotate)
+		err = CleanupUnrotatedSegment(segstore, streamid, false, !forceRotate)
 		if err != nil {
 			log.Errorf("checkAndRotateColFiles: failed to cleanup unrotated segment %v, err=%v", segstore.SegmentKey, err)
 			return err
@@ -845,17 +830,19 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 	return nil
 }
 
-func CleanupUnrotatedSegment(segstore *SegStore, streamId string, resetSegstore bool) error {
+func CleanupUnrotatedSegment(segstore *SegStore, streamId string, removeDir bool, resetSegstore bool) error {
 	removeSegKeyFromUnrotatedInfo(segstore.SegmentKey)
 
-	err := os.RemoveAll(segstore.segbaseDir)
-	if err != nil {
-		log.Errorf("CleanupUnrotatedSegment: failed to remove segbaseDir=%v; err=%v", segstore.segbaseDir, err)
-		return err
+	if removeDir {
+		err := os.RemoveAll(segstore.segbaseDir)
+		if err != nil {
+			log.Errorf("CleanupUnrotatedSegment: failed to remove segbaseDir=%v; err=%v", segstore.segbaseDir, err)
+			return err
+		}
 	}
 
 	if resetSegstore {
-		err = segstore.resetSegStore(streamId, segstore.VirtualTableName)
+		err := segstore.resetSegStore(streamId, segstore.VirtualTableName)
 		if err != nil {
 			return err
 		}

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -753,6 +753,8 @@ func getBlockBloomSize(bi *BloomIndex) uint32 {
 }
 
 func getBaseSegDir(streamid string, virtualTableName string, suffix uint64) string {
+	// Note: this is coupled to getSegBaseDirFromFilename. If the directory
+	// structure changes, change getSegBaseDirFromFilename too.
 	// TODO: use filepath.Join to avoid "/" issues
 	var sb strings.Builder
 	sb.WriteString(config.GetDataPath())

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -752,11 +752,12 @@ func getBlockBloomSize(bi *BloomIndex) uint32 {
 	return nextBloomSize
 }
 
-func getActiveBaseSegDir(streamid string, virtualTableName string, suffix uint64) string {
+func getBaseSegDir(streamid string, virtualTableName string, suffix uint64) string {
+	// TODO: use filepath.Join to avoid "/" issues
 	var sb strings.Builder
 	sb.WriteString(config.GetDataPath())
 	sb.WriteString(config.GetHostID())
-	sb.WriteString("/active/")
+	sb.WriteString("/final/")
 	sb.WriteString(virtualTableName + "/")
 	sb.WriteString(streamid + "/")
 	sb.WriteString(strconv.FormatUint(suffix, 10) + "/")
@@ -764,21 +765,14 @@ func getActiveBaseSegDir(streamid string, virtualTableName string, suffix uint64
 	return basedir
 }
 
+// TODO: delete this function
 func getFinalBaseSegDirFromActive(activeBaseSegDir string) (string, error) {
-	if !strings.Contains(activeBaseSegDir, "/active/") {
-		err := fmt.Errorf("getFinalBaseSegDirFromActive: invalid activeBaseSegDir=%v does not contain /active/", activeBaseSegDir)
-		log.Errorf(err.Error())
-		return "", err
-	}
-
-	return GetRotatedVersion(activeBaseSegDir), nil
+	return activeBaseSegDir, nil
 }
 
-// Take a string that is based on a rotated/unrotated segkey (e.g., just a
-// segkey, or a filename that contains a segkey), and return the rotated
-// version of that string.
+// TODO: delete this function
 func GetRotatedVersion(segKey string) string {
-	return strings.Replace(segKey, "/active/", "/final/", 1)
+	return segKey
 }
 
 func updateRangeIndex(key string, rangeIndexPtr map[string]*structs.Numbers, numType SS_IntUintFloatTypes, intVal int64,
@@ -993,7 +987,7 @@ func getActiveBaseDirVTable(virtualTableName string) string {
 	var sb strings.Builder
 	sb.WriteString(config.GetRunningConfig().DataPath)
 	sb.WriteString(config.GetHostID())
-	sb.WriteString("/active/")
+	sb.WriteString("/final/")
 	sb.WriteString(virtualTableName + "/")
 	basedir := sb.String()
 	return basedir

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -766,11 +766,6 @@ func getBaseSegDir(streamid string, virtualTableName string, suffix uint64) stri
 }
 
 // TODO: delete this function
-func getFinalBaseSegDirFromActive(activeBaseSegDir string) (string, error) {
-	return activeBaseSegDir, nil
-}
-
-// TODO: delete this function
 func GetRotatedVersion(segKey string) string {
 	return segKey
 }

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -115,18 +115,6 @@ func Test_getActiveBaseSegDir(t *testing.T) {
 	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/final/"+virtualTableName+"/"+streamid+"/1/", basedir)
 }
 
-func Test_getFinalBaseSegDirFromActive(t *testing.T) {
-	dataPath := t.TempDir()
-	config.InitializeDefaultConfig(dataPath)
-	virtualTableName := "evts"
-	streamid := "10005995996882630313"
-	nextsuff_idx := uint64(1)
-	activeBasedir := getBaseSegDir(streamid, virtualTableName, nextsuff_idx)
-	finalBasedir, err := getFinalBaseSegDirFromActive(activeBasedir)
-	assert.Nil(t, err)
-	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/final/"+virtualTableName+"/"+streamid+"/1/", finalBasedir)
-}
-
 func Test_ReplaceSingleSegMeta(t *testing.T) {
 	config.InitializeDefaultConfig(t.TempDir())
 	initSmr()

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -111,8 +111,8 @@ func Test_getActiveBaseSegDir(t *testing.T) {
 	virtualTableName := "evts"
 	streamid := "10005995996882630313"
 	nextsuff_idx := uint64(1)
-	basedir := getActiveBaseSegDir(streamid, virtualTableName, nextsuff_idx)
-	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/active/"+virtualTableName+"/"+streamid+"/1/", basedir)
+	basedir := getBaseSegDir(streamid, virtualTableName, nextsuff_idx)
+	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/final/"+virtualTableName+"/"+streamid+"/1/", basedir)
 }
 
 func Test_getFinalBaseSegDirFromActive(t *testing.T) {
@@ -121,19 +121,10 @@ func Test_getFinalBaseSegDirFromActive(t *testing.T) {
 	virtualTableName := "evts"
 	streamid := "10005995996882630313"
 	nextsuff_idx := uint64(1)
-	activeBasedir := getActiveBaseSegDir(streamid, virtualTableName, nextsuff_idx)
+	activeBasedir := getBaseSegDir(streamid, virtualTableName, nextsuff_idx)
 	finalBasedir, err := getFinalBaseSegDirFromActive(activeBasedir)
 	assert.Nil(t, err)
 	assert.EqualValues(t, dataPath+"/"+config.GetHostID()+"/final/"+virtualTableName+"/"+streamid+"/1/", finalBasedir)
-}
-
-func Test_GetRotatedVersion(t *testing.T) {
-	unrotatedSegKey := "data/test.abc/active/ind-0/0-0-17399183820399492381/4/4"
-	rotatedVersion := GetRotatedVersion(unrotatedSegKey)
-	assert.Equal(t, "data/test.abc/final/ind-0/0-0-17399183820399492381/4/4", rotatedVersion)
-
-	doubleRotatedVersion := GetRotatedVersion(rotatedVersion)
-	assert.Equal(t, "data/test.abc/final/ind-0/0-0-17399183820399492381/4/4", doubleRotatedVersion)
 }
 
 func Test_ReplaceSingleSegMeta(t *testing.T) {

--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -123,10 +123,11 @@ func removeSegKeyFromUnrotatedInfo(segkey string) {
 	}
 }
 
-func updateRecentlyRotatedSegmentFiles(segkey string, finalKey string) {
+func updateRecentlyRotatedSegmentFiles(segkey string) {
+	// TODO: Does this function do anything useful now? Can it be removed?
 	recentlyRotatedSegmentFilesLock.Lock()
 	RecentlyRotatedSegmentFiles[segkey] = &SegfileRotateInfo{
-		FinalName:   finalKey,
+		FinalName:   segkey,
 		TimeRotated: utils.GetCurrentTimeInMs(),
 	}
 	recentlyRotatedSegmentFilesLock.Unlock()

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -157,18 +157,26 @@ func IsFileForRotatedSegment(filename string) bool {
 func getSegBaseDirFromFilename(filename string) (string, error) {
 	// Note: this is coupled to getBaseSegDir. If getBaseSegDir changes, this
 	// should change too.
-	depth := 6 // getBaseSegDir has 6 components: data/hostid/final/index/streamid/suffix
+	// getBaseSegDir looks like path/to/data/hostid/final/index/streamid/suffix
+	// where path/to/data is the base data directory.
+	depthAfterFinal := 3
 
-	pos := 0
+	const finalStr = "/final/"
+	pos := strings.Index(filename, finalStr)
+	if pos == -1 {
+		return "", TeeErrorf("getSegBaseDirFromFilename: cannot find /final/ in %v", filename)
+	}
+	pos += len(finalStr)
+
 	curDepth := 0
-	for curDepth < depth {
-		pos = strings.Index(filename[pos:], "/")
-		if pos == -1 {
-			return "", TeeErrorf("getSegBaseDirFromFilename: cannot find %v parts in %v",
-				depth, filename)
+	for curDepth < depthAfterFinal {
+		nextPos := strings.Index(filename[pos:], "/")
+		if nextPos == -1 {
+			return "", TeeErrorf("getSegBaseDirFromFilename: cannot find %v parts in %v after /final/",
+				depthAfterFinal, filename)
 		}
 
-		pos += 1
+		pos += nextPos + 1
 		curDepth += 1
 	}
 

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -157,7 +157,7 @@ func IsFileForRotatedSegment(filename string) bool {
 func getSegBaseDirFromFilename(filename string) (string, error) {
 	// Note: this is coupled to getBaseSegDir. If getBaseSegDir changes, this
 	// should change too.
-	depth := 6 // getBaseSegDir has 6 components
+	depth := 6 // getBaseSegDir has 6 components: data/hostid/final/index/streamid/suffix
 
 	pos := 0
 	curDepth := 0

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -139,11 +139,8 @@ func IsSubWordPresent(haystack []byte, needle []byte, isCaseInsensitive bool) bo
 
 func IsSegmentRotated(segKey string) bool {
 	_, err := os.Stat(filepath.Join(segKey, SegmentValidityFname))
-	if err != nil {
-		return false
-	}
 
-	return true
+	return err == nil
 }
 
 func IsFileForRotatedSegment(filename string) bool {
@@ -154,11 +151,7 @@ func IsFileForRotatedSegment(filename string) bool {
 	}
 
 	_, err = os.Stat(filepath.Join(segBaseDir, SegmentValidityFname))
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 func getSegBaseDirFromFilename(filename string) (string, error) {

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -174,3 +174,19 @@ func getSegBaseDirFromFilename(filename string) (string, error) {
 
 	return filename[:pos], nil
 }
+
+func WriteValidityFile(segBaseDir string) error {
+	err := os.MkdirAll(segBaseDir, 0755)
+	if err != nil {
+		log.Errorf("WriteValidityFile: cannot create dir=%v; err=%v", segBaseDir, err)
+		return err
+	}
+
+	f, err := os.Create(filepath.Join(segBaseDir, SegmentValidityFname))
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	return nil
+}

--- a/pkg/utils/segutils_test.go
+++ b/pkg/utils/segutils_test.go
@@ -19,12 +19,15 @@ package utils
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/cespare/xxhash"
 	"github.com/google/uuid"
 	"github.com/rogpeppe/fastuuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_IsSubWordPresent(t *testing.T) {
@@ -197,6 +200,32 @@ func Test_IsSubWordPresent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_SegmentValidityFile_SimpleBase(t *testing.T) {
+	t.Cleanup(func() { os.RemoveAll("data") })
+
+	dataDir := "data"
+	segBaseDir := filepath.Join(dataDir, "hostid/final/index/streamid/suffix/")
+	filename := filepath.Join(segBaseDir, "foo/bar.txt")
+	assert.False(t, IsFileForRotatedSegment(filename))
+
+	err := WriteValidityFile(segBaseDir)
+	assert.NoError(t, err)
+	assert.True(t, IsFileForRotatedSegment(filename))
+}
+
+func Test_SegmentValidityFile_NestedBase(t *testing.T) {
+	t.Cleanup(func() { os.RemoveAll("foo") })
+
+	dataDir := "foo/data/baz"
+	segBaseDir := filepath.Join(dataDir, "hostid/final/index/streamid/suffix/")
+	filename := filepath.Join(segBaseDir, "foo/bar.txt")
+	assert.False(t, IsFileForRotatedSegment(filename))
+
+	err := WriteValidityFile(segBaseDir)
+	assert.NoError(t, err)
+	assert.True(t, IsFileForRotatedSegment(filename))
 }
 
 func Benchmark_UUIDNew(b *testing.B) {


### PR DESCRIPTION
# Description
Previously we would flush WIP blocks for a segment into an `active` directory, and when we rotated the segment we'd move that `active` directory to `final`. This causes some problems during query because sometimes we obtain segkeys for `active`, but then the segment rotates, and then when we look for that data we can't find it because it's in `final`. This PR addresses this issue by removing the `active` dir; now we put all data—even unrotated data—in `final`.

With this, we do lose some ease of identifying if a segment is rotated or not. We can look in segmeta.json for the segkey; also, this PR adds a new file (segment-validity.json) that is created during segment rotation—if that file is present, then the segment is valid and rotated.

# Testing
Ran continuous ingest and query, and it seems to be working normally.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
