### PR TITLE
Limit number of running queries

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -319,8 +319,7 @@ func ParseAndExecutePipeRequest(readJSON map[string]interface{}, qid uint64, myi
 	if config.IsNewQueryPipelineEnabled() {
 		_, err := query.StartQuery(qid, false, nil)
 		if err != nil {
-			log.Errorf("qid=%v, ParseAndExecutePipeRequest: failed to associate search results with qid! Error: %+v",
-				qid, err)
+			log.Errorf("qid=%v, ParseAndExecutePipeRequest: failed to start query, err: %v", qid, err)
 			return nil, false, nil, err
 		}
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -175,6 +175,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthtt
 				processQueryUpdate(conn, qid, sizeLimit, scrollFrom, qscd, aggs, includeNulls)
 			case query.TIMEOUT:
 				processTimeoutUpdate(conn, qid)
+				query.DeleteQuery(qid)
 				return
 			case query.COMPLETE:
 				processCompleteUpdate(conn, sizeLimit, qid, aggs)
@@ -186,6 +187,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid uint64, ctx *fasthtt
 			if !ok {
 				log.Errorf("qid=%v, ProcessPipeSearchWebsocket: Got non ok, state: %v", qid, qscd.StateName)
 				query.LogGlobalSearchErrors(qid)
+				query.DeleteQuery(qid)
 				return
 			}
 		case readMsg := <-websocketR:
@@ -226,6 +228,7 @@ func RunAsyncQueryForNewPipeline(conn *websocket.Conn, qid uint64, simpleNode *s
 				processRunningUpdate(conn, qid)
 			case query.TIMEOUT:
 				processTimeoutUpdate(conn, qid)
+				query.DeleteQuery(qid)
 				return
 			case query.QUERY_UPDATE:
 				wErr := conn.WriteJSON(queryStateChanData.UpdateWSResp)

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -221,6 +221,7 @@ func RunAsyncQueryForNewPipeline(conn *websocket.Conn, qid uint64, simpleNode *s
 			if !ok {
 				log.Errorf("qid=%v, RunAsyncQueryForNewPipeline: Got non ok, state: %v", qid, queryStateChanData.StateName)
 				query.LogGlobalSearchErrors(qid)
+				query.DeleteQuery(qid)
 				return
 			}
 			switch queryStateChanData.StateName {

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -170,7 +170,7 @@ func StartQuery(qid uint64, async bool, cleanupCallback func()) (*RunningQuerySt
 		return nil, fmt.Errorf("qid has already been started")
 	}
 
-	if len(allRunningQueries) == MAX_RUNNING_QUERIES {
+	if len(allRunningQueries) >= MAX_RUNNING_QUERIES {
 		return nil, putils.TeeErrorf("StartQuery: qid=%v cannot be started, Max number of running queries reached", qid)
 	}
 

--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -42,6 +42,7 @@ var numStates = 4
 
 const MAX_GRP_BUCKS = 3000
 const CANCEL_QUERY_AFTER_SECONDS = 5 * 60 // If 0, the query will never timeout
+const MAX_RUNNING_QUERIES = 100
 
 type QueryUpdateType int
 
@@ -167,6 +168,10 @@ func StartQuery(qid uint64, async bool, cleanupCallback func()) (*RunningQuerySt
 	if _, ok := allRunningQueries[qid]; ok {
 		log.Errorf("StartQuery: qid %+v already exists!", qid)
 		return nil, fmt.Errorf("qid has already been started")
+	}
+
+	if len(allRunningQueries) == MAX_RUNNING_QUERIES {
+		return nil, putils.TeeErrorf("StartQuery: qid=%v cannot be started, Max number of running queries reached", qid)
 	}
 
 	var stateChan chan *QueryStateChanData

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -456,7 +456,7 @@ func ExecuteQuery(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uin
 func ExecuteAsyncQueryForNewPipeline(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uint64, qc *structs.QueryContext, scrollFrom int) (chan *query.QueryStateChanData, error) {
 	rQuery, err := query.StartQuery(qid, true, nil)
 	if err != nil {
-		log.Errorf("ExecuteAsyncQueryForNewPipeline: Error while starting query, err: %v", err)
+		log.Errorf("qid=%v, ExecuteAsyncQueryForNewPipeline: failed to start query, err: %v", qid, err)
 		return nil, err
 	}
 

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -456,7 +456,7 @@ func ExecuteQuery(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uin
 func ExecuteAsyncQueryForNewPipeline(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uint64, qc *structs.QueryContext, scrollFrom int) (chan *query.QueryStateChanData, error) {
 	rQuery, err := query.StartQuery(qid, true, nil)
 	if err != nil {
-		log.Errorf("ExecuteAsyncQueryForNewPipeline: Error initializing query status! %+v", err)
+		log.Errorf("ExecuteAsyncQueryForNewPipeline: Error while starting query, err: %v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description
Summarize the change.
- Limit the number of running queries to 100.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Tested by running parallel queries greater than the limit.
- Verified that siglens only accepts 100 queries and will reject the rest of them.
- Added delay to check the scenario where more than 100 queries are sent but with delay to ensure that only running queries are considered.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
