### PR TITLE
Config var for Enabling pprof

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -103,7 +103,9 @@ type Configuration struct {
 	MaxSegFileSize              uint64   `yaml:"maxSegFileSize"` // segment file size (in bytes)
 	LicenseKeyPath              string   `yaml:"licenseKeyPath"`
 	ESVersion                   string   `yaml:"esVersion"`
-	Debug                       bool     `yaml:"debug"`                  // debug logging
+	Debug                       bool     `yaml:"debug"`        // debug logging
+	PProfEnabled                string   `yaml:"pprofEnabled"` // enable pprof
+	PProfEnabledConverted       bool     // converted bool value of PprofEnabled yaml
 	MemoryThresholdPercent      uint64   `yaml:"memoryThresholdPercent"` // percent of all available free data allocated for loading micro indices in memory
 	DataDiskThresholdPercent    uint64   `yaml:"dataDiskThresholdPercent"`
 	S3IngestQueueName           string   `yaml:"s3IngestQueueName"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,6 +268,10 @@ func IsDebugMode() bool {
 	return runningConfig.Debug
 }
 
+func IsPProfEnabled() bool {
+	return runningConfig.PProfEnabledConverted
+}
+
 func IsPQSEnabled() bool {
 	return runningConfig.PQSEnabledConverted
 }
@@ -514,6 +518,8 @@ func GetTestConfig(dataPath string) common.Configuration {
 		LicenseKeyPath:              "./",
 		ESVersion:                   "",
 		Debug:                       false,
+		PProfEnabled:                "true",
+		PProfEnabledConverted:       true,
 		MemoryThresholdPercent:      80,
 		DataDiskThresholdPercent:    85,
 		S3IngestQueueName:           "",
@@ -657,6 +663,17 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	if len(config.IngestNode) <= 0 {
 		config.IngestNode = "true"
 	}
+
+	if len(config.PProfEnabled) <= 0 {
+		config.PProfEnabled = "true"
+	}
+	pprofEnabled, err := strconv.ParseBool(config.PProfEnabled)
+	if err != nil {
+		log.Errorf("ExtractConfigData: failed to parse pprof enabled flag. Defaulting to true. Error: %v", err)
+		pprofEnabled = true
+		config.PProfEnabled = "true"
+	}
+	config.PProfEnabledConverted = pprofEnabled
 
 	if len(config.PQSEnabled) <= 0 {
 		config.PQSEnabled = "true"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -46,6 +46,7 @@ func Test_ExtractConfigData(t *testing.T) {
  seedNode: true
  segreaderNode: true
  metareaderNode: true
+ pprofEnabled: false
  DataPath: "data/"
  s3:
   enabled: true
@@ -109,6 +110,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				S3IngestBufferSize:          1000,
 				MaxParallelS3IngestBuffers:  10,
 				QueryHostname:               "abc:123",
+				PProfEnabled:                "false",
+				PProfEnabledConverted:       false,
 				PQSEnabled:                  "true",
 				PQSEnabledConverted:         true,
 				AnalyticsEnabled:            "false",
@@ -153,6 +156,7 @@ func Test_ExtractConfigData(t *testing.T) {
  S3IngestQueueRegion: ""
  S3IngestBufferSize: 1000
  MaxParallelS3IngestBuffers: 10
+ pprofEnabled: Fa
  PQSEnabled: F
  dualCaseCheck: true
  analyticsEnabled: bad string
@@ -193,6 +197,8 @@ func Test_ExtractConfigData(t *testing.T) {
 				S3IngestBufferSize:          1000,
 				MaxParallelS3IngestBuffers:  10,
 				QueryHostname:               "localhost:9000",
+				PProfEnabled:                "true",
+				PProfEnabledConverted:       true,
 				PQSEnabled:                  "true",
 				PQSEnabledConverted:         true,
 				DualCaseCheck:               "true",
@@ -239,6 +245,8 @@ invalid input, we should error out
 				S3IngestBufferSize:         1000,
 				MaxParallelS3IngestBuffers: 10,
 				QueryHostname:              "localhost:5122",
+				PProfEnabled:               "true",
+				PProfEnabledConverted:      true,
 				AnalyticsEnabled:           "true",
 				AnalyticsEnabledConverted:  true,
 				AgileAggsEnabled:           "true",
@@ -278,6 +286,8 @@ a: b
 				S3IngestBufferSize:          1000,
 				MaxParallelS3IngestBuffers:  10,
 				QueryHostname:               "localhost:5122",
+				PProfEnabled:                "true",
+				PProfEnabledConverted:       true,
 				PQSEnabled:                  "true",
 				PQSEnabledConverted:         true,
 				SafeServerStart:             false,

--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -112,7 +112,7 @@ func (hs *ingestionServerCfg) Run() (err error) {
 	// OTLP Handlers
 	hs.router.POST(server_utils.OTLP_PREFIX+"/v1/traces", hs.Recovery(otlpIngestTracesHandler()))
 
-	if config.IsDebugMode() {
+	if config.IsPProfEnabled() {
 		hs.router.GET("/debug/pprof/{profile:*}", pprofhandler.PprofHandler)
 	}
 


### PR DESCRIPTION
# Description
- Enable `pprof` through a new config variable. By default the `pprof` is enabled.

# Testing
- All unit tests pass
- Tested by starting the server and going to the pprof endpoint.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
