### PR TITLE
Fix for query 293 not working on the new pipeline.

### DIFF
--- a/pkg/segment/query/processor/wherecommand.go
+++ b/pkg/segment/query/processor/wherecommand.go
@@ -59,7 +59,7 @@ func (p *whereProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 		shouldKeep, err := p.options.Evaluate(singleRow)
 		if err != nil {
 			log.Errorf("where.Process: cannot evaluate expression; err=%v", err)
-			return nil, err
+			continue
 		}
 
 		if !shouldKeep {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -960,6 +960,8 @@ func (e *CValueEnclosure) GetString() (string, error) {
 		return strconv.FormatInt(e.CVal.(int64), 10), nil
 	case SS_DT_FLOAT:
 		return fmt.Sprintf("%f", e.CVal.(float64)), nil
+	case SS_DT_BACKFILL:
+		return fmt.Sprintf("%v", nil), nil
 	default:
 		return "", fmt.Errorf("CValueEnclosure GetString: unsupported Dtype: %v", e.Dtype)
 	}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -960,8 +960,6 @@ func (e *CValueEnclosure) GetString() (string, error) {
 		return strconv.FormatInt(e.CVal.(int64), 10), nil
 	case SS_DT_FLOAT:
 		return fmt.Sprintf("%f", e.CVal.(float64)), nil
-	case SS_DT_BACKFILL:
-		return fmt.Sprintf("%v", nil), nil
 	default:
 		return "", fmt.Errorf("CValueEnclosure GetString: unsupported Dtype: %v", e.Dtype)
 	}

--- a/tools/sigclient/pkg/query/query.go
+++ b/tools/sigclient/pkg/query/query.go
@@ -924,7 +924,6 @@ var skipIndexes = map[int]bool{
 	// Misc
 	35:  true, // IQR.AsResult: error getting final result for GroupBy: IQR.getFinalStatsResults: knownValues is empty
 	291: true, // sum(countVal) is not computed properly (most likely due to if which is returning data as string not number) so no results are returned for (where count=sum_count)
-	293: true, // where.Process: cannot evaluate expression; err=BoolExpr.Evaluate: left cannot be evaluated to a string or float
 	161: true, // Older pipeline removes the groupByCol/value if something else is renamed to it, NOT SURE ON THE CORRECT APPROACH!
 
 	// PQS Issue


### PR DESCRIPTION
# Description
Summarize the change.
This change is for the query `city=Boston | eval nullField1=null() | eval nullField2=null() | eval nullStatus=nullif(http_status, 200) | fillnull value=FILLING nullField1 nullField2 | fields city, http_status, nullField1, nullField2, nullStatus | where nullStatus=null() | stats count(*)`.

Earlier in the old pipeline we were just [logging the error and moving on](https://github.com/siglens/siglens/blob/d96796f01f64b3dd9fdd400bdbf1c5c36519c3d2/pkg/segment/aggregations/segaggs.go#L3653) while computing where command.
All the null fields were generating the error because they were not being converted to float or [string](https://github.com/siglens/siglens/blob/d96796f01f64b3dd9fdd400bdbf1c5c36519c3d2/pkg/segment/utils/segconsts.go#L964) from [here](https://github.com/siglens/siglens/blob/d96796f01f64b3dd9fdd400bdbf1c5c36519c3d2/pkg/segment/structs/evaluationstructs.go#L2615).

We cannot evaluate null to string, because many commands assume that null value will result in an error and we check the null fields for that.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
