### PR TITLE
Rename blockIdx to blockNum

### DIFF
--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -134,7 +134,7 @@ func updateRecentlyRotatedSegmentFiles(segkey string) {
 }
 
 func updateUnrotatedBlockInfo(segkey string, virtualTable string, wipBlock *WipBlock,
-	blockMetadata *structs.BlockMetadataHolder, allCols map[string]uint32, blockIdx uint16,
+	blockMetadata *structs.BlockMetadataHolder, allCols map[string]uint32, blockNum uint16,
 	metadataSize uint64, earliestTs uint64, latestTs uint64, recordCount int, orgid uint64,
 	pqMatches map[string]*pqmr.PQMatchResults) {
 	UnrotatedInfoLock.Lock()
@@ -155,7 +155,7 @@ func updateUnrotatedBlockInfo(segkey string, virtualTable string, wipBlock *WipB
 		}
 	}
 	AllUnrotatedSegmentInfo[segkey].blockSummaries = append(AllUnrotatedSegmentInfo[segkey].blockSummaries, blkSumCpy)
-	AllUnrotatedSegmentInfo[segkey].blockInfo[blockIdx] = blockMetadata
+	AllUnrotatedSegmentInfo[segkey].blockInfo[blockNum] = blockMetadata
 	AllUnrotatedSegmentInfo[segkey].tsRange = tRange
 	AllUnrotatedSegmentInfo[segkey].RecordCount = recordCount
 
@@ -165,8 +165,8 @@ func updateUnrotatedBlockInfo(segkey string, virtualTable string, wipBlock *WipB
 
 	var pqidSize uint64
 	if AllUnrotatedSegmentInfo[segkey].isCmiLoaded {
-		AllUnrotatedSegmentInfo[segkey].addMicroIndicesToUnrotatedInfo(blockIdx, wipBlock.columnBlooms, wipBlock.columnRangeIndexes)
-		pqidSize = AllUnrotatedSegmentInfo[segkey].addUnrotatedQIDInfo(blockIdx, pqMatches)
+		AllUnrotatedSegmentInfo[segkey].addMicroIndicesToUnrotatedInfo(blockNum, wipBlock.columnBlooms, wipBlock.columnRangeIndexes)
+		pqidSize = AllUnrotatedSegmentInfo[segkey].addUnrotatedQIDInfo(blockNum, pqMatches)
 	}
 
 	blkSumSize := blkSumCpy.GetSize()


### PR DESCRIPTION
# Description
Most of the repo was using `blockNum` but some parts used `blockIdx`. Now everywhere uses `blockNum`.

# Testing
unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
