### PR TITLE
log query execution when the query is completed E2E

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -300,7 +300,7 @@ func ParseAndExecutePipeRequest(readJSON map[string]interface{}, qid uint64, myi
 	qc := structs.InitQueryContextWithTableInfo(ti, sizeLimit, scrollFrom, myid, false)
 	qc.RawQuery = searchText
 	if config.IsNewQueryPipelineEnabled() {
-		_, err = query.StartQuery(qid, false, nil)
+		rQuery, err := query.StartQuery(qid, false, nil)
 		if err != nil {
 			log.Errorf("qid=%v, ParseAndExecutePipeRequest: failed to associate search results with qid! Error: %+v",
 				qid, err)
@@ -315,10 +315,16 @@ func ParseAndExecutePipeRequest(readJSON map[string]interface{}, qid uint64, myi
 
 		query.SetQidAsFinishedForPipeRespQuery(qid)
 
+		startTime := rQuery.GetStartTime()
+		log.Infof("qid=%v, Finished execution in %+v", qid, time.Since(startTime))
+
+		query.DeleteQuery(qid)
+
 		return httpResponse, false, simpleNode.TimeRange, nil
 	} else {
 		result := segment.ExecuteQuery(simpleNode, aggs, qid, qc)
 		httpRespOuter := getQueryResponseJson(result, indexNameIn, queryStart, sizeLimit, qid, aggs, result.TotalRRCCount, dbPanelId, result.AllColumnsInAggs)
+		log.Infof("qid=%v, Finished execution in %+v", qid, time.Since(result.QueryStartTime))
 
 		return &httpRespOuter, false, simpleNode.TimeRange, nil
 	}

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -316,8 +316,13 @@ func processCompleteUpdate(conn *websocket.Conn, sizeLimit, qid uint64, aggs *st
 	if err != nil {
 		log.Errorf("qid=%d, processCompleteUpdate: failed to get number of RRCs for qid! Error: %v", qid, err)
 	}
+	startTime, err := query.GetQueryStartTime(qid)
+	if err != nil {
+		log.Errorf("qid=%d, processCompleteUpdate: failed to get query start time for qid! Error: %v", qid, err)
+	}
 
 	aggMeasureRes, aggMeasureFunctions, aggGroupByCols, columnsOrder, bucketCount := query.GetMeasureResultsForQid(qid, true, 0, aggs.BucketLimit) //aggs.BucketLimit
+	log.Infof("qid=%d, Finished execution in %+v", qid, time.Since(startTime))
 
 	var canScrollMore bool
 	if numRRCs == sizeLimit {

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
@@ -447,6 +446,9 @@ func ExecuteQuery(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uin
 		log.Errorf("qid=%d, ExecuteQuery: failed to get remote logs for qid! Error: %v", qid, err)
 	}
 
+	startTime := rQuery.GetStartTime()
+	res.QueryStartTime = startTime
+
 	query.DeleteQuery(qid)
 
 	return res
@@ -518,8 +520,6 @@ func executePipeRespQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggr
 func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uint64,
 	qc *structs.QueryContext, rQuery *query.RunningQueryState) *structs.NodeResult {
 
-	startTime := time.Now()
-
 	if qc.GetNumTables() == 0 {
 		log.Infof("qid=%d, ExecuteQuery: empty array of Index Names provided", qid)
 		return &structs.NodeResult{
@@ -553,7 +553,6 @@ func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators,
 	if uint64(len(nodeRes.AllRecords)) > qc.SizeLimit {
 		nodeRes.AllRecords = nodeRes.AllRecords[0:qc.SizeLimit]
 	}
-	log.Infof("qid=%d, Finished execution in %+v", qid, time.Since(startTime))
 
 	if rQuery.IsAsync() && aggs != nil && (aggs.Next != nil || aggs.HasGeneratedEventsWithoutSearch()) {
 		err := query.SetFinalStatsForQid(qid, nodeRes)

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"reflect"
 	"sync/atomic"
+	"time"
 
 	"github.com/cespare/xxhash"
 	"github.com/siglens/go-hll"
@@ -498,6 +499,7 @@ type NodeResult struct {
 	FinalColumns                map[string]bool
 	AllColumnsInAggs            map[string]struct{}
 	RemoteLogs                  []map[string]interface{}
+	QueryStartTime              time.Time // time when the query execution started. Can be removed once we switch to the new query pipeline
 }
 
 type SegStats struct {


### PR DESCRIPTION
# Description
- Logs the execution time, when the query is finished doing raw search and also fetched the final json records to send to the UI.
- This works for both old and new query pipeline

# Testing
- All unit test cases pass.
- I have tested by running WS and Http queries for both old and new query pipelines.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
