### PR TITLE
Fix install.sh for migrating siglens.db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "${UI_PORT}:5122"
     volumes:
       - "${WORK_DIR}/data:/siglens/data"
-      - "${WORK_DIR}/data/siglens.db:/siglens/data/siglens.db"
       - "${WORK_DIR}/logs:/siglens/logs"
       - "${WORK_DIR}/${CONFIG_FILE}:/siglens/${CONFIG_FILE}"
     command: ["./siglens", "--config", "${CONFIG_FILE}"]

--- a/install.sh
+++ b/install.sh
@@ -718,6 +718,14 @@ chmod a+rwx data || {
     print_error_and_exit "Failed to change permissions for directory 'data'. Please check your file permissions."
 }
 
+if [ ! -f "data/siglens.db" ] && [ -f "siglens.db" ]; then
+    mv siglens.db data/ || {
+        post_event "install_failed" "Failed to move 'siglens.db' to data directory."
+        print_error_and_exit "Failed to move 'siglens.db' to data directory. Please check your permissions."
+    }
+    echo "Moved siglens.db from root directory to data directory."
+fi
+
 touch data/siglens.db || {
     post_event "install_failed" "Failed to create file 'siglens.db'."
     print_error_and_exit "Failed to create file 'siglens.db'. Please check your permissions."


### PR DESCRIPTION
# Description
Summarize the change.
Fixed the install.sh script to migrate `siglens.db` from the dockerbased installation folder to its relevant data directory.
Cleaned up the docker-compose.yml file.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

install.sh Testing

- Installed siglens using docker
- Created some alerts.
- Stopped and restarted the siglens using docker-compose and verified that alerts are present as expected.
- Moved the siglens.db outside the data folder.
- Re-ran siglens and verified that alerts are not visible (cannot find siglens.db)
- Updated the script and docker-compose.yml and ran the installation with the updated script
- It migrated the correct, existing siglens.db from the installation folder to the data folder.
- Verified on the UI that alerts are visible.

docker-compose.yml Testing

- To test the docker-compose.yml change, I commented the code in the install script to fetch it from web.
- So, that it will use the one that is present locally (which is the updated one).

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
