### PR TITLE
Fix for column does not exist in block error

### DIFF
--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -175,8 +175,7 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]struct{}, blockNum uint16) error {
 	for keyIndex := range colsIndexMap {
 		if keyIndex >= len(mcsr.allFileReaders) {
-			// This can happen if the column does not exist.
-			return nil
+			continue // This can happen if the column does not exist
 		}
 
 		sfr := mcsr.allFileReaders[keyIndex]
@@ -184,7 +183,7 @@ func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]str
 			valid, err := sfr.readBlock(blockNum)
 			if !valid {
 				log.Debugf("Skipped invalid block %d, error: %v", blockNum, err)
-				continue // since other cols might be useful
+				continue // This can happen if the column does not exist.
 			}
 			if err != nil {
 				return fmt.Errorf("MultiColSegmentReader.ValidateAndReadBlock: error loading blockNum: %v. Error: %+v", blockNum, err)

--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -183,6 +183,7 @@ func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]str
 		if !sfr.isBlockLoaded || sfr.currBlockNum != blockNum {
 			valid, err := sfr.readBlock(blockNum)
 			if !valid {
+				log.Debugf("Skipped invalid block %d, error: %v", blockNum, err)
 				continue // since other cols might be useful
 			}
 			if err != nil {

--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -183,7 +183,7 @@ func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]str
 		if !sfr.isBlockLoaded || sfr.currBlockNum != blockNum {
 			valid, err := sfr.readBlock(blockNum)
 			if !valid {
-				return err
+				continue // since other cols might be useful
 			}
 			if err != nil {
 				return fmt.Errorf("MultiColSegmentReader.ValidateAndReadBlock: error loading blockNum: %v. Error: %+v", blockNum, err)


### PR DESCRIPTION
# Description
Summarize the change.
We were facing errors from filterSearchQuery because ValidateAndReadBlock was returning error when some blocks did not have specific columns that are present in the segment.
`
filterRecordsFromSearchQuery: failed to validate and read block: 3, err: SegmentFileReader.readBlock: column does not exist in block: 3 colNum: perseite-u file: data/sigsingle.9rDJ3exZ6KfZJskdDj34WP/final/svcgroup-1/0-0-13435680861203573242/0/0_15363296528398503342.csg 
`

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

Steps to reproduce:
- Make max_recs per wip to 1
- Based on a random number assign an extra column
- Run query say `*vector*`

Earlier I was getting the above mentioned error, with this fix we should not get these errors.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
