### PR TITLE
Enabled pprof on query server and remove it on ingest server

### DIFF
--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -32,7 +32,6 @@ import (
 	"github.com/siglens/siglens/pkg/segment/writer"
 	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/pprofhandler"
 )
 
 type ingestionServerCfg struct {
@@ -111,10 +110,6 @@ func (hs *ingestionServerCfg) Run() (err error) {
 
 	// OTLP Handlers
 	hs.router.POST(server_utils.OTLP_PREFIX+"/v1/traces", hs.Recovery(otlpIngestTracesHandler()))
-
-	if config.IsPProfEnabled() {
-		hs.router.GET("/debug/pprof/{profile:*}", pprofhandler.PprofHandler)
-	}
 
 	if hook := hooks.GlobalHooks.ExtraIngestEndpointsHook; hook != nil {
 		hook(hs.router, hs.Recovery)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -264,7 +264,7 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.DELETE(server_utils.API_PREFIX+"/lookup-files/{lookupFilename}", hs.Recovery(deleteLookupFileHandler()))
 
 	hs.Router.GET(server_utils.API_PREFIX+"/system-info", tracing.TraceMiddleware(hs.Recovery(getSystemInfoHandler())))
-	if config.IsDebugMode() {
+	if config.IsPProfEnabled() {
 		hs.Router.GET("/debug/pprof/{profile:*}", pprofhandler.PprofHandler)
 	}
 


### PR DESCRIPTION
# Description
- Removed the `pprofHandler` on the ingest server and enabled it on query server

# Testing
- Tested by running the server and calling the pprof endpoint.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
