### PR TITLE
Fix Append method was not updating deleted columns and columnIndex

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -366,6 +366,8 @@ func (iqr *IQR) Append(other *IQR) error {
 
 	iqr.mode = mergedIQR.mode
 	iqr.encodingToSegKey = mergedIQR.encodingToSegKey
+	iqr.deletedColumns = mergedIQR.deletedColumns
+	iqr.columnIndex = mergedIQR.columnIndex
 
 	numInitialRecords := iqr.NumberOfRecords()
 	numAddedRecords := other.NumberOfRecords()


### PR DESCRIPTION
# Description
Summarize the change.
Earlier this query was returning all columns because the [mergedIQR](https://github.com/siglens/siglens/blob/2442244de2c6b5ae08f04decf79ac031c0c7cd1e/pkg/segment/query/iqr/intermediateQueryResult.go#L361) metadata was not reflected in the iqr created for append. So deletedColumns and columIndex were not updated.

`http_method=POST AND (app_name=Bracecould OR app_name=R*could) | fields app_name, app_version`

Not sure on do we want groupByColumns, and measureColumns to update as well, shouldn't they be same every time. I was not sure so I have not updated those.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Ingest benchmark dataset
- Run the given query
- Observe that only 2 fields are visible. Earlier all the fields were visible.

Wrote a unit test to validate this.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
