### PR TITLE
Check If SegKey is Rotated for Segment Stats Search

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -813,6 +813,12 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 		}
 		isSegmentFullyEnclosed := segReq.segKeyTsRange.AreTimesFullyEnclosed(segReq.segKeyTsRange.StartEpochMs, segReq.segKeyTsRange.EndEpochMs)
 
+		if segReq.sType != structs.SEGMENT_STATS_SEARCH {
+			if utils.IsFileForRotatedSegment(segReq.segKey) {
+				segReq.sType = structs.SEGMENT_STATS_SEARCH
+			}
+		}
+
 		// Because segment only store statistical data such as min, max..., for some functions we should recompute raw data to get the results
 		// If agg has evaluation functions, we should recompute raw data instead of using the previously stored statistical data in the segment
 		aggHasEvalFunc := segReq.aggs.HasValueColRequest()

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -813,6 +813,7 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 		}
 		isSegmentFullyEnclosed := segReq.segKeyTsRange.AreTimesFullyEnclosed(segReq.segKeyTsRange.StartEpochMs, segReq.segKeyTsRange.EndEpochMs)
 
+		// For Unrotated search, Check if the segment is rotated and update the search type accordingly
 		if segReq.sType != structs.SEGMENT_STATS_SEARCH {
 			if utils.IsFileForRotatedSegment(segReq.segKey) {
 				segReq.sType = structs.SEGMENT_STATS_SEARCH

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -814,7 +814,7 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 		isSegmentFullyEnclosed := segReq.segKeyTsRange.AreTimesFullyEnclosed(segReq.segKeyTsRange.StartEpochMs, segReq.segKeyTsRange.EndEpochMs)
 
 		// For Unrotated search, Check if the segment is rotated and update the search type accordingly
-		if segReq.sType != structs.SEGMENT_STATS_SEARCH {
+		if segReq.sType == structs.UNROTATED_SEGMENT_STATS_SEARCH {
 			if utils.IsFileForRotatedSegment(segReq.segKey) {
 				segReq.sType = structs.SEGMENT_STATS_SEARCH
 			}


### PR DESCRIPTION
# Description
- Checks if the SegKey is rotated for Segment Stats Search and assigns the proper search type

# Testing
- Tested by running the log bench tool and verified that there were no errors.
- All unit test cases pass.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
