### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/ast/common.go
+++ b/pkg/ast/common.go
@@ -188,7 +188,7 @@ func createMatchPhraseFilterCriteria(k, v interface{}, opr LogicalOperator, nega
 	var matchWordsOriginal [][]byte
 	if cci != nil && cci.ShouldAlsoSearchWithOriginalCase() {
 		originalRtInput = strings.TrimSpace(cci.originalColValue.(string))
-		matchWordsOriginal = make([][]byte, len(matchWords))
+		matchWordsOriginal = make([][]byte, 0, len(matchWords))
 		for _, word := range strings.Split(originalRtInput, " ") {
 			matchWordsOriginal = append(matchWordsOriginal, [][]byte{[]byte(word)}...)
 		}
@@ -239,7 +239,7 @@ func createMatchFilterCriteria(colName, colValue interface{}, opr LogicalOperato
 
 	var matchWordsOriginal [][]byte
 	if cci != nil && cci.ShouldAlsoSearchWithOriginalCase() {
-		matchWordsOriginal = make([][]byte, len(matchWords))
+		matchWordsOriginal = make([][]byte, 0, len(matchWords))
 		for _, word := range strings.Split(cci.originalColValue.(string), " ") {
 			matchWordsOriginal = append(matchWordsOriginal, []byte(word))
 		}

--- a/pkg/integrations/loki/loki.go
+++ b/pkg/integrations/loki/loki.go
@@ -576,7 +576,7 @@ func ProcessQueryRequest(ctx *fasthttp.RequestCtx, myid uint64) {
 	if queryResult != nil && queryResult.ErrList != nil && len(queryResult.ErrList) > 0 {
 		responsebody := make(map[string]interface{})
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
-		errors := make([]string, len(queryResult.ErrList))
+		errors := make([]string, 0, len(queryResult.ErrList))
 		for _, err := range queryResult.ErrList {
 			errors = append(errors, err.Error())
 		}

--- a/pkg/querytracker/snhasher.go
+++ b/pkg/querytracker/snhasher.go
@@ -83,13 +83,13 @@ func getHashForSearchCondition(sc *structs.SearchCondition) uint64 {
 		return 0
 	}
 
-	sqhids := make([]uint64, len(sc.SearchQueries))
+	sqhids := make([]uint64, 0, len(sc.SearchQueries))
 	for _, sq := range sc.SearchQueries {
 		sqhids = append(sqhids, getHashForSearchQuery(sq))
 	}
 	sort.Slice(sqhids, func(i, j int) bool { return sqhids[i] < sqhids[j] })
 
-	snhids := make([]uint64, len(sc.SearchNode))
+	snhids := make([]uint64, 0, len(sc.SearchNode))
 	for _, sn := range sc.SearchNode {
 		snhids = append(snhids, getHashForSearchNode(sn))
 	}
@@ -142,7 +142,7 @@ func getHashForMatchFilter(mf *structs.MatchFilter) uint64 {
 		return 0
 	}
 
-	mwords := make([]string, len(mf.MatchWords))
+	mwords := make([]string, 0, len(mf.MatchWords))
 	for _, w := range mf.MatchWords {
 		mwords = append(mwords, string(w))
 	}


### PR DESCRIPTION
# Description


The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
