### PR TITLE
Add Search Bar for Filtering Log Panels

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -541,6 +541,7 @@
   font-weight: 700;
   color: var(--empty-response-text-color);
   z-index: 1;
+  transform: none;
 }
 
 /* EMPTY-RESPONSE CSS FIX */

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2773,6 +2773,10 @@ hr {
     border-radius: 4px;
 }
 
+#date-start.error, #date-end.error {
+    border: 1px solid var(--error-trace);
+}
+
 #date-start:hover, #date-end:hover, #time-start:hover, #time-end:hover {
     border: 1px solid var(--drop-down-btn-border-active);
 }

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2773,10 +2773,6 @@ hr {
     border-radius: 4px;
 }
 
-#date-start.error, #date-end.error {
-    border: 1px solid var(--error-trace);
-}
-
 #date-start:hover, #date-end:hover, #time-start:hover, #time-end:hover {
     border: 1px solid var(--drop-down-btn-border-active);
 }
@@ -3374,6 +3370,7 @@ float: right;
     font-weight: 700;
     color: var(--empty-response-text-color);
     z-index: 1;
+    transform: none;
 }
 
 .panel-body #empty-response {
@@ -3468,10 +3465,11 @@ float: right;
     background-image: url(../assets/remove-icon-dark-mode.svg);
 }
 
-.search-db-input,.metrics-input{
+.search-db-input{
     padding-left: 1rem;
     padding-right: 4.4rem;
     height: 32px;
+    color: var(--text-color) !important;
 }
 
 .dbSet-textareaContainer .copy{

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -169,6 +169,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
 
             <div class="p-3">
+                <div class="d-flex" style="margin: 0px 10px;">
+                    <input type="text" class="form-control search-db-input" placeholder="Filter logs panel (e.g., app_version=1.2.* OR http_status=404)" title="Search query" style="background-color: var(--top-bar-bg-color-regular);">
+                    <div class="text-end d-flex">
+                        <button class="btn run-filter-btn" id="run-dashboard-fliter"></button>
+                    </div>
+                </div>
                 <div id="panel-container" class="grid-stack">
                 </div>
             </div>

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1427,7 +1427,6 @@ function setDashboardQueryModeHandler(panelQueryMode) {
     }
 }
 
-
 $('#run-dashboard-fliter').on('click', function () {
     const filterValue = $('.search-db-input').val();
     if (!validateFilterInput(filterValue)) {

--- a/static/js/edit-panel-screen.js
+++ b/static/js/edit-panel-screen.js
@@ -517,7 +517,25 @@ $('.panEdit-save').on('click', async function (_redirectedFromViewScreen) {
         const data = getQueryParamsData();
         currentPanel.queryData = data;
     }
+
     localPanels[panelIndex] = JSON.parse(JSON.stringify(currentPanel));
+
+    // Update originalQueries for the edited panel
+    if (currentPanel.queryData && currentPanel.queryData.searchText) {
+        //eslint-disable-next-line no-undef
+        originalQueries[currentPanel.panelId] = currentPanel.queryData.searchText;
+    }
+
+    // Restore original queries for non-edited panels
+    localPanels.forEach((panel) => {
+        //eslint-disable-next-line no-undef
+        if (panel.panelId !== currentPanel.panelId && originalQueries[panel.panelId]) {
+            //eslint-disable-next-line no-undef
+            panel.queryData.searchText = originalQueries[panel.panelId];
+        }
+    });
+
+    $('.search-db-input').val('');
     updateTimeRangeForAllPanels(filterStartDate, filterEndDate);
     await updateDashboard();
     $('.panelEditor-container').hide();
@@ -1124,7 +1142,7 @@ function goToDashboard() {
         }
     }
     resetNestedUnitMenuOptions(selectedUnitTypeIndex);
-    currentPanel = {};
+    currentPanel = null;
     resetEditPanelScreen();
 
     $('.panelEditor-container').hide();


### PR DESCRIPTION
# Description
This PR adds a search bar to the dashboard screen, allowing users to filter existing SplunkQL log panels.
Users can save the filter for all panels or edit a specific panel, which will reset the rest to their original state.
The filter only supports valid filter commands—stats and group by commands are not allowed - a tooltip shown for invalid inputs.

Fixes https://github.com/siglens/siglens/issues/901

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
