### PR TITLE
fix the segment deletion sequence during retention

### DIFF
--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -324,10 +324,17 @@ func DeleteSegmentData(segmentsToDelete map[string]*structs.SegMeta, updateBlob 
 	if len(segmentsToDelete) == 0 {
 		return
 	}
-	deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete)
-	// Delete segment key from all SiglensMetadata structs
+
+	// 1) First delete from segmeta.json
+	segBaseDirs := writer.RemoveSegMetas(segmentsToDelete)
+
+	// 2) Then from in memory metadata
 	for _, segMetaEntry := range segmentsToDelete {
 		segmetadata.DeleteSegmentKey(segMetaEntry.SegmentKey)
+	}
+
+	// 3) then iterate through blob
+	for _, segMetaEntry := range segmentsToDelete {
 
 		// Delete segment files from s3
 		dirPath := segMetaEntry.SegmentKey
@@ -355,7 +362,11 @@ func DeleteSegmentData(segmentsToDelete map[string]*structs.SegMeta, updateBlob 
 		log.Infof("DeleteSegmentData: deleted seg: %v", segMetaEntry.SegmentKey)
 	}
 
-	writer.RemoveSegments(utils.MapToSet(segmentsToDelete))
+	// 4) then recursively delete local files
+	writer.RemoveSegBasedirs(segBaseDirs)
+
+	//	5) then emptyPqMeta files
+	deleteSegmentsFromEmptyPqMetaFiles(segmentsToDelete)
 
 	// Upload the latest ingest nodes dir to s3 only if updateBlob is true
 	if !updateBlob {

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1087,8 +1087,24 @@ func DeleteSegmentsForIndex(indexName string) {
 	removeSegmentsByIndexOrSegkeys(nil, indexName)
 }
 
-func RemoveSegments(segmentsToDelete map[string]struct{}) {
-	removeSegmentsByIndexOrSegkeys(segmentsToDelete, "")
+func RemoveSegMetas(segmentsToDelete map[string]*structs.SegMeta) map[string]struct{} {
+
+	segKeysToDelete := make(map[string]struct{})
+	for segkey := range segmentsToDelete {
+		segKeysToDelete[segkey] = struct{}{}
+	}
+
+	return removeSegmetas(segKeysToDelete, "")
+}
+
+func RemoveSegBasedirs(segbaseDirs map[string]struct{}) {
+	for segdir := range segbaseDirs {
+		if err := os.RemoveAll(segdir); err != nil {
+			log.Errorf("RemoveSegBasedirs: Failed to remove directory name=%v, err:%v",
+				segdir, err)
+		}
+		fileutils.RecursivelyDeleteEmptyParentDirectories(segdir)
+	}
 }
 
 func removeSegmentsByIndexOrSegkeys(segmentsToDelete map[string]struct{}, indexName string) {


### PR DESCRIPTION
# Description
When retention based deletion is kicked in, we have to delete a bunch of things. The sequence on how we delete those things matter. This PR fixes a bug wherein an incorrect sequence caused `allSegmentMicroIndex` to have entries for segments that were already deleted and removed from segmeta.json.

When a deletion is kicked off, we were
1. Deleting the segkey from metadata.allSegmentMicroIndex
2. deleting pqmr files
3. Removing entry from segmeta.json
4. Deleting all files as part of the segment

After 1 was executed and before 3, some other segment got rotated and caused the segmeta.json file's timestamp to get modified. The populateMicroIndex thread would come in and read the segmeta.json. It would also read the segkey that was just deleted in step 1, and then it would add it back to `allSegmentMicroIndex`.
This segkey would then never get deleted from `allSegmentMicroIndex` and the list of the array keep growing, and bunch of errors kept popping about (could not read bsum and other files for these orphan segkeys). 
This PR fixes the sequence so that this does not happen


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
