### PR TITLE
Make memory limits configurable

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -142,6 +142,7 @@ type Configuration struct {
 	EmailConfig                 EmailConfig    `yaml:"emailConfig"`
 	DatabaseConfig              DatabaseConfig `yaml:"minionSearch"`
 	MemoryConfig                MemoryConfig   `yaml:"memoryLimits"`
+	MaxOpenColumns              uint64         `yaml:"maxOpenColumns"`
 	UseNewPipelineConverted     bool
 	UseNewQueryPipeline         string `yaml:"isNewQueryPipelineEnabled"`
 }

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -81,6 +81,16 @@ type DatabaseConfig struct {
 	Dbname   string `yaml:"dbname"`
 }
 
+type MemoryConfig struct {
+	MaxUsagePercent uint64 `yaml:"maxUsagePercent"`
+
+	// These should sum to 100.
+	SearchPercent   uint64 `yaml:"searchPercent"`
+	CMIPercent      uint64 `yaml:"microIndexPercent"`
+	MetadataPercent uint64 `yaml:"metadataPercent"`
+	MetricsPercent  uint64 `yaml:"metricsPercent"`
+}
+
 /*  If you add a new config parameters to the Configuration struct below, make sure to add the default value
 assignment in the following functions
 1) ExtractConfigData function
@@ -106,7 +116,6 @@ type Configuration struct {
 	Debug                       bool     `yaml:"debug"`        // debug logging
 	PProfEnabled                string   `yaml:"pprofEnabled"` // enable pprof
 	PProfEnabledConverted       bool     // converted bool value of PprofEnabled yaml
-	MemoryThresholdPercent      uint64   `yaml:"memoryThresholdPercent"` // percent of all available free data allocated for loading micro indices in memory
 	DataDiskThresholdPercent    uint64   `yaml:"dataDiskThresholdPercent"`
 	S3IngestQueueName           string   `yaml:"s3IngestQueueName"`
 	S3IngestQueueRegion         string   `yaml:"s3IngestQueueRegion"`
@@ -132,6 +141,7 @@ type Configuration struct {
 	Tracing                     TracingConfig  `yaml:"tracing"` // Tracing related config
 	EmailConfig                 EmailConfig    `yaml:"emailConfig"`
 	DatabaseConfig              DatabaseConfig `yaml:"minionSearch"`
+	MemoryConfig                MemoryConfig   `yaml:"memoryLimits"`
 	UseNewPipelineConverted     bool
 	UseNewQueryPipeline         string `yaml:"isNewQueryPipelineEnabled"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,8 @@ const DEFAULT_METADATA_MEM_PERCENT = 20
 const DEFAULT_SEG_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
 const DEFAULT_METRICS_MEM_PERCENT = 2
 
+const DEFAULT_MAX_OPEN_COLUMNS = 1000 // Max concurrent unrotated columns across all indexes
+
 var configFileLastModified uint64
 
 var runningConfig common.Configuration
@@ -99,6 +101,10 @@ func GetTotalMemoryAvailable() uint64 {
 
 func GetMemoryConfig() common.MemoryConfig {
 	return runningConfig.MemoryConfig
+}
+
+func GetMaxOpenColumns() uint64 {
+	return runningConfig.MaxOpenColumns
 }
 
 /*
@@ -565,6 +571,7 @@ func GetTestConfig(dataPath string) common.Configuration {
 			MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
 			MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
 		},
+		MaxOpenColumns: DEFAULT_MAX_OPEN_COLUMNS,
 	}
 
 	return testConfig
@@ -847,6 +854,10 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	}
 
 	config.MemoryConfig = memoryLimits
+
+	if config.MaxOpenColumns == 0 {
+		config.MaxOpenColumns = DEFAULT_MAX_OPEN_COLUMNS
+	}
 
 	if len(config.S3IngestQueueName) <= 0 {
 		config.S3IngestQueueName = ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,6 +97,10 @@ func GetTotalMemoryAvailable() uint64 {
 	return allowedMemory
 }
 
+func GetMemoryConfig() common.MemoryConfig {
+	return runningConfig.MemoryConfig
+}
+
 /*
 Returns GOMAXPROCS
 */
