### PR TITLE
Add Data Processor

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -132,7 +132,7 @@ func (iqr *IQR) AppendKnownValues(knownValues map[string][]utils.CValueEnclosure
 		iqr.mode = withoutRRCs
 	}
 
-	numExistingRecords := iqr.numberOfRecords()
+	numExistingRecords := iqr.NumberOfRecords()
 
 	for cname, values := range knownValues {
 		if _, ok := iqr.deletedColumns[cname]; ok {
@@ -150,9 +150,9 @@ func (iqr *IQR) AppendKnownValues(knownValues map[string][]utils.CValueEnclosure
 	return nil
 }
 
-func (iqr *IQR) numberOfRecords() int {
+func (iqr *IQR) NumberOfRecords() int {
 	if err := iqr.validate(); err != nil {
-		log.Errorf("IQR.numberOfRecords: validation failed: %v", err)
+		log.Errorf("IQR.NumberOfRecords: validation failed: %v", err)
 		return 0
 	}
 
@@ -168,7 +168,7 @@ func (iqr *IQR) numberOfRecords() int {
 
 		return 0
 	default:
-		log.Errorf("IQR.numberOfRecords: unexpected mode %v", iqr.mode)
+		log.Errorf("IQR.NumberOfRecords: unexpected mode %v", iqr.mode)
 		return 0
 	}
 }
@@ -359,7 +359,7 @@ func (iqr *IQR) AsResult() (*pipesearch.PipeSearchResponseOuter, error) {
 
 	response := &pipesearch.PipeSearchResponseOuter{
 		Hits: pipesearch.PipeSearchResponse{
-			TotalMatched: iqr.numberOfRecords(),
+			TotalMatched: iqr.NumberOfRecords(),
 			Hits:         recordsAsAny,
 		},
 		AllPossibleColumns: toputils.GetKeysOfMap(records),

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -324,6 +324,7 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 }
 
 // TODO: Add option/method to return the result for a websocket query.
+// TODO: Add option/method to return the result for an ES/kibana query.
 func (iqr *IQR) AsResult() (*pipesearch.PipeSearchResponseOuter, error) {
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.AsResult: validation failed: %v", err)

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -77,9 +77,9 @@ func (dp *DataProcessor) Rewind() {
 
 func (dp *DataProcessor) Fetch() (*iqr.IQR, error) {
 	var output *iqr.IQR
-	gotEOF := false
 
 	for {
+		gotEOF := false
 		input, err := dp.getStreamInput()
 		if err == io.EOF {
 			gotEOF = true
@@ -101,11 +101,7 @@ func (dp *DataProcessor) Fetch() (*iqr.IQR, error) {
 				continue
 			}
 
-			if output == nil {
-				return output, io.EOF
-			} else {
-				return output, nil
-			}
+			return output, io.EOF
 		} else if output != nil {
 			if !dp.isBottleneckCmd || (dp.isTwoPassCmd && dp.finishedFirstPass) {
 				return output, nil

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package processor
+
+import (
+	"github.com/siglens/siglens/pkg/segment/query/iqr"
+)
+
+type streamer interface {
+	Fetch() (*iqr.IQR, error)
+	Reset()
+}
+
+type processor interface {
+	Process(*iqr.IQR) (*iqr.IQR, error)
+}
+
+type DataProcessor struct {
+	streams   []streamer
+	processor processor
+
+	inputOrderMatters bool
+	isPermutingCmd    bool
+	isBottleneckCmd   bool
+	isTwoPassCmd      bool
+}

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -88,7 +88,9 @@ func (dp *DataProcessor) Fetch() (*iqr.IQR, error) {
 		}
 
 		output, err = dp.processor.Process(input)
-		if err != nil {
+		if err == io.EOF {
+			gotEOF = true
+		} else if err != nil {
 			return nil, utils.TeeErrorf("DP.Fetch: failed to process input: %v", err)
 		}
 

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -18,16 +18,22 @@
 package processor
 
 import (
+	"errors"
+	"fmt"
+	"io"
+
 	"github.com/siglens/siglens/pkg/segment/query/iqr"
+	"github.com/siglens/siglens/pkg/utils"
 )
 
 type streamer interface {
 	Fetch() (*iqr.IQR, error)
-	Reset()
+	Rewind()
 }
 
 type processor interface {
 	Process(*iqr.IQR) (*iqr.IQR, error)
+	Rewind()
 }
 
 type DataProcessor struct {
@@ -35,9 +41,10 @@ type DataProcessor struct {
 	processor processor
 
 	inputOrderMatters bool
-	isPermutingCmd    bool
-	isBottleneckCmd   bool
-	isTwoPassCmd      bool
+	isPermutingCmd    bool // This command may change the order of input.
+	isBottleneckCmd   bool // This command must see all input before yielding any output.
+	isTwoPassCmd      bool // A subset of bottleneck commands.
+	finishedFirstPass bool // Only used for two-pass commands.
 }
 
 func (dp *DataProcessor) DoesInputOrderMatter() bool {
@@ -54,4 +61,65 @@ func (dp *DataProcessor) IsBottleneckCmd() bool {
 
 func (dp *DataProcessor) IsTwoPassCmd() bool {
 	return dp.isTwoPassCmd
+}
+
+// Rewind sets up this DataProcessor to read the input streams from the
+// beginning; however, it doesn't fully reset it to its initial state. For
+// example, a two-pass command that finishes its first pass should remember
+// whatever state information it got from the first pass.
+func (dp *DataProcessor) Rewind() {
+	for _, stream := range dp.streams {
+		stream.Rewind()
+	}
+
+	dp.processor.Rewind()
+}
+
+func (dp *DataProcessor) Fetch() (*iqr.IQR, error) {
+	var output *iqr.IQR
+	gotEOF := false
+
+	for {
+		input, err := dp.getStreamInput()
+		if err == io.EOF {
+			gotEOF = true
+		} else if err != nil {
+			return nil, utils.TeeErrorf("DP.Fetch: failed to fetch input: %v", err)
+		}
+
+		output, err = dp.processor.Process(input)
+		if err != nil {
+			return nil, utils.TeeErrorf("DP.Fetch: failed to process input: %v", err)
+		}
+
+		if gotEOF {
+			if dp.isTwoPassCmd && !dp.finishedFirstPass {
+				dp.finishedFirstPass = true
+				dp.Rewind()
+				continue
+			}
+
+			if output == nil {
+				return output, io.EOF
+			} else {
+				return output, nil
+			}
+		} else if output != nil {
+			if !dp.isBottleneckCmd || (dp.isTwoPassCmd && dp.finishedFirstPass) {
+				return output, nil
+			}
+		}
+	}
+}
+
+func (dp *DataProcessor) getStreamInput() (*iqr.IQR, error) {
+	switch len(dp.streams) {
+	case 0:
+		return nil, errors.New("no streams")
+	case 1:
+		return dp.streams[0].Fetch()
+	}
+
+	// TODO: fetch from all streams and merge them.
+	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/segment/query/processor/dataprocessor_test.go
+++ b/pkg/segment/query/processor/dataprocessor_test.go
@@ -18,40 +18,33 @@
 package processor
 
 import (
-	"github.com/siglens/siglens/pkg/segment/query/iqr"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-type streamer interface {
-	Fetch() (*iqr.IQR, error)
-	Reset()
-}
+func Test_Getters(t *testing.T) {
+	dp := &DataProcessor{
+		inputOrderMatters: true,
+		isPermutingCmd:    true,
+		isBottleneckCmd:   true,
+		isTwoPassCmd:      true,
+	}
 
-type processor interface {
-	Process(*iqr.IQR) (*iqr.IQR, error)
-}
+	assert.True(t, dp.DoesInputOrderMatter())
+	assert.True(t, dp.IsPermutingCmd())
+	assert.True(t, dp.IsBottleneckCmd())
+	assert.True(t, dp.IsTwoPassCmd())
 
-type DataProcessor struct {
-	streams   []streamer
-	processor processor
+	dp = &DataProcessor{
+		inputOrderMatters: false,
+		isPermutingCmd:    false,
+		isBottleneckCmd:   false,
+		isTwoPassCmd:      false,
+	}
 
-	inputOrderMatters bool
-	isPermutingCmd    bool
-	isBottleneckCmd   bool
-	isTwoPassCmd      bool
-}
-
-func (dp *DataProcessor) DoesInputOrderMatter() bool {
-	return dp.inputOrderMatters
-}
-
-func (dp *DataProcessor) IsPermutingCmd() bool {
-	return dp.isPermutingCmd
-}
-
-func (dp *DataProcessor) IsBottleneckCmd() bool {
-	return dp.isBottleneckCmd
-}
-
-func (dp *DataProcessor) IsTwoPassCmd() bool {
-	return dp.isTwoPassCmd
+	assert.False(t, dp.DoesInputOrderMatter())
+	assert.False(t, dp.IsPermutingCmd())
+	assert.False(t, dp.IsBottleneckCmd())
+	assert.False(t, dp.IsTwoPassCmd())
 }


### PR DESCRIPTION
# Description
This adds the `DataProcessor` type that will handle the execution of an individual query command (e.g., eval, stats, etc.). The logic specific to each command will be implemented by a type implementing the `processor` interface. This PR adds the general functionality that is shared across all commands.

Merging multiple input streams is not yet implemented—that will come in the next PR

# Testing
New unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
