### PR TITLE
Set query early exit limit to 100

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -184,7 +184,7 @@ const SEGMENT_ROTATE_DURATION_SECONDS = 15 * 60            // 15 mins
 var UPLOAD_INGESTNODE_DIR = time.Duration(1 * time.Minute) // one minute
 const SEGMENT_ROTATE_SLEEP_DURATION_SECONDS = 120
 
-const QUERY_EARLY_EXIT_LIMIT = uint64(10_000)
+const QUERY_EARLY_EXIT_LIMIT = uint64(100)
 const QUERY_MAX_BUCKETS = uint64(10_000)
 
 var ZSTD_COMLUNAR_BLOCK = []byte{0}

--- a/tools/sigclient/functionalQueries/simple_sort.json
+++ b/tools/sigclient/functionalQueries/simple_sort.json
@@ -2,7 +2,7 @@
     "queryText": "city=Boston | sort app_name",
     "expectedResult": {
         "totalMatched": {
-            "value": 984,
+            "value": 100,
             "relation": "eq"
         },
         "qtype": "logs-query",


### PR DESCRIPTION
# Description
- Sets the query exit limit to 100

# Testing
- Ran `*`  query and verified that the result has only 100 Records

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
