### PR TITLE
Avoid prematurely writing to pqmeta file

### DIFF
--- a/pkg/segment/query/metadata/blockmeta.go
+++ b/pkg/segment/query/metadata/blockmeta.go
@@ -26,7 +26,6 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
-	"github.com/siglens/siglens/pkg/segment/writer"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -86,10 +85,6 @@ func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
 
 	totalBlockCount := uint64(len(smi.BlockSummaries))
 	timeFilteredBlocks := metautils.FilterBlocksByTime(smi.BlockSummaries, blockTracker, timeRange)
-	droppedBlocksDueToTime := false
-	if len(timeFilteredBlocks) < int(totalBlockCount) {
-		droppedBlocksDueToTime = true
-	}
 
 	var missingBlockCMI bool
 	if len(timeFilteredBlocks) > 0 && !isMatchAll && !wildCardValue {
@@ -125,12 +120,6 @@ func RunCmiCheck(segkey string, tableName string, timeRange *dtu.TimeRange,
 	}
 
 	smi.RUnlockSmi()
-
-	if len(timeFilteredBlocks) == 0 && !droppedBlocksDueToTime {
-		if isQueryPersistent {
-			go writer.AddToBackFillAndEmptyPQSChan(segkey, pqid, true)
-		}
-	}
 
 	return finalReq, totalBlockCount, filteredBlockCount, err
 }


### PR DESCRIPTION
# Description
This fixes a bug with PQS in the new query pipeline. For PQS, each segment has a .pqmr file for each persistent query being tracked that stores results for that query. Also, there's one .meta file for the segment storing which of those .pqmr files have no results. There was a bug where that .meta file would have entries that it shouldn't have, causing queries to give too few matches. We were writing to the .meta file after doing CMI checks; this worked for the old pipeline because we do CMI checks for all the relevant blocks in a segment at once; however, in the new pipeline we often to CMI checks for just some of the blocks in a segment, and do checks for other blocks in that segment later (if at all). So in the new pipeline we incorrectly wrote to the .meta file when none of the blocks in the batch passed CMI, but there could still be other blocks in the segment that will have matching records.

For now, there will be less info stored in the .meta file. However, we still have the .pqmr files so PQS can still efficiently find which records will match.


# Testing
I ingested data, and ran queries multiple times with PQS enabled and disabled. The queries mentioned below failed without this PR when PQS was enabled, but with this PR they give the correct results.

## Functional dataset
```
go run main.go functional -d http://localhost:8081/elastic -f functionalQueries/functionalQueries.yml -q localhost:5122
```
Then ran this query
```
http_method=POST AND (app_name=Bracecould OR app_name=R*) | regex app_name=".*could" | stats avg(http_status), max(latency) as max, min(longitude) as min, sum(latitude) as sum, range(latency), count as cnt, values(weekday), dc(weekday) as distinct_count, list(http_method) BY gender, bool_col
```

## Benchmark dataset
```
go run main.go ingest esbulk -n 10 -g benchmark -d http://localhost:8081/elastic -t 100_000
```
And ran this query
```
app_name=Bracecould OR app_name=R* | stats count as Count BY gender
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
