### PR TITLE
Bump Version to 0.2.45

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -382,7 +382,7 @@ func startQueryServer(serverAddr string) {
 					return emptyHtmlContent
 				},
 				"CSSVersion": func() string {
-					return "0.2.45d"
+					return config.SigLensVersion
 				},
 			})
 			textTemplate := texttemplate.New("other")

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -21,4 +21,4 @@
 
 package config
 
-const SigLensVersion = "0.2.45d"
+const SigLensVersion = "0.2.45"


### PR DESCRIPTION
# Description
- Bump version to 0.2.45.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
