### PR TITLE
Clean up memory limiting

### DIFF
--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -39,15 +39,10 @@ func InitMemoryLimiter() {
 	totalAvailableSizeBytes := config.GetTotalMemoryAvailable()
 	log.Infof("InitMemoryLimiter: Total available memory %+v MB", utils.ConvertUintBytesToMB(totalAvailableSizeBytes))
 
-	cmiInMemory := uint64(0)
-	maxSearchAvailableSize := uint64(0)
-	maxSsmInMemory := uint64(0)
-	metricsInMemory := uint64(0)
-
-	maxSearchAvailableSize = uint64(float64(totalAvailableSizeBytes) * utils.RAW_SEARCH_MEM_PERCENT / 100)
-	cmiInMemory = uint64(float64(totalAvailableSizeBytes) * utils.MICRO_IDX_MEM_PERCENT / 100)
-	maxSsmInMemory = uint64(float64(totalAvailableSizeBytes) * utils.SSM_MEM_PERCENT / 100)
-	metricsInMemory = uint64(float64(totalAvailableSizeBytes) * utils.METRICS_MEM_PERCENT / 100)
+	maxSearchAvailableSize := uint64(float64(totalAvailableSizeBytes) * utils.RAW_SEARCH_MEM_PERCENT / 100)
+	cmiInMemory := uint64(float64(totalAvailableSizeBytes) * utils.MICRO_IDX_MEM_PERCENT / 100)
+	maxSsmInMemory := uint64(float64(totalAvailableSizeBytes) * utils.SSM_MEM_PERCENT / 100)
+	metricsInMemory := uint64(float64(totalAvailableSizeBytes) * utils.METRICS_MEM_PERCENT / 100)
 
 	if config.IsDebugMode() {
 		LOG_GLOBAL_MEM_FREQUENCY = 1

--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -47,7 +47,7 @@ func InitMemoryLimiter() {
 	maxSearchAvailableSize = uint64(float64(totalAvailableSizeBytes) * utils.RAW_SEARCH_MEM_PERCENT / 100)
 	cmiInMemory = uint64(float64(totalAvailableSizeBytes) * utils.MICRO_IDX_MEM_PERCENT / 100)
 	maxSsmInMemory = uint64(float64(totalAvailableSizeBytes) * utils.SSM_MEM_PERCENT / 100)
-	metricsInMemory = uint64(float64(totalAvailableSizeBytes) * utils.METRICS_MEMORY_MEM_PERCENT / 100)
+	metricsInMemory = uint64(float64(totalAvailableSizeBytes) * utils.METRICS_MEM_PERCENT / 100)
 
 	if config.IsDebugMode() {
 		LOG_GLOBAL_MEM_FREQUENCY = 1

--- a/pkg/segment/metadata/metadata.go
+++ b/pkg/segment/metadata/metadata.go
@@ -361,12 +361,9 @@ func DeleteVirtualTable(vTable string, orgid uint64) {
 	globalMetadata.deleteTable(vTable, orgid)
 }
 
-/*
-Internally, this will allocate 30% of the SSM size to metrics and the remaining to logs
-*/
 func RebalanceInMemorySsm(ssmSizeBytes uint64) {
-	logsSSM := uint64(float64(ssmSizeBytes) * 0.30)
-	metricsSSM := uint64(float64(ssmSizeBytes) * 0.70)
+	logsSSM := uint64(float64(ssmSizeBytes) * utils.SSM_LOGS_MEM_PERCENT / 100)
+	metricsSSM := uint64(float64(ssmSizeBytes) * utils.SSM_METRICS_MEM_PERCENT / 100)
 	globalMetadata.rebalanceSsm(logsSSM)
 	globalMetricsMetadata.rebalanceMetricsSsm(metricsSSM)
 }

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -51,7 +51,7 @@ import (
 const MICRO_IDX_MEM_PERCENT = 63 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
 const SSM_MEM_PERCENT = 20
 const RAW_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
-const METRICS_MEMORY_MEM_PERCENT = 2
+const METRICS_MEM_PERCENT = 2
 
 // percent allocated for segmentsearchmeta (blocksummaries, blocklen/off)
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -53,13 +53,6 @@ const SSM_MEM_PERCENT = 20
 const RAW_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
 const METRICS_MEM_PERCENT = 2
 
-// percent allocated for segmentsearchmeta (blocksummaries, blocklen/off)
-
-const BLOCK_MICRO_MULTINODE_MEM_PERCENT = 80
-const BLOCK_MICRO_CHECK_MULTINODE_MEM_PERCENT = 15
-const RAW_SEARCH_MULTINODE_MEM_PERCENT = 95
-const MULTINODE_SSM_MEM_PERCENT = 20
-
 // if you change this size, adjust the block bloom size
 const WIP_SIZE = 2_000_000
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -53,6 +53,10 @@ const SSM_MEM_PERCENT = 20
 const RAW_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
 const METRICS_MEM_PERCENT = 2
 
+// How the SSM memory is split. These should sum to 100.
+const SSM_LOGS_MEM_PERCENT = 70
+const SSM_METRICS_MEM_PERCENT = 30
+
 // if you change this size, adjust the block bloom size
 const WIP_SIZE = 2_000_000
 


### PR DESCRIPTION
# Description
This is mostly a refactor, but one thing changed: for SSM, documentation said 70% and 30% go to logs and metrics respectively, but really they went to metrics and logs respectively; this was fixed so they actually do go to logs and metrics respectively.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
