### PR TITLE
Fix PQS bug in new query pipeline

### DIFF
--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -230,10 +230,14 @@ func rawSearchColumnar(searchReq *structs.SegmentSearchRequest, searchNode *stru
 	querySummary.UpdateSummary(summary.RAW, timeElapsed, queryMetrics)
 
 	if pqid, ok := shouldBackFillPQMR(searchNode, searchReq, qid); ok {
-		if finalMatched == 0 {
-			go writeEmptyPqmetaFilesWrapper(pqid, searchReq.SegmentKey)
-		} else {
+		if config.IsNewQueryPipelineEnabled() {
 			go writePqmrFilesWrapper(segmentSearchRecords, searchReq, qid, pqid)
+		} else {
+			if finalMatched == 0 {
+				go writeEmptyPqmetaFilesWrapper(pqid, searchReq.SegmentKey)
+			} else {
+				go writePqmrFilesWrapper(segmentSearchRecords, searchReq, qid, pqid)
+			}
 		}
 	}
 }

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -135,20 +135,6 @@ func writePqmrFiles(segmentSearchRecords *SegmentSearchStatus, segmentKey string
 		reqLen += size
 	}
 
-	var idxEmpty uint32
-	emptyBitset := pqmr.CreatePQMatchResults(0)
-	bufEmpty := make([]byte, (4+emptyBitset.GetInMemSize())*uint64(len(cmiPassedCnames)))
-	for blockNum := range cmiPassedCnames {
-		if _, ok := segmentSearchRecords.AllBlockStatus[blockNum]; !ok {
-			packedLen, err := emptyBitset.EncodePqmr(bufEmpty[idxEmpty:], blockNum)
-			if err != nil {
-				log.Errorf("qid=%d, writePqmrFiles: failed to encode pqmr. Err:%v", qid, err)
-				return err
-			}
-			idxEmpty += uint32(packedLen)
-		}
-	}
-
 	// Creating a buffer of a required length
 	buf := make([]byte, reqLen)
 	var idx uint32
@@ -161,13 +147,6 @@ func writePqmrFiles(segmentSearchRecords *SegmentSearchStatus, segmentKey string
 		idx += uint32(packedLen)
 	}
 
-	sizeToAdd := len(bufEmpty)
-	if sizeToAdd > 0 {
-		newArr := make([]byte, sizeToAdd)
-		buf = append(buf, newArr...)
-	}
-	copy(buf[idx:], bufEmpty)
-	idx += uint32(sizeToAdd)
 	err := pqmr.WritePqmrToDisk(buf[0:idx], pqidFname)
 	if err != nil {
 		log.Errorf("qid=%d, writePqmrFiles: failed to flush pqmr results to fname %s. Err:%v", qid, pqidFname, err)


### PR DESCRIPTION
# Description
This fixes the remaining issue mentioned in https://github.com/siglens/siglens/pull/1793

The function that writes the pqmr file previously assumed we already searched all the blocks that we're going to (for that segment). Then it compares that to the blocks that passed CMI to figure out which blocks have no results, and it writes the results in the pqmr file. However, that assumption doesn't hold for the new query pipeline; in the new pipeline, we generally search one block at a time instead of one full segment at a time. This caused the pqmr file to get written like this (for a segment with N blocks):
```
[block 1 results][N-1 blocks with no data][block 2 results][N-1 blocks with no data]...
```
No that function is changed so the file will look like this
```
[block 1 results][block 2 results]...
```
Although the order of the blocks doesn't matter (and might not be guaranteed).

As before, we still write block results if the block has no matches for the query.

This PR also fixes an issue where if only some of the blocks in a segment had pqmr data for a certain search, then running that same query on a time span that should hit all the blocks ignored the blocks without pqmr data. Now those blocks without pqmr data are raw searched. There's still one inefficiency: those raw-searched blocks don't add their pqmr data afterwards, so those blocks will always be raw searched.

# Testing
## Doesn't break the old pipeline
This PR changes how the pqmr file is written. We don't want this change to break the old query pipeline. To test this, I added some logging when reading the pqmr file. After multiple blocks into one segment, rotating the segment, and running a query (`city=Boston AND country=Italy`) which matched some but not all of the blocks, I ran the same query again. In the second run, the query used PQS, and I got logs indicating that the pqmr file showed some of the blocks had 0 match results (as expected).

## Fixes the new pipeline issue
I did the steps mentioned in the Testing section of #1793, but this time I got the full correct results, instead of the results for just one block. (I also had the commit from that PR, to avoid the panic issue that PR addresses)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
