### PR TITLE
Improve Error Handling for Invalid Chart Types on Dashboard Panel Query Execution

### DIFF
--- a/playwright-tests/tests/all-alerts.test.js
+++ b/playwright-tests/tests/all-alerts.test.js
@@ -12,6 +12,7 @@ test.describe('All Alerts Screen Flow', () => {
     });
 
     test('should create a new logs alert', async () => {
+        test.setTimeout(120000);
         await test.step('Navigate to create alert page', async () => {
             await page.click('#new-alert-rule');
             await expect(page.locator('#alert-rule-name')).toBeVisible();
@@ -61,8 +62,13 @@ test.describe('All Alerts Screen Flow', () => {
             await page.click('.add-label-container');
             await page.fill('.label-container #label-key', 'TestLabel');
             await page.fill('.label-container #label-value', 'TestValue');
-            await page.click('#save-alert-btn');
-            await expect(page.locator('.ag-root-wrapper')).toBeVisible();
+            
+            await Promise.all([
+                page.waitForNavigation({ url: '**/all-alerts.html' }),
+                page.click('#save-alert-btn')
+            ]);
+
+            await expect(page).toHaveURL(/all-alerts\.html/);
         });
     });
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -515,7 +515,11 @@ function renderPanelAggsQueryRes(data, panelId, chartType, dataType, panelIndex,
             }
 
             if ((chartType === 'Pie Chart' || chartType === 'Bar Chart') && (res.hits.totalMatched === 0 || res.hits.totalMatched.value === 0)) {
-                panelProcessEmptyQueryResults('', panelId);
+                if (res.qtype === 'segstats-query') {
+                    panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);  
+                } else {
+                    panelProcessEmptyQueryResults('', panelId);
+                }
             } else if (chartType === 'number' && (resultVal === undefined || resultVal === null)) {
                 panelProcessEmptyQueryResults('', panelId);
             } else {

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -601,7 +601,7 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
             }
             $(`#panel${panelId} .panel-body #panel-loading`).hide();
         }
-    } else if (chartType ==='Line Chart'){
+    } else if (chartType === 'Line Chart') {
         chartDataCollection = {};
         if (panelId === -1) {
             formulas = {};
@@ -624,7 +624,7 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
                     addVisualizationContainer(queryData.queries[0].name, chartData, queryString, panelId);
                 } catch (error) {
                     const errorMessage = (error.responseJSON && error.responseJSON.error) || (error.responseText && JSON.parse(error.responseText).error) || 'An unknown error occurred';
-                    const errorCanvas=$(`#panel${panelId} .panel-body .panEdit-panel canvas`);
+                    const errorCanvas = $(`#panel${panelId} .panel-body .panEdit-panel canvas`);
                     if (isDashboardScreen) {
                         if (errorCanvas.length > 0) {
                             errorCanvas.remove();
@@ -635,23 +635,23 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
                     }
                 }
             }
-            
+
             for (const formulaData of data.formulasData) {
                 try {
                     const rawTimeSeriesData = await fetchTimeSeriesData(formulaData);
                     const chartData = await convertDataForChart(rawTimeSeriesData);
                     let formulaString = formulaData.formulas[0].formula;
-            
+
                     // Replace a, b, etc., with actual query values
                     formulaData.queries.forEach((query) => {
                         const regex = new RegExp(`\\b${query.name}\\b`, 'g');
                         formulaString = formulaString.replace(regex, query.query);
                     });
-            
+
                     addVisualizationContainer(formulaData.formulas[0].formula, chartData, formulaString, panelId);
                 } catch (error) {
                     const errorMessage = (error.responseJSON && error.responseJSON.error) || (error.responseText && JSON.parse(error.responseText).error) || 'An unknown error occurred';
-                    const errorCanvas=$(`#panel${panelId} .panel-body .panEdit-panel canvas`);
+                    const errorCanvas = $(`#panel${panelId} .panel-body .panEdit-panel canvas`);
                     if (isDashboardScreen) {
                         if (errorCanvas.length > 0) {
                             errorCanvas.remove();
@@ -662,32 +662,28 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
                     }
                 }
             }
-            
         }
         if (currentPanel && currentPanel.style) {
             toggleLineOptions(currentPanel.style.display);
-            chartType=currentPanel.style.display;
+            chartType = currentPanel.style.display;
             toggleChartType(chartType);
             updateChartTheme(currentPanel.style.color);
-            updateLineCharts(
-                currentPanel.style.lineStyle,
-                currentPanel.style.lineStroke
-            );
-        } 
+            updateLineCharts(currentPanel.style.lineStyle, currentPanel.style.lineStroke);
+        }
         $(`#panel${panelId} .panel-body #panel-loading`).hide();
         allResultsDisplayed--;
         if (allResultsDisplayed <= 0 || panelId === -1) {
             $('body').css('cursor', 'default');
         }
         $('body').css('cursor', 'default');
