### PR TITLE
Remove UI Sorting for Logs Data to Preserve Backend Order

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -63,7 +63,6 @@ let measureFunctions = [];
 let measureInfo = [];
 let isTimechart = false;
 let isQueryBuilderSearch = false;
-let sortByTimestampAtDefault = true;
 let defaultDashboardIds = ['10329b95-47a8-48df-8b1d-0a0a01ec6c42', 'a28f485c-4747-4024-bb6b-d230f101f852', 'bd74f11e-26c8-4827-bf65-c0b464e1f2a4', '53cb3dde-fd78-4253-808c-18e4077ef0f1'];
 let initialSearchData = {};
 let columnsWithNonNullValues = new Set();

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -182,6 +182,7 @@ const gridOptions = {
     singleClickEdit: true,
     headerHeight: 32,
     suppressDragLeaveHidesColumns: true,
+    maintainRowOrder: true,
     defaultColDef: {
         initialWidth: 100,
         sortable: true,

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -681,8 +681,6 @@ function processQueryUpdate(res, eventType, totalEventsSearched, timeToFirstByte
             );
         }
 
-        // for sort function display
-        sortByTimestampAtDefault = res.sortByTimestampAtDefault;
         columnCount = Math.max(columnCount, columnOrder.length) - 1; // Excluding timestamp
 
         renderAvailableFields(columnOrder, columnCount);
@@ -1193,11 +1191,6 @@ function codeToBuilderParsing(filterValue) {
 }
 
 function renderLogsGrid(columnOrder, hits) {
-    if (sortByTimestampAtDefault) {
-        logsColumnDefs[0].sort = 'desc';
-    } else {
-        logsColumnDefs[0].sort = undefined;
-    }
     if (gridDiv == null) {
         gridDiv = document.querySelector('#LogResultsGrid');
         //eslint-disable-next-line no-undef
@@ -1255,8 +1248,7 @@ function renderLogsGrid(columnOrder, hits) {
             return reorderedHit;
         });
 
-        logsRowData = mappedHits.concat(logsRowData);
-
+        logsRowData = [...logsRowData, ...mappedHits];
         if (liveTailState && logsRowData.length > 500) {
             logsRowData = logsRowData.slice(0, 500);
         }


### PR DESCRIPTION
# Description
Updated the logs data display to remove frontend sorting, ensuring the data is shown in the same order as received from the backend.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
