### PR TITLE
Overwritting the SegStat file should happen atomically

### DIFF
--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1458,10 +1458,10 @@ func (ss *SegStore) FlushSegStats() error {
 		}
 	}
 
-	fname := fmt.Sprintf("%v.sst", ss.SegmentKey)
-	fd, err := os.OpenFile(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	tempSSTFile := fmt.Sprintf("%v.sst.tmp", ss.SegmentKey)
+	fd, err := os.OpenFile(tempSSTFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
-		log.Errorf("FlushSegStats: Failed to open file=%v, err=%v", fname, err)
+		log.Errorf("FlushSegStats: Failed to open tempSSTFile=%v, err=%v", tempSSTFile, err)
 		return err
 	}
 	defer fd.Close()
@@ -1508,6 +1508,12 @@ func (ss *SegStore) FlushSegStats() error {
 			log.Errorf("FlushSegStats: failed to write colsegencoding cname=%v err=%v", cname, err)
 			return err
 		}
+	}
+
+	finalName := fmt.Sprintf("%v.sst", ss.SegmentKey)
+	err = os.Rename(tempSSTFile, finalName)
+	if err != nil {
+		return fmt.Errorf("FlushSegStats: error while migrating %v to %v, err: %v", tempSSTFile, finalName, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description
Summarize the change.
We should use a temp file to write the stats and rename it to correct name only after all the data is written.
Moreover, in this PR we are doing an os.Rename before closing the file. This is safe for [Linux/Unix](https://github.com/golang/go/issues/32088) based systems and should not cause issues. But this is not allowed in windows. Since, siglens is supported for MacOS/Linux this shouldn't be a problem.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
