### PR TITLE
Fix PQS panic when a segment has multiple blocks

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -501,7 +501,7 @@ func (s *searcher) readSortedRRCs(blocks []*block, segkey string) ([]*segutils.R
 	}
 	searchResults.NextSegKeyEnc = encoding
 
-	if segmentPQMR, ok := blocks[0].parentPQMR.Get(); ok {
+	if _, ok := blocks[0].parentPQMR.Get(); ok {
 		metas := make(map[uint16]*structs.BlockMetadataHolder)
 		summaries := make([]*structs.BlockSummary, 0)
 		for _, block := range blocks {
@@ -511,7 +511,19 @@ func (s *searcher) readSortedRRCs(blocks []*block, segkey string) ([]*segutils.R
 			}
 			summaries[block.BlkNum] = block.BlockSummary
 		}
-		err := query.ApplySinglePQSRawSearch(blocks[0].parentQSR, searchResults, segmentPQMR, metas, summaries, qs)
+		for i := range summaries {
+			if summaries[i] == nil {
+				summaries[i] = &structs.BlockSummary{}
+			}
+		}
+
+		pqmr, err := getPQMR(blocks)
+		if err != nil {
+			log.Errorf("qid=%v, searchProcessor.readSortedRRCs: failed to get PQMR: %v", s.qid, err)
+			return nil, nil, err
+		}
+
+		err = query.ApplySinglePQSRawSearch(blocks[0].parentQSR, searchResults, pqmr, metas, summaries, qs)
 		if err != nil {
 			log.Errorf("qid=%v, searchProcessor.readSortedRRCs: failed to apply PQS: %v", s.qid, err)
 			return nil, nil, err
@@ -533,6 +545,40 @@ func (s *searcher) readSortedRRCs(blocks []*block, segkey string) ([]*segutils.R
 
 	// TODO: verify the results or sorted, or sort them here.
 	return searchResults.GetResults(), searchResults.SegEncToKey, nil
+}
+
+// All of the blocks should be for the same PQMR.
+func getPQMR(blocks []*block) (*pqmr.SegmentPQMRResults, error) {
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+
+	// Each block should have come from the same PQMR.
+	firstPQMR, ok := blocks[0].parentPQMR.Get()
+	if !ok {
+		return nil, toputils.TeeErrorf("getPQMR: first block has no PQMR")
+	}
+
+	for _, block := range blocks {
+		pqmr, ok := block.parentPQMR.Get()
+		if !ok {
+			return nil, toputils.TeeErrorf("getPQMR: block has no PQMR")
+		} else if pqmr != firstPQMR {
+			return nil, toputils.TeeErrorf("getPQMR: blocks are from different PQMRs")
+		}
+	}
+
+	finalPQMR := pqmr.InitSegmentPQMResults()
+	for _, block := range blocks {
+		blockResults, ok := firstPQMR.GetBlockResults(block.BlkNum)
+		if !ok {
+			return nil, toputils.TeeErrorf("getPQMR: block %v not found", block.BlkNum)
+		}
+
+		finalPQMR.SetBlockResults(block.BlkNum, blockResults)
+	}
+
+	return finalPQMR, nil
 }
 
 // All of the blocks should be for the same SSR.


### PR DESCRIPTION
# Description
This fixes a panic when PQS had to read multiple blocks in a segment.

There's still an issue to fix, that will come in a future PR. When a segment has multiple blocks and PQS is enabled, on the first query it writes the pqmr file incorrectly; when future queries read the file, they think only one of the blocks in the segment has matches, so query results are inaccurate.

# Testing
1. Ingest multiple blocks of data into one segment: `go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 100_000 -p 1
`
2. Restart siglens, to rotate the segment
3. Make sure PQS is enabled
4. Run this query twice: `city=Boston | eval temp_value = http_status%2 | stats count, sum(latitude) BY gender, temp_value`. The first one works correctly (since there's no pqmr data yet); without this PR, the second run crashes; with this PR, the second run returns normally, but only gets data from one of the blocks, so the result is inaccurate


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
