### PR TITLE
Skip CICD when only the version changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,96 +1,13 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.4
+  path-filtering: circleci/path-filtering@1.1.0
 
-jobs:
-  e2e-server:
-    working_directory: ~/repo
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/go:1.19
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: docker23
-      - run:
-          name: Build Siglens
-          command: make build
-      - run:
-          name: Run Siglens
-          command: ./siglens --config server.yaml
-          background: true
-      - run:
-          name: Tail logs file
-          command: |
-            sleep 10
-            ls -l
-            tail -f logs/siglens.log
-          background: true
-      - run:
-          name: Run E2E Test
-          command: |
-            cd tools/sigclient
-            go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 100_000
-            go run main.go ingest metrics -d http://localhost:8081/otsdb -t 1_000 -m 5 -p 1 -b 10_000 -g benchmark
-            sleep 40
-            go run main.go query esbulk -d http://localhost:5122 -f ../../cicd/ingest.csv -l ../../cicd/test_lookup.csv
-            go run main.go query otsdb -d http://localhost:5122/otsdb -n 5 -y
-            go run main.go query otsdb -d http://localhost:5122/metrics-explorer/api/v1/timeseries -f ../../cicd/metrics_test.csv
-            go run main.go query promql -d http://localhost:5122/promql/api/v1/query_range -v -f ../../cicd/promql_test.csv
-            go run main.go alerts e2e -d http://localhost:5122
-      - run:
-          name: Kill Siglens
-          command: |
-            pkill siglens
-            sleep 2
-      - run:
-          name: Restart Siglens
-          command: make run
-          background: true
-
-      - run:
-          name: Run Restart CI/CD tests
-          command: |
-            cd tools/sigclient
-            sleep 5
-            go run main.go query esbulk -d http://localhost:5122 -f ../../cicd/ingest.csv -l ../../cicd/test_lookup.csv
-            go run main.go query otsdb -d http://localhost:5122/otsdb -n 5 -y
-
-  functional-test:
-    working_directory: ~/repo
-    docker:
-      - image: cimg/go:1.19
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: docker23
-      - run:
-          name: Build Siglens
-          command: make build
-      - run:
-          name: Update config.yml
-          command: |
-            echo -e "\nisNewQueryPipelineEnabled: true" >> server.yaml
-      - run:
-          name: Run Siglens
-          command: ./siglens --config server.yaml
-          background: true
-      
-      - run:
-          name: Run Functional Test
-          command: |
-            sleep 5  # Wait for Siglens to start
-            cd tools/sigclient
-            go run main.go functional -d http://localhost:8081/elastic -f functionalQueries/functionalQueries.yml -q localhost:5122
-            
-
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  test_and_lint:
+  setup-workflow:
     jobs:
-      - functional-test
-      - e2e-server
+      - path-filtering/filter:
+          base-revision: develop
+          config-path: .circleci/continue-config.yml
+          mapping: |
+            pkg/config/version.go run-tests false
+            .* run-tests true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+
+setup: true
+
 orbs:
   path-filtering: circleci/path-filtering@1.1.0
 

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1,0 +1,102 @@
+version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.4.4
+
+parameters:
+  run-tests:
+    type: boolean
+    default: true
+
+jobs:
+  e2e-server:
+    working_directory: ~/repo
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/go:1.19
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: docker23
+      - run:
+          name: Build Siglens
+          command: make build
+      - run:
+          name: Run Siglens
+          command: ./siglens --config server.yaml
+          background: true
+      - run:
+          name: Tail logs file
+          command: |
+            sleep 10
+            ls -l
+            tail -f logs/siglens.log
+          background: true
+      - run:
+          name: Run E2E Test
+          command: |
+            cd tools/sigclient
+            go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 100_000
+            go run main.go ingest metrics -d http://localhost:8081/otsdb -t 1_000 -m 5 -p 1 -b 10_000 -g benchmark
+            sleep 40
+            go run main.go query esbulk -d http://localhost:5122 -f ../../cicd/ingest.csv -l ../../cicd/test_lookup.csv
+            go run main.go query otsdb -d http://localhost:5122/otsdb -n 5 -y
+            go run main.go query otsdb -d http://localhost:5122/metrics-explorer/api/v1/timeseries -f ../../cicd/metrics_test.csv
+            go run main.go query promql -d http://localhost:5122/promql/api/v1/query_range -v -f ../../cicd/promql_test.csv
+            go run main.go alerts e2e -d http://localhost:5122
+      - run:
+          name: Kill Siglens
+          command: |
+            pkill siglens
+            sleep 2
+      - run:
+          name: Restart Siglens
+          command: make run
+          background: true
+
+      - run:
+          name: Run Restart CI/CD tests
+          command: |
+            cd tools/sigclient
+            sleep 5
+            go run main.go query esbulk -d http://localhost:5122 -f ../../cicd/ingest.csv -l ../../cicd/test_lookup.csv
+            go run main.go query otsdb -d http://localhost:5122/otsdb -n 5 -y
+
+  functional-test:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/go:1.19
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: docker23
+      - run:
+          name: Build Siglens
+          command: make build
+      - run:
+          name: Update config.yml
+          command: |
+            echo -e "\nisNewQueryPipelineEnabled: true" >> server.yaml
+      - run:
+          name: Run Siglens
+          command: ./siglens --config server.yaml
+          background: true
+
+      - run:
+          name: Run Functional Test
+          command: |
+            sleep 5  # Wait for Siglens to start
+            cd tools/sigclient
+            go run main.go functional -d http://localhost:8081/elastic -f functionalQueries/functionalQueries.yml -q localhost:5122
+
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  test_and_lint:
+    when: << pipeline.parameters.run-tests >>
+    jobs:
+      - functional-test
+      - e2e-server

--- a/.github/workflows/jsformat.yml
+++ b/.github/workflows/jsformat.yml
@@ -1,6 +1,9 @@
 name: Format the JS code
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'pkg/config/version.go'
 
 jobs:
   format:

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -3,6 +3,8 @@ name: Playwright UI Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'pkg/config/version.go'
 
 jobs:
   playwright-tests:

--- a/.github/workflows/uts.yml
+++ b/.github/workflows/uts.yml
@@ -2,6 +2,8 @@ name: siglens-lint-ut
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'pkg/config/version.go'
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
# Description
Currently we run CICD on every PR. When only pkg/config/version.go is changed, we want to skip CICD. If a PR changes that file and other files, we want to run CICD. This PR should make those changes.

For the github workflows, I followed this doc: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths

For CircleCI I followed https://gist.github.com/ryanpedersen42/c867acd9b0837789a92836e8f5bd8b55 from https://support.circleci.com/hc/en-us/articles/10269416203163--Advanced-path-filtering

The diff doesn't show well because I renamed config.yml to continue-config.yml. There I added
```
parameters:
  run-tests:
    type: boolean
    default: true
```
and changed this part to use `when`:
```
workflows:
  test_and_lint:
    when: << pipeline.parameters.run-tests >>
    jobs:
      - functional-test
      - e2e-server
```

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