-    } else{
+    } else {
         panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
         return;
     }
 }
 
 function processMetricsSearchResult(res, startTime, panelId, chartType, panelIndex, queryType) {
-    if(queryType==='logs'){
+    if (queryType === 'logs') {
         panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
         return;
     }
@@ -981,7 +977,7 @@ function initializeFilterInputEvents() {
         const formatButton = $('#formatInput');
         if (selectedLanguage === 'Splunk QL' && selectedTab === 'tab-title2') {
             formatButton.show();
-        }else {
+        } else {
             formatButton.hide();
         }
     }
@@ -1000,7 +996,7 @@ function initializeFilterInputEvents() {
     $('.tab-list .tab-li').click(handleTabClick);
 
     // Event listeners for query language changes
-    $('#query-language-options').on('click', '.query-language-option', function() {
+    $('#query-language-options').on('click', '.query-language-option', function () {
         setTimeout(checkFormatButtonVisibility, 10);
     });
 
@@ -1096,8 +1092,8 @@ function initializeFilterInputEvents() {
     });
 
     // Format button click event
-    $('#formatInput').click(function() {
-        let input = $("#filter-input");
+    $('#formatInput').click(function () {
+        let input = $('#filter-input');
         let value = input.val();
 
         // Format the input value by ensuring each '|' is preceded by a newline
@@ -1118,8 +1114,6 @@ function initializeFilterInputEvents() {
         toggleClearButtonVisibility();
     });
 }
-
-
 
 //eslint-disable-next-line no-unused-vars
 function getMetricsQData() {
@@ -1177,7 +1171,7 @@ function getMetricsQData() {
             let functionsArray = formulaDetailsMap[key].functions || [];
             // Update the formula by wrapping it with each function in the functionsArray
             let formula = formulas[key].formula;
-            
+
             for (let func of functionsArray) {
                 // Create a regex to match the function being applied
                 const funcRegex = new RegExp(`\\b${func}\\(`);

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -226,7 +226,7 @@ function resetQueryResAttr(res, panelId) {
 function renderPanelLogsQueryRes(data, panelId, currentPanel, res) {
     //if data source is metrics
     if (!res.qtype) {
-        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);
         return;
     }
     if (res.hits) {
@@ -258,6 +258,7 @@ function renderPanelLogsQueryRes(data, panelId, currentPanel, res) {
                     columnOrder = _.uniq(_.concat(columnOrder, res.measureFunctions));
                 }
             }
+            $('#avail-field-container ').css('display', 'none');
             renderPanelAggsGrid(columnOrder, res, panelId);
         } //for logs-query
         else if (res.hits && res.hits.records !== null && res.hits.records.length >= 1) {
@@ -272,6 +273,7 @@ function renderPanelLogsQueryRes(data, panelId, currentPanel, res) {
             } else {
                 selectedFieldsList = columnOrder;
             }
+            $('#avail-field-container ').css('display', 'inline-flex');
             renderAvailableFields(columnOrder);
             renderPanelLogsGrid(columnOrder, res.hits.records, panelId, currentPanel);
         }
@@ -466,10 +468,10 @@ function renderPanelAggsQueryRes(data, panelId, chartType, dataType, panelIndex,
     resetQueryResAttr(res, panelId);
     //if data source is metrics
     if (!res.qtype && chartType != 'number') {
-        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);
     }
     if (res.qtype === 'logs-query') {
-        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);
     }
 
     if (res.qtype === 'aggs-query' || res.qtype === 'segstats-query') {
@@ -677,14 +679,14 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
         }
         $('body').css('cursor', 'default');
     } else {
-        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);
         return;
     }
 }
 
 function processMetricsSearchResult(res, startTime, panelId, chartType, panelIndex, queryType) {
     if (queryType === 'logs') {
-        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        panelProcessEmptyQueryResults('This chart type is not compatible with your query. Please select a different chart type.', panelId);
         return;
     }
     resetQueryResAttr(res, panelId);

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -469,7 +469,7 @@ function renderPanelAggsQueryRes(data, panelId, chartType, dataType, panelIndex,
         panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
     }
     if (res.qtype === 'logs-query') {
-        panelProcessEmptyQueryResults('', panelId);
+        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
     }
 
     if (res.qtype === 'aggs-query' || res.qtype === 'segstats-query') {
@@ -601,7 +601,7 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
             }
             $(`#panel${panelId} .panel-body #panel-loading`).hide();
         }
-    } else {
+    } else if (chartType ==='Line Chart'){
         chartDataCollection = {};
         if (panelId === -1) {
             formulas = {};
@@ -680,10 +680,17 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
             $('body').css('cursor', 'default');
         }
         $('body').css('cursor', 'default');
+    } else{
+        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        return;
     }
 }
 
-function processMetricsSearchResult(res, startTime, panelId, chartType, panelIndex, dataType) {
+function processMetricsSearchResult(res, startTime, panelId, chartType, panelIndex, queryType) {
+    if(queryType==='logs'){
+        panelProcessEmptyQueryResults('Unsupported chart type. Please select a different chart type.', panelId);
+        return;
+    }
     resetQueryResAttr(res, panelId);
     let bigNumVal = null;
     if (panelId == -1) {
@@ -894,7 +901,7 @@ function renderChartByChartType(data, queryRes, panelId, currentPanel) {
             break;
         case 'Line Chart': {
             let startTime = new Date().getTime();
-            processMetricsSearchResult(queryRes, startTime, panelId, currentPanel.chartType, currentPanel.panelIndex, '');
+            processMetricsSearchResult(queryRes, startTime, panelId, currentPanel.chartType, currentPanel.panelIndex, currentPanel.queryType);
             break;
         }
         case 'number':

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -21,8 +21,8 @@
 function setupEventHandlers() {
     $('#filter-input').on('keyup', filterInputHandler);
 
-    $('#run-filter-btn').on('click', runFilterBtnHandler);
-    $('#query-builder-btn').on('click', runFilterBtnHandler);
+    $('#run-filter-btn').off('click').on('click', runFilterBtnHandler);
+    $('#query-builder-btn').off('click').on('click', runFilterBtnHandler);
     $('#live-tail-btn').on('click', runLiveTailBtnHandler);
 
     $('#available-fields').on('click', availableFieldsClickHandler);
@@ -63,10 +63,10 @@ function setupEventHandlers() {
 
     $('#time-start').on('change', getStartTimeHandler);
     $('#time-end').on('change', getEndTimeHandler);
-    $('#customrange-btn').on('click', customRangeHandler);
+    $('#customrange-btn').off('click').on('click', customRangeHandler);
 
     $('.range-item').on('click', rangeItemHandler);
-    $('.db-range-item').on('click', dashboardRangeItemHandler);
+    $('.db-range-item').off('click').on('click', dashboardRangeItemHandler);
 
     $('.ui-widget input').on('keyup', saveqInputHandler);
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -49,23 +49,24 @@ function getRetentionDataFromConfig() {
 
 {{ .SettingsExtraFunctions }}
 
-function getSystemInfo() {
-    $.ajax({
-        method: "GET",
-        url: "/api/system-info",
-        headers: {
-            "Content-Type": "application/json; charset=utf-8",
-            Accept: "*/*",
-        },
-        dataType: "json",
-        crossDomain: true,
-        success: function (res) {
-            addSystemInfoTable(res);
-        },
-        error: function (xhr, status, error) {
-            console.error("Update failed:", xhr, status, error);
-        },
-    });
+async function getSystemInfo() {
+    try {
+        const res = await $.ajax({
+            method: "GET",
+            url: "/api/system-info",
+            headers: {
+                "Content-Type": "application/json; charset=utf-8",
+                Accept: "*/*",
+            },
+            dataType: "json",
+            crossDomain: true,
+        });
+
+        addSystemInfoTable(res);
+        return res;
+    } catch (error) {
+        console.error("Update failed:", error);
+    }
 }
 
 function addSystemInfoTable(systemInfo) {


### PR DESCRIPTION
# Description
- Display the error message `This chart type is not compatible with your query. Please select a different chart type.` for cases where the chart type selected is incompatible with the query.
Example - Metrics queries support only number and line charts and do not support other chart types.

- Fix the issue where running a query and changing the time range was triggering two backend calls

Fixes #440 

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