@@ -554,7 +558,13 @@ func GetTestConfig(dataPath string) common.Configuration {
 		Tracing:                     common.TracingConfig{ServiceName: "", Endpoint: "", SamplingPercentage: 1},
 		DatabaseConfig:              common.DatabaseConfig{Enabled: true, Provider: "sqlite"},
 		EmailConfig:                 common.EmailConfig{SmtpHost: "smtp.gmail.com", SmtpPort: 587, SenderEmail: "doe1024john@gmail.com", GmailAppPassword: " "},
-		MemoryConfig:                common.MemoryConfig{MaxUsagePercent: 80},
+		MemoryConfig: common.MemoryConfig{
+			MaxUsagePercent: 80,
+			SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
+			CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
+			MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
+			MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
+		},
 	}
 
 	return testConfig

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,7 +62,6 @@ func Test_ExtractConfigData(t *testing.T) {
  logFileRotationSizeMB: 100
  compressLogFile: false
  dataDiskThresholdPercent: 85
- memoryThresholdPercent: 80
  partitionCountConsistentHasher: 271
  replicationFactorConsistentHasher: 40
  loadConsistentHasher: 1.2
@@ -85,6 +84,12 @@ func Test_ExtractConfigData(t *testing.T) {
    logFileRotationSizeMB: 100
    compressLogFile: false
  compressStatic: false
+ memoryLimits:
+   maxUsagePercent: 80
+   searchPercent: 50
+   microIndexPercent: 20
+   metadataPercent: 20
+   metricsPercent: 10
  `),
 			common.Configuration{
 				IngestListenIP:              "0.0.0.0",
@@ -105,7 +110,6 @@ func Test_ExtractConfigData(t *testing.T) {
 				LicenseKeyPath:              "./",
 				ESVersion:                   "6.8.20",
 				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
 				S3IngestQueueName:           "",
 				S3IngestQueueRegion:         "",
 				S3IngestBufferSize:          1000,
@@ -128,6 +132,13 @@ func Test_ExtractConfigData(t *testing.T) {
 				Tracing:                     common.TracingConfig{Endpoint: "http://localhost:4317", ServiceName: "siglens", SamplingPercentage: 100},
 				UseNewQueryPipeline:         "false",
 				UseNewPipelineConverted:     false,
+				MemoryConfig: common.MemoryConfig{
+					MaxUsagePercent: 80,
+					SearchPercent:   50,
+					CMIPercent:      20,
+					MetadataPercent: 20,
+					MetricsPercent:  10,
+				},
 			},
 		},
 		{ // case 2 - For wrong input type, show error message
@@ -151,7 +162,6 @@ func Test_ExtractConfigData(t *testing.T) {
  licensekeyPath: "./"
  esVersion: "6.8.20"
  dataDiskThresholdPercent: 85
- memoryThresholdPercent: 80
  partitionCountConsistentHasher: 271
  replicationFactorConsistentHasher: 40
  loadConsistentHasher: 1.2
@@ -194,7 +204,6 @@ func Test_ExtractConfigData(t *testing.T) {
 				LicenseKeyPath:              "./",
 				ESVersion:                   "6.8.20",
 				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
 				S3IngestQueueName:           "",
 				S3IngestQueueRegion:         "",
 				S3IngestBufferSize:          1000,
@@ -217,6 +226,13 @@ func Test_ExtractConfigData(t *testing.T) {
 				Tracing:                     common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
+				MemoryConfig: common.MemoryConfig{
+					MaxUsagePercent: 80,
+					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
+					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
+					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
+					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
+				},
 			},
 		},
 		{ // case 3 - Error out on bad yaml
@@ -243,7 +259,6 @@ invalid input, we should error out
 				LicenseKeyPath:              "./",
 				ESVersion:                   "6.8.20",
 				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
 				S3IngestQueueName:           "",
 				S3IngestQueueRegion:         "",
 
@@ -262,6 +277,13 @@ invalid input, we should error out
 				Tracing:                    common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 1},
 				UseNewQueryPipeline:        "true",
 				UseNewPipelineConverted:    true,
+				MemoryConfig: common.MemoryConfig{
+					MaxUsagePercent: 80,
+					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
+					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
+					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
+					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
+				},
 			},
 		},
 		{ // case 4 - For no input, pick defaults
@@ -287,7 +309,6 @@ a: b
 				LicenseKeyPath:              "./",
 				ESVersion:                   "6.8.20",
 				DataDiskThresholdPercent:    85,
-				MemoryThresholdPercent:      80,
 				S3IngestQueueName:           "",
 				S3IngestQueueRegion:         "",
 				S3IngestBufferSize:          1000,
@@ -310,6 +331,13 @@ a: b
 				Tracing:                     common.TracingConfig{Endpoint: "", ServiceName: "siglens", SamplingPercentage: 0},
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
+				MemoryConfig: common.MemoryConfig{
+					MaxUsagePercent: 80,
+					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
+					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
+					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
+					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
+				},
 			},
 		},
 	}
@@ -320,10 +348,10 @@ a: b
 			continue
 		}
 		if segutils.ConvertUintBytesToMB(memory.TotalMemory()) < SIZE_8GB_IN_MB {
-			assert.Equal(t, uint64(50), actualConfig.MemoryThresholdPercent)
+			assert.Equal(t, uint64(50), actualConfig.MemoryConfig.MaxUsagePercent)
 			// If memory is less than 8GB, config by default returns 50% as the threshold
 			// For testing purpose resetting it to 80%
-			actualConfig.MemoryThresholdPercent = 80
+			actualConfig.MemoryConfig.MaxUsagePercent = 80
 		}
 		assert.NoError(t, err, fmt.Sprintf("Comparison failed, test=%v", i+1))
 		assert.EqualValues(t, test.expected, actualConfig, fmt.Sprintf("Comparison failed, test=%v", i+1))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -90,6 +90,7 @@ func Test_ExtractConfigData(t *testing.T) {
    microIndexPercent: 20
    metadataPercent: 20
    metricsPercent: 10
+ maxOpenColumns: 42
  `),
 			common.Configuration{
 				IngestListenIP:              "0.0.0.0",
@@ -139,6 +140,7 @@ func Test_ExtractConfigData(t *testing.T) {
 					MetadataPercent: 20,
 					MetricsPercent:  10,
 				},
+				MaxOpenColumns: 42,
 			},
 		},
 		{ // case 2 - For wrong input type, show error message
@@ -233,6 +235,7 @@ func Test_ExtractConfigData(t *testing.T) {
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
 					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
 				},
+				MaxOpenColumns: DEFAULT_MAX_OPEN_COLUMNS,
 			},
 		},
 		{ // case 3 - Error out on bad yaml
@@ -284,6 +287,7 @@ invalid input, we should error out
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
 					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
 				},
