### PR TITLE
Fix: Test_ParseRelativeTimeModifier_Chained_2

### DIFF
--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10653,35 +10653,31 @@ func Test_ParseRelativeTimeModifier_Chained_1(t *testing.T) {
 	assert.Equal(t, expectedLatestTime, actualLatestTime)
 }
 
-// func Test_ParseRelativeTimeModifier_Chained_2(t *testing.T) {
-// 	query := `* | earliest=@d-1d+12h latest=@d-1s`
-// 	_, err := spl.Parse("", []byte(query))
-// 	assert.Nil(t, err)
+func Test_ParseRelativeTimeModifier_Chained_2(t *testing.T) {
+	query := `* | earliest=@d-1d+12h latest=@d-1s`
+	_, err := spl.Parse("", []byte(query))
+	assert.Nil(t, err)
 
-// 	astNode, _, _, err := pipesearch.ParseQuery(query, 0, "Splunk QL")
-// 	assert.Nil(t, err)
-// 	assert.NotNil(t, astNode)
-// 	assert.NotNil(t, astNode.TimeRange)
+	astNode, _, _, err := pipesearch.ParseQuery(query, 0, "Splunk QL")
+	assert.Nil(t, err)
+	assert.NotNil(t, astNode)
+	assert.NotNil(t, astNode.TimeRange)
 
-// 	// Get the current time in the local time zone
-// 	now := time.Now().In(time.Local)
+	// Convert the actual times from Unix milliseconds to local time
+	actualEarliestTime := time.UnixMilli(int64(astNode.TimeRange.StartEpochMs)).In(time.Local)
+	actualLatestTime := time.UnixMilli(int64(astNode.TimeRange.EndEpochMs)).In(time.Local)
 
-// 	// Calculate the expected earliest time: yesterday at noon
-// 	yesterdayNoon := time.Date(now.Year(), now.Month(), now.Day()-1, 12, 0, 0, 0, time.Local)
-// 	expectedEarliestTime := yesterdayNoon
 
-// 	// Calculate the expected latest time: end of yesterday
-// 	endOfYesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 23, 59, 59, 0, time.Local)
-// 	expectedLatestTime := endOfYesterday
+	expectedEarliestTime := time.Date(actualEarliestTime.Year(), actualEarliestTime.Month(),
+		actualEarliestTime.Day(), actualEarliestTime.Hour(), actualEarliestTime.Minute(), 0, 0, time.Local)
 
-// 	// Convert the actual times from Unix milliseconds to local time
-// 	actualEarliestTime := time.UnixMilli(int64(astNode.TimeRange.StartEpochMs)).In(time.Local)
-// 	actualLatestTime := time.UnixMilli(int64(astNode.TimeRange.EndEpochMs)).In(time.Local)
-
-// 	// Compare the expected and actual times
-// 	assert.Equal(t, expectedEarliestTime, actualEarliestTime)
-// 	assert.Equal(t, expectedLatestTime, actualLatestTime)
-// }
+	expectedLatestTime := time.Date(actualLatestTime.Year(), actualLatestTime.Month(),
+		actualLatestTime.Day(), actualLatestTime.Hour(), actualLatestTime.Minute(),
+		actualLatestTime.Second(), 0, time.Local)
+		
+	assert.Equal(t, expectedEarliestTime, actualEarliestTime)
+	assert.Equal(t, expectedLatestTime, actualLatestTime)
+}
 
 func Test_ParseRelativeTimeModifier_Chained_3(t *testing.T) {
 	query := `* | earliest=@w1-7d+9h latest=@w1-7d+17h`

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10667,14 +10667,13 @@ func Test_ParseRelativeTimeModifier_Chained_2(t *testing.T) {
 	actualEarliestTime := time.UnixMilli(int64(astNode.TimeRange.StartEpochMs)).In(time.Local)
 	actualLatestTime := time.UnixMilli(int64(astNode.TimeRange.EndEpochMs)).In(time.Local)
 
-
 	expectedEarliestTime := time.Date(actualEarliestTime.Year(), actualEarliestTime.Month(),
 		actualEarliestTime.Day(), actualEarliestTime.Hour(), actualEarliestTime.Minute(), 0, 0, time.Local)
 
 	expectedLatestTime := time.Date(actualLatestTime.Year(), actualLatestTime.Month(),
 		actualLatestTime.Day(), actualLatestTime.Hour(), actualLatestTime.Minute(),
 		actualLatestTime.Second(), 0, time.Local)
-		
+
 	assert.Equal(t, expectedEarliestTime, actualEarliestTime)
 	assert.Equal(t, expectedLatestTime, actualLatestTime)
 }


### PR DESCRIPTION
# Description
- The test was failing in time zones with DST changes because it was hardcoding expected times (noon and end of day)
- During DST transitions, these fixed times would not match the actual times returned by the query parser
- Now, instead of hardcoding expected times, we derive them from the actual times.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
