### PR TITLE
Parallelize search in the new pipeline

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -159,7 +159,6 @@ func (s *searcher) fetchRRCs() (*iqr.IQR, error) {
 	s.remainingBlocksSorted = s.remainingBlocksSorted[len(nextBlocks):]
 
 	allRRCsSlices := make([][]*segutils.RecordResultContainer, 0, len(nextBlocks)+1)
-	log.Errorf("andrew len(nextBlocks)=%v", len(nextBlocks))
 
 	// Prepare to call BatchProcess.
 	getBatchKey := func(block *block) string {
@@ -168,7 +167,6 @@ func (s *searcher) fetchRRCs() (*iqr.IQR, error) {
 	batchKeyLess := toputils.NewUnsetOption[func(string, string) bool]()
 	// The return value is not needed, so use struct{} as a placeholder.
 	batchOperation := func(blocks []*block) ([]*struct{}, error) {
-		log.Errorf("andrew len(blocksInBatch)=%v", len(blocks))
 		if len(blocks) == 0 {
 			// This should never happen.
 			return nil, nil

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -91,7 +91,7 @@ func Test_sortBlocks(t *testing.T) {
 	}
 }
 
-func Test_getNextEndTime_recentFirst(t *testing.T) {
+func Test_getNextBlocks_recentFirst(t *testing.T) {
 	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 40, low: 15},
 		{high: 30, low: 25},
@@ -125,7 +125,7 @@ func Test_getNextEndTime_recentFirst(t *testing.T) {
 	assert.Equal(t, uint64(10), blocks[3].HighTs)
 }
 
-func Test_getNextEndTime_recentLast(t *testing.T) {
+func Test_getNextBlocks_recentLast(t *testing.T) {
 	blocksSortedLow := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 20, low: 5},
 		{high: 10, low: 8},
@@ -159,7 +159,7 @@ func Test_getNextEndTime_recentLast(t *testing.T) {
 	assert.Equal(t, uint64(25), blocks[3].LowTs)
 }
 
-func Test_getNextEndTime_anyOrder(t *testing.T) {
+func Test_getNextBlocks_anyOrder(t *testing.T) {
 	allBlocks := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 20, low: 5},
 		{high: 30, low: 25},

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -117,7 +117,7 @@ func Test_getNextEndTime_recentFirst(t *testing.T) {
 	desiredMaxBlocks = 10 // More than the number of blocks.
 	blocks, endTime, err = getNextBlocks(blocksSortedHigh, desiredMaxBlocks, recentFirst)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(8), endTime)
+	assert.Equal(t, uint64(5), endTime)
 	assert.Equal(t, 4, len(blocks))
 	assert.Equal(t, uint64(40), blocks[0].HighTs)
 	assert.Equal(t, uint64(30), blocks[1].HighTs)
@@ -151,12 +151,45 @@ func Test_getNextEndTime_recentLast(t *testing.T) {
 	desiredMaxBlocks = 10 // More than the number of blocks.
 	blocks, endTime, err = getNextBlocks(blocksSortedLow, desiredMaxBlocks, recentLast)
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(30), endTime)
+	assert.Equal(t, uint64(40), endTime)
 	assert.Equal(t, 4, len(blocks))
 	assert.Equal(t, uint64(5), blocks[0].LowTs)
 	assert.Equal(t, uint64(8), blocks[1].LowTs)
 	assert.Equal(t, uint64(15), blocks[2].LowTs)
 	assert.Equal(t, uint64(25), blocks[3].LowTs)
+}
+
+func Test_getNextEndTime_anyOrder(t *testing.T) {
+	allBlocks := makeBlocksWithSummaryOnly([]timeRange{
+		{high: 20, low: 5},
+		{high: 30, low: 25},
+		{high: 10, low: 8},
+		{high: 40, low: 15},
+	})
+
+	desiredMaxBlocks := 1
+	blocks, _, err := getNextBlocks(allBlocks, desiredMaxBlocks, anyOrder)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(blocks))
+	assert.Equal(t, uint64(20), blocks[0].HighTs)
+
+	desiredMaxBlocks = 4
+	blocks, _, err = getNextBlocks(allBlocks, desiredMaxBlocks, anyOrder)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(blocks))
+	assert.Equal(t, uint64(20), blocks[0].HighTs)
+	assert.Equal(t, uint64(30), blocks[1].HighTs)
+	assert.Equal(t, uint64(10), blocks[2].HighTs)
+	assert.Equal(t, uint64(40), blocks[3].HighTs)
+
+	desiredMaxBlocks = 10 // More than the number of blocks.
+	blocks, _, err = getNextBlocks(allBlocks, desiredMaxBlocks, anyOrder)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(blocks))
+	assert.Equal(t, uint64(20), blocks[0].HighTs)
+	assert.Equal(t, uint64(30), blocks[1].HighTs)
+	assert.Equal(t, uint64(10), blocks[2].HighTs)
+	assert.Equal(t, uint64(40), blocks[3].HighTs)
 }
 
 func Test_getSSRs(t *testing.T) {

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -91,7 +91,7 @@ func Test_sortBlocks(t *testing.T) {
 	}
 }
 
-func Test_getNextEndTime(t *testing.T) {
+func Test_getNextEndTime_recentFirst(t *testing.T) {
 	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 40, low: 15},
 		{high: 30, low: 25},
@@ -102,7 +102,9 @@ func Test_getNextEndTime(t *testing.T) {
 	endTime, err := getNextEndTime(blocksSortedHigh, recentFirst)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(15), endTime)
+}
 
+func Test_getNextEndTime_recentLast(t *testing.T) {
 	blocksSortedLow := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 20, low: 5},
 		{high: 10, low: 8},
@@ -110,7 +112,7 @@ func Test_getNextEndTime(t *testing.T) {
 		{high: 30, low: 25},
 	})
 
-	endTime, err = getNextEndTime(blocksSortedLow, recentLast)
+	endTime, err := getNextEndTime(blocksSortedLow, recentLast)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(20), endTime)
 }

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -91,48 +91,6 @@ func Test_sortBlocks(t *testing.T) {
 	}
 }
 
