### PR TITLE
fix: flooding of error logs from MulticolReader

### DIFF
--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -177,9 +177,8 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*utils.RecordResultContaine
 	}
 	defer sharedReader.Close()
 
-	colErrorMap := sharedReader.GetReaderColumnsErrorsMap()
+	colErrorMap := sharedReader.GetColumnsErrorsMap()
 	if len(colErrorMap) > 0 {
-		// sharedReader.LogReaderErrorsForColumns(qid)
 		return nil, colErrorMap[cname]
 	}
 

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -28,6 +28,7 @@ import (
 	"github.com/siglens/siglens/pkg/common/fileutils"
 	"github.com/siglens/siglens/pkg/config"
 	segmetadata "github.com/siglens/siglens/pkg/segment/metadata"
+	"github.com/siglens/siglens/pkg/segment/query"
 	"github.com/siglens/siglens/pkg/segment/reader/segread"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -161,17 +162,24 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*utils.RecordResultContaine
 		}
 	}
 
+	nodeRes, err := query.GetOrCreateQuerySearchNodeResult(qid)
+	if err != nil {
+		// This should not happen, unless qid is deleted.
+		log.Errorf("qid=%v, readUserDefinedColForRRCs: failed to get or create query search node result; err=%v", qid, err)
+		nodeRes = &structs.NodeResult{}
+	}
 	consistentCValLen := map[string]uint32{cname: utils.INCONSISTENT_CVAL_SIZE} // TODO: use correct value
 	sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, map[string]bool{cname: true},
-		blockMetadata, blockSummary, 1, consistentCValLen, qid)
+		blockMetadata, blockSummary, 1, consistentCValLen, qid, nodeRes)
 	if err != nil {
 		log.Errorf("qid=%v, readUserDefinedColForRRCs: failed to initialize shared readers for segkey %v; err=%v", qid, segKey, err)
 		return nil, err
 	}
 	defer sharedReader.Close()
 
-	colErrorMap := sharedReader.GetColumnsErrorsMap()
+	colErrorMap := sharedReader.GetReaderColumnsErrorsMap()
 	if len(colErrorMap) > 0 {
+		// sharedReader.LogReaderErrorsForColumns(qid)
 		return nil, colErrorMap[cname]
 	}
 
@@ -347,7 +355,7 @@ func getRecordsFromSegmentHelper(segKey string, vTable string, blkRecIndexes map
 	}
 
 	result := make(map[string]map[string]interface{})
-	sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, allCols, blockMetadata, blockSum, 1, consistentCValLen, qid)
+	sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, allCols, blockMetadata, blockSum, 1, consistentCValLen, qid, nodeRes)
 	if err != nil {
 		log.Errorf("getRecordsFromSegmentHelper: failed to initialize shared readers for segkey=%v, err=%v", segKey, err)
 		return nil, map[string]bool{}, err

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -248,7 +248,7 @@ func (scr *SharedMultiColReaders) Close() {
 	fileutils.GLOBAL_FD_LIMITER.Release(scr.numOpenFDs)
 }
 
-func (scr *SharedMultiColReaders) GetReaderColumnsErrorsMap() map[string]error {
+func (scr *SharedMultiColReaders) GetColumnsErrorsMap() map[string]error {
 	return scr.columnErrorMap
 }
 

--- a/pkg/segment/reader/segread/multicolreader_test.go
+++ b/pkg/segment/reader/segread/multicolreader_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/siglens/siglens/pkg/config"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
 	log "github.com/sirupsen/logrus"
@@ -40,7 +41,7 @@ func Test_multiSegReader(t *testing.T) {
 	_, bSum, _, cols, blockmeta, _ := writer.WriteMockColSegFile(segBaseDir, segKey, numBlocks, numEntriesInBlock)
 
 	assert.Greater(t, len(cols), 1)
-	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9)
+	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9, &structs.NodeResult{})
 	assert.Nil(t, foundErr)
 	assert.Len(t, sharedReader.MultiColReaders, sharedReader.numReaders)
 	assert.Equal(t, 3, sharedReader.numReaders)
@@ -113,13 +114,13 @@ func Test_InitSharedMultiColumnReaders(t *testing.T) {
 	_, bSum, _, cols, blockmeta, _ := writer.WriteMockColSegFile(segBaseDir, segKey, numBlocks, numEntriesInBlock)
 
 	assert.Greater(t, len(cols), 1)
-	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9)
+	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9, &structs.NodeResult{})
 	assert.Nil(t, foundErr)
 	assert.Len(t, sharedReader.MultiColReaders, sharedReader.numReaders)
 	assert.Equal(t, 3, sharedReader.numReaders)
 
 	cols["*"] = true
