### PR TITLE
Fix total cols for unrotated data in cluster stats

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/writer"
@@ -355,6 +356,10 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 			allIndexCols[indexName][col] = struct{}{}
 			totalCols[col] = struct{}{}
 		}
+		allIndexCols[indexName][config.GetTimeStampKey()] = struct{}{}
+	}
+	if len(allIndexCols) > 0 {
+		totalCols[config.GetTimeStampKey()] = struct{}{}
 	}
 
 	for _, indexName := range indices {
@@ -382,9 +387,9 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 				segmentCounts[indexName] = 1
 			} else {
 				utils.AddMapKeysToSet(currentIndexCols, columnNamesSet)
-				utils.AddMapKeysToSet(totalCols, columnNamesSet)
 				indexSegmentCount++
 			}
+			utils.AddMapKeysToSet(totalCols, columnNamesSet)
 		}
 
 		totalEventsForIndex := uint64(counts.RecordCount) + uint64(unrotatedEventCount)


### PR DESCRIPTION
# Description
Summarize the change.
We were not updating the totalCols for the case of unrotated data when there is no existing data for that [index](https://github.com/siglens/siglens/blob/f0257e9e377f71a7f28143bcead60648172b333c/pkg/health/clusterStatsHandler.go#L382). We have to update totalCols if there is any unrotated data like [here](https://github.com/siglens/siglens/blob/f0257e9e377f71a7f28143bcead60648172b333c/pkg/health/clusterStatsHandler.go#L385).
Moreover, earlier we were just using segMeta to get the column count, in the unrotated data we get the data from segstore, which has `timestamp` as a column too. Added this timestamp column for rotated data as well.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Clean the data directory.
- Start siglens server
- Ingest Some data
- Observe the cluster stats, earlier we were getting 0 as the total column count.
- After this change it should show correctly.
- After ingestion, restart the server (let the data be rotated). Look at the cluster stats, they should be same as what you saw before.
- Earlier, the segment count was 1 less than what we see for unrotated data. Now, they should be same.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