-func Test_getNumBlocksBefore_recentFirst(t *testing.T) {
-	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
-		{high: 40, low: 15},
-		{high: 30, low: 25},
-		{high: 20, low: 5},
-		{high: 10, low: 8},
-	})
-
-	numBlocksBefore := getNumBlocksBefore(blocksSortedHigh, 60, recentFirst)
-	assert.Equal(t, 0, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedHigh, 30, recentFirst)
-	assert.Equal(t, 1, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedHigh, 23, recentFirst)
-	assert.Equal(t, 2, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedHigh, 0, recentFirst)
-	assert.Equal(t, 4, numBlocksBefore)
-}
-
-func Test_getNumBlocksBefore_recentLast(t *testing.T) {
-	blocksSortedLow := makeBlocksWithSummaryOnly([]timeRange{
-		{high: 20, low: 5},
-		{high: 10, low: 8},
-		{high: 40, low: 15},
-		{high: 30, low: 25},
-	})
-
-	numBlocksBefore := getNumBlocksBefore(blocksSortedLow, 0, recentLast)
-	assert.Equal(t, 0, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedLow, 8, recentLast)
-	assert.Equal(t, 1, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedLow, 10, recentLast)
-	assert.Equal(t, 2, numBlocksBefore)
-
-	numBlocksBefore = getNumBlocksBefore(blocksSortedLow, 50, recentLast)
-	assert.Equal(t, 4, numBlocksBefore)
-}
-
 func Test_getNextEndTime_recentFirst(t *testing.T) {
 	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 40, low: 15},

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -91,6 +91,45 @@ func Test_sortBlocks(t *testing.T) {
 	}
 }
 
+func Test_getNextBlocks_exceedsMaxDesired(t *testing.T) {
+	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
+		{high: 40, low: 20},
+		{high: 40, low: 15},
+		{high: 40, low: 25},
+		{high: 30, low: 10},
+	})
+
+	desiredMaxBlocks := 1
+	blocks, endTime, err := getNextBlocks(blocksSortedHigh, desiredMaxBlocks, recentFirst)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(30), endTime)
+	assert.Equal(t, 3, len(blocks))
+	assert.Equal(t, uint64(40), blocks[0].HighTs)
+	assert.Equal(t, uint64(20), blocks[0].LowTs)
+	assert.Equal(t, uint64(40), blocks[1].HighTs)
+	assert.Equal(t, uint64(15), blocks[1].LowTs)
+	assert.Equal(t, uint64(40), blocks[2].HighTs)
+	assert.Equal(t, uint64(25), blocks[2].LowTs)
+}
+
+func Test_getNextBlocks_lessThanMaxDesired(t *testing.T) {
+	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
+		{high: 40, low: 20},
+		{high: 30, low: 15},
+		{high: 30, low: 25},
+		{high: 20, low: 10},
+	})
+
+	// Since taking the second block would require taking the third, only one
+	// block can be taken.
+	desiredMaxBlocks := 2
+	blocks, endTime, err := getNextBlocks(blocksSortedHigh, desiredMaxBlocks, recentFirst)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(30), endTime)
+	assert.Equal(t, 1, len(blocks))
+	assert.Equal(t, uint64(40), blocks[0].HighTs)
+}
+
 func Test_getNextBlocks_recentFirst(t *testing.T) {
 	blocksSortedHigh := makeBlocksWithSummaryOnly([]timeRange{
 		{high: 40, low: 15},

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -43,9 +43,9 @@ func RawSearchSingleQuery(query *structs.SearchQuery, searchReq *structs.Segment
 		// if we fail to read needed columns, we can convert it to a match none
 		// TODO: what would this look like in complex relations
 		queryType = structs.EditQueryTypeForInvalidColumn(queryType)
-		log.Warnf("qid=%d, filterBlockRequestFromQuery: Unable to read all columns in query new query type %+v",
+		log.Warnf("qid=%d, RawSearchSingleQuery: Unable to read all columns in query new query type %+v",
 			qid, queryType)
-		log.Warnf("qid=%d, filterBlockRequestFromQuery: Tried to initialized a multi reader for %+v. Error: %v",
+		log.Warnf("qid=%d, RawSearchSingleQuery: Tried to initialized a multi reader for %+v. Error: %v",
 			qid, searchCols, err)
 	}
 


### PR DESCRIPTION
# Description
The old pipeline already does search in parallel. The new pipeline called functions in the old pipeline, but it called them on one block at a time, so the search was not able to happen in parallel. This PR fixes that; it's especially apparent for bottleneck commands because then we have to search a lot more data.

# Testing
## Correctness
New unit tests

## Performance
I ran tests using a dataset of 5.5 million rows with 330 columns and many null values; I tested with the query `electrogenic | sort timestamp`. About 8k records matched.

**Time results**
Old pipeline: 32.5 seconds
New pipeline without this PR: 49.7 seconds
New pipeline with this PR: 13.5 seconds

I also enabled pprof and check the CPU usage via
```
curl -s -v "http://localhost:5122/debug/pprof/trace?seconds=5" > trace.out && go tool trace trace.out
```
Without this PR, the trace showed only one CPU was being used on the new pipeline. With this PR, 5 CPUs are used (because I ran on a 10-CPU machine, and we set parallelism to half the CPUs on the machine). The old pipeline always used 5 CPUs.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
