### PR TITLE
Stop a UI query if it gets an error

### DIFF
--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -239,6 +239,13 @@ func RunAsyncQueryForNewPipeline(conn *websocket.Conn, qid uint64, simpleNode *s
 				}
 				query.DeleteQuery(qid)
 				return
+			case query.ERROR:
+				wErr := conn.WriteJSON(createErrorResponse(queryStateChanData.Error.Error()))
+				if wErr != nil {
+					log.Errorf("qid=%d, RunAsyncQueryForNewPipeline: failed to write error response; err: %+v", qid, wErr)
+				}
+				query.DeleteQuery(qid)
+				return
 			default:
 				log.Errorf("qid=%v, RunAsyncQueryForNewPipeline: Got unknown state: %v", qid, queryStateChanData.StateName)
 			}

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -254,7 +254,7 @@ func (qp *QueryProcessor) GetFullResult() (*structs.PipeSearchResponseOuter, err
 		if qp.queryType == structs.RRCCmd && iqr.NumberOfRecords() > 0 {
 			err := query.IncRecordsSent(qp.qid, uint64(iqr.NumberOfRecords()))
 			if err != nil {
-				return nil, utils.TeeErrorf("GetStreamedResult: failed to increment records sent, err: %v", err)
+				return nil, utils.TeeErrorf("GetFullResult: failed to increment records sent, err: %v", err)
 			}
 			totalRecords += iqr.NumberOfRecords()
 		}
@@ -280,13 +280,12 @@ func (qp *QueryProcessor) GetFullResult() (*structs.PipeSearchResponseOuter, err
 }
 
 // Usage:
-// 1. Make channels for updates and the final result.
+// 1. Make a channel to receive updates.
 // 2. Call GetStreamedResult as a goroutine.
-// 3. Read from the update channel and the final result channel.
+// 3. Poll the channel.
 //
 // Once the final result is sent, no more updates will be sent.
 func (qp *QueryProcessor) GetStreamedResult(stateChan chan *query.QueryStateChanData) error {
-
 	var finalIQR *iqr.IQR
 	var err error
 	totalRecords := 0

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -62,6 +62,7 @@ type QueryStateChanData struct {
 	PercentComplete float64
 	UpdateWSResp    *structs.PipeSearchWSUpdateResponse
 	CompleteWSResp  *structs.PipeSearchCompleteResponse
+	Error           error // Only used when the state is ERROR
 }
 
 const (

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -42,7 +42,7 @@ func ExecuteMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTim
 	defer querySummary.LogMetricsQuerySummary(mQuery.OrgId)
 	_, err := query.StartQuery(qid, false, nil)
 	if err != nil {
-		log.Errorf("ExecuteAsyncQuery: Error initializing query status! %+v", err)
+		log.Errorf("ExecuteMetricsQuery: Error initializing query status! %+v", err)
 		return &mresults.MetricsResult{
 			ErrList: []error{err},
 		}
@@ -67,7 +67,7 @@ func ExecuteMultipleMetricsQuery(hashList []uint64, mQueries []*structs.MetricsQ
 		defer querySummary.LogMetricsQuerySummary(mQuery.OrgId)
 		_, err := query.StartQuery(qid, false, nil)
 		if err != nil {
-			log.Errorf("ExecuteAsyncQuery: Error initializing query status! %+v", err)
+			log.Errorf("ExecuteMultipleMetricsQuery: Error initializing query status! %+v", err)
 			return &mresults.MetricsResult{
 				ErrList: []error{err},
 			}
@@ -471,6 +471,12 @@ func ExecuteAsyncQueryForNewPipeline(root *structs.ASTNode, aggs *structs.QueryA
 		if err != nil {
 			log.Errorf("qid=%v, ExecuteAsyncQueryForNewPipeline: failed to GetStreamedResult, err: %v", qid, err)
 		}
+
+		errorState := query.QueryStateChanData{
+			StateName: query.ERROR,
+			Error:     err,
+		}
+		rQuery.StateChan <- &errorState
 	}()
 	return rQuery.StateChan, nil
 }


### PR DESCRIPTION
# Description
Sometimes a query will yield an error instead of a response. In those cases, the UI was erroneously hanging. Now the query gets stopped.

# Testing
I made `GetStreamedResult()` always return an error, and then ran a query on the UI. Without this PR, the UI would hang and the cursor would spin. With this PR, the error message is displayed on the UI and the query is terminated

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
