### PR TITLE
Get Bucket count from the length of first column

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -1096,8 +1096,12 @@ func (iqr *IQR) getFinalStatsResults() ([]*structs.BucketHolder, []string, []str
 		return nil, nil, nil, 0, fmt.Errorf("IQR.getFinalStatsResults: measureColumns is empty")
 	}
 
+	bucketCount := 0
 	// The bucket count is the number of rows in the final result. So we can use the length of any column.
-	bucketCount := len(knownValues[iqr.measureColumns[0]])
+	for _, values := range iqr.knownValues {
+		bucketCount = len(values)
+		break
+	}
 	if bucketCount == 0 {
 		return nil, nil, nil, 0, fmt.Errorf("IQR.getFinalStatsResults: bucketCount is 0")
 	}


### PR DESCRIPTION
# Description
- If the field in measure columns is deleted from `knownValues`, the length of the slice for that columns will be zero and we will return an error.
- But that column might be eliminated through fields commands

Example Query:
`* | stats count(*) as count, sum(http_status) as sum | eval n=2 | fields n`
In the above, the server is throwing an error that the `"IQR.getFinalStatsResults: bucketCount is 0"`. But it is actually not and this PR fixes that.

# Testing
- All unit tests passed.
- Tested by running the above query

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