-	sharedAsteriskReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9)
+	sharedAsteriskReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bSum, 3, nil, 9, &structs.NodeResult{})
 	assert.Nil(t, foundErr)
 	assert.Len(t, sharedAsteriskReader.MultiColReaders, sharedAsteriskReader.numReaders)
 	assert.Equal(t, 3, sharedAsteriskReader.numReaders)

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -49,7 +49,7 @@ func Test_segReader(t *testing.T) {
 	var queryCol string
 
 	colsToReadIndices := make(map[int]struct{})
-	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bsm, 3, nil, 9)
+	sharedReader, foundErr := InitSharedMultiColumnReaders(segKey, cols, blockmeta, bsm, 3, nil, 9, &structs.NodeResult{})
 	assert.Nil(t, foundErr)
 	assert.Len(t, sharedReader.MultiColReaders, sharedReader.numReaders)
 	assert.Equal(t, 3, sharedReader.numReaders)

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -37,7 +37,7 @@ func RawSearchSingleQuery(query *structs.SearchQuery, searchReq *structs.Segment
 	queryType := query.GetQueryType()
 	searchCols := getAllColumnsNeededForSearch(query, searchReq.AllPossibleColumns)
 	sharedMultiReader, err := segread.InitSharedMultiColumnReaders(searchReq.SegmentKey, searchCols, searchReq.AllBlocksToSearch,
-		searchReq.SearchMetadata.BlockSummaries, len(allBlockSearchHelpers), searchReq.ConsistentCValLenMap, qid)
+		searchReq.SearchMetadata.BlockSummaries, len(allBlockSearchHelpers), searchReq.ConsistentCValLenMap, qid, nodeRes)
 
 	if err != nil {
 		// if we fail to read needed columns, we can convert it to a match none

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -49,7 +49,7 @@ func applyAggregationsToResult(aggs *structs.QueryAggregators, segmentSearchReco
 	allBlocksChan := make(chan *BlockSearchStatus, fileParallelism)
 	aggCols, _, _ := GetAggColsAndTimestamp(aggs)
 	sharedReader, err := segread.InitSharedMultiColumnReaders(searchReq.SegmentKey, aggCols, searchReq.AllBlocksToSearch,
-		blockSummaries, int(fileParallelism), searchReq.ConsistentCValLenMap, qid)
+		blockSummaries, int(fileParallelism), searchReq.ConsistentCValLenMap, qid, nodeRes)
 	if err != nil {
 		log.Errorf("applyAggregationsToResult: failed to load all column files reader for %s. Needed cols %+v. Err: %+v",
 			searchReq.SegmentKey, aggCols, err)
@@ -800,7 +800,7 @@ func applySegStatsToMatchedRecords(ops []*structs.MeasureAggregator, segmentSear
 
 	measureColAndTS, aggColUsage, valuesUsage, listUsage := GetSegStatsMeasureCols(ops)
 	sharedReader, err := segread.InitSharedMultiColumnReaders(searchReq.SegmentKey, measureColAndTS, searchReq.AllBlocksToSearch,
-		blockSummaries, int(fileParallelism), searchReq.ConsistentCValLenMap, qid)
+		blockSummaries, int(fileParallelism), searchReq.ConsistentCValLenMap, qid, nodeRes)
 	if err != nil {
 		log.Errorf("applyAggregationsToResult: failed to load all column files reader for %s. Needed cols %+v. Err: %+v",
 			searchReq.SegmentKey, measureColAndTS, err)

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -298,7 +298,7 @@ func RawSearchPQMResults(req *structs.SegmentSearchRequest, fileParallelism int6
 	defer segread.ReturnTimeBuffers(allTimestamps)
 
 	sharedReader, err := segread.InitSharedMultiColumnReaders(req.SegmentKey, req.AllPossibleColumns, req.AllBlocksToSearch,
-		req.SearchMetadata.BlockSummaries, int(fileParallelism), req.ConsistentCValLenMap, qid)
+		req.SearchMetadata.BlockSummaries, int(fileParallelism), req.ConsistentCValLenMap, qid, nodeRes)
 	if err != nil {
 		log.Errorf("qid=%v, RawSearchPQMResults: failed to load all column files reader for %s. Needed cols %+v. Err: %+v",
 			qid, req.SegmentKey, req.AllPossibleColumns, err)


### PR DESCRIPTION
# Description
- Fixes flooding of error logs due to the error in reading Column files.
- Stores those errors in `NodeResult.GlobalSerachErrors` which will be logged at the end.

# Testing
- Verified by running the particular queries and observed that error is being logged only once at the end.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
