### PR TITLE
Add option to not compress static files

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -120,12 +120,14 @@ type Configuration struct {
 	AgileAggsEnabledConverted   bool
 	DualCaseCheck               string `yaml:"dualCaseCheck"` // This is to support the old data that does not have case-insensitive search support. TODO: Remove this after 2 months from now: Aug 21st, 2024.
 	DualCaseCheckConverted      bool
-	QueryHostname               string         `yaml:"queryHostname"` // hostname of the query server. i.e. if DNS is https://cloud.siglens.com, this should be cloud.siglens.com
-	IngestUrl                   string         `yaml:"ingestUrl"`     // full address of the ingest server, including scheme and port, e.g. https://ingest.siglens.com:8080
-	S3                          S3Config       `yaml:"s3"`            // s3 related config
-	Log                         LogConfig      `yaml:"log"`           // Log related config
-	TLS                         TLSConfig      `yaml:"tls"`           // TLS related config
-	Tracing                     TracingConfig  `yaml:"tracing"`       // Tracing related config
+	QueryHostname               string    `yaml:"queryHostname"`  // hostname of the query server. i.e. if DNS is https://cloud.siglens.com, this should be cloud.siglens.com
+	IngestUrl                   string    `yaml:"ingestUrl"`      // full address of the ingest server, including scheme and port, e.g. https://ingest.siglens.com:8080
+	S3                          S3Config  `yaml:"s3"`             // s3 related config
+	Log                         LogConfig `yaml:"log"`            // Log related config
+	TLS                         TLSConfig `yaml:"tls"`            // TLS related config
+	CompressStatic              string    `yaml:"compressStatic"` // compress static files
+	CompressStaticConverted     bool
+	Tracing                     TracingConfig  `yaml:"tracing"` // Tracing related config
 	EmailConfig                 EmailConfig    `yaml:"emailConfig"`
 	DatabaseConfig              DatabaseConfig `yaml:"minionSearch"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -789,7 +789,7 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	}
 
 	if len(config.CompressStatic) <= 0 {
-		config.CompressStatic = "false"
+		config.CompressStatic = "true"
 	}
 	compressStatic, err := strconv.ParseBool(config.CompressStatic)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -200,6 +200,10 @@ func GetTLSPrivateKeyPath() string {
 	return runningConfig.TLS.PrivateKeyPath
 }
 
+func ShouldCompressStaticFiles() bool {
+	return runningConfig.CompressStaticConverted
+}
+
 // used by
 func GetQueryHostname() string {
 	return runningConfig.QueryHostname
@@ -518,6 +522,8 @@ func GetTestConfig(dataPath string) common.Configuration {
 		QueryHostname:               "",
 		Log:                         common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
 		TLS:                         common.TLSConfig{Enabled: false, CertificatePath: "", PrivateKeyPath: ""},
+		CompressStatic:              "false",
+		CompressStaticConverted:     false,
 		Tracing:                     common.TracingConfig{ServiceName: "", Endpoint: "", SamplingPercentage: 1},
 		DatabaseConfig:              common.DatabaseConfig{Enabled: true, Provider: "sqlite"},
 		EmailConfig:                 common.EmailConfig{SmtpHost: "smtp.gmail.com", SmtpPort: 587, SenderEmail: "doe1024john@gmail.com", GmailAppPassword: " "},
@@ -781,6 +787,18 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	if len(config.TLS.PrivateKeyPath) >= 0 && strings.HasPrefix(config.TLS.PrivateKeyPath, "./") {
 		config.TLS.PrivateKeyPath = strings.Trim(config.TLS.PrivateKeyPath, "./")
 	}
+
+	if len(config.CompressStatic) <= 0 {
+		config.CompressStatic = "false"
+	}
+	compressStatic, err := strconv.ParseBool(config.CompressStatic)
+	if err != nil {
+		compressStatic = true
+		config.CompressStatic = "true"
+		log.Errorf("ExtractConfigData: failed to parse compress static flag. Defaulting to %v. Error: %v",
+			compressStatic, err)
+	}
+	config.CompressStaticConverted = compressStatic
 
 	// Check for Tracing Config through environment variables
 	if os.Getenv("TRACESTORE_ENDPOINT") != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -80,6 +80,7 @@ func Test_ExtractConfigData(t *testing.T) {
    samplingPercentage: 100
  log:
    logPrefix: "./pkg/ingestor/httpserver/"
+ compressStatic: false
  `),
 
 			common.Configuration{
@@ -117,6 +118,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				DualCaseCheckConverted:      true,
 				SafeServerStart:             true,
 				Log:                         common.LogConfig{LogPrefix: "./pkg/ingestor/httpserver/", LogFileRotationSizeMB: 100, CompressLogFile: false},
+				CompressStatic:              "false",
+				CompressStaticConverted:     false,
 				Tracing:                     common.TracingConfig{Endpoint: "http://localhost:4317", ServiceName: "siglens", SamplingPercentage: 100},
 			},
 		},
@@ -161,6 +164,7 @@ func Test_ExtractConfigData(t *testing.T) {
    logPrefix: "./pkg/ingestor/httpserver/"
    logFileRotationSizeMB: 1000
    compressLogFile: true
+ compressStatic: bad string
  `),
 
 			common.Configuration{
@@ -198,6 +202,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				AgileAggsEnabledConverted:   true,
 				SafeServerStart:             false,
 				Log:                         common.LogConfig{LogPrefix: "./pkg/ingestor/httpserver/", LogFileRotationSizeMB: 1000, CompressLogFile: true},
+				CompressStatic:              "true",
+				CompressStaticConverted:     true,
 				Tracing:                     common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
 			},
 		},
@@ -239,6 +245,8 @@ invalid input, we should error out
 				DualCaseCheck:              "true",
 				DualCaseCheckConverted:     true,
 				Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
+				CompressStatic:             "true",
+				CompressStaticConverted:    true,
 				Tracing:                    common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 1},
 			},
 		},
@@ -281,6 +289,8 @@ a: b
 				DualCaseCheck:               "true",
 				DualCaseCheckConverted:      true,
 				Log:                         common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
+				CompressStatic:              "true",
+				CompressStaticConverted:     true,
 				Tracing:                     common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
 			},
 		},

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -59,9 +59,10 @@ var (
 // ConstructHttpServer new fasthttp server
 func ConstructQueryServer(cfg config.WebConfig, ServerAddr string) *queryserverCfg {
 	staticFs := fasthttp.FS{
-		Root:       "./static",
-		IndexNames: []string{"index.html"},
-		Compress:   config.ShouldCompressStaticFiles(),
+		Root:           "./static",
+		IndexNames:     []string{"index.html"},
+		Compress:       config.ShouldCompressStaticFiles(),
+		CompressBrotli: config.ShouldCompressStaticFiles(),
 	}
 
 	s := &queryserverCfg{


### PR DESCRIPTION
# Description
This adds a config option to not compress files in `static/`. By default, these will be compressed. When compression is enabled, there will be some files like myfile.fasthttp.br that get written to `static/`. For some use cases, users may want to have `static/` be read-only; this new option allows that.

# Testing
1. Clear the .br files: `find . -name "*.br*" | xargs rm`
2. Start siglens
3. Run `watch -n 1 'find . -name "*.br*" | xargs ls'`
4. Go to the UI and click on several pages. Without this PR (or with this PR and having `compressStatic: true`), after a while your `watch` command should show some files; but with compression disabled, your `watch` command should continue showing no files.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
