### PR TITLE
Add Playwright Tests for Logs Screen with Ingested Data

### DIFF
--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -28,7 +28,14 @@ jobs:
       - name: Run SigLens
         run: |
           ./siglens --config server.yaml &
-          sleep 10  # Give some time for SigLens to start
+          sleep 10 
+
+      - name: Ingest Logs & Metrics
+        run: |
+          cd tools/sigclient
+          go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 10_000
+          go run main.go ingest metrics -d http://localhost:8081/otsdb -t 1_000 -m 5 -p 1 -b 10_000 -g benchmark
+          sleep 40
 
       - name: Install Playwright Dependencies
         run: |
@@ -37,7 +44,7 @@ jobs:
           npm install @playwright/test
           npx playwright install --with-deps
 
-      - name: Run Playwright tests
+      - name: Run Playwright Tests
         run: |
           cd playwright-tests
           npx playwright test

--- a/playwright-tests/tests/common-functions.js
+++ b/playwright-tests/tests/common-functions.js
@@ -29,11 +29,11 @@ async function testDateTimePicker(page) {
     await page.click('#date-picker-btn');
     await datePickerBtn.click();
     await expect(page.locator('.daterangepicker')).toBeVisible();
-    const timeRangeOption = page.locator('#now-5m');
+    const timeRangeOption = page.locator('#now-24h');
     await timeRangeOption.click();
     await expect(timeRangeOption).toHaveClass(/active/);
     const datePickerButtonText = page.locator('#date-picker-btn span');
-    await expect(datePickerButtonText).toHaveText('Last 5 Mins');
+    await expect(datePickerButtonText).toHaveText('Last 24 Hrs');
 }
 
 module.exports = {

--- a/playwright-tests/tests/dashboard.test.js
+++ b/playwright-tests/tests/dashboard.test.js
@@ -1,12 +1,17 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('Dashboard Page Tests', () => {
-    test('Dashboard Functionality Tests', async ({ page }) => {
-        let dashboardId;
+    let page;
+    let dashboardId;
+    let uniqueName;
+
+    test.beforeEach(async ({ browser }) => {
+        page = await browser.newPage();
+        
         // Create dashboard
         await page.goto('http://localhost:5122/dashboards-home.html');
         await page.click('#create-db-btn');
-        const uniqueName = `Test Dashboard Playwright ${Date.now()}`;
+        uniqueName = `Test Dashboard Playwright ${Date.now()}`;
         await page.fill('#db-name', uniqueName);
         await page.fill('#db-description', 'This is a test dashboard');
         await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle' }), page.click('#save-dbbtn')]);
@@ -17,12 +22,6 @@ test.describe('Dashboard Page Tests', () => {
         // Navigate to the created dashboard
         await page.goto(`http://localhost:5122/dashboard.html?id=${dashboardId}`);
 
-        // Verify dashboard loaded correctly
-        await expect(page.locator('#new-dashboard')).toBeVisible();
-        await expect(page.locator('.name-dashboard')).toBeVisible();
-        await expect(page.locator('#panel-container')).toBeVisible();
-        await expect(page.locator('.name-dashboard')).toContainText('Test Dashboard Playwright');
-
         // Create a new panel
         await expect(page.locator('#add-widget-options .editPanelMenu')).toBeVisible();
         await page.click('#add-panel-btn');
@@ -30,61 +29,83 @@ test.describe('Dashboard Page Tests', () => {
         await page.click('#add-panel-btn');
         await page.click('.widget-option[data-index="0"]'); // Select Line Chart
         await expect(page.locator('.panelEditor-container')).toBeVisible();
+        await page.fill('#panEdit-nameChangeInput', 'Test Panel');
+        await page.click('.panEdit-save');
+        await expect(page.locator('.panel-header p')).toContainText('Test Panel');
+    });
+
+    test('Verify dashboard loads correctly', async () => {
+        await expect(page.locator('#new-dashboard')).toBeVisible();
+        await expect(page.locator('.name-dashboard')).toBeVisible();
+        await expect(page.locator('#panel-container')).toBeVisible();
+        await expect(page.locator('.name-dashboard')).toContainText(uniqueName);
+    });
+
+    test('Edit panel', async () => {
+        const panelHeader = page.locator('.panel-header').first();
+        const editIcon = panelHeader.locator('img.panel-edit-li');
+        
+        await panelHeader.hover();
+        await expect(editIcon).toBeVisible();
+        await editIcon.click();
+        
+        const editPanel = page.locator('.panelEditor-container');
+        await expect(editPanel).toBeVisible();
         await page.fill('#panEdit-nameChangeInput', 'Updated Panel Name');
         await page.click('.panEdit-save');
         await expect(page.locator('.panel-header p')).toContainText('Updated Panel Name');
+    });
 
-        // Panel Header Buttons Check
+    test('View panel', async () => {
         const panelHeader = page.locator('.panel-header').first();
-        const editIcon = panelHeader.locator('img.panel-edit-li');
         const viewIcon = panelHeader.locator('img.panel-view-li');
-        const optionsBtn = panelHeader.locator('#panel-options-btn');
-
+        
         await panelHeader.hover();
-        await expect(editIcon).toBeVisible();
         await expect(viewIcon).toBeVisible();
-        await expect(optionsBtn).toBeVisible();
-
-        // Edit and View Panel
-        await editIcon.click();
-        const editPanel = page.locator('.panelEditor-container');
-        await expect(editPanel).toBeVisible();
-
-        const viewButton = page.locator('#overview-button');
-        await expect(viewButton).toBeVisible();
-        await viewButton.click();
+        await viewIcon.click();
+        
         const viewPanel = page.locator('#viewPanel-container');
         await expect(viewPanel).toBeVisible();
         await expect(page.locator('#overview-button')).toHaveClass(/active/);
+        
         const editButton = page.locator('#edit-button');
         await editButton.click();
         await expect(page.locator('#edit-button')).toHaveClass(/active/);
-        const cancelButton = editPanel.locator('#discard-btn');
+        
+        const cancelButton = page.locator('.panelEditor-container #discard-btn');
         await expect(cancelButton).toBeVisible();
         await cancelButton.click();
-        await expect(editPanel).not.toBeVisible();
+        await expect(page.locator('.panelEditor-container')).not.toBeVisible();
         await expect(page.locator('#panel-container')).toBeVisible();
+    });
 
-        // Delete Panel
+    test('Delete panel', async () => {
+        const panelHeader = page.locator('.panel-header').first();
+        const optionsBtn = panelHeader.locator('#panel-options-btn');
+        
         const initialPanelCount = await page.locator('.panel').count();
         await panelHeader.hover();
         await expect(optionsBtn).toBeVisible();
         await optionsBtn.click();
+        
         const dropdownMenu = page.locator('#panel-dropdown-modal');
         await expect(dropdownMenu).toBeVisible();
         const deleteOption = dropdownMenu.locator('.panel-remove-li');
         await expect(deleteOption).toBeVisible();
         await deleteOption.click();
+        
         const deleteConfirmDialog = page.locator('#panel-del-prompt');
         await expect(deleteConfirmDialog).toBeVisible();
         const confirmDeleteBtn = deleteConfirmDialog.locator('#delete-btn-panel');
         await expect(confirmDeleteBtn).toBeVisible();
         await confirmDeleteBtn.click();
+        
         await page.waitForTimeout(2000);
         const finalPanelCount = await page.locator('.panel').count();
         expect(finalPanelCount).toBe(initialPanelCount - 1);
+    });
 
-        // Change dashboard settings
+    test('Change dashboard settings', async () => {
         await page.click('#db-settings-btn');
         await expect(page.locator('.dbSet-container')).toBeVisible();
         const updatedName = 'Updated Dashboard Name ' + Date.now();
@@ -92,14 +113,16 @@ test.describe('Dashboard Page Tests', () => {
         await page.click('#dbSet-save');
         await page.waitForTimeout(2000);
         await expect(page.locator('.name-dashboard')).toContainText(updatedName);
+    });
 
-        // Toggle favorite status
+    test('Toggle favorite status', async () => {
         const initialState = await page.locator('#favbutton').getAttribute('class');
         await page.click('#favbutton');
         const newState = await page.locator('#favbutton').getAttribute('class');
         expect(newState).not.toBe(initialState);
+    });
 
-        // Set refresh interval
+    test('Set refresh interval', async () => {
         await page.click('#refresh-picker-btn');
         const refreshDropdownMenu = page.locator('.refresh-picker');
         await expect(refreshDropdownMenu).toBeVisible();
@@ -108,8 +131,9 @@ test.describe('Dashboard Page Tests', () => {
         await expect(refreshOption).toHaveClass(/active/);
         const refreshButtonText = page.locator('#refresh-picker-btn span');
         await expect(refreshButtonText).toHaveText('5m');
+    });
 
-        // Test date picker
+    test('Test date picker', async () => {
         await page.click('#new-dashboard #date-picker-btn');
         const datePickerMenu = page.locator('#new-dashboard .daterangepicker');
         await expect(datePickerMenu).toBeVisible();
@@ -118,5 +142,9 @@ test.describe('Dashboard Page Tests', () => {
         await expect(timeRangeOption).toHaveClass(/active/);
         const datePickerButtonText = page.locator('#new-dashboard #date-picker-btn span');
         await expect(datePickerButtonText).toHaveText('Last 5 Mins');
+    });
+
+    test.afterEach(async () => {
+        await page.close();
     });
 });

--- a/playwright-tests/tests/index.test.js
+++ b/playwright-tests/tests/index.test.js
@@ -4,6 +4,12 @@ const { testDateTimePicker, testThemeToggle } = require('./common-functions');
 test.describe('Logs Page Tests', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('http://localhost:5122/index.html');
+        
+        // Perform search to show results table
+        await testDateTimePicker(page);
+        await page.locator('#query-builder-btn').click();
+        await page.waitForTimeout(1000);
+        await expect(page.locator('#logs-result-container')).toBeVisible();
     });
 
     test('verify date picker functionality', async ({ page }) => {
@@ -11,10 +17,13 @@ test.describe('Logs Page Tests', () => {
     });
 
     test('verify search and show records functionality', async ({ page }) => {
+        await testDateTimePicker(page);
+
         const searchButton = page.locator('#query-builder-btn');
 
         await searchButton.click();
-        await expect(page.locator('#empty-response')).toBeVisible();
+        await page.waitForTimeout(1000);
+        await expect(page.locator('#logs-result-container')).toBeVisible();
 
         const showRecordsBtn = page.locator('#show-record-intro-btn');
         await expect(showRecordsBtn).toBeVisible();
@@ -68,5 +77,126 @@ test.describe('Logs Page Tests', () => {
 
     test('should change theme', async ({ page }) => {
         await testThemeToggle(page);
+    });
+
+    test('should add to alert', async ({ page, context }) => {
+        await page.click('#alert-from-logs-btn');
+        await expect(page.locator('.addrulepopupContent')).toBeVisible();
+
+        await page.fill('#rule-name', 'Test Alert');
+
+        // Wait for the new page to be created
+        const newPagePromise = context.waitForEvent('page');
+
+        await page.click('#addrule-save-btn');
+
+        const newPage = await newPagePromise;
+        await newPage.waitForLoadState();
+
+        // Verify that the new page's URL contains 'alert.html'
+        expect(newPage.url()).toContain('alert.html');
+
+        await newPage.close();
+    });
+
+    test('should add to dashboard', async ({ page, context }) => {
+        await page.click('#add-logs-to-db-btn');
+        await expect(page.locator('#create-db-popup')).toBeVisible();
+
+        await page.fill('#db-name', `Test Dashboard + ${Date.now()}`);
+
+        // Wait for the new page to be created
+        const newPagePromise = context.waitForEvent('page');
+
+        await page.click('#create-db');
+
+        const newPage = await newPagePromise;
+        await newPage.waitForLoadState();
+
+        // Verify that the new page's URL contains 'dashboard.html'
+        expect(newPage.url()).toContain('dashboard.html');
+
+        await newPage.close();
+    });
+
+    test('should add to existing dashboard', async ({ page, context }) => {
+        await page.click('#add-logs-to-db-btn');
+        await expect(page.locator('#create-db-popup')).toBeVisible();
+
+        await page.click('.existing-dashboard-btn');
+
+        await page.click('#selected-dashboard');
+        await page.click('#dashboard-options li:first-child'); // Selects the first dashboard in the list
+
+        const newPagePromise = context.waitForEvent('page');
+
+        await page.click('#create-panel');
+
+        const newPage = await newPagePromise;
+        await newPage.waitForLoadState();
+
+        // Verify that the new page's URL contains 'dashboard.html'
+        expect(newPage.url()).toContain('dashboard.html');
+        await newPage.close();
+    });
+
+    test('should save query', async ({ page }) => {
+        await page.click('#saveq-btn');
+
+        // Wait for the dialog to be visible
+        const dialog = page.locator('[aria-describedby="save-queries"]');
+        await dialog.waitFor({ state: 'visible' });
+
+        // Fill in the form
+        await page.fill('[aria-describedby="save-queries"] #qname', 'Test-Query');
+        await page.fill('[aria-describedby="save-queries"] #description', 'This is a test query');
+
+        // Click the Save button within the dialog
+        const saveButton = dialog.locator('.saveqButton');
+        await saveButton.waitFor({ state: 'visible' });
+        await saveButton.click();
+
+        const toast = page.locator('#message-toast');
+        const toastText = await toast.innerText();
+        const normalizedToastText = toastText.replace(/\s+/g, ' ').trim();
+        expect(normalizedToastText).toContain('Query saved successfully');
+    });
+
+    test('should download logs', async ({ page }) => {
+        await page.click('.download-all-logs-btn');
+        await page.click('#csv-block');
+        const dialog = page.locator('[aria-describedby="download-info"]');
+        await dialog.waitFor({ state: 'visible' });
+
+        // Fill in the form
+        await page.fill('#qnameDL', 'Test-CSV-Download');
+
+        // Click the Save button within the dialog
+        const saveButton = dialog.locator('.saveqButton');
+        await saveButton.click();
+
+        // Verify download started
+        const downloadPromise = page.waitForEvent('download');
+        await downloadPromise;
+    });
+
+    test('should change table view', async ({ page }) => {
+        await page.click('#log-opt-single-btn');
+        await page.click('#log-opt-multi-btn');
+        await page.click('#log-opt-table-btn');
+    });
+
+    test('should toggle available fields', async ({ page }) => {
+        // Open the available fields dropdown
+        await page.click('#avail-fields-btn');
+        await expect(page.locator('#available-fields')).toBeVisible();
+
+        // Click on the 'app_name' field
+        await page.click('#available-fields .fields .available-fields-dropdown-item[data-index="app_name"]');
+
+        await page.waitForTimeout(1000);
+
+        // Verify the field was toggled (column should not be visible in the grid)
+        await expect(page.locator('.LogResultsGrid')).not.toContainText('app_name');
     });
 });

--- a/playwright-tests/tests/navbar.test.js
+++ b/playwright-tests/tests/navbar.test.js
@@ -54,7 +54,8 @@ test('Navigation Menu Functionality Tests', async ({ page }) => {
     for (const { selector, url } of navItems) {
         await page.click(`${selector} a`);
         expect(page.url()).toContain(url);
-        await expect(page.locator(selector)).toHaveClass(/active/);
+        await expect(page.locator(selector)).toBeVisible({ timeout: 10000 });
+        await expect(page.locator(selector)).toHaveClass(/active/, { timeout: 10000 });
 
         if (url === 'all-alerts.html') {
             await expect(page.locator('.alerts-nav-tab')).toBeVisible();

--- a/static/js/dashboard-from-logs-metrics.js
+++ b/static/js/dashboard-from-logs-metrics.js
@@ -284,14 +284,20 @@ function selectDashboardHandler() {
 }
 
 function handlePanelPosition(existingDashboard, newPanel) {
-    const maxY = existingDashboard.panels.reduce((max, panel) => {
-        return Math.max(max, panel.gridpos.y + panel.gridpos.h);
-    }, 0);
-    const maxX = existingDashboard.panels.reduce((max, panel) => {
-        return Math.max(max, panel.gridpos.x + panel.gridpos.w);
-    });
-    newPanel.gridpos.y = maxY + 20;
-    newPanel.gridpos.x = maxX + 20;
+    if (!existingDashboard.panels || existingDashboard.panels.length === 0) {
+        // If there are no existing panels
+        newPanel.gridpos.x = '0';
+        newPanel.gridpos.y = '0';
+    } else {
+        const maxY = existingDashboard.panels.reduce((max, panel) => {
+            return Math.max(max, panel.gridpos.y + panel.gridpos.h);
+        }, 0);
+        const maxX = existingDashboard.panels.reduce((max, panel) => {
+            return Math.max(max, panel.gridpos.x + panel.gridpos.w);
+        });
+        newPanel.gridpos.y = maxY + 20;
+        newPanel.gridpos.x = maxX + 20;
+    }
     existingDashboard.panels.push(newPanel);
     return existingDashboard;
 }

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
# Description
1. Modified the playwright.yml to include data ingestion, ensuring that logs & metrics are ingested before running tests.
2.  Added Playwright tests for the Logs screen to test the functionality of features such as saving queries, adding logs to dashboards, creating alerts, downloading logs and available fields toggle.
3. Refactored the dashboard.test.js file for faster test execution.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
