### PR TITLE
write empty pqs meta only through channel

### DIFF
--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -194,9 +194,9 @@ func GetRetentionTimeMs(retentionHours int, currTime time.Time) uint64 {
 func deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete map[string]*structs.SegMeta) {
 	for _, segmetaEntry := range segmentsToDelete {
 		for pqid := range segmetaEntry.AllPQIDs {
-			updatedEmptyPQS := pqsmeta.GetUpdatedPQSMapAfterSegmentRemoval(pqid, segmetaEntry.SegmentKey)
-			if updatedEmptyPQS != nil {
-				go writer.AddEmptyPQIDMapToChan(pqid, updatedEmptyPQS)
+			updatedEmptyPQSMap := pqsmeta.GetUpdatedPQSMapAfterSegmentRemoval(pqid, segmetaEntry.SegmentKey)
+			if updatedEmptyPQSMap != nil {
+				go writer.AddEmptyPQIDMapToChan(pqid, updatedEmptyPQSMap)
 			}
 		}
 	}

--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -194,7 +194,10 @@ func GetRetentionTimeMs(retentionHours int, currTime time.Time) uint64 {
 func deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete map[string]*structs.SegMeta) {
 	for _, segmetaEntry := range segmentsToDelete {
 		for pqid := range segmetaEntry.AllPQIDs {
-			pqsmeta.DeleteSegmentFromPqid(pqid, segmetaEntry.SegmentKey)
+			updatedEmptyPQS := pqsmeta.GetUpdatedPQSMapAfterSegmentRemoval(pqid, segmetaEntry.SegmentKey)
+			if updatedEmptyPQS != nil {
+				go writer.AddEmptyPQIDMapToChan(pqid, updatedEmptyPQS)
+			}
 		}
 	}
 }

--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -195,7 +195,7 @@ func GetRetentionTimeMs(retentionHours int, currTime time.Time) uint64 {
 func deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete map[string]*structs.SegMeta) {
 	for _, segmetaEntry := range segmentsToDelete {
 		for pqid := range segmetaEntry.AllPQIDs {
-			go writer.RemoveSegmentFromEmptyPqmeta(pqid, segmetaEntry.SegmentKey)
+			writer.RemoveSegmentFromEmptyPqmeta(pqid, segmetaEntry.SegmentKey)
 		}
 	}
 }

--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -30,7 +30,6 @@ import (
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
 	segmetadata "github.com/siglens/siglens/pkg/segment/metadata"
-	pqsmeta "github.com/siglens/siglens/pkg/segment/query/pqs/meta"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/writer"
 	mmeta "github.com/siglens/siglens/pkg/segment/writer/metrics/meta"
@@ -194,10 +193,7 @@ func GetRetentionTimeMs(retentionHours int, currTime time.Time) uint64 {
 func deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete map[string]*structs.SegMeta) {
 	for _, segmetaEntry := range segmentsToDelete {
 		for pqid := range segmetaEntry.AllPQIDs {
-			updatedEmptyPQSMap := pqsmeta.GetUpdatedPQSMapAfterSegmentRemoval(pqid, segmetaEntry.SegmentKey)
-			if updatedEmptyPQSMap != nil {
-				go writer.AddEmptyPQIDMapToChan(pqid, updatedEmptyPQSMap)
-			}
+			go writer.RemoveSegmentFromEmptyPqmeta(pqid, segmetaEntry.SegmentKey)
 		}
 	}
 }

--- a/pkg/segment/query/pqs/meta/pqsmeta.go
+++ b/pkg/segment/query/pqs/meta/pqsmeta.go
@@ -157,22 +157,25 @@ func removePqmrFilesAndDirectory(pqid string) error {
 }
 
 // This function will remove the PQMRFiles and directory if there are no segments left in the PQID
-func GetUpdatedPQSMapAfterSegmentRemoval(pqid string, segKey string) map[string]bool {
+func BulkDeleteSegKeysFromPqid(pqid string, segKeyMap map[string]bool) {
 	pqFname := getPqmetaFilename(pqid)
 	emptyPQS, err := getAllEmptyPQSToMap(pqFname)
 	if err != nil {
-		log.Errorf("DeleteSegmentFromPqid: Failed to get empty PQS data from file at %s: Error=%v", pqFname, err)
+		log.Errorf("BulkDeleteSegKeysFromPqid: Failed to get empty PQS data from file at %s: Error=%v", pqFname, err)
 	}
-	delete(emptyPQS, segKey)
+
+	for segKey := range segKeyMap {
+		delete(emptyPQS, segKey)
+	}
+
 	if len(emptyPQS) == 0 {
 		err := removePqmrFilesAndDirectory(pqid)
 		if err != nil {
-			log.Errorf("DeleteSegmentFromPqid: Error removing segKey %v from %v pqid, Error=%v", segKey, pqid, err)
+			log.Errorf("BulkDeleteSegKeysFromPqid: Error removing segKeyMap %v from %v pqid, Error=%v", segKeyMap, pqid, err)
 		}
-		return nil
+		return
 	}
-
-	return emptyPQS
+	writeEmptyPqsMapToFile(pqFname, emptyPQS)
 }
 
 func DeletePQMetaDir() error {

--- a/pkg/segment/query/pqs/meta/pqsmeta.go
+++ b/pkg/segment/query/pqs/meta/pqsmeta.go
@@ -100,10 +100,6 @@ func BulkAddEmptyResults(pqid string, segKeyMap map[string]bool) {
 	}
 }
 
-func AddEmptyResults(pqid string, segKey string) {
-	BulkAddEmptyResults(pqid, map[string]bool{segKey: true})
-}
-
 func writeEmptyPqsMapToFile(fileName string, emptyPqs map[string]bool) {
 
 	fd, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0764)
@@ -160,7 +156,7 @@ func removePqmrFilesAndDirectory(pqid string) error {
 	return nil
 }
 
-func DeleteSegmentFromPqid(pqid string, segKey string) {
+func GetUpdatedPQSMapAfterSegmentRemoval(pqid string, segKey string) map[string]bool {
 	pqFname := getPqmetaFilename(pqid)
 	emptyPQS, err := getAllEmptyPQSToMap(pqFname)
 	if err != nil {
@@ -172,9 +168,10 @@ func DeleteSegmentFromPqid(pqid string, segKey string) {
 		if err != nil {
 			log.Errorf("DeleteSegmentFromPqid: Error removing segKey %v from %v pqid, Error=%v", segKey, pqid, err)
 		}
-		return
+		return nil
 	}
-	writeEmptyPqsMapToFile(pqFname, emptyPQS)
+
+	return emptyPQS
 }
 
 func DeletePQMetaDir() error {

--- a/pkg/segment/query/pqs/meta/pqsmeta.go
+++ b/pkg/segment/query/pqs/meta/pqsmeta.go
@@ -156,6 +156,7 @@ func removePqmrFilesAndDirectory(pqid string) error {
 	return nil
 }
 
+// This function will remove the PQMRFiles and directory if there are no segments left in the PQID
 func GetUpdatedPQSMapAfterSegmentRemoval(pqid string, segKey string) map[string]bool {
 	pqFname := getPqmetaFilename(pqid)
 	emptyPQS, err := getAllEmptyPQSToMap(pqFname)

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -40,7 +40,6 @@ import (
 	"github.com/siglens/siglens/pkg/instrumentation"
 	"github.com/siglens/siglens/pkg/querytracker"
 	"github.com/siglens/siglens/pkg/segment/metadata"
-	pqsmeta "github.com/siglens/siglens/pkg/segment/query/pqs/meta"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer/suffix"
@@ -776,7 +775,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 				if err != nil {
 					log.Errorf("checkAndRotateColFiles: Error deleting pqmr files and directory. Err: %v", err)
 				}
-				go pqsmeta.AddEmptyResults(pqid, segstore.SegmentKey)
+				go AddEmptyPQIDToChan(pqid, segstore.SegmentKey)
 			}
 		}
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -775,7 +775,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 				if err != nil {
 					log.Errorf("checkAndRotateColFiles: Error deleting pqmr files and directory. Err: %v", err)
 				}
-				go AddEmptyPQIDToChan(pqid, segstore.SegmentKey)
+				go AddToEmptyPqmetaChan(pqid, segstore.SegmentKey)
 			}
 		}
 

--- a/pkg/utils/maputils.go
+++ b/pkg/utils/maputils.go
@@ -22,6 +22,41 @@ import (
 	"sort"
 )
 
+// GetOrCreateNestedMap returns the inner map corresponding to key1 from the outer map.
+// If the key1 does not exist in the outer map, a new inner map is created and returned.
+func GetOrCreateNestedMap[K1 comparable, K2 comparable, V any](m map[K1]map[K2]V, key1 K1) map[K2]V {
+	if _, exists := m[key1]; !exists {
+		m[key1] = make(map[K2]V)
+	}
+
+	return m[key1]
+}
+
+// GetEntryFromNestedMap returns the value corresponding to key1 and key2 from the nested map.
+// If the key1 does not exist in the outer map, the function returns false.
+// If the key2 does not exist in the inner map, the function returns false.
+func GetEntryFromNestedMap[K1 comparable, K2 comparable, V any](m map[K1]map[K2]V, key1 K1, key2 K2) (V, bool) {
+	if innerMap, exists := m[key1]; exists {
+		value, exists := innerMap[key2]
+		return value, exists
+	}
+
+	var nilOrZeroValue V
+
+	return nilOrZeroValue, false
+}
+
+// RemoveKeyFromNestedMap removes the key2 from the inner map corresponding to key1.
+// If the inner map becomes empty after removing key2, the inner map is also removed.
+func RemoveKeyFromNestedMap[K1 comparable, K2 comparable](m map[K1]map[K2]bool, key1 K1, key2 K2) {
+	if innerMap, exists := m[key1]; exists {
+		delete(innerMap, key2)
+		if len(innerMap) == 0 {
+			delete(m, key1)
+		}
+	}
+}
+
 // If there are duplicate keys, values from the second map will overwrite those
 // from the first map.
 func MergeMaps[K comparable, V any](map1, map2 map[K]V) map[K]V {

--- a/pkg/utils/maputils_test.go
+++ b/pkg/utils/maputils_test.go
@@ -322,3 +322,55 @@ func Test_TwoWayMap(t *testing.T) {
 	_, ok = twm.GetReverse(2)
 	assert.False(t, ok)
 }
+
+func TestGetOrCreateNestedMap(t *testing.T) {
+	m := make(map[string]map[string]int)
+
+	// Test when key1 does not exist
+	innerMap := GetOrCreateNestedMap(m, "key1")
+	assert.NotNil(t, innerMap)
+	assert.Equal(t, 0, len(innerMap))
+
+	// Test if key1 now exists and inner map is accessible
+	innerMap["key2"] = 42
+	newInnerMap := GetOrCreateNestedMap(m, "key1")
+	assert.Equal(t, 42, newInnerMap["key2"])
+}
+
+func TestGetEntryFromNestedMap(t *testing.T) {
+	m := make(map[string]map[string]int)
+
+	// Test when outer map key1 does not exist
+	value, exists := GetEntryFromNestedMap(m, "key1", "key2")
+	assert.False(t, exists, "Value should not exist for a non-existent outer key")
+	assert.Equal(t, 0, value, "Returned value should be the zero value of the type")
+
+	// Test when key1 exists but key2 does not
+	m["key1"] = map[string]int{"key3": 100}
+	value, exists = GetEntryFromNestedMap(m, "key1", "key2")
+	assert.False(t, exists, "Value should not exist for a non-existent inner key")
+	assert.Equal(t, 0, value, "Returned value should be the zero value of the type")
+
+	// Test when both key1 and key2 exist
+	value, exists = GetEntryFromNestedMap(m, "key1", "key3")
+	assert.True(t, exists, "Value should exist when both outer and inner keys exist")
+	assert.Equal(t, 100, value, "The correct value should be returned")
+}
+
+func TestRemoveKeyFromNestedMap(t *testing.T) {
+	m := make(map[string]map[string]bool)
+
+	// Test removing key from an empty map (no-op)
+	RemoveKeyFromNestedMap(m, "key1", "key2")
+	assert.Equal(t, 0, len(m))
+
+	// Test removing an existing inner key and leaving the outer map intact
+	m["key1"] = map[string]bool{"key2": true, "key3": true}
+	RemoveKeyFromNestedMap(m, "key1", "key2")
+	assert.Equal(t, 1, len(m["key1"]), "One key should remain in the inner map after removing one key")
+	assert.Equal(t, true, m["key1"]["key3"], "The remaining key should still exist in the map")
+
+	// Test removing the last inner key and removing the outer map key
+	RemoveKeyFromNestedMap(m, "key1", "key3")
+	assert.Equal(t, 0, len(m), "Outer map key should be removed when the inner map becomes empty")
+}


### PR DESCRIPTION
# Description
- All the writes to empty PQS meta is only done through the `PQSChan` channel.

# Testing
- Tested by ingesting and making some queries and ensuring those were written to the empty pqid meta file and sfm file.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