+				MaxOpenColumns: DEFAULT_MAX_OPEN_COLUMNS,
 			},
 		},
 		{ // case 4 - For no input, pick defaults
@@ -338,6 +342,7 @@ a: b
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
 					MetricsPercent:  DEFAULT_METRICS_MEM_PERCENT,
 				},
+				MaxOpenColumns: DEFAULT_MAX_OPEN_COLUMNS,
 			},
 		},
 	}

--- a/pkg/segment/metadata/metadata.go
+++ b/pkg/segment/metadata/metadata.go
@@ -362,8 +362,8 @@ func DeleteVirtualTable(vTable string, orgid uint64) {
 }
 
 func RebalanceInMemorySsm(ssmSizeBytes uint64) {
-	logsSSM := uint64(float64(ssmSizeBytes) * utils.SSM_LOGS_MEM_PERCENT / 100)
-	metricsSSM := uint64(float64(ssmSizeBytes) * utils.SSM_METRICS_MEM_PERCENT / 100)
+	logsSSM := uint64(float64(ssmSizeBytes) * utils.METADATA_LOGS_MEM_PERCENT / 100)
+	metricsSSM := uint64(float64(ssmSizeBytes) * utils.METADATA_METRICS_MEM_PERCENT / 100)
 	globalMetadata.rebalanceSsm(logsSSM)
 	globalMetricsMetadata.rebalanceMetricsSsm(metricsSSM)
 }

