### PR TITLE
Add bin with span to new query pipeline

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -3109,34 +3109,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1700, col: 3, offset: 53177},
+						pos: position{line: 1703, col: 3, offset: 53335},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1700, col: 3, offset: 53177},
+							pos: position{line: 1703, col: 3, offset: 53335},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1700, col: 3, offset: 53177},
+									pos:  position{line: 1703, col: 3, offset: 53335},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1700, col: 8, offset: 53182},
+									pos:  position{line: 1703, col: 8, offset: 53340},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1700, col: 16, offset: 53190},
+									pos:   position{line: 1703, col: 16, offset: 53348},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1700, col: 22, offset: 53196},
+										pos:  position{line: 1703, col: 22, offset: 53354},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1700, col: 32, offset: 53206},
+									pos:   position{line: 1703, col: 32, offset: 53364},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1700, col: 45, offset: 53219},
+										pos: position{line: 1703, col: 45, offset: 53377},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1700, col: 46, offset: 53220},
+											pos:  position{line: 1703, col: 46, offset: 53378},
 											name: "AsField",
 										},
 									},
@@ -3149,15 +3149,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1727, col: 1, offset: 53958},
+			pos:  position{line: 1730, col: 1, offset: 54116},
 			expr: &actionExpr{
-				pos: position{line: 1727, col: 15, offset: 53972},
+				pos: position{line: 1730, col: 15, offset: 54130},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1727, col: 15, offset: 53972},
+					pos:   position{line: 1730, col: 15, offset: 54130},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1727, col: 27, offset: 53984},
+						pos:  position{line: 1730, col: 27, offset: 54142},
 						name: "SpanOptions",
 					},
 				},
@@ -3165,26 +3165,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1735, col: 1, offset: 54209},
+			pos:  position{line: 1738, col: 1, offset: 54367},
 			expr: &actionExpr{
-				pos: position{line: 1735, col: 16, offset: 54224},
+				pos: position{line: 1738, col: 16, offset: 54382},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1735, col: 16, offset: 54224},
+					pos: position{line: 1738, col: 16, offset: 54382},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1735, col: 16, offset: 54224},
+							pos:  position{line: 1738, col: 16, offset: 54382},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1735, col: 25, offset: 54233},
+							pos:  position{line: 1738, col: 25, offset: 54391},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1735, col: 31, offset: 54239},
+							pos:   position{line: 1738, col: 31, offset: 54397},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1735, col: 42, offset: 54250},
+								pos:  position{line: 1738, col: 42, offset: 54408},
 								name: "SpanLength",
 							},
 						},
@@ -3194,26 +3194,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1742, col: 1, offset: 54396},
+			pos:  position{line: 1745, col: 1, offset: 54554},
 			expr: &actionExpr{
-				pos: position{line: 1742, col: 15, offset: 54410},
+				pos: position{line: 1745, col: 15, offset: 54568},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1742, col: 15, offset: 54410},
+					pos: position{line: 1745, col: 15, offset: 54568},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1742, col: 15, offset: 54410},
+							pos:   position{line: 1745, col: 15, offset: 54568},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 24, offset: 54419},
+								pos:  position{line: 1745, col: 24, offset: 54577},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1742, col: 40, offset: 54435},
+							pos:   position{line: 1745, col: 40, offset: 54593},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1742, col: 50, offset: 54445},
+								pos:  position{line: 1745, col: 50, offset: 54603},
 								name: "AllTimeScale",
 							},
 						},
@@ -3223,43 +3223,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1759, col: 1, offset: 54991},
+			pos:  position{line: 1762, col: 1, offset: 55149},
 			expr: &actionExpr{
-				pos: position{line: 1759, col: 14, offset: 55004},
+				pos: position{line: 1762, col: 14, offset: 55162},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1759, col: 14, offset: 55004},
+					pos: position{line: 1762, col: 14, offset: 55162},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1759, col: 14, offset: 55004},
+							pos:  position{line: 1762, col: 14, offset: 55162},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1759, col: 20, offset: 55010},
+							pos:        position{line: 1762, col: 20, offset: 55168},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1759, col: 28, offset: 55018},
+							pos:  position{line: 1762, col: 28, offset: 55176},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1759, col: 34, offset: 55024},
+							pos:   position{line: 1762, col: 34, offset: 55182},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1759, col: 41, offset: 55031},
+								pos: position{line: 1762, col: 41, offset: 55189},
 								expr: &choiceExpr{
-									pos: position{line: 1759, col: 42, offset: 55032},
+									pos: position{line: 1762, col: 42, offset: 55190},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1759, col: 42, offset: 55032},
+											pos:        position{line: 1762, col: 42, offset: 55190},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1759, col: 50, offset: 55040},
+											pos:        position{line: 1762, col: 50, offset: 55198},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3269,14 +3269,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1759, col: 61, offset: 55051},
+							pos:  position{line: 1762, col: 61, offset: 55209},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1759, col: 76, offset: 55066},
+							pos:   position{line: 1762, col: 76, offset: 55224},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1759, col: 86, offset: 55076},
+								pos:  position{line: 1762, col: 86, offset: 55234},
 								name: "IntegerAsString",
 							},
 						},
@@ -3286,22 +3286,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1783, col: 1, offset: 55657},
+			pos:  position{line: 1786, col: 1, offset: 55815},
 			expr: &actionExpr{
-				pos: position{line: 1783, col: 19, offset: 55675},
+				pos: position{line: 1786, col: 19, offset: 55833},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1783, col: 19, offset: 55675},
+					pos: position{line: 1786, col: 19, offset: 55833},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1783, col: 19, offset: 55675},
+							pos:  position{line: 1786, col: 19, offset: 55833},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1783, col: 24, offset: 55680},
+							pos:   position{line: 1786, col: 24, offset: 55838},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1783, col: 38, offset: 55694},
+								pos:  position{line: 1786, col: 38, offset: 55852},
 								name: "StatisticExpr",
 							},
 						},
@@ -3311,76 +3311,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1816, col: 1, offset: 56672},
+			pos:  position{line: 1819, col: 1, offset: 56830},
 			expr: &actionExpr{
-				pos: position{line: 1816, col: 18, offset: 56689},
+				pos: position{line: 1819, col: 18, offset: 56847},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1816, col: 18, offset: 56689},
+					pos: position{line: 1819, col: 18, offset: 56847},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1816, col: 18, offset: 56689},
+							pos:   position{line: 1819, col: 18, offset: 56847},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1816, col: 23, offset: 56694},
+								pos: position{line: 1819, col: 23, offset: 56852},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1816, col: 23, offset: 56694},
+										pos:  position{line: 1819, col: 23, offset: 56852},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1816, col: 33, offset: 56704},
+										pos:  position{line: 1819, col: 33, offset: 56862},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1816, col: 43, offset: 56714},
+							pos:   position{line: 1819, col: 43, offset: 56872},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1816, col: 49, offset: 56720},
+								pos: position{line: 1819, col: 49, offset: 56878},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1816, col: 50, offset: 56721},
+									pos:  position{line: 1819, col: 50, offset: 56879},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1816, col: 67, offset: 56738},
+							pos:   position{line: 1819, col: 67, offset: 56896},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1816, col: 78, offset: 56749},
+								pos: position{line: 1819, col: 78, offset: 56907},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1816, col: 78, offset: 56749},
+										pos:  position{line: 1819, col: 78, offset: 56907},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1816, col: 84, offset: 56755},
+										pos:  position{line: 1819, col: 84, offset: 56913},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1816, col: 99, offset: 56770},
+							pos:   position{line: 1819, col: 99, offset: 56928},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1816, col: 108, offset: 56779},
+								pos: position{line: 1819, col: 108, offset: 56937},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1816, col: 109, offset: 56780},
+									pos:  position{line: 1819, col: 109, offset: 56938},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1816, col: 120, offset: 56791},
+							pos:   position{line: 1819, col: 120, offset: 56949},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1816, col: 128, offset: 56799},
+								pos: position{line: 1819, col: 128, offset: 56957},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1816, col: 129, offset: 56800},
+									pos:  position{line: 1819, col: 129, offset: 56958},
 									name: "StatisticOptions",
 								},
 							},
@@ -3391,25 +3391,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1858, col: 1, offset: 57885},
+			pos:  position{line: 1861, col: 1, offset: 58043},
 			expr: &choiceExpr{
-				pos: position{line: 1858, col: 19, offset: 57903},
+				pos: position{line: 1861, col: 19, offset: 58061},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1858, col: 19, offset: 57903},
+						pos: position{line: 1861, col: 19, offset: 58061},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1858, col: 19, offset: 57903},
+							pos: position{line: 1861, col: 19, offset: 58061},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1858, col: 19, offset: 57903},
+									pos:  position{line: 1861, col: 19, offset: 58061},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1858, col: 25, offset: 57909},
+									pos:   position{line: 1861, col: 25, offset: 58067},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1858, col: 32, offset: 57916},
+										pos:  position{line: 1861, col: 32, offset: 58074},
 										name: "IntegerAsString",
 									},
 								},
@@ -3417,30 +3417,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1861, col: 3, offset: 57970},
+						pos: position{line: 1864, col: 3, offset: 58128},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1861, col: 3, offset: 57970},
+							pos: position{line: 1864, col: 3, offset: 58128},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1861, col: 3, offset: 57970},
+									pos:  position{line: 1864, col: 3, offset: 58128},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1861, col: 9, offset: 57976},
+									pos:        position{line: 1864, col: 9, offset: 58134},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1861, col: 17, offset: 57984},
+									pos:  position{line: 1864, col: 17, offset: 58142},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1861, col: 23, offset: 57990},
+									pos:   position{line: 1864, col: 23, offset: 58148},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1861, col: 30, offset: 57997},
+										pos:  position{line: 1864, col: 30, offset: 58155},
 										name: "IntegerAsString",
 									},
 								},
@@ -3452,17 +3452,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1866, col: 1, offset: 58095},
+			pos:  position{line: 1869, col: 1, offset: 58253},
 			expr: &actionExpr{
-				pos: position{line: 1866, col: 21, offset: 58115},
+				pos: position{line: 1869, col: 21, offset: 58273},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1866, col: 21, offset: 58115},
+					pos:   position{line: 1869, col: 21, offset: 58273},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1866, col: 28, offset: 58122},
+						pos: position{line: 1869, col: 28, offset: 58280},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1866, col: 29, offset: 58123},
+							pos:  position{line: 1869, col: 29, offset: 58281},
 							name: "StatisticOption",
 						},
 					},
@@ -3471,34 +3471,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1915, col: 1, offset: 59685},
+			pos:  position{line: 1918, col: 1, offset: 59843},
 			expr: &actionExpr{
-				pos: position{line: 1915, col: 20, offset: 59704},
+				pos: position{line: 1918, col: 20, offset: 59862},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1915, col: 20, offset: 59704},
+					pos: position{line: 1918, col: 20, offset: 59862},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1915, col: 20, offset: 59704},
+							pos:  position{line: 1918, col: 20, offset: 59862},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 26, offset: 59710},
+							pos:   position{line: 1918, col: 26, offset: 59868},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 36, offset: 59720},
+								pos:  position{line: 1918, col: 36, offset: 59878},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1915, col: 55, offset: 59739},
+							pos:  position{line: 1918, col: 55, offset: 59897},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1915, col: 61, offset: 59745},
+							pos:   position{line: 1918, col: 61, offset: 59903},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1915, col: 67, offset: 59751},
+								pos:  position{line: 1918, col: 67, offset: 59909},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3508,48 +3508,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1920, col: 1, offset: 59860},
+			pos:  position{line: 1923, col: 1, offset: 60018},
 			expr: &actionExpr{
-				pos: position{line: 1920, col: 23, offset: 59882},
+				pos: position{line: 1923, col: 23, offset: 60040},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1920, col: 23, offset: 59882},
+					pos:   position{line: 1923, col: 23, offset: 60040},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1920, col: 31, offset: 59890},
+						pos: position{line: 1923, col: 31, offset: 60048},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1920, col: 31, offset: 59890},
+								pos:        position{line: 1923, col: 31, offset: 60048},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1920, col: 46, offset: 59905},
+								pos:        position{line: 1923, col: 46, offset: 60063},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1920, col: 60, offset: 59919},
+								pos:        position{line: 1923, col: 60, offset: 60077},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1920, col: 73, offset: 59932},
+								pos:        position{line: 1923, col: 73, offset: 60090},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1920, col: 85, offset: 59944},
+								pos:        position{line: 1923, col: 85, offset: 60102},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1920, col: 102, offset: 59961},
+								pos:        position{line: 1923, col: 102, offset: 60119},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3561,25 +3561,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1928, col: 1, offset: 60148},
+			pos:  position{line: 1931, col: 1, offset: 60306},
 			expr: &choiceExpr{
-				pos: position{line: 1928, col: 13, offset: 60160},
+				pos: position{line: 1931, col: 13, offset: 60318},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1928, col: 13, offset: 60160},
+						pos: position{line: 1931, col: 13, offset: 60318},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1928, col: 13, offset: 60160},
+							pos: position{line: 1931, col: 13, offset: 60318},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1928, col: 13, offset: 60160},
+									pos:  position{line: 1931, col: 13, offset: 60318},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1928, col: 16, offset: 60163},
+									pos:   position{line: 1931, col: 16, offset: 60321},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1928, col: 26, offset: 60173},
+										pos:  position{line: 1931, col: 26, offset: 60331},
 										name: "FieldNameList",
 									},
 								},
@@ -3587,13 +3587,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1931, col: 3, offset: 60230},
+						pos: position{line: 1934, col: 3, offset: 60388},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1931, col: 3, offset: 60230},
+							pos:   position{line: 1934, col: 3, offset: 60388},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1931, col: 16, offset: 60243},
+								pos:  position{line: 1934, col: 16, offset: 60401},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3603,26 +3603,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1935, col: 1, offset: 60301},
+			pos:  position{line: 1938, col: 1, offset: 60459},
 			expr: &actionExpr{
-				pos: position{line: 1935, col: 15, offset: 60315},
+				pos: position{line: 1938, col: 15, offset: 60473},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1935, col: 15, offset: 60315},
+					pos: position{line: 1938, col: 15, offset: 60473},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1935, col: 15, offset: 60315},
+							pos:  position{line: 1938, col: 15, offset: 60473},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1935, col: 20, offset: 60320},
+							pos:  position{line: 1938, col: 20, offset: 60478},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1935, col: 30, offset: 60330},
+							pos:   position{line: 1938, col: 30, offset: 60488},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1935, col: 40, offset: 60340},
+								pos:  position{line: 1938, col: 40, offset: 60498},
 								name: "DedupExpr",
 							},
 						},
@@ -3632,27 +3632,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1955, col: 1, offset: 60908},
+			pos:  position{line: 1958, col: 1, offset: 61066},
 			expr: &actionExpr{
-				pos: position{line: 1955, col: 14, offset: 60921},
+				pos: position{line: 1958, col: 14, offset: 61079},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1955, col: 14, offset: 60921},
+					pos: position{line: 1958, col: 14, offset: 61079},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1955, col: 14, offset: 60921},
+							pos:   position{line: 1958, col: 14, offset: 61079},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 23, offset: 60930},
+								pos: position{line: 1958, col: 23, offset: 61088},
 								expr: &seqExpr{
-									pos: position{line: 1955, col: 24, offset: 60931},
+									pos: position{line: 1958, col: 24, offset: 61089},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1955, col: 24, offset: 60931},
+											pos:  position{line: 1958, col: 24, offset: 61089},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1955, col: 30, offset: 60937},
+											pos:  position{line: 1958, col: 30, offset: 61095},
 											name: "IntegerAsString",
 										},
 									},
@@ -3660,45 +3660,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 48, offset: 60955},
+							pos:   position{line: 1958, col: 48, offset: 61113},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 57, offset: 60964},
+								pos: position{line: 1958, col: 57, offset: 61122},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 58, offset: 60965},
+									pos:  position{line: 1958, col: 58, offset: 61123},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 73, offset: 60980},
+							pos:   position{line: 1958, col: 73, offset: 61138},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 83, offset: 60990},
+								pos: position{line: 1958, col: 83, offset: 61148},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 84, offset: 60991},
+									pos:  position{line: 1958, col: 84, offset: 61149},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 101, offset: 61008},
+							pos:   position{line: 1958, col: 101, offset: 61166},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 110, offset: 61017},
+								pos: position{line: 1958, col: 110, offset: 61175},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 111, offset: 61018},
+									pos:  position{line: 1958, col: 111, offset: 61176},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1955, col: 126, offset: 61033},
+							pos:   position{line: 1958, col: 126, offset: 61191},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1955, col: 139, offset: 61046},
+								pos: position{line: 1958, col: 139, offset: 61204},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1955, col: 140, offset: 61047},
+									pos:  position{line: 1958, col: 140, offset: 61205},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3709,27 +3709,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2012, col: 1, offset: 62785},
+			pos:  position{line: 2015, col: 1, offset: 62943},
 			expr: &actionExpr{
-				pos: position{line: 2012, col: 19, offset: 62803},
+				pos: position{line: 2015, col: 19, offset: 62961},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2012, col: 19, offset: 62803},
+					pos: position{line: 2015, col: 19, offset: 62961},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2012, col: 19, offset: 62803},
+							pos: position{line: 2015, col: 19, offset: 62961},
 							expr: &litMatcher{
-								pos:        position{line: 2012, col: 21, offset: 62805},
+								pos:        position{line: 2015, col: 21, offset: 62963},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2012, col: 31, offset: 62815},
+							pos:   position{line: 2015, col: 31, offset: 62973},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2012, col: 37, offset: 62821},
+								pos:  position{line: 2015, col: 37, offset: 62979},
 								name: "FieldName",
 							},
 						},
@@ -3739,48 +3739,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2018, col: 1, offset: 62960},
+			pos:  position{line: 2021, col: 1, offset: 63118},
 			expr: &actionExpr{
-				pos: position{line: 2018, col: 32, offset: 62991},
+				pos: position{line: 2021, col: 32, offset: 63149},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2018, col: 32, offset: 62991},
+					pos: position{line: 2021, col: 32, offset: 63149},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2018, col: 32, offset: 62991},
+							pos:   position{line: 2021, col: 32, offset: 63149},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2018, col: 38, offset: 62997},
+								pos:  position{line: 2021, col: 38, offset: 63155},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2018, col: 48, offset: 63007},
+							pos: position{line: 2021, col: 48, offset: 63165},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2018, col: 50, offset: 63009},
+								pos:  position{line: 2021, col: 50, offset: 63167},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2018, col: 57, offset: 63016},
+							pos:   position{line: 2021, col: 57, offset: 63174},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2018, col: 62, offset: 63021},
+								pos: position{line: 2021, col: 62, offset: 63179},
 								expr: &seqExpr{
-									pos: position{line: 2018, col: 63, offset: 63022},
+									pos: position{line: 2021, col: 63, offset: 63180},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2018, col: 63, offset: 63022},
+											pos:  position{line: 2021, col: 63, offset: 63180},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2018, col: 69, offset: 63028},
+											pos:  position{line: 2021, col: 69, offset: 63186},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2018, col: 79, offset: 63038},
+											pos: position{line: 2021, col: 79, offset: 63196},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2018, col: 81, offset: 63040},
+												pos:  position{line: 2021, col: 81, offset: 63198},
 												name: "EQUAL",
 											},
 										},
@@ -3794,45 +3794,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2029, col: 1, offset: 63315},
+			pos:  position{line: 2032, col: 1, offset: 63473},
 			expr: &actionExpr{
-				pos: position{line: 2029, col: 19, offset: 63333},
+				pos: position{line: 2032, col: 19, offset: 63491},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2029, col: 19, offset: 63333},
+					pos: position{line: 2032, col: 19, offset: 63491},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 19, offset: 63333},
+							pos:  position{line: 2032, col: 19, offset: 63491},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 25, offset: 63339},
+							pos:   position{line: 2032, col: 25, offset: 63497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2029, col: 31, offset: 63345},
+								pos:  position{line: 2032, col: 31, offset: 63503},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 46, offset: 63360},
+							pos:   position{line: 2032, col: 46, offset: 63518},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2029, col: 51, offset: 63365},
+								pos: position{line: 2032, col: 51, offset: 63523},
 								expr: &seqExpr{
-									pos: position{line: 2029, col: 52, offset: 63366},
+									pos: position{line: 2032, col: 52, offset: 63524},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2029, col: 52, offset: 63366},
+											pos:  position{line: 2032, col: 52, offset: 63524},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2029, col: 58, offset: 63372},
+											pos:  position{line: 2032, col: 58, offset: 63530},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2029, col: 73, offset: 63387},
+											pos: position{line: 2032, col: 73, offset: 63545},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2029, col: 74, offset: 63388},
+												pos:  position{line: 2032, col: 74, offset: 63546},
 												name: "EQUAL",
 											},
 										},
@@ -3846,17 +3846,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2047, col: 1, offset: 63916},
+			pos:  position{line: 2050, col: 1, offset: 64074},
 			expr: &actionExpr{
-				pos: position{line: 2047, col: 17, offset: 63932},
+				pos: position{line: 2050, col: 17, offset: 64090},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2047, col: 17, offset: 63932},
+					pos:   position{line: 2050, col: 17, offset: 64090},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2047, col: 24, offset: 63939},
+						pos: position{line: 2050, col: 24, offset: 64097},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2047, col: 25, offset: 63940},
+							pos:  position{line: 2050, col: 25, offset: 64098},
 							name: "DedupOption",
 						},
 					},
@@ -3865,36 +3865,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2087, col: 1, offset: 65206},
+			pos:  position{line: 2090, col: 1, offset: 65364},
 			expr: &actionExpr{
-				pos: position{line: 2087, col: 16, offset: 65221},
+				pos: position{line: 2090, col: 16, offset: 65379},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2087, col: 16, offset: 65221},
+					pos: position{line: 2090, col: 16, offset: 65379},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2087, col: 16, offset: 65221},
+							pos:  position{line: 2090, col: 16, offset: 65379},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2087, col: 22, offset: 65227},
+							pos:   position{line: 2090, col: 22, offset: 65385},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2087, col: 32, offset: 65237},
+								pos:  position{line: 2090, col: 32, offset: 65395},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2087, col: 47, offset: 65252},
+							pos:        position{line: 2090, col: 47, offset: 65410},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2087, col: 51, offset: 65256},
+							pos:   position{line: 2090, col: 51, offset: 65414},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2087, col: 57, offset: 65262},
+								pos:  position{line: 2090, col: 57, offset: 65420},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3904,30 +3904,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2092, col: 1, offset: 65371},
+			pos:  position{line: 2095, col: 1, offset: 65529},
 			expr: &actionExpr{
-				pos: position{line: 2092, col: 19, offset: 65389},
+				pos: position{line: 2095, col: 19, offset: 65547},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2092, col: 19, offset: 65389},
+					pos:   position{line: 2095, col: 19, offset: 65547},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2092, col: 27, offset: 65397},
+						pos: position{line: 2095, col: 27, offset: 65555},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2092, col: 27, offset: 65397},
+								pos:        position{line: 2095, col: 27, offset: 65555},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2092, col: 43, offset: 65413},
+								pos:        position{line: 2095, col: 43, offset: 65571},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2092, col: 57, offset: 65427},
+								pos:        position{line: 2095, col: 57, offset: 65585},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3939,22 +3939,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2100, col: 1, offset: 65612},
+			pos:  position{line: 2103, col: 1, offset: 65770},
 			expr: &actionExpr{
-				pos: position{line: 2100, col: 22, offset: 65633},
+				pos: position{line: 2103, col: 22, offset: 65791},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2100, col: 22, offset: 65633},
+					pos: position{line: 2103, col: 22, offset: 65791},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2100, col: 22, offset: 65633},
+							pos:  position{line: 2103, col: 22, offset: 65791},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2100, col: 39, offset: 65650},
+							pos:   position{line: 2103, col: 39, offset: 65808},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2100, col: 53, offset: 65664},
+								pos:  position{line: 2103, col: 53, offset: 65822},
 								name: "SortElements",
 							},
 						},
@@ -3964,35 +3964,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2105, col: 1, offset: 65772},
+			pos:  position{line: 2108, col: 1, offset: 65930},
 			expr: &actionExpr{
-				pos: position{line: 2105, col: 17, offset: 65788},
+				pos: position{line: 2108, col: 17, offset: 65946},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2105, col: 17, offset: 65788},
+					pos: position{line: 2108, col: 17, offset: 65946},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2105, col: 17, offset: 65788},
+							pos:   position{line: 2108, col: 17, offset: 65946},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2105, col: 23, offset: 65794},
+								pos:  position{line: 2108, col: 23, offset: 65952},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2105, col: 41, offset: 65812},
+							pos:   position{line: 2108, col: 41, offset: 65970},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2105, col: 46, offset: 65817},
+								pos: position{line: 2108, col: 46, offset: 65975},
 								expr: &seqExpr{
-									pos: position{line: 2105, col: 47, offset: 65818},
+									pos: position{line: 2108, col: 47, offset: 65976},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2105, col: 47, offset: 65818},
+											pos:  position{line: 2108, col: 47, offset: 65976},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2105, col: 62, offset: 65833},
+											pos:  position{line: 2108, col: 62, offset: 65991},
 											name: "SingleSortElement",
 										},
 									},
@@ -4005,22 +4005,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2120, col: 1, offset: 66191},
+			pos:  position{line: 2123, col: 1, offset: 66349},
 			expr: &actionExpr{
-				pos: position{line: 2120, col: 22, offset: 66212},
+				pos: position{line: 2123, col: 22, offset: 66370},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2120, col: 22, offset: 66212},
+					pos:   position{line: 2123, col: 22, offset: 66370},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2120, col: 31, offset: 66221},
+						pos: position{line: 2123, col: 31, offset: 66379},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2120, col: 31, offset: 66221},
+								pos:  position{line: 2123, col: 31, offset: 66379},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2120, col: 59, offset: 66249},
+								pos:  position{line: 2123, col: 59, offset: 66407},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4030,33 +4030,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2124, col: 1, offset: 66308},
+			pos:  position{line: 2127, col: 1, offset: 66466},
 			expr: &actionExpr{
-				pos: position{line: 2124, col: 33, offset: 66340},
+				pos: position{line: 2127, col: 33, offset: 66498},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2124, col: 33, offset: 66340},
+					pos: position{line: 2127, col: 33, offset: 66498},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2124, col: 33, offset: 66340},
+							pos:   position{line: 2127, col: 33, offset: 66498},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2124, col: 47, offset: 66354},
+								pos: position{line: 2127, col: 47, offset: 66512},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2124, col: 47, offset: 66354},
+										pos:        position{line: 2127, col: 47, offset: 66512},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2124, col: 53, offset: 66360},
+										pos:        position{line: 2127, col: 53, offset: 66518},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2124, col: 59, offset: 66366},
+										pos:        position{line: 2127, col: 59, offset: 66524},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4065,10 +4065,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2124, col: 63, offset: 66370},
+							pos:   position{line: 2127, col: 63, offset: 66528},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2124, col: 69, offset: 66376},
+								pos:  position{line: 2127, col: 69, offset: 66534},
 								name: "FieldName",
 							},
 						},
@@ -4078,33 +4078,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2139, col: 1, offset: 66651},
+			pos:  position{line: 2142, col: 1, offset: 66809},
 			expr: &actionExpr{
-				pos: position{line: 2139, col: 30, offset: 66680},
+				pos: position{line: 2142, col: 30, offset: 66838},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2139, col: 30, offset: 66680},
+					pos: position{line: 2142, col: 30, offset: 66838},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2139, col: 30, offset: 66680},
+							pos:   position{line: 2142, col: 30, offset: 66838},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2139, col: 44, offset: 66694},
+								pos: position{line: 2142, col: 44, offset: 66852},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2139, col: 44, offset: 66694},
+										pos:        position{line: 2142, col: 44, offset: 66852},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2139, col: 50, offset: 66700},
+										pos:        position{line: 2142, col: 50, offset: 66858},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2139, col: 56, offset: 66706},
+										pos:        position{line: 2142, col: 56, offset: 66864},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4113,31 +4113,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2139, col: 60, offset: 66710},
+							pos:   position{line: 2142, col: 60, offset: 66868},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2139, col: 64, offset: 66714},
+								pos: position{line: 2142, col: 64, offset: 66872},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2139, col: 64, offset: 66714},
+										pos:        position{line: 2142, col: 64, offset: 66872},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2139, col: 73, offset: 66723},
+										pos:        position{line: 2142, col: 73, offset: 66881},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2139, col: 81, offset: 66731},
+										pos:        position{line: 2142, col: 81, offset: 66889},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2139, col: 88, offset: 66738},
+										pos:        position{line: 2142, col: 88, offset: 66896},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4146,19 +4146,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 95, offset: 66745},
+							pos:  position{line: 2142, col: 95, offset: 66903},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2139, col: 103, offset: 66753},
+							pos:   position{line: 2142, col: 103, offset: 66911},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2139, col: 109, offset: 66759},
+								pos:  position{line: 2142, col: 109, offset: 66917},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2139, col: 119, offset: 66769},
+							pos:  position{line: 2142, col: 119, offset: 66927},
 							name: "R_PAREN",
 						},
 					},
@@ -4167,26 +4167,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2159, col: 1, offset: 67194},
+			pos:  position{line: 2162, col: 1, offset: 67352},
 			expr: &actionExpr{
-				pos: position{line: 2159, col: 16, offset: 67209},
+				pos: position{line: 2162, col: 16, offset: 67367},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2159, col: 16, offset: 67209},
+					pos: position{line: 2162, col: 16, offset: 67367},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2159, col: 16, offset: 67209},
+							pos:  position{line: 2162, col: 16, offset: 67367},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2159, col: 21, offset: 67214},
+							pos:  position{line: 2162, col: 21, offset: 67372},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2159, col: 32, offset: 67225},
+							pos:   position{line: 2162, col: 32, offset: 67383},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2159, col: 43, offset: 67236},
+								pos:  position{line: 2162, col: 43, offset: 67394},
 								name: "RenameExpr",
 							},
 						},
@@ -4196,33 +4196,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2175, col: 1, offset: 67611},
+			pos:  position{line: 2178, col: 1, offset: 67769},
 			expr: &choiceExpr{
-				pos: position{line: 2175, col: 15, offset: 67625},
+				pos: position{line: 2178, col: 15, offset: 67783},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2175, col: 15, offset: 67625},
+						pos: position{line: 2178, col: 15, offset: 67783},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2175, col: 15, offset: 67625},
+							pos: position{line: 2178, col: 15, offset: 67783},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2175, col: 15, offset: 67625},
+									pos:   position{line: 2178, col: 15, offset: 67783},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2175, col: 31, offset: 67641},
+										pos:  position{line: 2178, col: 31, offset: 67799},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2175, col: 45, offset: 67655},
+									pos:  position{line: 2178, col: 45, offset: 67813},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2175, col: 48, offset: 67658},
+									pos:   position{line: 2178, col: 48, offset: 67816},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2175, col: 59, offset: 67669},
+										pos:  position{line: 2178, col: 59, offset: 67827},
 										name: "QuotedString",
 									},
 								},
@@ -4230,28 +4230,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2186, col: 3, offset: 67988},
+						pos: position{line: 2189, col: 3, offset: 68146},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2186, col: 3, offset: 67988},
+							pos: position{line: 2189, col: 3, offset: 68146},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2186, col: 3, offset: 67988},
+									pos:   position{line: 2189, col: 3, offset: 68146},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2186, col: 19, offset: 68004},
+										pos:  position{line: 2189, col: 19, offset: 68162},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2186, col: 33, offset: 68018},
+									pos:  position{line: 2189, col: 33, offset: 68176},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2186, col: 36, offset: 68021},
+									pos:   position{line: 2189, col: 36, offset: 68179},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2186, col: 47, offset: 68032},
+										pos:  position{line: 2189, col: 47, offset: 68190},
 										name: "RenamePattern",
 									},
 								},
@@ -4263,48 +4263,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2208, col: 1, offset: 68598},
+			pos:  position{line: 2211, col: 1, offset: 68756},
 			expr: &actionExpr{
-				pos: position{line: 2208, col: 13, offset: 68610},
+				pos: position{line: 2211, col: 13, offset: 68768},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2208, col: 13, offset: 68610},
+					pos: position{line: 2211, col: 13, offset: 68768},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2208, col: 13, offset: 68610},
+							pos:  position{line: 2211, col: 13, offset: 68768},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2208, col: 18, offset: 68615},
+							pos:  position{line: 2211, col: 18, offset: 68773},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2208, col: 26, offset: 68623},
+							pos:        position{line: 2211, col: 26, offset: 68781},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2208, col: 34, offset: 68631},
+							pos:  position{line: 2211, col: 34, offset: 68789},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2208, col: 40, offset: 68637},
+							pos:   position{line: 2211, col: 40, offset: 68795},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2208, col: 46, offset: 68643},
+								pos:  position{line: 2211, col: 46, offset: 68801},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2208, col: 62, offset: 68659},
+							pos:  position{line: 2211, col: 62, offset: 68817},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2208, col: 68, offset: 68665},
+							pos:   position{line: 2211, col: 68, offset: 68823},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2208, col: 72, offset: 68669},
+								pos:  position{line: 2211, col: 72, offset: 68827},
 								name: "QuotedString",
 							},
 						},
@@ -4314,37 +4314,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2236, col: 1, offset: 69372},
+			pos:  position{line: 2239, col: 1, offset: 69530},
 			expr: &actionExpr{
-				pos: position{line: 2236, col: 14, offset: 69385},
+				pos: position{line: 2239, col: 14, offset: 69543},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2236, col: 14, offset: 69385},
+					pos: position{line: 2239, col: 14, offset: 69543},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2236, col: 14, offset: 69385},
+							pos:  position{line: 2239, col: 14, offset: 69543},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2236, col: 19, offset: 69390},
+							pos:  position{line: 2239, col: 19, offset: 69548},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2236, col: 28, offset: 69399},
+							pos:   position{line: 2239, col: 28, offset: 69557},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2236, col: 34, offset: 69405},
+								pos: position{line: 2239, col: 34, offset: 69563},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2236, col: 35, offset: 69406},
+									pos:  position{line: 2239, col: 35, offset: 69564},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2236, col: 47, offset: 69418},
+							pos:   position{line: 2239, col: 47, offset: 69576},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2236, col: 58, offset: 69429},
+								pos:  position{line: 2239, col: 58, offset: 69587},
 								name: "SortElements",
 							},
 						},
@@ -4354,41 +4354,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2274, col: 1, offset: 70308},
+			pos:  position{line: 2277, col: 1, offset: 70466},
 			expr: &actionExpr{
-				pos: position{line: 2274, col: 14, offset: 70321},
+				pos: position{line: 2277, col: 14, offset: 70479},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2274, col: 14, offset: 70321},
+					pos: position{line: 2277, col: 14, offset: 70479},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2274, col: 14, offset: 70321},
+							pos: position{line: 2277, col: 14, offset: 70479},
 							expr: &seqExpr{
-								pos: position{line: 2274, col: 15, offset: 70322},
+								pos: position{line: 2277, col: 15, offset: 70480},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2274, col: 15, offset: 70322},
+										pos:        position{line: 2277, col: 15, offset: 70480},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2274, col: 23, offset: 70330},
+										pos:  position{line: 2277, col: 23, offset: 70488},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2274, col: 31, offset: 70338},
+							pos:   position{line: 2277, col: 31, offset: 70496},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2274, col: 40, offset: 70347},
+								pos:  position{line: 2277, col: 40, offset: 70505},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2274, col: 56, offset: 70363},
+							pos:  position{line: 2277, col: 56, offset: 70521},
 							name: "SPACE",
 						},
 					},
@@ -4397,43 +4397,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2288, col: 1, offset: 70662},
+			pos:  position{line: 2291, col: 1, offset: 70820},
 			expr: &actionExpr{
-				pos: position{line: 2288, col: 14, offset: 70675},
+				pos: position{line: 2291, col: 14, offset: 70833},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2288, col: 14, offset: 70675},
+					pos: position{line: 2291, col: 14, offset: 70833},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2288, col: 14, offset: 70675},
+							pos:  position{line: 2291, col: 14, offset: 70833},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2288, col: 19, offset: 70680},
+							pos:  position{line: 2291, col: 19, offset: 70838},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2288, col: 28, offset: 70689},
+							pos:   position{line: 2291, col: 28, offset: 70847},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2288, col: 34, offset: 70695},
+								pos:  position{line: 2291, col: 34, offset: 70853},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2288, col: 45, offset: 70706},
+							pos:   position{line: 2291, col: 45, offset: 70864},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2288, col: 50, offset: 70711},
+								pos: position{line: 2291, col: 50, offset: 70869},
 								expr: &seqExpr{
-									pos: position{line: 2288, col: 51, offset: 70712},
+									pos: position{line: 2291, col: 51, offset: 70870},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2288, col: 51, offset: 70712},
+											pos:  position{line: 2291, col: 51, offset: 70870},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2288, col: 57, offset: 70718},
+											pos:  position{line: 2291, col: 57, offset: 70876},
 											name: "SingleEval",
 										},
 									},
@@ -4446,30 +4446,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2315, col: 1, offset: 71519},
+			pos:  position{line: 2318, col: 1, offset: 71677},
 			expr: &actionExpr{
-				pos: position{line: 2315, col: 15, offset: 71533},
+				pos: position{line: 2318, col: 15, offset: 71691},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2315, col: 15, offset: 71533},
+					pos: position{line: 2318, col: 15, offset: 71691},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2315, col: 15, offset: 71533},
+							pos:   position{line: 2318, col: 15, offset: 71691},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2315, col: 21, offset: 71539},
+								pos:  position{line: 2318, col: 21, offset: 71697},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2315, col: 31, offset: 71549},
+							pos:  position{line: 2318, col: 31, offset: 71707},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2315, col: 37, offset: 71555},
+							pos:   position{line: 2318, col: 37, offset: 71713},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2315, col: 42, offset: 71560},
+								pos:  position{line: 2318, col: 42, offset: 71718},
 								name: "EvalExpression",
 							},
 						},
@@ -4479,15 +4479,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2328, col: 1, offset: 71961},
+			pos:  position{line: 2331, col: 1, offset: 72119},
 			expr: &actionExpr{
-				pos: position{line: 2328, col: 19, offset: 71979},
+				pos: position{line: 2331, col: 19, offset: 72137},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2328, col: 19, offset: 71979},
+					pos:   position{line: 2331, col: 19, offset: 72137},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2328, col: 25, offset: 71985},
+						pos:  position{line: 2331, col: 25, offset: 72143},
 						name: "ValueExpr",
 					},
 				},
@@ -4495,85 +4495,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2337, col: 1, offset: 72209},
+			pos:  position{line: 2340, col: 1, offset: 72367},
 			expr: &choiceExpr{
-				pos: position{line: 2337, col: 18, offset: 72226},
+				pos: position{line: 2340, col: 18, offset: 72384},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2337, col: 18, offset: 72226},
+						pos: position{line: 2340, col: 18, offset: 72384},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2337, col: 18, offset: 72226},
+							pos: position{line: 2340, col: 18, offset: 72384},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2337, col: 18, offset: 72226},
+									pos:        position{line: 2340, col: 18, offset: 72384},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 23, offset: 72231},
+									pos:  position{line: 2340, col: 23, offset: 72389},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2337, col: 31, offset: 72239},
+									pos:   position{line: 2340, col: 31, offset: 72397},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2337, col: 41, offset: 72249},
+										pos:  position{line: 2340, col: 41, offset: 72407},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 50, offset: 72258},
+									pos:  position{line: 2340, col: 50, offset: 72416},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2337, col: 56, offset: 72264},
+									pos:   position{line: 2340, col: 56, offset: 72422},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2337, col: 66, offset: 72274},
+										pos:  position{line: 2340, col: 66, offset: 72432},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 76, offset: 72284},
+									pos:  position{line: 2340, col: 76, offset: 72442},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2337, col: 82, offset: 72290},
+									pos:   position{line: 2340, col: 82, offset: 72448},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2337, col: 93, offset: 72301},
+										pos:  position{line: 2340, col: 93, offset: 72459},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 103, offset: 72311},
+									pos:  position{line: 2340, col: 103, offset: 72469},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2348, col: 3, offset: 72562},
+						pos: position{line: 2351, col: 3, offset: 72720},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2348, col: 3, offset: 72562},
+							pos: position{line: 2351, col: 3, offset: 72720},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2348, col: 3, offset: 72562},
+									pos:   position{line: 2351, col: 3, offset: 72720},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2348, col: 11, offset: 72570},
+										pos: position{line: 2351, col: 11, offset: 72728},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2348, col: 11, offset: 72570},
+												pos:        position{line: 2351, col: 11, offset: 72728},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2348, col: 20, offset: 72579},
+												pos:        position{line: 2351, col: 20, offset: 72737},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4582,31 +4582,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2348, col: 32, offset: 72591},
+									pos:  position{line: 2351, col: 32, offset: 72749},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2348, col: 40, offset: 72599},
+									pos:   position{line: 2351, col: 40, offset: 72757},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2348, col: 45, offset: 72604},
+										pos:  position{line: 2351, col: 45, offset: 72762},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2348, col: 64, offset: 72623},
+									pos:   position{line: 2351, col: 64, offset: 72781},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2348, col: 69, offset: 72628},
+										pos: position{line: 2351, col: 69, offset: 72786},
 										expr: &seqExpr{
-											pos: position{line: 2348, col: 70, offset: 72629},
+											pos: position{line: 2351, col: 70, offset: 72787},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2348, col: 70, offset: 72629},
+													pos:  position{line: 2351, col: 70, offset: 72787},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2348, col: 76, offset: 72635},
+													pos:  position{line: 2351, col: 76, offset: 72793},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4614,50 +4614,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2348, col: 97, offset: 72656},
+									pos:  position{line: 2351, col: 97, offset: 72814},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2371, col: 3, offset: 73260},
+						pos: position{line: 2374, col: 3, offset: 73418},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2371, col: 3, offset: 73260},
+							pos: position{line: 2374, col: 3, offset: 73418},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2371, col: 3, offset: 73260},
+									pos:        position{line: 2374, col: 3, offset: 73418},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2371, col: 14, offset: 73271},
+									pos:  position{line: 2374, col: 14, offset: 73429},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2371, col: 22, offset: 73279},
+									pos:   position{line: 2374, col: 22, offset: 73437},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2371, col: 32, offset: 73289},
+										pos:  position{line: 2374, col: 32, offset: 73447},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2371, col: 42, offset: 73299},
+									pos:   position{line: 2374, col: 42, offset: 73457},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2371, col: 47, offset: 73304},
+										pos: position{line: 2374, col: 47, offset: 73462},
 										expr: &seqExpr{
-											pos: position{line: 2371, col: 48, offset: 73305},
+											pos: position{line: 2374, col: 48, offset: 73463},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2371, col: 48, offset: 73305},
+													pos:  position{line: 2374, col: 48, offset: 73463},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2371, col: 54, offset: 73311},
+													pos:  position{line: 2374, col: 54, offset: 73469},
 													name: "ValueExpr",
 												},
 											},
@@ -4665,73 +4665,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2371, col: 66, offset: 73323},
+									pos:  position{line: 2374, col: 66, offset: 73481},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2388, col: 3, offset: 73742},
+						pos: position{line: 2391, col: 3, offset: 73900},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2388, col: 3, offset: 73742},
+							pos: position{line: 2391, col: 3, offset: 73900},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2388, col: 3, offset: 73742},
+									pos:        position{line: 2391, col: 3, offset: 73900},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2388, col: 12, offset: 73751},
+									pos:  position{line: 2391, col: 12, offset: 73909},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2388, col: 20, offset: 73759},
+									pos:   position{line: 2391, col: 20, offset: 73917},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2388, col: 30, offset: 73769},
+										pos:  position{line: 2391, col: 30, offset: 73927},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2388, col: 40, offset: 73779},
+									pos:  position{line: 2391, col: 40, offset: 73937},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2388, col: 46, offset: 73785},
+									pos:   position{line: 2391, col: 46, offset: 73943},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2388, col: 57, offset: 73796},
+										pos:  position{line: 2391, col: 57, offset: 73954},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2388, col: 67, offset: 73806},
+									pos:  position{line: 2391, col: 67, offset: 73964},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2400, col: 3, offset: 74086},
+						pos: position{line: 2403, col: 3, offset: 74244},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2400, col: 3, offset: 74086},
+							pos: position{line: 2403, col: 3, offset: 74244},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2400, col: 3, offset: 74086},
+									pos:        position{line: 2403, col: 3, offset: 74244},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2400, col: 10, offset: 74093},
+									pos:  position{line: 2403, col: 10, offset: 74251},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2400, col: 18, offset: 74101},
+									pos:  position{line: 2403, col: 18, offset: 74259},
 									name: "R_PAREN",
 								},
 							},
@@ -4742,30 +4742,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2407, col: 1, offset: 74198},
+			pos:  position{line: 2410, col: 1, offset: 74356},
 			expr: &actionExpr{
-				pos: position{line: 2407, col: 23, offset: 74220},
+				pos: position{line: 2410, col: 23, offset: 74378},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2407, col: 23, offset: 74220},
+					pos: position{line: 2410, col: 23, offset: 74378},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2407, col: 23, offset: 74220},
+							pos:   position{line: 2410, col: 23, offset: 74378},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2407, col: 33, offset: 74230},
+								pos:  position{line: 2410, col: 33, offset: 74388},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2407, col: 42, offset: 74239},
+							pos:  position{line: 2410, col: 42, offset: 74397},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2407, col: 48, offset: 74245},
+							pos:   position{line: 2410, col: 48, offset: 74403},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2407, col: 54, offset: 74251},
+								pos:  position{line: 2410, col: 54, offset: 74409},
 								name: "ValueExpr",
 							},
 						},
@@ -4775,15 +4775,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2415, col: 1, offset: 74456},
+			pos:  position{line: 2418, col: 1, offset: 74614},
 			expr: &actionExpr{
-				pos: position{line: 2415, col: 26, offset: 74481},
+				pos: position{line: 2418, col: 26, offset: 74639},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2415, col: 26, offset: 74481},
+					pos:   position{line: 2418, col: 26, offset: 74639},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2415, col: 37, offset: 74492},
+						pos:  position{line: 2418, col: 37, offset: 74650},
 						name: "StringExpr",
 					},
 				},
@@ -4791,15 +4791,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2425, col: 1, offset: 74701},
+			pos:  position{line: 2428, col: 1, offset: 74859},
 			expr: &actionExpr{
-				pos: position{line: 2425, col: 30, offset: 74730},
+				pos: position{line: 2428, col: 30, offset: 74888},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2425, col: 30, offset: 74730},
+					pos:   position{line: 2428, col: 30, offset: 74888},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2425, col: 45, offset: 74745},
+						pos:  position{line: 2428, col: 45, offset: 74903},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4807,22 +4807,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2434, col: 1, offset: 74951},
+			pos:  position{line: 2437, col: 1, offset: 75109},
 			expr: &actionExpr{
-				pos: position{line: 2434, col: 27, offset: 74977},
+				pos: position{line: 2437, col: 27, offset: 75135},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2434, col: 27, offset: 74977},
+					pos:   position{line: 2437, col: 27, offset: 75135},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2434, col: 40, offset: 74990},
+						pos: position{line: 2437, col: 40, offset: 75148},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2434, col: 40, offset: 74990},
+								pos:  position{line: 2437, col: 40, offset: 75148},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2434, col: 68, offset: 75018},
+								pos:  position{line: 2437, col: 68, offset: 75176},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4832,135 +4832,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2438, col: 1, offset: 75095},
+			pos:  position{line: 2441, col: 1, offset: 75253},
 			expr: &choiceExpr{
-				pos: position{line: 2438, col: 19, offset: 75113},
+				pos: position{line: 2441, col: 19, offset: 75271},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2438, col: 19, offset: 75113},
+						pos: position{line: 2441, col: 19, offset: 75271},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2438, col: 20, offset: 75114},
+							pos: position{line: 2441, col: 20, offset: 75272},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2438, col: 20, offset: 75114},
+									pos:   position{line: 2441, col: 20, offset: 75272},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2438, col: 28, offset: 75122},
+										pos:        position{line: 2441, col: 28, offset: 75280},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 37, offset: 75131},
+									pos:  position{line: 2441, col: 37, offset: 75289},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 45, offset: 75139},
+									pos:   position{line: 2441, col: 45, offset: 75297},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 56, offset: 75150},
+										pos:  position{line: 2441, col: 56, offset: 75308},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 67, offset: 75161},
+									pos:  position{line: 2441, col: 67, offset: 75319},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 73, offset: 75167},
+									pos:   position{line: 2441, col: 73, offset: 75325},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 79, offset: 75173},
+										pos:  position{line: 2441, col: 79, offset: 75331},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 90, offset: 75184},
+									pos:  position{line: 2441, col: 90, offset: 75342},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2450, col: 3, offset: 75545},
+						pos: position{line: 2453, col: 3, offset: 75703},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2450, col: 4, offset: 75546},
+							pos: position{line: 2453, col: 4, offset: 75704},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2450, col: 4, offset: 75546},
+									pos:   position{line: 2453, col: 4, offset: 75704},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2450, col: 12, offset: 75554},
+										pos:        position{line: 2453, col: 12, offset: 75712},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 23, offset: 75565},
+									pos:  position{line: 2453, col: 23, offset: 75723},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 31, offset: 75573},
+									pos:   position{line: 2453, col: 31, offset: 75731},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2450, col: 46, offset: 75588},
+										pos:  position{line: 2453, col: 46, offset: 75746},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 61, offset: 75603},
+									pos:  position{line: 2453, col: 61, offset: 75761},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 67, offset: 75609},
+									pos:   position{line: 2453, col: 67, offset: 75767},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2450, col: 78, offset: 75620},
+										pos:  position{line: 2453, col: 78, offset: 75778},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 90, offset: 75632},
+									pos:   position{line: 2453, col: 90, offset: 75790},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2450, col: 99, offset: 75641},
+										pos: position{line: 2453, col: 99, offset: 75799},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2450, col: 100, offset: 75642},
+											pos:  position{line: 2453, col: 100, offset: 75800},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 119, offset: 75661},
+									pos:  position{line: 2453, col: 119, offset: 75819},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2466, col: 3, offset: 76223},
+						pos: position{line: 2469, col: 3, offset: 76381},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2466, col: 4, offset: 76224},
+							pos: position{line: 2469, col: 4, offset: 76382},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2466, col: 4, offset: 76224},
+									pos:   position{line: 2469, col: 4, offset: 76382},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2466, col: 12, offset: 76232},
+										pos: position{line: 2469, col: 12, offset: 76390},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2466, col: 12, offset: 76232},
+												pos:        position{line: 2469, col: 12, offset: 76390},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2466, col: 24, offset: 76244},
+												pos:        position{line: 2469, col: 24, offset: 76402},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4969,222 +4969,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2466, col: 34, offset: 76254},
+									pos:  position{line: 2469, col: 34, offset: 76412},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2466, col: 42, offset: 76262},
+									pos:   position{line: 2469, col: 42, offset: 76420},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2466, col: 57, offset: 76277},
+										pos:  position{line: 2469, col: 57, offset: 76435},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2466, col: 72, offset: 76292},
+									pos:  position{line: 2469, col: 72, offset: 76450},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2478, col: 3, offset: 76640},
+						pos: position{line: 2481, col: 3, offset: 76798},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2478, col: 4, offset: 76641},
+							pos: position{line: 2481, col: 4, offset: 76799},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2478, col: 4, offset: 76641},
+									pos:   position{line: 2481, col: 4, offset: 76799},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2478, col: 12, offset: 76649},
+										pos:        position{line: 2481, col: 12, offset: 76807},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2478, col: 24, offset: 76661},
+									pos:  position{line: 2481, col: 24, offset: 76819},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2478, col: 32, offset: 76669},
+									pos:   position{line: 2481, col: 32, offset: 76827},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2478, col: 42, offset: 76679},
+										pos:  position{line: 2481, col: 42, offset: 76837},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2478, col: 51, offset: 76688},
+									pos:  position{line: 2481, col: 51, offset: 76846},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2491, col: 3, offset: 77035},
+						pos: position{line: 2494, col: 3, offset: 77193},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2491, col: 4, offset: 77036},
+							pos: position{line: 2494, col: 4, offset: 77194},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2491, col: 4, offset: 77036},
+									pos:   position{line: 2494, col: 4, offset: 77194},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2491, col: 12, offset: 77044},
+										pos:        position{line: 2494, col: 12, offset: 77202},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2491, col: 21, offset: 77053},
+									pos:  position{line: 2494, col: 21, offset: 77211},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2491, col: 29, offset: 77061},
+									pos:   position{line: 2494, col: 29, offset: 77219},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2491, col: 44, offset: 77076},
+										pos:  position{line: 2494, col: 44, offset: 77234},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2491, col: 59, offset: 77091},
+									pos:  position{line: 2494, col: 59, offset: 77249},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2491, col: 65, offset: 77097},
+									pos:   position{line: 2494, col: 65, offset: 77255},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2491, col: 70, offset: 77102},
+										pos:  position{line: 2494, col: 70, offset: 77260},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2491, col: 80, offset: 77112},
+									pos:  position{line: 2494, col: 80, offset: 77270},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2504, col: 3, offset: 77534},
+						pos: position{line: 2507, col: 3, offset: 77692},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2504, col: 4, offset: 77535},
+							pos: position{line: 2507, col: 4, offset: 77693},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2504, col: 4, offset: 77535},
+									pos:   position{line: 2507, col: 4, offset: 77693},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2504, col: 12, offset: 77543},
+										pos:        position{line: 2507, col: 12, offset: 77701},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2504, col: 23, offset: 77554},
+									pos:  position{line: 2507, col: 23, offset: 77712},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2504, col: 31, offset: 77562},
+									pos:   position{line: 2507, col: 31, offset: 77720},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2504, col: 42, offset: 77573},
+										pos:  position{line: 2507, col: 42, offset: 77731},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2504, col: 54, offset: 77585},
+									pos:  position{line: 2507, col: 54, offset: 77743},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2504, col: 60, offset: 77591},
+									pos:   position{line: 2507, col: 60, offset: 77749},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2504, col: 69, offset: 77600},
+										pos:  position{line: 2507, col: 69, offset: 77758},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2504, col: 81, offset: 77612},
+									pos:  position{line: 2507, col: 81, offset: 77770},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2504, col: 87, offset: 77618},
+									pos:   position{line: 2507, col: 87, offset: 77776},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2504, col: 98, offset: 77629},
+										pos: position{line: 2507, col: 98, offset: 77787},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2504, col: 99, offset: 77630},
+											pos:  position{line: 2507, col: 99, offset: 77788},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2504, col: 112, offset: 77643},
+									pos:  position{line: 2507, col: 112, offset: 77801},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2517, col: 3, offset: 78094},
+						pos: position{line: 2520, col: 3, offset: 78252},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2517, col: 4, offset: 78095},
+							pos: position{line: 2520, col: 4, offset: 78253},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2517, col: 4, offset: 78095},
+									pos:   position{line: 2520, col: 4, offset: 78253},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2517, col: 12, offset: 78103},
+										pos:        position{line: 2520, col: 12, offset: 78261},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2517, col: 21, offset: 78112},
+									pos:  position{line: 2520, col: 21, offset: 78270},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2517, col: 29, offset: 78120},
+									pos:   position{line: 2520, col: 29, offset: 78278},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2517, col: 36, offset: 78127},
+										pos:  position{line: 2520, col: 36, offset: 78285},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2517, col: 51, offset: 78142},
+									pos:  position{line: 2520, col: 51, offset: 78300},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2517, col: 57, offset: 78148},
+									pos:   position{line: 2520, col: 57, offset: 78306},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2517, col: 65, offset: 78156},
+										pos:  position{line: 2520, col: 65, offset: 78314},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2517, col: 80, offset: 78171},
+									pos:   position{line: 2520, col: 80, offset: 78329},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2517, col: 85, offset: 78176},
+										pos: position{line: 2520, col: 85, offset: 78334},
 										expr: &seqExpr{
-											pos: position{line: 2517, col: 86, offset: 78177},
+											pos: position{line: 2520, col: 86, offset: 78335},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2517, col: 86, offset: 78177},
+													pos:  position{line: 2520, col: 86, offset: 78335},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2517, col: 92, offset: 78183},
+													pos:  position{line: 2520, col: 92, offset: 78341},
 													name: "StringExpr",
 												},
 											},
@@ -5192,63 +5192,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2517, col: 105, offset: 78196},
+									pos:  position{line: 2520, col: 105, offset: 78354},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2534, col: 3, offset: 78724},
+						pos: position{line: 2537, col: 3, offset: 78882},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2534, col: 4, offset: 78725},
+							pos: position{line: 2537, col: 4, offset: 78883},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2534, col: 4, offset: 78725},
+									pos:   position{line: 2537, col: 4, offset: 78883},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2534, col: 12, offset: 78733},
+										pos:        position{line: 2537, col: 12, offset: 78891},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2534, col: 32, offset: 78753},
+									pos:  position{line: 2537, col: 32, offset: 78911},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2534, col: 40, offset: 78761},
+									pos:   position{line: 2537, col: 40, offset: 78919},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2534, col: 55, offset: 78776},
+										pos:  position{line: 2537, col: 55, offset: 78934},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2534, col: 70, offset: 78791},
+									pos:   position{line: 2537, col: 70, offset: 78949},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2534, col: 75, offset: 78796},
+										pos: position{line: 2537, col: 75, offset: 78954},
 										expr: &seqExpr{
-											pos: position{line: 2534, col: 76, offset: 78797},
+											pos: position{line: 2537, col: 76, offset: 78955},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2534, col: 76, offset: 78797},
+													pos:  position{line: 2537, col: 76, offset: 78955},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2534, col: 83, offset: 78804},
+													pos: position{line: 2537, col: 83, offset: 78962},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2534, col: 83, offset: 78804},
+															pos:        position{line: 2537, col: 83, offset: 78962},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2534, col: 92, offset: 78813},
+															pos:        position{line: 2537, col: 92, offset: 78971},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5256,7 +5256,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2534, col: 101, offset: 78822},
+													pos:        position{line: 2537, col: 101, offset: 78980},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5266,54 +5266,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2534, col: 108, offset: 78829},
+									pos:  position{line: 2537, col: 108, offset: 78987},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2559, col: 3, offset: 79532},
+						pos: position{line: 2562, col: 3, offset: 79690},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2559, col: 4, offset: 79533},
+							pos: position{line: 2562, col: 4, offset: 79691},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2559, col: 4, offset: 79533},
+									pos:   position{line: 2562, col: 4, offset: 79691},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2559, col: 12, offset: 79541},
+										pos:        position{line: 2562, col: 12, offset: 79699},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2559, col: 24, offset: 79553},
+									pos:  position{line: 2562, col: 24, offset: 79711},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2559, col: 32, offset: 79561},
+									pos:   position{line: 2562, col: 32, offset: 79719},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2559, col: 41, offset: 79570},
+										pos:  position{line: 2562, col: 41, offset: 79728},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2559, col: 64, offset: 79593},
+									pos:   position{line: 2562, col: 64, offset: 79751},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2559, col: 69, offset: 79598},
+										pos: position{line: 2562, col: 69, offset: 79756},
 										expr: &seqExpr{
-											pos: position{line: 2559, col: 70, offset: 79599},
+											pos: position{line: 2562, col: 70, offset: 79757},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2559, col: 70, offset: 79599},
+													pos:  position{line: 2562, col: 70, offset: 79757},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2559, col: 76, offset: 79605},
+													pos:  position{line: 2562, col: 76, offset: 79763},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5321,57 +5321,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2559, col: 101, offset: 79630},
+									pos:  position{line: 2562, col: 101, offset: 79788},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2579, col: 3, offset: 80218},
+						pos: position{line: 2582, col: 3, offset: 80376},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2579, col: 3, offset: 80218},
+							pos: position{line: 2582, col: 3, offset: 80376},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2579, col: 3, offset: 80218},
+									pos:   position{line: 2582, col: 3, offset: 80376},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2579, col: 9, offset: 80224},
+										pos:  position{line: 2582, col: 9, offset: 80382},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2579, col: 25, offset: 80240},
+									pos: position{line: 2582, col: 25, offset: 80398},
 									expr: &choiceExpr{
-										pos: position{line: 2579, col: 27, offset: 80242},
+										pos: position{line: 2582, col: 27, offset: 80400},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 27, offset: 80242},
+												pos:  position{line: 2582, col: 27, offset: 80400},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 36, offset: 80251},
+												pos:  position{line: 2582, col: 36, offset: 80409},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 46, offset: 80261},
+												pos:  position{line: 2582, col: 46, offset: 80419},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 54, offset: 80269},
+												pos:  position{line: 2582, col: 54, offset: 80427},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 62, offset: 80277},
+												pos:  position{line: 2582, col: 62, offset: 80435},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2579, col: 70, offset: 80285},
+												pos:  position{line: 2582, col: 70, offset: 80443},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2579, col: 84, offset: 80299},
+												pos:        position{line: 2582, col: 84, offset: 80457},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5387,36 +5387,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2591, col: 1, offset: 80694},
+			pos:  position{line: 2594, col: 1, offset: 80852},
 			expr: &choiceExpr{
-				pos: position{line: 2591, col: 13, offset: 80706},
+				pos: position{line: 2594, col: 13, offset: 80864},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2591, col: 13, offset: 80706},
+						pos: position{line: 2594, col: 13, offset: 80864},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2591, col: 14, offset: 80707},
+							pos: position{line: 2594, col: 14, offset: 80865},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2591, col: 14, offset: 80707},
+									pos:   position{line: 2594, col: 14, offset: 80865},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2591, col: 22, offset: 80715},
+										pos: position{line: 2594, col: 22, offset: 80873},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2591, col: 22, offset: 80715},
+												pos:        position{line: 2594, col: 22, offset: 80873},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2591, col: 32, offset: 80725},
+												pos:        position{line: 2594, col: 32, offset: 80883},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2591, col: 42, offset: 80735},
+												pos:        position{line: 2594, col: 42, offset: 80893},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5425,44 +5425,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 55, offset: 80748},
+									pos:  position{line: 2594, col: 55, offset: 80906},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2591, col: 63, offset: 80756},
+									pos:   position{line: 2594, col: 63, offset: 80914},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2591, col: 74, offset: 80767},
+										pos:  position{line: 2594, col: 74, offset: 80925},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 85, offset: 80778},
+									pos:  position{line: 2594, col: 85, offset: 80936},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2603, col: 3, offset: 81092},
+						pos: position{line: 2606, col: 3, offset: 81250},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2603, col: 4, offset: 81093},
+							pos: position{line: 2606, col: 4, offset: 81251},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2603, col: 4, offset: 81093},
+									pos:   position{line: 2606, col: 4, offset: 81251},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2603, col: 12, offset: 81101},
+										pos: position{line: 2606, col: 12, offset: 81259},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2603, col: 12, offset: 81101},
+												pos:        position{line: 2606, col: 12, offset: 81259},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2603, col: 20, offset: 81109},
+												pos:        position{line: 2606, col: 20, offset: 81267},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5471,31 +5471,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2603, col: 27, offset: 81116},
+									pos:  position{line: 2606, col: 27, offset: 81274},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2603, col: 35, offset: 81124},
+									pos:   position{line: 2606, col: 35, offset: 81282},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2603, col: 44, offset: 81133},
+										pos:  position{line: 2606, col: 44, offset: 81291},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2603, col: 55, offset: 81144},
+									pos:   position{line: 2606, col: 55, offset: 81302},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2603, col: 60, offset: 81149},
+										pos: position{line: 2606, col: 60, offset: 81307},
 										expr: &seqExpr{
-											pos: position{line: 2603, col: 61, offset: 81150},
+											pos: position{line: 2606, col: 61, offset: 81308},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2603, col: 61, offset: 81150},
+													pos:  position{line: 2606, col: 61, offset: 81308},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2603, col: 67, offset: 81156},
+													pos:  position{line: 2606, col: 67, offset: 81314},
 													name: "StringExpr",
 												},
 											},
@@ -5503,195 +5503,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2603, col: 80, offset: 81169},
+									pos:  position{line: 2606, col: 80, offset: 81327},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2625, col: 3, offset: 81769},
+						pos: position{line: 2628, col: 3, offset: 81927},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2625, col: 4, offset: 81770},
+							pos: position{line: 2628, col: 4, offset: 81928},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2625, col: 4, offset: 81770},
+									pos:   position{line: 2628, col: 4, offset: 81928},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2625, col: 12, offset: 81778},
+										pos:        position{line: 2628, col: 12, offset: 81936},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2625, col: 23, offset: 81789},
+									pos:  position{line: 2628, col: 23, offset: 81947},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2625, col: 31, offset: 81797},
+									pos:   position{line: 2628, col: 31, offset: 81955},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2625, col: 46, offset: 81812},
+										pos:  position{line: 2628, col: 46, offset: 81970},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2625, col: 61, offset: 81827},
+									pos:  position{line: 2628, col: 61, offset: 81985},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2636, col: 3, offset: 82129},
+						pos: position{line: 2639, col: 3, offset: 82287},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2636, col: 4, offset: 82130},
+							pos: position{line: 2639, col: 4, offset: 82288},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2636, col: 4, offset: 82130},
+									pos:   position{line: 2639, col: 4, offset: 82288},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2636, col: 12, offset: 82138},
+										pos:        position{line: 2639, col: 12, offset: 82296},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 22, offset: 82148},
+									pos:  position{line: 2639, col: 22, offset: 82306},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2636, col: 30, offset: 82156},
+									pos:   position{line: 2639, col: 30, offset: 82314},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2636, col: 45, offset: 82171},
+										pos:  position{line: 2639, col: 45, offset: 82329},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 60, offset: 82186},
+									pos:  position{line: 2639, col: 60, offset: 82344},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2636, col: 66, offset: 82192},
+									pos:   position{line: 2639, col: 66, offset: 82350},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2636, col: 72, offset: 82198},
+										pos:  position{line: 2639, col: 72, offset: 82356},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 83, offset: 82209},
+									pos:  position{line: 2639, col: 83, offset: 82367},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2648, col: 3, offset: 82559},
+						pos: position{line: 2651, col: 3, offset: 82717},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2648, col: 4, offset: 82560},
+							pos: position{line: 2651, col: 4, offset: 82718},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2648, col: 4, offset: 82560},
+									pos:   position{line: 2651, col: 4, offset: 82718},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2648, col: 12, offset: 82568},
+										pos:        position{line: 2651, col: 12, offset: 82726},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2648, col: 22, offset: 82578},
+									pos:  position{line: 2651, col: 22, offset: 82736},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2648, col: 30, offset: 82586},
+									pos:   position{line: 2651, col: 30, offset: 82744},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2648, col: 45, offset: 82601},
+										pos:  position{line: 2651, col: 45, offset: 82759},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2648, col: 60, offset: 82616},
+									pos:  position{line: 2651, col: 60, offset: 82774},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2648, col: 66, offset: 82622},
+									pos:   position{line: 2651, col: 66, offset: 82780},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2648, col: 79, offset: 82635},
+										pos:  position{line: 2651, col: 79, offset: 82793},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2648, col: 90, offset: 82646},
+									pos:  position{line: 2651, col: 90, offset: 82804},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2672, col: 3, offset: 83315},
+						pos: position{line: 2675, col: 3, offset: 83473},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2672, col: 4, offset: 83316},
+							pos: position{line: 2675, col: 4, offset: 83474},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2672, col: 4, offset: 83316},
+									pos:   position{line: 2675, col: 4, offset: 83474},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2672, col: 12, offset: 83324},
+										pos:        position{line: 2675, col: 12, offset: 83482},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 22, offset: 83334},
+									pos:  position{line: 2675, col: 22, offset: 83492},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 30, offset: 83342},
+									pos:   position{line: 2675, col: 30, offset: 83500},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2672, col: 41, offset: 83353},
+										pos:  position{line: 2675, col: 41, offset: 83511},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 52, offset: 83364},
+									pos:  position{line: 2675, col: 52, offset: 83522},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 58, offset: 83370},
+									pos:   position{line: 2675, col: 58, offset: 83528},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2672, col: 69, offset: 83381},
+										pos:  position{line: 2675, col: 69, offset: 83539},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 81, offset: 83393},
+									pos:   position{line: 2675, col: 81, offset: 83551},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2672, col: 93, offset: 83405},
+										pos: position{line: 2675, col: 93, offset: 83563},
 										expr: &seqExpr{
-											pos: position{line: 2672, col: 94, offset: 83406},
+											pos: position{line: 2675, col: 94, offset: 83564},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2672, col: 94, offset: 83406},
+													pos:  position{line: 2675, col: 94, offset: 83564},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2672, col: 100, offset: 83412},
+													pos:  position{line: 2675, col: 100, offset: 83570},
 													name: "NumericExpr",
 												},
 											},
@@ -5699,50 +5699,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 114, offset: 83426},
+									pos:  position{line: 2675, col: 114, offset: 83584},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2697, col: 3, offset: 84256},
+						pos: position{line: 2700, col: 3, offset: 84414},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2697, col: 3, offset: 84256},
+							pos: position{line: 2700, col: 3, offset: 84414},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2697, col: 3, offset: 84256},
+									pos:        position{line: 2700, col: 3, offset: 84414},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2697, col: 14, offset: 84267},
+									pos:  position{line: 2700, col: 14, offset: 84425},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2697, col: 22, offset: 84275},
+									pos:   position{line: 2700, col: 22, offset: 84433},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2697, col: 28, offset: 84281},
+										pos:  position{line: 2700, col: 28, offset: 84439},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2697, col: 38, offset: 84291},
+									pos:   position{line: 2700, col: 38, offset: 84449},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2697, col: 45, offset: 84298},
+										pos: position{line: 2700, col: 45, offset: 84456},
 										expr: &seqExpr{
-											pos: position{line: 2697, col: 46, offset: 84299},
+											pos: position{line: 2700, col: 46, offset: 84457},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2697, col: 46, offset: 84299},
+													pos:  position{line: 2700, col: 46, offset: 84457},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2697, col: 52, offset: 84305},
+													pos:  position{line: 2700, col: 52, offset: 84463},
 													name: "StringExpr",
 												},
 											},
@@ -5750,38 +5750,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2697, col: 65, offset: 84318},
+									pos:  position{line: 2700, col: 65, offset: 84476},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2710, col: 3, offset: 84686},
+						pos: position{line: 2713, col: 3, offset: 84844},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2710, col: 4, offset: 84687},
+							pos: position{line: 2713, col: 4, offset: 84845},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2710, col: 4, offset: 84687},
+									pos:   position{line: 2713, col: 4, offset: 84845},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2710, col: 12, offset: 84695},
+										pos: position{line: 2713, col: 12, offset: 84853},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2710, col: 12, offset: 84695},
+												pos:        position{line: 2713, col: 12, offset: 84853},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2710, col: 22, offset: 84705},
+												pos:        position{line: 2713, col: 22, offset: 84863},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2710, col: 32, offset: 84715},
+												pos:        position{line: 2713, col: 32, offset: 84873},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5790,223 +5790,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 40, offset: 84723},
+									pos:  position{line: 2713, col: 40, offset: 84881},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 48, offset: 84731},
+									pos:   position{line: 2713, col: 48, offset: 84889},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2710, col: 54, offset: 84737},
+										pos:  position{line: 2713, col: 54, offset: 84895},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2710, col: 66, offset: 84749},
+									pos:   position{line: 2713, col: 66, offset: 84907},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2710, col: 82, offset: 84765},
+										pos: position{line: 2713, col: 82, offset: 84923},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2710, col: 83, offset: 84766},
+											pos:  position{line: 2713, col: 83, offset: 84924},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2710, col: 101, offset: 84784},
+									pos:  position{line: 2713, col: 101, offset: 84942},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2729, col: 3, offset: 85224},
+						pos: position{line: 2732, col: 3, offset: 85382},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2729, col: 3, offset: 85224},
+							pos: position{line: 2732, col: 3, offset: 85382},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2729, col: 3, offset: 85224},
+									pos:        position{line: 2732, col: 3, offset: 85382},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2729, col: 11, offset: 85232},
+									pos:  position{line: 2732, col: 11, offset: 85390},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2729, col: 19, offset: 85240},
+									pos:   position{line: 2732, col: 19, offset: 85398},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2729, col: 30, offset: 85251},
+										pos:  position{line: 2732, col: 30, offset: 85409},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2729, col: 50, offset: 85271},
+									pos:  position{line: 2732, col: 50, offset: 85429},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2729, col: 56, offset: 85277},
+									pos:   position{line: 2732, col: 56, offset: 85435},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2729, col: 62, offset: 85283},
+										pos: position{line: 2732, col: 62, offset: 85441},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2729, col: 62, offset: 85283},
+												pos:  position{line: 2732, col: 62, offset: 85441},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2729, col: 81, offset: 85302},
+												pos:  position{line: 2732, col: 81, offset: 85460},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2729, col: 100, offset: 85321},
+									pos:  position{line: 2732, col: 100, offset: 85479},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2740, col: 3, offset: 85626},
+						pos: position{line: 2743, col: 3, offset: 85784},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2740, col: 3, offset: 85626},
+							pos: position{line: 2743, col: 3, offset: 85784},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2740, col: 3, offset: 85626},
+									pos:        position{line: 2743, col: 3, offset: 85784},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2740, col: 12, offset: 85635},
+									pos:  position{line: 2743, col: 12, offset: 85793},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2740, col: 20, offset: 85643},
+									pos:   position{line: 2743, col: 20, offset: 85801},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2740, col: 25, offset: 85648},
+										pos:  position{line: 2743, col: 25, offset: 85806},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2740, col: 36, offset: 85659},
+									pos:  position{line: 2743, col: 36, offset: 85817},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2740, col: 42, offset: 85665},
+									pos:   position{line: 2743, col: 42, offset: 85823},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2740, col: 45, offset: 85668},
+										pos:  position{line: 2743, col: 45, offset: 85826},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2740, col: 55, offset: 85678},
+									pos:  position{line: 2743, col: 55, offset: 85836},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2747, col: 3, offset: 85836},
+						pos: position{line: 2750, col: 3, offset: 85994},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2747, col: 3, offset: 85836},
+							pos: position{line: 2750, col: 3, offset: 85994},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2747, col: 3, offset: 85836},
+									pos:        position{line: 2750, col: 3, offset: 85994},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2747, col: 21, offset: 85854},
+									pos:  position{line: 2750, col: 21, offset: 86012},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2747, col: 29, offset: 85862},
+									pos:   position{line: 2750, col: 29, offset: 86020},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2747, col: 33, offset: 85866},
+										pos:  position{line: 2750, col: 33, offset: 86024},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2747, col: 43, offset: 85876},
+									pos:  position{line: 2750, col: 43, offset: 86034},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2747, col: 49, offset: 85882},
+									pos:   position{line: 2750, col: 49, offset: 86040},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2747, col: 53, offset: 85886},
+										pos:  position{line: 2750, col: 53, offset: 86044},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2747, col: 66, offset: 85899},
+									pos:  position{line: 2750, col: 66, offset: 86057},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2747, col: 72, offset: 85905},
+									pos:   position{line: 2750, col: 72, offset: 86063},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2747, col: 78, offset: 85911},
+										pos:  position{line: 2750, col: 78, offset: 86069},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2747, col: 91, offset: 85924},
+									pos:  position{line: 2750, col: 91, offset: 86082},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2758, col: 3, offset: 86232},
+						pos: position{line: 2761, col: 3, offset: 86390},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2758, col: 3, offset: 86232},
+							pos: position{line: 2761, col: 3, offset: 86390},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2758, col: 3, offset: 86232},
+									pos:        position{line: 2761, col: 3, offset: 86390},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2758, col: 12, offset: 86241},
+									pos:  position{line: 2761, col: 12, offset: 86399},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2758, col: 20, offset: 86249},
+									pos:   position{line: 2761, col: 20, offset: 86407},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2758, col: 27, offset: 86256},
+										pos:  position{line: 2761, col: 27, offset: 86414},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2758, col: 38, offset: 86267},
+									pos:   position{line: 2761, col: 38, offset: 86425},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2758, col: 43, offset: 86272},
+										pos: position{line: 2761, col: 43, offset: 86430},
 										expr: &seqExpr{
-											pos: position{line: 2758, col: 44, offset: 86273},
+											pos: position{line: 2761, col: 44, offset: 86431},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2758, col: 44, offset: 86273},
+													pos:  position{line: 2761, col: 44, offset: 86431},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2758, col: 50, offset: 86279},
+													pos:  position{line: 2761, col: 50, offset: 86437},
 													name: "StringExpr",
 												},
 											},
@@ -6014,47 +6014,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2758, col: 63, offset: 86292},
+									pos:  position{line: 2761, col: 63, offset: 86450},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2776, col: 3, offset: 86759},
+						pos: position{line: 2779, col: 3, offset: 86917},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2776, col: 3, offset: 86759},
+							pos: position{line: 2779, col: 3, offset: 86917},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2776, col: 3, offset: 86759},
+									pos:        position{line: 2779, col: 3, offset: 86917},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2776, col: 12, offset: 86768},
+									pos:  position{line: 2779, col: 12, offset: 86926},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2776, col: 20, offset: 86776},
+									pos:   position{line: 2779, col: 20, offset: 86934},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2776, col: 42, offset: 86798},
+										pos: position{line: 2779, col: 42, offset: 86956},
 										expr: &seqExpr{
-											pos: position{line: 2776, col: 43, offset: 86799},
+											pos: position{line: 2779, col: 43, offset: 86957},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2776, col: 44, offset: 86800},
+													pos: position{line: 2779, col: 44, offset: 86958},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2776, col: 44, offset: 86800},
+															pos:        position{line: 2779, col: 44, offset: 86958},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2776, col: 53, offset: 86809},
+															pos:        position{line: 2779, col: 53, offset: 86967},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6062,7 +6062,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2776, col: 62, offset: 86818},
+													pos:        position{line: 2779, col: 62, offset: 86976},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6072,56 +6072,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2776, col: 69, offset: 86825},
+									pos:  position{line: 2779, col: 69, offset: 86983},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2798, col: 3, offset: 87422},
+						pos: position{line: 2801, col: 3, offset: 87580},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2798, col: 3, offset: 87422},
+							pos: position{line: 2801, col: 3, offset: 87580},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2798, col: 3, offset: 87422},
+									pos:        position{line: 2801, col: 3, offset: 87580},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 13, offset: 87432},
+									pos:  position{line: 2801, col: 13, offset: 87590},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 21, offset: 87440},
+									pos:   position{line: 2801, col: 21, offset: 87598},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2798, col: 27, offset: 87446},
+										pos:  position{line: 2801, col: 27, offset: 87604},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 43, offset: 87462},
+									pos:   position{line: 2801, col: 43, offset: 87620},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2798, col: 53, offset: 87472},
+										pos: position{line: 2801, col: 53, offset: 87630},
 										expr: &seqExpr{
-											pos: position{line: 2798, col: 54, offset: 87473},
+											pos: position{line: 2801, col: 54, offset: 87631},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 54, offset: 87473},
+													pos:  position{line: 2801, col: 54, offset: 87631},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2798, col: 60, offset: 87479},
+													pos:        position{line: 2801, col: 60, offset: 87637},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 73, offset: 87492},
+													pos:  position{line: 2801, col: 73, offset: 87650},
 													name: "FloatAsString",
 												},
 											},
@@ -6129,40 +6129,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 89, offset: 87508},
+									pos:   position{line: 2801, col: 89, offset: 87666},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2798, col: 95, offset: 87514},
+										pos: position{line: 2801, col: 95, offset: 87672},
 										expr: &seqExpr{
-											pos: position{line: 2798, col: 96, offset: 87515},
+											pos: position{line: 2801, col: 96, offset: 87673},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 96, offset: 87515},
+													pos:  position{line: 2801, col: 96, offset: 87673},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2798, col: 102, offset: 87521},
+													pos:        position{line: 2801, col: 102, offset: 87679},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2798, col: 112, offset: 87531},
+													pos: position{line: 2801, col: 112, offset: 87689},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2798, col: 112, offset: 87531},
+															pos:        position{line: 2801, col: 112, offset: 87689},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2798, col: 125, offset: 87544},
+															pos:        position{line: 2801, col: 125, offset: 87702},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2798, col: 137, offset: 87556},
+															pos:        position{line: 2801, col: 137, offset: 87714},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6174,25 +6174,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 151, offset: 87570},
+									pos:   position{line: 2801, col: 151, offset: 87728},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2798, col: 158, offset: 87577},
+										pos: position{line: 2801, col: 158, offset: 87735},
 										expr: &seqExpr{
-											pos: position{line: 2798, col: 159, offset: 87578},
+											pos: position{line: 2801, col: 159, offset: 87736},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 159, offset: 87578},
+													pos:  position{line: 2801, col: 159, offset: 87736},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2798, col: 165, offset: 87584},
+													pos:        position{line: 2801, col: 165, offset: 87742},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 175, offset: 87594},
+													pos:  position{line: 2801, col: 175, offset: 87752},
 													name: "QuotedString",
 												},
 											},
@@ -6200,213 +6200,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 190, offset: 87609},
+									pos:  position{line: 2801, col: 190, offset: 87767},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2838, col: 3, offset: 88604},
+						pos: position{line: 2841, col: 3, offset: 88762},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2838, col: 3, offset: 88604},
+							pos: position{line: 2841, col: 3, offset: 88762},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2838, col: 3, offset: 88604},
+									pos:        position{line: 2841, col: 3, offset: 88762},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2838, col: 15, offset: 88616},
+									pos:  position{line: 2841, col: 15, offset: 88774},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2838, col: 23, offset: 88624},
+									pos:   position{line: 2841, col: 23, offset: 88782},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2838, col: 30, offset: 88631},
+										pos: position{line: 2841, col: 30, offset: 88789},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2838, col: 31, offset: 88632},
+											pos:  position{line: 2841, col: 31, offset: 88790},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2838, col: 44, offset: 88645},
+									pos:  position{line: 2841, col: 44, offset: 88803},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2849, col: 3, offset: 88836},
+						pos: position{line: 2852, col: 3, offset: 88994},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2849, col: 3, offset: 88836},
+							pos: position{line: 2852, col: 3, offset: 88994},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2849, col: 3, offset: 88836},
+									pos:        position{line: 2852, col: 3, offset: 88994},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2849, col: 12, offset: 88845},
+									pos:  position{line: 2852, col: 12, offset: 89003},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2849, col: 20, offset: 88853},
+									pos:   position{line: 2852, col: 20, offset: 89011},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2849, col: 30, offset: 88863},
+										pos:  position{line: 2852, col: 30, offset: 89021},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2849, col: 40, offset: 88873},
+									pos:  position{line: 2852, col: 40, offset: 89031},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2855, col: 3, offset: 88996},
+						pos: position{line: 2858, col: 3, offset: 89154},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2855, col: 3, offset: 88996},
+							pos: position{line: 2858, col: 3, offset: 89154},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2855, col: 3, offset: 88996},
+									pos:        position{line: 2858, col: 3, offset: 89154},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 13, offset: 89006},
+									pos:  position{line: 2858, col: 13, offset: 89164},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2855, col: 21, offset: 89014},
+									pos:   position{line: 2858, col: 21, offset: 89172},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2855, col: 25, offset: 89018},
+										pos:  position{line: 2858, col: 25, offset: 89176},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 35, offset: 89028},
+									pos:  position{line: 2858, col: 35, offset: 89186},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2855, col: 41, offset: 89034},
+									pos:   position{line: 2858, col: 41, offset: 89192},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2855, col: 47, offset: 89040},
+										pos:  position{line: 2858, col: 47, offset: 89198},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 58, offset: 89051},
+									pos:  position{line: 2858, col: 58, offset: 89209},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2855, col: 64, offset: 89057},
+									pos:   position{line: 2858, col: 64, offset: 89215},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2855, col: 76, offset: 89069},
+										pos:  position{line: 2858, col: 76, offset: 89227},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 87, offset: 89080},
+									pos:  position{line: 2858, col: 87, offset: 89238},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2862, col: 3, offset: 89304},
+						pos: position{line: 2865, col: 3, offset: 89462},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2862, col: 3, offset: 89304},
+							pos: position{line: 2865, col: 3, offset: 89462},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2862, col: 3, offset: 89304},
+									pos:        position{line: 2865, col: 3, offset: 89462},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 14, offset: 89315},
+									pos:  position{line: 2865, col: 14, offset: 89473},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2862, col: 22, offset: 89323},
+									pos:   position{line: 2865, col: 22, offset: 89481},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2862, col: 26, offset: 89327},
+										pos:  position{line: 2865, col: 26, offset: 89485},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 36, offset: 89337},
+									pos:  position{line: 2865, col: 36, offset: 89495},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2862, col: 42, offset: 89343},
+									pos:   position{line: 2865, col: 42, offset: 89501},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2862, col: 49, offset: 89350},
+										pos:  position{line: 2865, col: 49, offset: 89508},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 60, offset: 89361},
+									pos:  position{line: 2865, col: 60, offset: 89519},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2870, col: 3, offset: 89525},
+						pos: position{line: 2873, col: 3, offset: 89683},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2870, col: 3, offset: 89525},
+							pos: position{line: 2873, col: 3, offset: 89683},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2870, col: 3, offset: 89525},
+									pos:        position{line: 2873, col: 3, offset: 89683},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2870, col: 14, offset: 89536},
+									pos:  position{line: 2873, col: 14, offset: 89694},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2870, col: 22, offset: 89544},
+									pos:   position{line: 2873, col: 22, offset: 89702},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2870, col: 26, offset: 89548},
+										pos:  position{line: 2873, col: 26, offset: 89706},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2870, col: 36, offset: 89558},
+									pos:  position{line: 2873, col: 36, offset: 89716},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2870, col: 42, offset: 89564},
+									pos:   position{line: 2873, col: 42, offset: 89722},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2870, col: 49, offset: 89571},
+										pos:  position{line: 2873, col: 49, offset: 89729},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2870, col: 60, offset: 89582},
+									pos:  position{line: 2873, col: 60, offset: 89740},
 									name: "R_PAREN",
 								},
 							},
@@ -6417,15 +6417,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2878, col: 1, offset: 89744},
+			pos:  position{line: 2881, col: 1, offset: 89902},
 			expr: &actionExpr{
-				pos: position{line: 2878, col: 21, offset: 89764},
+				pos: position{line: 2881, col: 21, offset: 89922},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2878, col: 21, offset: 89764},
+					pos:   position{line: 2881, col: 21, offset: 89922},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2878, col: 25, offset: 89768},
+						pos:  position{line: 2881, col: 25, offset: 89926},
 						name: "QuotedString",
 					},
 				},
@@ -6433,15 +6433,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2885, col: 1, offset: 89895},
+			pos:  position{line: 2888, col: 1, offset: 90053},
 			expr: &actionExpr{
-				pos: position{line: 2885, col: 22, offset: 89916},
+				pos: position{line: 2888, col: 22, offset: 90074},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2885, col: 22, offset: 89916},
+					pos:   position{line: 2888, col: 22, offset: 90074},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2885, col: 26, offset: 89920},
+						pos:  position{line: 2888, col: 26, offset: 90078},
 						name: "UnquotedString",
 					},
 				},
@@ -6449,22 +6449,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2892, col: 1, offset: 90048},
+			pos:  position{line: 2895, col: 1, offset: 90206},
 			expr: &actionExpr{
-				pos: position{line: 2892, col: 20, offset: 90067},
+				pos: position{line: 2895, col: 20, offset: 90225},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2892, col: 20, offset: 90067},
+					pos: position{line: 2895, col: 20, offset: 90225},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2892, col: 20, offset: 90067},
+							pos:  position{line: 2895, col: 20, offset: 90225},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2892, col: 26, offset: 90073},
+							pos:   position{line: 2895, col: 26, offset: 90231},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2892, col: 38, offset: 90085},
+								pos:  position{line: 2895, col: 38, offset: 90243},
 								name: "String",
 							},
 						},
@@ -6474,20 +6474,20 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2898, col: 1, offset: 90270},
+			pos:  position{line: 2901, col: 1, offset: 90428},
 			expr: &choiceExpr{
-				pos: position{line: 2898, col: 20, offset: 90289},
+				pos: position{line: 2901, col: 20, offset: 90447},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2898, col: 20, offset: 90289},
+						pos: position{line: 2901, col: 20, offset: 90447},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2898, col: 20, offset: 90289},
+							pos: position{line: 2901, col: 20, offset: 90447},
 							exprs: []any{
 								&oneOrMoreExpr{
-									pos: position{line: 2898, col: 20, offset: 90289},
+									pos: position{line: 2901, col: 20, offset: 90447},
 									expr: &charClassMatcher{
-										pos:        position{line: 2898, col: 20, offset: 90289},
+										pos:        position{line: 2901, col: 20, offset: 90447},
 										val:        "[a-zA-Z_]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -6496,9 +6496,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2898, col: 31, offset: 90300},
+									pos: position{line: 2901, col: 31, offset: 90458},
 									expr: &litMatcher{
-										pos:        position{line: 2898, col: 33, offset: 90302},
+										pos:        position{line: 2901, col: 33, offset: 90460},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6508,27 +6508,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2901, col: 3, offset: 90344},
+						pos: position{line: 2904, col: 3, offset: 90502},
 						run: (*parser).callonEvalFieldToRead8,
 						expr: &seqExpr{
-							pos: position{line: 2901, col: 3, offset: 90344},
+							pos: position{line: 2904, col: 3, offset: 90502},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2901, col: 3, offset: 90344},
+									pos:        position{line: 2904, col: 3, offset: 90502},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2901, col: 7, offset: 90348},
+									pos:   position{line: 2904, col: 7, offset: 90506},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2901, col: 13, offset: 90354},
+										pos:  position{line: 2904, col: 13, offset: 90512},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2901, col: 23, offset: 90364},
+									pos:        position{line: 2904, col: 23, offset: 90522},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6541,26 +6541,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2906, col: 1, offset: 90432},
+			pos:  position{line: 2909, col: 1, offset: 90590},
 			expr: &actionExpr{
-				pos: position{line: 2906, col: 15, offset: 90446},
+				pos: position{line: 2909, col: 15, offset: 90604},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2906, col: 15, offset: 90446},
+					pos: position{line: 2909, col: 15, offset: 90604},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2906, col: 15, offset: 90446},
+							pos:  position{line: 2909, col: 15, offset: 90604},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2906, col: 20, offset: 90451},
+							pos:  position{line: 2909, col: 20, offset: 90609},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2906, col: 30, offset: 90461},
+							pos:   position{line: 2909, col: 30, offset: 90619},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2906, col: 40, offset: 90471},
+								pos:  position{line: 2909, col: 40, offset: 90629},
 								name: "BoolExpr",
 							},
 						},
@@ -6570,15 +6570,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2919, col: 1, offset: 90814},
+			pos:  position{line: 2922, col: 1, offset: 90972},
 			expr: &actionExpr{
-				pos: position{line: 2919, col: 13, offset: 90826},
+				pos: position{line: 2922, col: 13, offset: 90984},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2919, col: 13, offset: 90826},
+					pos:   position{line: 2922, col: 13, offset: 90984},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2919, col: 18, offset: 90831},
+						pos:  position{line: 2922, col: 18, offset: 90989},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6586,35 +6586,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2924, col: 1, offset: 90901},
+			pos:  position{line: 2927, col: 1, offset: 91059},
 			expr: &actionExpr{
-				pos: position{line: 2924, col: 19, offset: 90919},
+				pos: position{line: 2927, col: 19, offset: 91077},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2924, col: 19, offset: 90919},
+					pos: position{line: 2927, col: 19, offset: 91077},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2924, col: 19, offset: 90919},
+							pos:   position{line: 2927, col: 19, offset: 91077},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2924, col: 25, offset: 90925},
+								pos:  position{line: 2927, col: 25, offset: 91083},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2924, col: 40, offset: 90940},
+							pos:   position{line: 2927, col: 40, offset: 91098},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2924, col: 45, offset: 90945},
+								pos: position{line: 2927, col: 45, offset: 91103},
 								expr: &seqExpr{
-									pos: position{line: 2924, col: 46, offset: 90946},
+									pos: position{line: 2927, col: 46, offset: 91104},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2924, col: 46, offset: 90946},
+											pos:  position{line: 2927, col: 46, offset: 91104},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2924, col: 49, offset: 90949},
+											pos:  position{line: 2927, col: 49, offset: 91107},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6627,35 +6627,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 2944, col: 1, offset: 91387},
+			pos:  position{line: 2947, col: 1, offset: 91545},
 			expr: &actionExpr{
-				pos: position{line: 2944, col: 19, offset: 91405},
+				pos: position{line: 2947, col: 19, offset: 91563},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 2944, col: 19, offset: 91405},
+					pos: position{line: 2947, col: 19, offset: 91563},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2944, col: 19, offset: 91405},
+							pos:   position{line: 2947, col: 19, offset: 91563},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2944, col: 25, offset: 91411},
+								pos:  position{line: 2947, col: 25, offset: 91569},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2944, col: 40, offset: 91426},
+							pos:   position{line: 2947, col: 40, offset: 91584},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2944, col: 45, offset: 91431},
+								pos: position{line: 2947, col: 45, offset: 91589},
 								expr: &seqExpr{
-									pos: position{line: 2944, col: 46, offset: 91432},
+									pos: position{line: 2947, col: 46, offset: 91590},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2944, col: 46, offset: 91432},
+											pos:  position{line: 2947, col: 46, offset: 91590},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2944, col: 50, offset: 91436},
+											pos:  position{line: 2947, col: 50, offset: 91594},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6668,47 +6668,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 2964, col: 1, offset: 91875},
+			pos:  position{line: 2967, col: 1, offset: 92033},
 			expr: &choiceExpr{
-				pos: position{line: 2964, col: 19, offset: 91893},
+				pos: position{line: 2967, col: 19, offset: 92051},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2964, col: 19, offset: 91893},
+						pos: position{line: 2967, col: 19, offset: 92051},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 2964, col: 19, offset: 91893},
+							pos: position{line: 2967, col: 19, offset: 92051},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2964, col: 19, offset: 91893},
+									pos:  position{line: 2967, col: 19, offset: 92051},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2964, col: 23, offset: 91897},
+									pos:  position{line: 2967, col: 23, offset: 92055},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2964, col: 31, offset: 91905},
+									pos:   position{line: 2967, col: 31, offset: 92063},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2964, col: 37, offset: 91911},
+										pos:  position{line: 2967, col: 37, offset: 92069},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2964, col: 52, offset: 91926},
+									pos:  position{line: 2967, col: 52, offset: 92084},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2974, col: 3, offset: 92129},
+						pos: position{line: 2977, col: 3, offset: 92287},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 2974, col: 3, offset: 92129},
+							pos:   position{line: 2977, col: 3, offset: 92287},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2974, col: 9, offset: 92135},
+								pos:  position{line: 2977, col: 9, offset: 92293},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6718,50 +6718,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 2979, col: 1, offset: 92206},
+			pos:  position{line: 2982, col: 1, offset: 92364},
 			expr: &choiceExpr{
-				pos: position{line: 2979, col: 19, offset: 92224},
+				pos: position{line: 2982, col: 19, offset: 92382},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2979, col: 19, offset: 92224},
+						pos: position{line: 2982, col: 19, offset: 92382},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 2979, col: 19, offset: 92224},
+							pos: position{line: 2982, col: 19, offset: 92382},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2979, col: 19, offset: 92224},
+									pos:  position{line: 2982, col: 19, offset: 92382},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2979, col: 27, offset: 92232},
+									pos:   position{line: 2982, col: 27, offset: 92390},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2979, col: 33, offset: 92238},
+										pos:  position{line: 2982, col: 33, offset: 92396},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2979, col: 48, offset: 92253},
+									pos:  position{line: 2982, col: 48, offset: 92411},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2982, col: 3, offset: 92289},
+						pos: position{line: 2985, col: 3, offset: 92447},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 2982, col: 3, offset: 92289},
+							pos:   position{line: 2985, col: 3, offset: 92447},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 2982, col: 10, offset: 92296},
+								pos: position{line: 2985, col: 10, offset: 92454},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2982, col: 10, offset: 92296},
+										pos:  position{line: 2985, col: 10, offset: 92454},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2982, col: 31, offset: 92317},
+										pos:  position{line: 2985, col: 31, offset: 92475},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6773,60 +6773,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 2987, col: 1, offset: 92437},
+			pos:  position{line: 2990, col: 1, offset: 92595},
 			expr: &choiceExpr{
-				pos: position{line: 2987, col: 23, offset: 92459},
+				pos: position{line: 2990, col: 23, offset: 92617},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2987, col: 23, offset: 92459},
+						pos: position{line: 2990, col: 23, offset: 92617},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2987, col: 24, offset: 92460},
+							pos: position{line: 2990, col: 24, offset: 92618},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2987, col: 24, offset: 92460},
+									pos:   position{line: 2990, col: 24, offset: 92618},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 2987, col: 28, offset: 92464},
+										pos: position{line: 2990, col: 28, offset: 92622},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2987, col: 28, offset: 92464},
+												pos:        position{line: 2990, col: 28, offset: 92622},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 39, offset: 92475},
+												pos:        position{line: 2990, col: 39, offset: 92633},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 49, offset: 92485},
+												pos:        position{line: 2990, col: 49, offset: 92643},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 59, offset: 92495},
+												pos:        position{line: 2990, col: 59, offset: 92653},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 70, offset: 92506},
+												pos:        position{line: 2990, col: 70, offset: 92664},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 84, offset: 92520},
+												pos:        position{line: 2990, col: 84, offset: 92678},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2987, col: 94, offset: 92530},
+												pos:        position{line: 2990, col: 94, offset: 92688},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6835,56 +6835,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2987, col: 109, offset: 92545},
+									pos:  position{line: 2990, col: 109, offset: 92703},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2987, col: 117, offset: 92553},
+									pos:   position{line: 2990, col: 117, offset: 92711},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2987, col: 123, offset: 92559},
+										pos:  position{line: 2990, col: 123, offset: 92717},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2987, col: 133, offset: 92569},
+									pos:  position{line: 2990, col: 133, offset: 92727},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3017, col: 3, offset: 93440},
+						pos: position{line: 3020, col: 3, offset: 93598},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3017, col: 3, offset: 93440},
+							pos: position{line: 3020, col: 3, offset: 93598},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3017, col: 3, offset: 93440},
+									pos:   position{line: 3020, col: 3, offset: 93598},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3017, col: 11, offset: 93448},
+										pos: position{line: 3020, col: 11, offset: 93606},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3017, col: 11, offset: 93448},
+												pos:        position{line: 3020, col: 11, offset: 93606},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3017, col: 20, offset: 93457},
+												pos:        position{line: 3020, col: 20, offset: 93615},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3017, col: 29, offset: 93466},
+												pos:        position{line: 3020, col: 29, offset: 93624},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3017, col: 39, offset: 93476},
+												pos:        position{line: 3020, col: 39, offset: 93634},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6893,86 +6893,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3017, col: 52, offset: 93489},
+									pos:  position{line: 3020, col: 52, offset: 93647},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3017, col: 60, offset: 93497},
+									pos:   position{line: 3020, col: 60, offset: 93655},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3017, col: 70, offset: 93507},
+										pos:  position{line: 3020, col: 70, offset: 93665},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3017, col: 80, offset: 93517},
+									pos:  position{line: 3020, col: 80, offset: 93675},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3017, col: 86, offset: 93523},
+									pos:   position{line: 3020, col: 86, offset: 93681},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3017, col: 97, offset: 93534},
+										pos:  position{line: 3020, col: 97, offset: 93692},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3017, col: 107, offset: 93544},
+									pos:  position{line: 3020, col: 107, offset: 93702},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3030, col: 3, offset: 93914},
+						pos: position{line: 3033, col: 3, offset: 94072},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3030, col: 3, offset: 93914},
+							pos: position{line: 3033, col: 3, offset: 94072},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3030, col: 3, offset: 93914},
+									pos:   position{line: 3033, col: 3, offset: 94072},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 8, offset: 93919},
+										pos:  position{line: 3033, col: 8, offset: 94077},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 18, offset: 93929},
+									pos:  position{line: 3033, col: 18, offset: 94087},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3030, col: 24, offset: 93935},
+									pos:        position{line: 3033, col: 24, offset: 94093},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 29, offset: 93940},
+									pos:  position{line: 3033, col: 29, offset: 94098},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 37, offset: 93948},
+									pos:   position{line: 3033, col: 37, offset: 94106},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 50, offset: 93961},
+										pos:  position{line: 3033, col: 50, offset: 94119},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 60, offset: 93971},
+									pos:   position{line: 3033, col: 60, offset: 94129},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3030, col: 65, offset: 93976},
+										pos: position{line: 3033, col: 65, offset: 94134},
 										expr: &seqExpr{
-											pos: position{line: 3030, col: 66, offset: 93977},
+											pos: position{line: 3033, col: 66, offset: 94135},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3030, col: 66, offset: 93977},
+													pos:  position{line: 3033, col: 66, offset: 94135},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3030, col: 72, offset: 93983},
+													pos:  position{line: 3033, col: 72, offset: 94141},
 													name: "ValueExpr",
 												},
 											},
@@ -6980,50 +6980,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 84, offset: 93995},
+									pos:  position{line: 3033, col: 84, offset: 94153},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3049, col: 3, offset: 94546},
+						pos: position{line: 3052, col: 3, offset: 94704},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3049, col: 3, offset: 94546},
+							pos: position{line: 3052, col: 3, offset: 94704},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3049, col: 3, offset: 94546},
+									pos:        position{line: 3052, col: 3, offset: 94704},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3049, col: 8, offset: 94551},
+									pos:  position{line: 3052, col: 8, offset: 94709},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3049, col: 16, offset: 94559},
+									pos:   position{line: 3052, col: 16, offset: 94717},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3049, col: 29, offset: 94572},
+										pos:  position{line: 3052, col: 29, offset: 94730},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3049, col: 39, offset: 94582},
+									pos:   position{line: 3052, col: 39, offset: 94740},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3049, col: 44, offset: 94587},
+										pos: position{line: 3052, col: 44, offset: 94745},
 										expr: &seqExpr{
-											pos: position{line: 3049, col: 45, offset: 94588},
+											pos: position{line: 3052, col: 45, offset: 94746},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3049, col: 45, offset: 94588},
+													pos:  position{line: 3052, col: 45, offset: 94746},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3049, col: 51, offset: 94594},
+													pos:  position{line: 3052, col: 51, offset: 94752},
 													name: "ValueExpr",
 												},
 											},
@@ -7031,7 +7031,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3049, col: 63, offset: 94606},
+									pos:  position{line: 3052, col: 63, offset: 94764},
 									name: "R_PAREN",
 								},
 							},
@@ -7042,34 +7042,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3067, col: 1, offset: 95027},
+			pos:  position{line: 3070, col: 1, offset: 95185},
 			expr: &actionExpr{
-				pos: position{line: 3067, col: 23, offset: 95049},
+				pos: position{line: 3070, col: 23, offset: 95207},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3067, col: 23, offset: 95049},
+					pos: position{line: 3070, col: 23, offset: 95207},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3067, col: 23, offset: 95049},
+							pos:   position{line: 3070, col: 23, offset: 95207},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3067, col: 28, offset: 95054},
+								pos:  position{line: 3070, col: 28, offset: 95212},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3067, col: 38, offset: 95064},
+							pos:   position{line: 3070, col: 38, offset: 95222},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3067, col: 41, offset: 95067},
+								pos:  position{line: 3070, col: 41, offset: 95225},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3067, col: 62, offset: 95088},
+							pos:   position{line: 3070, col: 62, offset: 95246},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3067, col: 68, offset: 95094},
+								pos:  position{line: 3070, col: 68, offset: 95252},
 								name: "ValueExpr",
 							},
 						},
@@ -7079,129 +7079,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3085, col: 1, offset: 95688},
+			pos:  position{line: 3088, col: 1, offset: 95846},
 			expr: &choiceExpr{
-				pos: position{line: 3085, col: 14, offset: 95701},
+				pos: position{line: 3088, col: 14, offset: 95859},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3085, col: 14, offset: 95701},
+						pos: position{line: 3088, col: 14, offset: 95859},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3085, col: 14, offset: 95701},
+							pos:   position{line: 3088, col: 14, offset: 95859},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3085, col: 24, offset: 95711},
+								pos:  position{line: 3088, col: 24, offset: 95869},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3094, col: 3, offset: 95901},
+						pos: position{line: 3097, col: 3, offset: 96059},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3094, col: 3, offset: 95901},
+							pos: position{line: 3097, col: 3, offset: 96059},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3094, col: 3, offset: 95901},
+									pos:  position{line: 3097, col: 3, offset: 96059},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3094, col: 12, offset: 95910},
+									pos:   position{line: 3097, col: 12, offset: 96068},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3094, col: 22, offset: 95920},
+										pos:  position{line: 3097, col: 22, offset: 96078},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3094, col: 37, offset: 95935},
+									pos:  position{line: 3097, col: 37, offset: 96093},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3103, col: 3, offset: 96119},
+						pos: position{line: 3106, col: 3, offset: 96277},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3103, col: 3, offset: 96119},
+							pos:   position{line: 3106, col: 3, offset: 96277},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3103, col: 11, offset: 96127},
+								pos:  position{line: 3106, col: 11, offset: 96285},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3112, col: 3, offset: 96307},
+						pos: position{line: 3115, col: 3, offset: 96465},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3112, col: 3, offset: 96307},
+							pos:   position{line: 3115, col: 3, offset: 96465},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3112, col: 7, offset: 96311},
+								pos:  position{line: 3115, col: 7, offset: 96469},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3121, col: 3, offset: 96483},
+						pos: position{line: 3124, col: 3, offset: 96641},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3121, col: 3, offset: 96483},
+							pos: position{line: 3124, col: 3, offset: 96641},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3121, col: 3, offset: 96483},
+									pos:  position{line: 3124, col: 3, offset: 96641},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3121, col: 12, offset: 96492},
+									pos:   position{line: 3124, col: 12, offset: 96650},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3121, col: 16, offset: 96496},
+										pos:  position{line: 3124, col: 16, offset: 96654},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3121, col: 28, offset: 96508},
+									pos:  position{line: 3124, col: 28, offset: 96666},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3130, col: 3, offset: 96677},
+						pos: position{line: 3133, col: 3, offset: 96835},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3130, col: 3, offset: 96677},
+							pos: position{line: 3133, col: 3, offset: 96835},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 3, offset: 96677},
+									pos:  position{line: 3133, col: 3, offset: 96835},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3130, col: 11, offset: 96685},
+									pos:   position{line: 3133, col: 11, offset: 96843},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3130, col: 19, offset: 96693},
+										pos:  position{line: 3133, col: 19, offset: 96851},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 28, offset: 96702},
+									pos:  position{line: 3133, col: 28, offset: 96860},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3139, col: 3, offset: 96874},
+						pos: position{line: 3142, col: 3, offset: 97032},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3139, col: 3, offset: 96874},
+							pos:   position{line: 3142, col: 3, offset: 97032},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3139, col: 18, offset: 96889},
+								pos:  position{line: 3142, col: 18, offset: 97047},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7211,28 +7211,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3149, col: 1, offset: 97086},
+			pos:  position{line: 3152, col: 1, offset: 97244},
 			expr: &choiceExpr{
-				pos: position{line: 3149, col: 15, offset: 97100},
+				pos: position{line: 3152, col: 15, offset: 97258},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3149, col: 15, offset: 97100},
+						pos: position{line: 3152, col: 15, offset: 97258},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3149, col: 15, offset: 97100},
+							pos: position{line: 3152, col: 15, offset: 97258},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3149, col: 15, offset: 97100},
+									pos:   position{line: 3152, col: 15, offset: 97258},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3149, col: 20, offset: 97105},
+										pos:  position{line: 3152, col: 20, offset: 97263},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3149, col: 29, offset: 97114},
+									pos: position{line: 3152, col: 29, offset: 97272},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3149, col: 31, offset: 97116},
+										pos:  position{line: 3152, col: 31, offset: 97274},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7240,23 +7240,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3157, col: 3, offset: 97286},
+						pos: position{line: 3160, col: 3, offset: 97444},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3157, col: 3, offset: 97286},
+							pos: position{line: 3160, col: 3, offset: 97444},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3157, col: 3, offset: 97286},
+									pos:   position{line: 3160, col: 3, offset: 97444},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3157, col: 7, offset: 97290},
+										pos:  position{line: 3160, col: 7, offset: 97448},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3157, col: 20, offset: 97303},
+									pos: position{line: 3160, col: 20, offset: 97461},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3157, col: 22, offset: 97305},
+										pos:  position{line: 3160, col: 22, offset: 97463},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7264,50 +7264,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3165, col: 3, offset: 97470},
+						pos: position{line: 3168, col: 3, offset: 97628},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3165, col: 3, offset: 97470},
+							pos: position{line: 3168, col: 3, offset: 97628},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3165, col: 3, offset: 97470},
+									pos:   position{line: 3168, col: 3, offset: 97628},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3165, col: 9, offset: 97476},
+										pos:  position{line: 3168, col: 9, offset: 97634},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3165, col: 25, offset: 97492},
+									pos: position{line: 3168, col: 25, offset: 97650},
 									expr: &choiceExpr{
-										pos: position{line: 3165, col: 27, offset: 97494},
+										pos: position{line: 3168, col: 27, offset: 97652},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 27, offset: 97494},
+												pos:  position{line: 3168, col: 27, offset: 97652},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 36, offset: 97503},
+												pos:  position{line: 3168, col: 36, offset: 97661},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 46, offset: 97513},
+												pos:  position{line: 3168, col: 46, offset: 97671},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 54, offset: 97521},
+												pos:  position{line: 3168, col: 54, offset: 97679},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 62, offset: 97529},
+												pos:  position{line: 3168, col: 62, offset: 97687},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3165, col: 70, offset: 97537},
+												pos:  position{line: 3168, col: 70, offset: 97695},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3165, col: 84, offset: 97551},
+												pos:        position{line: 3168, col: 84, offset: 97709},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7319,13 +7319,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3173, col: 3, offset: 97701},
+						pos: position{line: 3176, col: 3, offset: 97859},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3173, col: 3, offset: 97701},
+							pos:   position{line: 3176, col: 3, offset: 97859},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3173, col: 10, offset: 97708},
+								pos:  position{line: 3176, col: 10, offset: 97866},
 								name: "ConcatExpr",
 							},
 						},
@@ -7335,35 +7335,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3183, col: 1, offset: 97914},
+			pos:  position{line: 3186, col: 1, offset: 98072},
 			expr: &actionExpr{
-				pos: position{line: 3183, col: 15, offset: 97928},
+				pos: position{line: 3186, col: 15, offset: 98086},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3183, col: 15, offset: 97928},
+					pos: position{line: 3186, col: 15, offset: 98086},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3183, col: 15, offset: 97928},
+							pos:   position{line: 3186, col: 15, offset: 98086},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3183, col: 21, offset: 97934},
+								pos:  position{line: 3186, col: 21, offset: 98092},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3183, col: 32, offset: 97945},
+							pos:   position{line: 3186, col: 32, offset: 98103},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3183, col: 37, offset: 97950},
+								pos: position{line: 3186, col: 37, offset: 98108},
 								expr: &seqExpr{
-									pos: position{line: 3183, col: 38, offset: 97951},
+									pos: position{line: 3186, col: 38, offset: 98109},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3183, col: 38, offset: 97951},
+											pos:  position{line: 3186, col: 38, offset: 98109},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3183, col: 50, offset: 97963},
+											pos:  position{line: 3186, col: 50, offset: 98121},
 											name: "ConcatAtom",
 										},
 									},
@@ -7371,28 +7371,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3183, col: 63, offset: 97976},
+							pos: position{line: 3186, col: 63, offset: 98134},
 							expr: &choiceExpr{
-								pos: position{line: 3183, col: 65, offset: 97978},
+								pos: position{line: 3186, col: 65, offset: 98136},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3183, col: 65, offset: 97978},
+										pos:  position{line: 3186, col: 65, offset: 98136},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3183, col: 74, offset: 97987},
+										pos:  position{line: 3186, col: 74, offset: 98145},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3183, col: 84, offset: 97997},
+										pos:  position{line: 3186, col: 84, offset: 98155},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3183, col: 92, offset: 98005},
+										pos:  position{line: 3186, col: 92, offset: 98163},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3183, col: 100, offset: 98013},
+										pos:        position{line: 3186, col: 100, offset: 98171},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7406,54 +7406,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3201, col: 1, offset: 98419},
+			pos:  position{line: 3204, col: 1, offset: 98577},
 			expr: &choiceExpr{
-				pos: position{line: 3201, col: 15, offset: 98433},
+				pos: position{line: 3204, col: 15, offset: 98591},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3201, col: 15, offset: 98433},
+						pos: position{line: 3204, col: 15, offset: 98591},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3201, col: 15, offset: 98433},
+							pos:   position{line: 3204, col: 15, offset: 98591},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3201, col: 20, offset: 98438},
+								pos:  position{line: 3204, col: 20, offset: 98596},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3210, col: 3, offset: 98602},
+						pos: position{line: 3213, col: 3, offset: 98760},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3210, col: 3, offset: 98602},
+							pos:   position{line: 3213, col: 3, offset: 98760},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3210, col: 7, offset: 98606},
+								pos:  position{line: 3213, col: 7, offset: 98764},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3218, col: 3, offset: 98745},
+						pos: position{line: 3221, col: 3, offset: 98903},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3218, col: 3, offset: 98745},
+							pos:   position{line: 3221, col: 3, offset: 98903},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3218, col: 10, offset: 98752},
+								pos:  position{line: 3221, col: 10, offset: 98910},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3226, col: 3, offset: 98891},
+						pos: position{line: 3229, col: 3, offset: 99049},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3226, col: 3, offset: 98891},
+							pos:   position{line: 3229, col: 3, offset: 99049},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3226, col: 9, offset: 98897},
+								pos:  position{line: 3229, col: 9, offset: 99055},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7463,32 +7463,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3236, col: 1, offset: 99066},
+			pos:  position{line: 3239, col: 1, offset: 99224},
 			expr: &actionExpr{
-				pos: position{line: 3236, col: 16, offset: 99081},
+				pos: position{line: 3239, col: 16, offset: 99239},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3236, col: 16, offset: 99081},
+					pos: position{line: 3239, col: 16, offset: 99239},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3236, col: 16, offset: 99081},
+							pos:   position{line: 3239, col: 16, offset: 99239},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3236, col: 21, offset: 99086},
+								pos:  position{line: 3239, col: 21, offset: 99244},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3236, col: 39, offset: 99104},
+							pos: position{line: 3239, col: 39, offset: 99262},
 							expr: &choiceExpr{
-								pos: position{line: 3236, col: 41, offset: 99106},
+								pos: position{line: 3239, col: 41, offset: 99264},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3236, col: 41, offset: 99106},
+										pos:  position{line: 3239, col: 41, offset: 99264},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3236, col: 55, offset: 99120},
+										pos:        position{line: 3239, col: 55, offset: 99278},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7502,44 +7502,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3241, col: 1, offset: 99185},
+			pos:  position{line: 3244, col: 1, offset: 99343},
 			expr: &actionExpr{
-				pos: position{line: 3241, col: 22, offset: 99206},
+				pos: position{line: 3244, col: 22, offset: 99364},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3241, col: 22, offset: 99206},
+					pos: position{line: 3244, col: 22, offset: 99364},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3241, col: 22, offset: 99206},
+							pos:   position{line: 3244, col: 22, offset: 99364},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3241, col: 28, offset: 99212},
+								pos:  position{line: 3244, col: 28, offset: 99370},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3241, col: 46, offset: 99230},
+							pos:   position{line: 3244, col: 46, offset: 99388},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3241, col: 51, offset: 99235},
+								pos: position{line: 3244, col: 51, offset: 99393},
 								expr: &seqExpr{
-									pos: position{line: 3241, col: 52, offset: 99236},
+									pos: position{line: 3244, col: 52, offset: 99394},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3241, col: 53, offset: 99237},
+											pos: position{line: 3244, col: 53, offset: 99395},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3241, col: 53, offset: 99237},
+													pos:  position{line: 3244, col: 53, offset: 99395},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3241, col: 62, offset: 99246},
+													pos:  position{line: 3244, col: 62, offset: 99404},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3241, col: 71, offset: 99255},
+											pos:  position{line: 3244, col: 71, offset: 99413},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7552,48 +7552,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3262, col: 1, offset: 99756},
+			pos:  position{line: 3265, col: 1, offset: 99914},
 			expr: &actionExpr{
-				pos: position{line: 3262, col: 22, offset: 99777},
+				pos: position{line: 3265, col: 22, offset: 99935},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3262, col: 22, offset: 99777},
+					pos: position{line: 3265, col: 22, offset: 99935},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3262, col: 22, offset: 99777},
+							pos:   position{line: 3265, col: 22, offset: 99935},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3262, col: 28, offset: 99783},
+								pos:  position{line: 3265, col: 28, offset: 99941},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3262, col: 46, offset: 99801},
+							pos:   position{line: 3265, col: 46, offset: 99959},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3262, col: 51, offset: 99806},
+								pos: position{line: 3265, col: 51, offset: 99964},
 								expr: &seqExpr{
-									pos: position{line: 3262, col: 52, offset: 99807},
+									pos: position{line: 3265, col: 52, offset: 99965},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3262, col: 53, offset: 99808},
+											pos: position{line: 3265, col: 53, offset: 99966},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3262, col: 53, offset: 99808},
+													pos:  position{line: 3265, col: 53, offset: 99966},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3262, col: 61, offset: 99816},
+													pos:  position{line: 3265, col: 61, offset: 99974},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3262, col: 69, offset: 99824},
+													pos:  position{line: 3265, col: 69, offset: 99982},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3262, col: 76, offset: 99831},
+											pos:  position{line: 3265, col: 76, offset: 99989},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7606,22 +7606,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3282, col: 1, offset: 100300},
+			pos:  position{line: 3285, col: 1, offset: 100458},
 			expr: &actionExpr{
-				pos: position{line: 3282, col: 21, offset: 100320},
+				pos: position{line: 3285, col: 21, offset: 100478},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3282, col: 21, offset: 100320},
+					pos: position{line: 3285, col: 21, offset: 100478},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3282, col: 21, offset: 100320},
+							pos:  position{line: 3285, col: 21, offset: 100478},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3282, col: 27, offset: 100326},
+							pos:   position{line: 3285, col: 27, offset: 100484},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3282, col: 32, offset: 100331},
+								pos:  position{line: 3285, col: 32, offset: 100489},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7631,67 +7631,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3292, col: 1, offset: 100575},
+			pos:  position{line: 3295, col: 1, offset: 100733},
 			expr: &choiceExpr{
-				pos: position{line: 3292, col: 22, offset: 100596},
+				pos: position{line: 3295, col: 22, offset: 100754},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3292, col: 22, offset: 100596},
+						pos: position{line: 3295, col: 22, offset: 100754},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3292, col: 22, offset: 100596},
+							pos: position{line: 3295, col: 22, offset: 100754},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 22, offset: 100596},
+									pos:  position{line: 3295, col: 22, offset: 100754},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3292, col: 30, offset: 100604},
+									pos:   position{line: 3295, col: 30, offset: 100762},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3292, col: 35, offset: 100609},
+										pos:  position{line: 3295, col: 35, offset: 100767},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3292, col: 53, offset: 100627},
+									pos:  position{line: 3295, col: 53, offset: 100785},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3295, col: 3, offset: 100662},
+						pos: position{line: 3298, col: 3, offset: 100820},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3295, col: 3, offset: 100662},
+							pos:   position{line: 3298, col: 3, offset: 100820},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3295, col: 20, offset: 100679},
+								pos:  position{line: 3298, col: 20, offset: 100837},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3298, col: 3, offset: 100733},
+						pos: position{line: 3301, col: 3, offset: 100891},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3298, col: 3, offset: 100733},
+							pos:   position{line: 3301, col: 3, offset: 100891},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3298, col: 9, offset: 100739},
+								pos:  position{line: 3301, col: 9, offset: 100897},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3308, col: 3, offset: 100958},
+						pos: position{line: 3311, col: 3, offset: 101116},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3308, col: 3, offset: 100958},
+							pos:   position{line: 3311, col: 3, offset: 101116},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3308, col: 10, offset: 100965},
+								pos:  position{line: 3311, col: 10, offset: 101123},
 								name: "NumberAsString",
 							},
 						},
@@ -7701,144 +7701,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3321, col: 1, offset: 101343},
+			pos:  position{line: 3324, col: 1, offset: 101501},
 			expr: &choiceExpr{
-				pos: position{line: 3321, col: 20, offset: 101362},
+				pos: position{line: 3324, col: 20, offset: 101520},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3321, col: 20, offset: 101362},
+						pos: position{line: 3324, col: 20, offset: 101520},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3321, col: 21, offset: 101363},
+							pos: position{line: 3324, col: 21, offset: 101521},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3321, col: 21, offset: 101363},
+									pos:   position{line: 3324, col: 21, offset: 101521},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3321, col: 29, offset: 101371},
+										pos: position{line: 3324, col: 29, offset: 101529},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3321, col: 29, offset: 101371},
+												pos:        position{line: 3324, col: 29, offset: 101529},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 37, offset: 101379},
+												pos:        position{line: 3324, col: 37, offset: 101537},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 46, offset: 101388},
+												pos:        position{line: 3324, col: 46, offset: 101546},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 58, offset: 101400},
+												pos:        position{line: 3324, col: 58, offset: 101558},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 67, offset: 101409},
+												pos:        position{line: 3324, col: 67, offset: 101567},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 77, offset: 101419},
+												pos:        position{line: 3324, col: 77, offset: 101577},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 85, offset: 101427},
+												pos:        position{line: 3324, col: 85, offset: 101585},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 95, offset: 101437},
+												pos:        position{line: 3324, col: 95, offset: 101595},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 102, offset: 101444},
+												pos:        position{line: 3324, col: 102, offset: 101602},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 113, offset: 101455},
+												pos:        position{line: 3324, col: 113, offset: 101613},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 123, offset: 101465},
+												pos:        position{line: 3324, col: 123, offset: 101623},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 132, offset: 101474},
+												pos:        position{line: 3324, col: 132, offset: 101632},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 142, offset: 101484},
+												pos:        position{line: 3324, col: 142, offset: 101642},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 151, offset: 101493},
+												pos:        position{line: 3324, col: 151, offset: 101651},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 161, offset: 101503},
+												pos:        position{line: 3324, col: 161, offset: 101661},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 170, offset: 101512},
+												pos:        position{line: 3324, col: 170, offset: 101670},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 179, offset: 101521},
+												pos:        position{line: 3324, col: 179, offset: 101679},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 187, offset: 101529},
+												pos:        position{line: 3324, col: 187, offset: 101687},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 196, offset: 101538},
+												pos:        position{line: 3324, col: 196, offset: 101696},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 204, offset: 101546},
+												pos:        position{line: 3324, col: 204, offset: 101704},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3321, col: 213, offset: 101555},
+												pos:        position{line: 3324, col: 213, offset: 101713},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7847,102 +7847,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3321, col: 220, offset: 101562},
+									pos:  position{line: 3324, col: 220, offset: 101720},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3321, col: 228, offset: 101570},
+									pos:   position{line: 3324, col: 228, offset: 101728},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3321, col: 234, offset: 101576},
+										pos:  position{line: 3324, col: 234, offset: 101734},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3321, col: 253, offset: 101595},
+									pos:  position{line: 3324, col: 253, offset: 101753},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3341, col: 3, offset: 102107},
+						pos: position{line: 3344, col: 3, offset: 102265},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3341, col: 3, offset: 102107},
+							pos: position{line: 3344, col: 3, offset: 102265},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3341, col: 3, offset: 102107},
+									pos:   position{line: 3344, col: 3, offset: 102265},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3341, col: 13, offset: 102117},
+										pos:        position{line: 3344, col: 13, offset: 102275},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3341, col: 21, offset: 102125},
+									pos:  position{line: 3344, col: 21, offset: 102283},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3341, col: 29, offset: 102133},
+									pos:   position{line: 3344, col: 29, offset: 102291},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3341, col: 35, offset: 102139},
+										pos:  position{line: 3344, col: 35, offset: 102297},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3341, col: 54, offset: 102158},
+									pos:   position{line: 3344, col: 54, offset: 102316},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3341, col: 69, offset: 102173},
+										pos: position{line: 3344, col: 69, offset: 102331},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3341, col: 70, offset: 102174},
+											pos:  position{line: 3344, col: 70, offset: 102332},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3341, col: 89, offset: 102193},
+									pos:  position{line: 3344, col: 89, offset: 102351},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3362, col: 3, offset: 102811},
+						pos: position{line: 3365, col: 3, offset: 102969},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3362, col: 4, offset: 102812},
+							pos: position{line: 3365, col: 4, offset: 102970},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3362, col: 4, offset: 102812},
+									pos:   position{line: 3365, col: 4, offset: 102970},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3362, col: 12, offset: 102820},
+										pos: position{line: 3365, col: 12, offset: 102978},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3362, col: 12, offset: 102820},
+												pos:        position{line: 3365, col: 12, offset: 102978},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3362, col: 20, offset: 102828},
+												pos:        position{line: 3365, col: 20, offset: 102986},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3362, col: 27, offset: 102835},
+												pos:        position{line: 3365, col: 27, offset: 102993},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3362, col: 38, offset: 102846},
+												pos:        position{line: 3365, col: 38, offset: 103004},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7951,54 +7951,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3362, col: 46, offset: 102854},
+									pos:  position{line: 3365, col: 46, offset: 103012},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3362, col: 54, offset: 102862},
+									pos:  position{line: 3365, col: 54, offset: 103020},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3375, col: 3, offset: 103148},
+						pos: position{line: 3378, col: 3, offset: 103306},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3375, col: 3, offset: 103148},
+							pos: position{line: 3378, col: 3, offset: 103306},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3375, col: 3, offset: 103148},
+									pos:        position{line: 3378, col: 3, offset: 103306},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3375, col: 14, offset: 103159},
+									pos:  position{line: 3378, col: 14, offset: 103317},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3375, col: 22, offset: 103167},
+									pos:   position{line: 3378, col: 22, offset: 103325},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3375, col: 33, offset: 103178},
+										pos:  position{line: 3378, col: 33, offset: 103336},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3375, col: 44, offset: 103189},
+									pos:   position{line: 3378, col: 44, offset: 103347},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3375, col: 53, offset: 103198},
+										pos: position{line: 3378, col: 53, offset: 103356},
 										expr: &seqExpr{
-											pos: position{line: 3375, col: 54, offset: 103199},
+											pos: position{line: 3378, col: 54, offset: 103357},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3375, col: 54, offset: 103199},
+													pos:  position{line: 3378, col: 54, offset: 103357},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3375, col: 60, offset: 103205},
+													pos:  position{line: 3378, col: 60, offset: 103363},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8006,73 +8006,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3375, col: 80, offset: 103225},
+									pos:  position{line: 3378, col: 80, offset: 103383},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3403, col: 3, offset: 104067},
+						pos: position{line: 3406, col: 3, offset: 104225},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3403, col: 3, offset: 104067},
+							pos: position{line: 3406, col: 3, offset: 104225},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3403, col: 3, offset: 104067},
+									pos:   position{line: 3406, col: 3, offset: 104225},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3403, col: 12, offset: 104076},
+										pos:        position{line: 3406, col: 12, offset: 104234},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3403, col: 18, offset: 104082},
+									pos:  position{line: 3406, col: 18, offset: 104240},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3403, col: 26, offset: 104090},
+									pos:   position{line: 3406, col: 26, offset: 104248},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3403, col: 31, offset: 104095},
+										pos:  position{line: 3406, col: 31, offset: 104253},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3403, col: 39, offset: 104103},
+									pos:  position{line: 3406, col: 39, offset: 104261},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3406, col: 3, offset: 104138},
+						pos: position{line: 3409, col: 3, offset: 104296},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3406, col: 4, offset: 104139},
+							pos: position{line: 3409, col: 4, offset: 104297},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3406, col: 4, offset: 104139},
+									pos:   position{line: 3409, col: 4, offset: 104297},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3406, col: 12, offset: 104147},
+										pos: position{line: 3409, col: 12, offset: 104305},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3406, col: 12, offset: 104147},
+												pos:        position{line: 3409, col: 12, offset: 104305},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3406, col: 20, offset: 104155},
+												pos:        position{line: 3409, col: 20, offset: 104313},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3406, col: 30, offset: 104165},
+												pos:        position{line: 3409, col: 30, offset: 104323},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8081,128 +8081,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3406, col: 39, offset: 104174},
+									pos:  position{line: 3409, col: 39, offset: 104332},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3406, col: 47, offset: 104182},
+									pos:   position{line: 3409, col: 47, offset: 104340},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3406, col: 53, offset: 104188},
+										pos:  position{line: 3409, col: 53, offset: 104346},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3406, col: 72, offset: 104207},
+									pos:   position{line: 3409, col: 72, offset: 104365},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3406, col: 79, offset: 104214},
+										pos:  position{line: 3409, col: 79, offset: 104372},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3406, col: 97, offset: 104232},
+									pos:  position{line: 3409, col: 97, offset: 104390},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3436, col: 3, offset: 105071},
+						pos: position{line: 3439, col: 3, offset: 105229},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3436, col: 4, offset: 105072},
+							pos: position{line: 3439, col: 4, offset: 105230},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3436, col: 4, offset: 105072},
+									pos:   position{line: 3439, col: 4, offset: 105230},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3436, col: 11, offset: 105079},
+										pos:        position{line: 3439, col: 11, offset: 105237},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3436, col: 17, offset: 105085},
+									pos:  position{line: 3439, col: 17, offset: 105243},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3436, col: 25, offset: 105093},
+									pos:   position{line: 3439, col: 25, offset: 105251},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3436, col: 31, offset: 105099},
+										pos:  position{line: 3439, col: 31, offset: 105257},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3436, col: 50, offset: 105118},
+									pos:   position{line: 3439, col: 50, offset: 105276},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3436, col: 56, offset: 105124},
+										pos: position{line: 3439, col: 56, offset: 105282},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3436, col: 57, offset: 105125},
+											pos:  position{line: 3439, col: 57, offset: 105283},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3436, col: 76, offset: 105144},
+									pos:  position{line: 3439, col: 76, offset: 105302},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3465, col: 3, offset: 105917},
+						pos: position{line: 3468, col: 3, offset: 106075},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3465, col: 3, offset: 105917},
+							pos: position{line: 3468, col: 3, offset: 106075},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3465, col: 3, offset: 105917},
+									pos:   position{line: 3468, col: 3, offset: 106075},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3465, col: 11, offset: 105925},
+										pos:        position{line: 3468, col: 11, offset: 106083},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3465, col: 28, offset: 105942},
+									pos:  position{line: 3468, col: 28, offset: 106100},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3465, col: 36, offset: 105950},
+									pos:   position{line: 3468, col: 36, offset: 106108},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3465, col: 42, offset: 105956},
+										pos:  position{line: 3468, col: 42, offset: 106114},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3465, col: 61, offset: 105975},
+									pos:  position{line: 3468, col: 61, offset: 106133},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3465, col: 67, offset: 105981},
+									pos:  position{line: 3468, col: 67, offset: 106139},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3465, col: 73, offset: 105987},
+									pos:   position{line: 3468, col: 73, offset: 106145},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3465, col: 84, offset: 105998},
+										pos:  position{line: 3468, col: 84, offset: 106156},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3465, col: 120, offset: 106034},
+									pos:  position{line: 3468, col: 120, offset: 106192},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3465, col: 126, offset: 106040},
+									pos:  position{line: 3468, col: 126, offset: 106198},
 									name: "R_PAREN",
 								},
 							},
@@ -8213,28 +8213,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3482, col: 1, offset: 106569},
+			pos:  position{line: 3485, col: 1, offset: 106727},
 			expr: &choiceExpr{
-				pos: position{line: 3482, col: 12, offset: 106580},
+				pos: position{line: 3485, col: 12, offset: 106738},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3482, col: 12, offset: 106580},
+						pos: position{line: 3485, col: 12, offset: 106738},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3482, col: 12, offset: 106580},
+							pos: position{line: 3485, col: 12, offset: 106738},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3482, col: 12, offset: 106580},
+									pos:   position{line: 3485, col: 12, offset: 106738},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3482, col: 16, offset: 106584},
+										pos:  position{line: 3485, col: 16, offset: 106742},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3482, col: 29, offset: 106597},
+									pos: position{line: 3485, col: 29, offset: 106755},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3482, col: 31, offset: 106599},
+										pos:  position{line: 3485, col: 31, offset: 106757},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8242,50 +8242,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3498, col: 3, offset: 106960},
+						pos: position{line: 3501, col: 3, offset: 107118},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3498, col: 3, offset: 106960},
+							pos: position{line: 3501, col: 3, offset: 107118},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3498, col: 3, offset: 106960},
+									pos:   position{line: 3501, col: 3, offset: 107118},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3498, col: 9, offset: 106966},
+										pos:  position{line: 3501, col: 9, offset: 107124},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3498, col: 25, offset: 106982},
+									pos: position{line: 3501, col: 25, offset: 107140},
 									expr: &choiceExpr{
-										pos: position{line: 3498, col: 27, offset: 106984},
+										pos: position{line: 3501, col: 27, offset: 107142},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 27, offset: 106984},
+												pos:  position{line: 3501, col: 27, offset: 107142},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 36, offset: 106993},
+												pos:  position{line: 3501, col: 36, offset: 107151},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 46, offset: 107003},
+												pos:  position{line: 3501, col: 46, offset: 107161},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 54, offset: 107011},
+												pos:  position{line: 3501, col: 54, offset: 107169},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 62, offset: 107019},
+												pos:  position{line: 3501, col: 62, offset: 107177},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3498, col: 70, offset: 107027},
+												pos:  position{line: 3501, col: 70, offset: 107185},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3498, col: 84, offset: 107041},
+												pos:        position{line: 3501, col: 84, offset: 107199},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8301,28 +8301,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3515, col: 1, offset: 107392},
+			pos:  position{line: 3518, col: 1, offset: 107550},
 			expr: &actionExpr{
-				pos: position{line: 3515, col: 19, offset: 107410},
+				pos: position{line: 3518, col: 19, offset: 107568},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3515, col: 19, offset: 107410},
+					pos: position{line: 3518, col: 19, offset: 107568},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3515, col: 19, offset: 107410},
+							pos:        position{line: 3518, col: 19, offset: 107568},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3515, col: 26, offset: 107417},
+							pos:  position{line: 3518, col: 26, offset: 107575},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3515, col: 32, offset: 107423},
+							pos:   position{line: 3518, col: 32, offset: 107581},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3515, col: 40, offset: 107431},
+								pos:  position{line: 3518, col: 40, offset: 107589},
 								name: "Boolean",
 							},
 						},
@@ -8332,28 +8332,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3526, col: 1, offset: 107620},
+			pos:  position{line: 3529, col: 1, offset: 107778},
 			expr: &actionExpr{
-				pos: position{line: 3526, col: 23, offset: 107642},
+				pos: position{line: 3529, col: 23, offset: 107800},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3526, col: 23, offset: 107642},
+					pos: position{line: 3529, col: 23, offset: 107800},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3526, col: 23, offset: 107642},
+							pos:        position{line: 3529, col: 23, offset: 107800},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3526, col: 34, offset: 107653},
+							pos:  position{line: 3529, col: 34, offset: 107811},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3526, col: 40, offset: 107659},
+							pos:   position{line: 3529, col: 40, offset: 107817},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3526, col: 48, offset: 107667},
+								pos:  position{line: 3529, col: 48, offset: 107825},
 								name: "Boolean",
 							},
 						},
@@ -8363,28 +8363,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3537, col: 1, offset: 107864},
+			pos:  position{line: 3540, col: 1, offset: 108022},
 			expr: &actionExpr{
-				pos: position{line: 3537, col: 20, offset: 107883},
+				pos: position{line: 3540, col: 20, offset: 108041},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3537, col: 20, offset: 107883},
+					pos: position{line: 3540, col: 20, offset: 108041},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3537, col: 20, offset: 107883},
+							pos:        position{line: 3540, col: 20, offset: 108041},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3537, col: 28, offset: 107891},
+							pos:  position{line: 3540, col: 28, offset: 108049},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3537, col: 34, offset: 107897},
+							pos:   position{line: 3540, col: 34, offset: 108055},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3537, col: 43, offset: 107906},
+								pos:  position{line: 3540, col: 43, offset: 108064},
 								name: "IntegerAsString",
 							},
 						},
@@ -8394,15 +8394,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3552, col: 1, offset: 108268},
+			pos:  position{line: 3555, col: 1, offset: 108426},
 			expr: &actionExpr{
-				pos: position{line: 3552, col: 19, offset: 108286},
+				pos: position{line: 3555, col: 19, offset: 108444},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3552, col: 19, offset: 108286},
+					pos:   position{line: 3555, col: 19, offset: 108444},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3552, col: 28, offset: 108295},
+						pos:  position{line: 3555, col: 28, offset: 108453},
 						name: "BoolExpr",
 					},
 				},
@@ -8410,30 +8410,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3563, col: 1, offset: 108507},
+			pos:  position{line: 3566, col: 1, offset: 108665},
 			expr: &actionExpr{
-				pos: position{line: 3563, col: 15, offset: 108521},
+				pos: position{line: 3566, col: 15, offset: 108679},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3563, col: 15, offset: 108521},
+					pos:   position{line: 3566, col: 15, offset: 108679},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3563, col: 23, offset: 108529},
+						pos: position{line: 3566, col: 23, offset: 108687},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3563, col: 23, offset: 108529},
+								pos:  position{line: 3566, col: 23, offset: 108687},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3563, col: 44, offset: 108550},
+								pos:  position{line: 3566, col: 44, offset: 108708},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3563, col: 61, offset: 108567},
+								pos:  position{line: 3566, col: 61, offset: 108725},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3563, col: 79, offset: 108585},
+								pos:  position{line: 3566, col: 79, offset: 108743},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8443,35 +8443,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3567, col: 1, offset: 108629},
+			pos:  position{line: 3570, col: 1, offset: 108787},
 			expr: &actionExpr{
-				pos: position{line: 3567, col: 19, offset: 108647},
+				pos: position{line: 3570, col: 19, offset: 108805},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3567, col: 19, offset: 108647},
+					pos: position{line: 3570, col: 19, offset: 108805},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3567, col: 19, offset: 108647},
+							pos:   position{line: 3570, col: 19, offset: 108805},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3567, col: 26, offset: 108654},
+								pos:  position{line: 3570, col: 26, offset: 108812},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3567, col: 37, offset: 108665},
+							pos:   position{line: 3570, col: 37, offset: 108823},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3567, col: 43, offset: 108671},
+								pos: position{line: 3570, col: 43, offset: 108829},
 								expr: &seqExpr{
-									pos: position{line: 3567, col: 44, offset: 108672},
+									pos: position{line: 3570, col: 44, offset: 108830},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3567, col: 44, offset: 108672},
+											pos:  position{line: 3570, col: 44, offset: 108830},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3567, col: 50, offset: 108678},
+											pos:  position{line: 3570, col: 50, offset: 108836},
 											name: "HeadOption",
 										},
 									},
@@ -8484,29 +8484,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3629, col: 1, offset: 110725},
+			pos:  position{line: 3632, col: 1, offset: 110883},
 			expr: &choiceExpr{
-				pos: position{line: 3629, col: 14, offset: 110738},
+				pos: position{line: 3632, col: 14, offset: 110896},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3629, col: 14, offset: 110738},
+						pos: position{line: 3632, col: 14, offset: 110896},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3629, col: 14, offset: 110738},
+							pos: position{line: 3632, col: 14, offset: 110896},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3629, col: 14, offset: 110738},
+									pos:  position{line: 3632, col: 14, offset: 110896},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3629, col: 19, offset: 110743},
+									pos:  position{line: 3632, col: 19, offset: 110901},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3629, col: 28, offset: 110752},
+									pos:   position{line: 3632, col: 28, offset: 110910},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3629, col: 37, offset: 110761},
+										pos:  position{line: 3632, col: 37, offset: 110919},
 										name: "HeadOptionList",
 									},
 								},
@@ -8514,24 +8514,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3640, col: 3, offset: 111080},
+						pos: position{line: 3643, col: 3, offset: 111238},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3640, col: 3, offset: 111080},
+							pos: position{line: 3643, col: 3, offset: 111238},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3640, col: 3, offset: 111080},
+									pos:  position{line: 3643, col: 3, offset: 111238},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3640, col: 8, offset: 111085},
+									pos:  position{line: 3643, col: 8, offset: 111243},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3640, col: 17, offset: 111094},
+									pos:   position{line: 3643, col: 17, offset: 111252},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3640, col: 26, offset: 111103},
+										pos:  position{line: 3643, col: 26, offset: 111261},
 										name: "IntegerAsString",
 									},
 								},
@@ -8539,17 +8539,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3657, col: 3, offset: 111582},
+						pos: position{line: 3660, col: 3, offset: 111740},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3657, col: 3, offset: 111582},
+							pos: position{line: 3660, col: 3, offset: 111740},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3657, col: 3, offset: 111582},
+									pos:  position{line: 3660, col: 3, offset: 111740},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3657, col: 8, offset: 111587},
+									pos:  position{line: 3660, col: 8, offset: 111745},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8560,29 +8560,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3671, col: 1, offset: 112018},
+			pos:  position{line: 3674, col: 1, offset: 112176},
 			expr: &choiceExpr{
-				pos: position{line: 3671, col: 14, offset: 112031},
+				pos: position{line: 3674, col: 14, offset: 112189},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3671, col: 14, offset: 112031},
+						pos: position{line: 3674, col: 14, offset: 112189},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3671, col: 14, offset: 112031},
+							pos: position{line: 3674, col: 14, offset: 112189},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3671, col: 14, offset: 112031},
+									pos:  position{line: 3674, col: 14, offset: 112189},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3671, col: 19, offset: 112036},
+									pos:  position{line: 3674, col: 19, offset: 112194},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3671, col: 28, offset: 112045},
+									pos:   position{line: 3674, col: 28, offset: 112203},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3671, col: 37, offset: 112054},
+										pos:  position{line: 3674, col: 37, offset: 112212},
 										name: "IntegerAsString",
 									},
 								},
@@ -8590,17 +8590,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3691, col: 3, offset: 112603},
+						pos: position{line: 3694, col: 3, offset: 112761},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3691, col: 3, offset: 112603},
+							pos: position{line: 3694, col: 3, offset: 112761},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3691, col: 3, offset: 112603},
+									pos:  position{line: 3694, col: 3, offset: 112761},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3691, col: 8, offset: 112608},
+									pos:  position{line: 3694, col: 8, offset: 112766},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8611,44 +8611,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3711, col: 1, offset: 113201},
+			pos:  position{line: 3714, col: 1, offset: 113359},
 			expr: &actionExpr{
-				pos: position{line: 3711, col: 20, offset: 113220},
+				pos: position{line: 3714, col: 20, offset: 113378},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3711, col: 20, offset: 113220},
+					pos: position{line: 3714, col: 20, offset: 113378},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3711, col: 20, offset: 113220},
+							pos:   position{line: 3714, col: 20, offset: 113378},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3711, col: 26, offset: 113226},
+								pos:  position{line: 3714, col: 26, offset: 113384},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3711, col: 37, offset: 113237},
+							pos:   position{line: 3714, col: 37, offset: 113395},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3711, col: 42, offset: 113242},
+								pos: position{line: 3714, col: 42, offset: 113400},
 								expr: &seqExpr{
-									pos: position{line: 3711, col: 43, offset: 113243},
+									pos: position{line: 3714, col: 43, offset: 113401},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3711, col: 44, offset: 113244},
+											pos: position{line: 3714, col: 44, offset: 113402},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3711, col: 44, offset: 113244},
+													pos:  position{line: 3714, col: 44, offset: 113402},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3711, col: 52, offset: 113252},
+													pos:  position{line: 3714, col: 52, offset: 113410},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3711, col: 59, offset: 113259},
+											pos:  position{line: 3714, col: 59, offset: 113417},
 											name: "Aggregator",
 										},
 									},
@@ -8661,28 +8661,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3728, col: 1, offset: 113762},
+			pos:  position{line: 3731, col: 1, offset: 113920},
 			expr: &actionExpr{
-				pos: position{line: 3728, col: 15, offset: 113776},
+				pos: position{line: 3731, col: 15, offset: 113934},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3728, col: 15, offset: 113776},
+					pos: position{line: 3731, col: 15, offset: 113934},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3728, col: 15, offset: 113776},
+							pos:   position{line: 3731, col: 15, offset: 113934},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3728, col: 23, offset: 113784},
+								pos:  position{line: 3731, col: 23, offset: 113942},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3728, col: 35, offset: 113796},
+							pos:   position{line: 3731, col: 35, offset: 113954},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3728, col: 43, offset: 113804},
+								pos: position{line: 3731, col: 43, offset: 113962},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3728, col: 43, offset: 113804},
+									pos:  position{line: 3731, col: 43, offset: 113962},
 									name: "AsField",
 								},
 							},
@@ -8693,26 +8693,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3744, col: 1, offset: 114645},
+			pos:  position{line: 3747, col: 1, offset: 114803},
 			expr: &actionExpr{
-				pos: position{line: 3744, col: 16, offset: 114660},
+				pos: position{line: 3747, col: 16, offset: 114818},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3744, col: 16, offset: 114660},
+					pos:   position{line: 3747, col: 16, offset: 114818},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3744, col: 21, offset: 114665},
+						pos: position{line: 3747, col: 21, offset: 114823},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3744, col: 21, offset: 114665},
+								pos:  position{line: 3747, col: 21, offset: 114823},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3744, col: 32, offset: 114676},
+								pos:  position{line: 3747, col: 32, offset: 114834},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3744, col: 48, offset: 114692},
+								pos:  position{line: 3747, col: 48, offset: 114850},
 								name: "AggCommon",
 							},
 						},
@@ -8722,165 +8722,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3749, col: 1, offset: 114898},
+			pos:  position{line: 3752, col: 1, offset: 115056},
 			expr: &actionExpr{
-				pos: position{line: 3749, col: 18, offset: 114915},
+				pos: position{line: 3752, col: 18, offset: 115073},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3749, col: 19, offset: 114916},
+					pos: position{line: 3752, col: 19, offset: 115074},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3749, col: 19, offset: 114916},
+							pos:        position{line: 3752, col: 19, offset: 115074},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 30, offset: 114927},
+							pos:        position{line: 3752, col: 30, offset: 115085},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 39, offset: 114936},
+							pos:        position{line: 3752, col: 39, offset: 115094},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 47, offset: 114944},
+							pos:        position{line: 3752, col: 47, offset: 115102},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 57, offset: 114954},
+							pos:        position{line: 3752, col: 57, offset: 115112},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 65, offset: 114962},
+							pos:        position{line: 3752, col: 65, offset: 115120},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 76, offset: 114973},
+							pos:        position{line: 3752, col: 76, offset: 115131},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 86, offset: 114983},
+							pos:        position{line: 3752, col: 86, offset: 115141},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 95, offset: 114992},
+							pos:        position{line: 3752, col: 95, offset: 115150},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 105, offset: 115002},
+							pos:        position{line: 3752, col: 105, offset: 115160},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 114, offset: 115011},
+							pos:        position{line: 3752, col: 114, offset: 115169},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 122, offset: 115019},
+							pos:        position{line: 3752, col: 122, offset: 115177},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 133, offset: 115030},
+							pos:        position{line: 3752, col: 133, offset: 115188},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3749, col: 142, offset: 115039},
+							pos:        position{line: 3752, col: 142, offset: 115197},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 1, offset: 115048},
+							pos:        position{line: 3753, col: 1, offset: 115206},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 10, offset: 115057},
+							pos:        position{line: 3753, col: 10, offset: 115215},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 26, offset: 115073},
+							pos:        position{line: 3753, col: 26, offset: 115231},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 37, offset: 115084},
+							pos:        position{line: 3753, col: 37, offset: 115242},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 46, offset: 115093},
+							pos:        position{line: 3753, col: 46, offset: 115251},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 56, offset: 115103},
+							pos:        position{line: 3753, col: 56, offset: 115261},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 72, offset: 115119},
+							pos:        position{line: 3753, col: 72, offset: 115277},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 82, offset: 115129},
+							pos:        position{line: 3753, col: 82, offset: 115287},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 100, offset: 115147},
+							pos:        position{line: 3753, col: 100, offset: 115305},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 113, offset: 115160},
+							pos:        position{line: 3753, col: 113, offset: 115318},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 132, offset: 115179},
+							pos:        position{line: 3753, col: 132, offset: 115337},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3750, col: 139, offset: 115186},
+							pos:        position{line: 3753, col: 139, offset: 115344},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8891,27 +8891,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3754, col: 1, offset: 115229},
+			pos:  position{line: 3757, col: 1, offset: 115387},
 			expr: &actionExpr{
-				pos: position{line: 3754, col: 22, offset: 115250},
+				pos: position{line: 3757, col: 22, offset: 115408},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3754, col: 23, offset: 115251},
+					pos: position{line: 3757, col: 23, offset: 115409},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3754, col: 23, offset: 115251},
+							pos:        position{line: 3757, col: 23, offset: 115409},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3754, col: 37, offset: 115265},
+							pos:        position{line: 3757, col: 37, offset: 115423},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3754, col: 51, offset: 115279},
+							pos:        position{line: 3757, col: 51, offset: 115437},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8922,29 +8922,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3758, col: 1, offset: 115323},
+			pos:  position{line: 3761, col: 1, offset: 115481},
 			expr: &actionExpr{
-				pos: position{line: 3758, col: 12, offset: 115334},
+				pos: position{line: 3761, col: 12, offset: 115492},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3758, col: 12, offset: 115334},
+					pos: position{line: 3761, col: 12, offset: 115492},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3758, col: 12, offset: 115334},
+							pos:  position{line: 3761, col: 12, offset: 115492},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3758, col: 15, offset: 115337},
+							pos:   position{line: 3761, col: 15, offset: 115495},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3758, col: 23, offset: 115345},
+								pos: position{line: 3761, col: 23, offset: 115503},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3758, col: 23, offset: 115345},
+										pos:  position{line: 3761, col: 23, offset: 115503},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3758, col: 35, offset: 115357},
+										pos:  position{line: 3761, col: 35, offset: 115515},
 										name: "String",
 									},
 								},
@@ -8956,27 +8956,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3772, col: 1, offset: 115686},
+			pos:  position{line: 3775, col: 1, offset: 115844},
 			expr: &choiceExpr{
-				pos: position{line: 3772, col: 13, offset: 115698},
+				pos: position{line: 3775, col: 13, offset: 115856},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3772, col: 13, offset: 115698},
+						pos: position{line: 3775, col: 13, offset: 115856},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3772, col: 13, offset: 115698},
+							pos: position{line: 3775, col: 13, offset: 115856},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3772, col: 14, offset: 115699},
+									pos: position{line: 3775, col: 14, offset: 115857},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3772, col: 14, offset: 115699},
+											pos:        position{line: 3775, col: 14, offset: 115857},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3772, col: 24, offset: 115709},
+											pos:        position{line: 3775, col: 24, offset: 115867},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -8984,47 +8984,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3772, col: 29, offset: 115714},
+									pos:  position{line: 3775, col: 29, offset: 115872},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3772, col: 37, offset: 115722},
+									pos:        position{line: 3775, col: 37, offset: 115880},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3772, col: 44, offset: 115729},
+									pos:   position{line: 3775, col: 44, offset: 115887},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3772, col: 54, offset: 115739},
+										pos:  position{line: 3775, col: 54, offset: 115897},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3772, col: 64, offset: 115749},
+									pos:  position{line: 3775, col: 64, offset: 115907},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3782, col: 3, offset: 115977},
+						pos: position{line: 3785, col: 3, offset: 116135},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3782, col: 3, offset: 115977},
+							pos: position{line: 3785, col: 3, offset: 116135},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3782, col: 4, offset: 115978},
+									pos: position{line: 3785, col: 4, offset: 116136},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3782, col: 4, offset: 115978},
+											pos:        position{line: 3785, col: 4, offset: 116136},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3782, col: 14, offset: 115988},
+											pos:        position{line: 3785, col: 14, offset: 116146},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9032,38 +9032,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3782, col: 19, offset: 115993},
+									pos:  position{line: 3785, col: 19, offset: 116151},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3782, col: 27, offset: 116001},
+									pos:   position{line: 3785, col: 27, offset: 116159},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3782, col: 33, offset: 116007},
+										pos:  position{line: 3785, col: 33, offset: 116165},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3782, col: 43, offset: 116017},
+									pos:  position{line: 3785, col: 43, offset: 116175},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3789, col: 5, offset: 116168},
+						pos: position{line: 3792, col: 5, offset: 116326},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3789, col: 6, offset: 116169},
+							pos: position{line: 3792, col: 6, offset: 116327},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3789, col: 6, offset: 116169},
+									pos:        position{line: 3792, col: 6, offset: 116327},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3789, col: 16, offset: 116179},
+									pos:        position{line: 3792, col: 16, offset: 116337},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9076,77 +9076,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3798, col: 1, offset: 116315},
+			pos:  position{line: 3801, col: 1, offset: 116473},
 			expr: &choiceExpr{
-				pos: position{line: 3798, col: 14, offset: 116328},
+				pos: position{line: 3801, col: 14, offset: 116486},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3798, col: 14, offset: 116328},
+						pos: position{line: 3801, col: 14, offset: 116486},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3798, col: 14, offset: 116328},
+							pos: position{line: 3801, col: 14, offset: 116486},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3798, col: 14, offset: 116328},
+									pos:   position{line: 3801, col: 14, offset: 116486},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3798, col: 22, offset: 116336},
+										pos:  position{line: 3801, col: 22, offset: 116494},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3798, col: 36, offset: 116350},
+									pos:  position{line: 3801, col: 36, offset: 116508},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3798, col: 44, offset: 116358},
+									pos:        position{line: 3801, col: 44, offset: 116516},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3798, col: 51, offset: 116365},
+									pos:   position{line: 3801, col: 51, offset: 116523},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3798, col: 61, offset: 116375},
+										pos:  position{line: 3801, col: 61, offset: 116533},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3798, col: 71, offset: 116385},
+									pos:  position{line: 3801, col: 71, offset: 116543},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3813, col: 3, offset: 116795},
+						pos: position{line: 3816, col: 3, offset: 116953},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3813, col: 3, offset: 116795},
+							pos: position{line: 3816, col: 3, offset: 116953},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3813, col: 3, offset: 116795},
+									pos:   position{line: 3816, col: 3, offset: 116953},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3813, col: 11, offset: 116803},
+										pos:  position{line: 3816, col: 11, offset: 116961},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3813, col: 25, offset: 116817},
+									pos:  position{line: 3816, col: 25, offset: 116975},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3813, col: 33, offset: 116825},
+									pos:   position{line: 3816, col: 33, offset: 116983},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3813, col: 39, offset: 116831},
+										pos:  position{line: 3816, col: 39, offset: 116989},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3813, col: 49, offset: 116841},
+									pos:  position{line: 3816, col: 49, offset: 116999},
 									name: "R_PAREN",
 								},
 							},
@@ -9157,22 +9157,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3827, col: 1, offset: 117173},
+			pos:  position{line: 3830, col: 1, offset: 117331},
 			expr: &actionExpr{
-				pos: position{line: 3827, col: 18, offset: 117190},
+				pos: position{line: 3830, col: 18, offset: 117348},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3827, col: 18, offset: 117190},
+					pos:   position{line: 3830, col: 18, offset: 117348},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3827, col: 26, offset: 117198},
+						pos: position{line: 3830, col: 26, offset: 117356},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3827, col: 26, offset: 117198},
+								pos:  position{line: 3830, col: 26, offset: 117356},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3827, col: 42, offset: 117214},
+								pos:  position{line: 3830, col: 42, offset: 117372},
 								name: "IntegerAsString",
 							},
 						},
@@ -9182,93 +9182,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3839, col: 1, offset: 117588},
+			pos:  position{line: 3842, col: 1, offset: 117746},
 			expr: &choiceExpr{
-				pos: position{line: 3839, col: 18, offset: 117605},
+				pos: position{line: 3842, col: 18, offset: 117763},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3839, col: 18, offset: 117605},
+						pos: position{line: 3842, col: 18, offset: 117763},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3839, col: 18, offset: 117605},
+							pos: position{line: 3842, col: 18, offset: 117763},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3839, col: 18, offset: 117605},
+									pos:   position{line: 3842, col: 18, offset: 117763},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3839, col: 26, offset: 117613},
+										pos:  position{line: 3842, col: 26, offset: 117771},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3839, col: 44, offset: 117631},
+									pos:   position{line: 3842, col: 44, offset: 117789},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3839, col: 58, offset: 117645},
+										pos:  position{line: 3842, col: 58, offset: 117803},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3839, col: 72, offset: 117659},
+									pos:  position{line: 3842, col: 72, offset: 117817},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3839, col: 80, offset: 117667},
+									pos:        position{line: 3842, col: 80, offset: 117825},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3839, col: 87, offset: 117674},
+									pos:   position{line: 3842, col: 87, offset: 117832},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3839, col: 97, offset: 117684},
+										pos:  position{line: 3842, col: 97, offset: 117842},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3839, col: 107, offset: 117694},
+									pos:  position{line: 3842, col: 107, offset: 117852},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3855, col: 3, offset: 118143},
+						pos: position{line: 3858, col: 3, offset: 118301},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3855, col: 3, offset: 118143},
+							pos: position{line: 3858, col: 3, offset: 118301},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3855, col: 3, offset: 118143},
+									pos:   position{line: 3858, col: 3, offset: 118301},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3855, col: 11, offset: 118151},
+										pos:  position{line: 3858, col: 11, offset: 118309},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3855, col: 29, offset: 118169},
+									pos:   position{line: 3858, col: 29, offset: 118327},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3855, col: 43, offset: 118183},
+										pos:  position{line: 3858, col: 43, offset: 118341},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3855, col: 57, offset: 118197},
+									pos:  position{line: 3858, col: 57, offset: 118355},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3855, col: 65, offset: 118205},
+									pos:   position{line: 3858, col: 65, offset: 118363},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3855, col: 71, offset: 118211},
+										pos:  position{line: 3858, col: 71, offset: 118369},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3855, col: 81, offset: 118221},
+									pos:  position{line: 3858, col: 81, offset: 118379},
 									name: "R_PAREN",
 								},
 							},
@@ -9279,22 +9279,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3871, col: 1, offset: 118593},
+			pos:  position{line: 3874, col: 1, offset: 118751},
 			expr: &actionExpr{
-				pos: position{line: 3871, col: 25, offset: 118617},
+				pos: position{line: 3874, col: 25, offset: 118775},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3871, col: 25, offset: 118617},
+					pos:   position{line: 3874, col: 25, offset: 118775},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3871, col: 39, offset: 118631},
+						pos: position{line: 3874, col: 39, offset: 118789},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3871, col: 39, offset: 118631},
+								pos:  position{line: 3874, col: 39, offset: 118789},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3871, col: 67, offset: 118659},
+								pos:  position{line: 3874, col: 67, offset: 118817},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9304,43 +9304,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3875, col: 1, offset: 118722},
+			pos:  position{line: 3878, col: 1, offset: 118880},
 			expr: &actionExpr{
-				pos: position{line: 3875, col: 30, offset: 118751},
+				pos: position{line: 3878, col: 30, offset: 118909},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3875, col: 30, offset: 118751},
+					pos: position{line: 3878, col: 30, offset: 118909},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3875, col: 30, offset: 118751},
+							pos:   position{line: 3878, col: 30, offset: 118909},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3875, col: 34, offset: 118755},
+								pos:  position{line: 3878, col: 34, offset: 118913},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3875, col: 44, offset: 118765},
+							pos:   position{line: 3878, col: 44, offset: 118923},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3875, col: 48, offset: 118769},
+								pos: position{line: 3878, col: 48, offset: 118927},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3875, col: 48, offset: 118769},
+										pos:  position{line: 3878, col: 48, offset: 118927},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3875, col: 67, offset: 118788},
+										pos:  position{line: 3878, col: 67, offset: 118946},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3875, col: 87, offset: 118808},
+							pos:   position{line: 3878, col: 87, offset: 118966},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3875, col: 93, offset: 118814},
+								pos:  position{line: 3878, col: 93, offset: 118972},
 								name: "Number",
 							},
 						},
@@ -9350,15 +9350,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3888, col: 1, offset: 119048},
+			pos:  position{line: 3891, col: 1, offset: 119206},
 			expr: &actionExpr{
-				pos: position{line: 3888, col: 32, offset: 119079},
+				pos: position{line: 3891, col: 32, offset: 119237},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3888, col: 32, offset: 119079},
+					pos:   position{line: 3891, col: 32, offset: 119237},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3888, col: 38, offset: 119085},
+						pos:  position{line: 3891, col: 38, offset: 119243},
 						name: "Number",
 					},
 				},
@@ -9366,34 +9366,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3901, col: 1, offset: 119302},
+			pos:  position{line: 3904, col: 1, offset: 119460},
 			expr: &actionExpr{
-				pos: position{line: 3901, col: 26, offset: 119327},
+				pos: position{line: 3904, col: 26, offset: 119485},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3901, col: 26, offset: 119327},
+					pos: position{line: 3904, col: 26, offset: 119485},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3901, col: 26, offset: 119327},
+							pos:   position{line: 3904, col: 26, offset: 119485},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3901, col: 30, offset: 119331},
+								pos:  position{line: 3904, col: 30, offset: 119489},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3901, col: 40, offset: 119341},
+							pos:   position{line: 3904, col: 40, offset: 119499},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3901, col: 43, offset: 119344},
+								pos:  position{line: 3904, col: 43, offset: 119502},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3901, col: 60, offset: 119361},
+							pos:   position{line: 3904, col: 60, offset: 119519},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3901, col: 66, offset: 119367},
+								pos:  position{line: 3904, col: 66, offset: 119525},
 								name: "Boolean",
 							},
 						},
@@ -9403,22 +9403,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3914, col: 1, offset: 119602},
+			pos:  position{line: 3917, col: 1, offset: 119760},
 			expr: &actionExpr{
-				pos: position{line: 3914, col: 25, offset: 119626},
+				pos: position{line: 3917, col: 25, offset: 119784},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3914, col: 25, offset: 119626},
+					pos:   position{line: 3917, col: 25, offset: 119784},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3914, col: 39, offset: 119640},
+						pos: position{line: 3917, col: 39, offset: 119798},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3914, col: 39, offset: 119640},
+								pos:  position{line: 3917, col: 39, offset: 119798},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3914, col: 67, offset: 119668},
+								pos:  position{line: 3917, col: 67, offset: 119826},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9428,41 +9428,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3918, col: 1, offset: 119731},
+			pos:  position{line: 3921, col: 1, offset: 119889},
 			expr: &actionExpr{
-				pos: position{line: 3918, col: 30, offset: 119760},
+				pos: position{line: 3921, col: 30, offset: 119918},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3918, col: 30, offset: 119760},
+					pos: position{line: 3921, col: 30, offset: 119918},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3918, col: 30, offset: 119760},
+							pos:   position{line: 3921, col: 30, offset: 119918},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3918, col: 34, offset: 119764},
+								pos:  position{line: 3921, col: 34, offset: 119922},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3918, col: 44, offset: 119774},
+							pos:   position{line: 3921, col: 44, offset: 119932},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3918, col: 47, offset: 119777},
+								pos:  position{line: 3921, col: 47, offset: 119935},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3918, col: 64, offset: 119794},
+							pos:   position{line: 3921, col: 64, offset: 119952},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 3918, col: 81, offset: 119811},
+								pos: position{line: 3921, col: 81, offset: 119969},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3918, col: 81, offset: 119811},
+										pos:  position{line: 3921, col: 81, offset: 119969},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3918, col: 103, offset: 119833},
+										pos:  position{line: 3921, col: 103, offset: 119991},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9474,22 +9474,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3933, col: 1, offset: 120233},
+			pos:  position{line: 3936, col: 1, offset: 120391},
 			expr: &actionExpr{
-				pos: position{line: 3933, col: 32, offset: 120264},
+				pos: position{line: 3936, col: 32, offset: 120422},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3933, col: 32, offset: 120264},
+					pos:   position{line: 3936, col: 32, offset: 120422},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 3933, col: 49, offset: 120281},
+						pos: position{line: 3936, col: 49, offset: 120439},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3933, col: 49, offset: 120281},
+								pos:  position{line: 3936, col: 49, offset: 120439},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3933, col: 71, offset: 120303},
+								pos:  position{line: 3936, col: 71, offset: 120461},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9499,33 +9499,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 3948, col: 1, offset: 120686},
+			pos:  position{line: 3951, col: 1, offset: 120844},
 			expr: &actionExpr{
-				pos: position{line: 3948, col: 24, offset: 120709},
+				pos: position{line: 3951, col: 24, offset: 120867},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 3948, col: 24, offset: 120709},
+					pos: position{line: 3951, col: 24, offset: 120867},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3948, col: 24, offset: 120709},
+							pos:        position{line: 3951, col: 24, offset: 120867},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3948, col: 31, offset: 120716},
+							pos:  position{line: 3951, col: 31, offset: 120874},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 3948, col: 39, offset: 120724},
+							pos:   position{line: 3951, col: 39, offset: 120882},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3948, col: 45, offset: 120730},
+								pos:  position{line: 3951, col: 45, offset: 120888},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3948, col: 52, offset: 120737},
+							pos:  position{line: 3951, col: 52, offset: 120895},
 							name: "R_PAREN",
 						},
 					},
@@ -9534,15 +9534,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 3956, col: 1, offset: 120878},
+			pos:  position{line: 3959, col: 1, offset: 121036},
 			expr: &actionExpr{
-				pos: position{line: 3956, col: 26, offset: 120903},
+				pos: position{line: 3959, col: 26, offset: 121061},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3956, col: 26, offset: 120903},
+					pos:   position{line: 3959, col: 26, offset: 121061},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3956, col: 32, offset: 120909},
+						pos:  position{line: 3959, col: 32, offset: 121067},
 						name: "String",
 					},
 				},
@@ -9550,35 +9550,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 3966, col: 1, offset: 121189},
+			pos:  position{line: 3969, col: 1, offset: 121347},
 			expr: &actionExpr{
-				pos: position{line: 3966, col: 18, offset: 121206},
+				pos: position{line: 3969, col: 18, offset: 121364},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 3966, col: 18, offset: 121206},
+					pos: position{line: 3969, col: 18, offset: 121364},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3966, col: 18, offset: 121206},
+							pos:   position{line: 3969, col: 18, offset: 121364},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3966, col: 24, offset: 121212},
+								pos:  position{line: 3969, col: 24, offset: 121370},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3966, col: 34, offset: 121222},
+							pos:   position{line: 3969, col: 34, offset: 121380},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3966, col: 39, offset: 121227},
+								pos: position{line: 3969, col: 39, offset: 121385},
 								expr: &seqExpr{
-									pos: position{line: 3966, col: 40, offset: 121228},
+									pos: position{line: 3969, col: 40, offset: 121386},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3966, col: 40, offset: 121228},
+											pos:  position{line: 3969, col: 40, offset: 121386},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3966, col: 46, offset: 121234},
+											pos:  position{line: 3969, col: 46, offset: 121392},
 											name: "FieldName",
 										},
 									},
@@ -9591,16 +9591,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 3983, col: 1, offset: 121729},
+			pos:  position{line: 3986, col: 1, offset: 121887},
 			expr: &choiceExpr{
-				pos: position{line: 3983, col: 18, offset: 121746},
+				pos: position{line: 3986, col: 18, offset: 121904},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 3983, col: 18, offset: 121746},
+						pos:  position{line: 3986, col: 18, offset: 121904},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 3983, col: 38, offset: 121766},
+						pos:  position{line: 3986, col: 38, offset: 121924},
 						name: "EarliestOnly",
 					},
 				},
@@ -9608,71 +9608,71 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 3985, col: 1, offset: 121780},
+			pos:  position{line: 3988, col: 1, offset: 121938},
 			expr: &actionExpr{
-				pos: position{line: 3985, col: 22, offset: 121801},
+				pos: position{line: 3988, col: 22, offset: 121959},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 3985, col: 22, offset: 121801},
+					pos: position{line: 3988, col: 22, offset: 121959},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3985, col: 22, offset: 121801},
+							pos:  position{line: 3988, col: 22, offset: 121959},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3985, col: 35, offset: 121814},
+							pos:  position{line: 3988, col: 35, offset: 121972},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3985, col: 41, offset: 121820},
+							pos:   position{line: 3988, col: 41, offset: 121978},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3985, col: 55, offset: 121834},
+								pos: position{line: 3988, col: 55, offset: 121992},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3985, col: 55, offset: 121834},
+										pos:  position{line: 3988, col: 55, offset: 121992},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3985, col: 75, offset: 121854},
+										pos:  position{line: 3988, col: 75, offset: 122012},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3985, col: 94, offset: 121873},
+							pos:  position{line: 3988, col: 94, offset: 122031},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3985, col: 100, offset: 121879},
+							pos:  position{line: 3988, col: 100, offset: 122037},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3985, col: 111, offset: 121890},
+							pos:  position{line: 3988, col: 111, offset: 122048},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3985, col: 117, offset: 121896},
+							pos:   position{line: 3988, col: 117, offset: 122054},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 3985, col: 129, offset: 121908},
+								pos: position{line: 3988, col: 129, offset: 122066},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3985, col: 129, offset: 121908},
+										pos:  position{line: 3988, col: 129, offset: 122066},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3985, col: 149, offset: 121928},
+										pos:  position{line: 3988, col: 149, offset: 122086},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 3985, col: 168, offset: 121947},
+							pos: position{line: 3988, col: 168, offset: 122105},
 							expr: &anyMatcher{
-								line: 3985, col: 169, offset: 121948,
+								line: 3988, col: 169, offset: 122106,
 							},
 						},
 					},
@@ -9681,42 +9681,42 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4026, col: 1, offset: 123070},
+			pos:  position{line: 4029, col: 1, offset: 123228},
 			expr: &actionExpr{
-				pos: position{line: 4026, col: 17, offset: 123086},
+				pos: position{line: 4029, col: 17, offset: 123244},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4026, col: 17, offset: 123086},
+					pos: position{line: 4029, col: 17, offset: 123244},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4026, col: 17, offset: 123086},
+							pos:  position{line: 4029, col: 17, offset: 123244},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4026, col: 30, offset: 123099},
+							pos:  position{line: 4029, col: 30, offset: 123257},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4026, col: 36, offset: 123105},
+							pos:   position{line: 4029, col: 36, offset: 123263},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4026, col: 50, offset: 123119},
+								pos: position{line: 4029, col: 50, offset: 123277},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4026, col: 50, offset: 123119},
+										pos:  position{line: 4029, col: 50, offset: 123277},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4026, col: 70, offset: 123139},
+										pos:  position{line: 4029, col: 70, offset: 123297},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&notExpr{
-							pos: position{line: 4026, col: 89, offset: 123158},
+							pos: position{line: 4029, col: 89, offset: 123316},
 							expr: &anyMatcher{
-								line: 4026, col: 90, offset: 123159,
+								line: 4029, col: 90, offset: 123317,
 							},
 						},
 					},
@@ -9725,24 +9725,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4054, col: 1, offset: 123850},
+			pos:  position{line: 4057, col: 1, offset: 124008},
 			expr: &actionExpr{
-				pos: position{line: 4054, col: 23, offset: 123872},
+				pos: position{line: 4057, col: 23, offset: 124030},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4054, col: 23, offset: 123872},
+					pos: position{line: 4057, col: 23, offset: 124030},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4054, col: 23, offset: 123872},
+							pos:        position{line: 4057, col: 23, offset: 124030},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4054, col: 27, offset: 123876},
+							pos: position{line: 4057, col: 27, offset: 124034},
 							expr: &charClassMatcher{
-								pos:        position{line: 4054, col: 27, offset: 123876},
+								pos:        position{line: 4057, col: 27, offset: 124034},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9755,21 +9755,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4058, col: 1, offset: 123919},
+			pos:  position{line: 4061, col: 1, offset: 124077},
 			expr: &actionExpr{
-				pos: position{line: 4058, col: 13, offset: 123931},
+				pos: position{line: 4061, col: 13, offset: 124089},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4058, col: 14, offset: 123932},
+					pos: position{line: 4061, col: 14, offset: 124090},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4058, col: 14, offset: 123932},
+							pos:        position{line: 4061, col: 14, offset: 124090},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4058, col: 17, offset: 123935},
+							pos:        position{line: 4061, col: 17, offset: 124093},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9781,15 +9781,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4062, col: 1, offset: 123978},
+			pos:  position{line: 4065, col: 1, offset: 124136},
 			expr: &actionExpr{
-				pos: position{line: 4062, col: 16, offset: 123993},
+				pos: position{line: 4065, col: 16, offset: 124151},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4062, col: 16, offset: 123993},
+					pos:   position{line: 4065, col: 16, offset: 124151},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4062, col: 26, offset: 124003},
+						pos:  position{line: 4065, col: 26, offset: 124161},
 						name: "AllTimeScale",
 					},
 				},
@@ -9797,31 +9797,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4069, col: 1, offset: 124227},
+			pos:  position{line: 4072, col: 1, offset: 124385},
 			expr: &actionExpr{
-				pos: position{line: 4069, col: 9, offset: 124235},
+				pos: position{line: 4072, col: 9, offset: 124393},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4069, col: 9, offset: 124235},
+					pos: position{line: 4072, col: 9, offset: 124393},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4069, col: 9, offset: 124235},
+							pos:        position{line: 4072, col: 9, offset: 124393},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4069, col: 13, offset: 124239},
+							pos:   position{line: 4072, col: 13, offset: 124397},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4069, col: 19, offset: 124245},
+								pos: position{line: 4072, col: 19, offset: 124403},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4069, col: 19, offset: 124245},
+										pos:  position{line: 4072, col: 19, offset: 124403},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4069, col: 30, offset: 124256},
+										pos:  position{line: 4072, col: 30, offset: 124414},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9833,26 +9833,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4073, col: 1, offset: 124304},
+			pos:  position{line: 4076, col: 1, offset: 124462},
 			expr: &actionExpr{
-				pos: position{line: 4073, col: 11, offset: 124314},
+				pos: position{line: 4076, col: 11, offset: 124472},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4073, col: 11, offset: 124314},
+					pos: position{line: 4076, col: 11, offset: 124472},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4073, col: 11, offset: 124314},
+							pos:   position{line: 4076, col: 11, offset: 124472},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4073, col: 16, offset: 124319},
+								pos:  position{line: 4076, col: 16, offset: 124477},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4073, col: 36, offset: 124339},
+							pos:   position{line: 4076, col: 36, offset: 124497},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4073, col: 43, offset: 124346},
+								pos:  position{line: 4076, col: 43, offset: 124504},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9862,44 +9862,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4101, col: 1, offset: 125084},
+			pos:  position{line: 4104, col: 1, offset: 125242},
 			expr: &actionExpr{
-				pos: position{line: 4101, col: 29, offset: 125112},
+				pos: position{line: 4104, col: 29, offset: 125270},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4101, col: 29, offset: 125112},
+					pos: position{line: 4104, col: 29, offset: 125270},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4101, col: 29, offset: 125112},
+							pos:   position{line: 4104, col: 29, offset: 125270},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4101, col: 36, offset: 125119},
+								pos: position{line: 4104, col: 36, offset: 125277},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4101, col: 36, offset: 125119},
+										pos:  position{line: 4104, col: 36, offset: 125277},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4101, col: 45, offset: 125128},
+										pos:  position{line: 4104, col: 45, offset: 125286},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4101, col: 51, offset: 125134},
+							pos:   position{line: 4104, col: 51, offset: 125292},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4101, col: 57, offset: 125140},
+								pos: position{line: 4104, col: 57, offset: 125298},
 								expr: &choiceExpr{
-									pos: position{line: 4101, col: 58, offset: 125141},
+									pos: position{line: 4104, col: 58, offset: 125299},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4101, col: 58, offset: 125141},
+											pos:  position{line: 4104, col: 58, offset: 125299},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4101, col: 67, offset: 125150},
+											pos:  position{line: 4104, col: 67, offset: 125308},
 											name: "Snap",
 										},
 									},
@@ -9912,29 +9912,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4148, col: 1, offset: 126582},
+			pos:  position{line: 4151, col: 1, offset: 126740},
 			expr: &actionExpr{
-				pos: position{line: 4148, col: 22, offset: 126603},
+				pos: position{line: 4151, col: 22, offset: 126761},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4148, col: 22, offset: 126603},
+					pos: position{line: 4151, col: 22, offset: 126761},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4148, col: 22, offset: 126603},
+							pos:   position{line: 4151, col: 22, offset: 126761},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4148, col: 34, offset: 126615},
+								pos: position{line: 4151, col: 34, offset: 126773},
 								expr: &choiceExpr{
-									pos: position{line: 4148, col: 35, offset: 126616},
+									pos: position{line: 4151, col: 35, offset: 126774},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4148, col: 35, offset: 126616},
+											pos:        position{line: 4151, col: 35, offset: 126774},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4148, col: 43, offset: 126624},
+											pos:        position{line: 4151, col: 43, offset: 126782},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9944,12 +9944,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4148, col: 49, offset: 126630},
+							pos:   position{line: 4151, col: 49, offset: 126788},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4148, col: 57, offset: 126638},
+								pos: position{line: 4151, col: 57, offset: 126796},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4148, col: 58, offset: 126639},
+									pos:  position{line: 4151, col: 58, offset: 126797},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9960,31 +9960,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4173, col: 1, offset: 127322},
+			pos:  position{line: 4176, col: 1, offset: 127480},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 39, offset: 127360},
+				pos: position{line: 4176, col: 39, offset: 127518},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4173, col: 39, offset: 127360},
+					pos: position{line: 4176, col: 39, offset: 127518},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4173, col: 39, offset: 127360},
+							pos:   position{line: 4176, col: 39, offset: 127518},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4173, col: 46, offset: 127367},
+								pos: position{line: 4176, col: 46, offset: 127525},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4173, col: 47, offset: 127368},
+									pos:  position{line: 4176, col: 47, offset: 127526},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4173, col: 56, offset: 127377},
+							pos:   position{line: 4176, col: 56, offset: 127535},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4173, col: 66, offset: 127387},
+								pos: position{line: 4176, col: 66, offset: 127545},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4173, col: 67, offset: 127388},
+									pos:  position{line: 4176, col: 67, offset: 127546},
 									name: "Snap",
 								},
 							},
@@ -9995,136 +9995,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4200, col: 1, offset: 128016},
+			pos:  position{line: 4203, col: 1, offset: 128174},
 			expr: &actionExpr{
-				pos: position{line: 4200, col: 18, offset: 128033},
+				pos: position{line: 4203, col: 18, offset: 128191},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4200, col: 18, offset: 128033},
+					pos: position{line: 4203, col: 18, offset: 128191},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 18, offset: 128033},
+							pos:        position{line: 4203, col: 18, offset: 128191},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 23, offset: 128038},
+							pos:        position{line: 4203, col: 23, offset: 128196},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4200, col: 29, offset: 128044},
+							pos:        position{line: 4203, col: 29, offset: 128202},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 33, offset: 128048},
+							pos:        position{line: 4203, col: 33, offset: 128206},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 38, offset: 128053},
+							pos:        position{line: 4203, col: 38, offset: 128211},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4200, col: 44, offset: 128059},
+							pos:        position{line: 4203, col: 44, offset: 128217},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 48, offset: 128063},
+							pos:        position{line: 4203, col: 48, offset: 128221},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 53, offset: 128068},
+							pos:        position{line: 4203, col: 53, offset: 128226},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 58, offset: 128073},
+							pos:        position{line: 4203, col: 58, offset: 128231},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 63, offset: 128078},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4200, col: 69, offset: 128084},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4200, col: 73, offset: 128088},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4200, col: 78, offset: 128093},
+							pos:        position{line: 4203, col: 63, offset: 128236},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4200, col: 84, offset: 128099},
+							pos:        position{line: 4203, col: 69, offset: 128242},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 88, offset: 128103},
+							pos:        position{line: 4203, col: 73, offset: 128246},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 93, offset: 128108},
+							pos:        position{line: 4203, col: 78, offset: 128251},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4200, col: 99, offset: 128114},
+							pos:        position{line: 4203, col: 84, offset: 128257},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 103, offset: 128118},
+							pos:        position{line: 4203, col: 88, offset: 128261},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4200, col: 108, offset: 128123},
+							pos:        position{line: 4203, col: 93, offset: 128266},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4203, col: 99, offset: 128272},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4203, col: 103, offset: 128276},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4203, col: 108, offset: 128281},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10136,15 +10136,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4204, col: 1, offset: 128165},
+			pos:  position{line: 4207, col: 1, offset: 128323},
 			expr: &actionExpr{
-				pos: position{line: 4204, col: 22, offset: 128186},
+				pos: position{line: 4207, col: 22, offset: 128344},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4204, col: 22, offset: 128186},
+					pos:   position{line: 4207, col: 22, offset: 128344},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4204, col: 32, offset: 128196},
+						pos:  position{line: 4207, col: 32, offset: 128354},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10152,15 +10152,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4214, col: 1, offset: 128604},
+			pos:  position{line: 4217, col: 1, offset: 128762},
 			expr: &actionExpr{
-				pos: position{line: 4214, col: 14, offset: 128617},
+				pos: position{line: 4217, col: 14, offset: 128775},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4214, col: 14, offset: 128617},
+					pos: position{line: 4217, col: 14, offset: 128775},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4214, col: 14, offset: 128617},
+							pos:        position{line: 4217, col: 14, offset: 128775},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10168,9 +10168,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4214, col: 27, offset: 128630},
+							pos: position{line: 4217, col: 27, offset: 128788},
 							expr: &charClassMatcher{
-								pos:        position{line: 4214, col: 27, offset: 128630},
+								pos:        position{line: 4217, col: 27, offset: 128788},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10184,15 +10184,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4218, col: 1, offset: 128683},
+			pos:  position{line: 4221, col: 1, offset: 128841},
 			expr: &actionExpr{
-				pos: position{line: 4218, col: 24, offset: 128706},
+				pos: position{line: 4221, col: 24, offset: 128864},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4218, col: 24, offset: 128706},
+					pos: position{line: 4221, col: 24, offset: 128864},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4218, col: 24, offset: 128706},
+							pos:        position{line: 4221, col: 24, offset: 128864},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10200,9 +10200,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4218, col: 39, offset: 128721},
+							pos: position{line: 4221, col: 39, offset: 128879},
 							expr: &charClassMatcher{
-								pos:        position{line: 4218, col: 39, offset: 128721},
+								pos:        position{line: 4221, col: 39, offset: 128879},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10216,22 +10216,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4222, col: 1, offset: 128774},
+			pos:  position{line: 4225, col: 1, offset: 128932},
 			expr: &actionExpr{
-				pos: position{line: 4222, col: 11, offset: 128784},
+				pos: position{line: 4225, col: 11, offset: 128942},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4222, col: 11, offset: 128784},
+					pos:   position{line: 4225, col: 11, offset: 128942},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4222, col: 16, offset: 128789},
+						pos: position{line: 4225, col: 16, offset: 128947},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4222, col: 16, offset: 128789},
+								pos:  position{line: 4225, col: 16, offset: 128947},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4222, col: 31, offset: 128804},
+								pos:  position{line: 4225, col: 31, offset: 128962},
 								name: "UnquotedString",
 							},
 						},
@@ -10241,23 +10241,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4226, col: 1, offset: 128845},
+			pos:  position{line: 4229, col: 1, offset: 129003},
 			expr: &actionExpr{
-				pos: position{line: 4226, col: 17, offset: 128861},
+				pos: position{line: 4229, col: 17, offset: 129019},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4226, col: 17, offset: 128861},
+					pos: position{line: 4229, col: 17, offset: 129019},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4226, col: 17, offset: 128861},
+							pos:        position{line: 4229, col: 17, offset: 129019},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4226, col: 21, offset: 128865},
+							pos: position{line: 4229, col: 21, offset: 129023},
 							expr: &charClassMatcher{
-								pos:        position{line: 4226, col: 21, offset: 128865},
+								pos:        position{line: 4229, col: 21, offset: 129023},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10265,7 +10265,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4226, col: 27, offset: 128871},
+							pos:        position{line: 4229, col: 27, offset: 129029},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10276,48 +10276,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4231, col: 1, offset: 128982},
+			pos:  position{line: 4234, col: 1, offset: 129140},
 			expr: &actionExpr{
-				pos: position{line: 4231, col: 19, offset: 129000},
+				pos: position{line: 4234, col: 19, offset: 129158},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4231, col: 19, offset: 129000},
+					pos: position{line: 4234, col: 19, offset: 129158},
 					expr: &choiceExpr{
-						pos: position{line: 4231, col: 20, offset: 129001},
+						pos: position{line: 4234, col: 20, offset: 129159},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4231, col: 20, offset: 129001},
+								pos:        position{line: 4234, col: 20, offset: 129159},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4231, col: 27, offset: 129008},
+								pos: position{line: 4234, col: 27, offset: 129166},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4231, col: 27, offset: 129008},
+										pos: position{line: 4234, col: 27, offset: 129166},
 										expr: &choiceExpr{
-											pos: position{line: 4231, col: 29, offset: 129010},
+											pos: position{line: 4234, col: 29, offset: 129168},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4231, col: 29, offset: 129010},
+													pos:  position{line: 4234, col: 29, offset: 129168},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4231, col: 43, offset: 129024},
+													pos:        position{line: 4234, col: 43, offset: 129182},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4231, col: 49, offset: 129030},
+													pos:  position{line: 4234, col: 49, offset: 129188},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4231, col: 54, offset: 129035,
+										line: 4234, col: 54, offset: 129193,
 									},
 								},
 							},
@@ -10328,12 +10328,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4238, col: 1, offset: 129150},
+			pos:  position{line: 4241, col: 1, offset: 129308},
 			expr: &choiceExpr{
-				pos: position{line: 4238, col: 16, offset: 129165},
+				pos: position{line: 4241, col: 16, offset: 129323},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4238, col: 16, offset: 129165},
+						pos:        position{line: 4241, col: 16, offset: 129323},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10341,18 +10341,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4238, col: 37, offset: 129186},
+						pos: position{line: 4241, col: 37, offset: 129344},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4238, col: 37, offset: 129186},
+								pos:        position{line: 4241, col: 37, offset: 129344},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4238, col: 41, offset: 129190},
+								pos: position{line: 4241, col: 41, offset: 129348},
 								expr: &charClassMatcher{
-									pos:        position{line: 4238, col: 41, offset: 129190},
+									pos:        position{line: 4241, col: 41, offset: 129348},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10360,7 +10360,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4238, col: 48, offset: 129197},
+								pos:        position{line: 4241, col: 48, offset: 129355},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10372,46 +10372,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4240, col: 1, offset: 129203},
+			pos:  position{line: 4243, col: 1, offset: 129361},
 			expr: &actionExpr{
-				pos: position{line: 4240, col: 39, offset: 129241},
+				pos: position{line: 4243, col: 39, offset: 129399},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4240, col: 39, offset: 129241},
+					pos: position{line: 4243, col: 39, offset: 129399},
 					expr: &choiceExpr{
-						pos: position{line: 4240, col: 40, offset: 129242},
+						pos: position{line: 4243, col: 40, offset: 129400},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4240, col: 40, offset: 129242},
+								pos:  position{line: 4243, col: 40, offset: 129400},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4240, col: 54, offset: 129256},
+								pos: position{line: 4243, col: 54, offset: 129414},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4240, col: 54, offset: 129256},
+										pos: position{line: 4243, col: 54, offset: 129414},
 										expr: &choiceExpr{
-											pos: position{line: 4240, col: 56, offset: 129258},
+											pos: position{line: 4243, col: 56, offset: 129416},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4240, col: 56, offset: 129258},
+													pos:  position{line: 4243, col: 56, offset: 129416},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4240, col: 70, offset: 129272},
+													pos:        position{line: 4243, col: 70, offset: 129430},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4240, col: 76, offset: 129278},
+													pos:  position{line: 4243, col: 76, offset: 129436},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4240, col: 81, offset: 129283,
+										line: 4243, col: 81, offset: 129441,
 									},
 								},
 							},
@@ -10422,21 +10422,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4244, col: 1, offset: 129323},
+			pos:  position{line: 4247, col: 1, offset: 129481},
 			expr: &actionExpr{
-				pos: position{line: 4244, col: 12, offset: 129334},
+				pos: position{line: 4247, col: 12, offset: 129492},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4244, col: 13, offset: 129335},
+					pos: position{line: 4247, col: 13, offset: 129493},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4244, col: 13, offset: 129335},
+							pos:        position{line: 4247, col: 13, offset: 129493},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4244, col: 22, offset: 129344},
+							pos:        position{line: 4247, col: 22, offset: 129502},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10447,14 +10447,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4250, col: 1, offset: 129498},
+			pos:  position{line: 4253, col: 1, offset: 129656},
 			expr: &actionExpr{
-				pos: position{line: 4250, col: 18, offset: 129515},
+				pos: position{line: 4253, col: 18, offset: 129673},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4250, col: 18, offset: 129515},
+					pos: position{line: 4253, col: 18, offset: 129673},
 					expr: &charClassMatcher{
-						pos:        position{line: 4250, col: 18, offset: 129515},
+						pos:        position{line: 4253, col: 18, offset: 129673},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10466,15 +10466,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4254, col: 1, offset: 129566},
+			pos:  position{line: 4257, col: 1, offset: 129724},
 			expr: &actionExpr{
-				pos: position{line: 4254, col: 11, offset: 129576},
+				pos: position{line: 4257, col: 11, offset: 129734},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4254, col: 11, offset: 129576},
+					pos:   position{line: 4257, col: 11, offset: 129734},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4254, col: 18, offset: 129583},
+						pos:  position{line: 4257, col: 18, offset: 129741},
 						name: "NumberAsString",
 					},
 				},
@@ -10482,59 +10482,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4260, col: 1, offset: 129772},
+			pos:  position{line: 4263, col: 1, offset: 129930},
 			expr: &actionExpr{
-				pos: position{line: 4260, col: 19, offset: 129790},
+				pos: position{line: 4263, col: 19, offset: 129948},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4260, col: 19, offset: 129790},
+					pos: position{line: 4263, col: 19, offset: 129948},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4260, col: 19, offset: 129790},
+							pos:   position{line: 4263, col: 19, offset: 129948},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4260, col: 27, offset: 129798},
+								pos: position{line: 4263, col: 27, offset: 129956},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4260, col: 27, offset: 129798},
+										pos:  position{line: 4263, col: 27, offset: 129956},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4260, col: 43, offset: 129814},
+										pos:  position{line: 4263, col: 43, offset: 129972},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4260, col: 60, offset: 129831},
+							pos: position{line: 4263, col: 60, offset: 129989},
 							expr: &choiceExpr{
-								pos: position{line: 4260, col: 62, offset: 129833},
+								pos: position{line: 4263, col: 62, offset: 129991},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4260, col: 62, offset: 129833},
+										pos:  position{line: 4263, col: 62, offset: 129991},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4260, col: 70, offset: 129841},
+										pos:        position{line: 4263, col: 70, offset: 129999},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4260, col: 76, offset: 129847},
+										pos:        position{line: 4263, col: 76, offset: 130005},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4260, col: 82, offset: 129853},
+										pos:        position{line: 4263, col: 82, offset: 130011},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4260, col: 88, offset: 129859},
+										pos:  position{line: 4263, col: 88, offset: 130017},
 										name: "EOF",
 									},
 								},
@@ -10546,17 +10546,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4266, col: 1, offset: 129988},
+			pos:  position{line: 4269, col: 1, offset: 130146},
 			expr: &actionExpr{
-				pos: position{line: 4266, col: 18, offset: 130005},
+				pos: position{line: 4269, col: 18, offset: 130163},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4266, col: 18, offset: 130005},
+					pos: position{line: 4269, col: 18, offset: 130163},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4266, col: 18, offset: 130005},
+							pos: position{line: 4269, col: 18, offset: 130163},
 							expr: &charClassMatcher{
-								pos:        position{line: 4266, col: 18, offset: 130005},
+								pos:        position{line: 4269, col: 18, offset: 130163},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10564,9 +10564,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4266, col: 24, offset: 130011},
+							pos: position{line: 4269, col: 24, offset: 130169},
 							expr: &charClassMatcher{
-								pos:        position{line: 4266, col: 24, offset: 130011},
+								pos:        position{line: 4269, col: 24, offset: 130169},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10574,15 +10574,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4266, col: 31, offset: 130018},
+							pos:        position{line: 4269, col: 31, offset: 130176},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4266, col: 35, offset: 130022},
+							pos: position{line: 4269, col: 35, offset: 130180},
 							expr: &charClassMatcher{
-								pos:        position{line: 4266, col: 35, offset: 130022},
+								pos:        position{line: 4269, col: 35, offset: 130180},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10595,17 +10595,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4271, col: 1, offset: 130117},
+			pos:  position{line: 4274, col: 1, offset: 130275},
 			expr: &actionExpr{
-				pos: position{line: 4271, col: 20, offset: 130136},
+				pos: position{line: 4274, col: 20, offset: 130294},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4271, col: 20, offset: 130136},
+					pos: position{line: 4274, col: 20, offset: 130294},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4271, col: 20, offset: 130136},
+							pos: position{line: 4274, col: 20, offset: 130294},
 							expr: &charClassMatcher{
-								pos:        position{line: 4271, col: 20, offset: 130136},
+								pos:        position{line: 4274, col: 20, offset: 130294},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10613,9 +10613,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4271, col: 26, offset: 130142},
+							pos: position{line: 4274, col: 26, offset: 130300},
 							expr: &charClassMatcher{
-								pos:        position{line: 4271, col: 26, offset: 130142},
+								pos:        position{line: 4274, col: 26, offset: 130300},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10628,14 +10628,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4275, col: 1, offset: 130185},
+			pos:  position{line: 4278, col: 1, offset: 130343},
 			expr: &actionExpr{
-				pos: position{line: 4275, col: 28, offset: 130212},
+				pos: position{line: 4278, col: 28, offset: 130370},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4275, col: 28, offset: 130212},
+					pos: position{line: 4278, col: 28, offset: 130370},
 					expr: &charClassMatcher{
-						pos:        position{line: 4275, col: 28, offset: 130212},
+						pos:        position{line: 4278, col: 28, offset: 130370},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10646,15 +10646,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4279, col: 1, offset: 130255},
+			pos:  position{line: 4282, col: 1, offset: 130413},
 			expr: &actionExpr{
-				pos: position{line: 4279, col: 20, offset: 130274},
+				pos: position{line: 4282, col: 20, offset: 130432},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4279, col: 20, offset: 130274},
+					pos:   position{line: 4282, col: 20, offset: 130432},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4279, col: 27, offset: 130281},
+						pos:  position{line: 4282, col: 27, offset: 130439},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10662,31 +10662,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4287, col: 1, offset: 130528},
+			pos:  position{line: 4290, col: 1, offset: 130686},
 			expr: &actionExpr{
-				pos: position{line: 4287, col: 21, offset: 130548},
+				pos: position{line: 4290, col: 21, offset: 130706},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4287, col: 21, offset: 130548},
+					pos: position{line: 4290, col: 21, offset: 130706},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4287, col: 21, offset: 130548},
+							pos:  position{line: 4290, col: 21, offset: 130706},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4287, col: 36, offset: 130563},
+							pos:   position{line: 4290, col: 36, offset: 130721},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4287, col: 40, offset: 130567},
+								pos: position{line: 4290, col: 40, offset: 130725},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4287, col: 40, offset: 130567},
+										pos:        position{line: 4290, col: 40, offset: 130725},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4287, col: 46, offset: 130573},
+										pos:        position{line: 4290, col: 46, offset: 130731},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10695,7 +10695,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4287, col: 52, offset: 130579},
+							pos:  position{line: 4290, col: 52, offset: 130737},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10704,43 +10704,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4295, col: 1, offset: 130760},
+			pos:  position{line: 4298, col: 1, offset: 130918},
 			expr: &actionExpr{
-				pos: position{line: 4295, col: 23, offset: 130782},
+				pos: position{line: 4298, col: 23, offset: 130940},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4295, col: 23, offset: 130782},
+					pos: position{line: 4298, col: 23, offset: 130940},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4295, col: 23, offset: 130782},
+							pos:  position{line: 4298, col: 23, offset: 130940},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4295, col: 38, offset: 130797},
+							pos:   position{line: 4298, col: 38, offset: 130955},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4295, col: 42, offset: 130801},
+								pos: position{line: 4298, col: 42, offset: 130959},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4295, col: 42, offset: 130801},
+										pos:        position{line: 4298, col: 42, offset: 130959},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4295, col: 49, offset: 130808},
+										pos:        position{line: 4298, col: 49, offset: 130966},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4295, col: 55, offset: 130814},
+										pos:        position{line: 4298, col: 55, offset: 130972},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4295, col: 62, offset: 130821},
+										pos:        position{line: 4298, col: 62, offset: 130979},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10749,7 +10749,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4295, col: 67, offset: 130826},
+							pos:  position{line: 4298, col: 67, offset: 130984},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10758,30 +10758,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4303, col: 1, offset: 131009},
+			pos:  position{line: 4306, col: 1, offset: 131167},
 			expr: &choiceExpr{
-				pos: position{line: 4303, col: 25, offset: 131033},
+				pos: position{line: 4306, col: 25, offset: 131191},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4303, col: 25, offset: 131033},
+						pos: position{line: 4306, col: 25, offset: 131191},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4303, col: 25, offset: 131033},
+							pos:   position{line: 4306, col: 25, offset: 131191},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4303, col: 28, offset: 131036},
+								pos:  position{line: 4306, col: 28, offset: 131194},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4306, col: 3, offset: 131078},
+						pos: position{line: 4309, col: 3, offset: 131236},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4306, col: 3, offset: 131078},
+							pos:   position{line: 4309, col: 3, offset: 131236},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4306, col: 6, offset: 131081},
+								pos:  position{line: 4309, col: 6, offset: 131239},
 								name: "InequalityOperator",
 							},
 						},
@@ -10791,25 +10791,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4310, col: 1, offset: 131124},
+			pos:  position{line: 4313, col: 1, offset: 131282},
 			expr: &actionExpr{
-				pos: position{line: 4310, col: 11, offset: 131134},
+				pos: position{line: 4313, col: 11, offset: 131292},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4310, col: 11, offset: 131134},
+					pos: position{line: 4313, col: 11, offset: 131292},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4310, col: 11, offset: 131134},
+							pos:  position{line: 4313, col: 11, offset: 131292},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4310, col: 26, offset: 131149},
+							pos:        position{line: 4313, col: 26, offset: 131307},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4310, col: 30, offset: 131153},
+							pos:  position{line: 4313, col: 30, offset: 131311},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10818,25 +10818,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4314, col: 1, offset: 131193},
+			pos:  position{line: 4317, col: 1, offset: 131351},
 			expr: &actionExpr{
-				pos: position{line: 4314, col: 12, offset: 131204},
+				pos: position{line: 4317, col: 12, offset: 131362},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4314, col: 12, offset: 131204},
+					pos: position{line: 4317, col: 12, offset: 131362},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4314, col: 12, offset: 131204},
+							pos:  position{line: 4317, col: 12, offset: 131362},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4314, col: 27, offset: 131219},
+							pos:        position{line: 4317, col: 27, offset: 131377},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4314, col: 31, offset: 131223},
+							pos:  position{line: 4317, col: 31, offset: 131381},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10845,25 +10845,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4318, col: 1, offset: 131263},
+			pos:  position{line: 4321, col: 1, offset: 131421},
 			expr: &actionExpr{
-				pos: position{line: 4318, col: 10, offset: 131272},
+				pos: position{line: 4321, col: 10, offset: 131430},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4318, col: 10, offset: 131272},
+					pos: position{line: 4321, col: 10, offset: 131430},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4318, col: 10, offset: 131272},
+							pos:  position{line: 4321, col: 10, offset: 131430},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4318, col: 25, offset: 131287},
+							pos:        position{line: 4321, col: 25, offset: 131445},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4318, col: 29, offset: 131291},
+							pos:  position{line: 4321, col: 29, offset: 131449},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10872,25 +10872,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4322, col: 1, offset: 131331},
+			pos:  position{line: 4325, col: 1, offset: 131489},
 			expr: &actionExpr{
-				pos: position{line: 4322, col: 10, offset: 131340},
+				pos: position{line: 4325, col: 10, offset: 131498},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4322, col: 10, offset: 131340},
+					pos: position{line: 4325, col: 10, offset: 131498},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4322, col: 10, offset: 131340},
+							pos:  position{line: 4325, col: 10, offset: 131498},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4322, col: 25, offset: 131355},
+							pos:        position{line: 4325, col: 25, offset: 131513},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4322, col: 29, offset: 131359},
+							pos:  position{line: 4325, col: 29, offset: 131517},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10899,25 +10899,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4326, col: 1, offset: 131399},
+			pos:  position{line: 4329, col: 1, offset: 131557},
 			expr: &actionExpr{
-				pos: position{line: 4326, col: 10, offset: 131408},
+				pos: position{line: 4329, col: 10, offset: 131566},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4326, col: 10, offset: 131408},
+					pos: position{line: 4329, col: 10, offset: 131566},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4326, col: 10, offset: 131408},
+							pos:  position{line: 4329, col: 10, offset: 131566},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4326, col: 25, offset: 131423},
+							pos:        position{line: 4329, col: 25, offset: 131581},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4326, col: 29, offset: 131427},
+							pos:  position{line: 4329, col: 29, offset: 131585},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10926,39 +10926,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4331, col: 1, offset: 131491},
+			pos:  position{line: 4334, col: 1, offset: 131649},
 			expr: &actionExpr{
-				pos: position{line: 4331, col: 11, offset: 131501},
+				pos: position{line: 4334, col: 11, offset: 131659},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4331, col: 12, offset: 131502},
+					pos: position{line: 4334, col: 12, offset: 131660},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4331, col: 12, offset: 131502},
+							pos:        position{line: 4334, col: 12, offset: 131660},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4331, col: 24, offset: 131514},
+							pos:        position{line: 4334, col: 24, offset: 131672},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4331, col: 35, offset: 131525},
+							pos:        position{line: 4334, col: 35, offset: 131683},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4331, col: 44, offset: 131534},
+							pos:        position{line: 4334, col: 44, offset: 131692},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4331, col: 52, offset: 131542},
+							pos:        position{line: 4334, col: 52, offset: 131700},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10969,39 +10969,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4335, col: 1, offset: 131583},
+			pos:  position{line: 4338, col: 1, offset: 131741},
 			expr: &actionExpr{
-				pos: position{line: 4335, col: 11, offset: 131593},
+				pos: position{line: 4338, col: 11, offset: 131751},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4335, col: 12, offset: 131594},
+					pos: position{line: 4338, col: 12, offset: 131752},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4335, col: 12, offset: 131594},
+							pos:        position{line: 4338, col: 12, offset: 131752},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4335, col: 24, offset: 131606},
+							pos:        position{line: 4338, col: 24, offset: 131764},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4335, col: 35, offset: 131617},
+							pos:        position{line: 4338, col: 35, offset: 131775},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4335, col: 44, offset: 131626},
+							pos:        position{line: 4338, col: 44, offset: 131784},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4335, col: 52, offset: 131634},
+							pos:        position{line: 4338, col: 52, offset: 131792},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11012,39 +11012,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4339, col: 1, offset: 131675},
+			pos:  position{line: 4342, col: 1, offset: 131833},
 			expr: &actionExpr{
-				pos: position{line: 4339, col: 9, offset: 131683},
+				pos: position{line: 4342, col: 9, offset: 131841},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4339, col: 10, offset: 131684},
+					pos: position{line: 4342, col: 10, offset: 131842},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4339, col: 10, offset: 131684},
+							pos:        position{line: 4342, col: 10, offset: 131842},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4339, col: 20, offset: 131694},
+							pos:        position{line: 4342, col: 20, offset: 131852},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4339, col: 29, offset: 131703},
+							pos:        position{line: 4342, col: 29, offset: 131861},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4339, col: 37, offset: 131711},
+							pos:        position{line: 4342, col: 37, offset: 131869},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4339, col: 44, offset: 131718},
+							pos:        position{line: 4342, col: 44, offset: 131876},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11055,27 +11055,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4343, col: 1, offset: 131757},
+			pos:  position{line: 4346, col: 1, offset: 131915},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 8, offset: 131764},
+				pos: position{line: 4346, col: 8, offset: 131922},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4343, col: 9, offset: 131765},
+					pos: position{line: 4346, col: 9, offset: 131923},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4343, col: 9, offset: 131765},
+							pos:        position{line: 4346, col: 9, offset: 131923},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4343, col: 18, offset: 131774},
+							pos:        position{line: 4346, col: 18, offset: 131932},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4343, col: 26, offset: 131782},
+							pos:        position{line: 4346, col: 26, offset: 131940},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11086,27 +11086,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4347, col: 1, offset: 131820},
+			pos:  position{line: 4350, col: 1, offset: 131978},
 			expr: &actionExpr{
-				pos: position{line: 4347, col: 9, offset: 131828},
+				pos: position{line: 4350, col: 9, offset: 131986},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4347, col: 10, offset: 131829},
+					pos: position{line: 4350, col: 10, offset: 131987},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4347, col: 10, offset: 131829},
+							pos:        position{line: 4350, col: 10, offset: 131987},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4347, col: 20, offset: 131839},
+							pos:        position{line: 4350, col: 20, offset: 131997},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4347, col: 29, offset: 131848},
+							pos:        position{line: 4350, col: 29, offset: 132006},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11117,27 +11117,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4351, col: 1, offset: 131887},
+			pos:  position{line: 4354, col: 1, offset: 132045},
 			expr: &actionExpr{
-				pos: position{line: 4351, col: 10, offset: 131896},
+				pos: position{line: 4354, col: 10, offset: 132054},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4351, col: 11, offset: 131897},
+					pos: position{line: 4354, col: 11, offset: 132055},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4351, col: 11, offset: 131897},
+							pos:        position{line: 4354, col: 11, offset: 132055},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4351, col: 22, offset: 131908},
+							pos:        position{line: 4354, col: 22, offset: 132066},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4351, col: 32, offset: 131918},
+							pos:        position{line: 4354, col: 32, offset: 132076},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11148,39 +11148,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4355, col: 1, offset: 131960},
+			pos:  position{line: 4358, col: 1, offset: 132118},
 			expr: &actionExpr{
-				pos: position{line: 4355, col: 12, offset: 131971},
+				pos: position{line: 4358, col: 12, offset: 132129},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4355, col: 13, offset: 131972},
+					pos: position{line: 4358, col: 13, offset: 132130},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4355, col: 13, offset: 131972},
+							pos:        position{line: 4358, col: 13, offset: 132130},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4355, col: 26, offset: 131985},
+							pos:        position{line: 4358, col: 26, offset: 132143},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4355, col: 38, offset: 131997},
+							pos:        position{line: 4358, col: 38, offset: 132155},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4355, col: 47, offset: 132006},
+							pos:        position{line: 4358, col: 47, offset: 132164},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4355, col: 55, offset: 132014},
+							pos:        position{line: 4358, col: 55, offset: 132172},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11191,39 +11191,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4359, col: 1, offset: 132056},
+			pos:  position{line: 4362, col: 1, offset: 132214},
 			expr: &actionExpr{
-				pos: position{line: 4359, col: 9, offset: 132064},
+				pos: position{line: 4362, col: 9, offset: 132222},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4359, col: 10, offset: 132065},
+					pos: position{line: 4362, col: 10, offset: 132223},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4359, col: 10, offset: 132065},
+							pos:        position{line: 4362, col: 10, offset: 132223},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4359, col: 20, offset: 132075},
+							pos:        position{line: 4362, col: 20, offset: 132233},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4359, col: 29, offset: 132084},
+							pos:        position{line: 4362, col: 29, offset: 132242},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4359, col: 37, offset: 132092},
+							pos:        position{line: 4362, col: 37, offset: 132250},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4359, col: 44, offset: 132099},
+							pos:        position{line: 4362, col: 44, offset: 132257},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11234,33 +11234,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4364, col: 1, offset: 132230},
+			pos:  position{line: 4367, col: 1, offset: 132388},
 			expr: &actionExpr{
-				pos: position{line: 4364, col: 15, offset: 132244},
+				pos: position{line: 4367, col: 15, offset: 132402},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4364, col: 16, offset: 132245},
+					pos: position{line: 4367, col: 16, offset: 132403},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4364, col: 16, offset: 132245},
+							pos:        position{line: 4367, col: 16, offset: 132403},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4364, col: 23, offset: 132252},
+							pos:        position{line: 4367, col: 23, offset: 132410},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4364, col: 30, offset: 132259},
+							pos:        position{line: 4367, col: 30, offset: 132417},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4364, col: 37, offset: 132266},
+							pos:        position{line: 4367, col: 37, offset: 132424},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11271,26 +11271,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4373, col: 1, offset: 132489},
+			pos:  position{line: 4376, col: 1, offset: 132647},
 			expr: &actionExpr{
-				pos: position{line: 4373, col: 21, offset: 132509},
+				pos: position{line: 4376, col: 21, offset: 132667},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4373, col: 21, offset: 132509},
+					pos: position{line: 4376, col: 21, offset: 132667},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4373, col: 21, offset: 132509},
+							pos:  position{line: 4376, col: 21, offset: 132667},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4373, col: 26, offset: 132514},
+							pos:  position{line: 4376, col: 26, offset: 132672},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4373, col: 42, offset: 132530},
+							pos:   position{line: 4376, col: 42, offset: 132688},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4373, col: 53, offset: 132541},
+								pos:  position{line: 4376, col: 53, offset: 132699},
 								name: "TransactionOptions",
 							},
 						},
@@ -11300,17 +11300,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4382, col: 1, offset: 132847},
+			pos:  position{line: 4385, col: 1, offset: 133005},
 			expr: &actionExpr{
-				pos: position{line: 4382, col: 23, offset: 132869},
+				pos: position{line: 4385, col: 23, offset: 133027},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4382, col: 23, offset: 132869},
+					pos:   position{line: 4385, col: 23, offset: 133027},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4382, col: 34, offset: 132880},
+						pos: position{line: 4385, col: 34, offset: 133038},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4382, col: 34, offset: 132880},
+							pos:  position{line: 4385, col: 34, offset: 133038},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11319,35 +11319,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4397, col: 1, offset: 133271},
+			pos:  position{line: 4400, col: 1, offset: 133429},
 			expr: &actionExpr{
-				pos: position{line: 4397, col: 37, offset: 133307},
+				pos: position{line: 4400, col: 37, offset: 133465},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4397, col: 37, offset: 133307},
+					pos: position{line: 4400, col: 37, offset: 133465},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4397, col: 37, offset: 133307},
+							pos:   position{line: 4400, col: 37, offset: 133465},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4397, col: 43, offset: 133313},
+								pos:  position{line: 4400, col: 43, offset: 133471},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4397, col: 71, offset: 133341},
+							pos:   position{line: 4400, col: 71, offset: 133499},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4397, col: 76, offset: 133346},
+								pos: position{line: 4400, col: 76, offset: 133504},
 								expr: &seqExpr{
-									pos: position{line: 4397, col: 77, offset: 133347},
+									pos: position{line: 4400, col: 77, offset: 133505},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4397, col: 77, offset: 133347},
+											pos:  position{line: 4400, col: 77, offset: 133505},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4397, col: 83, offset: 133353},
+											pos:  position{line: 4400, col: 83, offset: 133511},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11360,26 +11360,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4432, col: 1, offset: 134342},
+			pos:  position{line: 4435, col: 1, offset: 134500},
 			expr: &actionExpr{
-				pos: position{line: 4432, col: 32, offset: 134373},
+				pos: position{line: 4435, col: 32, offset: 134531},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4432, col: 32, offset: 134373},
+					pos:   position{line: 4435, col: 32, offset: 134531},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4432, col: 40, offset: 134381},
+						pos: position{line: 4435, col: 40, offset: 134539},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4432, col: 40, offset: 134381},
+								pos:  position{line: 4435, col: 40, offset: 134539},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4432, col: 77, offset: 134418},
+								pos:  position{line: 4435, col: 77, offset: 134576},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4432, col: 96, offset: 134437},
+								pos:  position{line: 4435, col: 96, offset: 134595},
 								name: "EndsWithOption",
 							},
 						},
@@ -11389,15 +11389,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4436, col: 1, offset: 134481},
+			pos:  position{line: 4439, col: 1, offset: 134639},
 			expr: &actionExpr{
-				pos: position{line: 4436, col: 39, offset: 134519},
+				pos: position{line: 4439, col: 39, offset: 134677},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4436, col: 39, offset: 134519},
+					pos:   position{line: 4439, col: 39, offset: 134677},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4436, col: 46, offset: 134526},
+						pos:  position{line: 4439, col: 46, offset: 134684},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11405,28 +11405,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4447, col: 1, offset: 134742},
+			pos:  position{line: 4450, col: 1, offset: 134900},
 			expr: &actionExpr{
-				pos: position{line: 4447, col: 21, offset: 134762},
+				pos: position{line: 4450, col: 21, offset: 134920},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4447, col: 21, offset: 134762},
+					pos: position{line: 4450, col: 21, offset: 134920},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4447, col: 21, offset: 134762},
+							pos:        position{line: 4450, col: 21, offset: 134920},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4447, col: 34, offset: 134775},
+							pos:  position{line: 4450, col: 34, offset: 134933},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4447, col: 40, offset: 134781},
+							pos:   position{line: 4450, col: 40, offset: 134939},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4447, col: 48, offset: 134789},
+								pos:  position{line: 4450, col: 48, offset: 134947},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11436,28 +11436,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4457, col: 1, offset: 135027},
+			pos:  position{line: 4460, col: 1, offset: 135185},
 			expr: &actionExpr{
-				pos: position{line: 4457, col: 19, offset: 135045},
+				pos: position{line: 4460, col: 19, offset: 135203},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4457, col: 19, offset: 135045},
+					pos: position{line: 4460, col: 19, offset: 135203},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4457, col: 19, offset: 135045},
+							pos:        position{line: 4460, col: 19, offset: 135203},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4457, col: 30, offset: 135056},
+							pos:  position{line: 4460, col: 30, offset: 135214},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4457, col: 36, offset: 135062},
+							pos:   position{line: 4460, col: 36, offset: 135220},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4457, col: 44, offset: 135070},
+								pos:  position{line: 4460, col: 44, offset: 135228},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11467,26 +11467,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4468, col: 1, offset: 135339},
+			pos:  position{line: 4471, col: 1, offset: 135497},
 			expr: &actionExpr{
-				pos: position{line: 4468, col: 28, offset: 135366},
+				pos: position{line: 4471, col: 28, offset: 135524},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4468, col: 28, offset: 135366},
+					pos:   position{line: 4471, col: 28, offset: 135524},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4468, col: 37, offset: 135375},
+						pos: position{line: 4471, col: 37, offset: 135533},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4468, col: 37, offset: 135375},
+								pos:  position{line: 4471, col: 37, offset: 135533},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4468, col: 63, offset: 135401},
+								pos:  position{line: 4471, col: 63, offset: 135559},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4468, col: 81, offset: 135419},
+								pos:  position{line: 4471, col: 81, offset: 135577},
 								name: "TransactionSearch",
 							},
 						},
@@ -11496,22 +11496,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4472, col: 1, offset: 135467},
+			pos:  position{line: 4475, col: 1, offset: 135625},
 			expr: &actionExpr{
-				pos: position{line: 4472, col: 28, offset: 135494},
+				pos: position{line: 4475, col: 28, offset: 135652},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4472, col: 28, offset: 135494},
+					pos:   position{line: 4475, col: 28, offset: 135652},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4472, col: 33, offset: 135499},
+						pos: position{line: 4475, col: 33, offset: 135657},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4472, col: 33, offset: 135499},
+								pos:  position{line: 4475, col: 33, offset: 135657},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4472, col: 64, offset: 135530},
+								pos:  position{line: 4475, col: 64, offset: 135688},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11521,29 +11521,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4476, col: 1, offset: 135590},
+			pos:  position{line: 4479, col: 1, offset: 135748},
 			expr: &actionExpr{
-				pos: position{line: 4476, col: 38, offset: 135627},
+				pos: position{line: 4479, col: 38, offset: 135785},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4476, col: 38, offset: 135627},
+					pos: position{line: 4479, col: 38, offset: 135785},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4476, col: 38, offset: 135627},
+							pos:        position{line: 4479, col: 38, offset: 135785},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4476, col: 42, offset: 135631},
+							pos:   position{line: 4479, col: 42, offset: 135789},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4476, col: 55, offset: 135644},
+								pos:  position{line: 4479, col: 55, offset: 135802},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4476, col: 68, offset: 135657},
+							pos:        position{line: 4479, col: 68, offset: 135815},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11554,23 +11554,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4484, col: 1, offset: 135796},
+			pos:  position{line: 4487, col: 1, offset: 135954},
 			expr: &actionExpr{
-				pos: position{line: 4484, col: 21, offset: 135816},
+				pos: position{line: 4487, col: 21, offset: 135974},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4484, col: 21, offset: 135816},
+					pos: position{line: 4487, col: 21, offset: 135974},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4484, col: 21, offset: 135816},
+							pos:        position{line: 4487, col: 21, offset: 135974},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4484, col: 25, offset: 135820},
+							pos: position{line: 4487, col: 25, offset: 135978},
 							expr: &charClassMatcher{
-								pos:        position{line: 4484, col: 25, offset: 135820},
+								pos:        position{line: 4487, col: 25, offset: 135978},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11578,7 +11578,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4484, col: 44, offset: 135839},
+							pos:        position{line: 4487, col: 44, offset: 135997},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11589,15 +11589,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4489, col: 1, offset: 135950},
+			pos:  position{line: 4492, col: 1, offset: 136108},
 			expr: &actionExpr{
-				pos: position{line: 4489, col: 33, offset: 135982},
+				pos: position{line: 4492, col: 33, offset: 136140},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4489, col: 33, offset: 135982},
+					pos:   position{line: 4492, col: 33, offset: 136140},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4489, col: 37, offset: 135986},
+						pos:  position{line: 4492, col: 37, offset: 136144},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11605,15 +11605,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4497, col: 1, offset: 136141},
+			pos:  position{line: 4500, col: 1, offset: 136299},
 			expr: &actionExpr{
-				pos: position{line: 4497, col: 22, offset: 136162},
+				pos: position{line: 4500, col: 22, offset: 136320},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4497, col: 22, offset: 136162},
+					pos:   position{line: 4500, col: 22, offset: 136320},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4497, col: 27, offset: 136167},
+						pos:  position{line: 4500, col: 27, offset: 136325},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11621,37 +11621,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4507, col: 1, offset: 136339},
+			pos:  position{line: 4510, col: 1, offset: 136497},
 			expr: &actionExpr{
-				pos: position{line: 4507, col: 20, offset: 136358},
+				pos: position{line: 4510, col: 20, offset: 136516},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4507, col: 20, offset: 136358},
+					pos: position{line: 4510, col: 20, offset: 136516},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4507, col: 20, offset: 136358},
+							pos:        position{line: 4510, col: 20, offset: 136516},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4507, col: 27, offset: 136365},
+							pos:  position{line: 4510, col: 27, offset: 136523},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4507, col: 42, offset: 136380},
+							pos:  position{line: 4510, col: 42, offset: 136538},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4507, col: 50, offset: 136388},
+							pos:   position{line: 4510, col: 50, offset: 136546},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4507, col: 60, offset: 136398},
+								pos:  position{line: 4510, col: 60, offset: 136556},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4507, col: 69, offset: 136407},
+							pos:  position{line: 4510, col: 69, offset: 136565},
 							name: "R_PAREN",
 						},
 					},
@@ -11660,22 +11660,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4517, col: 1, offset: 136710},
+			pos:  position{line: 4520, col: 1, offset: 136868},
 			expr: &actionExpr{
-				pos: position{line: 4517, col: 20, offset: 136729},
+				pos: position{line: 4520, col: 20, offset: 136887},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4517, col: 20, offset: 136729},
+					pos: position{line: 4520, col: 20, offset: 136887},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4517, col: 20, offset: 136729},
+							pos:  position{line: 4520, col: 20, offset: 136887},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4517, col: 25, offset: 136734},
+							pos:   position{line: 4520, col: 25, offset: 136892},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4517, col: 42, offset: 136751},
+								pos:  position{line: 4520, col: 42, offset: 136909},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11685,41 +11685,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4521, col: 1, offset: 136800},
+			pos:  position{line: 4524, col: 1, offset: 136958},
 			expr: &actionExpr{
-				pos: position{line: 4521, col: 16, offset: 136815},
+				pos: position{line: 4524, col: 16, offset: 136973},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4521, col: 16, offset: 136815},
+					pos: position{line: 4524, col: 16, offset: 136973},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4521, col: 16, offset: 136815},
+							pos:  position{line: 4524, col: 16, offset: 136973},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4521, col: 27, offset: 136826},
+							pos:  position{line: 4524, col: 27, offset: 136984},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4521, col: 33, offset: 136832},
+							pos:   position{line: 4524, col: 33, offset: 136990},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4521, col: 50, offset: 136849},
+								pos: position{line: 4524, col: 50, offset: 137007},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4521, col: 50, offset: 136849},
+									pos:  position{line: 4524, col: 50, offset: 137007},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4521, col: 70, offset: 136869},
+							pos:  position{line: 4524, col: 70, offset: 137027},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4521, col: 85, offset: 136884},
+							pos:   position{line: 4524, col: 85, offset: 137042},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4521, col: 91, offset: 136890},
+								pos:  position{line: 4524, col: 91, offset: 137048},
 								name: "FieldName",
 							},
 						},
@@ -11729,35 +11729,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4550, col: 1, offset: 137661},
+			pos:  position{line: 4553, col: 1, offset: 137819},
 			expr: &actionExpr{
-				pos: position{line: 4550, col: 23, offset: 137683},
+				pos: position{line: 4553, col: 23, offset: 137841},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4550, col: 23, offset: 137683},
+					pos: position{line: 4553, col: 23, offset: 137841},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4550, col: 23, offset: 137683},
+							pos:   position{line: 4553, col: 23, offset: 137841},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4550, col: 31, offset: 137691},
+								pos:  position{line: 4553, col: 31, offset: 137849},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4550, col: 46, offset: 137706},
+							pos:   position{line: 4553, col: 46, offset: 137864},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4550, col: 52, offset: 137712},
+								pos: position{line: 4553, col: 52, offset: 137870},
 								expr: &seqExpr{
-									pos: position{line: 4550, col: 53, offset: 137713},
+									pos: position{line: 4553, col: 53, offset: 137871},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4550, col: 53, offset: 137713},
+											pos:  position{line: 4553, col: 53, offset: 137871},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4550, col: 59, offset: 137719},
+											pos:  position{line: 4553, col: 59, offset: 137877},
 											name: "MVBlockOption",
 										},
 									},
@@ -11770,26 +11770,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4584, col: 1, offset: 138775},
+			pos:  position{line: 4587, col: 1, offset: 138933},
 			expr: &actionExpr{
-				pos: position{line: 4584, col: 18, offset: 138792},
+				pos: position{line: 4587, col: 18, offset: 138950},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4584, col: 18, offset: 138792},
+					pos:   position{line: 4587, col: 18, offset: 138950},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4584, col: 27, offset: 138801},
+						pos: position{line: 4587, col: 27, offset: 138959},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4584, col: 27, offset: 138801},
+								pos:  position{line: 4587, col: 27, offset: 138959},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4584, col: 41, offset: 138815},
+								pos:  position{line: 4587, col: 41, offset: 138973},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4584, col: 60, offset: 138834},
+								pos:  position{line: 4587, col: 60, offset: 138992},
 								name: "SetSvOption",
 							},
 						},
@@ -11799,22 +11799,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4588, col: 1, offset: 138875},
+			pos:  position{line: 4591, col: 1, offset: 139033},
 			expr: &actionExpr{
-				pos: position{line: 4588, col: 16, offset: 138890},
+				pos: position{line: 4591, col: 16, offset: 139048},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4588, col: 16, offset: 138890},
+					pos:   position{line: 4591, col: 16, offset: 139048},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4588, col: 28, offset: 138902},
+						pos: position{line: 4591, col: 28, offset: 139060},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4588, col: 28, offset: 138902},
+								pos:  position{line: 4591, col: 28, offset: 139060},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4588, col: 46, offset: 138920},
+								pos:  position{line: 4591, col: 46, offset: 139078},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11824,28 +11824,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4592, col: 1, offset: 138967},
+			pos:  position{line: 4595, col: 1, offset: 139125},
 			expr: &actionExpr{
-				pos: position{line: 4592, col: 20, offset: 138986},
+				pos: position{line: 4595, col: 20, offset: 139144},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4592, col: 20, offset: 138986},
+					pos: position{line: 4595, col: 20, offset: 139144},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4592, col: 20, offset: 138986},
+							pos:        position{line: 4595, col: 20, offset: 139144},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4592, col: 28, offset: 138994},
+							pos:  position{line: 4595, col: 28, offset: 139152},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4592, col: 34, offset: 139000},
+							pos:   position{line: 4595, col: 34, offset: 139158},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4592, col: 38, offset: 139004},
+								pos:  position{line: 4595, col: 38, offset: 139162},
 								name: "QuotedString",
 							},
 						},
@@ -11855,28 +11855,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4603, col: 1, offset: 139255},
+			pos:  position{line: 4606, col: 1, offset: 139413},
 			expr: &actionExpr{
-				pos: position{line: 4603, col: 19, offset: 139273},
+				pos: position{line: 4606, col: 19, offset: 139431},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4603, col: 19, offset: 139273},
+					pos: position{line: 4606, col: 19, offset: 139431},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4603, col: 19, offset: 139273},
+							pos:        position{line: 4606, col: 19, offset: 139431},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4603, col: 31, offset: 139285},
+							pos:  position{line: 4606, col: 31, offset: 139443},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4603, col: 37, offset: 139291},
+							pos:   position{line: 4606, col: 37, offset: 139449},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4603, col: 41, offset: 139295},
+								pos:  position{line: 4606, col: 41, offset: 139453},
 								name: "QuotedString",
 							},
 						},
@@ -11886,28 +11886,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4621, col: 1, offset: 139766},
+			pos:  position{line: 4624, col: 1, offset: 139924},
 			expr: &actionExpr{
-				pos: position{line: 4621, col: 21, offset: 139786},
+				pos: position{line: 4624, col: 21, offset: 139944},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4621, col: 21, offset: 139786},
+					pos: position{line: 4624, col: 21, offset: 139944},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4621, col: 21, offset: 139786},
+							pos:        position{line: 4624, col: 21, offset: 139944},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4621, col: 34, offset: 139799},
+							pos:  position{line: 4624, col: 34, offset: 139957},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4621, col: 40, offset: 139805},
+							pos:   position{line: 4624, col: 40, offset: 139963},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4621, col: 48, offset: 139813},
+								pos:  position{line: 4624, col: 48, offset: 139971},
 								name: "Boolean",
 							},
 						},
@@ -11917,28 +11917,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4633, col: 1, offset: 140053},
+			pos:  position{line: 4636, col: 1, offset: 140211},
 			expr: &actionExpr{
-				pos: position{line: 4633, col: 16, offset: 140068},
+				pos: position{line: 4636, col: 16, offset: 140226},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4633, col: 16, offset: 140068},
+					pos: position{line: 4636, col: 16, offset: 140226},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4633, col: 16, offset: 140068},
+							pos:        position{line: 4636, col: 16, offset: 140226},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4633, col: 24, offset: 140076},
+							pos:  position{line: 4636, col: 24, offset: 140234},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4633, col: 30, offset: 140082},
+							pos:   position{line: 4636, col: 30, offset: 140240},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4633, col: 38, offset: 140090},
+								pos:  position{line: 4636, col: 38, offset: 140248},
 								name: "Boolean",
 							},
 						},
@@ -11948,28 +11948,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4645, col: 1, offset: 140355},
+			pos:  position{line: 4648, col: 1, offset: 140513},
 			expr: &actionExpr{
-				pos: position{line: 4645, col: 15, offset: 140369},
+				pos: position{line: 4648, col: 15, offset: 140527},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4645, col: 15, offset: 140369},
+					pos: position{line: 4648, col: 15, offset: 140527},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4645, col: 15, offset: 140369},
+							pos:  position{line: 4648, col: 15, offset: 140527},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4645, col: 20, offset: 140374},
+							pos:  position{line: 4648, col: 20, offset: 140532},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4645, col: 30, offset: 140384},
+							pos:   position{line: 4648, col: 30, offset: 140542},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4645, col: 40, offset: 140394},
+								pos: position{line: 4648, col: 40, offset: 140552},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4645, col: 40, offset: 140394},
+									pos:  position{line: 4648, col: 40, offset: 140552},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -11980,39 +11980,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4652, col: 1, offset: 140520},
+			pos:  position{line: 4655, col: 1, offset: 140678},
 			expr: &actionExpr{
-				pos: position{line: 4652, col: 23, offset: 140542},
+				pos: position{line: 4655, col: 23, offset: 140700},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4652, col: 23, offset: 140542},
+					pos: position{line: 4655, col: 23, offset: 140700},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4652, col: 23, offset: 140542},
+							pos:  position{line: 4655, col: 23, offset: 140700},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4652, col: 29, offset: 140548},
+							pos:   position{line: 4655, col: 29, offset: 140706},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4652, col: 35, offset: 140554},
+								pos:  position{line: 4655, col: 35, offset: 140712},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4652, col: 49, offset: 140568},
+							pos:   position{line: 4655, col: 49, offset: 140726},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4652, col: 54, offset: 140573},
+								pos: position{line: 4655, col: 54, offset: 140731},
 								expr: &seqExpr{
-									pos: position{line: 4652, col: 55, offset: 140574},
+									pos: position{line: 4655, col: 55, offset: 140732},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4652, col: 55, offset: 140574},
+											pos:  position{line: 4655, col: 55, offset: 140732},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4652, col: 61, offset: 140580},
+											pos:  position{line: 4655, col: 61, offset: 140738},
 											name: "SPathArgument",
 										},
 									},
@@ -12025,26 +12025,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4684, col: 1, offset: 141473},
+			pos:  position{line: 4687, col: 1, offset: 141631},
 			expr: &actionExpr{
-				pos: position{line: 4684, col: 18, offset: 141490},
+				pos: position{line: 4687, col: 18, offset: 141648},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4684, col: 18, offset: 141490},
+					pos:   position{line: 4687, col: 18, offset: 141648},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4684, col: 23, offset: 141495},
+						pos: position{line: 4687, col: 23, offset: 141653},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4684, col: 23, offset: 141495},
+								pos:  position{line: 4687, col: 23, offset: 141653},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4684, col: 36, offset: 141508},
+								pos:  position{line: 4687, col: 36, offset: 141666},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4684, col: 50, offset: 141522},
+								pos:  position{line: 4687, col: 50, offset: 141680},
 								name: "PathField",
 							},
 						},
@@ -12054,28 +12054,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4688, col: 1, offset: 141558},
+			pos:  position{line: 4691, col: 1, offset: 141716},
 			expr: &actionExpr{
-				pos: position{line: 4688, col: 15, offset: 141572},
+				pos: position{line: 4691, col: 15, offset: 141730},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4688, col: 15, offset: 141572},
+					pos: position{line: 4691, col: 15, offset: 141730},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4688, col: 15, offset: 141572},
+							pos:        position{line: 4691, col: 15, offset: 141730},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4688, col: 23, offset: 141580},
+							pos:  position{line: 4691, col: 23, offset: 141738},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4688, col: 29, offset: 141586},
+							pos:   position{line: 4691, col: 29, offset: 141744},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4688, col: 35, offset: 141592},
+								pos:  position{line: 4691, col: 35, offset: 141750},
 								name: "FieldName",
 							},
 						},
@@ -12085,28 +12085,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4691, col: 1, offset: 141648},
+			pos:  position{line: 4694, col: 1, offset: 141806},
 			expr: &actionExpr{
-				pos: position{line: 4691, col: 16, offset: 141663},
+				pos: position{line: 4694, col: 16, offset: 141821},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4691, col: 16, offset: 141663},
+					pos: position{line: 4694, col: 16, offset: 141821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4691, col: 16, offset: 141663},
+							pos:        position{line: 4694, col: 16, offset: 141821},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4691, col: 25, offset: 141672},
+							pos:  position{line: 4694, col: 25, offset: 141830},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4691, col: 31, offset: 141678},
+							pos:   position{line: 4694, col: 31, offset: 141836},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4691, col: 37, offset: 141684},
+								pos:  position{line: 4694, col: 37, offset: 141842},
 								name: "FieldName",
 							},
 						},
@@ -12116,34 +12116,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4694, col: 1, offset: 141741},
+			pos:  position{line: 4697, col: 1, offset: 141899},
 			expr: &actionExpr{
-				pos: position{line: 4694, col: 14, offset: 141754},
+				pos: position{line: 4697, col: 14, offset: 141912},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4694, col: 15, offset: 141755},
+					pos: position{line: 4697, col: 15, offset: 141913},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4694, col: 15, offset: 141755},
+							pos: position{line: 4697, col: 15, offset: 141913},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4694, col: 15, offset: 141755},
+									pos:        position{line: 4697, col: 15, offset: 141913},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4694, col: 22, offset: 141762},
+									pos:  position{line: 4697, col: 22, offset: 141920},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4694, col: 28, offset: 141768},
+									pos:  position{line: 4697, col: 28, offset: 141926},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4694, col: 47, offset: 141787},
+							pos:  position{line: 4697, col: 47, offset: 141945},
 							name: "SPathFieldString",
 						},
 					},
@@ -12152,16 +12152,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4706, col: 1, offset: 142199},
+			pos:  position{line: 4709, col: 1, offset: 142357},
 			expr: &choiceExpr{
-				pos: position{line: 4706, col: 21, offset: 142219},
+				pos: position{line: 4709, col: 21, offset: 142377},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4706, col: 21, offset: 142219},
+						pos:  position{line: 4709, col: 21, offset: 142377},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4706, col: 36, offset: 142234},
+						pos:  position{line: 4709, col: 36, offset: 142392},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12169,28 +12169,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4709, col: 1, offset: 142307},
+			pos:  position{line: 4712, col: 1, offset: 142465},
 			expr: &actionExpr{
-				pos: position{line: 4709, col: 16, offset: 142322},
+				pos: position{line: 4712, col: 16, offset: 142480},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4709, col: 16, offset: 142322},
+					pos: position{line: 4712, col: 16, offset: 142480},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4709, col: 16, offset: 142322},
+							pos:  position{line: 4712, col: 16, offset: 142480},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4709, col: 21, offset: 142327},
+							pos:  position{line: 4712, col: 21, offset: 142485},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4709, col: 32, offset: 142338},
+							pos:   position{line: 4712, col: 32, offset: 142496},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4709, col: 46, offset: 142352},
+								pos: position{line: 4712, col: 46, offset: 142510},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4709, col: 46, offset: 142352},
+									pos:  position{line: 4712, col: 46, offset: 142510},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12201,39 +12201,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4731, col: 1, offset: 142961},
+			pos:  position{line: 4734, col: 1, offset: 143119},
 			expr: &actionExpr{
-				pos: position{line: 4731, col: 24, offset: 142984},
+				pos: position{line: 4734, col: 24, offset: 143142},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4731, col: 24, offset: 142984},
+					pos: position{line: 4734, col: 24, offset: 143142},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 24, offset: 142984},
+							pos:  position{line: 4734, col: 24, offset: 143142},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4731, col: 30, offset: 142990},
+							pos:   position{line: 4734, col: 30, offset: 143148},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4731, col: 37, offset: 142997},
+								pos:  position{line: 4734, col: 37, offset: 143155},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4731, col: 52, offset: 143012},
+							pos:   position{line: 4734, col: 52, offset: 143170},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4731, col: 57, offset: 143017},
+								pos: position{line: 4734, col: 57, offset: 143175},
 								expr: &seqExpr{
-									pos: position{line: 4731, col: 58, offset: 143018},
+									pos: position{line: 4734, col: 58, offset: 143176},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4731, col: 58, offset: 143018},
+											pos:  position{line: 4734, col: 58, offset: 143176},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4731, col: 64, offset: 143024},
+											pos:  position{line: 4734, col: 64, offset: 143182},
 											name: "FormatArgument",
 										},
 									},
@@ -12246,30 +12246,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4765, col: 1, offset: 144213},
+			pos:  position{line: 4768, col: 1, offset: 144371},
 			expr: &actionExpr{
-				pos: position{line: 4765, col: 19, offset: 144231},
+				pos: position{line: 4768, col: 19, offset: 144389},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4765, col: 19, offset: 144231},
+					pos:   position{line: 4768, col: 19, offset: 144389},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4765, col: 28, offset: 144240},
+						pos: position{line: 4768, col: 28, offset: 144398},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4765, col: 28, offset: 144240},
+								pos:  position{line: 4768, col: 28, offset: 144398},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4765, col: 46, offset: 144258},
+								pos:  position{line: 4768, col: 46, offset: 144416},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4765, col: 65, offset: 144277},
+								pos:  position{line: 4768, col: 65, offset: 144435},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4765, col: 82, offset: 144294},
+								pos:  position{line: 4768, col: 82, offset: 144452},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12279,28 +12279,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4769, col: 1, offset: 144344},
+			pos:  position{line: 4772, col: 1, offset: 144502},
 			expr: &actionExpr{
-				pos: position{line: 4769, col: 20, offset: 144363},
+				pos: position{line: 4772, col: 20, offset: 144521},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4769, col: 20, offset: 144363},
+					pos: position{line: 4772, col: 20, offset: 144521},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4769, col: 20, offset: 144363},
+							pos:        position{line: 4772, col: 20, offset: 144521},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4769, col: 28, offset: 144371},
+							pos:  position{line: 4772, col: 28, offset: 144529},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4769, col: 34, offset: 144377},
+							pos:   position{line: 4772, col: 34, offset: 144535},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4769, col: 38, offset: 144381},
+								pos:  position{line: 4772, col: 38, offset: 144539},
 								name: "QuotedString",
 							},
 						},
@@ -12310,28 +12310,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4778, col: 1, offset: 144593},
+			pos:  position{line: 4781, col: 1, offset: 144751},
 			expr: &actionExpr{
-				pos: position{line: 4778, col: 21, offset: 144613},
+				pos: position{line: 4781, col: 21, offset: 144771},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4778, col: 21, offset: 144613},
+					pos: position{line: 4781, col: 21, offset: 144771},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4778, col: 21, offset: 144613},
+							pos:        position{line: 4781, col: 21, offset: 144771},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4778, col: 34, offset: 144626},
+							pos:  position{line: 4781, col: 34, offset: 144784},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4778, col: 40, offset: 144632},
+							pos:   position{line: 4781, col: 40, offset: 144790},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4778, col: 47, offset: 144639},
+								pos:  position{line: 4781, col: 47, offset: 144797},
 								name: "IntegerAsString",
 							},
 						},
@@ -12341,28 +12341,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4791, col: 1, offset: 145045},
+			pos:  position{line: 4794, col: 1, offset: 145203},
 			expr: &actionExpr{
-				pos: position{line: 4791, col: 19, offset: 145063},
+				pos: position{line: 4794, col: 19, offset: 145221},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4791, col: 19, offset: 145063},
+					pos: position{line: 4794, col: 19, offset: 145221},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4791, col: 19, offset: 145063},
+							pos:        position{line: 4794, col: 19, offset: 145221},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4791, col: 30, offset: 145074},
+							pos:  position{line: 4794, col: 30, offset: 145232},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4791, col: 36, offset: 145080},
+							pos:   position{line: 4794, col: 36, offset: 145238},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4791, col: 40, offset: 145084},
+								pos:  position{line: 4794, col: 40, offset: 145242},
 								name: "QuotedString",
 							},
 						},
@@ -12372,78 +12372,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4800, col: 1, offset: 145299},
+			pos:  position{line: 4803, col: 1, offset: 145457},
 			expr: &actionExpr{
-				pos: position{line: 4800, col: 24, offset: 145322},
+				pos: position{line: 4803, col: 24, offset: 145480},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4800, col: 24, offset: 145322},
+					pos: position{line: 4803, col: 24, offset: 145480},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4800, col: 24, offset: 145322},
+							pos:   position{line: 4803, col: 24, offset: 145480},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 34, offset: 145332},
+								pos:  position{line: 4803, col: 34, offset: 145490},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 47, offset: 145345},
+							pos:  position{line: 4803, col: 47, offset: 145503},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4800, col: 53, offset: 145351},
+							pos:   position{line: 4803, col: 53, offset: 145509},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 63, offset: 145361},
+								pos:  position{line: 4803, col: 63, offset: 145519},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 76, offset: 145374},
+							pos:  position{line: 4803, col: 76, offset: 145532},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4800, col: 82, offset: 145380},
+							pos:   position{line: 4803, col: 82, offset: 145538},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 95, offset: 145393},
+								pos:  position{line: 4803, col: 95, offset: 145551},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 108, offset: 145406},
+							pos:  position{line: 4803, col: 108, offset: 145564},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4800, col: 114, offset: 145412},
+							pos:   position{line: 4803, col: 114, offset: 145570},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 121, offset: 145419},
+								pos:  position{line: 4803, col: 121, offset: 145577},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 134, offset: 145432},
+							pos:  position{line: 4803, col: 134, offset: 145590},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4800, col: 140, offset: 145438},
+							pos:   position{line: 4803, col: 140, offset: 145596},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 153, offset: 145451},
+								pos:  position{line: 4803, col: 153, offset: 145609},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 166, offset: 145464},
+							pos:  position{line: 4803, col: 166, offset: 145622},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4800, col: 172, offset: 145470},
+							pos:   position{line: 4803, col: 172, offset: 145628},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4800, col: 179, offset: 145477},
+								pos:  position{line: 4803, col: 179, offset: 145635},
 								name: "QuotedString",
 							},
 						},
@@ -12453,28 +12453,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4818, col: 1, offset: 146053},
+			pos:  position{line: 4821, col: 1, offset: 146211},
 			expr: &actionExpr{
-				pos: position{line: 4818, col: 20, offset: 146072},
+				pos: position{line: 4821, col: 20, offset: 146230},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4818, col: 20, offset: 146072},
+					pos: position{line: 4821, col: 20, offset: 146230},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4818, col: 20, offset: 146072},
+							pos:  position{line: 4821, col: 20, offset: 146230},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4818, col: 25, offset: 146077},
+							pos:  position{line: 4821, col: 25, offset: 146235},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4818, col: 40, offset: 146092},
+							pos:   position{line: 4821, col: 40, offset: 146250},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4818, col: 55, offset: 146107},
+								pos: position{line: 4821, col: 55, offset: 146265},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4818, col: 55, offset: 146107},
+									pos:  position{line: 4821, col: 55, offset: 146265},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12485,42 +12485,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4825, col: 1, offset: 146260},
+			pos:  position{line: 4828, col: 1, offset: 146418},
 			expr: &actionExpr{
-				pos: position{line: 4825, col: 28, offset: 146287},
+				pos: position{line: 4828, col: 28, offset: 146445},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4825, col: 28, offset: 146287},
+					pos: position{line: 4828, col: 28, offset: 146445},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4825, col: 28, offset: 146287},
+							pos:  position{line: 4828, col: 28, offset: 146445},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4825, col: 34, offset: 146293},
+							pos:   position{line: 4828, col: 34, offset: 146451},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4825, col: 40, offset: 146299},
+								pos: position{line: 4828, col: 40, offset: 146457},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4825, col: 40, offset: 146299},
+									pos:  position{line: 4828, col: 40, offset: 146457},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4825, col: 60, offset: 146319},
+							pos:   position{line: 4828, col: 60, offset: 146477},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4825, col: 65, offset: 146324},
+								pos: position{line: 4828, col: 65, offset: 146482},
 								expr: &seqExpr{
-									pos: position{line: 4825, col: 66, offset: 146325},
+									pos: position{line: 4828, col: 66, offset: 146483},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4825, col: 66, offset: 146325},
+											pos:  position{line: 4828, col: 66, offset: 146483},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4825, col: 72, offset: 146331},
+											pos:  position{line: 4828, col: 72, offset: 146489},
 											name: "EventCountArgument",
 										},
 									},
@@ -12533,30 +12533,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4881, col: 1, offset: 148208},
+			pos:  position{line: 4884, col: 1, offset: 148366},
 			expr: &actionExpr{
-				pos: position{line: 4881, col: 23, offset: 148230},
+				pos: position{line: 4884, col: 23, offset: 148388},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4881, col: 23, offset: 148230},
+					pos:   position{line: 4884, col: 23, offset: 148388},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4881, col: 28, offset: 148235},
+						pos: position{line: 4884, col: 28, offset: 148393},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4881, col: 28, offset: 148235},
+								pos:  position{line: 4884, col: 28, offset: 148393},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4881, col: 41, offset: 148248},
+								pos:  position{line: 4884, col: 41, offset: 148406},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4881, col: 58, offset: 148265},
+								pos:  position{line: 4884, col: 58, offset: 148423},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4881, col: 76, offset: 148283},
+								pos:  position{line: 4884, col: 76, offset: 148441},
 								name: "ListVixField",
 							},
 						},
@@ -12566,28 +12566,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4885, col: 1, offset: 148322},
+			pos:  position{line: 4888, col: 1, offset: 148480},
 			expr: &actionExpr{
-				pos: position{line: 4885, col: 15, offset: 148336},
+				pos: position{line: 4888, col: 15, offset: 148494},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4885, col: 15, offset: 148336},
+					pos: position{line: 4888, col: 15, offset: 148494},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4885, col: 15, offset: 148336},
+							pos:        position{line: 4888, col: 15, offset: 148494},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4885, col: 23, offset: 148344},
+							pos:  position{line: 4888, col: 23, offset: 148502},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4885, col: 29, offset: 148350},
+							pos:   position{line: 4888, col: 29, offset: 148508},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4885, col: 35, offset: 148356},
+								pos:  position{line: 4888, col: 35, offset: 148514},
 								name: "IndexName",
 							},
 						},
@@ -12597,28 +12597,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4888, col: 1, offset: 148412},
+			pos:  position{line: 4891, col: 1, offset: 148570},
 			expr: &actionExpr{
-				pos: position{line: 4888, col: 19, offset: 148430},
+				pos: position{line: 4891, col: 19, offset: 148588},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4888, col: 19, offset: 148430},
+					pos: position{line: 4891, col: 19, offset: 148588},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4888, col: 19, offset: 148430},
+							pos:        position{line: 4891, col: 19, offset: 148588},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4888, col: 31, offset: 148442},
+							pos:  position{line: 4891, col: 31, offset: 148600},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4888, col: 37, offset: 148448},
+							pos:   position{line: 4891, col: 37, offset: 148606},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4888, col: 43, offset: 148454},
+								pos:  position{line: 4891, col: 43, offset: 148612},
 								name: "Boolean",
 							},
 						},
@@ -12628,28 +12628,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4891, col: 1, offset: 148530},
+			pos:  position{line: 4894, col: 1, offset: 148688},
 			expr: &actionExpr{
-				pos: position{line: 4891, col: 20, offset: 148549},
+				pos: position{line: 4894, col: 20, offset: 148707},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4891, col: 20, offset: 148549},
+					pos: position{line: 4894, col: 20, offset: 148707},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4891, col: 20, offset: 148549},
+							pos:        position{line: 4894, col: 20, offset: 148707},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4891, col: 34, offset: 148563},
+							pos:  position{line: 4894, col: 34, offset: 148721},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4891, col: 40, offset: 148569},
+							pos:   position{line: 4894, col: 40, offset: 148727},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4891, col: 46, offset: 148575},
+								pos:  position{line: 4894, col: 46, offset: 148733},
 								name: "Boolean",
 							},
 						},
@@ -12659,28 +12659,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4894, col: 1, offset: 148653},
+			pos:  position{line: 4897, col: 1, offset: 148811},
 			expr: &actionExpr{
-				pos: position{line: 4894, col: 17, offset: 148669},
+				pos: position{line: 4897, col: 17, offset: 148827},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4894, col: 17, offset: 148669},
+					pos: position{line: 4897, col: 17, offset: 148827},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4894, col: 17, offset: 148669},
+							pos:        position{line: 4897, col: 17, offset: 148827},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4894, col: 28, offset: 148680},
+							pos:  position{line: 4897, col: 28, offset: 148838},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4894, col: 34, offset: 148686},
+							pos:   position{line: 4897, col: 34, offset: 148844},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4894, col: 40, offset: 148692},
+								pos:  position{line: 4897, col: 40, offset: 148850},
 								name: "Boolean",
 							},
 						},
@@ -12690,24 +12690,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4898, col: 1, offset: 148768},
+			pos:  position{line: 4901, col: 1, offset: 148926},
 			expr: &actionExpr{
-				pos: position{line: 4898, col: 14, offset: 148781},
+				pos: position{line: 4901, col: 14, offset: 148939},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4898, col: 14, offset: 148781},
+					pos: position{line: 4901, col: 14, offset: 148939},
 					expr: &seqExpr{
-						pos: position{line: 4898, col: 15, offset: 148782},
+						pos: position{line: 4901, col: 15, offset: 148940},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4898, col: 15, offset: 148782},
+								pos: position{line: 4901, col: 15, offset: 148940},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4898, col: 16, offset: 148783},
+									pos:  position{line: 4901, col: 16, offset: 148941},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4898, col: 22, offset: 148789,
+								line: 4901, col: 22, offset: 148947,
 							},
 						},
 					},
@@ -12716,39 +12716,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4903, col: 1, offset: 148862},
+			pos:  position{line: 4906, col: 1, offset: 149020},
 			expr: &actionExpr{
-				pos: position{line: 4903, col: 18, offset: 148879},
+				pos: position{line: 4906, col: 18, offset: 149037},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4903, col: 18, offset: 148879},
+					pos: position{line: 4906, col: 18, offset: 149037},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4903, col: 18, offset: 148879},
+							pos:  position{line: 4906, col: 18, offset: 149037},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4903, col: 23, offset: 148884},
+							pos:  position{line: 4906, col: 23, offset: 149042},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4903, col: 36, offset: 148897},
+							pos:   position{line: 4906, col: 36, offset: 149055},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4903, col: 49, offset: 148910},
+								pos: position{line: 4906, col: 49, offset: 149068},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4903, col: 49, offset: 148910},
+									pos:  position{line: 4906, col: 49, offset: 149068},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4903, col: 70, offset: 148931},
+							pos:   position{line: 4906, col: 70, offset: 149089},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4903, col: 77, offset: 148938},
+								pos: position{line: 4906, col: 77, offset: 149096},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4903, col: 77, offset: 148938},
+									pos:  position{line: 4906, col: 77, offset: 149096},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12759,32 +12759,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4932, col: 1, offset: 149665},
+			pos:  position{line: 4935, col: 1, offset: 149823},
 			expr: &actionExpr{
-				pos: position{line: 4932, col: 24, offset: 149688},
+				pos: position{line: 4935, col: 24, offset: 149846},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4932, col: 24, offset: 149688},
+					pos: position{line: 4935, col: 24, offset: 149846},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4932, col: 24, offset: 149688},
+							pos:  position{line: 4935, col: 24, offset: 149846},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4932, col: 30, offset: 149694},
+							pos:        position{line: 4935, col: 30, offset: 149852},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4932, col: 38, offset: 149702},
+							pos:  position{line: 4935, col: 38, offset: 149860},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4932, col: 44, offset: 149708},
+							pos:   position{line: 4935, col: 44, offset: 149866},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4932, col: 48, offset: 149712},
+								pos:  position{line: 4935, col: 48, offset: 149870},
 								name: "String",
 							},
 						},
@@ -12794,22 +12794,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 4936, col: 1, offset: 149758},
+			pos:  position{line: 4939, col: 1, offset: 149916},
 			expr: &actionExpr{
-				pos: position{line: 4936, col: 22, offset: 149779},
+				pos: position{line: 4939, col: 22, offset: 149937},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 4936, col: 22, offset: 149779},
+					pos: position{line: 4939, col: 22, offset: 149937},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4936, col: 22, offset: 149779},
+							pos:  position{line: 4939, col: 22, offset: 149937},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4936, col: 28, offset: 149785},
+							pos:   position{line: 4939, col: 28, offset: 149943},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4936, col: 38, offset: 149795},
+								pos:  position{line: 4939, col: 38, offset: 149953},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12819,36 +12819,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 4940, col: 1, offset: 149854},
+			pos:  position{line: 4943, col: 1, offset: 150012},
 			expr: &actionExpr{
-				pos: position{line: 4940, col: 18, offset: 149871},
+				pos: position{line: 4943, col: 18, offset: 150029},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4940, col: 18, offset: 149871},
+					pos: position{line: 4943, col: 18, offset: 150029},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4940, col: 18, offset: 149871},
+							pos:  position{line: 4943, col: 18, offset: 150029},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4940, col: 23, offset: 149876},
+							pos:  position{line: 4943, col: 23, offset: 150034},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 4940, col: 36, offset: 149889},
+							pos:   position{line: 4943, col: 36, offset: 150047},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4940, col: 42, offset: 149895},
+								pos:  position{line: 4943, col: 42, offset: 150053},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4940, col: 56, offset: 149909},
+							pos:   position{line: 4943, col: 56, offset: 150067},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4940, col: 62, offset: 149915},
+								pos: position{line: 4943, col: 62, offset: 150073},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4940, col: 62, offset: 149915},
+									pos:  position{line: 4943, col: 62, offset: 150073},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12859,22 +12859,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 4970, col: 1, offset: 150649},
+			pos:  position{line: 4973, col: 1, offset: 150807},
 			expr: &actionExpr{
-				pos: position{line: 4970, col: 18, offset: 150666},
+				pos: position{line: 4973, col: 18, offset: 150824},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 4970, col: 18, offset: 150666},
+					pos: position{line: 4973, col: 18, offset: 150824},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4970, col: 18, offset: 150666},
+							pos:  position{line: 4973, col: 18, offset: 150824},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4970, col: 24, offset: 150672},
+							pos:   position{line: 4973, col: 24, offset: 150830},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4970, col: 34, offset: 150682},
+								pos:  position{line: 4973, col: 34, offset: 150840},
 								name: "FieldName",
 							},
 						},
@@ -12884,32 +12884,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 4974, col: 1, offset: 150723},
+			pos:  position{line: 4977, col: 1, offset: 150881},
 			expr: &actionExpr{
-				pos: position{line: 4974, col: 18, offset: 150740},
+				pos: position{line: 4977, col: 18, offset: 150898},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4974, col: 18, offset: 150740},
+					pos: position{line: 4977, col: 18, offset: 150898},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4974, col: 18, offset: 150740},
+							pos:  position{line: 4977, col: 18, offset: 150898},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4974, col: 24, offset: 150746},
+							pos:        position{line: 4977, col: 24, offset: 150904},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4974, col: 32, offset: 150754},
+							pos:  position{line: 4977, col: 32, offset: 150912},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4974, col: 38, offset: 150760},
+							pos:   position{line: 4977, col: 38, offset: 150918},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4974, col: 47, offset: 150769},
+								pos:  position{line: 4977, col: 47, offset: 150927},
 								name: "IntegerAsString",
 							},
 						},
@@ -12919,26 +12919,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 4978, col: 1, offset: 150815},
+			pos:  position{line: 4981, col: 1, offset: 150973},
 			expr: &actionExpr{
-				pos: position{line: 4978, col: 16, offset: 150830},
+				pos: position{line: 4981, col: 16, offset: 150988},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 4978, col: 16, offset: 150830},
+					pos: position{line: 4981, col: 16, offset: 150988},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4978, col: 16, offset: 150830},
+							pos:  position{line: 4981, col: 16, offset: 150988},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4978, col: 22, offset: 150836},
+							pos:  position{line: 4981, col: 22, offset: 150994},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4978, col: 32, offset: 150846},
+							pos:   position{line: 4981, col: 32, offset: 151004},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4978, col: 42, offset: 150856},
+								pos:  position{line: 4981, col: 42, offset: 151014},
 								name: "BoolExpr",
 							},
 						},
@@ -12948,28 +12948,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 4982, col: 1, offset: 150916},
+			pos:  position{line: 4985, col: 1, offset: 151074},
 			expr: &actionExpr{
-				pos: position{line: 4982, col: 28, offset: 150943},
+				pos: position{line: 4985, col: 28, offset: 151101},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 4982, col: 28, offset: 150943},
+					pos: position{line: 4985, col: 28, offset: 151101},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4982, col: 28, offset: 150943},
+							pos:        position{line: 4985, col: 28, offset: 151101},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4982, col: 37, offset: 150952},
+							pos:  position{line: 4985, col: 37, offset: 151110},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4982, col: 43, offset: 150958},
+							pos:   position{line: 4985, col: 43, offset: 151116},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4982, col: 51, offset: 150966},
+								pos:  position{line: 4985, col: 51, offset: 151124},
 								name: "Boolean",
 							},
 						},
@@ -12979,28 +12979,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 4991, col: 1, offset: 151150},
+			pos:  position{line: 4994, col: 1, offset: 151308},
 			expr: &actionExpr{
-				pos: position{line: 4991, col: 28, offset: 151177},
+				pos: position{line: 4994, col: 28, offset: 151335},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 4991, col: 28, offset: 151177},
+					pos: position{line: 4994, col: 28, offset: 151335},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4991, col: 28, offset: 151177},
+							pos:        position{line: 4994, col: 28, offset: 151335},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4991, col: 37, offset: 151186},
+							pos:  position{line: 4994, col: 37, offset: 151344},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4991, col: 43, offset: 151192},
+							pos:   position{line: 4994, col: 43, offset: 151350},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4991, col: 51, offset: 151200},
+								pos:  position{line: 4994, col: 51, offset: 151358},
 								name: "Boolean",
 							},
 						},
@@ -13010,28 +13010,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5000, col: 1, offset: 151384},
+			pos:  position{line: 5003, col: 1, offset: 151542},
 			expr: &actionExpr{
-				pos: position{line: 5000, col: 27, offset: 151410},
+				pos: position{line: 5003, col: 27, offset: 151568},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5000, col: 27, offset: 151410},
+					pos: position{line: 5003, col: 27, offset: 151568},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5000, col: 27, offset: 151410},
+							pos:        position{line: 5003, col: 27, offset: 151568},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5000, col: 35, offset: 151418},
+							pos:  position{line: 5003, col: 35, offset: 151576},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5000, col: 41, offset: 151424},
+							pos:   position{line: 5003, col: 41, offset: 151582},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5000, col: 48, offset: 151431},
+								pos:  position{line: 5003, col: 48, offset: 151589},
 								name: "PositiveInteger",
 							},
 						},
@@ -13041,28 +13041,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5009, col: 1, offset: 151622},
+			pos:  position{line: 5012, col: 1, offset: 151780},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 25, offset: 151646},
+				pos: position{line: 5012, col: 25, offset: 151804},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 25, offset: 151646},
+					pos: position{line: 5012, col: 25, offset: 151804},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5009, col: 25, offset: 151646},
+							pos:        position{line: 5012, col: 25, offset: 151804},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 31, offset: 151652},
+							pos:  position{line: 5012, col: 31, offset: 151810},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 37, offset: 151658},
+							pos:   position{line: 5012, col: 37, offset: 151816},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5009, col: 44, offset: 151665},
+								pos:  position{line: 5012, col: 44, offset: 151823},
 								name: "PositiveInteger",
 							},
 						},
@@ -13072,30 +13072,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5018, col: 1, offset: 151852},
+			pos:  position{line: 5021, col: 1, offset: 152010},
 			expr: &actionExpr{
-				pos: position{line: 5018, col: 22, offset: 151873},
+				pos: position{line: 5021, col: 22, offset: 152031},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5018, col: 22, offset: 151873},
+					pos:   position{line: 5021, col: 22, offset: 152031},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5018, col: 41, offset: 151892},
+						pos: position{line: 5021, col: 41, offset: 152050},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5018, col: 41, offset: 151892},
+								pos:  position{line: 5021, col: 41, offset: 152050},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5018, col: 67, offset: 151918},
+								pos:  position{line: 5021, col: 67, offset: 152076},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5018, col: 93, offset: 151944},
+								pos:  position{line: 5021, col: 93, offset: 152102},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5018, col: 118, offset: 151969},
+								pos:  position{line: 5021, col: 118, offset: 152127},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13105,35 +13105,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5022, col: 1, offset: 152030},
+			pos:  position{line: 5025, col: 1, offset: 152188},
 			expr: &actionExpr{
-				pos: position{line: 5022, col: 26, offset: 152055},
+				pos: position{line: 5025, col: 26, offset: 152213},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5022, col: 26, offset: 152055},
+					pos: position{line: 5025, col: 26, offset: 152213},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5022, col: 26, offset: 152055},
+							pos:   position{line: 5025, col: 26, offset: 152213},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5022, col: 34, offset: 152063},
+								pos:  position{line: 5025, col: 34, offset: 152221},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5022, col: 53, offset: 152082},
+							pos:   position{line: 5025, col: 53, offset: 152240},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5022, col: 58, offset: 152087},
+								pos: position{line: 5025, col: 58, offset: 152245},
 								expr: &seqExpr{
-									pos: position{line: 5022, col: 59, offset: 152088},
+									pos: position{line: 5025, col: 59, offset: 152246},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5022, col: 59, offset: 152088},
+											pos:  position{line: 5025, col: 59, offset: 152246},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5022, col: 65, offset: 152094},
+											pos:  position{line: 5025, col: 65, offset: 152252},
 											name: "InputLookupOption",
 										},
 									},
@@ -13146,35 +13146,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5064, col: 1, offset: 153540},
+			pos:  position{line: 5067, col: 1, offset: 153698},
 			expr: &actionExpr{
-				pos: position{line: 5064, col: 21, offset: 153560},
+				pos: position{line: 5067, col: 21, offset: 153718},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5064, col: 21, offset: 153560},
+					pos: position{line: 5067, col: 21, offset: 153718},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5064, col: 21, offset: 153560},
+							pos:  position{line: 5067, col: 21, offset: 153718},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5064, col: 26, offset: 153565},
+							pos:  position{line: 5067, col: 26, offset: 153723},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5064, col: 42, offset: 153581},
+							pos:   position{line: 5067, col: 42, offset: 153739},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5064, col: 60, offset: 153599},
+								pos: position{line: 5067, col: 60, offset: 153757},
 								expr: &seqExpr{
-									pos: position{line: 5064, col: 61, offset: 153600},
+									pos: position{line: 5067, col: 61, offset: 153758},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5064, col: 61, offset: 153600},
+											pos:  position{line: 5067, col: 61, offset: 153758},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5064, col: 83, offset: 153622},
+											pos:  position{line: 5067, col: 83, offset: 153780},
 											name: "SPACE",
 										},
 									},
@@ -13182,20 +13182,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5064, col: 91, offset: 153630},
+							pos:   position{line: 5067, col: 91, offset: 153788},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5064, col: 101, offset: 153640},
+								pos:  position{line: 5067, col: 101, offset: 153798},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5064, col: 109, offset: 153648},
+							pos:   position{line: 5067, col: 109, offset: 153806},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5064, col: 121, offset: 153660},
+								pos: position{line: 5067, col: 121, offset: 153818},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5064, col: 122, offset: 153661},
+									pos:  position{line: 5067, col: 122, offset: 153819},
 									name: "WhereClause",
 								},
 							},
@@ -13206,15 +13206,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5086, col: 1, offset: 154311},
+			pos:  position{line: 5089, col: 1, offset: 154469},
 			expr: &actionExpr{
-				pos: position{line: 5086, col: 24, offset: 154334},
+				pos: position{line: 5089, col: 24, offset: 154492},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5086, col: 24, offset: 154334},
+					pos:   position{line: 5089, col: 24, offset: 154492},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5086, col: 41, offset: 154351},
+						pos:  position{line: 5089, col: 41, offset: 154509},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13222,26 +13222,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5097, col: 1, offset: 154750},
+			pos:  position{line: 5100, col: 1, offset: 154908},
 			expr: &actionExpr{
-				pos: position{line: 5097, col: 20, offset: 154769},
+				pos: position{line: 5100, col: 20, offset: 154927},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5097, col: 20, offset: 154769},
+					pos:   position{line: 5100, col: 20, offset: 154927},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5097, col: 28, offset: 154777},
+						pos: position{line: 5100, col: 28, offset: 154935},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5097, col: 28, offset: 154777},
+								pos:  position{line: 5100, col: 28, offset: 154935},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5097, col: 52, offset: 154801},
+								pos:  position{line: 5100, col: 52, offset: 154959},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5097, col: 68, offset: 154817},
+								pos:  position{line: 5100, col: 68, offset: 154975},
 								name: "MaxOutOption",
 							},
 						},
@@ -13251,28 +13251,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5102, col: 1, offset: 154915},
+			pos:  position{line: 5105, col: 1, offset: 155073},
 			expr: &actionExpr{
-				pos: position{line: 5102, col: 26, offset: 154940},
+				pos: position{line: 5105, col: 26, offset: 155098},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5102, col: 26, offset: 154940},
+					pos: position{line: 5105, col: 26, offset: 155098},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5102, col: 26, offset: 154940},
+							pos:        position{line: 5105, col: 26, offset: 155098},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5102, col: 44, offset: 154958},
+							pos:  position{line: 5105, col: 44, offset: 155116},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5102, col: 50, offset: 154964},
+							pos:   position{line: 5105, col: 50, offset: 155122},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5102, col: 58, offset: 154972},
+								pos:  position{line: 5105, col: 58, offset: 155130},
 								name: "Boolean",
 							},
 						},
@@ -13282,28 +13282,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5109, col: 1, offset: 155111},
+			pos:  position{line: 5112, col: 1, offset: 155269},
 			expr: &actionExpr{
-				pos: position{line: 5109, col: 18, offset: 155128},
+				pos: position{line: 5112, col: 18, offset: 155286},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5109, col: 18, offset: 155128},
+					pos: position{line: 5112, col: 18, offset: 155286},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5109, col: 18, offset: 155128},
+							pos:        position{line: 5112, col: 18, offset: 155286},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5109, col: 28, offset: 155138},
+							pos:  position{line: 5112, col: 28, offset: 155296},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5109, col: 34, offset: 155144},
+							pos:   position{line: 5112, col: 34, offset: 155302},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5109, col: 39, offset: 155149},
+								pos:  position{line: 5112, col: 39, offset: 155307},
 								name: "IntegerAsString",
 							},
 						},
@@ -13313,28 +13313,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5120, col: 1, offset: 155450},
+			pos:  position{line: 5123, col: 1, offset: 155608},
 			expr: &actionExpr{
-				pos: position{line: 5120, col: 17, offset: 155466},
+				pos: position{line: 5123, col: 17, offset: 155624},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5120, col: 17, offset: 155466},
+					pos: position{line: 5123, col: 17, offset: 155624},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5120, col: 17, offset: 155466},
+							pos:        position{line: 5123, col: 17, offset: 155624},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5120, col: 26, offset: 155475},
+							pos:  position{line: 5123, col: 26, offset: 155633},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5120, col: 32, offset: 155481},
+							pos:   position{line: 5123, col: 32, offset: 155639},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5120, col: 36, offset: 155485},
+								pos:  position{line: 5123, col: 36, offset: 155643},
 								name: "IntegerAsString",
 							},
 						},
@@ -13344,43 +13344,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5132, col: 1, offset: 155840},
+			pos:  position{line: 5135, col: 1, offset: 155998},
 			expr: &actionExpr{
-				pos: position{line: 5132, col: 14, offset: 155853},
+				pos: position{line: 5135, col: 14, offset: 156011},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5132, col: 14, offset: 155853},
+					pos: position{line: 5135, col: 14, offset: 156011},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5132, col: 14, offset: 155853},
+							pos:        position{line: 5135, col: 14, offset: 156011},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5132, col: 18, offset: 155857},
+							pos: position{line: 5135, col: 18, offset: 156015},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5132, col: 18, offset: 155857},
+								pos:  position{line: 5135, col: 18, offset: 156015},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5132, col: 25, offset: 155864},
+							pos:   position{line: 5135, col: 25, offset: 156022},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5132, col: 32, offset: 155871},
+								pos:  position{line: 5135, col: 32, offset: 156029},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5132, col: 44, offset: 155883},
+							pos: position{line: 5135, col: 44, offset: 156041},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5132, col: 44, offset: 155883},
+								pos:  position{line: 5135, col: 44, offset: 156041},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5132, col: 51, offset: 155890},
+							pos:        position{line: 5135, col: 51, offset: 156048},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13391,35 +13391,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5137, col: 1, offset: 155979},
+			pos:  position{line: 5140, col: 1, offset: 156137},
 			expr: &actionExpr{
-				pos: position{line: 5137, col: 25, offset: 156003},
+				pos: position{line: 5140, col: 25, offset: 156161},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5137, col: 25, offset: 156003},
+					pos: position{line: 5140, col: 25, offset: 156161},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5137, col: 25, offset: 156003},
+							pos:   position{line: 5140, col: 25, offset: 156161},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5137, col: 31, offset: 156009},
+								pos:  position{line: 5140, col: 31, offset: 156167},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5137, col: 47, offset: 156025},
+							pos:   position{line: 5140, col: 47, offset: 156183},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5137, col: 52, offset: 156030},
+								pos: position{line: 5140, col: 52, offset: 156188},
 								expr: &seqExpr{
-									pos: position{line: 5137, col: 53, offset: 156031},
+									pos: position{line: 5140, col: 53, offset: 156189},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5137, col: 53, offset: 156031},
+											pos:  position{line: 5140, col: 53, offset: 156189},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5137, col: 59, offset: 156037},
+											pos:  position{line: 5140, col: 59, offset: 156195},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13432,37 +13432,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5164, col: 1, offset: 156847},
+			pos:  position{line: 5167, col: 1, offset: 157005},
 			expr: &actionExpr{
-				pos: position{line: 5164, col: 16, offset: 156862},
+				pos: position{line: 5167, col: 16, offset: 157020},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5164, col: 16, offset: 156862},
+					pos: position{line: 5167, col: 16, offset: 157020},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5164, col: 16, offset: 156862},
+							pos:  position{line: 5167, col: 16, offset: 157020},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5164, col: 21, offset: 156867},
+							pos:  position{line: 5167, col: 21, offset: 157025},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5164, col: 32, offset: 156878},
+							pos:   position{line: 5167, col: 32, offset: 157036},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5164, col: 40, offset: 156886},
+								pos: position{line: 5167, col: 40, offset: 157044},
 								expr: &seqExpr{
-									pos: position{line: 5164, col: 41, offset: 156887},
+									pos: position{line: 5167, col: 41, offset: 157045},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5164, col: 41, offset: 156887},
+											pos:  position{line: 5167, col: 41, offset: 157045},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5164, col: 57, offset: 156903},
+											pos: position{line: 5167, col: 57, offset: 157061},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5164, col: 57, offset: 156903},
+												pos:  position{line: 5167, col: 57, offset: 157061},
 												name: "SPACE",
 											},
 										},
@@ -13471,10 +13471,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5164, col: 66, offset: 156912},
+							pos:   position{line: 5167, col: 66, offset: 157070},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5164, col: 76, offset: 156922},
+								pos:  position{line: 5167, col: 76, offset: 157080},
 								name: "Subsearch",
 							},
 						},
@@ -13484,128 +13484,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5208, col: 1, offset: 158494},
+			pos:  position{line: 5211, col: 1, offset: 158652},
 			expr: &choiceExpr{
-				pos: position{line: 5208, col: 12, offset: 158505},
+				pos: position{line: 5211, col: 12, offset: 158663},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 12, offset: 158505},
+						pos:  position{line: 5211, col: 12, offset: 158663},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 24, offset: 158517},
+						pos:  position{line: 5211, col: 24, offset: 158675},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 36, offset: 158529},
+						pos:  position{line: 5211, col: 36, offset: 158687},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 49, offset: 158542},
+						pos:  position{line: 5211, col: 49, offset: 158700},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 61, offset: 158554},
+						pos:  position{line: 5211, col: 61, offset: 158712},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 81, offset: 158574},
+						pos:  position{line: 5211, col: 81, offset: 158732},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 92, offset: 158585},
+						pos:  position{line: 5211, col: 92, offset: 158743},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 112, offset: 158605},
+						pos:  position{line: 5211, col: 112, offset: 158763},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 123, offset: 158616},
+						pos:  position{line: 5211, col: 123, offset: 158774},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 134, offset: 158627},
+						pos:  position{line: 5211, col: 134, offset: 158785},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 144, offset: 158637},
+						pos:  position{line: 5211, col: 144, offset: 158795},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 154, offset: 158647},
+						pos:  position{line: 5211, col: 154, offset: 158805},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 165, offset: 158658},
+						pos:  position{line: 5211, col: 165, offset: 158816},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 178, offset: 158671},
+						pos:  position{line: 5211, col: 178, offset: 158829},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 194, offset: 158687},
+						pos:  position{line: 5211, col: 194, offset: 158845},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 212, offset: 158705},
+						pos:  position{line: 5211, col: 212, offset: 158863},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 224, offset: 158717},
+						pos:  position{line: 5211, col: 224, offset: 158875},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 235, offset: 158728},
+						pos:  position{line: 5211, col: 235, offset: 158886},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 248, offset: 158741},
+						pos:  position{line: 5211, col: 248, offset: 158899},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 260, offset: 158753},
+						pos:  position{line: 5211, col: 260, offset: 158911},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 273, offset: 158766},
+						pos:  position{line: 5211, col: 273, offset: 158924},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 288, offset: 158781},
+						pos:  position{line: 5211, col: 288, offset: 158939},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 301, offset: 158794},
+						pos:  position{line: 5211, col: 301, offset: 158952},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 318, offset: 158811},
+						pos:  position{line: 5211, col: 318, offset: 158969},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 328, offset: 158821},
+						pos:  position{line: 5211, col: 328, offset: 158979},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 346, offset: 158839},
+						pos:  position{line: 5211, col: 346, offset: 158997},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 361, offset: 158854},
+						pos:  position{line: 5211, col: 361, offset: 159012},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 376, offset: 158869},
+						pos:  position{line: 5211, col: 376, offset: 159027},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 391, offset: 158884},
+						pos:  position{line: 5211, col: 391, offset: 159042},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5208, col: 409, offset: 158902},
+						pos:  position{line: 5211, col: 409, offset: 159060},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13613,18 +13613,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5209, col: 1, offset: 158914},
+			pos:  position{line: 5212, col: 1, offset: 159072},
 			expr: &seqExpr{
-				pos: position{line: 5209, col: 15, offset: 158928},
+				pos: position{line: 5212, col: 15, offset: 159086},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5209, col: 15, offset: 158928},
+						pos:        position{line: 5212, col: 15, offset: 159086},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5209, col: 24, offset: 158937},
+						pos:  position{line: 5212, col: 24, offset: 159095},
 						name: "SPACE",
 					},
 				},
@@ -13632,18 +13632,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5210, col: 1, offset: 158943},
+			pos:  position{line: 5213, col: 1, offset: 159101},
 			expr: &seqExpr{
-				pos: position{line: 5210, col: 14, offset: 158956},
+				pos: position{line: 5213, col: 14, offset: 159114},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5210, col: 14, offset: 158956},
+						pos:        position{line: 5213, col: 14, offset: 159114},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5210, col: 22, offset: 158964},
+						pos:  position{line: 5213, col: 22, offset: 159122},
 						name: "SPACE",
 					},
 				},
@@ -13651,18 +13651,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5211, col: 1, offset: 158970},
+			pos:  position{line: 5214, col: 1, offset: 159128},
 			expr: &seqExpr{
-				pos: position{line: 5211, col: 14, offset: 158983},
+				pos: position{line: 5214, col: 14, offset: 159141},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5211, col: 14, offset: 158983},
+						pos:        position{line: 5214, col: 14, offset: 159141},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5211, col: 22, offset: 158991},
+						pos:  position{line: 5214, col: 22, offset: 159149},
 						name: "SPACE",
 					},
 				},
@@ -13670,18 +13670,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5212, col: 1, offset: 158997},
+			pos:  position{line: 5215, col: 1, offset: 159155},
 			expr: &seqExpr{
-				pos: position{line: 5212, col: 20, offset: 159016},
+				pos: position{line: 5215, col: 20, offset: 159174},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5212, col: 20, offset: 159016},
+						pos:        position{line: 5215, col: 20, offset: 159174},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5212, col: 34, offset: 159030},
+						pos:  position{line: 5215, col: 34, offset: 159188},
 						name: "SPACE",
 					},
 				},
@@ -13689,18 +13689,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5213, col: 1, offset: 159036},
+			pos:  position{line: 5216, col: 1, offset: 159194},
 			expr: &seqExpr{
-				pos: position{line: 5213, col: 15, offset: 159050},
+				pos: position{line: 5216, col: 15, offset: 159208},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5213, col: 15, offset: 159050},
+						pos:        position{line: 5216, col: 15, offset: 159208},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5213, col: 24, offset: 159059},
+						pos:  position{line: 5216, col: 24, offset: 159217},
 						name: "SPACE",
 					},
 				},
@@ -13708,18 +13708,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5214, col: 1, offset: 159065},
+			pos:  position{line: 5217, col: 1, offset: 159223},
 			expr: &seqExpr{
-				pos: position{line: 5214, col: 14, offset: 159078},
+				pos: position{line: 5217, col: 14, offset: 159236},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5214, col: 14, offset: 159078},
+						pos:        position{line: 5217, col: 14, offset: 159236},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5214, col: 22, offset: 159086},
+						pos:  position{line: 5217, col: 22, offset: 159244},
 						name: "SPACE",
 					},
 				},
@@ -13727,9 +13727,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5215, col: 1, offset: 159092},
+			pos:  position{line: 5218, col: 1, offset: 159250},
 			expr: &litMatcher{
-				pos:        position{line: 5215, col: 22, offset: 159113},
+				pos:        position{line: 5218, col: 22, offset: 159271},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13737,16 +13737,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5216, col: 1, offset: 159120},
+			pos:  position{line: 5219, col: 1, offset: 159278},
 			expr: &seqExpr{
-				pos: position{line: 5216, col: 13, offset: 159132},
+				pos: position{line: 5219, col: 13, offset: 159290},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5216, col: 13, offset: 159132},
+						pos:  position{line: 5219, col: 13, offset: 159290},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5216, col: 31, offset: 159150},
+						pos:  position{line: 5219, col: 31, offset: 159308},
 						name: "SPACE",
 					},
 				},
@@ -13754,9 +13754,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5217, col: 1, offset: 159156},
+			pos:  position{line: 5220, col: 1, offset: 159314},
 			expr: &litMatcher{
-				pos:        position{line: 5217, col: 22, offset: 159177},
+				pos:        position{line: 5220, col: 22, offset: 159335},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13764,16 +13764,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5218, col: 1, offset: 159184},
+			pos:  position{line: 5221, col: 1, offset: 159342},
 			expr: &seqExpr{
-				pos: position{line: 5218, col: 13, offset: 159196},
+				pos: position{line: 5221, col: 13, offset: 159354},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5218, col: 13, offset: 159196},
+						pos:  position{line: 5221, col: 13, offset: 159354},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5218, col: 31, offset: 159214},
+						pos:  position{line: 5221, col: 31, offset: 159372},
 						name: "SPACE",
 					},
 				},
@@ -13781,18 +13781,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5219, col: 1, offset: 159220},
+			pos:  position{line: 5222, col: 1, offset: 159378},
 			expr: &seqExpr{
-				pos: position{line: 5219, col: 13, offset: 159232},
+				pos: position{line: 5222, col: 13, offset: 159390},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5219, col: 13, offset: 159232},
+						pos:        position{line: 5222, col: 13, offset: 159390},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5219, col: 20, offset: 159239},
+						pos:  position{line: 5222, col: 20, offset: 159397},
 						name: "SPACE",
 					},
 				},
@@ -13800,18 +13800,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5220, col: 1, offset: 159245},
+			pos:  position{line: 5223, col: 1, offset: 159403},
 			expr: &seqExpr{
-				pos: position{line: 5220, col: 12, offset: 159256},
+				pos: position{line: 5223, col: 12, offset: 159414},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5220, col: 12, offset: 159256},
+						pos:        position{line: 5223, col: 12, offset: 159414},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5220, col: 18, offset: 159262},
+						pos:  position{line: 5223, col: 18, offset: 159420},
 						name: "SPACE",
 					},
 				},
@@ -13819,18 +13819,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5221, col: 1, offset: 159268},
+			pos:  position{line: 5224, col: 1, offset: 159426},
 			expr: &seqExpr{
-				pos: position{line: 5221, col: 13, offset: 159280},
+				pos: position{line: 5224, col: 13, offset: 159438},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5221, col: 13, offset: 159280},
+						pos:        position{line: 5224, col: 13, offset: 159438},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5221, col: 20, offset: 159287},
+						pos:  position{line: 5224, col: 20, offset: 159445},
 						name: "SPACE",
 					},
 				},
@@ -13838,9 +13838,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5222, col: 1, offset: 159293},
+			pos:  position{line: 5225, col: 1, offset: 159451},
 			expr: &litMatcher{
-				pos:        position{line: 5222, col: 12, offset: 159304},
+				pos:        position{line: 5225, col: 12, offset: 159462},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13848,9 +13848,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5223, col: 1, offset: 159310},
+			pos:  position{line: 5226, col: 1, offset: 159468},
 			expr: &litMatcher{
-				pos:        position{line: 5223, col: 13, offset: 159322},
+				pos:        position{line: 5226, col: 13, offset: 159480},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13858,18 +13858,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5224, col: 1, offset: 159329},
+			pos:  position{line: 5227, col: 1, offset: 159487},
 			expr: &seqExpr{
-				pos: position{line: 5224, col: 15, offset: 159343},
+				pos: position{line: 5227, col: 15, offset: 159501},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5224, col: 15, offset: 159343},
+						pos:        position{line: 5227, col: 15, offset: 159501},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5224, col: 24, offset: 159352},
+						pos:  position{line: 5227, col: 24, offset: 159510},
 						name: "SPACE",
 					},
 				},
@@ -13877,18 +13877,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5225, col: 1, offset: 159358},
+			pos:  position{line: 5228, col: 1, offset: 159516},
 			expr: &seqExpr{
-				pos: position{line: 5225, col: 18, offset: 159375},
+				pos: position{line: 5228, col: 18, offset: 159533},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5225, col: 18, offset: 159375},
+						pos:        position{line: 5228, col: 18, offset: 159533},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5225, col: 30, offset: 159387},
+						pos:  position{line: 5228, col: 30, offset: 159545},
 						name: "SPACE",
 					},
 				},
@@ -13896,18 +13896,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5226, col: 1, offset: 159393},
+			pos:  position{line: 5229, col: 1, offset: 159551},
 			expr: &seqExpr{
-				pos: position{line: 5226, col: 12, offset: 159404},
+				pos: position{line: 5229, col: 12, offset: 159562},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5226, col: 12, offset: 159404},
+						pos:        position{line: 5229, col: 12, offset: 159562},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5226, col: 18, offset: 159410},
+						pos:  position{line: 5229, col: 18, offset: 159568},
 						name: "SPACE",
 					},
 				},
@@ -13915,9 +13915,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5227, col: 1, offset: 159416},
+			pos:  position{line: 5230, col: 1, offset: 159574},
 			expr: &litMatcher{
-				pos:        position{line: 5227, col: 13, offset: 159428},
+				pos:        position{line: 5230, col: 13, offset: 159586},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13925,18 +13925,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5228, col: 1, offset: 159435},
+			pos:  position{line: 5231, col: 1, offset: 159593},
 			expr: &seqExpr{
-				pos: position{line: 5228, col: 20, offset: 159454},
+				pos: position{line: 5231, col: 20, offset: 159612},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5228, col: 20, offset: 159454},
+						pos:        position{line: 5231, col: 20, offset: 159612},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5228, col: 34, offset: 159468},
+						pos:  position{line: 5231, col: 34, offset: 159626},
 						name: "SPACE",
 					},
 				},
@@ -13944,9 +13944,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5229, col: 1, offset: 159474},
+			pos:  position{line: 5232, col: 1, offset: 159632},
 			expr: &litMatcher{
-				pos:        position{line: 5229, col: 14, offset: 159487},
+				pos:        position{line: 5232, col: 14, offset: 159645},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13954,22 +13954,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5230, col: 1, offset: 159495},
+			pos:  position{line: 5233, col: 1, offset: 159653},
 			expr: &seqExpr{
-				pos: position{line: 5230, col: 21, offset: 159515},
+				pos: position{line: 5233, col: 21, offset: 159673},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5230, col: 21, offset: 159515},
+						pos:  position{line: 5233, col: 21, offset: 159673},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5230, col: 27, offset: 159521},
+						pos:        position{line: 5233, col: 27, offset: 159679},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5230, col: 36, offset: 159530},
+						pos:  position{line: 5233, col: 36, offset: 159688},
 						name: "SPACE",
 					},
 				},
@@ -13977,9 +13977,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5231, col: 1, offset: 159536},
+			pos:  position{line: 5234, col: 1, offset: 159694},
 			expr: &litMatcher{
-				pos:        position{line: 5231, col: 15, offset: 159550},
+				pos:        position{line: 5234, col: 15, offset: 159708},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -13987,9 +13987,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5232, col: 1, offset: 159559},
+			pos:  position{line: 5235, col: 1, offset: 159717},
 			expr: &litMatcher{
-				pos:        position{line: 5232, col: 14, offset: 159572},
+				pos:        position{line: 5235, col: 14, offset: 159730},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -13997,9 +13997,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5233, col: 1, offset: 159580},
+			pos:  position{line: 5236, col: 1, offset: 159738},
 			expr: &litMatcher{
-				pos:        position{line: 5233, col: 15, offset: 159594},
+				pos:        position{line: 5236, col: 15, offset: 159752},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14007,9 +14007,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5234, col: 1, offset: 159603},
+			pos:  position{line: 5237, col: 1, offset: 159761},
 			expr: &litMatcher{
-				pos:        position{line: 5234, col: 17, offset: 159619},
+				pos:        position{line: 5237, col: 17, offset: 159777},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14017,9 +14017,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5235, col: 1, offset: 159630},
+			pos:  position{line: 5238, col: 1, offset: 159788},
 			expr: &litMatcher{
-				pos:        position{line: 5235, col: 15, offset: 159644},
+				pos:        position{line: 5238, col: 15, offset: 159802},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14027,9 +14027,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5236, col: 1, offset: 159653},
+			pos:  position{line: 5239, col: 1, offset: 159811},
 			expr: &litMatcher{
-				pos:        position{line: 5236, col: 19, offset: 159671},
+				pos:        position{line: 5239, col: 19, offset: 159829},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14037,9 +14037,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5237, col: 1, offset: 159684},
+			pos:  position{line: 5240, col: 1, offset: 159842},
 			expr: &litMatcher{
-				pos:        position{line: 5237, col: 17, offset: 159700},
+				pos:        position{line: 5240, col: 17, offset: 159858},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14047,9 +14047,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5238, col: 1, offset: 159711},
+			pos:  position{line: 5241, col: 1, offset: 159869},
 			expr: &litMatcher{
-				pos:        position{line: 5238, col: 17, offset: 159727},
+				pos:        position{line: 5241, col: 17, offset: 159885},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14057,18 +14057,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5239, col: 1, offset: 159738},
+			pos:  position{line: 5242, col: 1, offset: 159896},
 			expr: &seqExpr{
-				pos: position{line: 5239, col: 20, offset: 159757},
+				pos: position{line: 5242, col: 20, offset: 159915},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5239, col: 20, offset: 159757},
+						pos:        position{line: 5242, col: 20, offset: 159915},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5239, col: 34, offset: 159771},
+						pos:  position{line: 5242, col: 34, offset: 159929},
 						name: "SPACE",
 					},
 				},
@@ -14076,28 +14076,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5240, col: 1, offset: 159777},
+			pos:  position{line: 5243, col: 1, offset: 159935},
 			expr: &seqExpr{
-				pos: position{line: 5240, col: 16, offset: 159792},
+				pos: position{line: 5243, col: 16, offset: 159950},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5240, col: 16, offset: 159792},
+						pos: position{line: 5243, col: 16, offset: 159950},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5240, col: 16, offset: 159792},
+							pos:  position{line: 5243, col: 16, offset: 159950},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5240, col: 24, offset: 159800},
+						pos: position{line: 5243, col: 24, offset: 159958},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5240, col: 24, offset: 159800},
+								pos:        position{line: 5243, col: 24, offset: 159958},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5240, col: 30, offset: 159806},
+								pos:        position{line: 5243, col: 30, offset: 159964},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14105,9 +14105,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5240, col: 35, offset: 159811},
+						pos: position{line: 5243, col: 35, offset: 159969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5240, col: 35, offset: 159811},
+							pos:  position{line: 5243, col: 35, offset: 159969},
 							name: "SPACE",
 						},
 					},
@@ -14116,9 +14116,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5241, col: 1, offset: 159818},
+			pos:  position{line: 5244, col: 1, offset: 159976},
 			expr: &litMatcher{
-				pos:        position{line: 5241, col: 17, offset: 159834},
+				pos:        position{line: 5244, col: 17, offset: 159992},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14126,18 +14126,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5242, col: 1, offset: 159845},
+			pos:  position{line: 5245, col: 1, offset: 160003},
 			expr: &seqExpr{
-				pos: position{line: 5242, col: 15, offset: 159859},
+				pos: position{line: 5245, col: 15, offset: 160017},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5242, col: 15, offset: 159859},
+						pos:        position{line: 5245, col: 15, offset: 160017},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5242, col: 24, offset: 159868},
+						pos:  position{line: 5245, col: 24, offset: 160026},
 						name: "SPACE",
 					},
 				},
@@ -14145,115 +14145,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5245, col: 1, offset: 159978},
+			pos:  position{line: 5248, col: 1, offset: 160136},
 			expr: &choiceExpr{
-				pos: position{line: 5245, col: 16, offset: 159993},
+				pos: position{line: 5248, col: 16, offset: 160151},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5245, col: 16, offset: 159993},
+						pos:        position{line: 5248, col: 16, offset: 160151},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5245, col: 47, offset: 160024},
+						pos:        position{line: 5248, col: 47, offset: 160182},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5245, col: 55, offset: 160032},
+						pos:        position{line: 5248, col: 55, offset: 160190},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 16, offset: 160055},
+						pos:        position{line: 5249, col: 16, offset: 160213},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 26, offset: 160065},
+						pos:        position{line: 5249, col: 26, offset: 160223},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 34, offset: 160073},
+						pos:        position{line: 5249, col: 34, offset: 160231},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 42, offset: 160081},
+						pos:        position{line: 5249, col: 42, offset: 160239},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 50, offset: 160089},
+						pos:        position{line: 5249, col: 50, offset: 160247},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 58, offset: 160097},
+						pos:        position{line: 5249, col: 58, offset: 160255},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5246, col: 66, offset: 160105},
+						pos:        position{line: 5249, col: 66, offset: 160263},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 16, offset: 160127},
+						pos:        position{line: 5250, col: 16, offset: 160285},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 26, offset: 160137},
+						pos:        position{line: 5250, col: 26, offset: 160295},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 34, offset: 160145},
+						pos:        position{line: 5250, col: 34, offset: 160303},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 42, offset: 160153},
+						pos:        position{line: 5250, col: 42, offset: 160311},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 50, offset: 160161},
+						pos:        position{line: 5250, col: 50, offset: 160319},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 58, offset: 160169},
+						pos:        position{line: 5250, col: 58, offset: 160327},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 66, offset: 160177},
+						pos:        position{line: 5250, col: 66, offset: 160335},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5247, col: 74, offset: 160185},
+						pos:        position{line: 5250, col: 74, offset: 160343},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14263,25 +14263,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5248, col: 1, offset: 160191},
+			pos:  position{line: 5251, col: 1, offset: 160349},
 			expr: &choiceExpr{
-				pos: position{line: 5248, col: 16, offset: 160206},
+				pos: position{line: 5251, col: 16, offset: 160364},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5248, col: 16, offset: 160206},
+						pos:        position{line: 5251, col: 16, offset: 160364},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5248, col: 30, offset: 160220},
+						pos:        position{line: 5251, col: 30, offset: 160378},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5248, col: 36, offset: 160226},
+						pos:        position{line: 5251, col: 36, offset: 160384},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14291,18 +14291,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5252, col: 1, offset: 160382},
+			pos:  position{line: 5255, col: 1, offset: 160540},
 			expr: &seqExpr{
-				pos: position{line: 5252, col: 8, offset: 160389},
+				pos: position{line: 5255, col: 8, offset: 160547},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5252, col: 8, offset: 160389},
+						pos:        position{line: 5255, col: 8, offset: 160547},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5252, col: 14, offset: 160395},
+						pos:  position{line: 5255, col: 14, offset: 160553},
 						name: "SPACE",
 					},
 				},
@@ -14310,22 +14310,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5253, col: 1, offset: 160401},
+			pos:  position{line: 5256, col: 1, offset: 160559},
 			expr: &seqExpr{
-				pos: position{line: 5253, col: 7, offset: 160407},
+				pos: position{line: 5256, col: 7, offset: 160565},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5253, col: 7, offset: 160407},
+						pos:  position{line: 5256, col: 7, offset: 160565},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5253, col: 13, offset: 160413},
+						pos:        position{line: 5256, col: 13, offset: 160571},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5253, col: 18, offset: 160418},
+						pos:  position{line: 5256, col: 18, offset: 160576},
 						name: "SPACE",
 					},
 				},
@@ -14333,22 +14333,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5254, col: 1, offset: 160424},
+			pos:  position{line: 5257, col: 1, offset: 160582},
 			expr: &seqExpr{
-				pos: position{line: 5254, col: 8, offset: 160431},
+				pos: position{line: 5257, col: 8, offset: 160589},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5254, col: 8, offset: 160431},
+						pos:  position{line: 5257, col: 8, offset: 160589},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5254, col: 14, offset: 160437},
+						pos:        position{line: 5257, col: 14, offset: 160595},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5254, col: 20, offset: 160443},
+						pos:  position{line: 5257, col: 20, offset: 160601},
 						name: "SPACE",
 					},
 				},
@@ -14356,22 +14356,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5255, col: 1, offset: 160449},
+			pos:  position{line: 5258, col: 1, offset: 160607},
 			expr: &seqExpr{
-				pos: position{line: 5255, col: 9, offset: 160457},
+				pos: position{line: 5258, col: 9, offset: 160615},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5255, col: 9, offset: 160457},
+						pos:  position{line: 5258, col: 9, offset: 160615},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5255, col: 24, offset: 160472},
+						pos:        position{line: 5258, col: 24, offset: 160630},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5255, col: 28, offset: 160476},
+						pos:  position{line: 5258, col: 28, offset: 160634},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14379,22 +14379,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5256, col: 1, offset: 160491},
+			pos:  position{line: 5259, col: 1, offset: 160649},
 			expr: &seqExpr{
-				pos: position{line: 5256, col: 7, offset: 160497},
+				pos: position{line: 5259, col: 7, offset: 160655},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5256, col: 7, offset: 160497},
+						pos:  position{line: 5259, col: 7, offset: 160655},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5256, col: 13, offset: 160503},
+						pos:        position{line: 5259, col: 13, offset: 160661},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5256, col: 19, offset: 160509},
+						pos:  position{line: 5259, col: 19, offset: 160667},
 						name: "SPACE",
 					},
 				},
@@ -14402,22 +14402,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5257, col: 1, offset: 160535},
+			pos:  position{line: 5260, col: 1, offset: 160693},
 			expr: &seqExpr{
-				pos: position{line: 5257, col: 7, offset: 160541},
+				pos: position{line: 5260, col: 7, offset: 160699},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5257, col: 7, offset: 160541},
+						pos:  position{line: 5260, col: 7, offset: 160699},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5257, col: 13, offset: 160547},
+						pos:        position{line: 5260, col: 13, offset: 160705},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5257, col: 19, offset: 160553},
+						pos:  position{line: 5260, col: 19, offset: 160711},
 						name: "SPACE",
 					},
 				},
@@ -14425,22 +14425,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5259, col: 1, offset: 160580},
+			pos:  position{line: 5262, col: 1, offset: 160738},
 			expr: &seqExpr{
-				pos: position{line: 5259, col: 10, offset: 160589},
+				pos: position{line: 5262, col: 10, offset: 160747},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5259, col: 10, offset: 160589},
+						pos:  position{line: 5262, col: 10, offset: 160747},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5259, col: 25, offset: 160604},
+						pos:        position{line: 5262, col: 25, offset: 160762},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5259, col: 29, offset: 160608},
+						pos:  position{line: 5262, col: 29, offset: 160766},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14448,22 +14448,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5260, col: 1, offset: 160623},
+			pos:  position{line: 5263, col: 1, offset: 160781},
 			expr: &seqExpr{
-				pos: position{line: 5260, col: 10, offset: 160632},
+				pos: position{line: 5263, col: 10, offset: 160790},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5260, col: 10, offset: 160632},
+						pos:  position{line: 5263, col: 10, offset: 160790},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5260, col: 25, offset: 160647},
+						pos:        position{line: 5263, col: 25, offset: 160805},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5260, col: 29, offset: 160651},
+						pos:  position{line: 5263, col: 29, offset: 160809},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14471,9 +14471,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5261, col: 1, offset: 160666},
+			pos:  position{line: 5264, col: 1, offset: 160824},
 			expr: &litMatcher{
-				pos:        position{line: 5261, col: 10, offset: 160675},
+				pos:        position{line: 5264, col: 10, offset: 160833},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14481,18 +14481,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5262, col: 1, offset: 160679},
+			pos:  position{line: 5265, col: 1, offset: 160837},
 			expr: &seqExpr{
-				pos: position{line: 5262, col: 12, offset: 160690},
+				pos: position{line: 5265, col: 12, offset: 160848},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5262, col: 12, offset: 160690},
+						pos:        position{line: 5265, col: 12, offset: 160848},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5262, col: 16, offset: 160694},
+						pos:  position{line: 5265, col: 16, offset: 160852},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14500,16 +14500,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5263, col: 1, offset: 160709},
+			pos:  position{line: 5266, col: 1, offset: 160867},
 			expr: &seqExpr{
-				pos: position{line: 5263, col: 12, offset: 160720},
+				pos: position{line: 5266, col: 12, offset: 160878},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5263, col: 12, offset: 160720},
+						pos:  position{line: 5266, col: 12, offset: 160878},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5263, col: 27, offset: 160735},
+						pos:        position{line: 5266, col: 27, offset: 160893},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14519,40 +14519,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5265, col: 1, offset: 160740},
+			pos:  position{line: 5268, col: 1, offset: 160898},
 			expr: &notExpr{
-				pos: position{line: 5265, col: 8, offset: 160747},
+				pos: position{line: 5268, col: 8, offset: 160905},
 				expr: &anyMatcher{
-					line: 5265, col: 9, offset: 160748,
+					line: 5268, col: 9, offset: 160906,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5266, col: 1, offset: 160750},
+			pos:  position{line: 5269, col: 1, offset: 160908},
 			expr: &choiceExpr{
-				pos: position{line: 5266, col: 15, offset: 160764},
+				pos: position{line: 5269, col: 15, offset: 160922},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5266, col: 15, offset: 160764},
+						pos:        position{line: 5269, col: 15, offset: 160922},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5266, col: 21, offset: 160770},
+						pos:        position{line: 5269, col: 21, offset: 160928},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5266, col: 28, offset: 160777},
+						pos:        position{line: 5269, col: 28, offset: 160935},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5266, col: 35, offset: 160784},
+						pos:        position{line: 5269, col: 35, offset: 160942},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14562,37 +14562,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5267, col: 1, offset: 160789},
+			pos:  position{line: 5270, col: 1, offset: 160947},
 			expr: &choiceExpr{
-				pos: position{line: 5267, col: 10, offset: 160798},
+				pos: position{line: 5270, col: 10, offset: 160956},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5267, col: 11, offset: 160799},
+						pos: position{line: 5270, col: 11, offset: 160957},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5267, col: 11, offset: 160799},
+								pos: position{line: 5270, col: 11, offset: 160957},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5267, col: 11, offset: 160799},
+									pos:  position{line: 5270, col: 11, offset: 160957},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5267, col: 23, offset: 160811},
+								pos:  position{line: 5270, col: 23, offset: 160969},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5267, col: 31, offset: 160819},
+								pos: position{line: 5270, col: 31, offset: 160977},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5267, col: 31, offset: 160819},
+									pos:  position{line: 5270, col: 31, offset: 160977},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5267, col: 46, offset: 160834},
+						pos: position{line: 5270, col: 46, offset: 160992},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5267, col: 46, offset: 160834},
+							pos:  position{line: 5270, col: 46, offset: 160992},
 							name: "WHITESPACE",
 						},
 					},
@@ -14601,38 +14601,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5268, col: 1, offset: 160846},
+			pos:  position{line: 5271, col: 1, offset: 161004},
 			expr: &seqExpr{
-				pos: position{line: 5268, col: 12, offset: 160857},
+				pos: position{line: 5271, col: 12, offset: 161015},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5268, col: 12, offset: 160857},
+						pos:        position{line: 5271, col: 12, offset: 161015},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5268, col: 18, offset: 160863},
+						pos: position{line: 5271, col: 18, offset: 161021},
 						expr: &seqExpr{
-							pos: position{line: 5268, col: 19, offset: 160864},
+							pos: position{line: 5271, col: 19, offset: 161022},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5268, col: 19, offset: 160864},
+									pos: position{line: 5271, col: 19, offset: 161022},
 									expr: &litMatcher{
-										pos:        position{line: 5268, col: 21, offset: 160866},
+										pos:        position{line: 5271, col: 21, offset: 161024},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5268, col: 28, offset: 160873,
+									line: 5271, col: 28, offset: 161031,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5268, col: 32, offset: 160877},
+						pos:        position{line: 5271, col: 32, offset: 161035},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14642,16 +14642,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5269, col: 1, offset: 160883},
+			pos:  position{line: 5272, col: 1, offset: 161041},
 			expr: &choiceExpr{
-				pos: position{line: 5269, col: 20, offset: 160902},
+				pos: position{line: 5272, col: 20, offset: 161060},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5269, col: 20, offset: 160902},
+						pos:  position{line: 5272, col: 20, offset: 161060},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5269, col: 28, offset: 160910},
+						pos:        position{line: 5272, col: 28, offset: 161068},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14661,16 +14661,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5270, col: 1, offset: 160913},
+			pos:  position{line: 5273, col: 1, offset: 161071},
 			expr: &choiceExpr{
-				pos: position{line: 5270, col: 19, offset: 160931},
+				pos: position{line: 5273, col: 19, offset: 161089},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5270, col: 19, offset: 160931},
+						pos:  position{line: 5273, col: 19, offset: 161089},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5270, col: 27, offset: 160939},
+						pos:  position{line: 5273, col: 27, offset: 161097},
 						name: "SPACE",
 					},
 				},
@@ -16257,7 +16257,10 @@ func (c *current) onBinBlock2(binCmdOption, field, newFieldName any) (any, error
 		NewColName: field.(string),
 	}
 	if newFieldName != nil {
-		letColReq.NewColName = newFieldName.(string)
+		newName := newFieldName.(string)
+		letColReq.NewColName = newName
+		binOptions := binCmdOption.(*structs.BinCmdOptions)
+		binOptions.NewFieldName = toputils.NewOptionWithValue(newName)
 	}
 
 	letColReq.BinRequest = binCmdOption.(*structs.BinCmdOptions)

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -1678,7 +1678,10 @@ BinBlock <- PIPE CMD_BIN binCmdOption:(BinCmdOptionsList) SPACE field:FieldName 
         NewColName: field.(string),
     }
     if newFieldName != nil {
-        letColReq.NewColName = newFieldName.(string)
+        newName := newFieldName.(string)
+        letColReq.NewColName = newName
+        binOptions := binCmdOption.(*structs.BinCmdOptions)
+        binOptions.NewFieldName = toputils.NewOptionWithValue(newName)
     }
 
     letColReq.BinRequest = binCmdOption.(*structs.BinCmdOptions)

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -283,6 +283,12 @@ func (iqr *IQR) readAllColumnsWithRRCs() (map[string][]utils.CValueEnclosure, er
 		}
 	}
 
+	for oldName := range iqr.renamedColumns {
+		// TODO: don't read these columns from the RRCs, instead of reading and
+		// then deleting them.
+		delete(results, oldName)
+	}
+
 	for cname, values := range iqr.knownValues {
 		results[cname] = values
 	}

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -287,6 +287,10 @@ func (iqr *IQR) readAllColumnsWithRRCs() (map[string][]utils.CValueEnclosure, er
 		}
 	}
 
+	for cname, values := range iqr.knownValues {
+		results[cname] = values
+	}
+
 	return results, nil
 }
 

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -228,10 +228,6 @@ func (iqr *IQR) ReadColumn(cname string) ([]utils.CValueEnclosure, error) {
 		return nil, fmt.Errorf("IQR.ReadColumn: column %s is deleted", cname)
 	}
 
-	if newCname, ok := iqr.renamedColumns[cname]; ok {
-		cname = newCname
-	}
-
 	if values, ok := iqr.knownValues[cname]; ok {
 		return values, nil
 	}
@@ -659,6 +655,21 @@ func (iqr *IQR) DiscardRows(rowsToDiscard []int) error {
 		}
 
 		iqr.knownValues[cname] = newValues
+	}
+
+	return nil
+}
+
+func (iqr *IQR) RenameColumn(oldName, newName string) error {
+	if err := iqr.validate(); err != nil {
+		log.Errorf("IQR.RenameColumn: validation failed: %v", err)
+		return err
+	}
+
+	iqr.renamedColumns[oldName] = newName
+	if values, ok := iqr.knownValues[oldName]; ok {
+		iqr.knownValues[newName] = values
+		delete(iqr.knownValues, oldName)
 	}
 
 	return nil

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -430,3 +430,32 @@ func Test_DiscardAfter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, iqr.NumberOfRecords())
 }
+
+func Test_RenameColumn(t *testing.T) {
+	iqr := NewIQR(0)
+	err := iqr.AppendKnownValues(map[string][]utils.CValueEnclosure{
+		"col1": {
+			utils.CValueEnclosure{Dtype: utils.SS_DT_STRING, CVal: "a"},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = iqr.RenameColumn("col1", "newCol1")
+	assert.NoError(t, err)
+	_, err = iqr.ReadColumn("col1")
+	assert.Error(t, err)
+	values, err := iqr.ReadColumn("newCol1")
+	assert.NoError(t, err)
+	assert.Equal(t, []utils.CValueEnclosure{{Dtype: utils.SS_DT_STRING, CVal: "a"}}, values)
+
+	// Rename the renamed column.
+	err = iqr.RenameColumn("newCol1", "superNewCol1")
+	assert.NoError(t, err)
+	_, err = iqr.ReadColumn("col1")
+	assert.Error(t, err)
+	_, err = iqr.ReadColumn("newCol1")
+	assert.Error(t, err)
+	values, err = iqr.ReadColumn("superNewCol1")
+	assert.NoError(t, err)
+	assert.Equal(t, []utils.CValueEnclosure{{Dtype: utils.SS_DT_STRING, CVal: "a"}}, values)
+}

--- a/pkg/segment/query/processor/bincommand.go
+++ b/pkg/segment/query/processor/bincommand.go
@@ -78,6 +78,14 @@ func (p *binProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 		}
 	}
 
+	if newName, ok := p.options.NewFieldName.Get(); ok {
+		err = iqr.RenameColumn(p.options.Field, newName)
+		if err != nil {
+			return nil, utils.TeeErrorf("bin.Process: cannot rename column %v to %v; err=%v",
+				p.options.Field, newName, err)
+		}
+	}
+
 	return iqr, nil
 }
 

--- a/pkg/segment/query/processor/bincommand.go
+++ b/pkg/segment/query/processor/bincommand.go
@@ -18,8 +18,16 @@
 package processor
 
 import (
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/query/iqr"
 	"github.com/siglens/siglens/pkg/segment/structs"
+	segutils "github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/siglens/siglens/pkg/utils"
 )
 
 type binProcessor struct {
@@ -27,15 +35,202 @@ type binProcessor struct {
 }
 
 func (p *binProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
-	panic("not implemented")
+	if p.options.BinSpanOptions == nil {
+		return nil, utils.TeeErrorf("bin.Process: computing span is not yet implemented")
+	}
+
+	if iqr == nil {
+		return nil, io.EOF
+	}
+
+	values, err := iqr.ReadColumn(p.options.Field)
+	if err != nil {
+		return nil, utils.TeeErrorf("bin.Process: cannot read values for field %v; err=%v",
+			p.options.Field, err)
+	}
+
+	if p.options.Field == config.GetTimeStampKey() {
+		for i := range values {
+			value := &values[i]
+			floatVal, err := value.GetFloatValue()
+			if err != nil {
+				return nil, utils.TeeErrorf("bin.Process: cannot convert value %v to float; err=%v",
+					value, err)
+			}
+
+			bucket, err := p.performBinWithSpanTime(floatVal, p.options.AlignTime)
+			if err != nil {
+				return nil, utils.TeeErrorf("bin.Process: cannot bin value %v; err=%v",
+					value, err)
+			}
+
+			value.CVal = bucket
+			value.Dtype = segutils.SS_DT_UNSIGNED_NUM
+		}
+	} else {
+		for i := range values {
+			value := &values[i]
+			err = p.performBinWithSpan(value)
+			if err != nil {
+				return nil, utils.TeeErrorf("bin.Process: cannot bin value %v; err=%v",
+					value, err)
+			}
+		}
+	}
+
+	return iqr, nil
 }
 
 // In the two-pass version of bin, Rewind() should remember the span it
 // calculated in the first pass.
 func (p *binProcessor) Rewind() {
-	panic("not implemented")
+	// TODO: handle this for two-pass bin.
 }
 
 func (p *binProcessor) Cleanup() {
-	panic("not implemented")
+	// Nothing to do.
+}
+
+func (p *binProcessor) performBinWithSpan(cval *segutils.CValueEnclosure) error {
+	value, err := cval.GetFloatValue()
+	if err != nil {
+		return fmt.Errorf("bin.performBinWithSpan: %+v cannot be converted to float; err=%v",
+			cval, err)
+	}
+
+	if p.options.BinSpanOptions.BinSpanLength != nil {
+		lowerBound, upperBound := getBinRange(value, p.options.BinSpanOptions.BinSpanLength.Num)
+		if p.options.BinSpanOptions.BinSpanLength.TimeScale == segutils.TMInvalid {
+			cval.Dtype = segutils.SS_DT_STRING
+			cval.CVal = fmt.Sprintf("%v-%v", lowerBound, upperBound)
+		} else {
+			cval.Dtype = segutils.SS_DT_FLOAT
+			cval.CVal = lowerBound
+		}
+
+		return nil
+	}
+
+	if p.options.BinSpanOptions.LogSpan != nil {
+		if value <= 0 {
+			cval.Dtype = segutils.SS_DT_FLOAT
+			cval.CVal = value
+			return nil
+		}
+
+		val := value / p.options.BinSpanOptions.LogSpan.Coefficient
+		logVal := math.Log10(val) / math.Log10(p.options.BinSpanOptions.LogSpan.Base)
+		floorVal := math.Floor(logVal)
+		ceilVal := math.Ceil(logVal)
+		if ceilVal == floorVal {
+			ceilVal += 1
+		}
+		lowerBound := math.Pow(p.options.BinSpanOptions.LogSpan.Base, floorVal) * p.options.BinSpanOptions.LogSpan.Coefficient
+		upperBound := math.Pow(p.options.BinSpanOptions.LogSpan.Base, ceilVal) * p.options.BinSpanOptions.LogSpan.Coefficient
+
+		cval.Dtype = segutils.SS_DT_STRING
+		cval.CVal = fmt.Sprintf("%v-%v", lowerBound, upperBound)
+		return nil
+	}
+
+	return fmt.Errorf("bin.performBinWithSpan: no span options set")
+}
+
+// Function to bin ranges with the given span length
+func getBinRange(val float64, spanRange float64) (float64, float64) {
+	lowerbound := math.Floor(val/spanRange) * spanRange
+	upperbound := math.Ceil(val/spanRange) * spanRange
+	if lowerbound == upperbound {
+		upperbound += spanRange
+	}
+
+	return lowerbound, upperbound
+}
+
+// Perform bin with span for time
+func (p *binProcessor) performBinWithSpanTime(value float64, alignTime *uint64) (uint64, error) {
+	spanLength := p.options.BinSpanOptions.BinSpanLength
+	if spanLength == nil {
+		return 0, fmt.Errorf("performBinWithSpanTime: spanLength is nil")
+	}
+
+	unixMilli := int64(value)
+	utcTime := time.UnixMilli(unixMilli)
+	startTime := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	bucket := 0
+	numIntervals := spanLength.Num
+
+	//Align time is only supported for units less than days
+	switch spanLength.TimeScale {
+	case segutils.TMMillisecond:
+		durationScale := time.Millisecond
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMCentisecond:
+		durationScale := time.Millisecond * 10
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMDecisecond:
+		durationScale := time.Millisecond * 100
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMSecond:
+		durationScale := time.Second
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMMinute:
+		durationScale := time.Minute
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMHour:
+		durationScale := time.Hour
+		bucket = getTimeBucketWithAlign(utcTime, durationScale, numIntervals, alignTime)
+	case segutils.TMDay:
+		totalDays := int(utcTime.Sub(startTime).Hours() / 24)
+		slotDays := (totalDays / (int(numIntervals))) * (int(numIntervals))
+		bucket = int(startTime.AddDate(0, 0, slotDays).UnixMilli())
+	case segutils.TMWeek:
+		totalDays := int(utcTime.Sub(startTime).Hours() / 24)
+		slotDays := (totalDays / (int(numIntervals) * 7)) * (int(numIntervals) * 7)
+		bucket = int(startTime.AddDate(0, 0, slotDays).UnixMilli())
+	case segutils.TMMonth:
+		return findBucketMonth(utcTime, int(numIntervals)), nil
+	case segutils.TMQuarter:
+		return findBucketMonth(utcTime, int(numIntervals)*3), nil
+	case segutils.TMYear:
+		num := int(numIntervals)
+		currYear := int(utcTime.Year())
+		bucketYear := ((currYear-1970)/num)*num + 1970
+		bucket = int(time.Date(bucketYear, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli())
+	default:
+		return 0, fmt.Errorf("performBinWithSpanTime: Time scale %v is not supported", spanLength.TimeScale)
+	}
+
+	return uint64(bucket), nil
+}
+
+func getTimeBucketWithAlign(utcTime time.Time, durationScale time.Duration, numIntervals float64, alignTime *uint64) int {
+	if alignTime == nil {
+		return int(utcTime.Truncate(time.Duration(numIntervals) * durationScale).UnixMilli())
+	}
+
+	factorInMillisecond := float64((time.Duration(numIntervals) * durationScale) / time.Millisecond)
+	currTime := float64(utcTime.UnixMilli())
+	baseTime := float64(*alignTime)
+	diff := math.Floor((currTime - baseTime) / factorInMillisecond)
+	bucket := int(baseTime + diff*factorInMillisecond)
+	if bucket < 0 {
+		bucket = 0
+	}
+
+	return bucket
+}
+
+// Find the bucket month based on the given number of months as span.
+func findBucketMonth(utcTime time.Time, numOfMonths int) uint64 {
+	var finalTime time.Time
+	if numOfMonths == 12 {
+		finalTime = time.Date(utcTime.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		currMonth := int(utcTime.Month())
+		month := ((currMonth-1)/numOfMonths)*numOfMonths + 1
+		finalTime = time.Date(utcTime.Year(), time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	return uint64(finalTime.UnixMilli())
 }

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -190,13 +190,14 @@ func (dp *DataProcessor) fetchFromAllStreamsWithData() ([]*iqr.IQR, []int, error
 }
 
 func NewBinDP(options *structs.BinCmdOptions) *DataProcessor {
+	hasSpan := options.BinSpanOptions != nil
 	return &DataProcessor{
 		streams:           make([]*cachedStream, 0),
 		processor:         &binProcessor{options: options},
 		inputOrderMatters: false,
 		isPermutingCmd:    false,
-		isBottleneckCmd:   false, // TODO: depends on whether the span option was set
-		isTwoPassCmd:      false, // TODO: depends on whether the span option was set
+		isBottleneckCmd:   !hasSpan,
+		isTwoPassCmd:      !hasSpan,
 	}
 }
 

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -267,6 +267,7 @@ type BinCmdOptions struct {
 	End                  *float64
 	AlignTime            *uint64
 	Field                string
+	NewFieldName         toputils.Option[string]
 	Records              map[string]map[string]interface{}
 	RecordIndex          map[int]map[string]int
 	NumProcessedSegments uint64


### PR DESCRIPTION
# Description
Now [bin commands](https://docs.splunk.com/Documentation/Splunk/9.1.1/SearchReference/Bin) can be used in the new query pipeline as long as the span is specified. Handling the case where the span is not specified will be done in a different PR.

Most of the actual bin calculation was copied from segaggs.go and slightly modified.

# Testing
```
curl -X POST -d '{
    "searchText": "* | bin span=10000 latency",
    "indexName": "*",
    "startEpoch": "now-24h",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search | python3 -m json.tool | less
```
I also tried `* | bin span=10000 latency as latencyBin` and the column renaming worked as expected.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
