### PR TITLE
Disallow unknown fields in server.yaml

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,8 +31,9 @@ import (
 func Test_ExtractConfigData(t *testing.T) {
 	flag.Parse()
 	cases := []struct {
-		input    []byte
-		expected common.Configuration
+		input       []byte
+		shouldError bool
+		expected    common.Configuration
 	}{
 		{ // case 1 - For correct input parameters and values
 			[]byte(`
@@ -40,37 +41,27 @@ func Test_ExtractConfigData(t *testing.T) {
  queryListenIP: "0.0.0.0"
  ingestPort: 9090
  eventTypeKeywords: ["utm_content"]
- baseLogDir: "./pkg/ingestor/httpserver/"
  queryNode: true
  ingestNode: true
- seedNode: true
- segreaderNode: true
- metareaderNode: true
- DataPath: "data/"
+ dataPath: "data/"
  s3:
   enabled: true
   bucketName: "test-1"
   bucketPrefix: ""
   regionName: "us-east-1"
  retentionHours: 90
- TimeStampKey: "timestamp"
+ timestampKey: "timestamp"
  maxSegFileSize: 10
- licensekeyPath: "./"
+ licenseKeyPath: "./"
  esVersion: "6.8.20"
- maxVirtualTables: 10_000
- logFileRotationSizeMB: 100
- compressLogFile: false
  dataDiskThresholdPercent: 85
  memoryThresholdPercent: 80
- partitionCountConsistentHasher: 271
- replicationFactorConsistentHasher: 40
- loadConsistentHasher: 1.2
  s3IngestQueueName: ""
  s3IngestQueueRegion: ""
  s3IngestBufferSize: 1000
  maxParallelS3IngestBuffers: 10
  queryHostname: "abc:123"
- PQSEnabled: bad string
+ pqsEnabled: bad string
  analyticsEnabled: false
  agileAggsEnabled: false
  safeMode: true
@@ -80,8 +71,10 @@ func Test_ExtractConfigData(t *testing.T) {
    samplingPercentage: 100
  log:
    logPrefix: "./pkg/ingestor/httpserver/"
+   logFileRotationSizeMB: 100
+   compressLogFile: false
  `),
-
+			false,
 			common.Configuration{
 				IngestListenIP:              "0.0.0.0",
 				QueryListenIP:               "0.0.0.0",
@@ -122,130 +115,28 @@ func Test_ExtractConfigData(t *testing.T) {
 		},
 		{ // case 2 - For wrong input type, show error message
 			[]byte(`
- ingestListenIP: "0.0.0.0"
- queryListenIP: "0.0.0.0"
- ingestPort: 9090
- queryPort: 9000
- eventTypeKeywords: ["utm_content"]
- queryNode: true
- ingestNode: true
- seedNode: true
- segreaderNode: true
- metareaderNode: true
- idleWipFlushIntervalSecs: 1200
- maxWaitWipFlushIntervalSecs: 300
- DataPath: "data/"
- retentionHours: 123
- TimeStampKey: "timestamp"
- maxSegFileSize: 12345
- licensekeyPath: "./"
- esVersion: "6.8.20"
- dataDiskThresholdPercent: 85
- memoryThresholdPercent: 80
- partitionCountConsistentHasher: 271
- replicationFactorConsistentHasher: 40
- loadConsistentHasher: 1.2
- S3IngestQueueName: ""
- S3IngestQueueRegion: ""
- S3IngestBufferSize: 1000
- MaxParallelS3IngestBuffers: 10
- PQSEnabled: F
- dualCaseCheck: true
- analyticsEnabled: bad string
- AgileAggsEnabled: bad string
- tracing:
-   endpoint: ""
-   serviceName: ""
-   smaplingPercentage: bad string
- log:
-   logPrefix: "./pkg/ingestor/httpserver/"
-   logFileRotationSizeMB: 1000
-   compressLogFile: true
+ memoryThresholdPercent: not a number
  `),
-
-			common.Configuration{
-				IngestListenIP:              "0.0.0.0",
-				QueryListenIP:               "0.0.0.0",
-				IngestPort:                  9090,
-				QueryPort:                   9000,
-				IngestUrl:                   "http://localhost:9090",
-				EventTypeKeywords:           []string{"utm_content"},
-				QueryNode:                   "true",
-				IngestNode:                  "true",
-				IdleWipFlushIntervalSecs:    60,
-				MaxWaitWipFlushIntervalSecs: 60,
-				DataPath:                    "data/",
-				S3:                          common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-				RetentionHours:              123,
-				TimeStampKey:                "timestamp",
-				MaxSegFileSize:              12345,
-				LicenseKeyPath:              "./",
-				ESVersion:                   "6.8.20",
-				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
-				S3IngestQueueName:           "",
-				S3IngestQueueRegion:         "",
-				S3IngestBufferSize:          1000,
-				MaxParallelS3IngestBuffers:  10,
-				QueryHostname:               "localhost:9000",
-				PQSEnabled:                  "true",
-				PQSEnabledConverted:         true,
-				DualCaseCheck:               "true",
-				DualCaseCheckConverted:      true,
-				AnalyticsEnabled:            "true",
-				AnalyticsEnabledConverted:   true,
-				AgileAggsEnabled:            "true",
-				AgileAggsEnabledConverted:   true,
-				SafeServerStart:             false,
-				Log:                         common.LogConfig{LogPrefix: "./pkg/ingestor/httpserver/", LogFileRotationSizeMB: 1000, CompressLogFile: true},
-				Tracing:                     common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
-			},
+			true,
+			common.Configuration{},
 		},
 		{ // case 3 - Error out on bad yaml
 			[]byte(`
 invalid input, we should error out
 `),
-
-			common.Configuration{
-				IngestListenIP:              "0.0.0.0",
-				QueryListenIP:               "0.0.0.0",
-				IngestPort:                  8081,
-				QueryPort:                   0,
-				IngestUrl:                   "http://localhost:8081",
-				EventTypeKeywords:           []string{"eventType"},
-				QueryNode:                   "true",
-				IngestNode:                  "true",
-				IdleWipFlushIntervalSecs:    5,
-				MaxWaitWipFlushIntervalSecs: 30,
-				DataPath:                    "data/",
-				S3:                          common.S3Config{Enabled: false, BucketName: "", BucketPrefix: "", RegionName: ""},
-				RetentionHours:              90,
-				TimeStampKey:                "timestamp",
-				MaxSegFileSize:              1_073_741_824,
-				LicenseKeyPath:              "./",
-				ESVersion:                   "6.8.20",
-				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
-				S3IngestQueueName:           "",
-				S3IngestQueueRegion:         "",
-
-				S3IngestBufferSize:         1000,
-				MaxParallelS3IngestBuffers: 10,
-				QueryHostname:              "localhost:5122",
-				AnalyticsEnabled:           "true",
-				AnalyticsEnabledConverted:  true,
-				AgileAggsEnabled:           "true",
-				AgileAggsEnabledConverted:  true,
-				DualCaseCheck:              "true",
-				DualCaseCheckConverted:     true,
-				Log:                        common.LogConfig{LogPrefix: "", LogFileRotationSizeMB: 100, CompressLogFile: false},
-				Tracing:                    common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 1},
-			},
+			true,
+			common.Configuration{},
 		},
-		{ // case 4 - For no input, pick defaults
+		{ // case 4 - Error out on invalid fields
 			[]byte(`
-a: b
+invalidField: "invalid"
 `),
+			true,
+			common.Configuration{},
+		},
+		{ // case 5 - For no input, pick defaults
+			[]byte(``),
+			false,
 			common.Configuration{
 				IngestListenIP:              "0.0.0.0",
 				QueryListenIP:               "0.0.0.0",
@@ -287,10 +178,13 @@ a: b
 	}
 	for i, test := range cases {
 		actualConfig, err := ExtractConfigData(test.input)
-		if i == 2 {
-			assert.Error(t, err)
+		if test.shouldError {
+			assert.Error(t, err, fmt.Sprintf("test=%v should have errored", i+1))
 			continue
+		} else {
+			assert.NoError(t, err, fmt.Sprintf("test=%v should not have errored", i+1))
 		}
+
 		if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
 			assert.Equal(t, uint64(50), actualConfig.MemoryThresholdPercent)
 			// If memory is less than 8GB, config by default returns 50% as the threshold


### PR DESCRIPTION
# Description
Previously, if the config file (server.yaml) had fields that we didn't expect, we'd silently ignore them. Now we crash on startup. The benefit of this is that if someone makes a typo in their server.yaml, that issue will be very prominent, so they'll know to fix it.

# Testing
Updated the unit tests.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