--- a/pkg/segment/structs/memorystructs.go
+++ b/pkg/segment/structs/memorystructs.go
@@ -32,14 +32,12 @@ type AllSegStoreSummary struct {
 }
 
 type MemoryTracker struct {
-	TotalAllocatableBytes     uint64 // total bytes that can be allocated. This should not include CmiRuntimeAllocatedBytes
-	CmiInMemoryAllocatedBytes uint64
-	CmiRuntimeAllocatedBytes  uint64
-	SegSearchRequestedBytes   uint64
-	SegWriterUsageBytes       uint64
-	SegStoreSummary           *AllSegStoreSummary
-	SsmInMemoryAllocatedBytes uint64
-	MetricsSegmentMaxSize     uint64
+	TotalAllocatableBytes   uint64 // total bytes that can be allocated. This should not include CmiRuntimeAllocatedBytes
+	RotatedCMIBytesInMemory uint64
+	SegSearchRequestedBytes uint64
+	SegWriterUsageBytes     uint64
+	SegStoreSummary         *AllSegStoreSummary
+	MetricsSegmentMaxSize   uint64
 }
 
 func (sum *AllSegStoreSummary) IncrementTotalSegmentCount() {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -46,16 +46,15 @@ import (
 // 0000 1010 ==> int64
 // 0000 1011 ==> Float64
 
-// GLOBAL Defs
-// proportion of available to allocate for specific uses
-const MICRO_IDX_MEM_PERCENT = 63 // percent allocated for both rotated & unrotated metadata (cmi/searchmetadata)
-const SSM_MEM_PERCENT = 20
-const RAW_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
+// How memory is split for rotated info. These should sum to 100.
+const ROTATED_CMI_MEM_PERCENT = 63
+const METADATA_MEM_PERCENT = 20
+const SEG_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
 const METRICS_MEM_PERCENT = 2
 
-// How the SSM memory is split. These should sum to 100.
-const SSM_LOGS_MEM_PERCENT = 70
-const SSM_METRICS_MEM_PERCENT = 30
+// How the metadata memory is split. These should sum to 100.
+const METADATA_LOGS_MEM_PERCENT = 70
+const METADATA_METRICS_MEM_PERCENT = 30
 
 // if you change this size, adjust the block bloom size
 const WIP_SIZE = 2_000_000

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -46,12 +46,6 @@ import (
 // 0000 1010 ==> int64
 // 0000 1011 ==> Float64
 
-// How memory is split for rotated info. These should sum to 100.
-const ROTATED_CMI_MEM_PERCENT = 63
-const METADATA_MEM_PERCENT = 20
-const SEG_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
-const METRICS_MEM_PERCENT = 2
-
 // How the metadata memory is split. These should sum to 100.
 const METADATA_LOGS_MEM_PERCENT = 70
 const METADATA_METRICS_MEM_PERCENT = 30

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -262,11 +262,9 @@ func GetInMemorySize() uint64 {
 	}
 
 	maxOpenCols := config.GetMaxOpenColumns()
-	if maxOpenCols == 0 {
-		log.Errorf("GetInMemorySize: maxOpenCols is 0")
-	} else if numOpenCols > int(maxOpenCols) {
+	if numOpenCols > int(maxOpenCols) {
 		log.Errorf("GetInMemorySize: numOpenCols=%v exceeds maxOpenCols=%v", numOpenCols, maxOpenCols)
-	} else {
+	} else if numOpenCols > 0 {
 		multiplier := float64(maxOpenCols) / float64(numOpenCols)
 		totalSize = uint64(float64(totalSize) * multiplier)
 	}


### PR DESCRIPTION
# Description
1. Moves some limits from segconsts.go into config.go
2. Added a `MaxOpenColumns` config to better estimate how much memory should be reserved for ingestion. However, the limit is not enforced yet.

# Testing
Unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
