### PR TITLE
Fix sort crash and search issues with the new pipeline

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -511,16 +511,16 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 		return nil, 0, toputils.TeeErrorf("MergeIQRs: the less function is nil")
 	}
 
-	for idx, iqr := range iqrs {
-		if iqr.NumberOfRecords() == 0 {
-			return iqr, idx, nil
-		}
-	}
-
 	iqr, err := mergeMetadata(iqrs)
 	if err != nil {
 		log.Errorf("qid=%v, MergeIQRs: error merging metadata: %v", iqr.qid, err)
 		return nil, 0, err
+	}
+
+	for idx, iqrToCheck := range iqrs {
+		if iqrToCheck.NumberOfRecords() == 0 {
+			return iqr, idx, nil
+		}
 	}
 
 	nextRecords := make([]*Record, len(iqrs))

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -103,9 +103,6 @@ func (iqr *IQR) validate() error {
 }
 
 func (iqr *IQR) AppendRRCs(rrcs []*utils.RecordResultContainer, segEncToKey map[uint16]string) error {
-	if len(rrcs) == 0 {
-		return nil
-	}
 
 	if err := iqr.validate(); err != nil {
 		log.Errorf("qid=%v, IQR.AppendRRCs: validation failed: %v", iqr.qid, err)
@@ -540,10 +537,8 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 			iqr.rrcs = append(iqr.rrcs, record.iqr.rrcs[record.index])
 		}
 		for cname, values := range record.iqr.knownValues {
-			if _, ok := iqr.knownValues[cname]; !ok {
-				err := toputils.TeeErrorf("MergeIQRs: column %v is missing from destination IQR", cname)
-				return nil, 0, err
-			}
+			// we should not validate cname in the destination iqr because caching
+			// will have populated the knownValue in the source IQR
 			iqr.knownValues[cname] = append(iqr.knownValues[cname], values[record.index])
 		}
 

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -511,6 +511,12 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 		return nil, 0, toputils.TeeErrorf("MergeIQRs: the less function is nil")
 	}
 
