### PR TITLE
fix: Nested json ingest and handling of null values

### DIFF
--- a/pkg/es/writer/esBulkHandler.go
+++ b/pkg/es/writer/esBulkHandler.go
@@ -220,6 +220,7 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 					}
 				} else {
 					ple := plePool.Get().(*writer.ParsedLogEvent)
+					ple.Reset()
 					allPLEs = append(allPLEs, ple)
 
 					ple.SetIndexName(indexName)
@@ -227,7 +228,7 @@ func HandleBulkBody(postBody []byte, ctx *fasthttp.RequestCtx, rid uint64, myid 
 
 					err := writer.ParseRawJsonObject("", line, &tsKey, jsParsingStackbuf[:], ple)
 					if err != nil {
-						log.Errorf("ParseRawJsonObject: failed to do parsing, err: %v", err)
+						log.Errorf("HandleBulkBody: ParseRawJsonObject: failed to do parsing, err: %v", err)
 						success = false
 					}
 				}

--- a/pkg/segment/writer/logpacker.go
+++ b/pkg/segment/writer/logpacker.go
@@ -29,8 +29,6 @@ import (
 func ParseRawJsonObject(currKey string, data []byte, tsKey *string,
 	jsParsingStackbuf []byte, ple *ParsedLogEvent) error {
 
-	ple.Reset()
-
 	handler := func(key []byte, value []byte, valueType jp.ValueType, off int) error {
 		// Maybe push some state onto a stack here?
 		var finalKey string

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1620,13 +1620,17 @@ func (ss *SegStore) getAllColsSizes() map[string]*structs.ColSizeInfo {
 			continue
 		}
 
+		// ColValueLen is 1 for Null Column and 2 for Bool Column.
+		// We do not create CMI files for Null and Bool columns.
+		shouldLogCMIError := colValueLen > 2
+
 		fname := ssutils.GetFileNameFromSegSetFile(structs.SegSetFile{
 			SegKey:     ss.SegmentKey,
 			Identifier: fmt.Sprintf("%v", xxhash.Sum64String(cname)),
 			FileType:   structs.Cmi,
 		})
 		cmiSize, onlocal := ssutils.GetFileSizeFromDisk(fname)
-		if !onlocal {
+		if !onlocal && shouldLogCMIError {
 			log.Errorf("getAllColsSizes: cmi cname: %v, fname: %+v not on local disk", cname, fname)
 		}
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -423,6 +423,10 @@ func (ss *SegStore) doLogEventFilling(ple *ParsedLogEvent, tsKey *string) (bool,
 			if !ss.skipDe {
 				ss.checkAddDictEnc(colWip, colWip.cbuf[startIdx:colWip.cbufidx], ss.wipBlock.blockSummary.RecCount, startIdx, false)
 			}
+		case VALTYPE_ENC_BACKFILL[0]:
+			copy(colWip.cbuf[colWip.cbufidx:], VALTYPE_ENC_BACKFILL[:])
+			colWip.cbufidx += 1
+			ss.updateColValueSizeInAllSeenColumns(cname, 1)
 		default:
 			return false, utils.TeeErrorf("doLogEventFilling: unknown ctype: %v", ctype)
 		}


### PR DESCRIPTION
# Description
- Fixes the Nested json ingest.
- Fixes the handling of null values


# Testing
- Tested by ingesting a nested json with some null values

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
