### PR TITLE
Fix totalMatched for segStatsCmd and groupByCmd.

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -430,7 +430,7 @@ func getQueryResponseJson(nodeResult *structs.NodeResult, indexName string, quer
 		canScrollMore = true
 	}
 	httpResp.Hits = json
-	httpResp.TotalMatched = convertQueryCountToTotalResponse(nodeResult.TotalResults)
+	httpResp.TotalMatched = query.ConvertQueryCountToTotalResponse(nodeResult.TotalResults)
 	httpRespOuter.Hits = httpResp
 	httpRespOuter.AllPossibleColumns = allCols
 	httpRespOuter.ElapedTimeMS = time.Since(queryStart).Milliseconds()
@@ -515,18 +515,6 @@ func convertBucketToAggregationResponse(buckets map[string]*structs.AggregationR
 		resp[aggName] = structs.AggregationResults{Buckets: allBuckets}
 	}
 	return resp
-}
-
-func convertQueryCountToTotalResponse(qc *structs.QueryCount) interface{} {
-	if qc == nil {
-		return 0
-	}
-
-	if !qc.EarlyExit {
-		return qc.TotalCount
-	}
-
-	return utils.HitsCount{Value: qc.TotalCount, Relation: qc.Op.ToString()}
 }
 
 func GetAutoCompleteData(ctx *fasthttp.RequestCtx, myid uint64) {

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -390,7 +390,7 @@ func processCompleteUpdate(conn *websocket.Conn, sizeLimit, qid uint64, aggs *st
 	}
 	queryType := query.GetQueryType(qid)
 	resp := &structs.PipeSearchCompleteResponse{
-		TotalMatched:        convertQueryCountToTotalResponse(queryC),
+		TotalMatched:        query.ConvertQueryCountToTotalResponse(queryC),
 		State:               query.COMPLETE.String(),
 		TotalEventsSearched: humanize.Comma(int64(totalEventsSearched)),
 		CanScrollMore:       canScrollMore,

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -320,6 +320,7 @@ func (qp *QueryProcessor) GetStreamedResult(stateChan chan *query.QueryStateChan
 		completeResp.MeasureFunctions = result.MeasureFunctions
 		completeResp.GroupByCols = result.GroupByCols
 		completeResp.BucketCount = result.BucketCount
+		completeResp.TotalMatched = result.Hits.TotalMatched
 	}
 
 	canScrollMore, relation, progress, err := qp.getStatusParams(uint64(totalRecords))
@@ -327,7 +328,9 @@ func (qp *QueryProcessor) GetStreamedResult(stateChan chan *query.QueryStateChan
 		return utils.TeeErrorf("GetStreamedResult: failed to get status params, err: %v", err)
 	}
 
-	completeResp.TotalMatched = utils.HitsCount{Value: uint64(progress.RecordsSent), Relation: relation}
+	if qp.queryType == structs.RRCCmd {
+		completeResp.TotalMatched = utils.HitsCount{Value: uint64(progress.RecordsSent), Relation: relation}
+	}
 	completeResp.State = query.COMPLETE.String()
 	completeResp.TotalEventsSearched = humanize.Comma(int64(progress.TotalRecords))
 	completeResp.TotalRRCCount = progress.RecordsSent

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -247,6 +247,10 @@ func (s *searcher) fetchStatsResults() (*iqr.IQR, error) {
 		log.Errorf("qid=%v, searcher.fetchGroupByResults: failed to initialize search results: %v", s.qid, err)
 		return nil, err
 	}
+	err = query.AssociateSearchResult(qid, searchResults)
+	if err != nil {
+		return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: failed to associate search results: %v", s.qid, err)
+	}
 
 	var nodeResult *structs.NodeResult
 

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -245,6 +245,21 @@ func AssociateSearchInfoWithQid(qid uint64, result *segresults.SearchResults, ag
 	return nil
 }
 
+func AssociateSearchResult(qid uint64, result *segresults.SearchResults) error {
+	arqMapLock.RLock()
+	rQuery, ok := allRunningQueries[qid]
+	arqMapLock.RUnlock()
+	if !ok {
+		return putils.TeeErrorf("AssociateSearchResult: qid %+v does not exist!", qid)
+	}
+
+	rQuery.rqsLock.Lock()
+	rQuery.searchRes = result
+	rQuery.rqsLock.Unlock()
+
+	return nil
+}
+
 // increments the finished segments. If incr is 0, then the current query is finished and a histogram will be flushed
 func IncrementNumFinishedSegments(incr int, qid uint64, recsSearched uint64,
 	skEnc uint16, remoteId string, doBuckPull bool, sstMap map[string]*structs.SegStats) {
@@ -1163,4 +1178,16 @@ func InitScrollFrom(qid uint64, scrollFrom uint64) error {
 	rQuery.scrollFrom = scrollFrom
 
 	return nil
+}
+
+func ConvertQueryCountToTotalResponse(qc *structs.QueryCount) interface{} {
+	if qc == nil {
+		return 0
+	}
+
+	if !qc.EarlyExit {
+		return putils.HitsCount{Value: qc.TotalCount, Relation: "eq"}
+	}
+
+	return putils.HitsCount{Value: qc.TotalCount, Relation: qc.Op.ToString()}
 }

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -836,6 +836,7 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 			sstMap["*"] = &structs.SegStats{
 				Count: uint64(segReq.TotalRecords),
 			}
+			allSegFileResults.AddResultCount(uint64(segReq.TotalRecords))
 		} else {
 			// run through micro index check for block tracker & generate SSR
 			blocksToRawSearch, err := segReq.GetMicroIndexFilter()

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -221,6 +221,12 @@ func (sr *SearchResults) AddSSTMap(sstMap map[string]*structs.SegStats, skEnc ui
 	sr.updateLock.Unlock()
 }
 
+func (sr *SearchResults) AddResultCount(count uint64) {
+	sr.updateLock.Lock()
+	sr.resultCount += count
+	sr.updateLock.Unlock()
+}
+
 // deletes segKeyEnc from the map of allSSTS and any errors associated with it
 func (sr *SearchResults) GetEncodedSegStats(segKeyEnc uint16) ([]byte, error) {
 	sr.updateLock.Lock()

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -788,6 +788,7 @@ func RawComputeSegmentStats(req *structs.SegmentSearchRequest, fileParallelism i
 	segmentSearchRecords.Close()
 	queryMetrics.SetNumRecordsMatched(finalMatched)
 	queryMetrics.SetNumRecordsUnmatched(finalUnmatched)
+	allSearchResults.AddResultCount(finalMatched)
 
 	timeElapsed := time.Since(sTime)
 	qs.UpdateSummary(summary.RAW, timeElapsed, queryMetrics)

--- a/pkg/segment/segexecution_test.go
+++ b/pkg/segment/segexecution_test.go
@@ -553,7 +553,7 @@ func nestedAggregationQueryTest(t *testing.T, numBuffers int, numEntriesForBuffe
 	result := ExecuteQuery(simpleNode, simpleMeasure, 48, qc)
 
 	assert.Len(t, result.AllRecords, 0)
-	assert.Zero(t, result.TotalResults.TotalCount)
+	assert.Equal(t, 100, int(result.TotalResults.TotalCount))
 	assert.False(t, result.TotalResults.EarlyExit)
 
 	assert.Len(t, result.MeasureFunctions, 1)
@@ -587,7 +587,7 @@ func nestedAggregationQueryTest(t *testing.T, numBuffers int, numEntriesForBuffe
 	result = ExecuteQuery(simpleNode, simpleMeasure, 49, qc)
 
 	assert.Len(t, result.AllRecords, 0)
-	assert.Zero(t, result.TotalResults.TotalCount)
+	assert.Equal(t, 100, int(result.TotalResults.TotalCount))
 	assert.False(t, result.TotalResults.EarlyExit)
 
 	assert.Len(t, result.MeasureFunctions, 2)
@@ -872,7 +872,7 @@ func nestedAggsNumericColRequestTest(t *testing.T, numBuffers int, numEntriesFor
 	result := ExecuteQuery(simpleNode, simpleMeasure, 51, qc)
 
 	assert.Len(t, result.AllRecords, 0)
-	assert.Zero(t, result.TotalResults.TotalCount)
+	assert.Equal(t, 100, int(result.TotalResults.TotalCount))
 	assert.False(t, result.TotalResults.EarlyExit)
 
 	assert.Len(t, result.MeasureFunctions, 2)
@@ -1800,7 +1800,7 @@ func measureColsTest(t *testing.T, numBuffers int, numEntriesForBuffer int, file
 
 	if measureCol == "*" && measureFunc != Count {
 		assert.Len(t, result.AllRecords, 0)
-		assert.Zero(t, result.TotalResults.TotalCount)
+		assert.Equal(t, 100, int(result.TotalResults.TotalCount))
 		assert.False(t, result.TotalResults.EarlyExit)
 	}
 }
@@ -1853,7 +1853,7 @@ func groupByAggQueryTest(t *testing.T, numBuffers int, numEntriesForBuffer int, 
 	} else if measureCol == "*" && measureFunc != Count {
 		assert.NotZero(t, len(result.ErrList))
 		assert.Len(t, result.AllRecords, 0)
-		assert.Zero(t, result.TotalResults.TotalCount)
+		assert.Equal(t, 0, int(result.TotalResults.TotalCount))
 		assert.False(t, result.TotalResults.EarlyExit)
 	}
 

--- a/tools/sigclient/pkg/query/query.go
+++ b/tools/sigclient/pkg/query/query.go
@@ -922,12 +922,6 @@ func RunQueryFromFileAndOutputResponseTimes(dest string, filepath string, queryR
 
 var skipIndexes = map[int]bool{
 
-	// Comparing totalMatched for stats query
-	4:   true,
-	8:   true,
-	13:  true,
-	134: true,
-
 	// Misc
 	35:  true, // IQR.AsResult: error getting final result for GroupBy: IQR.getFinalStatsResults: knownValues is empty
 	161: true, // Older pipeline removes the groupByCol/value if something else is renamed to it, NOT SURE ON THE CORRECT APPROACH!


### PR DESCRIPTION
# Description
Summarize the change.
- totalMatched returned for segStatsCmd and groupByCmd should be the value of initial search
- In the old pipeline the totalMatched was correct for groupByCmd but for segStatsCmd it was 0, now it should return the count of initial search match.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
Enabled the 4 queries that are testing this scenario in ingest.csv

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