+	for idx, iqr := range iqrs {
+		if iqr.NumberOfRecords() == 0 {
+			return iqr, idx, nil
+		}
+	}
+
 	iqr, err := mergeMetadata(iqrs)
 	if err != nil {
 		log.Errorf("qid=%v, MergeIQRs: error merging metadata: %v", iqr.qid, err)

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -406,6 +406,35 @@ func Test_MergeIQRs(t *testing.T) {
 	assert.Equal(t, 0, iqr3.NumberOfRecords())
 }
 
+func Test_MergeIQR_withNotSetIQRs(t *testing.T) {
+	less := func(a, b *Record) bool {
+		aVal, err := a.ReadColumn("col1")
+		assert.NoError(t, err)
+
+		bVal, err := b.ReadColumn("col1")
+		assert.NoError(t, err)
+
+		return aVal.CVal.(string) < bVal.CVal.(string)
+	}
+
+	_, firstExhaustedIndex, err := MergeIQRs([]*IQR{NewIQR(0), NewIQR(0), NewIQR(0)}, less)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, firstExhaustedIndex)
+
+	iqr1 := NewIQR(0)
+	err = iqr1.AppendKnownValues(map[string][]utils.CValueEnclosure{
+		"col1": {
+			utils.CValueEnclosure{Dtype: utils.SS_DT_STRING, CVal: "a"},
+			utils.CValueEnclosure{Dtype: utils.SS_DT_STRING, CVal: "e"},
+		},
+	})
+
+	assert.NoError(t, err)
+	_, firstExhausted, err := MergeIQRs([]*IQR{NewIQR(0), iqr1}, less)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, firstExhausted)
+}
+
 func Test_DiscardAfter(t *testing.T) {
 	iqr := NewIQR(0)
 	segKeyInfo1 := utils.SegKeyInfo{

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -435,6 +435,17 @@ func Test_MergeIQR_withNotSetIQRs(t *testing.T) {
 	assert.Equal(t, 0, firstExhausted)
 }
 
+func Test_Mode_AfterAppendRRC(t *testing.T) {
+	iqr := NewIQR(0)
+	assert.Equal(t, notSet, iqr.mode)
+
+	encodingToSegKey := map[uint16]string{1: "segKey1"}
+
+	err := iqr.AppendRRCs([]*utils.RecordResultContainer{}, encodingToSegKey)
+	assert.NoError(t, err)
+	assert.Equal(t, withRRCs, iqr.mode)
+}
+
 func Test_DiscardAfter(t *testing.T) {
 	iqr := NewIQR(0)
 	segKeyInfo1 := utils.SegKeyInfo{


### PR DESCRIPTION
# Description
Summarize the change.

**Sort Crash**
- For a certain query, the sort command was crashing siglens.

Stack trace
```
panic: runtime error: index out of range [0] with length 0
goroutine 102 [running]:
github.com/siglens/siglens/pkg/segment/query/iqr.MergeIQRs({0x140257efb68, 0x2, 0x1402429ba98?}, 0x140257efb78)
	/Users/Kalariya/siglens/pkg/segment/query/iqr/intermediateQueryResult.go:520 +0x5e0
github.com/siglens/siglens/pkg/segment/query/processor.(*sortProcessor).Process(0x14024402260, 0x1400945d100)
	/Users/Kalariya/siglens/pkg/segment/query/processor/sortcommand.go:60 +0xf8
github.com/siglens/siglens/pkg/segment/query/processor.(*DataProcessor).Fetch(0x1402440c080)
	/Users/Kalariya/siglens/pkg/segment/query/processor/dataprocessor.go:88 +0xa4
```

Root cause is that for an IQR that is not set should be returned as the firstExhausted IQR when merged with other IQRs, we cannot index into an empty IQR (this was causing the panic).

**Search Issues**

For the following queries, we were getting empty RRCs from the searcher which caused the mode of IQR to be notSet, when returned from the searcher and passed to the where command, which tries to read the column and raises an error saying mode is notSet from [here](https://github.com/siglens/siglens/blob/017dd3a40c798d51b6970e0b7b9f9e056343e364/pkg/segment/query/iqr/intermediateQueryResult.go#L230). We should return a withRRC IQR if an AppendRRCs has been called on this IQR, even if the rrcs are empty to prevent these kind of discrepancies.
```
http_method=POST AND (app_name=Bracecould OR app_name=R*could) | where weekday="Monday" OR latency<100000
http_method=POST AND (app_name=Bracecould OR app_name=Reamcould) | where weekday="Monday" OR latency<100000
```

For the following query, we see an error saying `first_name`, is not present in the destination IQR error from [here](https://github.com/siglens/siglens/blob/017dd3a40c798d51b6970e0b7b9f9e056343e364/pkg/segment/query/iqr/intermediateQueryResult.go#L538). This issue is caused because caching populates the known value with the result when computing the record to pick (based on sort) from [here](https://github.com/siglens/siglens/blob/017dd3a40c798d51b6970e0b7b9f9e056343e364/pkg/segment/query/iqr/intermediateQueryResult.go#L528). I don't think this is required because we are already populating all the knownValues from source IQR to destination IQR when performing [mergeMetaData](https://github.com/siglens/siglens/blob/017dd3a40c798d51b6970e0b7b9f9e056343e364/pkg/segment/query/iqr/intermediateQueryResult.go#L597).

```
http_method=POST AND (app_name=Bracecould) | sort limit=2 first_name
http_method=POST AND (app_name=Bracecould) | sort first_name
```

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

- Ingest benchmark data `go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 100_000`
- Enable new query pipeline
- Run query `http_method=POST AND (app_name=Bracecould OR app_name=R*could) | sort latency`
- Earlier it used to crash, now it should not.

Have also added an unit test for this edge case.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
