### PR TITLE
Dedup with sortby

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -3661,27 +3661,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 1999, col: 1, offset: 62429},
+			pos:  position{line: 2024, col: 1, offset: 63139},
 			expr: &actionExpr{
-				pos: position{line: 1999, col: 14, offset: 62442},
+				pos: position{line: 2024, col: 14, offset: 63152},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1999, col: 14, offset: 62442},
+					pos: position{line: 2024, col: 14, offset: 63152},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1999, col: 14, offset: 62442},
+							pos:   position{line: 2024, col: 14, offset: 63152},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1999, col: 23, offset: 62451},
+								pos: position{line: 2024, col: 23, offset: 63161},
 								expr: &seqExpr{
-									pos: position{line: 1999, col: 24, offset: 62452},
+									pos: position{line: 2024, col: 24, offset: 63162},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1999, col: 24, offset: 62452},
+											pos:  position{line: 2024, col: 24, offset: 63162},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1999, col: 30, offset: 62458},
+											pos:  position{line: 2024, col: 30, offset: 63168},
 											name: "IntegerAsString",
 										},
 									},
@@ -3689,45 +3689,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 48, offset: 62476},
+							pos:   position{line: 2024, col: 48, offset: 63186},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1999, col: 57, offset: 62485},
+								pos: position{line: 2024, col: 57, offset: 63195},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1999, col: 58, offset: 62486},
+									pos:  position{line: 2024, col: 58, offset: 63196},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 73, offset: 62501},
+							pos:   position{line: 2024, col: 73, offset: 63211},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1999, col: 83, offset: 62511},
+								pos: position{line: 2024, col: 83, offset: 63221},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1999, col: 84, offset: 62512},
+									pos:  position{line: 2024, col: 84, offset: 63222},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 101, offset: 62529},
+							pos:   position{line: 2024, col: 101, offset: 63239},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1999, col: 110, offset: 62538},
+								pos: position{line: 2024, col: 110, offset: 63248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1999, col: 111, offset: 62539},
+									pos:  position{line: 2024, col: 111, offset: 63249},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1999, col: 126, offset: 62554},
+							pos:   position{line: 2024, col: 126, offset: 63264},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1999, col: 139, offset: 62567},
+								pos: position{line: 2024, col: 139, offset: 63277},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1999, col: 140, offset: 62568},
+									pos:  position{line: 2024, col: 140, offset: 63278},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3738,27 +3738,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2056, col: 1, offset: 64306},
+			pos:  position{line: 2081, col: 1, offset: 65016},
 			expr: &actionExpr{
-				pos: position{line: 2056, col: 19, offset: 64324},
+				pos: position{line: 2081, col: 19, offset: 65034},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2056, col: 19, offset: 64324},
+					pos: position{line: 2081, col: 19, offset: 65034},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2056, col: 19, offset: 64324},
+							pos: position{line: 2081, col: 19, offset: 65034},
 							expr: &litMatcher{
-								pos:        position{line: 2056, col: 21, offset: 64326},
+								pos:        position{line: 2081, col: 21, offset: 65036},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2056, col: 31, offset: 64336},
+							pos:   position{line: 2081, col: 31, offset: 65046},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2056, col: 37, offset: 64342},
+								pos:  position{line: 2081, col: 37, offset: 65052},
 								name: "FieldName",
 							},
 						},
@@ -3768,48 +3768,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2062, col: 1, offset: 64481},
+			pos:  position{line: 2087, col: 1, offset: 65191},
 			expr: &actionExpr{
-				pos: position{line: 2062, col: 32, offset: 64512},
+				pos: position{line: 2087, col: 32, offset: 65222},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2062, col: 32, offset: 64512},
+					pos: position{line: 2087, col: 32, offset: 65222},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2062, col: 32, offset: 64512},
+							pos:   position{line: 2087, col: 32, offset: 65222},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 38, offset: 64518},
+								pos:  position{line: 2087, col: 38, offset: 65228},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2062, col: 48, offset: 64528},
+							pos: position{line: 2087, col: 48, offset: 65238},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2062, col: 50, offset: 64530},
+								pos:  position{line: 2087, col: 50, offset: 65240},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2062, col: 57, offset: 64537},
+							pos:   position{line: 2087, col: 57, offset: 65247},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2062, col: 62, offset: 64542},
+								pos: position{line: 2087, col: 62, offset: 65252},
 								expr: &seqExpr{
-									pos: position{line: 2062, col: 63, offset: 64543},
+									pos: position{line: 2087, col: 63, offset: 65253},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2062, col: 63, offset: 64543},
+											pos:  position{line: 2087, col: 63, offset: 65253},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2062, col: 69, offset: 64549},
+											pos:  position{line: 2087, col: 69, offset: 65259},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2062, col: 79, offset: 64559},
+											pos: position{line: 2087, col: 79, offset: 65269},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2062, col: 81, offset: 64561},
+												pos:  position{line: 2087, col: 81, offset: 65271},
 												name: "EQUAL",
 											},
 										},
@@ -3823,45 +3823,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2073, col: 1, offset: 64836},
+			pos:  position{line: 2098, col: 1, offset: 65546},
 			expr: &actionExpr{
-				pos: position{line: 2073, col: 19, offset: 64854},
+				pos: position{line: 2098, col: 19, offset: 65564},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2073, col: 19, offset: 64854},
+					pos: position{line: 2098, col: 19, offset: 65564},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2073, col: 19, offset: 64854},
+							pos:  position{line: 2098, col: 19, offset: 65564},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2073, col: 25, offset: 64860},
+							pos:   position{line: 2098, col: 25, offset: 65570},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2073, col: 31, offset: 64866},
+								pos:  position{line: 2098, col: 31, offset: 65576},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2073, col: 46, offset: 64881},
+							pos:   position{line: 2098, col: 46, offset: 65591},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2073, col: 51, offset: 64886},
+								pos: position{line: 2098, col: 51, offset: 65596},
 								expr: &seqExpr{
-									pos: position{line: 2073, col: 52, offset: 64887},
+									pos: position{line: 2098, col: 52, offset: 65597},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2073, col: 52, offset: 64887},
+											pos:  position{line: 2098, col: 52, offset: 65597},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2073, col: 58, offset: 64893},
+											pos:  position{line: 2098, col: 58, offset: 65603},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2073, col: 73, offset: 64908},
+											pos: position{line: 2098, col: 73, offset: 65618},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2073, col: 74, offset: 64909},
+												pos:  position{line: 2098, col: 74, offset: 65619},
 												name: "EQUAL",
 											},
 										},
@@ -3875,17 +3875,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2091, col: 1, offset: 65437},
+			pos:  position{line: 2116, col: 1, offset: 66147},
 			expr: &actionExpr{
-				pos: position{line: 2091, col: 17, offset: 65453},
+				pos: position{line: 2116, col: 17, offset: 66163},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2091, col: 17, offset: 65453},
+					pos:   position{line: 2116, col: 17, offset: 66163},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2091, col: 24, offset: 65460},
+						pos: position{line: 2116, col: 24, offset: 66170},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2091, col: 25, offset: 65461},
+							pos:  position{line: 2116, col: 25, offset: 66171},
 							name: "DedupOption",
 						},
 					},
@@ -3894,36 +3894,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2131, col: 1, offset: 66727},
+			pos:  position{line: 2156, col: 1, offset: 67437},
 			expr: &actionExpr{
-				pos: position{line: 2131, col: 16, offset: 66742},
+				pos: position{line: 2156, col: 16, offset: 67452},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2131, col: 16, offset: 66742},
+					pos: position{line: 2156, col: 16, offset: 67452},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2131, col: 16, offset: 66742},
+							pos:  position{line: 2156, col: 16, offset: 67452},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2131, col: 22, offset: 66748},
+							pos:   position{line: 2156, col: 22, offset: 67458},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2131, col: 32, offset: 66758},
+								pos:  position{line: 2156, col: 32, offset: 67468},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2131, col: 47, offset: 66773},
+							pos:        position{line: 2156, col: 47, offset: 67483},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2131, col: 51, offset: 66777},
+							pos:   position{line: 2156, col: 51, offset: 67487},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2131, col: 57, offset: 66783},
+								pos:  position{line: 2156, col: 57, offset: 67493},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3933,30 +3933,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2136, col: 1, offset: 66892},
+			pos:  position{line: 2161, col: 1, offset: 67602},
 			expr: &actionExpr{
-				pos: position{line: 2136, col: 19, offset: 66910},
+				pos: position{line: 2161, col: 19, offset: 67620},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2136, col: 19, offset: 66910},
+					pos:   position{line: 2161, col: 19, offset: 67620},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2136, col: 27, offset: 66918},
+						pos: position{line: 2161, col: 27, offset: 67628},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2136, col: 27, offset: 66918},
+								pos:        position{line: 2161, col: 27, offset: 67628},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2136, col: 43, offset: 66934},
+								pos:        position{line: 2161, col: 43, offset: 67644},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2136, col: 57, offset: 66948},
+								pos:        position{line: 2161, col: 57, offset: 67658},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3968,22 +3968,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2144, col: 1, offset: 67133},
+			pos:  position{line: 2169, col: 1, offset: 67843},
 			expr: &actionExpr{
-				pos: position{line: 2144, col: 22, offset: 67154},
+				pos: position{line: 2169, col: 22, offset: 67864},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2144, col: 22, offset: 67154},
+					pos: position{line: 2169, col: 22, offset: 67864},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2144, col: 22, offset: 67154},
+							pos:  position{line: 2169, col: 22, offset: 67864},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2144, col: 39, offset: 67171},
+							pos:   position{line: 2169, col: 39, offset: 67881},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2144, col: 53, offset: 67185},
+								pos:  position{line: 2169, col: 53, offset: 67895},
 								name: "SortElements",
 							},
 						},
@@ -3993,35 +3993,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2149, col: 1, offset: 67293},
+			pos:  position{line: 2174, col: 1, offset: 68003},
 			expr: &actionExpr{
-				pos: position{line: 2149, col: 17, offset: 67309},
+				pos: position{line: 2174, col: 17, offset: 68019},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2149, col: 17, offset: 67309},
+					pos: position{line: 2174, col: 17, offset: 68019},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2149, col: 17, offset: 67309},
+							pos:   position{line: 2174, col: 17, offset: 68019},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2149, col: 23, offset: 67315},
+								pos:  position{line: 2174, col: 23, offset: 68025},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2149, col: 41, offset: 67333},
+							pos:   position{line: 2174, col: 41, offset: 68043},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2149, col: 46, offset: 67338},
+								pos: position{line: 2174, col: 46, offset: 68048},
 								expr: &seqExpr{
-									pos: position{line: 2149, col: 47, offset: 67339},
+									pos: position{line: 2174, col: 47, offset: 68049},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2149, col: 47, offset: 67339},
+											pos:  position{line: 2174, col: 47, offset: 68049},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2149, col: 62, offset: 67354},
+											pos:  position{line: 2174, col: 62, offset: 68064},
 											name: "SingleSortElement",
 										},
 									},
@@ -4034,22 +4034,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2164, col: 1, offset: 67712},
+			pos:  position{line: 2189, col: 1, offset: 68422},
 			expr: &actionExpr{
-				pos: position{line: 2164, col: 22, offset: 67733},
+				pos: position{line: 2189, col: 22, offset: 68443},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2164, col: 22, offset: 67733},
+					pos:   position{line: 2189, col: 22, offset: 68443},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2164, col: 31, offset: 67742},
+						pos: position{line: 2189, col: 31, offset: 68452},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2164, col: 31, offset: 67742},
+								pos:  position{line: 2189, col: 31, offset: 68452},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2164, col: 59, offset: 67770},
+								pos:  position{line: 2189, col: 59, offset: 68480},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4059,33 +4059,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2168, col: 1, offset: 67829},
+			pos:  position{line: 2193, col: 1, offset: 68539},
 			expr: &actionExpr{
-				pos: position{line: 2168, col: 33, offset: 67861},
+				pos: position{line: 2193, col: 33, offset: 68571},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2168, col: 33, offset: 67861},
+					pos: position{line: 2193, col: 33, offset: 68571},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2168, col: 33, offset: 67861},
+							pos:   position{line: 2193, col: 33, offset: 68571},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2168, col: 47, offset: 67875},
+								pos: position{line: 2193, col: 47, offset: 68585},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2168, col: 47, offset: 67875},
+										pos:        position{line: 2193, col: 47, offset: 68585},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2168, col: 53, offset: 67881},
+										pos:        position{line: 2193, col: 53, offset: 68591},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2168, col: 59, offset: 67887},
+										pos:        position{line: 2193, col: 59, offset: 68597},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4094,10 +4094,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2168, col: 63, offset: 67891},
+							pos:   position{line: 2193, col: 63, offset: 68601},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2168, col: 69, offset: 67897},
+								pos:  position{line: 2193, col: 69, offset: 68607},
 								name: "FieldName",
 							},
 						},
@@ -4107,33 +4107,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2183, col: 1, offset: 68172},
+			pos:  position{line: 2208, col: 1, offset: 68882},
 			expr: &actionExpr{
-				pos: position{line: 2183, col: 30, offset: 68201},
+				pos: position{line: 2208, col: 30, offset: 68911},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2183, col: 30, offset: 68201},
+					pos: position{line: 2208, col: 30, offset: 68911},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2183, col: 30, offset: 68201},
+							pos:   position{line: 2208, col: 30, offset: 68911},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2183, col: 44, offset: 68215},
+								pos: position{line: 2208, col: 44, offset: 68925},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2183, col: 44, offset: 68215},
+										pos:        position{line: 2208, col: 44, offset: 68925},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2183, col: 50, offset: 68221},
+										pos:        position{line: 2208, col: 50, offset: 68931},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2183, col: 56, offset: 68227},
+										pos:        position{line: 2208, col: 56, offset: 68937},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4142,31 +4142,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2183, col: 60, offset: 68231},
+							pos:   position{line: 2208, col: 60, offset: 68941},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2183, col: 64, offset: 68235},
+								pos: position{line: 2208, col: 64, offset: 68945},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2183, col: 64, offset: 68235},
+										pos:        position{line: 2208, col: 64, offset: 68945},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2183, col: 73, offset: 68244},
+										pos:        position{line: 2208, col: 73, offset: 68954},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2183, col: 81, offset: 68252},
+										pos:        position{line: 2208, col: 81, offset: 68962},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2183, col: 88, offset: 68259},
+										pos:        position{line: 2208, col: 88, offset: 68969},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4175,19 +4175,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2183, col: 95, offset: 68266},
+							pos:  position{line: 2208, col: 95, offset: 68976},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2183, col: 103, offset: 68274},
+							pos:   position{line: 2208, col: 103, offset: 68984},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2183, col: 109, offset: 68280},
+								pos:  position{line: 2208, col: 109, offset: 68990},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2183, col: 119, offset: 68290},
+							pos:  position{line: 2208, col: 119, offset: 69000},
 							name: "R_PAREN",
 						},
 					},
@@ -4196,26 +4196,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2203, col: 1, offset: 68715},
+			pos:  position{line: 2228, col: 1, offset: 69425},
 			expr: &actionExpr{
-				pos: position{line: 2203, col: 16, offset: 68730},
+				pos: position{line: 2228, col: 16, offset: 69440},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2203, col: 16, offset: 68730},
+					pos: position{line: 2228, col: 16, offset: 69440},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 16, offset: 68730},
+							pos:  position{line: 2228, col: 16, offset: 69440},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2203, col: 21, offset: 68735},
+							pos:  position{line: 2228, col: 21, offset: 69445},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2203, col: 32, offset: 68746},
+							pos:   position{line: 2228, col: 32, offset: 69456},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2203, col: 43, offset: 68757},
+								pos:  position{line: 2228, col: 43, offset: 69467},
 								name: "RenameExpr",
 							},
 						},
@@ -4225,33 +4225,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2226, col: 1, offset: 69421},
+			pos:  position{line: 2251, col: 1, offset: 70131},
 			expr: &choiceExpr{
-				pos: position{line: 2226, col: 15, offset: 69435},
+				pos: position{line: 2251, col: 15, offset: 70145},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2226, col: 15, offset: 69435},
+						pos: position{line: 2251, col: 15, offset: 70145},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2226, col: 15, offset: 69435},
+							pos: position{line: 2251, col: 15, offset: 70145},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2226, col: 15, offset: 69435},
+									pos:   position{line: 2251, col: 15, offset: 70145},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2226, col: 31, offset: 69451},
+										pos:  position{line: 2251, col: 31, offset: 70161},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2226, col: 45, offset: 69465},
+									pos:  position{line: 2251, col: 45, offset: 70175},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2226, col: 48, offset: 69468},
+									pos:   position{line: 2251, col: 48, offset: 70178},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2226, col: 59, offset: 69479},
+										pos:  position{line: 2251, col: 59, offset: 70189},
 										name: "QuotedString",
 									},
 								},
@@ -4259,28 +4259,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2237, col: 3, offset: 69798},
+						pos: position{line: 2262, col: 3, offset: 70508},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2237, col: 3, offset: 69798},
+							pos: position{line: 2262, col: 3, offset: 70508},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2237, col: 3, offset: 69798},
+									pos:   position{line: 2262, col: 3, offset: 70508},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2237, col: 19, offset: 69814},
+										pos:  position{line: 2262, col: 19, offset: 70524},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2237, col: 33, offset: 69828},
+									pos:  position{line: 2262, col: 33, offset: 70538},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2237, col: 36, offset: 69831},
+									pos:   position{line: 2262, col: 36, offset: 70541},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2237, col: 47, offset: 69842},
+										pos:  position{line: 2262, col: 47, offset: 70552},
 										name: "RenamePattern",
 									},
 								},
@@ -4292,48 +4292,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2259, col: 1, offset: 70408},
+			pos:  position{line: 2284, col: 1, offset: 71118},
 			expr: &actionExpr{
-				pos: position{line: 2259, col: 13, offset: 70420},
+				pos: position{line: 2284, col: 13, offset: 71130},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2259, col: 13, offset: 70420},
+					pos: position{line: 2284, col: 13, offset: 71130},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2259, col: 13, offset: 70420},
+							pos:  position{line: 2284, col: 13, offset: 71130},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2259, col: 18, offset: 70425},
+							pos:  position{line: 2284, col: 18, offset: 71135},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2259, col: 26, offset: 70433},
+							pos:        position{line: 2284, col: 26, offset: 71143},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2259, col: 34, offset: 70441},
+							pos:  position{line: 2284, col: 34, offset: 71151},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2259, col: 40, offset: 70447},
+							pos:   position{line: 2284, col: 40, offset: 71157},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2259, col: 46, offset: 70453},
+								pos:  position{line: 2284, col: 46, offset: 71163},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2259, col: 62, offset: 70469},
+							pos:  position{line: 2284, col: 62, offset: 71179},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2259, col: 68, offset: 70475},
+							pos:   position{line: 2284, col: 68, offset: 71185},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2259, col: 72, offset: 70479},
+								pos:  position{line: 2284, col: 72, offset: 71189},
 								name: "QuotedString",
 							},
 						},
@@ -4343,37 +4343,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2288, col: 1, offset: 71208},
+			pos:  position{line: 2313, col: 1, offset: 71918},
 			expr: &actionExpr{
-				pos: position{line: 2288, col: 14, offset: 71221},
+				pos: position{line: 2313, col: 14, offset: 71931},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2288, col: 14, offset: 71221},
+					pos: position{line: 2313, col: 14, offset: 71931},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2288, col: 14, offset: 71221},
+							pos:  position{line: 2313, col: 14, offset: 71931},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2288, col: 19, offset: 71226},
+							pos:  position{line: 2313, col: 19, offset: 71936},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2288, col: 28, offset: 71235},
+							pos:   position{line: 2313, col: 28, offset: 71945},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2288, col: 34, offset: 71241},
+								pos: position{line: 2313, col: 34, offset: 71951},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2288, col: 35, offset: 71242},
+									pos:  position{line: 2313, col: 35, offset: 71952},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2288, col: 47, offset: 71254},
+							pos:   position{line: 2313, col: 47, offset: 71964},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2288, col: 58, offset: 71265},
+								pos:  position{line: 2313, col: 58, offset: 71975},
 								name: "SortElements",
 							},
 						},
@@ -4383,41 +4383,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2326, col: 1, offset: 72144},
+			pos:  position{line: 2351, col: 1, offset: 72854},
 			expr: &actionExpr{
-				pos: position{line: 2326, col: 14, offset: 72157},
+				pos: position{line: 2351, col: 14, offset: 72867},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2326, col: 14, offset: 72157},
+					pos: position{line: 2351, col: 14, offset: 72867},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2326, col: 14, offset: 72157},
+							pos: position{line: 2351, col: 14, offset: 72867},
 							expr: &seqExpr{
-								pos: position{line: 2326, col: 15, offset: 72158},
+								pos: position{line: 2351, col: 15, offset: 72868},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2326, col: 15, offset: 72158},
+										pos:        position{line: 2351, col: 15, offset: 72868},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2326, col: 23, offset: 72166},
+										pos:  position{line: 2351, col: 23, offset: 72876},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2326, col: 31, offset: 72174},
+							pos:   position{line: 2351, col: 31, offset: 72884},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2326, col: 40, offset: 72183},
+								pos:  position{line: 2351, col: 40, offset: 72893},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2326, col: 56, offset: 72199},
+							pos:  position{line: 2351, col: 56, offset: 72909},
 							name: "SPACE",
 						},
 					},
@@ -4426,43 +4426,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2340, col: 1, offset: 72498},
+			pos:  position{line: 2365, col: 1, offset: 73208},
 			expr: &actionExpr{
-				pos: position{line: 2340, col: 14, offset: 72511},
+				pos: position{line: 2365, col: 14, offset: 73221},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2340, col: 14, offset: 72511},
+					pos: position{line: 2365, col: 14, offset: 73221},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2340, col: 14, offset: 72511},
+							pos:  position{line: 2365, col: 14, offset: 73221},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2340, col: 19, offset: 72516},
+							pos:  position{line: 2365, col: 19, offset: 73226},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2340, col: 28, offset: 72525},
+							pos:   position{line: 2365, col: 28, offset: 73235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2340, col: 34, offset: 72531},
+								pos:  position{line: 2365, col: 34, offset: 73241},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2340, col: 45, offset: 72542},
+							pos:   position{line: 2365, col: 45, offset: 73252},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2340, col: 50, offset: 72547},
+								pos: position{line: 2365, col: 50, offset: 73257},
 								expr: &seqExpr{
-									pos: position{line: 2340, col: 51, offset: 72548},
+									pos: position{line: 2365, col: 51, offset: 73258},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2340, col: 51, offset: 72548},
+											pos:  position{line: 2365, col: 51, offset: 73258},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2340, col: 57, offset: 72554},
+											pos:  position{line: 2365, col: 57, offset: 73264},
 											name: "SingleEval",
 										},
 									},
@@ -4475,30 +4475,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2375, col: 1, offset: 73787},
+			pos:  position{line: 2400, col: 1, offset: 74497},
 			expr: &actionExpr{
-				pos: position{line: 2375, col: 15, offset: 73801},
+				pos: position{line: 2400, col: 15, offset: 74511},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2375, col: 15, offset: 73801},
+					pos: position{line: 2400, col: 15, offset: 74511},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2375, col: 15, offset: 73801},
+							pos:   position{line: 2400, col: 15, offset: 74511},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2375, col: 21, offset: 73807},
+								pos:  position{line: 2400, col: 21, offset: 74517},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2375, col: 31, offset: 73817},
+							pos:  position{line: 2400, col: 31, offset: 74527},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2375, col: 37, offset: 73823},
+							pos:   position{line: 2400, col: 37, offset: 74533},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2375, col: 42, offset: 73828},
+								pos:  position{line: 2400, col: 42, offset: 74538},
 								name: "EvalExpression",
 							},
 						},
@@ -4508,15 +4508,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2388, col: 1, offset: 74229},
+			pos:  position{line: 2413, col: 1, offset: 74939},
 			expr: &actionExpr{
-				pos: position{line: 2388, col: 19, offset: 74247},
+				pos: position{line: 2413, col: 19, offset: 74957},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2388, col: 19, offset: 74247},
+					pos:   position{line: 2413, col: 19, offset: 74957},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2388, col: 25, offset: 74253},
+						pos:  position{line: 2413, col: 25, offset: 74963},
 						name: "ValueExpr",
 					},
 				},
@@ -4524,85 +4524,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2397, col: 1, offset: 74477},
+			pos:  position{line: 2422, col: 1, offset: 75187},
 			expr: &choiceExpr{
-				pos: position{line: 2397, col: 18, offset: 74494},
+				pos: position{line: 2422, col: 18, offset: 75204},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2397, col: 18, offset: 74494},
+						pos: position{line: 2422, col: 18, offset: 75204},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2397, col: 18, offset: 74494},
+							pos: position{line: 2422, col: 18, offset: 75204},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2397, col: 18, offset: 74494},
+									pos:        position{line: 2422, col: 18, offset: 75204},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 23, offset: 74499},
+									pos:  position{line: 2422, col: 23, offset: 75209},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 31, offset: 74507},
+									pos:   position{line: 2422, col: 31, offset: 75217},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2397, col: 41, offset: 74517},
+										pos:  position{line: 2422, col: 41, offset: 75227},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 50, offset: 74526},
+									pos:  position{line: 2422, col: 50, offset: 75236},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 56, offset: 74532},
+									pos:   position{line: 2422, col: 56, offset: 75242},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2397, col: 66, offset: 74542},
+										pos:  position{line: 2422, col: 66, offset: 75252},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 76, offset: 74552},
+									pos:  position{line: 2422, col: 76, offset: 75262},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2397, col: 82, offset: 74558},
+									pos:   position{line: 2422, col: 82, offset: 75268},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2397, col: 93, offset: 74569},
+										pos:  position{line: 2422, col: 93, offset: 75279},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2397, col: 103, offset: 74579},
+									pos:  position{line: 2422, col: 103, offset: 75289},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2408, col: 3, offset: 74830},
+						pos: position{line: 2433, col: 3, offset: 75540},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2408, col: 3, offset: 74830},
+							pos: position{line: 2433, col: 3, offset: 75540},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2408, col: 3, offset: 74830},
+									pos:   position{line: 2433, col: 3, offset: 75540},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2408, col: 11, offset: 74838},
+										pos: position{line: 2433, col: 11, offset: 75548},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2408, col: 11, offset: 74838},
+												pos:        position{line: 2433, col: 11, offset: 75548},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2408, col: 20, offset: 74847},
+												pos:        position{line: 2433, col: 20, offset: 75557},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4611,31 +4611,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2408, col: 32, offset: 74859},
+									pos:  position{line: 2433, col: 32, offset: 75569},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2408, col: 40, offset: 74867},
+									pos:   position{line: 2433, col: 40, offset: 75577},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2408, col: 45, offset: 74872},
+										pos:  position{line: 2433, col: 45, offset: 75582},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2408, col: 64, offset: 74891},
+									pos:   position{line: 2433, col: 64, offset: 75601},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2408, col: 69, offset: 74896},
+										pos: position{line: 2433, col: 69, offset: 75606},
 										expr: &seqExpr{
-											pos: position{line: 2408, col: 70, offset: 74897},
+											pos: position{line: 2433, col: 70, offset: 75607},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2408, col: 70, offset: 74897},
+													pos:  position{line: 2433, col: 70, offset: 75607},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2408, col: 76, offset: 74903},
+													pos:  position{line: 2433, col: 76, offset: 75613},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4643,50 +4643,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2408, col: 97, offset: 74924},
+									pos:  position{line: 2433, col: 97, offset: 75634},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2431, col: 3, offset: 75528},
+						pos: position{line: 2456, col: 3, offset: 76238},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2431, col: 3, offset: 75528},
+							pos: position{line: 2456, col: 3, offset: 76238},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2431, col: 3, offset: 75528},
+									pos:        position{line: 2456, col: 3, offset: 76238},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2431, col: 14, offset: 75539},
+									pos:  position{line: 2456, col: 14, offset: 76249},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2431, col: 22, offset: 75547},
+									pos:   position{line: 2456, col: 22, offset: 76257},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2431, col: 32, offset: 75557},
+										pos:  position{line: 2456, col: 32, offset: 76267},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2431, col: 42, offset: 75567},
+									pos:   position{line: 2456, col: 42, offset: 76277},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2431, col: 47, offset: 75572},
+										pos: position{line: 2456, col: 47, offset: 76282},
 										expr: &seqExpr{
-											pos: position{line: 2431, col: 48, offset: 75573},
+											pos: position{line: 2456, col: 48, offset: 76283},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2431, col: 48, offset: 75573},
+													pos:  position{line: 2456, col: 48, offset: 76283},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2431, col: 54, offset: 75579},
+													pos:  position{line: 2456, col: 54, offset: 76289},
 													name: "ValueExpr",
 												},
 											},
@@ -4694,73 +4694,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2431, col: 66, offset: 75591},
+									pos:  position{line: 2456, col: 66, offset: 76301},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2448, col: 3, offset: 76010},
+						pos: position{line: 2473, col: 3, offset: 76720},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2448, col: 3, offset: 76010},
+							pos: position{line: 2473, col: 3, offset: 76720},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2448, col: 3, offset: 76010},
+									pos:        position{line: 2473, col: 3, offset: 76720},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2448, col: 12, offset: 76019},
+									pos:  position{line: 2473, col: 12, offset: 76729},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2448, col: 20, offset: 76027},
+									pos:   position{line: 2473, col: 20, offset: 76737},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2448, col: 30, offset: 76037},
+										pos:  position{line: 2473, col: 30, offset: 76747},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2448, col: 40, offset: 76047},
+									pos:  position{line: 2473, col: 40, offset: 76757},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2448, col: 46, offset: 76053},
+									pos:   position{line: 2473, col: 46, offset: 76763},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2448, col: 57, offset: 76064},
+										pos:  position{line: 2473, col: 57, offset: 76774},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2448, col: 67, offset: 76074},
+									pos:  position{line: 2473, col: 67, offset: 76784},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2460, col: 3, offset: 76354},
+						pos: position{line: 2485, col: 3, offset: 77064},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2460, col: 3, offset: 76354},
+							pos: position{line: 2485, col: 3, offset: 77064},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2460, col: 3, offset: 76354},
+									pos:        position{line: 2485, col: 3, offset: 77064},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2460, col: 10, offset: 76361},
+									pos:  position{line: 2485, col: 10, offset: 77071},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2460, col: 18, offset: 76369},
+									pos:  position{line: 2485, col: 18, offset: 77079},
 									name: "R_PAREN",
 								},
 							},
@@ -4771,30 +4771,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2467, col: 1, offset: 76466},
+			pos:  position{line: 2492, col: 1, offset: 77176},
 			expr: &actionExpr{
-				pos: position{line: 2467, col: 23, offset: 76488},
+				pos: position{line: 2492, col: 23, offset: 77198},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2467, col: 23, offset: 76488},
+					pos: position{line: 2492, col: 23, offset: 77198},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2467, col: 23, offset: 76488},
+							pos:   position{line: 2492, col: 23, offset: 77198},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2467, col: 33, offset: 76498},
+								pos:  position{line: 2492, col: 33, offset: 77208},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2467, col: 42, offset: 76507},
+							pos:  position{line: 2492, col: 42, offset: 77217},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2467, col: 48, offset: 76513},
+							pos:   position{line: 2492, col: 48, offset: 77223},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2467, col: 54, offset: 76519},
+								pos:  position{line: 2492, col: 54, offset: 77229},
 								name: "ValueExpr",
 							},
 						},
@@ -4804,15 +4804,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2475, col: 1, offset: 76724},
+			pos:  position{line: 2500, col: 1, offset: 77434},
 			expr: &actionExpr{
-				pos: position{line: 2475, col: 26, offset: 76749},
+				pos: position{line: 2500, col: 26, offset: 77459},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2475, col: 26, offset: 76749},
+					pos:   position{line: 2500, col: 26, offset: 77459},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2475, col: 37, offset: 76760},
+						pos:  position{line: 2500, col: 37, offset: 77470},
 						name: "StringExpr",
 					},
 				},
@@ -4820,15 +4820,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2485, col: 1, offset: 76969},
+			pos:  position{line: 2510, col: 1, offset: 77679},
 			expr: &actionExpr{
-				pos: position{line: 2485, col: 30, offset: 76998},
+				pos: position{line: 2510, col: 30, offset: 77708},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2485, col: 30, offset: 76998},
+					pos:   position{line: 2510, col: 30, offset: 77708},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2485, col: 45, offset: 77013},
+						pos:  position{line: 2510, col: 45, offset: 77723},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4836,22 +4836,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2494, col: 1, offset: 77219},
+			pos:  position{line: 2519, col: 1, offset: 77929},
 			expr: &actionExpr{
-				pos: position{line: 2494, col: 27, offset: 77245},
+				pos: position{line: 2519, col: 27, offset: 77955},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2494, col: 27, offset: 77245},
+					pos:   position{line: 2519, col: 27, offset: 77955},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2494, col: 40, offset: 77258},
+						pos: position{line: 2519, col: 40, offset: 77968},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2494, col: 40, offset: 77258},
+								pos:  position{line: 2519, col: 40, offset: 77968},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2494, col: 68, offset: 77286},
+								pos:  position{line: 2519, col: 68, offset: 77996},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4861,135 +4861,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2498, col: 1, offset: 77363},
+			pos:  position{line: 2523, col: 1, offset: 78073},
 			expr: &choiceExpr{
-				pos: position{line: 2498, col: 19, offset: 77381},
+				pos: position{line: 2523, col: 19, offset: 78091},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2498, col: 19, offset: 77381},
+						pos: position{line: 2523, col: 19, offset: 78091},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2498, col: 20, offset: 77382},
+							pos: position{line: 2523, col: 20, offset: 78092},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2498, col: 20, offset: 77382},
+									pos:   position{line: 2523, col: 20, offset: 78092},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2498, col: 28, offset: 77390},
+										pos:        position{line: 2523, col: 28, offset: 78100},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2498, col: 37, offset: 77399},
+									pos:  position{line: 2523, col: 37, offset: 78109},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2498, col: 45, offset: 77407},
+									pos:   position{line: 2523, col: 45, offset: 78117},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2498, col: 56, offset: 77418},
+										pos:  position{line: 2523, col: 56, offset: 78128},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2498, col: 67, offset: 77429},
+									pos:  position{line: 2523, col: 67, offset: 78139},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2498, col: 73, offset: 77435},
+									pos:   position{line: 2523, col: 73, offset: 78145},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2498, col: 79, offset: 77441},
+										pos:  position{line: 2523, col: 79, offset: 78151},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2498, col: 90, offset: 77452},
+									pos:  position{line: 2523, col: 90, offset: 78162},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2510, col: 3, offset: 77813},
+						pos: position{line: 2535, col: 3, offset: 78523},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2510, col: 4, offset: 77814},
+							pos: position{line: 2535, col: 4, offset: 78524},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2510, col: 4, offset: 77814},
+									pos:   position{line: 2535, col: 4, offset: 78524},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2510, col: 12, offset: 77822},
+										pos:        position{line: 2535, col: 12, offset: 78532},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2510, col: 23, offset: 77833},
+									pos:  position{line: 2535, col: 23, offset: 78543},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2510, col: 31, offset: 77841},
+									pos:   position{line: 2535, col: 31, offset: 78551},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2510, col: 46, offset: 77856},
+										pos:  position{line: 2535, col: 46, offset: 78566},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2510, col: 61, offset: 77871},
+									pos:  position{line: 2535, col: 61, offset: 78581},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2510, col: 67, offset: 77877},
+									pos:   position{line: 2535, col: 67, offset: 78587},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2510, col: 78, offset: 77888},
+										pos:  position{line: 2535, col: 78, offset: 78598},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2510, col: 90, offset: 77900},
+									pos:   position{line: 2535, col: 90, offset: 78610},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2510, col: 99, offset: 77909},
+										pos: position{line: 2535, col: 99, offset: 78619},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2510, col: 100, offset: 77910},
+											pos:  position{line: 2535, col: 100, offset: 78620},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2510, col: 119, offset: 77929},
+									pos:  position{line: 2535, col: 119, offset: 78639},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2526, col: 3, offset: 78491},
+						pos: position{line: 2551, col: 3, offset: 79201},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2526, col: 4, offset: 78492},
+							pos: position{line: 2551, col: 4, offset: 79202},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2526, col: 4, offset: 78492},
+									pos:   position{line: 2551, col: 4, offset: 79202},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2526, col: 12, offset: 78500},
+										pos: position{line: 2551, col: 12, offset: 79210},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2526, col: 12, offset: 78500},
+												pos:        position{line: 2551, col: 12, offset: 79210},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2526, col: 24, offset: 78512},
+												pos:        position{line: 2551, col: 24, offset: 79222},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4998,222 +4998,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2526, col: 34, offset: 78522},
+									pos:  position{line: 2551, col: 34, offset: 79232},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2526, col: 42, offset: 78530},
+									pos:   position{line: 2551, col: 42, offset: 79240},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2526, col: 57, offset: 78545},
+										pos:  position{line: 2551, col: 57, offset: 79255},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2526, col: 72, offset: 78560},
+									pos:  position{line: 2551, col: 72, offset: 79270},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2538, col: 3, offset: 78908},
+						pos: position{line: 2563, col: 3, offset: 79618},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2538, col: 4, offset: 78909},
+							pos: position{line: 2563, col: 4, offset: 79619},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2538, col: 4, offset: 78909},
+									pos:   position{line: 2563, col: 4, offset: 79619},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2538, col: 12, offset: 78917},
+										pos:        position{line: 2563, col: 12, offset: 79627},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 24, offset: 78929},
+									pos:  position{line: 2563, col: 24, offset: 79639},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2538, col: 32, offset: 78937},
+									pos:   position{line: 2563, col: 32, offset: 79647},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2538, col: 42, offset: 78947},
+										pos:  position{line: 2563, col: 42, offset: 79657},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 51, offset: 78956},
+									pos:  position{line: 2563, col: 51, offset: 79666},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2551, col: 3, offset: 79303},
+						pos: position{line: 2576, col: 3, offset: 80013},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2551, col: 4, offset: 79304},
+							pos: position{line: 2576, col: 4, offset: 80014},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2551, col: 4, offset: 79304},
+									pos:   position{line: 2576, col: 4, offset: 80014},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2551, col: 12, offset: 79312},
+										pos:        position{line: 2576, col: 12, offset: 80022},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 21, offset: 79321},
+									pos:  position{line: 2576, col: 21, offset: 80031},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 29, offset: 79329},
+									pos:   position{line: 2576, col: 29, offset: 80039},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 44, offset: 79344},
+										pos:  position{line: 2576, col: 44, offset: 80054},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 59, offset: 79359},
+									pos:  position{line: 2576, col: 59, offset: 80069},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 65, offset: 79365},
+									pos:   position{line: 2576, col: 65, offset: 80075},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 70, offset: 79370},
+										pos:  position{line: 2576, col: 70, offset: 80080},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 80, offset: 79380},
+									pos:  position{line: 2576, col: 80, offset: 80090},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2564, col: 3, offset: 79802},
+						pos: position{line: 2589, col: 3, offset: 80512},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2564, col: 4, offset: 79803},
+							pos: position{line: 2589, col: 4, offset: 80513},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2564, col: 4, offset: 79803},
+									pos:   position{line: 2589, col: 4, offset: 80513},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2564, col: 12, offset: 79811},
+										pos:        position{line: 2589, col: 12, offset: 80521},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2564, col: 23, offset: 79822},
+									pos:  position{line: 2589, col: 23, offset: 80532},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2564, col: 31, offset: 79830},
+									pos:   position{line: 2589, col: 31, offset: 80540},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2564, col: 42, offset: 79841},
+										pos:  position{line: 2589, col: 42, offset: 80551},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2564, col: 54, offset: 79853},
+									pos:  position{line: 2589, col: 54, offset: 80563},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2564, col: 60, offset: 79859},
+									pos:   position{line: 2589, col: 60, offset: 80569},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2564, col: 69, offset: 79868},
+										pos:  position{line: 2589, col: 69, offset: 80578},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2564, col: 81, offset: 79880},
+									pos:  position{line: 2589, col: 81, offset: 80590},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2564, col: 87, offset: 79886},
+									pos:   position{line: 2589, col: 87, offset: 80596},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2564, col: 98, offset: 79897},
+										pos: position{line: 2589, col: 98, offset: 80607},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2564, col: 99, offset: 79898},
+											pos:  position{line: 2589, col: 99, offset: 80608},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2564, col: 112, offset: 79911},
+									pos:  position{line: 2589, col: 112, offset: 80621},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2577, col: 3, offset: 80362},
+						pos: position{line: 2602, col: 3, offset: 81072},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2577, col: 4, offset: 80363},
+							pos: position{line: 2602, col: 4, offset: 81073},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2577, col: 4, offset: 80363},
+									pos:   position{line: 2602, col: 4, offset: 81073},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2577, col: 12, offset: 80371},
+										pos:        position{line: 2602, col: 12, offset: 81081},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 21, offset: 80380},
+									pos:  position{line: 2602, col: 21, offset: 81090},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2577, col: 29, offset: 80388},
+									pos:   position{line: 2602, col: 29, offset: 81098},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2577, col: 36, offset: 80395},
+										pos:  position{line: 2602, col: 36, offset: 81105},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 51, offset: 80410},
+									pos:  position{line: 2602, col: 51, offset: 81120},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2577, col: 57, offset: 80416},
+									pos:   position{line: 2602, col: 57, offset: 81126},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2577, col: 65, offset: 80424},
+										pos:  position{line: 2602, col: 65, offset: 81134},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2577, col: 80, offset: 80439},
+									pos:   position{line: 2602, col: 80, offset: 81149},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2577, col: 85, offset: 80444},
+										pos: position{line: 2602, col: 85, offset: 81154},
 										expr: &seqExpr{
-											pos: position{line: 2577, col: 86, offset: 80445},
+											pos: position{line: 2602, col: 86, offset: 81155},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2577, col: 86, offset: 80445},
+													pos:  position{line: 2602, col: 86, offset: 81155},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2577, col: 92, offset: 80451},
+													pos:  position{line: 2602, col: 92, offset: 81161},
 													name: "StringExpr",
 												},
 											},
@@ -5221,63 +5221,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2577, col: 105, offset: 80464},
+									pos:  position{line: 2602, col: 105, offset: 81174},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2594, col: 3, offset: 80992},
+						pos: position{line: 2619, col: 3, offset: 81702},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2594, col: 4, offset: 80993},
+							pos: position{line: 2619, col: 4, offset: 81703},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2594, col: 4, offset: 80993},
+									pos:   position{line: 2619, col: 4, offset: 81703},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2594, col: 12, offset: 81001},
+										pos:        position{line: 2619, col: 12, offset: 81711},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2594, col: 32, offset: 81021},
+									pos:  position{line: 2619, col: 32, offset: 81731},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2594, col: 40, offset: 81029},
+									pos:   position{line: 2619, col: 40, offset: 81739},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2594, col: 55, offset: 81044},
+										pos:  position{line: 2619, col: 55, offset: 81754},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2594, col: 70, offset: 81059},
+									pos:   position{line: 2619, col: 70, offset: 81769},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2594, col: 75, offset: 81064},
+										pos: position{line: 2619, col: 75, offset: 81774},
 										expr: &seqExpr{
-											pos: position{line: 2594, col: 76, offset: 81065},
+											pos: position{line: 2619, col: 76, offset: 81775},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2594, col: 76, offset: 81065},
+													pos:  position{line: 2619, col: 76, offset: 81775},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2594, col: 83, offset: 81072},
+													pos: position{line: 2619, col: 83, offset: 81782},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2594, col: 83, offset: 81072},
+															pos:        position{line: 2619, col: 83, offset: 81782},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2594, col: 92, offset: 81081},
+															pos:        position{line: 2619, col: 92, offset: 81791},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5285,7 +5285,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2594, col: 101, offset: 81090},
+													pos:        position{line: 2619, col: 101, offset: 81800},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5295,54 +5295,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2594, col: 108, offset: 81097},
+									pos:  position{line: 2619, col: 108, offset: 81807},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2619, col: 3, offset: 81800},
+						pos: position{line: 2644, col: 3, offset: 82510},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2619, col: 4, offset: 81801},
+							pos: position{line: 2644, col: 4, offset: 82511},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2619, col: 4, offset: 81801},
+									pos:   position{line: 2644, col: 4, offset: 82511},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2619, col: 12, offset: 81809},
+										pos:        position{line: 2644, col: 12, offset: 82519},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 24, offset: 81821},
+									pos:  position{line: 2644, col: 24, offset: 82531},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 32, offset: 81829},
+									pos:   position{line: 2644, col: 32, offset: 82539},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2619, col: 41, offset: 81838},
+										pos:  position{line: 2644, col: 41, offset: 82548},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 64, offset: 81861},
+									pos:   position{line: 2644, col: 64, offset: 82571},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2619, col: 69, offset: 81866},
+										pos: position{line: 2644, col: 69, offset: 82576},
 										expr: &seqExpr{
-											pos: position{line: 2619, col: 70, offset: 81867},
+											pos: position{line: 2644, col: 70, offset: 82577},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2619, col: 70, offset: 81867},
+													pos:  position{line: 2644, col: 70, offset: 82577},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2619, col: 76, offset: 81873},
+													pos:  position{line: 2644, col: 76, offset: 82583},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5350,57 +5350,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 101, offset: 81898},
+									pos:  position{line: 2644, col: 101, offset: 82608},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2639, col: 3, offset: 82486},
+						pos: position{line: 2664, col: 3, offset: 83196},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2639, col: 3, offset: 82486},
+							pos: position{line: 2664, col: 3, offset: 83196},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2639, col: 3, offset: 82486},
+									pos:   position{line: 2664, col: 3, offset: 83196},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2639, col: 9, offset: 82492},
+										pos:  position{line: 2664, col: 9, offset: 83202},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2639, col: 25, offset: 82508},
+									pos: position{line: 2664, col: 25, offset: 83218},
 									expr: &choiceExpr{
-										pos: position{line: 2639, col: 27, offset: 82510},
+										pos: position{line: 2664, col: 27, offset: 83220},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 27, offset: 82510},
+												pos:  position{line: 2664, col: 27, offset: 83220},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 36, offset: 82519},
+												pos:  position{line: 2664, col: 36, offset: 83229},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 46, offset: 82529},
+												pos:  position{line: 2664, col: 46, offset: 83239},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 54, offset: 82537},
+												pos:  position{line: 2664, col: 54, offset: 83247},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 62, offset: 82545},
+												pos:  position{line: 2664, col: 62, offset: 83255},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2639, col: 70, offset: 82553},
+												pos:  position{line: 2664, col: 70, offset: 83263},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2639, col: 84, offset: 82567},
+												pos:        position{line: 2664, col: 84, offset: 83277},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5416,36 +5416,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2651, col: 1, offset: 82962},
+			pos:  position{line: 2676, col: 1, offset: 83672},
 			expr: &choiceExpr{
-				pos: position{line: 2651, col: 13, offset: 82974},
+				pos: position{line: 2676, col: 13, offset: 83684},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2651, col: 13, offset: 82974},
+						pos: position{line: 2676, col: 13, offset: 83684},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2651, col: 14, offset: 82975},
+							pos: position{line: 2676, col: 14, offset: 83685},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2651, col: 14, offset: 82975},
+									pos:   position{line: 2676, col: 14, offset: 83685},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2651, col: 22, offset: 82983},
+										pos: position{line: 2676, col: 22, offset: 83693},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2651, col: 22, offset: 82983},
+												pos:        position{line: 2676, col: 22, offset: 83693},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2651, col: 32, offset: 82993},
+												pos:        position{line: 2676, col: 32, offset: 83703},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2651, col: 42, offset: 83003},
+												pos:        position{line: 2676, col: 42, offset: 83713},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5454,44 +5454,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2651, col: 55, offset: 83016},
+									pos:  position{line: 2676, col: 55, offset: 83726},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2651, col: 63, offset: 83024},
+									pos:   position{line: 2676, col: 63, offset: 83734},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2651, col: 74, offset: 83035},
+										pos:  position{line: 2676, col: 74, offset: 83745},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2651, col: 85, offset: 83046},
+									pos:  position{line: 2676, col: 85, offset: 83756},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2663, col: 3, offset: 83360},
+						pos: position{line: 2688, col: 3, offset: 84070},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2663, col: 4, offset: 83361},
+							pos: position{line: 2688, col: 4, offset: 84071},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2663, col: 4, offset: 83361},
+									pos:   position{line: 2688, col: 4, offset: 84071},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2663, col: 12, offset: 83369},
+										pos: position{line: 2688, col: 12, offset: 84079},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2663, col: 12, offset: 83369},
+												pos:        position{line: 2688, col: 12, offset: 84079},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2663, col: 20, offset: 83377},
+												pos:        position{line: 2688, col: 20, offset: 84087},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5500,31 +5500,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2663, col: 27, offset: 83384},
+									pos:  position{line: 2688, col: 27, offset: 84094},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2663, col: 35, offset: 83392},
+									pos:   position{line: 2688, col: 35, offset: 84102},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2663, col: 44, offset: 83401},
+										pos:  position{line: 2688, col: 44, offset: 84111},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2663, col: 55, offset: 83412},
+									pos:   position{line: 2688, col: 55, offset: 84122},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2663, col: 60, offset: 83417},
+										pos: position{line: 2688, col: 60, offset: 84127},
 										expr: &seqExpr{
-											pos: position{line: 2663, col: 61, offset: 83418},
+											pos: position{line: 2688, col: 61, offset: 84128},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2663, col: 61, offset: 83418},
+													pos:  position{line: 2688, col: 61, offset: 84128},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2663, col: 67, offset: 83424},
+													pos:  position{line: 2688, col: 67, offset: 84134},
 													name: "StringExpr",
 												},
 											},
@@ -5532,195 +5532,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2663, col: 80, offset: 83437},
+									pos:  position{line: 2688, col: 80, offset: 84147},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2685, col: 3, offset: 84037},
+						pos: position{line: 2710, col: 3, offset: 84747},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2685, col: 4, offset: 84038},
+							pos: position{line: 2710, col: 4, offset: 84748},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2685, col: 4, offset: 84038},
+									pos:   position{line: 2710, col: 4, offset: 84748},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2685, col: 12, offset: 84046},
+										pos:        position{line: 2710, col: 12, offset: 84756},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 23, offset: 84057},
+									pos:  position{line: 2710, col: 23, offset: 84767},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 31, offset: 84065},
+									pos:   position{line: 2710, col: 31, offset: 84775},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 46, offset: 84080},
+										pos:  position{line: 2710, col: 46, offset: 84790},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 61, offset: 84095},
+									pos:  position{line: 2710, col: 61, offset: 84805},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2696, col: 3, offset: 84397},
+						pos: position{line: 2721, col: 3, offset: 85107},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2696, col: 4, offset: 84398},
+							pos: position{line: 2721, col: 4, offset: 85108},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2696, col: 4, offset: 84398},
+									pos:   position{line: 2721, col: 4, offset: 85108},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2696, col: 12, offset: 84406},
+										pos:        position{line: 2721, col: 12, offset: 85116},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2696, col: 22, offset: 84416},
+									pos:  position{line: 2721, col: 22, offset: 85126},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2696, col: 30, offset: 84424},
+									pos:   position{line: 2721, col: 30, offset: 85134},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2696, col: 45, offset: 84439},
+										pos:  position{line: 2721, col: 45, offset: 85149},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2696, col: 60, offset: 84454},
+									pos:  position{line: 2721, col: 60, offset: 85164},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2696, col: 66, offset: 84460},
+									pos:   position{line: 2721, col: 66, offset: 85170},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2696, col: 72, offset: 84466},
+										pos:  position{line: 2721, col: 72, offset: 85176},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2696, col: 83, offset: 84477},
+									pos:  position{line: 2721, col: 83, offset: 85187},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2708, col: 3, offset: 84827},
+						pos: position{line: 2733, col: 3, offset: 85537},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2708, col: 4, offset: 84828},
+							pos: position{line: 2733, col: 4, offset: 85538},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2708, col: 4, offset: 84828},
+									pos:   position{line: 2733, col: 4, offset: 85538},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2708, col: 12, offset: 84836},
+										pos:        position{line: 2733, col: 12, offset: 85546},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2708, col: 22, offset: 84846},
+									pos:  position{line: 2733, col: 22, offset: 85556},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2708, col: 30, offset: 84854},
+									pos:   position{line: 2733, col: 30, offset: 85564},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2708, col: 45, offset: 84869},
+										pos:  position{line: 2733, col: 45, offset: 85579},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2708, col: 60, offset: 84884},
+									pos:  position{line: 2733, col: 60, offset: 85594},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2708, col: 66, offset: 84890},
+									pos:   position{line: 2733, col: 66, offset: 85600},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2708, col: 79, offset: 84903},
+										pos:  position{line: 2733, col: 79, offset: 85613},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2708, col: 90, offset: 84914},
+									pos:  position{line: 2733, col: 90, offset: 85624},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2732, col: 3, offset: 85583},
+						pos: position{line: 2757, col: 3, offset: 86293},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2732, col: 4, offset: 85584},
+							pos: position{line: 2757, col: 4, offset: 86294},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2732, col: 4, offset: 85584},
+									pos:   position{line: 2757, col: 4, offset: 86294},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2732, col: 12, offset: 85592},
+										pos:        position{line: 2757, col: 12, offset: 86302},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 22, offset: 85602},
+									pos:  position{line: 2757, col: 22, offset: 86312},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2732, col: 30, offset: 85610},
+									pos:   position{line: 2757, col: 30, offset: 86320},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2732, col: 41, offset: 85621},
+										pos:  position{line: 2757, col: 41, offset: 86331},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 52, offset: 85632},
+									pos:  position{line: 2757, col: 52, offset: 86342},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2732, col: 58, offset: 85638},
+									pos:   position{line: 2757, col: 58, offset: 86348},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2732, col: 69, offset: 85649},
+										pos:  position{line: 2757, col: 69, offset: 86359},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2732, col: 81, offset: 85661},
+									pos:   position{line: 2757, col: 81, offset: 86371},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2732, col: 93, offset: 85673},
+										pos: position{line: 2757, col: 93, offset: 86383},
 										expr: &seqExpr{
-											pos: position{line: 2732, col: 94, offset: 85674},
+											pos: position{line: 2757, col: 94, offset: 86384},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2732, col: 94, offset: 85674},
+													pos:  position{line: 2757, col: 94, offset: 86384},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2732, col: 100, offset: 85680},
+													pos:  position{line: 2757, col: 100, offset: 86390},
 													name: "NumericExpr",
 												},
 											},
@@ -5728,50 +5728,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 114, offset: 85694},
+									pos:  position{line: 2757, col: 114, offset: 86404},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2757, col: 3, offset: 86524},
+						pos: position{line: 2782, col: 3, offset: 87234},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2757, col: 3, offset: 86524},
+							pos: position{line: 2782, col: 3, offset: 87234},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2757, col: 3, offset: 86524},
+									pos:        position{line: 2782, col: 3, offset: 87234},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2757, col: 14, offset: 86535},
+									pos:  position{line: 2782, col: 14, offset: 87245},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2757, col: 22, offset: 86543},
+									pos:   position{line: 2782, col: 22, offset: 87253},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2757, col: 28, offset: 86549},
+										pos:  position{line: 2782, col: 28, offset: 87259},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2757, col: 38, offset: 86559},
+									pos:   position{line: 2782, col: 38, offset: 87269},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2757, col: 45, offset: 86566},
+										pos: position{line: 2782, col: 45, offset: 87276},
 										expr: &seqExpr{
-											pos: position{line: 2757, col: 46, offset: 86567},
+											pos: position{line: 2782, col: 46, offset: 87277},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2757, col: 46, offset: 86567},
+													pos:  position{line: 2782, col: 46, offset: 87277},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2757, col: 52, offset: 86573},
+													pos:  position{line: 2782, col: 52, offset: 87283},
 													name: "StringExpr",
 												},
 											},
@@ -5779,38 +5779,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2757, col: 65, offset: 86586},
+									pos:  position{line: 2782, col: 65, offset: 87296},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2770, col: 3, offset: 86954},
+						pos: position{line: 2795, col: 3, offset: 87664},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2770, col: 4, offset: 86955},
+							pos: position{line: 2795, col: 4, offset: 87665},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2770, col: 4, offset: 86955},
+									pos:   position{line: 2795, col: 4, offset: 87665},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2770, col: 12, offset: 86963},
+										pos: position{line: 2795, col: 12, offset: 87673},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2770, col: 12, offset: 86963},
+												pos:        position{line: 2795, col: 12, offset: 87673},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2770, col: 22, offset: 86973},
+												pos:        position{line: 2795, col: 22, offset: 87683},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2770, col: 32, offset: 86983},
+												pos:        position{line: 2795, col: 32, offset: 87693},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5819,223 +5819,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2770, col: 40, offset: 86991},
+									pos:  position{line: 2795, col: 40, offset: 87701},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2770, col: 48, offset: 86999},
+									pos:   position{line: 2795, col: 48, offset: 87709},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2770, col: 54, offset: 87005},
+										pos:  position{line: 2795, col: 54, offset: 87715},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2770, col: 66, offset: 87017},
+									pos:   position{line: 2795, col: 66, offset: 87727},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2770, col: 82, offset: 87033},
+										pos: position{line: 2795, col: 82, offset: 87743},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2770, col: 83, offset: 87034},
+											pos:  position{line: 2795, col: 83, offset: 87744},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2770, col: 101, offset: 87052},
+									pos:  position{line: 2795, col: 101, offset: 87762},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2789, col: 3, offset: 87492},
+						pos: position{line: 2814, col: 3, offset: 88202},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2789, col: 3, offset: 87492},
+							pos: position{line: 2814, col: 3, offset: 88202},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2789, col: 3, offset: 87492},
+									pos:        position{line: 2814, col: 3, offset: 88202},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2789, col: 11, offset: 87500},
+									pos:  position{line: 2814, col: 11, offset: 88210},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2789, col: 19, offset: 87508},
+									pos:   position{line: 2814, col: 19, offset: 88218},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2789, col: 30, offset: 87519},
+										pos:  position{line: 2814, col: 30, offset: 88229},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2789, col: 50, offset: 87539},
+									pos:  position{line: 2814, col: 50, offset: 88249},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2789, col: 56, offset: 87545},
+									pos:   position{line: 2814, col: 56, offset: 88255},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2789, col: 62, offset: 87551},
+										pos: position{line: 2814, col: 62, offset: 88261},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2789, col: 62, offset: 87551},
+												pos:  position{line: 2814, col: 62, offset: 88261},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2789, col: 81, offset: 87570},
+												pos:  position{line: 2814, col: 81, offset: 88280},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2789, col: 100, offset: 87589},
+									pos:  position{line: 2814, col: 100, offset: 88299},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2800, col: 3, offset: 87894},
+						pos: position{line: 2825, col: 3, offset: 88604},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2800, col: 3, offset: 87894},
+							pos: position{line: 2825, col: 3, offset: 88604},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2800, col: 3, offset: 87894},
+									pos:        position{line: 2825, col: 3, offset: 88604},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2800, col: 12, offset: 87903},
+									pos:  position{line: 2825, col: 12, offset: 88613},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2800, col: 20, offset: 87911},
+									pos:   position{line: 2825, col: 20, offset: 88621},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2800, col: 25, offset: 87916},
+										pos:  position{line: 2825, col: 25, offset: 88626},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2800, col: 36, offset: 87927},
+									pos:  position{line: 2825, col: 36, offset: 88637},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2800, col: 42, offset: 87933},
+									pos:   position{line: 2825, col: 42, offset: 88643},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2800, col: 45, offset: 87936},
+										pos:  position{line: 2825, col: 45, offset: 88646},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2800, col: 55, offset: 87946},
+									pos:  position{line: 2825, col: 55, offset: 88656},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2807, col: 3, offset: 88104},
+						pos: position{line: 2832, col: 3, offset: 88814},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2807, col: 3, offset: 88104},
+							pos: position{line: 2832, col: 3, offset: 88814},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2807, col: 3, offset: 88104},
+									pos:        position{line: 2832, col: 3, offset: 88814},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 21, offset: 88122},
+									pos:  position{line: 2832, col: 21, offset: 88832},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 29, offset: 88130},
+									pos:   position{line: 2832, col: 29, offset: 88840},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 33, offset: 88134},
+										pos:  position{line: 2832, col: 33, offset: 88844},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 43, offset: 88144},
+									pos:  position{line: 2832, col: 43, offset: 88854},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 49, offset: 88150},
+									pos:   position{line: 2832, col: 49, offset: 88860},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 53, offset: 88154},
+										pos:  position{line: 2832, col: 53, offset: 88864},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 66, offset: 88167},
+									pos:  position{line: 2832, col: 66, offset: 88877},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 72, offset: 88173},
+									pos:   position{line: 2832, col: 72, offset: 88883},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 78, offset: 88179},
+										pos:  position{line: 2832, col: 78, offset: 88889},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 91, offset: 88192},
+									pos:  position{line: 2832, col: 91, offset: 88902},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2818, col: 3, offset: 88500},
+						pos: position{line: 2843, col: 3, offset: 89210},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2818, col: 3, offset: 88500},
+							pos: position{line: 2843, col: 3, offset: 89210},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2818, col: 3, offset: 88500},
+									pos:        position{line: 2843, col: 3, offset: 89210},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2818, col: 12, offset: 88509},
+									pos:  position{line: 2843, col: 12, offset: 89219},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2818, col: 20, offset: 88517},
+									pos:   position{line: 2843, col: 20, offset: 89227},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2818, col: 27, offset: 88524},
+										pos:  position{line: 2843, col: 27, offset: 89234},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2818, col: 38, offset: 88535},
+									pos:   position{line: 2843, col: 38, offset: 89245},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2818, col: 43, offset: 88540},
+										pos: position{line: 2843, col: 43, offset: 89250},
 										expr: &seqExpr{
-											pos: position{line: 2818, col: 44, offset: 88541},
+											pos: position{line: 2843, col: 44, offset: 89251},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2818, col: 44, offset: 88541},
+													pos:  position{line: 2843, col: 44, offset: 89251},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2818, col: 50, offset: 88547},
+													pos:  position{line: 2843, col: 50, offset: 89257},
 													name: "StringExpr",
 												},
 											},
@@ -6043,47 +6043,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2818, col: 63, offset: 88560},
+									pos:  position{line: 2843, col: 63, offset: 89270},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2836, col: 3, offset: 89027},
+						pos: position{line: 2861, col: 3, offset: 89737},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2836, col: 3, offset: 89027},
+							pos: position{line: 2861, col: 3, offset: 89737},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2836, col: 3, offset: 89027},
+									pos:        position{line: 2861, col: 3, offset: 89737},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2836, col: 12, offset: 89036},
+									pos:  position{line: 2861, col: 12, offset: 89746},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2836, col: 20, offset: 89044},
+									pos:   position{line: 2861, col: 20, offset: 89754},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2836, col: 42, offset: 89066},
+										pos: position{line: 2861, col: 42, offset: 89776},
 										expr: &seqExpr{
-											pos: position{line: 2836, col: 43, offset: 89067},
+											pos: position{line: 2861, col: 43, offset: 89777},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2836, col: 44, offset: 89068},
+													pos: position{line: 2861, col: 44, offset: 89778},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2836, col: 44, offset: 89068},
+															pos:        position{line: 2861, col: 44, offset: 89778},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2836, col: 53, offset: 89077},
+															pos:        position{line: 2861, col: 53, offset: 89787},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6091,7 +6091,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2836, col: 62, offset: 89086},
+													pos:        position{line: 2861, col: 62, offset: 89796},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6101,56 +6101,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2836, col: 69, offset: 89093},
+									pos:  position{line: 2861, col: 69, offset: 89803},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2858, col: 3, offset: 89690},
+						pos: position{line: 2883, col: 3, offset: 90400},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2858, col: 3, offset: 89690},
+							pos: position{line: 2883, col: 3, offset: 90400},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2858, col: 3, offset: 89690},
+									pos:        position{line: 2883, col: 3, offset: 90400},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 13, offset: 89700},
+									pos:  position{line: 2883, col: 13, offset: 90410},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 21, offset: 89708},
+									pos:   position{line: 2883, col: 21, offset: 90418},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2858, col: 27, offset: 89714},
+										pos:  position{line: 2883, col: 27, offset: 90424},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 43, offset: 89730},
+									pos:   position{line: 2883, col: 43, offset: 90440},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2858, col: 53, offset: 89740},
+										pos: position{line: 2883, col: 53, offset: 90450},
 										expr: &seqExpr{
-											pos: position{line: 2858, col: 54, offset: 89741},
+											pos: position{line: 2883, col: 54, offset: 90451},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 54, offset: 89741},
+													pos:  position{line: 2883, col: 54, offset: 90451},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2858, col: 60, offset: 89747},
+													pos:        position{line: 2883, col: 60, offset: 90457},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 73, offset: 89760},
+													pos:  position{line: 2883, col: 73, offset: 90470},
 													name: "FloatAsString",
 												},
 											},
@@ -6158,40 +6158,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 89, offset: 89776},
+									pos:   position{line: 2883, col: 89, offset: 90486},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2858, col: 95, offset: 89782},
+										pos: position{line: 2883, col: 95, offset: 90492},
 										expr: &seqExpr{
-											pos: position{line: 2858, col: 96, offset: 89783},
+											pos: position{line: 2883, col: 96, offset: 90493},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 96, offset: 89783},
+													pos:  position{line: 2883, col: 96, offset: 90493},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2858, col: 102, offset: 89789},
+													pos:        position{line: 2883, col: 102, offset: 90499},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2858, col: 112, offset: 89799},
+													pos: position{line: 2883, col: 112, offset: 90509},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2858, col: 112, offset: 89799},
+															pos:        position{line: 2883, col: 112, offset: 90509},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2858, col: 125, offset: 89812},
+															pos:        position{line: 2883, col: 125, offset: 90522},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2858, col: 137, offset: 89824},
+															pos:        position{line: 2883, col: 137, offset: 90534},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6203,25 +6203,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 151, offset: 89838},
+									pos:   position{line: 2883, col: 151, offset: 90548},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2858, col: 158, offset: 89845},
+										pos: position{line: 2883, col: 158, offset: 90555},
 										expr: &seqExpr{
-											pos: position{line: 2858, col: 159, offset: 89846},
+											pos: position{line: 2883, col: 159, offset: 90556},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 159, offset: 89846},
+													pos:  position{line: 2883, col: 159, offset: 90556},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2858, col: 165, offset: 89852},
+													pos:        position{line: 2883, col: 165, offset: 90562},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 175, offset: 89862},
+													pos:  position{line: 2883, col: 175, offset: 90572},
 													name: "QuotedString",
 												},
 											},
@@ -6229,213 +6229,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 190, offset: 89877},
+									pos:  position{line: 2883, col: 190, offset: 90587},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2898, col: 3, offset: 90872},
+						pos: position{line: 2923, col: 3, offset: 91582},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2898, col: 3, offset: 90872},
+							pos: position{line: 2923, col: 3, offset: 91582},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2898, col: 3, offset: 90872},
+									pos:        position{line: 2923, col: 3, offset: 91582},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2898, col: 15, offset: 90884},
+									pos:  position{line: 2923, col: 15, offset: 91594},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2898, col: 23, offset: 90892},
+									pos:   position{line: 2923, col: 23, offset: 91602},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2898, col: 30, offset: 90899},
+										pos: position{line: 2923, col: 30, offset: 91609},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2898, col: 31, offset: 90900},
+											pos:  position{line: 2923, col: 31, offset: 91610},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2898, col: 44, offset: 90913},
+									pos:  position{line: 2923, col: 44, offset: 91623},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2909, col: 3, offset: 91104},
+						pos: position{line: 2934, col: 3, offset: 91814},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2909, col: 3, offset: 91104},
+							pos: position{line: 2934, col: 3, offset: 91814},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2909, col: 3, offset: 91104},
+									pos:        position{line: 2934, col: 3, offset: 91814},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2909, col: 12, offset: 91113},
+									pos:  position{line: 2934, col: 12, offset: 91823},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2909, col: 20, offset: 91121},
+									pos:   position{line: 2934, col: 20, offset: 91831},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2909, col: 30, offset: 91131},
+										pos:  position{line: 2934, col: 30, offset: 91841},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2909, col: 40, offset: 91141},
+									pos:  position{line: 2934, col: 40, offset: 91851},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2915, col: 3, offset: 91264},
+						pos: position{line: 2940, col: 3, offset: 91974},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2915, col: 3, offset: 91264},
+							pos: position{line: 2940, col: 3, offset: 91974},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2915, col: 3, offset: 91264},
+									pos:        position{line: 2940, col: 3, offset: 91974},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 13, offset: 91274},
+									pos:  position{line: 2940, col: 13, offset: 91984},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 21, offset: 91282},
+									pos:   position{line: 2940, col: 21, offset: 91992},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 25, offset: 91286},
+										pos:  position{line: 2940, col: 25, offset: 91996},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 35, offset: 91296},
+									pos:  position{line: 2940, col: 35, offset: 92006},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 41, offset: 91302},
+									pos:   position{line: 2940, col: 41, offset: 92012},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 47, offset: 91308},
+										pos:  position{line: 2940, col: 47, offset: 92018},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 58, offset: 91319},
+									pos:  position{line: 2940, col: 58, offset: 92029},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 64, offset: 91325},
+									pos:   position{line: 2940, col: 64, offset: 92035},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 76, offset: 91337},
+										pos:  position{line: 2940, col: 76, offset: 92047},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 87, offset: 91348},
+									pos:  position{line: 2940, col: 87, offset: 92058},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2922, col: 3, offset: 91572},
+						pos: position{line: 2947, col: 3, offset: 92282},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2922, col: 3, offset: 91572},
+							pos: position{line: 2947, col: 3, offset: 92282},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2922, col: 3, offset: 91572},
+									pos:        position{line: 2947, col: 3, offset: 92282},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 14, offset: 91583},
+									pos:  position{line: 2947, col: 14, offset: 92293},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2922, col: 22, offset: 91591},
+									pos:   position{line: 2947, col: 22, offset: 92301},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2922, col: 26, offset: 91595},
+										pos:  position{line: 2947, col: 26, offset: 92305},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 36, offset: 91605},
+									pos:  position{line: 2947, col: 36, offset: 92315},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2922, col: 42, offset: 91611},
+									pos:   position{line: 2947, col: 42, offset: 92321},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2922, col: 49, offset: 91618},
+										pos:  position{line: 2947, col: 49, offset: 92328},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 60, offset: 91629},
+									pos:  position{line: 2947, col: 60, offset: 92339},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2930, col: 3, offset: 91793},
+						pos: position{line: 2955, col: 3, offset: 92503},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2930, col: 3, offset: 91793},
+							pos: position{line: 2955, col: 3, offset: 92503},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2930, col: 3, offset: 91793},
+									pos:        position{line: 2955, col: 3, offset: 92503},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 14, offset: 91804},
+									pos:  position{line: 2955, col: 14, offset: 92514},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 22, offset: 91812},
+									pos:   position{line: 2955, col: 22, offset: 92522},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 26, offset: 91816},
+										pos:  position{line: 2955, col: 26, offset: 92526},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 36, offset: 91826},
+									pos:  position{line: 2955, col: 36, offset: 92536},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 42, offset: 91832},
+									pos:   position{line: 2955, col: 42, offset: 92542},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 49, offset: 91839},
+										pos:  position{line: 2955, col: 49, offset: 92549},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 60, offset: 91850},
+									pos:  position{line: 2955, col: 60, offset: 92560},
 									name: "R_PAREN",
 								},
 							},
@@ -6446,15 +6446,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2938, col: 1, offset: 92012},
+			pos:  position{line: 2963, col: 1, offset: 92722},
 			expr: &actionExpr{
-				pos: position{line: 2938, col: 21, offset: 92032},
+				pos: position{line: 2963, col: 21, offset: 92742},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2938, col: 21, offset: 92032},
+					pos:   position{line: 2963, col: 21, offset: 92742},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2938, col: 25, offset: 92036},
+						pos:  position{line: 2963, col: 25, offset: 92746},
 						name: "QuotedString",
 					},
 				},
@@ -6462,15 +6462,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2945, col: 1, offset: 92163},
+			pos:  position{line: 2970, col: 1, offset: 92873},
 			expr: &actionExpr{
-				pos: position{line: 2945, col: 22, offset: 92184},
+				pos: position{line: 2970, col: 22, offset: 92894},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2945, col: 22, offset: 92184},
+					pos:   position{line: 2970, col: 22, offset: 92894},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2945, col: 26, offset: 92188},
+						pos:  position{line: 2970, col: 26, offset: 92898},
 						name: "UnquotedString",
 					},
 				},
@@ -6478,22 +6478,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2952, col: 1, offset: 92316},
+			pos:  position{line: 2977, col: 1, offset: 93026},
 			expr: &actionExpr{
-				pos: position{line: 2952, col: 20, offset: 92335},
+				pos: position{line: 2977, col: 20, offset: 93045},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2952, col: 20, offset: 92335},
+					pos: position{line: 2977, col: 20, offset: 93045},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2952, col: 20, offset: 92335},
+							pos:  position{line: 2977, col: 20, offset: 93045},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2952, col: 26, offset: 92341},
+							pos:   position{line: 2977, col: 26, offset: 93051},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2952, col: 38, offset: 92353},
+								pos:  position{line: 2977, col: 38, offset: 93063},
 								name: "String",
 							},
 						},
@@ -6503,27 +6503,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2958, col: 1, offset: 92538},
+			pos:  position{line: 2983, col: 1, offset: 93248},
 			expr: &choiceExpr{
-				pos: position{line: 2958, col: 20, offset: 92557},
+				pos: position{line: 2983, col: 20, offset: 93267},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2958, col: 20, offset: 92557},
+						pos: position{line: 2983, col: 20, offset: 93267},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2958, col: 20, offset: 92557},
+							pos: position{line: 2983, col: 20, offset: 93267},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 2958, col: 20, offset: 92557},
+									pos:        position{line: 2983, col: 20, offset: 93267},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 2958, col: 28, offset: 92565},
+									pos: position{line: 2983, col: 28, offset: 93275},
 									expr: &charClassMatcher{
-										pos:        position{line: 2958, col: 28, offset: 92565},
+										pos:        position{line: 2983, col: 28, offset: 93275},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6532,9 +6532,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2958, col: 42, offset: 92579},
+									pos: position{line: 2983, col: 42, offset: 93289},
 									expr: &litMatcher{
-										pos:        position{line: 2958, col: 44, offset: 92581},
+										pos:        position{line: 2983, col: 44, offset: 93291},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6544,27 +6544,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2961, col: 3, offset: 92623},
+						pos: position{line: 2986, col: 3, offset: 93333},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 2961, col: 3, offset: 92623},
+							pos: position{line: 2986, col: 3, offset: 93333},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2961, col: 3, offset: 92623},
+									pos:        position{line: 2986, col: 3, offset: 93333},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 2961, col: 7, offset: 92627},
+									pos:   position{line: 2986, col: 7, offset: 93337},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2961, col: 13, offset: 92633},
+										pos:  position{line: 2986, col: 13, offset: 93343},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 2961, col: 23, offset: 92643},
+									pos:        position{line: 2986, col: 23, offset: 93353},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6577,26 +6577,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 2966, col: 1, offset: 92711},
+			pos:  position{line: 2991, col: 1, offset: 93421},
 			expr: &actionExpr{
-				pos: position{line: 2966, col: 15, offset: 92725},
+				pos: position{line: 2991, col: 15, offset: 93435},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2966, col: 15, offset: 92725},
+					pos: position{line: 2991, col: 15, offset: 93435},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2966, col: 15, offset: 92725},
+							pos:  position{line: 2991, col: 15, offset: 93435},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2966, col: 20, offset: 92730},
+							pos:  position{line: 2991, col: 20, offset: 93440},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2966, col: 30, offset: 92740},
+							pos:   position{line: 2991, col: 30, offset: 93450},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2966, col: 40, offset: 92750},
+								pos:  position{line: 2991, col: 40, offset: 93460},
 								name: "BoolExpr",
 							},
 						},
@@ -6606,15 +6606,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 2979, col: 1, offset: 93093},
+			pos:  position{line: 3004, col: 1, offset: 93803},
 			expr: &actionExpr{
-				pos: position{line: 2979, col: 13, offset: 93105},
+				pos: position{line: 3004, col: 13, offset: 93815},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2979, col: 13, offset: 93105},
+					pos:   position{line: 3004, col: 13, offset: 93815},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2979, col: 18, offset: 93110},
+						pos:  position{line: 3004, col: 18, offset: 93820},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6622,35 +6622,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 2984, col: 1, offset: 93180},
+			pos:  position{line: 3009, col: 1, offset: 93890},
 			expr: &actionExpr{
-				pos: position{line: 2984, col: 19, offset: 93198},
+				pos: position{line: 3009, col: 19, offset: 93908},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 2984, col: 19, offset: 93198},
+					pos: position{line: 3009, col: 19, offset: 93908},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2984, col: 19, offset: 93198},
+							pos:   position{line: 3009, col: 19, offset: 93908},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2984, col: 25, offset: 93204},
+								pos:  position{line: 3009, col: 25, offset: 93914},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2984, col: 40, offset: 93219},
+							pos:   position{line: 3009, col: 40, offset: 93929},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2984, col: 45, offset: 93224},
+								pos: position{line: 3009, col: 45, offset: 93934},
 								expr: &seqExpr{
-									pos: position{line: 2984, col: 46, offset: 93225},
+									pos: position{line: 3009, col: 46, offset: 93935},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2984, col: 46, offset: 93225},
+											pos:  position{line: 3009, col: 46, offset: 93935},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2984, col: 49, offset: 93228},
+											pos:  position{line: 3009, col: 49, offset: 93938},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6663,35 +6663,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3004, col: 1, offset: 93666},
+			pos:  position{line: 3029, col: 1, offset: 94376},
 			expr: &actionExpr{
-				pos: position{line: 3004, col: 19, offset: 93684},
+				pos: position{line: 3029, col: 19, offset: 94394},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3004, col: 19, offset: 93684},
+					pos: position{line: 3029, col: 19, offset: 94394},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3004, col: 19, offset: 93684},
+							pos:   position{line: 3029, col: 19, offset: 94394},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3004, col: 25, offset: 93690},
+								pos:  position{line: 3029, col: 25, offset: 94400},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3004, col: 40, offset: 93705},
+							pos:   position{line: 3029, col: 40, offset: 94415},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3004, col: 45, offset: 93710},
+								pos: position{line: 3029, col: 45, offset: 94420},
 								expr: &seqExpr{
-									pos: position{line: 3004, col: 46, offset: 93711},
+									pos: position{line: 3029, col: 46, offset: 94421},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3004, col: 46, offset: 93711},
+											pos:  position{line: 3029, col: 46, offset: 94421},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3004, col: 50, offset: 93715},
+											pos:  position{line: 3029, col: 50, offset: 94425},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6704,47 +6704,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3024, col: 1, offset: 94154},
+			pos:  position{line: 3049, col: 1, offset: 94864},
 			expr: &choiceExpr{
-				pos: position{line: 3024, col: 19, offset: 94172},
+				pos: position{line: 3049, col: 19, offset: 94882},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3024, col: 19, offset: 94172},
+						pos: position{line: 3049, col: 19, offset: 94882},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3024, col: 19, offset: 94172},
+							pos: position{line: 3049, col: 19, offset: 94882},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3024, col: 19, offset: 94172},
+									pos:  position{line: 3049, col: 19, offset: 94882},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3024, col: 23, offset: 94176},
+									pos:  position{line: 3049, col: 23, offset: 94886},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3024, col: 31, offset: 94184},
+									pos:   position{line: 3049, col: 31, offset: 94894},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3024, col: 37, offset: 94190},
+										pos:  position{line: 3049, col: 37, offset: 94900},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3024, col: 52, offset: 94205},
+									pos:  position{line: 3049, col: 52, offset: 94915},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3034, col: 3, offset: 94408},
+						pos: position{line: 3059, col: 3, offset: 95118},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3034, col: 3, offset: 94408},
+							pos:   position{line: 3059, col: 3, offset: 95118},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3034, col: 9, offset: 94414},
+								pos:  position{line: 3059, col: 9, offset: 95124},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6754,50 +6754,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3039, col: 1, offset: 94485},
+			pos:  position{line: 3064, col: 1, offset: 95195},
 			expr: &choiceExpr{
-				pos: position{line: 3039, col: 19, offset: 94503},
+				pos: position{line: 3064, col: 19, offset: 95213},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3039, col: 19, offset: 94503},
+						pos: position{line: 3064, col: 19, offset: 95213},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3039, col: 19, offset: 94503},
+							pos: position{line: 3064, col: 19, offset: 95213},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3039, col: 19, offset: 94503},
+									pos:  position{line: 3064, col: 19, offset: 95213},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3039, col: 27, offset: 94511},
+									pos:   position{line: 3064, col: 27, offset: 95221},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3039, col: 33, offset: 94517},
+										pos:  position{line: 3064, col: 33, offset: 95227},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3039, col: 48, offset: 94532},
+									pos:  position{line: 3064, col: 48, offset: 95242},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3042, col: 3, offset: 94568},
+						pos: position{line: 3067, col: 3, offset: 95278},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3042, col: 3, offset: 94568},
+							pos:   position{line: 3067, col: 3, offset: 95278},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3042, col: 10, offset: 94575},
+								pos: position{line: 3067, col: 10, offset: 95285},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3042, col: 10, offset: 94575},
+										pos:  position{line: 3067, col: 10, offset: 95285},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3042, col: 31, offset: 94596},
+										pos:  position{line: 3067, col: 31, offset: 95306},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6809,60 +6809,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3047, col: 1, offset: 94716},
+			pos:  position{line: 3072, col: 1, offset: 95426},
 			expr: &choiceExpr{
-				pos: position{line: 3047, col: 23, offset: 94738},
+				pos: position{line: 3072, col: 23, offset: 95448},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3047, col: 23, offset: 94738},
+						pos: position{line: 3072, col: 23, offset: 95448},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3047, col: 24, offset: 94739},
+							pos: position{line: 3072, col: 24, offset: 95449},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3047, col: 24, offset: 94739},
+									pos:   position{line: 3072, col: 24, offset: 95449},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3047, col: 28, offset: 94743},
+										pos: position{line: 3072, col: 28, offset: 95453},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3047, col: 28, offset: 94743},
+												pos:        position{line: 3072, col: 28, offset: 95453},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 39, offset: 94754},
+												pos:        position{line: 3072, col: 39, offset: 95464},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 49, offset: 94764},
+												pos:        position{line: 3072, col: 49, offset: 95474},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 59, offset: 94774},
+												pos:        position{line: 3072, col: 59, offset: 95484},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 70, offset: 94785},
+												pos:        position{line: 3072, col: 70, offset: 95495},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 84, offset: 94799},
+												pos:        position{line: 3072, col: 84, offset: 95509},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3047, col: 94, offset: 94809},
+												pos:        position{line: 3072, col: 94, offset: 95519},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6871,56 +6871,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3047, col: 109, offset: 94824},
+									pos:  position{line: 3072, col: 109, offset: 95534},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3047, col: 117, offset: 94832},
+									pos:   position{line: 3072, col: 117, offset: 95542},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3047, col: 123, offset: 94838},
+										pos:  position{line: 3072, col: 123, offset: 95548},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3047, col: 133, offset: 94848},
+									pos:  position{line: 3072, col: 133, offset: 95558},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3077, col: 3, offset: 95719},
+						pos: position{line: 3102, col: 3, offset: 96429},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3077, col: 3, offset: 95719},
+							pos: position{line: 3102, col: 3, offset: 96429},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3077, col: 3, offset: 95719},
+									pos:   position{line: 3102, col: 3, offset: 96429},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3077, col: 11, offset: 95727},
+										pos: position{line: 3102, col: 11, offset: 96437},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3077, col: 11, offset: 95727},
+												pos:        position{line: 3102, col: 11, offset: 96437},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3077, col: 20, offset: 95736},
+												pos:        position{line: 3102, col: 20, offset: 96446},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3077, col: 29, offset: 95745},
+												pos:        position{line: 3102, col: 29, offset: 96455},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3077, col: 39, offset: 95755},
+												pos:        position{line: 3102, col: 39, offset: 96465},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6929,86 +6929,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 52, offset: 95768},
+									pos:  position{line: 3102, col: 52, offset: 96478},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3077, col: 60, offset: 95776},
+									pos:   position{line: 3102, col: 60, offset: 96486},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3077, col: 70, offset: 95786},
+										pos:  position{line: 3102, col: 70, offset: 96496},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 80, offset: 95796},
+									pos:  position{line: 3102, col: 80, offset: 96506},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3077, col: 86, offset: 95802},
+									pos:   position{line: 3102, col: 86, offset: 96512},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3077, col: 97, offset: 95813},
+										pos:  position{line: 3102, col: 97, offset: 96523},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 107, offset: 95823},
+									pos:  position{line: 3102, col: 107, offset: 96533},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3090, col: 3, offset: 96193},
+						pos: position{line: 3115, col: 3, offset: 96903},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3090, col: 3, offset: 96193},
+							pos: position{line: 3115, col: 3, offset: 96903},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3090, col: 3, offset: 96193},
+									pos:   position{line: 3115, col: 3, offset: 96903},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3090, col: 8, offset: 96198},
+										pos:  position{line: 3115, col: 8, offset: 96908},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3090, col: 18, offset: 96208},
+									pos:  position{line: 3115, col: 18, offset: 96918},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3090, col: 24, offset: 96214},
+									pos:        position{line: 3115, col: 24, offset: 96924},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3090, col: 29, offset: 96219},
+									pos:  position{line: 3115, col: 29, offset: 96929},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3090, col: 37, offset: 96227},
+									pos:   position{line: 3115, col: 37, offset: 96937},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3090, col: 50, offset: 96240},
+										pos:  position{line: 3115, col: 50, offset: 96950},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3090, col: 60, offset: 96250},
+									pos:   position{line: 3115, col: 60, offset: 96960},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3090, col: 65, offset: 96255},
+										pos: position{line: 3115, col: 65, offset: 96965},
 										expr: &seqExpr{
-											pos: position{line: 3090, col: 66, offset: 96256},
+											pos: position{line: 3115, col: 66, offset: 96966},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3090, col: 66, offset: 96256},
+													pos:  position{line: 3115, col: 66, offset: 96966},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3090, col: 72, offset: 96262},
+													pos:  position{line: 3115, col: 72, offset: 96972},
 													name: "ValueExpr",
 												},
 											},
@@ -7016,50 +7016,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3090, col: 84, offset: 96274},
+									pos:  position{line: 3115, col: 84, offset: 96984},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3109, col: 3, offset: 96825},
+						pos: position{line: 3134, col: 3, offset: 97535},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3109, col: 3, offset: 96825},
+							pos: position{line: 3134, col: 3, offset: 97535},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3109, col: 3, offset: 96825},
+									pos:        position{line: 3134, col: 3, offset: 97535},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3109, col: 8, offset: 96830},
+									pos:  position{line: 3134, col: 8, offset: 97540},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3109, col: 16, offset: 96838},
+									pos:   position{line: 3134, col: 16, offset: 97548},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3109, col: 29, offset: 96851},
+										pos:  position{line: 3134, col: 29, offset: 97561},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3109, col: 39, offset: 96861},
+									pos:   position{line: 3134, col: 39, offset: 97571},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3109, col: 44, offset: 96866},
+										pos: position{line: 3134, col: 44, offset: 97576},
 										expr: &seqExpr{
-											pos: position{line: 3109, col: 45, offset: 96867},
+											pos: position{line: 3134, col: 45, offset: 97577},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3109, col: 45, offset: 96867},
+													pos:  position{line: 3134, col: 45, offset: 97577},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3109, col: 51, offset: 96873},
+													pos:  position{line: 3134, col: 51, offset: 97583},
 													name: "ValueExpr",
 												},
 											},
@@ -7067,7 +7067,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3109, col: 63, offset: 96885},
+									pos:  position{line: 3134, col: 63, offset: 97595},
 									name: "R_PAREN",
 								},
 							},
@@ -7078,34 +7078,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3127, col: 1, offset: 97306},
+			pos:  position{line: 3152, col: 1, offset: 98016},
 			expr: &actionExpr{
-				pos: position{line: 3127, col: 23, offset: 97328},
+				pos: position{line: 3152, col: 23, offset: 98038},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3127, col: 23, offset: 97328},
+					pos: position{line: 3152, col: 23, offset: 98038},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3127, col: 23, offset: 97328},
+							pos:   position{line: 3152, col: 23, offset: 98038},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3127, col: 28, offset: 97333},
+								pos:  position{line: 3152, col: 28, offset: 98043},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3127, col: 38, offset: 97343},
+							pos:   position{line: 3152, col: 38, offset: 98053},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3127, col: 41, offset: 97346},
+								pos:  position{line: 3152, col: 41, offset: 98056},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3127, col: 62, offset: 97367},
+							pos:   position{line: 3152, col: 62, offset: 98077},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3127, col: 68, offset: 97373},
+								pos:  position{line: 3152, col: 68, offset: 98083},
 								name: "ValueExpr",
 							},
 						},
@@ -7115,129 +7115,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3145, col: 1, offset: 97967},
+			pos:  position{line: 3170, col: 1, offset: 98677},
 			expr: &choiceExpr{
-				pos: position{line: 3145, col: 14, offset: 97980},
+				pos: position{line: 3170, col: 14, offset: 98690},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3145, col: 14, offset: 97980},
+						pos: position{line: 3170, col: 14, offset: 98690},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3145, col: 14, offset: 97980},
+							pos:   position{line: 3170, col: 14, offset: 98690},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3145, col: 24, offset: 97990},
+								pos:  position{line: 3170, col: 24, offset: 98700},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3154, col: 3, offset: 98180},
+						pos: position{line: 3179, col: 3, offset: 98890},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3154, col: 3, offset: 98180},
+							pos: position{line: 3179, col: 3, offset: 98890},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3154, col: 3, offset: 98180},
+									pos:  position{line: 3179, col: 3, offset: 98890},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3154, col: 12, offset: 98189},
+									pos:   position{line: 3179, col: 12, offset: 98899},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3154, col: 22, offset: 98199},
+										pos:  position{line: 3179, col: 22, offset: 98909},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3154, col: 37, offset: 98214},
+									pos:  position{line: 3179, col: 37, offset: 98924},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3163, col: 3, offset: 98398},
+						pos: position{line: 3188, col: 3, offset: 99108},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3163, col: 3, offset: 98398},
+							pos:   position{line: 3188, col: 3, offset: 99108},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3163, col: 11, offset: 98406},
+								pos:  position{line: 3188, col: 11, offset: 99116},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3172, col: 3, offset: 98586},
+						pos: position{line: 3197, col: 3, offset: 99296},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3172, col: 3, offset: 98586},
+							pos:   position{line: 3197, col: 3, offset: 99296},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3172, col: 7, offset: 98590},
+								pos:  position{line: 3197, col: 7, offset: 99300},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3181, col: 3, offset: 98762},
+						pos: position{line: 3206, col: 3, offset: 99472},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3181, col: 3, offset: 98762},
+							pos: position{line: 3206, col: 3, offset: 99472},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3181, col: 3, offset: 98762},
+									pos:  position{line: 3206, col: 3, offset: 99472},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3181, col: 12, offset: 98771},
+									pos:   position{line: 3206, col: 12, offset: 99481},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3181, col: 16, offset: 98775},
+										pos:  position{line: 3206, col: 16, offset: 99485},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3181, col: 28, offset: 98787},
+									pos:  position{line: 3206, col: 28, offset: 99497},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3190, col: 3, offset: 98956},
+						pos: position{line: 3215, col: 3, offset: 99666},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3190, col: 3, offset: 98956},
+							pos: position{line: 3215, col: 3, offset: 99666},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3190, col: 3, offset: 98956},
+									pos:  position{line: 3215, col: 3, offset: 99666},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3190, col: 11, offset: 98964},
+									pos:   position{line: 3215, col: 11, offset: 99674},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3190, col: 19, offset: 98972},
+										pos:  position{line: 3215, col: 19, offset: 99682},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3190, col: 28, offset: 98981},
+									pos:  position{line: 3215, col: 28, offset: 99691},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3199, col: 3, offset: 99153},
+						pos: position{line: 3224, col: 3, offset: 99863},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3199, col: 3, offset: 99153},
+							pos:   position{line: 3224, col: 3, offset: 99863},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3199, col: 18, offset: 99168},
+								pos:  position{line: 3224, col: 18, offset: 99878},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7247,28 +7247,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3209, col: 1, offset: 99365},
+			pos:  position{line: 3234, col: 1, offset: 100075},
 			expr: &choiceExpr{
-				pos: position{line: 3209, col: 15, offset: 99379},
+				pos: position{line: 3234, col: 15, offset: 100089},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3209, col: 15, offset: 99379},
+						pos: position{line: 3234, col: 15, offset: 100089},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3209, col: 15, offset: 99379},
+							pos: position{line: 3234, col: 15, offset: 100089},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3209, col: 15, offset: 99379},
+									pos:   position{line: 3234, col: 15, offset: 100089},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3209, col: 20, offset: 99384},
+										pos:  position{line: 3234, col: 20, offset: 100094},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3209, col: 29, offset: 99393},
+									pos: position{line: 3234, col: 29, offset: 100103},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3209, col: 31, offset: 99395},
+										pos:  position{line: 3234, col: 31, offset: 100105},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7276,23 +7276,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3217, col: 3, offset: 99565},
+						pos: position{line: 3242, col: 3, offset: 100275},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3217, col: 3, offset: 99565},
+							pos: position{line: 3242, col: 3, offset: 100275},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3217, col: 3, offset: 99565},
+									pos:   position{line: 3242, col: 3, offset: 100275},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3217, col: 7, offset: 99569},
+										pos:  position{line: 3242, col: 7, offset: 100279},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3217, col: 20, offset: 99582},
+									pos: position{line: 3242, col: 20, offset: 100292},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3217, col: 22, offset: 99584},
+										pos:  position{line: 3242, col: 22, offset: 100294},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7300,50 +7300,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3225, col: 3, offset: 99749},
+						pos: position{line: 3250, col: 3, offset: 100459},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3225, col: 3, offset: 99749},
+							pos: position{line: 3250, col: 3, offset: 100459},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3225, col: 3, offset: 99749},
+									pos:   position{line: 3250, col: 3, offset: 100459},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3225, col: 9, offset: 99755},
+										pos:  position{line: 3250, col: 9, offset: 100465},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3225, col: 25, offset: 99771},
+									pos: position{line: 3250, col: 25, offset: 100481},
 									expr: &choiceExpr{
-										pos: position{line: 3225, col: 27, offset: 99773},
+										pos: position{line: 3250, col: 27, offset: 100483},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 27, offset: 99773},
+												pos:  position{line: 3250, col: 27, offset: 100483},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 36, offset: 99782},
+												pos:  position{line: 3250, col: 36, offset: 100492},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 46, offset: 99792},
+												pos:  position{line: 3250, col: 46, offset: 100502},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 54, offset: 99800},
+												pos:  position{line: 3250, col: 54, offset: 100510},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 62, offset: 99808},
+												pos:  position{line: 3250, col: 62, offset: 100518},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3225, col: 70, offset: 99816},
+												pos:  position{line: 3250, col: 70, offset: 100526},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3225, col: 84, offset: 99830},
+												pos:        position{line: 3250, col: 84, offset: 100540},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7355,13 +7355,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3233, col: 3, offset: 99980},
+						pos: position{line: 3258, col: 3, offset: 100690},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3233, col: 3, offset: 99980},
+							pos:   position{line: 3258, col: 3, offset: 100690},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3233, col: 10, offset: 99987},
+								pos:  position{line: 3258, col: 10, offset: 100697},
 								name: "ConcatExpr",
 							},
 						},
@@ -7371,35 +7371,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3243, col: 1, offset: 100193},
+			pos:  position{line: 3268, col: 1, offset: 100903},
 			expr: &actionExpr{
-				pos: position{line: 3243, col: 15, offset: 100207},
+				pos: position{line: 3268, col: 15, offset: 100917},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3243, col: 15, offset: 100207},
+					pos: position{line: 3268, col: 15, offset: 100917},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3243, col: 15, offset: 100207},
+							pos:   position{line: 3268, col: 15, offset: 100917},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3243, col: 21, offset: 100213},
+								pos:  position{line: 3268, col: 21, offset: 100923},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3243, col: 32, offset: 100224},
+							pos:   position{line: 3268, col: 32, offset: 100934},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3243, col: 37, offset: 100229},
+								pos: position{line: 3268, col: 37, offset: 100939},
 								expr: &seqExpr{
-									pos: position{line: 3243, col: 38, offset: 100230},
+									pos: position{line: 3268, col: 38, offset: 100940},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3243, col: 38, offset: 100230},
+											pos:  position{line: 3268, col: 38, offset: 100940},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3243, col: 50, offset: 100242},
+											pos:  position{line: 3268, col: 50, offset: 100952},
 											name: "ConcatAtom",
 										},
 									},
@@ -7407,28 +7407,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3243, col: 63, offset: 100255},
+							pos: position{line: 3268, col: 63, offset: 100965},
 							expr: &choiceExpr{
-								pos: position{line: 3243, col: 65, offset: 100257},
+								pos: position{line: 3268, col: 65, offset: 100967},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3243, col: 65, offset: 100257},
+										pos:  position{line: 3268, col: 65, offset: 100967},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3243, col: 74, offset: 100266},
+										pos:  position{line: 3268, col: 74, offset: 100976},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3243, col: 84, offset: 100276},
+										pos:  position{line: 3268, col: 84, offset: 100986},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3243, col: 92, offset: 100284},
+										pos:  position{line: 3268, col: 92, offset: 100994},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3243, col: 100, offset: 100292},
+										pos:        position{line: 3268, col: 100, offset: 101002},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7442,54 +7442,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3261, col: 1, offset: 100698},
+			pos:  position{line: 3286, col: 1, offset: 101408},
 			expr: &choiceExpr{
-				pos: position{line: 3261, col: 15, offset: 100712},
+				pos: position{line: 3286, col: 15, offset: 101422},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3261, col: 15, offset: 100712},
+						pos: position{line: 3286, col: 15, offset: 101422},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3261, col: 15, offset: 100712},
+							pos:   position{line: 3286, col: 15, offset: 101422},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3261, col: 20, offset: 100717},
+								pos:  position{line: 3286, col: 20, offset: 101427},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3270, col: 3, offset: 100881},
+						pos: position{line: 3295, col: 3, offset: 101591},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3270, col: 3, offset: 100881},
+							pos:   position{line: 3295, col: 3, offset: 101591},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3270, col: 7, offset: 100885},
+								pos:  position{line: 3295, col: 7, offset: 101595},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3278, col: 3, offset: 101024},
+						pos: position{line: 3303, col: 3, offset: 101734},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3278, col: 3, offset: 101024},
+							pos:   position{line: 3303, col: 3, offset: 101734},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3278, col: 10, offset: 101031},
+								pos:  position{line: 3303, col: 10, offset: 101741},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3286, col: 3, offset: 101170},
+						pos: position{line: 3311, col: 3, offset: 101880},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3286, col: 3, offset: 101170},
+							pos:   position{line: 3311, col: 3, offset: 101880},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3286, col: 9, offset: 101176},
+								pos:  position{line: 3311, col: 9, offset: 101886},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7499,32 +7499,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3296, col: 1, offset: 101345},
+			pos:  position{line: 3321, col: 1, offset: 102055},
 			expr: &actionExpr{
-				pos: position{line: 3296, col: 16, offset: 101360},
+				pos: position{line: 3321, col: 16, offset: 102070},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3296, col: 16, offset: 101360},
+					pos: position{line: 3321, col: 16, offset: 102070},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3296, col: 16, offset: 101360},
+							pos:   position{line: 3321, col: 16, offset: 102070},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3296, col: 21, offset: 101365},
+								pos:  position{line: 3321, col: 21, offset: 102075},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3296, col: 39, offset: 101383},
+							pos: position{line: 3321, col: 39, offset: 102093},
 							expr: &choiceExpr{
-								pos: position{line: 3296, col: 41, offset: 101385},
+								pos: position{line: 3321, col: 41, offset: 102095},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3296, col: 41, offset: 101385},
+										pos:  position{line: 3321, col: 41, offset: 102095},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3296, col: 55, offset: 101399},
+										pos:        position{line: 3321, col: 55, offset: 102109},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7538,44 +7538,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3301, col: 1, offset: 101464},
+			pos:  position{line: 3326, col: 1, offset: 102174},
 			expr: &actionExpr{
-				pos: position{line: 3301, col: 22, offset: 101485},
+				pos: position{line: 3326, col: 22, offset: 102195},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3301, col: 22, offset: 101485},
+					pos: position{line: 3326, col: 22, offset: 102195},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3301, col: 22, offset: 101485},
+							pos:   position{line: 3326, col: 22, offset: 102195},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3301, col: 28, offset: 101491},
+								pos:  position{line: 3326, col: 28, offset: 102201},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3301, col: 46, offset: 101509},
+							pos:   position{line: 3326, col: 46, offset: 102219},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3301, col: 51, offset: 101514},
+								pos: position{line: 3326, col: 51, offset: 102224},
 								expr: &seqExpr{
-									pos: position{line: 3301, col: 52, offset: 101515},
+									pos: position{line: 3326, col: 52, offset: 102225},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3301, col: 53, offset: 101516},
+											pos: position{line: 3326, col: 53, offset: 102226},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3301, col: 53, offset: 101516},
+													pos:  position{line: 3326, col: 53, offset: 102226},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3301, col: 62, offset: 101525},
+													pos:  position{line: 3326, col: 62, offset: 102235},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3301, col: 71, offset: 101534},
+											pos:  position{line: 3326, col: 71, offset: 102244},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7588,48 +7588,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3322, col: 1, offset: 102035},
+			pos:  position{line: 3347, col: 1, offset: 102745},
 			expr: &actionExpr{
-				pos: position{line: 3322, col: 22, offset: 102056},
+				pos: position{line: 3347, col: 22, offset: 102766},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3322, col: 22, offset: 102056},
+					pos: position{line: 3347, col: 22, offset: 102766},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3322, col: 22, offset: 102056},
+							pos:   position{line: 3347, col: 22, offset: 102766},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3322, col: 28, offset: 102062},
+								pos:  position{line: 3347, col: 28, offset: 102772},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3322, col: 46, offset: 102080},
+							pos:   position{line: 3347, col: 46, offset: 102790},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3322, col: 51, offset: 102085},
+								pos: position{line: 3347, col: 51, offset: 102795},
 								expr: &seqExpr{
-									pos: position{line: 3322, col: 52, offset: 102086},
+									pos: position{line: 3347, col: 52, offset: 102796},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3322, col: 53, offset: 102087},
+											pos: position{line: 3347, col: 53, offset: 102797},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3322, col: 53, offset: 102087},
+													pos:  position{line: 3347, col: 53, offset: 102797},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3322, col: 61, offset: 102095},
+													pos:  position{line: 3347, col: 61, offset: 102805},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3322, col: 69, offset: 102103},
+													pos:  position{line: 3347, col: 69, offset: 102813},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3322, col: 76, offset: 102110},
+											pos:  position{line: 3347, col: 76, offset: 102820},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7642,22 +7642,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3342, col: 1, offset: 102579},
+			pos:  position{line: 3367, col: 1, offset: 103289},
 			expr: &actionExpr{
-				pos: position{line: 3342, col: 21, offset: 102599},
+				pos: position{line: 3367, col: 21, offset: 103309},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3342, col: 21, offset: 102599},
+					pos: position{line: 3367, col: 21, offset: 103309},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3342, col: 21, offset: 102599},
+							pos:  position{line: 3367, col: 21, offset: 103309},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3342, col: 27, offset: 102605},
+							pos:   position{line: 3367, col: 27, offset: 103315},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3342, col: 32, offset: 102610},
+								pos:  position{line: 3367, col: 32, offset: 103320},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7667,67 +7667,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3352, col: 1, offset: 102854},
+			pos:  position{line: 3377, col: 1, offset: 103564},
 			expr: &choiceExpr{
-				pos: position{line: 3352, col: 22, offset: 102875},
+				pos: position{line: 3377, col: 22, offset: 103585},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3352, col: 22, offset: 102875},
+						pos: position{line: 3377, col: 22, offset: 103585},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3352, col: 22, offset: 102875},
+							pos: position{line: 3377, col: 22, offset: 103585},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3352, col: 22, offset: 102875},
+									pos:  position{line: 3377, col: 22, offset: 103585},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3352, col: 30, offset: 102883},
+									pos:   position{line: 3377, col: 30, offset: 103593},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3352, col: 35, offset: 102888},
+										pos:  position{line: 3377, col: 35, offset: 103598},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3352, col: 53, offset: 102906},
+									pos:  position{line: 3377, col: 53, offset: 103616},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3355, col: 3, offset: 102941},
+						pos: position{line: 3380, col: 3, offset: 103651},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3355, col: 3, offset: 102941},
+							pos:   position{line: 3380, col: 3, offset: 103651},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3355, col: 20, offset: 102958},
+								pos:  position{line: 3380, col: 20, offset: 103668},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3358, col: 3, offset: 103012},
+						pos: position{line: 3383, col: 3, offset: 103722},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3358, col: 3, offset: 103012},
+							pos:   position{line: 3383, col: 3, offset: 103722},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3358, col: 9, offset: 103018},
+								pos:  position{line: 3383, col: 9, offset: 103728},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3368, col: 3, offset: 103237},
+						pos: position{line: 3393, col: 3, offset: 103947},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3368, col: 3, offset: 103237},
+							pos:   position{line: 3393, col: 3, offset: 103947},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3368, col: 10, offset: 103244},
+								pos:  position{line: 3393, col: 10, offset: 103954},
 								name: "NumberAsString",
 							},
 						},
@@ -7737,144 +7737,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3381, col: 1, offset: 103622},
+			pos:  position{line: 3406, col: 1, offset: 104332},
 			expr: &choiceExpr{
-				pos: position{line: 3381, col: 20, offset: 103641},
+				pos: position{line: 3406, col: 20, offset: 104351},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3381, col: 20, offset: 103641},
+						pos: position{line: 3406, col: 20, offset: 104351},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3381, col: 21, offset: 103642},
+							pos: position{line: 3406, col: 21, offset: 104352},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3381, col: 21, offset: 103642},
+									pos:   position{line: 3406, col: 21, offset: 104352},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3381, col: 29, offset: 103650},
+										pos: position{line: 3406, col: 29, offset: 104360},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3381, col: 29, offset: 103650},
+												pos:        position{line: 3406, col: 29, offset: 104360},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 37, offset: 103658},
+												pos:        position{line: 3406, col: 37, offset: 104368},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 46, offset: 103667},
+												pos:        position{line: 3406, col: 46, offset: 104377},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 58, offset: 103679},
+												pos:        position{line: 3406, col: 58, offset: 104389},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 67, offset: 103688},
+												pos:        position{line: 3406, col: 67, offset: 104398},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 77, offset: 103698},
+												pos:        position{line: 3406, col: 77, offset: 104408},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 85, offset: 103706},
+												pos:        position{line: 3406, col: 85, offset: 104416},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 95, offset: 103716},
+												pos:        position{line: 3406, col: 95, offset: 104426},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 102, offset: 103723},
+												pos:        position{line: 3406, col: 102, offset: 104433},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 113, offset: 103734},
+												pos:        position{line: 3406, col: 113, offset: 104444},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 123, offset: 103744},
+												pos:        position{line: 3406, col: 123, offset: 104454},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 132, offset: 103753},
+												pos:        position{line: 3406, col: 132, offset: 104463},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 142, offset: 103763},
+												pos:        position{line: 3406, col: 142, offset: 104473},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 151, offset: 103772},
+												pos:        position{line: 3406, col: 151, offset: 104482},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 161, offset: 103782},
+												pos:        position{line: 3406, col: 161, offset: 104492},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 170, offset: 103791},
+												pos:        position{line: 3406, col: 170, offset: 104501},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 179, offset: 103800},
+												pos:        position{line: 3406, col: 179, offset: 104510},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 187, offset: 103808},
+												pos:        position{line: 3406, col: 187, offset: 104518},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 196, offset: 103817},
+												pos:        position{line: 3406, col: 196, offset: 104527},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 204, offset: 103825},
+												pos:        position{line: 3406, col: 204, offset: 104535},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3381, col: 213, offset: 103834},
+												pos:        position{line: 3406, col: 213, offset: 104544},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7883,102 +7883,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3381, col: 220, offset: 103841},
+									pos:  position{line: 3406, col: 220, offset: 104551},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3381, col: 228, offset: 103849},
+									pos:   position{line: 3406, col: 228, offset: 104559},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3381, col: 234, offset: 103855},
+										pos:  position{line: 3406, col: 234, offset: 104565},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3381, col: 253, offset: 103874},
+									pos:  position{line: 3406, col: 253, offset: 104584},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3401, col: 3, offset: 104386},
+						pos: position{line: 3426, col: 3, offset: 105096},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3401, col: 3, offset: 104386},
+							pos: position{line: 3426, col: 3, offset: 105096},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3401, col: 3, offset: 104386},
+									pos:   position{line: 3426, col: 3, offset: 105096},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3401, col: 13, offset: 104396},
+										pos:        position{line: 3426, col: 13, offset: 105106},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3401, col: 21, offset: 104404},
+									pos:  position{line: 3426, col: 21, offset: 105114},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3401, col: 29, offset: 104412},
+									pos:   position{line: 3426, col: 29, offset: 105122},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3401, col: 35, offset: 104418},
+										pos:  position{line: 3426, col: 35, offset: 105128},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3401, col: 54, offset: 104437},
+									pos:   position{line: 3426, col: 54, offset: 105147},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3401, col: 69, offset: 104452},
+										pos: position{line: 3426, col: 69, offset: 105162},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3401, col: 70, offset: 104453},
+											pos:  position{line: 3426, col: 70, offset: 105163},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3401, col: 89, offset: 104472},
+									pos:  position{line: 3426, col: 89, offset: 105182},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3422, col: 3, offset: 105090},
+						pos: position{line: 3447, col: 3, offset: 105800},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3422, col: 4, offset: 105091},
+							pos: position{line: 3447, col: 4, offset: 105801},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3422, col: 4, offset: 105091},
+									pos:   position{line: 3447, col: 4, offset: 105801},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3422, col: 12, offset: 105099},
+										pos: position{line: 3447, col: 12, offset: 105809},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3422, col: 12, offset: 105099},
+												pos:        position{line: 3447, col: 12, offset: 105809},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 20, offset: 105107},
+												pos:        position{line: 3447, col: 20, offset: 105817},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 27, offset: 105114},
+												pos:        position{line: 3447, col: 27, offset: 105824},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 38, offset: 105125},
+												pos:        position{line: 3447, col: 38, offset: 105835},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7987,54 +7987,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3422, col: 46, offset: 105133},
+									pos:  position{line: 3447, col: 46, offset: 105843},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3422, col: 54, offset: 105141},
+									pos:  position{line: 3447, col: 54, offset: 105851},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3435, col: 3, offset: 105427},
+						pos: position{line: 3460, col: 3, offset: 106137},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3435, col: 3, offset: 105427},
+							pos: position{line: 3460, col: 3, offset: 106137},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3435, col: 3, offset: 105427},
+									pos:        position{line: 3460, col: 3, offset: 106137},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3435, col: 14, offset: 105438},
+									pos:  position{line: 3460, col: 14, offset: 106148},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3435, col: 22, offset: 105446},
+									pos:   position{line: 3460, col: 22, offset: 106156},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3435, col: 33, offset: 105457},
+										pos:  position{line: 3460, col: 33, offset: 106167},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3435, col: 44, offset: 105468},
+									pos:   position{line: 3460, col: 44, offset: 106178},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3435, col: 53, offset: 105477},
+										pos: position{line: 3460, col: 53, offset: 106187},
 										expr: &seqExpr{
-											pos: position{line: 3435, col: 54, offset: 105478},
+											pos: position{line: 3460, col: 54, offset: 106188},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3435, col: 54, offset: 105478},
+													pos:  position{line: 3460, col: 54, offset: 106188},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3435, col: 60, offset: 105484},
+													pos:  position{line: 3460, col: 60, offset: 106194},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8042,73 +8042,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3435, col: 80, offset: 105504},
+									pos:  position{line: 3460, col: 80, offset: 106214},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3463, col: 3, offset: 106346},
+						pos: position{line: 3488, col: 3, offset: 107056},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3463, col: 3, offset: 106346},
+							pos: position{line: 3488, col: 3, offset: 107056},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3463, col: 3, offset: 106346},
+									pos:   position{line: 3488, col: 3, offset: 107056},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3463, col: 12, offset: 106355},
+										pos:        position{line: 3488, col: 12, offset: 107065},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3463, col: 18, offset: 106361},
+									pos:  position{line: 3488, col: 18, offset: 107071},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3463, col: 26, offset: 106369},
+									pos:   position{line: 3488, col: 26, offset: 107079},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3463, col: 31, offset: 106374},
+										pos:  position{line: 3488, col: 31, offset: 107084},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3463, col: 39, offset: 106382},
+									pos:  position{line: 3488, col: 39, offset: 107092},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3466, col: 3, offset: 106417},
+						pos: position{line: 3491, col: 3, offset: 107127},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3466, col: 4, offset: 106418},
+							pos: position{line: 3491, col: 4, offset: 107128},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3466, col: 4, offset: 106418},
+									pos:   position{line: 3491, col: 4, offset: 107128},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3466, col: 12, offset: 106426},
+										pos: position{line: 3491, col: 12, offset: 107136},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3466, col: 12, offset: 106426},
+												pos:        position{line: 3491, col: 12, offset: 107136},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3466, col: 20, offset: 106434},
+												pos:        position{line: 3491, col: 20, offset: 107144},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3466, col: 30, offset: 106444},
+												pos:        position{line: 3491, col: 30, offset: 107154},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8117,128 +8117,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3466, col: 39, offset: 106453},
+									pos:  position{line: 3491, col: 39, offset: 107163},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3466, col: 47, offset: 106461},
+									pos:   position{line: 3491, col: 47, offset: 107171},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3466, col: 53, offset: 106467},
+										pos:  position{line: 3491, col: 53, offset: 107177},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3466, col: 72, offset: 106486},
+									pos:   position{line: 3491, col: 72, offset: 107196},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3466, col: 79, offset: 106493},
+										pos:  position{line: 3491, col: 79, offset: 107203},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3466, col: 97, offset: 106511},
+									pos:  position{line: 3491, col: 97, offset: 107221},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3496, col: 3, offset: 107350},
+						pos: position{line: 3521, col: 3, offset: 108060},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3496, col: 4, offset: 107351},
+							pos: position{line: 3521, col: 4, offset: 108061},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3496, col: 4, offset: 107351},
+									pos:   position{line: 3521, col: 4, offset: 108061},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3496, col: 11, offset: 107358},
+										pos:        position{line: 3521, col: 11, offset: 108068},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3496, col: 17, offset: 107364},
+									pos:  position{line: 3521, col: 17, offset: 108074},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3496, col: 25, offset: 107372},
+									pos:   position{line: 3521, col: 25, offset: 108082},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3496, col: 31, offset: 107378},
+										pos:  position{line: 3521, col: 31, offset: 108088},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3496, col: 50, offset: 107397},
+									pos:   position{line: 3521, col: 50, offset: 108107},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3496, col: 56, offset: 107403},
+										pos: position{line: 3521, col: 56, offset: 108113},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3496, col: 57, offset: 107404},
+											pos:  position{line: 3521, col: 57, offset: 108114},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3496, col: 76, offset: 107423},
+									pos:  position{line: 3521, col: 76, offset: 108133},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3525, col: 3, offset: 108196},
+						pos: position{line: 3550, col: 3, offset: 108906},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3525, col: 3, offset: 108196},
+							pos: position{line: 3550, col: 3, offset: 108906},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3525, col: 3, offset: 108196},
+									pos:   position{line: 3550, col: 3, offset: 108906},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3525, col: 11, offset: 108204},
+										pos:        position{line: 3550, col: 11, offset: 108914},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3525, col: 28, offset: 108221},
+									pos:  position{line: 3550, col: 28, offset: 108931},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3525, col: 36, offset: 108229},
+									pos:   position{line: 3550, col: 36, offset: 108939},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3525, col: 42, offset: 108235},
+										pos:  position{line: 3550, col: 42, offset: 108945},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3525, col: 61, offset: 108254},
+									pos:  position{line: 3550, col: 61, offset: 108964},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3525, col: 67, offset: 108260},
+									pos:  position{line: 3550, col: 67, offset: 108970},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3525, col: 73, offset: 108266},
+									pos:   position{line: 3550, col: 73, offset: 108976},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3525, col: 84, offset: 108277},
+										pos:  position{line: 3550, col: 84, offset: 108987},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3525, col: 120, offset: 108313},
+									pos:  position{line: 3550, col: 120, offset: 109023},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3525, col: 126, offset: 108319},
+									pos:  position{line: 3550, col: 126, offset: 109029},
 									name: "R_PAREN",
 								},
 							},
@@ -8249,28 +8249,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3542, col: 1, offset: 108848},
+			pos:  position{line: 3567, col: 1, offset: 109558},
 			expr: &choiceExpr{
-				pos: position{line: 3542, col: 12, offset: 108859},
+				pos: position{line: 3567, col: 12, offset: 109569},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3542, col: 12, offset: 108859},
+						pos: position{line: 3567, col: 12, offset: 109569},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3542, col: 12, offset: 108859},
+							pos: position{line: 3567, col: 12, offset: 109569},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3542, col: 12, offset: 108859},
+									pos:   position{line: 3567, col: 12, offset: 109569},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3542, col: 16, offset: 108863},
+										pos:  position{line: 3567, col: 16, offset: 109573},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3542, col: 29, offset: 108876},
+									pos: position{line: 3567, col: 29, offset: 109586},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3542, col: 31, offset: 108878},
+										pos:  position{line: 3567, col: 31, offset: 109588},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8278,50 +8278,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3558, col: 3, offset: 109239},
+						pos: position{line: 3583, col: 3, offset: 109949},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3558, col: 3, offset: 109239},
+							pos: position{line: 3583, col: 3, offset: 109949},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3558, col: 3, offset: 109239},
+									pos:   position{line: 3583, col: 3, offset: 109949},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3558, col: 9, offset: 109245},
+										pos:  position{line: 3583, col: 9, offset: 109955},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3558, col: 25, offset: 109261},
+									pos: position{line: 3583, col: 25, offset: 109971},
 									expr: &choiceExpr{
-										pos: position{line: 3558, col: 27, offset: 109263},
+										pos: position{line: 3583, col: 27, offset: 109973},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 27, offset: 109263},
+												pos:  position{line: 3583, col: 27, offset: 109973},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 36, offset: 109272},
+												pos:  position{line: 3583, col: 36, offset: 109982},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 46, offset: 109282},
+												pos:  position{line: 3583, col: 46, offset: 109992},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 54, offset: 109290},
+												pos:  position{line: 3583, col: 54, offset: 110000},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 62, offset: 109298},
+												pos:  position{line: 3583, col: 62, offset: 110008},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3558, col: 70, offset: 109306},
+												pos:  position{line: 3583, col: 70, offset: 110016},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3558, col: 84, offset: 109320},
+												pos:        position{line: 3583, col: 84, offset: 110030},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8337,28 +8337,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3575, col: 1, offset: 109671},
+			pos:  position{line: 3600, col: 1, offset: 110381},
 			expr: &actionExpr{
-				pos: position{line: 3575, col: 19, offset: 109689},
+				pos: position{line: 3600, col: 19, offset: 110399},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3575, col: 19, offset: 109689},
+					pos: position{line: 3600, col: 19, offset: 110399},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3575, col: 19, offset: 109689},
+							pos:        position{line: 3600, col: 19, offset: 110399},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3575, col: 26, offset: 109696},
+							pos:  position{line: 3600, col: 26, offset: 110406},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3575, col: 32, offset: 109702},
+							pos:   position{line: 3600, col: 32, offset: 110412},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3575, col: 40, offset: 109710},
+								pos:  position{line: 3600, col: 40, offset: 110420},
 								name: "Boolean",
 							},
 						},
@@ -8368,28 +8368,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3586, col: 1, offset: 109899},
+			pos:  position{line: 3611, col: 1, offset: 110609},
 			expr: &actionExpr{
-				pos: position{line: 3586, col: 23, offset: 109921},
+				pos: position{line: 3611, col: 23, offset: 110631},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3586, col: 23, offset: 109921},
+					pos: position{line: 3611, col: 23, offset: 110631},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3586, col: 23, offset: 109921},
+							pos:        position{line: 3611, col: 23, offset: 110631},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3586, col: 34, offset: 109932},
+							pos:  position{line: 3611, col: 34, offset: 110642},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3586, col: 40, offset: 109938},
+							pos:   position{line: 3611, col: 40, offset: 110648},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3586, col: 48, offset: 109946},
+								pos:  position{line: 3611, col: 48, offset: 110656},
 								name: "Boolean",
 							},
 						},
@@ -8399,28 +8399,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3597, col: 1, offset: 110143},
+			pos:  position{line: 3622, col: 1, offset: 110853},
 			expr: &actionExpr{
-				pos: position{line: 3597, col: 20, offset: 110162},
+				pos: position{line: 3622, col: 20, offset: 110872},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3597, col: 20, offset: 110162},
+					pos: position{line: 3622, col: 20, offset: 110872},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3597, col: 20, offset: 110162},
+							pos:        position{line: 3622, col: 20, offset: 110872},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3597, col: 28, offset: 110170},
+							pos:  position{line: 3622, col: 28, offset: 110880},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3597, col: 34, offset: 110176},
+							pos:   position{line: 3622, col: 34, offset: 110886},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3597, col: 43, offset: 110185},
+								pos:  position{line: 3622, col: 43, offset: 110895},
 								name: "IntegerAsString",
 							},
 						},
@@ -8430,15 +8430,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3612, col: 1, offset: 110547},
+			pos:  position{line: 3637, col: 1, offset: 111257},
 			expr: &actionExpr{
-				pos: position{line: 3612, col: 19, offset: 110565},
+				pos: position{line: 3637, col: 19, offset: 111275},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3612, col: 19, offset: 110565},
+					pos:   position{line: 3637, col: 19, offset: 111275},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3612, col: 28, offset: 110574},
+						pos:  position{line: 3637, col: 28, offset: 111284},
 						name: "BoolExpr",
 					},
 				},
@@ -8446,30 +8446,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3623, col: 1, offset: 110786},
+			pos:  position{line: 3648, col: 1, offset: 111496},
 			expr: &actionExpr{
-				pos: position{line: 3623, col: 15, offset: 110800},
+				pos: position{line: 3648, col: 15, offset: 111510},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3623, col: 15, offset: 110800},
+					pos:   position{line: 3648, col: 15, offset: 111510},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3623, col: 23, offset: 110808},
+						pos: position{line: 3648, col: 23, offset: 111518},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3623, col: 23, offset: 110808},
+								pos:  position{line: 3648, col: 23, offset: 111518},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3623, col: 44, offset: 110829},
+								pos:  position{line: 3648, col: 44, offset: 111539},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3623, col: 61, offset: 110846},
+								pos:  position{line: 3648, col: 61, offset: 111556},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3623, col: 79, offset: 110864},
+								pos:  position{line: 3648, col: 79, offset: 111574},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8479,35 +8479,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3627, col: 1, offset: 110908},
+			pos:  position{line: 3652, col: 1, offset: 111618},
 			expr: &actionExpr{
-				pos: position{line: 3627, col: 19, offset: 110926},
+				pos: position{line: 3652, col: 19, offset: 111636},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3627, col: 19, offset: 110926},
+					pos: position{line: 3652, col: 19, offset: 111636},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3627, col: 19, offset: 110926},
+							pos:   position{line: 3652, col: 19, offset: 111636},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3627, col: 26, offset: 110933},
+								pos:  position{line: 3652, col: 26, offset: 111643},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3627, col: 37, offset: 110944},
+							pos:   position{line: 3652, col: 37, offset: 111654},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3627, col: 43, offset: 110950},
+								pos: position{line: 3652, col: 43, offset: 111660},
 								expr: &seqExpr{
-									pos: position{line: 3627, col: 44, offset: 110951},
+									pos: position{line: 3652, col: 44, offset: 111661},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3627, col: 44, offset: 110951},
+											pos:  position{line: 3652, col: 44, offset: 111661},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3627, col: 50, offset: 110957},
+											pos:  position{line: 3652, col: 50, offset: 111667},
 											name: "HeadOption",
 										},
 									},
@@ -8520,29 +8520,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3684, col: 1, offset: 112757},
+			pos:  position{line: 3709, col: 1, offset: 113467},
 			expr: &choiceExpr{
-				pos: position{line: 3684, col: 14, offset: 112770},
+				pos: position{line: 3709, col: 14, offset: 113480},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3684, col: 14, offset: 112770},
+						pos: position{line: 3709, col: 14, offset: 113480},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3684, col: 14, offset: 112770},
+							pos: position{line: 3709, col: 14, offset: 113480},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3684, col: 14, offset: 112770},
+									pos:  position{line: 3709, col: 14, offset: 113480},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3684, col: 19, offset: 112775},
+									pos:  position{line: 3709, col: 19, offset: 113485},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3684, col: 28, offset: 112784},
+									pos:   position{line: 3709, col: 28, offset: 113494},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3684, col: 37, offset: 112793},
+										pos:  position{line: 3709, col: 37, offset: 113503},
 										name: "HeadOptionList",
 									},
 								},
@@ -8550,24 +8550,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3695, col: 3, offset: 113112},
+						pos: position{line: 3720, col: 3, offset: 113822},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3695, col: 3, offset: 113112},
+							pos: position{line: 3720, col: 3, offset: 113822},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3695, col: 3, offset: 113112},
+									pos:  position{line: 3720, col: 3, offset: 113822},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3695, col: 8, offset: 113117},
+									pos:  position{line: 3720, col: 8, offset: 113827},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3695, col: 17, offset: 113126},
+									pos:   position{line: 3720, col: 17, offset: 113836},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3695, col: 26, offset: 113135},
+										pos:  position{line: 3720, col: 26, offset: 113845},
 										name: "IntegerAsString",
 									},
 								},
@@ -8575,17 +8575,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3715, col: 3, offset: 113652},
+						pos: position{line: 3740, col: 3, offset: 114362},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3715, col: 3, offset: 113652},
+							pos: position{line: 3740, col: 3, offset: 114362},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3715, col: 3, offset: 113652},
+									pos:  position{line: 3740, col: 3, offset: 114362},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3715, col: 8, offset: 113657},
+									pos:  position{line: 3740, col: 8, offset: 114367},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8596,29 +8596,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3733, col: 1, offset: 114127},
+			pos:  position{line: 3758, col: 1, offset: 114837},
 			expr: &choiceExpr{
-				pos: position{line: 3733, col: 14, offset: 114140},
+				pos: position{line: 3758, col: 14, offset: 114850},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3733, col: 14, offset: 114140},
+						pos: position{line: 3758, col: 14, offset: 114850},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3733, col: 14, offset: 114140},
+							pos: position{line: 3758, col: 14, offset: 114850},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3733, col: 14, offset: 114140},
+									pos:  position{line: 3758, col: 14, offset: 114850},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3733, col: 19, offset: 114145},
+									pos:  position{line: 3758, col: 19, offset: 114855},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3733, col: 28, offset: 114154},
+									pos:   position{line: 3758, col: 28, offset: 114864},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3733, col: 37, offset: 114163},
+										pos:  position{line: 3758, col: 37, offset: 114873},
 										name: "IntegerAsString",
 									},
 								},
@@ -8626,17 +8626,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3754, col: 3, offset: 114737},
+						pos: position{line: 3779, col: 3, offset: 115447},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3754, col: 3, offset: 114737},
+							pos: position{line: 3779, col: 3, offset: 115447},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3754, col: 3, offset: 114737},
+									pos:  position{line: 3779, col: 3, offset: 115447},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3754, col: 8, offset: 114742},
+									pos:  position{line: 3779, col: 8, offset: 115452},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8647,44 +8647,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3775, col: 1, offset: 115360},
+			pos:  position{line: 3800, col: 1, offset: 116070},
 			expr: &actionExpr{
-				pos: position{line: 3775, col: 20, offset: 115379},
+				pos: position{line: 3800, col: 20, offset: 116089},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3775, col: 20, offset: 115379},
+					pos: position{line: 3800, col: 20, offset: 116089},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3775, col: 20, offset: 115379},
+							pos:   position{line: 3800, col: 20, offset: 116089},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3775, col: 26, offset: 115385},
+								pos:  position{line: 3800, col: 26, offset: 116095},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3775, col: 37, offset: 115396},
+							pos:   position{line: 3800, col: 37, offset: 116106},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3775, col: 42, offset: 115401},
+								pos: position{line: 3800, col: 42, offset: 116111},
 								expr: &seqExpr{
-									pos: position{line: 3775, col: 43, offset: 115402},
+									pos: position{line: 3800, col: 43, offset: 116112},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3775, col: 44, offset: 115403},
+											pos: position{line: 3800, col: 44, offset: 116113},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3775, col: 44, offset: 115403},
+													pos:  position{line: 3800, col: 44, offset: 116113},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3775, col: 52, offset: 115411},
+													pos:  position{line: 3800, col: 52, offset: 116121},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3775, col: 59, offset: 115418},
+											pos:  position{line: 3800, col: 59, offset: 116128},
 											name: "Aggregator",
 										},
 									},
@@ -8697,28 +8697,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3792, col: 1, offset: 115921},
+			pos:  position{line: 3817, col: 1, offset: 116631},
 			expr: &actionExpr{
-				pos: position{line: 3792, col: 15, offset: 115935},
+				pos: position{line: 3817, col: 15, offset: 116645},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3792, col: 15, offset: 115935},
+					pos: position{line: 3817, col: 15, offset: 116645},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3792, col: 15, offset: 115935},
+							pos:   position{line: 3817, col: 15, offset: 116645},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3792, col: 23, offset: 115943},
+								pos:  position{line: 3817, col: 23, offset: 116653},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3792, col: 35, offset: 115955},
+							pos:   position{line: 3817, col: 35, offset: 116665},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3792, col: 43, offset: 115963},
+								pos: position{line: 3817, col: 43, offset: 116673},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3792, col: 43, offset: 115963},
+									pos:  position{line: 3817, col: 43, offset: 116673},
 									name: "AsField",
 								},
 							},
@@ -8729,26 +8729,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3808, col: 1, offset: 116804},
+			pos:  position{line: 3833, col: 1, offset: 117514},
 			expr: &actionExpr{
-				pos: position{line: 3808, col: 16, offset: 116819},
+				pos: position{line: 3833, col: 16, offset: 117529},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3808, col: 16, offset: 116819},
+					pos:   position{line: 3833, col: 16, offset: 117529},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3808, col: 21, offset: 116824},
+						pos: position{line: 3833, col: 21, offset: 117534},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3808, col: 21, offset: 116824},
+								pos:  position{line: 3833, col: 21, offset: 117534},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3808, col: 32, offset: 116835},
+								pos:  position{line: 3833, col: 32, offset: 117545},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3808, col: 48, offset: 116851},
+								pos:  position{line: 3833, col: 48, offset: 117561},
 								name: "AggCommon",
 							},
 						},
@@ -8758,165 +8758,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3813, col: 1, offset: 117057},
+			pos:  position{line: 3838, col: 1, offset: 117767},
 			expr: &actionExpr{
-				pos: position{line: 3813, col: 18, offset: 117074},
+				pos: position{line: 3838, col: 18, offset: 117784},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3813, col: 19, offset: 117075},
+					pos: position{line: 3838, col: 19, offset: 117785},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3813, col: 19, offset: 117075},
+							pos:        position{line: 3838, col: 19, offset: 117785},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 30, offset: 117086},
+							pos:        position{line: 3838, col: 30, offset: 117796},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 39, offset: 117095},
+							pos:        position{line: 3838, col: 39, offset: 117805},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 47, offset: 117103},
+							pos:        position{line: 3838, col: 47, offset: 117813},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 57, offset: 117113},
+							pos:        position{line: 3838, col: 57, offset: 117823},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 65, offset: 117121},
+							pos:        position{line: 3838, col: 65, offset: 117831},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 76, offset: 117132},
+							pos:        position{line: 3838, col: 76, offset: 117842},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 86, offset: 117142},
+							pos:        position{line: 3838, col: 86, offset: 117852},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 95, offset: 117151},
+							pos:        position{line: 3838, col: 95, offset: 117861},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 105, offset: 117161},
+							pos:        position{line: 3838, col: 105, offset: 117871},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 114, offset: 117170},
+							pos:        position{line: 3838, col: 114, offset: 117880},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 122, offset: 117178},
+							pos:        position{line: 3838, col: 122, offset: 117888},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 133, offset: 117189},
+							pos:        position{line: 3838, col: 133, offset: 117899},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3813, col: 142, offset: 117198},
+							pos:        position{line: 3838, col: 142, offset: 117908},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 1, offset: 117207},
+							pos:        position{line: 3839, col: 1, offset: 117917},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 10, offset: 117216},
+							pos:        position{line: 3839, col: 10, offset: 117926},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 26, offset: 117232},
+							pos:        position{line: 3839, col: 26, offset: 117942},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 37, offset: 117243},
+							pos:        position{line: 3839, col: 37, offset: 117953},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 46, offset: 117252},
+							pos:        position{line: 3839, col: 46, offset: 117962},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 56, offset: 117262},
+							pos:        position{line: 3839, col: 56, offset: 117972},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 72, offset: 117278},
+							pos:        position{line: 3839, col: 72, offset: 117988},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 82, offset: 117288},
+							pos:        position{line: 3839, col: 82, offset: 117998},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 100, offset: 117306},
+							pos:        position{line: 3839, col: 100, offset: 118016},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 113, offset: 117319},
+							pos:        position{line: 3839, col: 113, offset: 118029},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 132, offset: 117338},
+							pos:        position{line: 3839, col: 132, offset: 118048},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3814, col: 139, offset: 117345},
+							pos:        position{line: 3839, col: 139, offset: 118055},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8927,27 +8927,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3818, col: 1, offset: 117388},
+			pos:  position{line: 3843, col: 1, offset: 118098},
 			expr: &actionExpr{
-				pos: position{line: 3818, col: 22, offset: 117409},
+				pos: position{line: 3843, col: 22, offset: 118119},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3818, col: 23, offset: 117410},
+					pos: position{line: 3843, col: 23, offset: 118120},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3818, col: 23, offset: 117410},
+							pos:        position{line: 3843, col: 23, offset: 118120},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3818, col: 37, offset: 117424},
+							pos:        position{line: 3843, col: 37, offset: 118134},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3818, col: 51, offset: 117438},
+							pos:        position{line: 3843, col: 51, offset: 118148},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8958,29 +8958,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3822, col: 1, offset: 117482},
+			pos:  position{line: 3847, col: 1, offset: 118192},
 			expr: &actionExpr{
-				pos: position{line: 3822, col: 12, offset: 117493},
+				pos: position{line: 3847, col: 12, offset: 118203},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3822, col: 12, offset: 117493},
+					pos: position{line: 3847, col: 12, offset: 118203},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3822, col: 12, offset: 117493},
+							pos:  position{line: 3847, col: 12, offset: 118203},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3822, col: 15, offset: 117496},
+							pos:   position{line: 3847, col: 15, offset: 118206},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3822, col: 23, offset: 117504},
+								pos: position{line: 3847, col: 23, offset: 118214},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3822, col: 23, offset: 117504},
+										pos:  position{line: 3847, col: 23, offset: 118214},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3822, col: 35, offset: 117516},
+										pos:  position{line: 3847, col: 35, offset: 118226},
 										name: "String",
 									},
 								},
@@ -8992,27 +8992,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3836, col: 1, offset: 117845},
+			pos:  position{line: 3861, col: 1, offset: 118555},
 			expr: &choiceExpr{
-				pos: position{line: 3836, col: 13, offset: 117857},
+				pos: position{line: 3861, col: 13, offset: 118567},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3836, col: 13, offset: 117857},
+						pos: position{line: 3861, col: 13, offset: 118567},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3836, col: 13, offset: 117857},
+							pos: position{line: 3861, col: 13, offset: 118567},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3836, col: 14, offset: 117858},
+									pos: position{line: 3861, col: 14, offset: 118568},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3836, col: 14, offset: 117858},
+											pos:        position{line: 3861, col: 14, offset: 118568},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3836, col: 24, offset: 117868},
+											pos:        position{line: 3861, col: 24, offset: 118578},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9020,47 +9020,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3836, col: 29, offset: 117873},
+									pos:  position{line: 3861, col: 29, offset: 118583},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3836, col: 37, offset: 117881},
+									pos:        position{line: 3861, col: 37, offset: 118591},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3836, col: 44, offset: 117888},
+									pos:   position{line: 3861, col: 44, offset: 118598},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3836, col: 54, offset: 117898},
+										pos:  position{line: 3861, col: 54, offset: 118608},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3836, col: 64, offset: 117908},
+									pos:  position{line: 3861, col: 64, offset: 118618},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3846, col: 3, offset: 118136},
+						pos: position{line: 3871, col: 3, offset: 118846},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3846, col: 3, offset: 118136},
+							pos: position{line: 3871, col: 3, offset: 118846},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3846, col: 4, offset: 118137},
+									pos: position{line: 3871, col: 4, offset: 118847},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3846, col: 4, offset: 118137},
+											pos:        position{line: 3871, col: 4, offset: 118847},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3846, col: 14, offset: 118147},
+											pos:        position{line: 3871, col: 14, offset: 118857},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9068,38 +9068,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3846, col: 19, offset: 118152},
+									pos:  position{line: 3871, col: 19, offset: 118862},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3846, col: 27, offset: 118160},
+									pos:   position{line: 3871, col: 27, offset: 118870},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3846, col: 33, offset: 118166},
+										pos:  position{line: 3871, col: 33, offset: 118876},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3846, col: 43, offset: 118176},
+									pos:  position{line: 3871, col: 43, offset: 118886},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3853, col: 5, offset: 118327},
+						pos: position{line: 3878, col: 5, offset: 119037},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3853, col: 6, offset: 118328},
+							pos: position{line: 3878, col: 6, offset: 119038},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3853, col: 6, offset: 118328},
+									pos:        position{line: 3878, col: 6, offset: 119038},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3853, col: 16, offset: 118338},
+									pos:        position{line: 3878, col: 16, offset: 119048},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9112,77 +9112,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3862, col: 1, offset: 118474},
+			pos:  position{line: 3887, col: 1, offset: 119184},
 			expr: &choiceExpr{
-				pos: position{line: 3862, col: 14, offset: 118487},
+				pos: position{line: 3887, col: 14, offset: 119197},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3862, col: 14, offset: 118487},
+						pos: position{line: 3887, col: 14, offset: 119197},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3862, col: 14, offset: 118487},
+							pos: position{line: 3887, col: 14, offset: 119197},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3862, col: 14, offset: 118487},
+									pos:   position{line: 3887, col: 14, offset: 119197},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3862, col: 22, offset: 118495},
+										pos:  position{line: 3887, col: 22, offset: 119205},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3862, col: 36, offset: 118509},
+									pos:  position{line: 3887, col: 36, offset: 119219},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3862, col: 44, offset: 118517},
+									pos:        position{line: 3887, col: 44, offset: 119227},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3862, col: 51, offset: 118524},
+									pos:   position{line: 3887, col: 51, offset: 119234},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3862, col: 61, offset: 118534},
+										pos:  position{line: 3887, col: 61, offset: 119244},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3862, col: 71, offset: 118544},
+									pos:  position{line: 3887, col: 71, offset: 119254},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3877, col: 3, offset: 118954},
+						pos: position{line: 3902, col: 3, offset: 119664},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3877, col: 3, offset: 118954},
+							pos: position{line: 3902, col: 3, offset: 119664},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3877, col: 3, offset: 118954},
+									pos:   position{line: 3902, col: 3, offset: 119664},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3877, col: 11, offset: 118962},
+										pos:  position{line: 3902, col: 11, offset: 119672},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3877, col: 25, offset: 118976},
+									pos:  position{line: 3902, col: 25, offset: 119686},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3877, col: 33, offset: 118984},
+									pos:   position{line: 3902, col: 33, offset: 119694},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3877, col: 39, offset: 118990},
+										pos:  position{line: 3902, col: 39, offset: 119700},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3877, col: 49, offset: 119000},
+									pos:  position{line: 3902, col: 49, offset: 119710},
 									name: "R_PAREN",
 								},
 							},
@@ -9193,22 +9193,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3891, col: 1, offset: 119332},
+			pos:  position{line: 3916, col: 1, offset: 120042},
 			expr: &actionExpr{
-				pos: position{line: 3891, col: 18, offset: 119349},
+				pos: position{line: 3916, col: 18, offset: 120059},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3891, col: 18, offset: 119349},
+					pos:   position{line: 3916, col: 18, offset: 120059},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3891, col: 26, offset: 119357},
+						pos: position{line: 3916, col: 26, offset: 120067},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3891, col: 26, offset: 119357},
+								pos:  position{line: 3916, col: 26, offset: 120067},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3891, col: 42, offset: 119373},
+								pos:  position{line: 3916, col: 42, offset: 120083},
 								name: "IntegerAsString",
 							},
 						},
@@ -9218,93 +9218,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3903, col: 1, offset: 119747},
+			pos:  position{line: 3928, col: 1, offset: 120457},
 			expr: &choiceExpr{
-				pos: position{line: 3903, col: 18, offset: 119764},
+				pos: position{line: 3928, col: 18, offset: 120474},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3903, col: 18, offset: 119764},
+						pos: position{line: 3928, col: 18, offset: 120474},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3903, col: 18, offset: 119764},
+							pos: position{line: 3928, col: 18, offset: 120474},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3903, col: 18, offset: 119764},
+									pos:   position{line: 3928, col: 18, offset: 120474},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3903, col: 26, offset: 119772},
+										pos:  position{line: 3928, col: 26, offset: 120482},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3903, col: 44, offset: 119790},
+									pos:   position{line: 3928, col: 44, offset: 120500},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3903, col: 58, offset: 119804},
+										pos:  position{line: 3928, col: 58, offset: 120514},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3903, col: 72, offset: 119818},
+									pos:  position{line: 3928, col: 72, offset: 120528},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3903, col: 80, offset: 119826},
+									pos:        position{line: 3928, col: 80, offset: 120536},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3903, col: 87, offset: 119833},
+									pos:   position{line: 3928, col: 87, offset: 120543},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3903, col: 97, offset: 119843},
+										pos:  position{line: 3928, col: 97, offset: 120553},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3903, col: 107, offset: 119853},
+									pos:  position{line: 3928, col: 107, offset: 120563},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3919, col: 3, offset: 120302},
+						pos: position{line: 3944, col: 3, offset: 121012},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3919, col: 3, offset: 120302},
+							pos: position{line: 3944, col: 3, offset: 121012},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3919, col: 3, offset: 120302},
+									pos:   position{line: 3944, col: 3, offset: 121012},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3919, col: 11, offset: 120310},
+										pos:  position{line: 3944, col: 11, offset: 121020},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3919, col: 29, offset: 120328},
+									pos:   position{line: 3944, col: 29, offset: 121038},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3919, col: 43, offset: 120342},
+										pos:  position{line: 3944, col: 43, offset: 121052},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3919, col: 57, offset: 120356},
+									pos:  position{line: 3944, col: 57, offset: 121066},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3919, col: 65, offset: 120364},
+									pos:   position{line: 3944, col: 65, offset: 121074},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3919, col: 71, offset: 120370},
+										pos:  position{line: 3944, col: 71, offset: 121080},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3919, col: 81, offset: 120380},
+									pos:  position{line: 3944, col: 81, offset: 121090},
 									name: "R_PAREN",
 								},
 							},
@@ -9315,22 +9315,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3935, col: 1, offset: 120752},
+			pos:  position{line: 3960, col: 1, offset: 121462},
 			expr: &actionExpr{
-				pos: position{line: 3935, col: 25, offset: 120776},
+				pos: position{line: 3960, col: 25, offset: 121486},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3935, col: 25, offset: 120776},
+					pos:   position{line: 3960, col: 25, offset: 121486},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3935, col: 39, offset: 120790},
+						pos: position{line: 3960, col: 39, offset: 121500},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3935, col: 39, offset: 120790},
+								pos:  position{line: 3960, col: 39, offset: 121500},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3935, col: 67, offset: 120818},
+								pos:  position{line: 3960, col: 67, offset: 121528},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9340,43 +9340,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3939, col: 1, offset: 120881},
+			pos:  position{line: 3964, col: 1, offset: 121591},
 			expr: &actionExpr{
-				pos: position{line: 3939, col: 30, offset: 120910},
+				pos: position{line: 3964, col: 30, offset: 121620},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3939, col: 30, offset: 120910},
+					pos: position{line: 3964, col: 30, offset: 121620},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3939, col: 30, offset: 120910},
+							pos:   position{line: 3964, col: 30, offset: 121620},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3939, col: 34, offset: 120914},
+								pos:  position{line: 3964, col: 34, offset: 121624},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3939, col: 44, offset: 120924},
+							pos:   position{line: 3964, col: 44, offset: 121634},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3939, col: 48, offset: 120928},
+								pos: position{line: 3964, col: 48, offset: 121638},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3939, col: 48, offset: 120928},
+										pos:  position{line: 3964, col: 48, offset: 121638},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3939, col: 67, offset: 120947},
+										pos:  position{line: 3964, col: 67, offset: 121657},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3939, col: 87, offset: 120967},
+							pos:   position{line: 3964, col: 87, offset: 121677},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3939, col: 93, offset: 120973},
+								pos:  position{line: 3964, col: 93, offset: 121683},
 								name: "Number",
 							},
 						},
@@ -9386,15 +9386,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3952, col: 1, offset: 121207},
+			pos:  position{line: 3977, col: 1, offset: 121917},
 			expr: &actionExpr{
-				pos: position{line: 3952, col: 32, offset: 121238},
+				pos: position{line: 3977, col: 32, offset: 121948},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3952, col: 32, offset: 121238},
+					pos:   position{line: 3977, col: 32, offset: 121948},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3952, col: 38, offset: 121244},
+						pos:  position{line: 3977, col: 38, offset: 121954},
 						name: "Number",
 					},
 				},
@@ -9402,34 +9402,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 3965, col: 1, offset: 121461},
+			pos:  position{line: 3990, col: 1, offset: 122171},
 			expr: &actionExpr{
-				pos: position{line: 3965, col: 26, offset: 121486},
+				pos: position{line: 3990, col: 26, offset: 122196},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 3965, col: 26, offset: 121486},
+					pos: position{line: 3990, col: 26, offset: 122196},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3965, col: 26, offset: 121486},
+							pos:   position{line: 3990, col: 26, offset: 122196},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3965, col: 30, offset: 121490},
+								pos:  position{line: 3990, col: 30, offset: 122200},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3965, col: 40, offset: 121500},
+							pos:   position{line: 3990, col: 40, offset: 122210},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3965, col: 43, offset: 121503},
+								pos:  position{line: 3990, col: 43, offset: 122213},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3965, col: 60, offset: 121520},
+							pos:   position{line: 3990, col: 60, offset: 122230},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3965, col: 66, offset: 121526},
+								pos:  position{line: 3990, col: 66, offset: 122236},
 								name: "Boolean",
 							},
 						},
@@ -9439,22 +9439,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 3978, col: 1, offset: 121761},
+			pos:  position{line: 4003, col: 1, offset: 122471},
 			expr: &actionExpr{
-				pos: position{line: 3978, col: 25, offset: 121785},
+				pos: position{line: 4003, col: 25, offset: 122495},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3978, col: 25, offset: 121785},
+					pos:   position{line: 4003, col: 25, offset: 122495},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3978, col: 39, offset: 121799},
+						pos: position{line: 4003, col: 39, offset: 122509},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3978, col: 39, offset: 121799},
+								pos:  position{line: 4003, col: 39, offset: 122509},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3978, col: 67, offset: 121827},
+								pos:  position{line: 4003, col: 67, offset: 122537},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9464,41 +9464,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 3982, col: 1, offset: 121890},
+			pos:  position{line: 4007, col: 1, offset: 122600},
 			expr: &actionExpr{
-				pos: position{line: 3982, col: 30, offset: 121919},
+				pos: position{line: 4007, col: 30, offset: 122629},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 3982, col: 30, offset: 121919},
+					pos: position{line: 4007, col: 30, offset: 122629},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3982, col: 30, offset: 121919},
+							pos:   position{line: 4007, col: 30, offset: 122629},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3982, col: 34, offset: 121923},
+								pos:  position{line: 4007, col: 34, offset: 122633},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3982, col: 44, offset: 121933},
+							pos:   position{line: 4007, col: 44, offset: 122643},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3982, col: 47, offset: 121936},
+								pos:  position{line: 4007, col: 47, offset: 122646},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3982, col: 64, offset: 121953},
+							pos:   position{line: 4007, col: 64, offset: 122663},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 3982, col: 81, offset: 121970},
+								pos: position{line: 4007, col: 81, offset: 122680},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3982, col: 81, offset: 121970},
+										pos:  position{line: 4007, col: 81, offset: 122680},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3982, col: 103, offset: 121992},
+										pos:  position{line: 4007, col: 103, offset: 122702},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9510,22 +9510,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 3997, col: 1, offset: 122392},
+			pos:  position{line: 4022, col: 1, offset: 123102},
 			expr: &actionExpr{
-				pos: position{line: 3997, col: 32, offset: 122423},
+				pos: position{line: 4022, col: 32, offset: 123133},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3997, col: 32, offset: 122423},
+					pos:   position{line: 4022, col: 32, offset: 123133},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 3997, col: 49, offset: 122440},
+						pos: position{line: 4022, col: 49, offset: 123150},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3997, col: 49, offset: 122440},
+								pos:  position{line: 4022, col: 49, offset: 123150},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3997, col: 71, offset: 122462},
+								pos:  position{line: 4022, col: 71, offset: 123172},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9535,33 +9535,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4012, col: 1, offset: 122845},
+			pos:  position{line: 4037, col: 1, offset: 123555},
 			expr: &actionExpr{
-				pos: position{line: 4012, col: 24, offset: 122868},
+				pos: position{line: 4037, col: 24, offset: 123578},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4012, col: 24, offset: 122868},
+					pos: position{line: 4037, col: 24, offset: 123578},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4012, col: 24, offset: 122868},
+							pos:        position{line: 4037, col: 24, offset: 123578},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4012, col: 31, offset: 122875},
+							pos:  position{line: 4037, col: 31, offset: 123585},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4012, col: 39, offset: 122883},
+							pos:   position{line: 4037, col: 39, offset: 123593},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4012, col: 45, offset: 122889},
+								pos:  position{line: 4037, col: 45, offset: 123599},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4012, col: 52, offset: 122896},
+							pos:  position{line: 4037, col: 52, offset: 123606},
 							name: "R_PAREN",
 						},
 					},
@@ -9570,15 +9570,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4020, col: 1, offset: 123037},
+			pos:  position{line: 4045, col: 1, offset: 123747},
 			expr: &actionExpr{
-				pos: position{line: 4020, col: 26, offset: 123062},
+				pos: position{line: 4045, col: 26, offset: 123772},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4020, col: 26, offset: 123062},
+					pos:   position{line: 4045, col: 26, offset: 123772},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4020, col: 32, offset: 123068},
+						pos:  position{line: 4045, col: 32, offset: 123778},
 						name: "String",
 					},
 				},
@@ -9586,35 +9586,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4030, col: 1, offset: 123348},
+			pos:  position{line: 4055, col: 1, offset: 124058},
 			expr: &actionExpr{
-				pos: position{line: 4030, col: 18, offset: 123365},
+				pos: position{line: 4055, col: 18, offset: 124075},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4030, col: 18, offset: 123365},
+					pos: position{line: 4055, col: 18, offset: 124075},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4030, col: 18, offset: 123365},
+							pos:   position{line: 4055, col: 18, offset: 124075},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4030, col: 24, offset: 123371},
+								pos:  position{line: 4055, col: 24, offset: 124081},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4030, col: 34, offset: 123381},
+							pos:   position{line: 4055, col: 34, offset: 124091},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4030, col: 39, offset: 123386},
+								pos: position{line: 4055, col: 39, offset: 124096},
 								expr: &seqExpr{
-									pos: position{line: 4030, col: 40, offset: 123387},
+									pos: position{line: 4055, col: 40, offset: 124097},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4030, col: 40, offset: 123387},
+											pos:  position{line: 4055, col: 40, offset: 124097},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4030, col: 46, offset: 123393},
+											pos:  position{line: 4055, col: 46, offset: 124103},
 											name: "FieldName",
 										},
 									},
@@ -9627,16 +9627,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4047, col: 1, offset: 123888},
+			pos:  position{line: 4072, col: 1, offset: 124598},
 			expr: &choiceExpr{
-				pos: position{line: 4047, col: 18, offset: 123905},
+				pos: position{line: 4072, col: 18, offset: 124615},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4047, col: 18, offset: 123905},
+						pos:  position{line: 4072, col: 18, offset: 124615},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4047, col: 38, offset: 123925},
+						pos:  position{line: 4072, col: 38, offset: 124635},
 						name: "EarliestOnly",
 					},
 				},
@@ -9644,62 +9644,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4049, col: 1, offset: 123939},
+			pos:  position{line: 4074, col: 1, offset: 124649},
 			expr: &actionExpr{
-				pos: position{line: 4049, col: 22, offset: 123960},
+				pos: position{line: 4074, col: 22, offset: 124670},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4049, col: 22, offset: 123960},
+					pos: position{line: 4074, col: 22, offset: 124670},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4049, col: 22, offset: 123960},
+							pos:  position{line: 4074, col: 22, offset: 124670},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4049, col: 35, offset: 123973},
+							pos:  position{line: 4074, col: 35, offset: 124683},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4049, col: 41, offset: 123979},
+							pos:   position{line: 4074, col: 41, offset: 124689},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4049, col: 55, offset: 123993},
+								pos: position{line: 4074, col: 55, offset: 124703},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4049, col: 55, offset: 123993},
+										pos:  position{line: 4074, col: 55, offset: 124703},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4049, col: 75, offset: 124013},
+										pos:  position{line: 4074, col: 75, offset: 124723},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4049, col: 94, offset: 124032},
+							pos:  position{line: 4074, col: 94, offset: 124742},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4049, col: 100, offset: 124038},
+							pos:  position{line: 4074, col: 100, offset: 124748},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4049, col: 111, offset: 124049},
+							pos:  position{line: 4074, col: 111, offset: 124759},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4049, col: 117, offset: 124055},
+							pos:   position{line: 4074, col: 117, offset: 124765},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4049, col: 129, offset: 124067},
+								pos: position{line: 4074, col: 129, offset: 124777},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4049, col: 129, offset: 124067},
+										pos:  position{line: 4074, col: 129, offset: 124777},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4049, col: 149, offset: 124087},
+										pos:  position{line: 4074, col: 149, offset: 124797},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9711,33 +9711,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4090, col: 1, offset: 125226},
+			pos:  position{line: 4115, col: 1, offset: 125936},
 			expr: &actionExpr{
-				pos: position{line: 4090, col: 17, offset: 125242},
+				pos: position{line: 4115, col: 17, offset: 125952},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4090, col: 17, offset: 125242},
+					pos: position{line: 4115, col: 17, offset: 125952},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 17, offset: 125242},
+							pos:  position{line: 4115, col: 17, offset: 125952},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 30, offset: 125255},
+							pos:  position{line: 4115, col: 30, offset: 125965},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4090, col: 36, offset: 125261},
+							pos:   position{line: 4115, col: 36, offset: 125971},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4090, col: 50, offset: 125275},
+								pos: position{line: 4115, col: 50, offset: 125985},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 50, offset: 125275},
+										pos:  position{line: 4115, col: 50, offset: 125985},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 70, offset: 125295},
+										pos:  position{line: 4115, col: 70, offset: 126005},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9749,24 +9749,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4118, col: 1, offset: 126003},
+			pos:  position{line: 4143, col: 1, offset: 126713},
 			expr: &actionExpr{
-				pos: position{line: 4118, col: 23, offset: 126025},
+				pos: position{line: 4143, col: 23, offset: 126735},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4118, col: 23, offset: 126025},
+					pos: position{line: 4143, col: 23, offset: 126735},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4118, col: 23, offset: 126025},
+							pos:        position{line: 4143, col: 23, offset: 126735},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4118, col: 27, offset: 126029},
+							pos: position{line: 4143, col: 27, offset: 126739},
 							expr: &charClassMatcher{
-								pos:        position{line: 4118, col: 27, offset: 126029},
+								pos:        position{line: 4143, col: 27, offset: 126739},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9779,21 +9779,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4122, col: 1, offset: 126072},
+			pos:  position{line: 4147, col: 1, offset: 126782},
 			expr: &actionExpr{
-				pos: position{line: 4122, col: 13, offset: 126084},
+				pos: position{line: 4147, col: 13, offset: 126794},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4122, col: 14, offset: 126085},
+					pos: position{line: 4147, col: 14, offset: 126795},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4122, col: 14, offset: 126085},
+							pos:        position{line: 4147, col: 14, offset: 126795},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4122, col: 17, offset: 126088},
+							pos:        position{line: 4147, col: 17, offset: 126798},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9805,15 +9805,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4126, col: 1, offset: 126131},
+			pos:  position{line: 4151, col: 1, offset: 126841},
 			expr: &actionExpr{
-				pos: position{line: 4126, col: 16, offset: 126146},
+				pos: position{line: 4151, col: 16, offset: 126856},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4126, col: 16, offset: 126146},
+					pos:   position{line: 4151, col: 16, offset: 126856},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4126, col: 26, offset: 126156},
+						pos:  position{line: 4151, col: 26, offset: 126866},
 						name: "AllTimeScale",
 					},
 				},
@@ -9821,31 +9821,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4133, col: 1, offset: 126380},
+			pos:  position{line: 4158, col: 1, offset: 127090},
 			expr: &actionExpr{
-				pos: position{line: 4133, col: 9, offset: 126388},
+				pos: position{line: 4158, col: 9, offset: 127098},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4133, col: 9, offset: 126388},
+					pos: position{line: 4158, col: 9, offset: 127098},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4133, col: 9, offset: 126388},
+							pos:        position{line: 4158, col: 9, offset: 127098},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4133, col: 13, offset: 126392},
+							pos:   position{line: 4158, col: 13, offset: 127102},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4133, col: 19, offset: 126398},
+								pos: position{line: 4158, col: 19, offset: 127108},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4133, col: 19, offset: 126398},
+										pos:  position{line: 4158, col: 19, offset: 127108},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4133, col: 30, offset: 126409},
+										pos:  position{line: 4158, col: 30, offset: 127119},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9857,26 +9857,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4137, col: 1, offset: 126457},
+			pos:  position{line: 4162, col: 1, offset: 127167},
 			expr: &actionExpr{
-				pos: position{line: 4137, col: 11, offset: 126467},
+				pos: position{line: 4162, col: 11, offset: 127177},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4137, col: 11, offset: 126467},
+					pos: position{line: 4162, col: 11, offset: 127177},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4137, col: 11, offset: 126467},
+							pos:   position{line: 4162, col: 11, offset: 127177},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4137, col: 16, offset: 126472},
+								pos:  position{line: 4162, col: 16, offset: 127182},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4137, col: 36, offset: 126492},
+							pos:   position{line: 4162, col: 36, offset: 127202},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4137, col: 43, offset: 126499},
+								pos:  position{line: 4162, col: 43, offset: 127209},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9886,44 +9886,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4165, col: 1, offset: 127237},
+			pos:  position{line: 4190, col: 1, offset: 127947},
 			expr: &actionExpr{
-				pos: position{line: 4165, col: 29, offset: 127265},
+				pos: position{line: 4190, col: 29, offset: 127975},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4165, col: 29, offset: 127265},
+					pos: position{line: 4190, col: 29, offset: 127975},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4165, col: 29, offset: 127265},
+							pos:   position{line: 4190, col: 29, offset: 127975},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4165, col: 36, offset: 127272},
+								pos: position{line: 4190, col: 36, offset: 127982},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4165, col: 36, offset: 127272},
+										pos:  position{line: 4190, col: 36, offset: 127982},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4165, col: 45, offset: 127281},
+										pos:  position{line: 4190, col: 45, offset: 127991},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4165, col: 51, offset: 127287},
+							pos:   position{line: 4190, col: 51, offset: 127997},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4165, col: 57, offset: 127293},
+								pos: position{line: 4190, col: 57, offset: 128003},
 								expr: &choiceExpr{
-									pos: position{line: 4165, col: 58, offset: 127294},
+									pos: position{line: 4190, col: 58, offset: 128004},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4165, col: 58, offset: 127294},
+											pos:  position{line: 4190, col: 58, offset: 128004},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4165, col: 67, offset: 127303},
+											pos:  position{line: 4190, col: 67, offset: 128013},
 											name: "Snap",
 										},
 									},
@@ -9936,29 +9936,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4212, col: 1, offset: 128735},
+			pos:  position{line: 4237, col: 1, offset: 129445},
 			expr: &actionExpr{
-				pos: position{line: 4212, col: 22, offset: 128756},
+				pos: position{line: 4237, col: 22, offset: 129466},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4212, col: 22, offset: 128756},
+					pos: position{line: 4237, col: 22, offset: 129466},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4212, col: 22, offset: 128756},
+							pos:   position{line: 4237, col: 22, offset: 129466},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4212, col: 34, offset: 128768},
+								pos: position{line: 4237, col: 34, offset: 129478},
 								expr: &choiceExpr{
-									pos: position{line: 4212, col: 35, offset: 128769},
+									pos: position{line: 4237, col: 35, offset: 129479},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4212, col: 35, offset: 128769},
+											pos:        position{line: 4237, col: 35, offset: 129479},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4212, col: 43, offset: 128777},
+											pos:        position{line: 4237, col: 43, offset: 129487},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9968,12 +9968,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4212, col: 49, offset: 128783},
+							pos:   position{line: 4237, col: 49, offset: 129493},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4212, col: 57, offset: 128791},
+								pos: position{line: 4237, col: 57, offset: 129501},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4212, col: 58, offset: 128792},
+									pos:  position{line: 4237, col: 58, offset: 129502},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9984,31 +9984,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4237, col: 1, offset: 129475},
+			pos:  position{line: 4262, col: 1, offset: 130185},
 			expr: &actionExpr{
-				pos: position{line: 4237, col: 39, offset: 129513},
+				pos: position{line: 4262, col: 39, offset: 130223},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4237, col: 39, offset: 129513},
+					pos: position{line: 4262, col: 39, offset: 130223},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4237, col: 39, offset: 129513},
+							pos:   position{line: 4262, col: 39, offset: 130223},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4237, col: 46, offset: 129520},
+								pos: position{line: 4262, col: 46, offset: 130230},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4237, col: 47, offset: 129521},
+									pos:  position{line: 4262, col: 47, offset: 130231},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4237, col: 56, offset: 129530},
+							pos:   position{line: 4262, col: 56, offset: 130240},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4237, col: 66, offset: 129540},
+								pos: position{line: 4262, col: 66, offset: 130250},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4237, col: 67, offset: 129541},
+									pos:  position{line: 4262, col: 67, offset: 130251},
 									name: "Snap",
 								},
 							},
@@ -10019,136 +10019,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4264, col: 1, offset: 130169},
+			pos:  position{line: 4289, col: 1, offset: 130879},
 			expr: &actionExpr{
-				pos: position{line: 4264, col: 18, offset: 130186},
+				pos: position{line: 4289, col: 18, offset: 130896},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4264, col: 18, offset: 130186},
+					pos: position{line: 4289, col: 18, offset: 130896},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 18, offset: 130186},
+							pos:        position{line: 4289, col: 18, offset: 130896},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 23, offset: 130191},
+							pos:        position{line: 4289, col: 23, offset: 130901},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 29, offset: 130197},
+							pos:        position{line: 4289, col: 29, offset: 130907},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 33, offset: 130201},
+							pos:        position{line: 4289, col: 33, offset: 130911},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 38, offset: 130206},
+							pos:        position{line: 4289, col: 38, offset: 130916},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 44, offset: 130212},
+							pos:        position{line: 4289, col: 44, offset: 130922},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 48, offset: 130216},
+							pos:        position{line: 4289, col: 48, offset: 130926},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 53, offset: 130221},
+							pos:        position{line: 4289, col: 53, offset: 130931},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 58, offset: 130226},
+							pos:        position{line: 4289, col: 58, offset: 130936},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 63, offset: 130231},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4264, col: 69, offset: 130237},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4264, col: 73, offset: 130241},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4264, col: 78, offset: 130246},
+							pos:        position{line: 4289, col: 63, offset: 130941},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 84, offset: 130252},
+							pos:        position{line: 4289, col: 69, offset: 130947},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 88, offset: 130256},
+							pos:        position{line: 4289, col: 73, offset: 130951},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 93, offset: 130261},
+							pos:        position{line: 4289, col: 78, offset: 130956},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4264, col: 99, offset: 130267},
+							pos:        position{line: 4289, col: 84, offset: 130962},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 103, offset: 130271},
+							pos:        position{line: 4289, col: 88, offset: 130966},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4264, col: 108, offset: 130276},
+							pos:        position{line: 4289, col: 93, offset: 130971},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4289, col: 99, offset: 130977},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4289, col: 103, offset: 130981},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4289, col: 108, offset: 130986},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10160,15 +10160,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4268, col: 1, offset: 130318},
+			pos:  position{line: 4293, col: 1, offset: 131028},
 			expr: &actionExpr{
-				pos: position{line: 4268, col: 22, offset: 130339},
+				pos: position{line: 4293, col: 22, offset: 131049},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4268, col: 22, offset: 130339},
+					pos:   position{line: 4293, col: 22, offset: 131049},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4268, col: 32, offset: 130349},
+						pos:  position{line: 4293, col: 32, offset: 131059},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10176,15 +10176,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4278, col: 1, offset: 130757},
+			pos:  position{line: 4303, col: 1, offset: 131467},
 			expr: &actionExpr{
-				pos: position{line: 4278, col: 14, offset: 130770},
+				pos: position{line: 4303, col: 14, offset: 131480},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4278, col: 14, offset: 130770},
+					pos: position{line: 4303, col: 14, offset: 131480},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4278, col: 14, offset: 130770},
+							pos:        position{line: 4303, col: 14, offset: 131480},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10192,9 +10192,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4278, col: 27, offset: 130783},
+							pos: position{line: 4303, col: 27, offset: 131493},
 							expr: &charClassMatcher{
-								pos:        position{line: 4278, col: 27, offset: 130783},
+								pos:        position{line: 4303, col: 27, offset: 131493},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10208,15 +10208,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4282, col: 1, offset: 130836},
+			pos:  position{line: 4307, col: 1, offset: 131546},
 			expr: &actionExpr{
-				pos: position{line: 4282, col: 24, offset: 130859},
+				pos: position{line: 4307, col: 24, offset: 131569},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4282, col: 24, offset: 130859},
+					pos: position{line: 4307, col: 24, offset: 131569},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4282, col: 24, offset: 130859},
+							pos:        position{line: 4307, col: 24, offset: 131569},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10224,9 +10224,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4282, col: 39, offset: 130874},
+							pos: position{line: 4307, col: 39, offset: 131584},
 							expr: &charClassMatcher{
-								pos:        position{line: 4282, col: 39, offset: 130874},
+								pos:        position{line: 4307, col: 39, offset: 131584},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10240,22 +10240,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4286, col: 1, offset: 130927},
+			pos:  position{line: 4311, col: 1, offset: 131637},
 			expr: &actionExpr{
-				pos: position{line: 4286, col: 11, offset: 130937},
+				pos: position{line: 4311, col: 11, offset: 131647},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4286, col: 11, offset: 130937},
+					pos:   position{line: 4311, col: 11, offset: 131647},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4286, col: 16, offset: 130942},
+						pos: position{line: 4311, col: 16, offset: 131652},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4286, col: 16, offset: 130942},
+								pos:  position{line: 4311, col: 16, offset: 131652},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4286, col: 31, offset: 130957},
+								pos:  position{line: 4311, col: 31, offset: 131667},
 								name: "UnquotedString",
 							},
 						},
@@ -10265,23 +10265,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4290, col: 1, offset: 130998},
+			pos:  position{line: 4315, col: 1, offset: 131708},
 			expr: &actionExpr{
-				pos: position{line: 4290, col: 17, offset: 131014},
+				pos: position{line: 4315, col: 17, offset: 131724},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4290, col: 17, offset: 131014},
+					pos: position{line: 4315, col: 17, offset: 131724},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4290, col: 17, offset: 131014},
+							pos:        position{line: 4315, col: 17, offset: 131724},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4290, col: 21, offset: 131018},
+							pos: position{line: 4315, col: 21, offset: 131728},
 							expr: &charClassMatcher{
-								pos:        position{line: 4290, col: 21, offset: 131018},
+								pos:        position{line: 4315, col: 21, offset: 131728},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10289,7 +10289,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4290, col: 27, offset: 131024},
+							pos:        position{line: 4315, col: 27, offset: 131734},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10300,48 +10300,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4295, col: 1, offset: 131135},
+			pos:  position{line: 4320, col: 1, offset: 131845},
 			expr: &actionExpr{
-				pos: position{line: 4295, col: 19, offset: 131153},
+				pos: position{line: 4320, col: 19, offset: 131863},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4295, col: 19, offset: 131153},
+					pos: position{line: 4320, col: 19, offset: 131863},
 					expr: &choiceExpr{
-						pos: position{line: 4295, col: 20, offset: 131154},
+						pos: position{line: 4320, col: 20, offset: 131864},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4295, col: 20, offset: 131154},
+								pos:        position{line: 4320, col: 20, offset: 131864},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4295, col: 27, offset: 131161},
+								pos: position{line: 4320, col: 27, offset: 131871},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4295, col: 27, offset: 131161},
+										pos: position{line: 4320, col: 27, offset: 131871},
 										expr: &choiceExpr{
-											pos: position{line: 4295, col: 29, offset: 131163},
+											pos: position{line: 4320, col: 29, offset: 131873},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4295, col: 29, offset: 131163},
+													pos:  position{line: 4320, col: 29, offset: 131873},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4295, col: 43, offset: 131177},
+													pos:        position{line: 4320, col: 43, offset: 131887},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4295, col: 49, offset: 131183},
+													pos:  position{line: 4320, col: 49, offset: 131893},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4295, col: 54, offset: 131188,
+										line: 4320, col: 54, offset: 131898,
 									},
 								},
 							},
@@ -10352,12 +10352,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4302, col: 1, offset: 131303},
+			pos:  position{line: 4327, col: 1, offset: 132013},
 			expr: &choiceExpr{
-				pos: position{line: 4302, col: 16, offset: 131318},
+				pos: position{line: 4327, col: 16, offset: 132028},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4302, col: 16, offset: 131318},
+						pos:        position{line: 4327, col: 16, offset: 132028},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10365,18 +10365,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4302, col: 37, offset: 131339},
+						pos: position{line: 4327, col: 37, offset: 132049},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4302, col: 37, offset: 131339},
+								pos:        position{line: 4327, col: 37, offset: 132049},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4302, col: 41, offset: 131343},
+								pos: position{line: 4327, col: 41, offset: 132053},
 								expr: &charClassMatcher{
-									pos:        position{line: 4302, col: 41, offset: 131343},
+									pos:        position{line: 4327, col: 41, offset: 132053},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10384,7 +10384,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4302, col: 48, offset: 131350},
+								pos:        position{line: 4327, col: 48, offset: 132060},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10396,46 +10396,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4304, col: 1, offset: 131356},
+			pos:  position{line: 4329, col: 1, offset: 132066},
 			expr: &actionExpr{
-				pos: position{line: 4304, col: 39, offset: 131394},
+				pos: position{line: 4329, col: 39, offset: 132104},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4304, col: 39, offset: 131394},
+					pos: position{line: 4329, col: 39, offset: 132104},
 					expr: &choiceExpr{
-						pos: position{line: 4304, col: 40, offset: 131395},
+						pos: position{line: 4329, col: 40, offset: 132105},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4304, col: 40, offset: 131395},
+								pos:  position{line: 4329, col: 40, offset: 132105},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4304, col: 54, offset: 131409},
+								pos: position{line: 4329, col: 54, offset: 132119},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4304, col: 54, offset: 131409},
+										pos: position{line: 4329, col: 54, offset: 132119},
 										expr: &choiceExpr{
-											pos: position{line: 4304, col: 56, offset: 131411},
+											pos: position{line: 4329, col: 56, offset: 132121},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4304, col: 56, offset: 131411},
+													pos:  position{line: 4329, col: 56, offset: 132121},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4304, col: 70, offset: 131425},
+													pos:        position{line: 4329, col: 70, offset: 132135},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4304, col: 76, offset: 131431},
+													pos:  position{line: 4329, col: 76, offset: 132141},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4304, col: 81, offset: 131436,
+										line: 4329, col: 81, offset: 132146,
 									},
 								},
 							},
@@ -10446,21 +10446,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4308, col: 1, offset: 131476},
+			pos:  position{line: 4333, col: 1, offset: 132186},
 			expr: &actionExpr{
-				pos: position{line: 4308, col: 12, offset: 131487},
+				pos: position{line: 4333, col: 12, offset: 132197},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4308, col: 13, offset: 131488},
+					pos: position{line: 4333, col: 13, offset: 132198},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4308, col: 13, offset: 131488},
+							pos:        position{line: 4333, col: 13, offset: 132198},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4308, col: 22, offset: 131497},
+							pos:        position{line: 4333, col: 22, offset: 132207},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10471,14 +10471,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4314, col: 1, offset: 131651},
+			pos:  position{line: 4339, col: 1, offset: 132361},
 			expr: &actionExpr{
-				pos: position{line: 4314, col: 18, offset: 131668},
+				pos: position{line: 4339, col: 18, offset: 132378},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4314, col: 18, offset: 131668},
+					pos: position{line: 4339, col: 18, offset: 132378},
 					expr: &charClassMatcher{
-						pos:        position{line: 4314, col: 18, offset: 131668},
+						pos:        position{line: 4339, col: 18, offset: 132378},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10490,15 +10490,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4318, col: 1, offset: 131719},
+			pos:  position{line: 4343, col: 1, offset: 132429},
 			expr: &actionExpr{
-				pos: position{line: 4318, col: 11, offset: 131729},
+				pos: position{line: 4343, col: 11, offset: 132439},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4318, col: 11, offset: 131729},
+					pos:   position{line: 4343, col: 11, offset: 132439},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4318, col: 18, offset: 131736},
+						pos:  position{line: 4343, col: 18, offset: 132446},
 						name: "NumberAsString",
 					},
 				},
@@ -10506,59 +10506,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4324, col: 1, offset: 131925},
+			pos:  position{line: 4349, col: 1, offset: 132635},
 			expr: &actionExpr{
-				pos: position{line: 4324, col: 19, offset: 131943},
+				pos: position{line: 4349, col: 19, offset: 132653},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4324, col: 19, offset: 131943},
+					pos: position{line: 4349, col: 19, offset: 132653},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4324, col: 19, offset: 131943},
+							pos:   position{line: 4349, col: 19, offset: 132653},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4324, col: 27, offset: 131951},
+								pos: position{line: 4349, col: 27, offset: 132661},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4324, col: 27, offset: 131951},
+										pos:  position{line: 4349, col: 27, offset: 132661},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4324, col: 43, offset: 131967},
+										pos:  position{line: 4349, col: 43, offset: 132677},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4324, col: 60, offset: 131984},
+							pos: position{line: 4349, col: 60, offset: 132694},
 							expr: &choiceExpr{
-								pos: position{line: 4324, col: 62, offset: 131986},
+								pos: position{line: 4349, col: 62, offset: 132696},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4324, col: 62, offset: 131986},
+										pos:  position{line: 4349, col: 62, offset: 132696},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4324, col: 70, offset: 131994},
+										pos:        position{line: 4349, col: 70, offset: 132704},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4324, col: 76, offset: 132000},
+										pos:        position{line: 4349, col: 76, offset: 132710},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4324, col: 82, offset: 132006},
+										pos:        position{line: 4349, col: 82, offset: 132716},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4324, col: 88, offset: 132012},
+										pos:  position{line: 4349, col: 88, offset: 132722},
 										name: "EOF",
 									},
 								},
@@ -10570,17 +10570,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4330, col: 1, offset: 132141},
+			pos:  position{line: 4355, col: 1, offset: 132851},
 			expr: &actionExpr{
-				pos: position{line: 4330, col: 18, offset: 132158},
+				pos: position{line: 4355, col: 18, offset: 132868},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4330, col: 18, offset: 132158},
+					pos: position{line: 4355, col: 18, offset: 132868},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4330, col: 18, offset: 132158},
+							pos: position{line: 4355, col: 18, offset: 132868},
 							expr: &charClassMatcher{
-								pos:        position{line: 4330, col: 18, offset: 132158},
+								pos:        position{line: 4355, col: 18, offset: 132868},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10588,9 +10588,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4330, col: 24, offset: 132164},
+							pos: position{line: 4355, col: 24, offset: 132874},
 							expr: &charClassMatcher{
-								pos:        position{line: 4330, col: 24, offset: 132164},
+								pos:        position{line: 4355, col: 24, offset: 132874},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10598,15 +10598,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4330, col: 31, offset: 132171},
+							pos:        position{line: 4355, col: 31, offset: 132881},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4330, col: 35, offset: 132175},
+							pos: position{line: 4355, col: 35, offset: 132885},
 							expr: &charClassMatcher{
-								pos:        position{line: 4330, col: 35, offset: 132175},
+								pos:        position{line: 4355, col: 35, offset: 132885},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10619,17 +10619,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4335, col: 1, offset: 132270},
+			pos:  position{line: 4360, col: 1, offset: 132980},
 			expr: &actionExpr{
-				pos: position{line: 4335, col: 20, offset: 132289},
+				pos: position{line: 4360, col: 20, offset: 132999},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4335, col: 20, offset: 132289},
+					pos: position{line: 4360, col: 20, offset: 132999},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4335, col: 20, offset: 132289},
+							pos: position{line: 4360, col: 20, offset: 132999},
 							expr: &charClassMatcher{
-								pos:        position{line: 4335, col: 20, offset: 132289},
+								pos:        position{line: 4360, col: 20, offset: 132999},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10637,9 +10637,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4335, col: 26, offset: 132295},
+							pos: position{line: 4360, col: 26, offset: 133005},
 							expr: &charClassMatcher{
-								pos:        position{line: 4335, col: 26, offset: 132295},
+								pos:        position{line: 4360, col: 26, offset: 133005},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10652,14 +10652,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4339, col: 1, offset: 132338},
+			pos:  position{line: 4364, col: 1, offset: 133048},
 			expr: &actionExpr{
-				pos: position{line: 4339, col: 28, offset: 132365},
+				pos: position{line: 4364, col: 28, offset: 133075},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4339, col: 28, offset: 132365},
+					pos: position{line: 4364, col: 28, offset: 133075},
 					expr: &charClassMatcher{
-						pos:        position{line: 4339, col: 28, offset: 132365},
+						pos:        position{line: 4364, col: 28, offset: 133075},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10670,15 +10670,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4343, col: 1, offset: 132408},
+			pos:  position{line: 4368, col: 1, offset: 133118},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 20, offset: 132427},
+				pos: position{line: 4368, col: 20, offset: 133137},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4343, col: 20, offset: 132427},
+					pos:   position{line: 4368, col: 20, offset: 133137},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4343, col: 27, offset: 132434},
+						pos:  position{line: 4368, col: 27, offset: 133144},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10686,31 +10686,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4351, col: 1, offset: 132681},
+			pos:  position{line: 4376, col: 1, offset: 133391},
 			expr: &actionExpr{
-				pos: position{line: 4351, col: 21, offset: 132701},
+				pos: position{line: 4376, col: 21, offset: 133411},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4351, col: 21, offset: 132701},
+					pos: position{line: 4376, col: 21, offset: 133411},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4351, col: 21, offset: 132701},
+							pos:  position{line: 4376, col: 21, offset: 133411},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4351, col: 36, offset: 132716},
+							pos:   position{line: 4376, col: 36, offset: 133426},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4351, col: 40, offset: 132720},
+								pos: position{line: 4376, col: 40, offset: 133430},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4351, col: 40, offset: 132720},
+										pos:        position{line: 4376, col: 40, offset: 133430},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4351, col: 46, offset: 132726},
+										pos:        position{line: 4376, col: 46, offset: 133436},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10719,7 +10719,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4351, col: 52, offset: 132732},
+							pos:  position{line: 4376, col: 52, offset: 133442},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10728,43 +10728,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4359, col: 1, offset: 132913},
+			pos:  position{line: 4384, col: 1, offset: 133623},
 			expr: &actionExpr{
-				pos: position{line: 4359, col: 23, offset: 132935},
+				pos: position{line: 4384, col: 23, offset: 133645},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4359, col: 23, offset: 132935},
+					pos: position{line: 4384, col: 23, offset: 133645},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4359, col: 23, offset: 132935},
+							pos:  position{line: 4384, col: 23, offset: 133645},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4359, col: 38, offset: 132950},
+							pos:   position{line: 4384, col: 38, offset: 133660},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4359, col: 42, offset: 132954},
+								pos: position{line: 4384, col: 42, offset: 133664},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4359, col: 42, offset: 132954},
+										pos:        position{line: 4384, col: 42, offset: 133664},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4359, col: 49, offset: 132961},
+										pos:        position{line: 4384, col: 49, offset: 133671},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4359, col: 55, offset: 132967},
+										pos:        position{line: 4384, col: 55, offset: 133677},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4359, col: 62, offset: 132974},
+										pos:        position{line: 4384, col: 62, offset: 133684},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10773,7 +10773,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4359, col: 67, offset: 132979},
+							pos:  position{line: 4384, col: 67, offset: 133689},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10782,30 +10782,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4367, col: 1, offset: 133162},
+			pos:  position{line: 4392, col: 1, offset: 133872},
 			expr: &choiceExpr{
-				pos: position{line: 4367, col: 25, offset: 133186},
+				pos: position{line: 4392, col: 25, offset: 133896},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4367, col: 25, offset: 133186},
+						pos: position{line: 4392, col: 25, offset: 133896},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4367, col: 25, offset: 133186},
+							pos:   position{line: 4392, col: 25, offset: 133896},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4367, col: 28, offset: 133189},
+								pos:  position{line: 4392, col: 28, offset: 133899},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4370, col: 3, offset: 133231},
+						pos: position{line: 4395, col: 3, offset: 133941},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4370, col: 3, offset: 133231},
+							pos:   position{line: 4395, col: 3, offset: 133941},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4370, col: 6, offset: 133234},
+								pos:  position{line: 4395, col: 6, offset: 133944},
 								name: "InequalityOperator",
 							},
 						},
@@ -10815,25 +10815,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4374, col: 1, offset: 133277},
+			pos:  position{line: 4399, col: 1, offset: 133987},
 			expr: &actionExpr{
-				pos: position{line: 4374, col: 11, offset: 133287},
+				pos: position{line: 4399, col: 11, offset: 133997},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4374, col: 11, offset: 133287},
+					pos: position{line: 4399, col: 11, offset: 133997},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4374, col: 11, offset: 133287},
+							pos:  position{line: 4399, col: 11, offset: 133997},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4374, col: 26, offset: 133302},
+							pos:        position{line: 4399, col: 26, offset: 134012},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4374, col: 30, offset: 133306},
+							pos:  position{line: 4399, col: 30, offset: 134016},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10842,25 +10842,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4378, col: 1, offset: 133346},
+			pos:  position{line: 4403, col: 1, offset: 134056},
 			expr: &actionExpr{
-				pos: position{line: 4378, col: 12, offset: 133357},
+				pos: position{line: 4403, col: 12, offset: 134067},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4378, col: 12, offset: 133357},
+					pos: position{line: 4403, col: 12, offset: 134067},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4378, col: 12, offset: 133357},
+							pos:  position{line: 4403, col: 12, offset: 134067},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4378, col: 27, offset: 133372},
+							pos:        position{line: 4403, col: 27, offset: 134082},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4378, col: 31, offset: 133376},
+							pos:  position{line: 4403, col: 31, offset: 134086},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10869,25 +10869,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4382, col: 1, offset: 133416},
+			pos:  position{line: 4407, col: 1, offset: 134126},
 			expr: &actionExpr{
-				pos: position{line: 4382, col: 10, offset: 133425},
+				pos: position{line: 4407, col: 10, offset: 134135},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4382, col: 10, offset: 133425},
+					pos: position{line: 4407, col: 10, offset: 134135},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4382, col: 10, offset: 133425},
+							pos:  position{line: 4407, col: 10, offset: 134135},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4382, col: 25, offset: 133440},
+							pos:        position{line: 4407, col: 25, offset: 134150},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4382, col: 29, offset: 133444},
+							pos:  position{line: 4407, col: 29, offset: 134154},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10896,25 +10896,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4386, col: 1, offset: 133484},
+			pos:  position{line: 4411, col: 1, offset: 134194},
 			expr: &actionExpr{
-				pos: position{line: 4386, col: 10, offset: 133493},
+				pos: position{line: 4411, col: 10, offset: 134203},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4386, col: 10, offset: 133493},
+					pos: position{line: 4411, col: 10, offset: 134203},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4386, col: 10, offset: 133493},
+							pos:  position{line: 4411, col: 10, offset: 134203},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4386, col: 25, offset: 133508},
+							pos:        position{line: 4411, col: 25, offset: 134218},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4386, col: 29, offset: 133512},
+							pos:  position{line: 4411, col: 29, offset: 134222},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10923,25 +10923,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4390, col: 1, offset: 133552},
+			pos:  position{line: 4415, col: 1, offset: 134262},
 			expr: &actionExpr{
-				pos: position{line: 4390, col: 10, offset: 133561},
+				pos: position{line: 4415, col: 10, offset: 134271},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4390, col: 10, offset: 133561},
+					pos: position{line: 4415, col: 10, offset: 134271},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4390, col: 10, offset: 133561},
+							pos:  position{line: 4415, col: 10, offset: 134271},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4390, col: 25, offset: 133576},
+							pos:        position{line: 4415, col: 25, offset: 134286},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4390, col: 29, offset: 133580},
+							pos:  position{line: 4415, col: 29, offset: 134290},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10950,39 +10950,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4395, col: 1, offset: 133644},
+			pos:  position{line: 4420, col: 1, offset: 134354},
 			expr: &actionExpr{
-				pos: position{line: 4395, col: 11, offset: 133654},
+				pos: position{line: 4420, col: 11, offset: 134364},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4395, col: 12, offset: 133655},
+					pos: position{line: 4420, col: 12, offset: 134365},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4395, col: 12, offset: 133655},
+							pos:        position{line: 4420, col: 12, offset: 134365},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4395, col: 24, offset: 133667},
+							pos:        position{line: 4420, col: 24, offset: 134377},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4395, col: 35, offset: 133678},
+							pos:        position{line: 4420, col: 35, offset: 134388},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4395, col: 44, offset: 133687},
+							pos:        position{line: 4420, col: 44, offset: 134397},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4395, col: 52, offset: 133695},
+							pos:        position{line: 4420, col: 52, offset: 134405},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10993,39 +10993,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4399, col: 1, offset: 133736},
+			pos:  position{line: 4424, col: 1, offset: 134446},
 			expr: &actionExpr{
-				pos: position{line: 4399, col: 11, offset: 133746},
+				pos: position{line: 4424, col: 11, offset: 134456},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4399, col: 12, offset: 133747},
+					pos: position{line: 4424, col: 12, offset: 134457},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4399, col: 12, offset: 133747},
+							pos:        position{line: 4424, col: 12, offset: 134457},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4399, col: 24, offset: 133759},
+							pos:        position{line: 4424, col: 24, offset: 134469},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4399, col: 35, offset: 133770},
+							pos:        position{line: 4424, col: 35, offset: 134480},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4399, col: 44, offset: 133779},
+							pos:        position{line: 4424, col: 44, offset: 134489},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4399, col: 52, offset: 133787},
+							pos:        position{line: 4424, col: 52, offset: 134497},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11036,39 +11036,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4403, col: 1, offset: 133828},
+			pos:  position{line: 4428, col: 1, offset: 134538},
 			expr: &actionExpr{
-				pos: position{line: 4403, col: 9, offset: 133836},
+				pos: position{line: 4428, col: 9, offset: 134546},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4403, col: 10, offset: 133837},
+					pos: position{line: 4428, col: 10, offset: 134547},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4403, col: 10, offset: 133837},
+							pos:        position{line: 4428, col: 10, offset: 134547},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4403, col: 20, offset: 133847},
+							pos:        position{line: 4428, col: 20, offset: 134557},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4403, col: 29, offset: 133856},
+							pos:        position{line: 4428, col: 29, offset: 134566},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4403, col: 37, offset: 133864},
+							pos:        position{line: 4428, col: 37, offset: 134574},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4403, col: 44, offset: 133871},
+							pos:        position{line: 4428, col: 44, offset: 134581},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11079,27 +11079,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4407, col: 1, offset: 133910},
+			pos:  position{line: 4432, col: 1, offset: 134620},
 			expr: &actionExpr{
-				pos: position{line: 4407, col: 8, offset: 133917},
+				pos: position{line: 4432, col: 8, offset: 134627},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4407, col: 9, offset: 133918},
+					pos: position{line: 4432, col: 9, offset: 134628},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4407, col: 9, offset: 133918},
+							pos:        position{line: 4432, col: 9, offset: 134628},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4407, col: 18, offset: 133927},
+							pos:        position{line: 4432, col: 18, offset: 134637},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4407, col: 26, offset: 133935},
+							pos:        position{line: 4432, col: 26, offset: 134645},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11110,27 +11110,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4411, col: 1, offset: 133973},
+			pos:  position{line: 4436, col: 1, offset: 134683},
 			expr: &actionExpr{
-				pos: position{line: 4411, col: 9, offset: 133981},
+				pos: position{line: 4436, col: 9, offset: 134691},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4411, col: 10, offset: 133982},
+					pos: position{line: 4436, col: 10, offset: 134692},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4411, col: 10, offset: 133982},
+							pos:        position{line: 4436, col: 10, offset: 134692},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4411, col: 20, offset: 133992},
+							pos:        position{line: 4436, col: 20, offset: 134702},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4411, col: 29, offset: 134001},
+							pos:        position{line: 4436, col: 29, offset: 134711},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11141,27 +11141,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4415, col: 1, offset: 134040},
+			pos:  position{line: 4440, col: 1, offset: 134750},
 			expr: &actionExpr{
-				pos: position{line: 4415, col: 10, offset: 134049},
+				pos: position{line: 4440, col: 10, offset: 134759},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4415, col: 11, offset: 134050},
+					pos: position{line: 4440, col: 11, offset: 134760},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4415, col: 11, offset: 134050},
+							pos:        position{line: 4440, col: 11, offset: 134760},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4415, col: 22, offset: 134061},
+							pos:        position{line: 4440, col: 22, offset: 134771},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4415, col: 32, offset: 134071},
+							pos:        position{line: 4440, col: 32, offset: 134781},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11172,39 +11172,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4419, col: 1, offset: 134113},
+			pos:  position{line: 4444, col: 1, offset: 134823},
 			expr: &actionExpr{
-				pos: position{line: 4419, col: 12, offset: 134124},
+				pos: position{line: 4444, col: 12, offset: 134834},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4419, col: 13, offset: 134125},
+					pos: position{line: 4444, col: 13, offset: 134835},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4419, col: 13, offset: 134125},
+							pos:        position{line: 4444, col: 13, offset: 134835},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4419, col: 26, offset: 134138},
+							pos:        position{line: 4444, col: 26, offset: 134848},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4419, col: 38, offset: 134150},
+							pos:        position{line: 4444, col: 38, offset: 134860},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4419, col: 47, offset: 134159},
+							pos:        position{line: 4444, col: 47, offset: 134869},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4419, col: 55, offset: 134167},
+							pos:        position{line: 4444, col: 55, offset: 134877},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11215,39 +11215,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4423, col: 1, offset: 134209},
+			pos:  position{line: 4448, col: 1, offset: 134919},
 			expr: &actionExpr{
-				pos: position{line: 4423, col: 9, offset: 134217},
+				pos: position{line: 4448, col: 9, offset: 134927},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4423, col: 10, offset: 134218},
+					pos: position{line: 4448, col: 10, offset: 134928},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4423, col: 10, offset: 134218},
+							pos:        position{line: 4448, col: 10, offset: 134928},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4423, col: 20, offset: 134228},
+							pos:        position{line: 4448, col: 20, offset: 134938},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4423, col: 29, offset: 134237},
+							pos:        position{line: 4448, col: 29, offset: 134947},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4423, col: 37, offset: 134245},
+							pos:        position{line: 4448, col: 37, offset: 134955},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4423, col: 44, offset: 134252},
+							pos:        position{line: 4448, col: 44, offset: 134962},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11258,33 +11258,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4428, col: 1, offset: 134383},
+			pos:  position{line: 4453, col: 1, offset: 135093},
 			expr: &actionExpr{
-				pos: position{line: 4428, col: 15, offset: 134397},
+				pos: position{line: 4453, col: 15, offset: 135107},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4428, col: 16, offset: 134398},
+					pos: position{line: 4453, col: 16, offset: 135108},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4428, col: 16, offset: 134398},
+							pos:        position{line: 4453, col: 16, offset: 135108},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4428, col: 23, offset: 134405},
+							pos:        position{line: 4453, col: 23, offset: 135115},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4428, col: 30, offset: 134412},
+							pos:        position{line: 4453, col: 30, offset: 135122},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4428, col: 37, offset: 134419},
+							pos:        position{line: 4453, col: 37, offset: 135129},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11295,26 +11295,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4437, col: 1, offset: 134642},
+			pos:  position{line: 4462, col: 1, offset: 135352},
 			expr: &actionExpr{
-				pos: position{line: 4437, col: 21, offset: 134662},
+				pos: position{line: 4462, col: 21, offset: 135372},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4437, col: 21, offset: 134662},
+					pos: position{line: 4462, col: 21, offset: 135372},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4437, col: 21, offset: 134662},
+							pos:  position{line: 4462, col: 21, offset: 135372},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4437, col: 26, offset: 134667},
+							pos:  position{line: 4462, col: 26, offset: 135377},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4437, col: 42, offset: 134683},
+							pos:   position{line: 4462, col: 42, offset: 135393},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4437, col: 53, offset: 134694},
+								pos:  position{line: 4462, col: 53, offset: 135404},
 								name: "TransactionOptions",
 							},
 						},
@@ -11324,17 +11324,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4446, col: 1, offset: 135000},
+			pos:  position{line: 4471, col: 1, offset: 135710},
 			expr: &actionExpr{
-				pos: position{line: 4446, col: 23, offset: 135022},
+				pos: position{line: 4471, col: 23, offset: 135732},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4446, col: 23, offset: 135022},
+					pos:   position{line: 4471, col: 23, offset: 135732},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4446, col: 34, offset: 135033},
+						pos: position{line: 4471, col: 34, offset: 135743},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4446, col: 34, offset: 135033},
+							pos:  position{line: 4471, col: 34, offset: 135743},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11343,35 +11343,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4461, col: 1, offset: 135424},
+			pos:  position{line: 4486, col: 1, offset: 136134},
 			expr: &actionExpr{
-				pos: position{line: 4461, col: 37, offset: 135460},
+				pos: position{line: 4486, col: 37, offset: 136170},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4461, col: 37, offset: 135460},
+					pos: position{line: 4486, col: 37, offset: 136170},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4461, col: 37, offset: 135460},
+							pos:   position{line: 4486, col: 37, offset: 136170},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4461, col: 43, offset: 135466},
+								pos:  position{line: 4486, col: 43, offset: 136176},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4461, col: 71, offset: 135494},
+							pos:   position{line: 4486, col: 71, offset: 136204},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4461, col: 76, offset: 135499},
+								pos: position{line: 4486, col: 76, offset: 136209},
 								expr: &seqExpr{
-									pos: position{line: 4461, col: 77, offset: 135500},
+									pos: position{line: 4486, col: 77, offset: 136210},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4461, col: 77, offset: 135500},
+											pos:  position{line: 4486, col: 77, offset: 136210},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4461, col: 83, offset: 135506},
+											pos:  position{line: 4486, col: 83, offset: 136216},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11384,26 +11384,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4496, col: 1, offset: 136495},
+			pos:  position{line: 4521, col: 1, offset: 137205},
 			expr: &actionExpr{
-				pos: position{line: 4496, col: 32, offset: 136526},
+				pos: position{line: 4521, col: 32, offset: 137236},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4496, col: 32, offset: 136526},
+					pos:   position{line: 4521, col: 32, offset: 137236},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4496, col: 40, offset: 136534},
+						pos: position{line: 4521, col: 40, offset: 137244},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4496, col: 40, offset: 136534},
+								pos:  position{line: 4521, col: 40, offset: 137244},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4496, col: 77, offset: 136571},
+								pos:  position{line: 4521, col: 77, offset: 137281},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4496, col: 96, offset: 136590},
+								pos:  position{line: 4521, col: 96, offset: 137300},
 								name: "EndsWithOption",
 							},
 						},
@@ -11413,15 +11413,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4500, col: 1, offset: 136634},
+			pos:  position{line: 4525, col: 1, offset: 137344},
 			expr: &actionExpr{
-				pos: position{line: 4500, col: 39, offset: 136672},
+				pos: position{line: 4525, col: 39, offset: 137382},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4500, col: 39, offset: 136672},
+					pos:   position{line: 4525, col: 39, offset: 137382},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4500, col: 46, offset: 136679},
+						pos:  position{line: 4525, col: 46, offset: 137389},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11429,28 +11429,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4511, col: 1, offset: 136895},
+			pos:  position{line: 4536, col: 1, offset: 137605},
 			expr: &actionExpr{
-				pos: position{line: 4511, col: 21, offset: 136915},
+				pos: position{line: 4536, col: 21, offset: 137625},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4511, col: 21, offset: 136915},
+					pos: position{line: 4536, col: 21, offset: 137625},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4511, col: 21, offset: 136915},
+							pos:        position{line: 4536, col: 21, offset: 137625},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4511, col: 34, offset: 136928},
+							pos:  position{line: 4536, col: 34, offset: 137638},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4511, col: 40, offset: 136934},
+							pos:   position{line: 4536, col: 40, offset: 137644},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4511, col: 48, offset: 136942},
+								pos:  position{line: 4536, col: 48, offset: 137652},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11460,28 +11460,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4521, col: 1, offset: 137180},
+			pos:  position{line: 4546, col: 1, offset: 137890},
 			expr: &actionExpr{
-				pos: position{line: 4521, col: 19, offset: 137198},
+				pos: position{line: 4546, col: 19, offset: 137908},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4521, col: 19, offset: 137198},
+					pos: position{line: 4546, col: 19, offset: 137908},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4521, col: 19, offset: 137198},
+							pos:        position{line: 4546, col: 19, offset: 137908},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4521, col: 30, offset: 137209},
+							pos:  position{line: 4546, col: 30, offset: 137919},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4521, col: 36, offset: 137215},
+							pos:   position{line: 4546, col: 36, offset: 137925},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4521, col: 44, offset: 137223},
+								pos:  position{line: 4546, col: 44, offset: 137933},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11491,26 +11491,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4532, col: 1, offset: 137492},
+			pos:  position{line: 4557, col: 1, offset: 138202},
 			expr: &actionExpr{
-				pos: position{line: 4532, col: 28, offset: 137519},
+				pos: position{line: 4557, col: 28, offset: 138229},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4532, col: 28, offset: 137519},
+					pos:   position{line: 4557, col: 28, offset: 138229},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4532, col: 37, offset: 137528},
+						pos: position{line: 4557, col: 37, offset: 138238},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4532, col: 37, offset: 137528},
+								pos:  position{line: 4557, col: 37, offset: 138238},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4532, col: 63, offset: 137554},
+								pos:  position{line: 4557, col: 63, offset: 138264},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4532, col: 81, offset: 137572},
+								pos:  position{line: 4557, col: 81, offset: 138282},
 								name: "TransactionSearch",
 							},
 						},
@@ -11520,22 +11520,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4536, col: 1, offset: 137620},
+			pos:  position{line: 4561, col: 1, offset: 138330},
 			expr: &actionExpr{
-				pos: position{line: 4536, col: 28, offset: 137647},
+				pos: position{line: 4561, col: 28, offset: 138357},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4536, col: 28, offset: 137647},
+					pos:   position{line: 4561, col: 28, offset: 138357},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4536, col: 33, offset: 137652},
+						pos: position{line: 4561, col: 33, offset: 138362},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 33, offset: 137652},
+								pos:  position{line: 4561, col: 33, offset: 138362},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 64, offset: 137683},
+								pos:  position{line: 4561, col: 64, offset: 138393},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11545,29 +11545,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4540, col: 1, offset: 137743},
+			pos:  position{line: 4565, col: 1, offset: 138453},
 			expr: &actionExpr{
-				pos: position{line: 4540, col: 38, offset: 137780},
+				pos: position{line: 4565, col: 38, offset: 138490},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4540, col: 38, offset: 137780},
+					pos: position{line: 4565, col: 38, offset: 138490},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4540, col: 38, offset: 137780},
+							pos:        position{line: 4565, col: 38, offset: 138490},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4540, col: 42, offset: 137784},
+							pos:   position{line: 4565, col: 42, offset: 138494},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4540, col: 55, offset: 137797},
+								pos:  position{line: 4565, col: 55, offset: 138507},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4540, col: 68, offset: 137810},
+							pos:        position{line: 4565, col: 68, offset: 138520},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11578,23 +11578,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4548, col: 1, offset: 137949},
+			pos:  position{line: 4573, col: 1, offset: 138659},
 			expr: &actionExpr{
-				pos: position{line: 4548, col: 21, offset: 137969},
+				pos: position{line: 4573, col: 21, offset: 138679},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4548, col: 21, offset: 137969},
+					pos: position{line: 4573, col: 21, offset: 138679},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4548, col: 21, offset: 137969},
+							pos:        position{line: 4573, col: 21, offset: 138679},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4548, col: 25, offset: 137973},
+							pos: position{line: 4573, col: 25, offset: 138683},
 							expr: &charClassMatcher{
-								pos:        position{line: 4548, col: 25, offset: 137973},
+								pos:        position{line: 4573, col: 25, offset: 138683},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11602,7 +11602,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4548, col: 44, offset: 137992},
+							pos:        position{line: 4573, col: 44, offset: 138702},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11613,15 +11613,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4553, col: 1, offset: 138103},
+			pos:  position{line: 4578, col: 1, offset: 138813},
 			expr: &actionExpr{
-				pos: position{line: 4553, col: 33, offset: 138135},
+				pos: position{line: 4578, col: 33, offset: 138845},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4553, col: 33, offset: 138135},
+					pos:   position{line: 4578, col: 33, offset: 138845},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4553, col: 37, offset: 138139},
+						pos:  position{line: 4578, col: 37, offset: 138849},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11629,15 +11629,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4561, col: 1, offset: 138294},
+			pos:  position{line: 4586, col: 1, offset: 139004},
 			expr: &actionExpr{
-				pos: position{line: 4561, col: 22, offset: 138315},
+				pos: position{line: 4586, col: 22, offset: 139025},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4561, col: 22, offset: 138315},
+					pos:   position{line: 4586, col: 22, offset: 139025},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4561, col: 27, offset: 138320},
+						pos:  position{line: 4586, col: 27, offset: 139030},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11645,37 +11645,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4571, col: 1, offset: 138492},
+			pos:  position{line: 4596, col: 1, offset: 139202},
 			expr: &actionExpr{
-				pos: position{line: 4571, col: 20, offset: 138511},
+				pos: position{line: 4596, col: 20, offset: 139221},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4571, col: 20, offset: 138511},
+					pos: position{line: 4596, col: 20, offset: 139221},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4571, col: 20, offset: 138511},
+							pos:        position{line: 4596, col: 20, offset: 139221},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4571, col: 27, offset: 138518},
+							pos:  position{line: 4596, col: 27, offset: 139228},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4571, col: 42, offset: 138533},
+							pos:  position{line: 4596, col: 42, offset: 139243},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4571, col: 50, offset: 138541},
+							pos:   position{line: 4596, col: 50, offset: 139251},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4571, col: 60, offset: 138551},
+								pos:  position{line: 4596, col: 60, offset: 139261},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4571, col: 69, offset: 138560},
+							pos:  position{line: 4596, col: 69, offset: 139270},
 							name: "R_PAREN",
 						},
 					},
@@ -11684,22 +11684,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4581, col: 1, offset: 138863},
+			pos:  position{line: 4606, col: 1, offset: 139573},
 			expr: &actionExpr{
-				pos: position{line: 4581, col: 20, offset: 138882},
+				pos: position{line: 4606, col: 20, offset: 139592},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4581, col: 20, offset: 138882},
+					pos: position{line: 4606, col: 20, offset: 139592},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4581, col: 20, offset: 138882},
+							pos:  position{line: 4606, col: 20, offset: 139592},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4581, col: 25, offset: 138887},
+							pos:   position{line: 4606, col: 25, offset: 139597},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4581, col: 42, offset: 138904},
+								pos:  position{line: 4606, col: 42, offset: 139614},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11709,41 +11709,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4585, col: 1, offset: 138953},
+			pos:  position{line: 4610, col: 1, offset: 139663},
 			expr: &actionExpr{
-				pos: position{line: 4585, col: 16, offset: 138968},
+				pos: position{line: 4610, col: 16, offset: 139678},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4585, col: 16, offset: 138968},
+					pos: position{line: 4610, col: 16, offset: 139678},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4585, col: 16, offset: 138968},
+							pos:  position{line: 4610, col: 16, offset: 139678},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4585, col: 27, offset: 138979},
+							pos:  position{line: 4610, col: 27, offset: 139689},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4585, col: 33, offset: 138985},
+							pos:   position{line: 4610, col: 33, offset: 139695},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4585, col: 50, offset: 139002},
+								pos: position{line: 4610, col: 50, offset: 139712},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4585, col: 50, offset: 139002},
+									pos:  position{line: 4610, col: 50, offset: 139712},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4585, col: 70, offset: 139022},
+							pos:  position{line: 4610, col: 70, offset: 139732},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4585, col: 85, offset: 139037},
+							pos:   position{line: 4610, col: 85, offset: 139747},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4585, col: 91, offset: 139043},
+								pos:  position{line: 4610, col: 91, offset: 139753},
 								name: "FieldName",
 							},
 						},
@@ -11753,35 +11753,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4614, col: 1, offset: 139814},
+			pos:  position{line: 4639, col: 1, offset: 140524},
 			expr: &actionExpr{
-				pos: position{line: 4614, col: 23, offset: 139836},
+				pos: position{line: 4639, col: 23, offset: 140546},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4614, col: 23, offset: 139836},
+					pos: position{line: 4639, col: 23, offset: 140546},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4614, col: 23, offset: 139836},
+							pos:   position{line: 4639, col: 23, offset: 140546},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4614, col: 31, offset: 139844},
+								pos:  position{line: 4639, col: 31, offset: 140554},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4614, col: 46, offset: 139859},
+							pos:   position{line: 4639, col: 46, offset: 140569},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4614, col: 52, offset: 139865},
+								pos: position{line: 4639, col: 52, offset: 140575},
 								expr: &seqExpr{
-									pos: position{line: 4614, col: 53, offset: 139866},
+									pos: position{line: 4639, col: 53, offset: 140576},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4614, col: 53, offset: 139866},
+											pos:  position{line: 4639, col: 53, offset: 140576},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4614, col: 59, offset: 139872},
+											pos:  position{line: 4639, col: 59, offset: 140582},
 											name: "MVBlockOption",
 										},
 									},
@@ -11794,26 +11794,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4648, col: 1, offset: 140928},
+			pos:  position{line: 4673, col: 1, offset: 141638},
 			expr: &actionExpr{
-				pos: position{line: 4648, col: 18, offset: 140945},
+				pos: position{line: 4673, col: 18, offset: 141655},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4648, col: 18, offset: 140945},
+					pos:   position{line: 4673, col: 18, offset: 141655},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4648, col: 27, offset: 140954},
+						pos: position{line: 4673, col: 27, offset: 141664},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4648, col: 27, offset: 140954},
+								pos:  position{line: 4673, col: 27, offset: 141664},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4648, col: 41, offset: 140968},
+								pos:  position{line: 4673, col: 41, offset: 141678},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4648, col: 60, offset: 140987},
+								pos:  position{line: 4673, col: 60, offset: 141697},
 								name: "SetSvOption",
 							},
 						},
@@ -11823,22 +11823,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4652, col: 1, offset: 141028},
+			pos:  position{line: 4677, col: 1, offset: 141738},
 			expr: &actionExpr{
-				pos: position{line: 4652, col: 16, offset: 141043},
+				pos: position{line: 4677, col: 16, offset: 141753},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4652, col: 16, offset: 141043},
+					pos:   position{line: 4677, col: 16, offset: 141753},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4652, col: 28, offset: 141055},
+						pos: position{line: 4677, col: 28, offset: 141765},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4652, col: 28, offset: 141055},
+								pos:  position{line: 4677, col: 28, offset: 141765},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4652, col: 46, offset: 141073},
+								pos:  position{line: 4677, col: 46, offset: 141783},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11848,28 +11848,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4656, col: 1, offset: 141120},
+			pos:  position{line: 4681, col: 1, offset: 141830},
 			expr: &actionExpr{
-				pos: position{line: 4656, col: 20, offset: 141139},
+				pos: position{line: 4681, col: 20, offset: 141849},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4656, col: 20, offset: 141139},
+					pos: position{line: 4681, col: 20, offset: 141849},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4656, col: 20, offset: 141139},
+							pos:        position{line: 4681, col: 20, offset: 141849},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4656, col: 28, offset: 141147},
+							pos:  position{line: 4681, col: 28, offset: 141857},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4656, col: 34, offset: 141153},
+							pos:   position{line: 4681, col: 34, offset: 141863},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4656, col: 38, offset: 141157},
+								pos:  position{line: 4681, col: 38, offset: 141867},
 								name: "QuotedString",
 							},
 						},
@@ -11879,28 +11879,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4667, col: 1, offset: 141408},
+			pos:  position{line: 4692, col: 1, offset: 142118},
 			expr: &actionExpr{
-				pos: position{line: 4667, col: 19, offset: 141426},
+				pos: position{line: 4692, col: 19, offset: 142136},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4667, col: 19, offset: 141426},
+					pos: position{line: 4692, col: 19, offset: 142136},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4667, col: 19, offset: 141426},
+							pos:        position{line: 4692, col: 19, offset: 142136},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4667, col: 31, offset: 141438},
+							pos:  position{line: 4692, col: 31, offset: 142148},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4667, col: 37, offset: 141444},
+							pos:   position{line: 4692, col: 37, offset: 142154},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4667, col: 41, offset: 141448},
+								pos:  position{line: 4692, col: 41, offset: 142158},
 								name: "QuotedString",
 							},
 						},
@@ -11910,28 +11910,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4685, col: 1, offset: 141919},
+			pos:  position{line: 4710, col: 1, offset: 142629},
 			expr: &actionExpr{
-				pos: position{line: 4685, col: 21, offset: 141939},
+				pos: position{line: 4710, col: 21, offset: 142649},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4685, col: 21, offset: 141939},
+					pos: position{line: 4710, col: 21, offset: 142649},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4685, col: 21, offset: 141939},
+							pos:        position{line: 4710, col: 21, offset: 142649},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4685, col: 34, offset: 141952},
+							pos:  position{line: 4710, col: 34, offset: 142662},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4685, col: 40, offset: 141958},
+							pos:   position{line: 4710, col: 40, offset: 142668},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4685, col: 48, offset: 141966},
+								pos:  position{line: 4710, col: 48, offset: 142676},
 								name: "Boolean",
 							},
 						},
@@ -11941,28 +11941,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4697, col: 1, offset: 142206},
+			pos:  position{line: 4722, col: 1, offset: 142916},
 			expr: &actionExpr{
-				pos: position{line: 4697, col: 16, offset: 142221},
+				pos: position{line: 4722, col: 16, offset: 142931},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4697, col: 16, offset: 142221},
+					pos: position{line: 4722, col: 16, offset: 142931},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4697, col: 16, offset: 142221},
+							pos:        position{line: 4722, col: 16, offset: 142931},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4697, col: 24, offset: 142229},
+							pos:  position{line: 4722, col: 24, offset: 142939},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4697, col: 30, offset: 142235},
+							pos:   position{line: 4722, col: 30, offset: 142945},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4697, col: 38, offset: 142243},
+								pos:  position{line: 4722, col: 38, offset: 142953},
 								name: "Boolean",
 							},
 						},
@@ -11972,28 +11972,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4709, col: 1, offset: 142508},
+			pos:  position{line: 4734, col: 1, offset: 143218},
 			expr: &actionExpr{
-				pos: position{line: 4709, col: 15, offset: 142522},
+				pos: position{line: 4734, col: 15, offset: 143232},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4709, col: 15, offset: 142522},
+					pos: position{line: 4734, col: 15, offset: 143232},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4709, col: 15, offset: 142522},
+							pos:  position{line: 4734, col: 15, offset: 143232},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4709, col: 20, offset: 142527},
+							pos:  position{line: 4734, col: 20, offset: 143237},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4709, col: 30, offset: 142537},
+							pos:   position{line: 4734, col: 30, offset: 143247},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4709, col: 40, offset: 142547},
+								pos: position{line: 4734, col: 40, offset: 143257},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4709, col: 40, offset: 142547},
+									pos:  position{line: 4734, col: 40, offset: 143257},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12004,39 +12004,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4716, col: 1, offset: 142673},
+			pos:  position{line: 4741, col: 1, offset: 143383},
 			expr: &actionExpr{
-				pos: position{line: 4716, col: 23, offset: 142695},
+				pos: position{line: 4741, col: 23, offset: 143405},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4716, col: 23, offset: 142695},
+					pos: position{line: 4741, col: 23, offset: 143405},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4716, col: 23, offset: 142695},
+							pos:  position{line: 4741, col: 23, offset: 143405},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4716, col: 29, offset: 142701},
+							pos:   position{line: 4741, col: 29, offset: 143411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4716, col: 35, offset: 142707},
+								pos:  position{line: 4741, col: 35, offset: 143417},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4716, col: 49, offset: 142721},
+							pos:   position{line: 4741, col: 49, offset: 143431},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4716, col: 54, offset: 142726},
+								pos: position{line: 4741, col: 54, offset: 143436},
 								expr: &seqExpr{
-									pos: position{line: 4716, col: 55, offset: 142727},
+									pos: position{line: 4741, col: 55, offset: 143437},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4716, col: 55, offset: 142727},
+											pos:  position{line: 4741, col: 55, offset: 143437},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4716, col: 61, offset: 142733},
+											pos:  position{line: 4741, col: 61, offset: 143443},
 											name: "SPathArgument",
 										},
 									},
@@ -12049,26 +12049,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4748, col: 1, offset: 143626},
+			pos:  position{line: 4773, col: 1, offset: 144336},
 			expr: &actionExpr{
-				pos: position{line: 4748, col: 18, offset: 143643},
+				pos: position{line: 4773, col: 18, offset: 144353},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4748, col: 18, offset: 143643},
+					pos:   position{line: 4773, col: 18, offset: 144353},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4748, col: 23, offset: 143648},
+						pos: position{line: 4773, col: 23, offset: 144358},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4748, col: 23, offset: 143648},
+								pos:  position{line: 4773, col: 23, offset: 144358},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4748, col: 36, offset: 143661},
+								pos:  position{line: 4773, col: 36, offset: 144371},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4748, col: 50, offset: 143675},
+								pos:  position{line: 4773, col: 50, offset: 144385},
 								name: "PathField",
 							},
 						},
@@ -12078,28 +12078,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4752, col: 1, offset: 143711},
+			pos:  position{line: 4777, col: 1, offset: 144421},
 			expr: &actionExpr{
-				pos: position{line: 4752, col: 15, offset: 143725},
+				pos: position{line: 4777, col: 15, offset: 144435},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4752, col: 15, offset: 143725},
+					pos: position{line: 4777, col: 15, offset: 144435},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4752, col: 15, offset: 143725},
+							pos:        position{line: 4777, col: 15, offset: 144435},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4752, col: 23, offset: 143733},
+							pos:  position{line: 4777, col: 23, offset: 144443},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4752, col: 29, offset: 143739},
+							pos:   position{line: 4777, col: 29, offset: 144449},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4752, col: 35, offset: 143745},
+								pos:  position{line: 4777, col: 35, offset: 144455},
 								name: "FieldName",
 							},
 						},
@@ -12109,28 +12109,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4755, col: 1, offset: 143801},
+			pos:  position{line: 4780, col: 1, offset: 144511},
 			expr: &actionExpr{
-				pos: position{line: 4755, col: 16, offset: 143816},
+				pos: position{line: 4780, col: 16, offset: 144526},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4755, col: 16, offset: 143816},
+					pos: position{line: 4780, col: 16, offset: 144526},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4755, col: 16, offset: 143816},
+							pos:        position{line: 4780, col: 16, offset: 144526},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4755, col: 25, offset: 143825},
+							pos:  position{line: 4780, col: 25, offset: 144535},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4755, col: 31, offset: 143831},
+							pos:   position{line: 4780, col: 31, offset: 144541},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4755, col: 37, offset: 143837},
+								pos:  position{line: 4780, col: 37, offset: 144547},
 								name: "FieldName",
 							},
 						},
@@ -12140,34 +12140,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4758, col: 1, offset: 143894},
+			pos:  position{line: 4783, col: 1, offset: 144604},
 			expr: &actionExpr{
-				pos: position{line: 4758, col: 14, offset: 143907},
+				pos: position{line: 4783, col: 14, offset: 144617},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4758, col: 15, offset: 143908},
+					pos: position{line: 4783, col: 15, offset: 144618},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4758, col: 15, offset: 143908},
+							pos: position{line: 4783, col: 15, offset: 144618},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4758, col: 15, offset: 143908},
+									pos:        position{line: 4783, col: 15, offset: 144618},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4758, col: 22, offset: 143915},
+									pos:  position{line: 4783, col: 22, offset: 144625},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4758, col: 28, offset: 143921},
+									pos:  position{line: 4783, col: 28, offset: 144631},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4758, col: 47, offset: 143940},
+							pos:  position{line: 4783, col: 47, offset: 144650},
 							name: "SPathFieldString",
 						},
 					},
@@ -12176,16 +12176,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4770, col: 1, offset: 144352},
+			pos:  position{line: 4795, col: 1, offset: 145062},
 			expr: &choiceExpr{
-				pos: position{line: 4770, col: 21, offset: 144372},
+				pos: position{line: 4795, col: 21, offset: 145082},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4770, col: 21, offset: 144372},
+						pos:  position{line: 4795, col: 21, offset: 145082},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4770, col: 36, offset: 144387},
+						pos:  position{line: 4795, col: 36, offset: 145097},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12193,28 +12193,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4773, col: 1, offset: 144460},
+			pos:  position{line: 4798, col: 1, offset: 145170},
 			expr: &actionExpr{
-				pos: position{line: 4773, col: 16, offset: 144475},
+				pos: position{line: 4798, col: 16, offset: 145185},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4773, col: 16, offset: 144475},
+					pos: position{line: 4798, col: 16, offset: 145185},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4773, col: 16, offset: 144475},
+							pos:  position{line: 4798, col: 16, offset: 145185},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4773, col: 21, offset: 144480},
+							pos:  position{line: 4798, col: 21, offset: 145190},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4773, col: 32, offset: 144491},
+							pos:   position{line: 4798, col: 32, offset: 145201},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4773, col: 46, offset: 144505},
+								pos: position{line: 4798, col: 46, offset: 145215},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4773, col: 46, offset: 144505},
+									pos:  position{line: 4798, col: 46, offset: 145215},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12225,39 +12225,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4795, col: 1, offset: 145114},
+			pos:  position{line: 4820, col: 1, offset: 145824},
 			expr: &actionExpr{
-				pos: position{line: 4795, col: 24, offset: 145137},
+				pos: position{line: 4820, col: 24, offset: 145847},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4795, col: 24, offset: 145137},
+					pos: position{line: 4820, col: 24, offset: 145847},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4795, col: 24, offset: 145137},
+							pos:  position{line: 4820, col: 24, offset: 145847},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4795, col: 30, offset: 145143},
+							pos:   position{line: 4820, col: 30, offset: 145853},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4795, col: 37, offset: 145150},
+								pos:  position{line: 4820, col: 37, offset: 145860},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4795, col: 52, offset: 145165},
+							pos:   position{line: 4820, col: 52, offset: 145875},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4795, col: 57, offset: 145170},
+								pos: position{line: 4820, col: 57, offset: 145880},
 								expr: &seqExpr{
-									pos: position{line: 4795, col: 58, offset: 145171},
+									pos: position{line: 4820, col: 58, offset: 145881},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4795, col: 58, offset: 145171},
+											pos:  position{line: 4820, col: 58, offset: 145881},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4795, col: 64, offset: 145177},
+											pos:  position{line: 4820, col: 64, offset: 145887},
 											name: "FormatArgument",
 										},
 									},
@@ -12270,30 +12270,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4829, col: 1, offset: 146366},
+			pos:  position{line: 4854, col: 1, offset: 147076},
 			expr: &actionExpr{
-				pos: position{line: 4829, col: 19, offset: 146384},
+				pos: position{line: 4854, col: 19, offset: 147094},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4829, col: 19, offset: 146384},
+					pos:   position{line: 4854, col: 19, offset: 147094},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4829, col: 28, offset: 146393},
+						pos: position{line: 4854, col: 28, offset: 147103},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4829, col: 28, offset: 146393},
+								pos:  position{line: 4854, col: 28, offset: 147103},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4829, col: 46, offset: 146411},
+								pos:  position{line: 4854, col: 46, offset: 147121},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4829, col: 65, offset: 146430},
+								pos:  position{line: 4854, col: 65, offset: 147140},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4829, col: 82, offset: 146447},
+								pos:  position{line: 4854, col: 82, offset: 147157},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12303,28 +12303,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4833, col: 1, offset: 146497},
+			pos:  position{line: 4858, col: 1, offset: 147207},
 			expr: &actionExpr{
-				pos: position{line: 4833, col: 20, offset: 146516},
+				pos: position{line: 4858, col: 20, offset: 147226},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4833, col: 20, offset: 146516},
+					pos: position{line: 4858, col: 20, offset: 147226},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4833, col: 20, offset: 146516},
+							pos:        position{line: 4858, col: 20, offset: 147226},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4833, col: 28, offset: 146524},
+							pos:  position{line: 4858, col: 28, offset: 147234},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4833, col: 34, offset: 146530},
+							pos:   position{line: 4858, col: 34, offset: 147240},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4833, col: 38, offset: 146534},
+								pos:  position{line: 4858, col: 38, offset: 147244},
 								name: "QuotedString",
 							},
 						},
@@ -12334,28 +12334,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4842, col: 1, offset: 146746},
+			pos:  position{line: 4867, col: 1, offset: 147456},
 			expr: &actionExpr{
-				pos: position{line: 4842, col: 21, offset: 146766},
+				pos: position{line: 4867, col: 21, offset: 147476},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4842, col: 21, offset: 146766},
+					pos: position{line: 4867, col: 21, offset: 147476},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4842, col: 21, offset: 146766},
+							pos:        position{line: 4867, col: 21, offset: 147476},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4842, col: 34, offset: 146779},
+							pos:  position{line: 4867, col: 34, offset: 147489},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4842, col: 40, offset: 146785},
+							pos:   position{line: 4867, col: 40, offset: 147495},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4842, col: 47, offset: 146792},
+								pos:  position{line: 4867, col: 47, offset: 147502},
 								name: "IntegerAsString",
 							},
 						},
@@ -12365,28 +12365,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4855, col: 1, offset: 147198},
+			pos:  position{line: 4880, col: 1, offset: 147908},
 			expr: &actionExpr{
-				pos: position{line: 4855, col: 19, offset: 147216},
+				pos: position{line: 4880, col: 19, offset: 147926},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4855, col: 19, offset: 147216},
+					pos: position{line: 4880, col: 19, offset: 147926},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4855, col: 19, offset: 147216},
+							pos:        position{line: 4880, col: 19, offset: 147926},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4855, col: 30, offset: 147227},
+							pos:  position{line: 4880, col: 30, offset: 147937},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4855, col: 36, offset: 147233},
+							pos:   position{line: 4880, col: 36, offset: 147943},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4855, col: 40, offset: 147237},
+								pos:  position{line: 4880, col: 40, offset: 147947},
 								name: "QuotedString",
 							},
 						},
@@ -12396,78 +12396,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4864, col: 1, offset: 147452},
+			pos:  position{line: 4889, col: 1, offset: 148162},
 			expr: &actionExpr{
-				pos: position{line: 4864, col: 24, offset: 147475},
+				pos: position{line: 4889, col: 24, offset: 148185},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4864, col: 24, offset: 147475},
+					pos: position{line: 4889, col: 24, offset: 148185},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4864, col: 24, offset: 147475},
+							pos:   position{line: 4889, col: 24, offset: 148185},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 34, offset: 147485},
+								pos:  position{line: 4889, col: 34, offset: 148195},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4864, col: 47, offset: 147498},
+							pos:  position{line: 4889, col: 47, offset: 148208},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4864, col: 53, offset: 147504},
+							pos:   position{line: 4889, col: 53, offset: 148214},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 63, offset: 147514},
+								pos:  position{line: 4889, col: 63, offset: 148224},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4864, col: 76, offset: 147527},
+							pos:  position{line: 4889, col: 76, offset: 148237},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4864, col: 82, offset: 147533},
+							pos:   position{line: 4889, col: 82, offset: 148243},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 95, offset: 147546},
+								pos:  position{line: 4889, col: 95, offset: 148256},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4864, col: 108, offset: 147559},
+							pos:  position{line: 4889, col: 108, offset: 148269},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4864, col: 114, offset: 147565},
+							pos:   position{line: 4889, col: 114, offset: 148275},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 121, offset: 147572},
+								pos:  position{line: 4889, col: 121, offset: 148282},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4864, col: 134, offset: 147585},
+							pos:  position{line: 4889, col: 134, offset: 148295},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4864, col: 140, offset: 147591},
+							pos:   position{line: 4889, col: 140, offset: 148301},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 153, offset: 147604},
+								pos:  position{line: 4889, col: 153, offset: 148314},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4864, col: 166, offset: 147617},
+							pos:  position{line: 4889, col: 166, offset: 148327},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4864, col: 172, offset: 147623},
+							pos:   position{line: 4889, col: 172, offset: 148333},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4864, col: 179, offset: 147630},
+								pos:  position{line: 4889, col: 179, offset: 148340},
 								name: "QuotedString",
 							},
 						},
@@ -12477,28 +12477,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4882, col: 1, offset: 148206},
+			pos:  position{line: 4907, col: 1, offset: 148916},
 			expr: &actionExpr{
-				pos: position{line: 4882, col: 20, offset: 148225},
+				pos: position{line: 4907, col: 20, offset: 148935},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4882, col: 20, offset: 148225},
+					pos: position{line: 4907, col: 20, offset: 148935},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4882, col: 20, offset: 148225},
+							pos:  position{line: 4907, col: 20, offset: 148935},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4882, col: 25, offset: 148230},
+							pos:  position{line: 4907, col: 25, offset: 148940},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4882, col: 40, offset: 148245},
+							pos:   position{line: 4907, col: 40, offset: 148955},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4882, col: 55, offset: 148260},
+								pos: position{line: 4907, col: 55, offset: 148970},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4882, col: 55, offset: 148260},
+									pos:  position{line: 4907, col: 55, offset: 148970},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12509,42 +12509,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4889, col: 1, offset: 148413},
+			pos:  position{line: 4914, col: 1, offset: 149123},
 			expr: &actionExpr{
-				pos: position{line: 4889, col: 28, offset: 148440},
+				pos: position{line: 4914, col: 28, offset: 149150},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4889, col: 28, offset: 148440},
+					pos: position{line: 4914, col: 28, offset: 149150},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4889, col: 28, offset: 148440},
+							pos:  position{line: 4914, col: 28, offset: 149150},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4889, col: 34, offset: 148446},
+							pos:   position{line: 4914, col: 34, offset: 149156},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4889, col: 40, offset: 148452},
+								pos: position{line: 4914, col: 40, offset: 149162},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4889, col: 40, offset: 148452},
+									pos:  position{line: 4914, col: 40, offset: 149162},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4889, col: 60, offset: 148472},
+							pos:   position{line: 4914, col: 60, offset: 149182},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4889, col: 65, offset: 148477},
+								pos: position{line: 4914, col: 65, offset: 149187},
 								expr: &seqExpr{
-									pos: position{line: 4889, col: 66, offset: 148478},
+									pos: position{line: 4914, col: 66, offset: 149188},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4889, col: 66, offset: 148478},
+											pos:  position{line: 4914, col: 66, offset: 149188},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4889, col: 72, offset: 148484},
+											pos:  position{line: 4914, col: 72, offset: 149194},
 											name: "EventCountArgument",
 										},
 									},
@@ -12557,30 +12557,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4945, col: 1, offset: 150361},
+			pos:  position{line: 4970, col: 1, offset: 151071},
 			expr: &actionExpr{
-				pos: position{line: 4945, col: 23, offset: 150383},
+				pos: position{line: 4970, col: 23, offset: 151093},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4945, col: 23, offset: 150383},
+					pos:   position{line: 4970, col: 23, offset: 151093},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4945, col: 28, offset: 150388},
+						pos: position{line: 4970, col: 28, offset: 151098},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4945, col: 28, offset: 150388},
+								pos:  position{line: 4970, col: 28, offset: 151098},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4945, col: 41, offset: 150401},
+								pos:  position{line: 4970, col: 41, offset: 151111},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4945, col: 58, offset: 150418},
+								pos:  position{line: 4970, col: 58, offset: 151128},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4945, col: 76, offset: 150436},
+								pos:  position{line: 4970, col: 76, offset: 151146},
 								name: "ListVixField",
 							},
 						},
@@ -12590,28 +12590,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4949, col: 1, offset: 150475},
+			pos:  position{line: 4974, col: 1, offset: 151185},
 			expr: &actionExpr{
-				pos: position{line: 4949, col: 15, offset: 150489},
+				pos: position{line: 4974, col: 15, offset: 151199},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4949, col: 15, offset: 150489},
+					pos: position{line: 4974, col: 15, offset: 151199},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4949, col: 15, offset: 150489},
+							pos:        position{line: 4974, col: 15, offset: 151199},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4949, col: 23, offset: 150497},
+							pos:  position{line: 4974, col: 23, offset: 151207},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4949, col: 29, offset: 150503},
+							pos:   position{line: 4974, col: 29, offset: 151213},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4949, col: 35, offset: 150509},
+								pos:  position{line: 4974, col: 35, offset: 151219},
 								name: "IndexName",
 							},
 						},
@@ -12621,28 +12621,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4952, col: 1, offset: 150565},
+			pos:  position{line: 4977, col: 1, offset: 151275},
 			expr: &actionExpr{
-				pos: position{line: 4952, col: 19, offset: 150583},
+				pos: position{line: 4977, col: 19, offset: 151293},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4952, col: 19, offset: 150583},
+					pos: position{line: 4977, col: 19, offset: 151293},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4952, col: 19, offset: 150583},
+							pos:        position{line: 4977, col: 19, offset: 151293},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4952, col: 31, offset: 150595},
+							pos:  position{line: 4977, col: 31, offset: 151305},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4952, col: 37, offset: 150601},
+							pos:   position{line: 4977, col: 37, offset: 151311},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4952, col: 43, offset: 150607},
+								pos:  position{line: 4977, col: 43, offset: 151317},
 								name: "Boolean",
 							},
 						},
@@ -12652,28 +12652,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4955, col: 1, offset: 150683},
+			pos:  position{line: 4980, col: 1, offset: 151393},
 			expr: &actionExpr{
-				pos: position{line: 4955, col: 20, offset: 150702},
+				pos: position{line: 4980, col: 20, offset: 151412},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4955, col: 20, offset: 150702},
+					pos: position{line: 4980, col: 20, offset: 151412},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4955, col: 20, offset: 150702},
+							pos:        position{line: 4980, col: 20, offset: 151412},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4955, col: 34, offset: 150716},
+							pos:  position{line: 4980, col: 34, offset: 151426},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4955, col: 40, offset: 150722},
+							pos:   position{line: 4980, col: 40, offset: 151432},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4955, col: 46, offset: 150728},
+								pos:  position{line: 4980, col: 46, offset: 151438},
 								name: "Boolean",
 							},
 						},
@@ -12683,28 +12683,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4958, col: 1, offset: 150806},
+			pos:  position{line: 4983, col: 1, offset: 151516},
 			expr: &actionExpr{
-				pos: position{line: 4958, col: 17, offset: 150822},
+				pos: position{line: 4983, col: 17, offset: 151532},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4958, col: 17, offset: 150822},
+					pos: position{line: 4983, col: 17, offset: 151532},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4958, col: 17, offset: 150822},
+							pos:        position{line: 4983, col: 17, offset: 151532},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4958, col: 28, offset: 150833},
+							pos:  position{line: 4983, col: 28, offset: 151543},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4958, col: 34, offset: 150839},
+							pos:   position{line: 4983, col: 34, offset: 151549},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4958, col: 40, offset: 150845},
+								pos:  position{line: 4983, col: 40, offset: 151555},
 								name: "Boolean",
 							},
 						},
@@ -12714,24 +12714,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 4962, col: 1, offset: 150921},
+			pos:  position{line: 4987, col: 1, offset: 151631},
 			expr: &actionExpr{
-				pos: position{line: 4962, col: 14, offset: 150934},
+				pos: position{line: 4987, col: 14, offset: 151644},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4962, col: 14, offset: 150934},
+					pos: position{line: 4987, col: 14, offset: 151644},
 					expr: &seqExpr{
-						pos: position{line: 4962, col: 15, offset: 150935},
+						pos: position{line: 4987, col: 15, offset: 151645},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 4962, col: 15, offset: 150935},
+								pos: position{line: 4987, col: 15, offset: 151645},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4962, col: 16, offset: 150936},
+									pos:  position{line: 4987, col: 16, offset: 151646},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 4962, col: 22, offset: 150942,
+								line: 4987, col: 22, offset: 151652,
 							},
 						},
 					},
@@ -12740,39 +12740,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 4967, col: 1, offset: 151015},
+			pos:  position{line: 4992, col: 1, offset: 151725},
 			expr: &actionExpr{
-				pos: position{line: 4967, col: 18, offset: 151032},
+				pos: position{line: 4992, col: 18, offset: 151742},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4967, col: 18, offset: 151032},
+					pos: position{line: 4992, col: 18, offset: 151742},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4967, col: 18, offset: 151032},
+							pos:  position{line: 4992, col: 18, offset: 151742},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4967, col: 23, offset: 151037},
+							pos:  position{line: 4992, col: 23, offset: 151747},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4967, col: 36, offset: 151050},
+							pos:   position{line: 4992, col: 36, offset: 151760},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4967, col: 49, offset: 151063},
+								pos: position{line: 4992, col: 49, offset: 151773},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4967, col: 49, offset: 151063},
+									pos:  position{line: 4992, col: 49, offset: 151773},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4967, col: 70, offset: 151084},
+							pos:   position{line: 4992, col: 70, offset: 151794},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4967, col: 77, offset: 151091},
+								pos: position{line: 4992, col: 77, offset: 151801},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4967, col: 77, offset: 151091},
+									pos:  position{line: 4992, col: 77, offset: 151801},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12783,32 +12783,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 4997, col: 1, offset: 151854},
+			pos:  position{line: 5022, col: 1, offset: 152564},
 			expr: &actionExpr{
-				pos: position{line: 4997, col: 24, offset: 151877},
+				pos: position{line: 5022, col: 24, offset: 152587},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 4997, col: 24, offset: 151877},
+					pos: position{line: 5022, col: 24, offset: 152587},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4997, col: 24, offset: 151877},
+							pos:  position{line: 5022, col: 24, offset: 152587},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4997, col: 30, offset: 151883},
+							pos:        position{line: 5022, col: 30, offset: 152593},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4997, col: 38, offset: 151891},
+							pos:  position{line: 5022, col: 38, offset: 152601},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4997, col: 44, offset: 151897},
+							pos:   position{line: 5022, col: 44, offset: 152607},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4997, col: 48, offset: 151901},
+								pos:  position{line: 5022, col: 48, offset: 152611},
 								name: "String",
 							},
 						},
@@ -12818,22 +12818,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5001, col: 1, offset: 151947},
+			pos:  position{line: 5026, col: 1, offset: 152657},
 			expr: &actionExpr{
-				pos: position{line: 5001, col: 22, offset: 151968},
+				pos: position{line: 5026, col: 22, offset: 152678},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5001, col: 22, offset: 151968},
+					pos: position{line: 5026, col: 22, offset: 152678},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5001, col: 22, offset: 151968},
+							pos:  position{line: 5026, col: 22, offset: 152678},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5001, col: 28, offset: 151974},
+							pos:   position{line: 5026, col: 28, offset: 152684},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5001, col: 38, offset: 151984},
+								pos:  position{line: 5026, col: 38, offset: 152694},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12843,36 +12843,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5005, col: 1, offset: 152043},
+			pos:  position{line: 5030, col: 1, offset: 152753},
 			expr: &actionExpr{
-				pos: position{line: 5005, col: 18, offset: 152060},
+				pos: position{line: 5030, col: 18, offset: 152770},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5005, col: 18, offset: 152060},
+					pos: position{line: 5030, col: 18, offset: 152770},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5005, col: 18, offset: 152060},
+							pos:  position{line: 5030, col: 18, offset: 152770},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5005, col: 23, offset: 152065},
+							pos:  position{line: 5030, col: 23, offset: 152775},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5005, col: 36, offset: 152078},
+							pos:   position{line: 5030, col: 36, offset: 152788},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5005, col: 42, offset: 152084},
+								pos:  position{line: 5030, col: 42, offset: 152794},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5005, col: 56, offset: 152098},
+							pos:   position{line: 5030, col: 56, offset: 152808},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5005, col: 65, offset: 152107},
+								pos: position{line: 5030, col: 65, offset: 152817},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5005, col: 65, offset: 152107},
+									pos:  position{line: 5030, col: 65, offset: 152817},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12883,22 +12883,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5034, col: 1, offset: 152896},
+			pos:  position{line: 5059, col: 1, offset: 153606},
 			expr: &actionExpr{
-				pos: position{line: 5034, col: 18, offset: 152913},
+				pos: position{line: 5059, col: 18, offset: 153623},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5034, col: 18, offset: 152913},
+					pos: position{line: 5059, col: 18, offset: 153623},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5034, col: 18, offset: 152913},
+							pos:  position{line: 5059, col: 18, offset: 153623},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5034, col: 24, offset: 152919},
+							pos:   position{line: 5059, col: 24, offset: 153629},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5034, col: 34, offset: 152929},
+								pos:  position{line: 5059, col: 34, offset: 153639},
 								name: "FieldName",
 							},
 						},
@@ -12908,32 +12908,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5038, col: 1, offset: 152970},
+			pos:  position{line: 5063, col: 1, offset: 153680},
 			expr: &actionExpr{
-				pos: position{line: 5038, col: 18, offset: 152987},
+				pos: position{line: 5063, col: 18, offset: 153697},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5038, col: 18, offset: 152987},
+					pos: position{line: 5063, col: 18, offset: 153697},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5038, col: 18, offset: 152987},
+							pos:  position{line: 5063, col: 18, offset: 153697},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5038, col: 24, offset: 152993},
+							pos:        position{line: 5063, col: 24, offset: 153703},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5038, col: 32, offset: 153001},
+							pos:  position{line: 5063, col: 32, offset: 153711},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5038, col: 38, offset: 153007},
+							pos:   position{line: 5063, col: 38, offset: 153717},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5038, col: 47, offset: 153016},
+								pos:  position{line: 5063, col: 47, offset: 153726},
 								name: "IntegerAsString",
 							},
 						},
@@ -12943,26 +12943,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5042, col: 1, offset: 153062},
+			pos:  position{line: 5067, col: 1, offset: 153772},
 			expr: &actionExpr{
-				pos: position{line: 5042, col: 16, offset: 153077},
+				pos: position{line: 5067, col: 16, offset: 153787},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5042, col: 16, offset: 153077},
+					pos: position{line: 5067, col: 16, offset: 153787},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5042, col: 16, offset: 153077},
+							pos:  position{line: 5067, col: 16, offset: 153787},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5042, col: 22, offset: 153083},
+							pos:  position{line: 5067, col: 22, offset: 153793},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5042, col: 32, offset: 153093},
+							pos:   position{line: 5067, col: 32, offset: 153803},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5042, col: 42, offset: 153103},
+								pos:  position{line: 5067, col: 42, offset: 153813},
 								name: "BoolExpr",
 							},
 						},
@@ -12972,28 +12972,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5046, col: 1, offset: 153163},
+			pos:  position{line: 5071, col: 1, offset: 153873},
 			expr: &actionExpr{
-				pos: position{line: 5046, col: 28, offset: 153190},
+				pos: position{line: 5071, col: 28, offset: 153900},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5046, col: 28, offset: 153190},
+					pos: position{line: 5071, col: 28, offset: 153900},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5046, col: 28, offset: 153190},
+							pos:        position{line: 5071, col: 28, offset: 153900},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5046, col: 37, offset: 153199},
+							pos:  position{line: 5071, col: 37, offset: 153909},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5046, col: 43, offset: 153205},
+							pos:   position{line: 5071, col: 43, offset: 153915},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5046, col: 51, offset: 153213},
+								pos:  position{line: 5071, col: 51, offset: 153923},
 								name: "Boolean",
 							},
 						},
@@ -13003,28 +13003,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5055, col: 1, offset: 153397},
+			pos:  position{line: 5080, col: 1, offset: 154107},
 			expr: &actionExpr{
-				pos: position{line: 5055, col: 28, offset: 153424},
+				pos: position{line: 5080, col: 28, offset: 154134},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5055, col: 28, offset: 153424},
+					pos: position{line: 5080, col: 28, offset: 154134},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5055, col: 28, offset: 153424},
+							pos:        position{line: 5080, col: 28, offset: 154134},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5055, col: 37, offset: 153433},
+							pos:  position{line: 5080, col: 37, offset: 154143},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5055, col: 43, offset: 153439},
+							pos:   position{line: 5080, col: 43, offset: 154149},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5055, col: 51, offset: 153447},
+								pos:  position{line: 5080, col: 51, offset: 154157},
 								name: "Boolean",
 							},
 						},
@@ -13034,28 +13034,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5064, col: 1, offset: 153631},
+			pos:  position{line: 5089, col: 1, offset: 154341},
 			expr: &actionExpr{
-				pos: position{line: 5064, col: 27, offset: 153657},
+				pos: position{line: 5089, col: 27, offset: 154367},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5064, col: 27, offset: 153657},
+					pos: position{line: 5089, col: 27, offset: 154367},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5064, col: 27, offset: 153657},
+							pos:        position{line: 5089, col: 27, offset: 154367},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5064, col: 35, offset: 153665},
+							pos:  position{line: 5089, col: 35, offset: 154375},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5064, col: 41, offset: 153671},
+							pos:   position{line: 5089, col: 41, offset: 154381},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5064, col: 48, offset: 153678},
+								pos:  position{line: 5089, col: 48, offset: 154388},
 								name: "PositiveInteger",
 							},
 						},
@@ -13065,28 +13065,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5073, col: 1, offset: 153869},
+			pos:  position{line: 5098, col: 1, offset: 154579},
 			expr: &actionExpr{
-				pos: position{line: 5073, col: 25, offset: 153893},
+				pos: position{line: 5098, col: 25, offset: 154603},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5073, col: 25, offset: 153893},
+					pos: position{line: 5098, col: 25, offset: 154603},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5073, col: 25, offset: 153893},
+							pos:        position{line: 5098, col: 25, offset: 154603},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5073, col: 31, offset: 153899},
+							pos:  position{line: 5098, col: 31, offset: 154609},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5073, col: 37, offset: 153905},
+							pos:   position{line: 5098, col: 37, offset: 154615},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5073, col: 44, offset: 153912},
+								pos:  position{line: 5098, col: 44, offset: 154622},
 								name: "PositiveInteger",
 							},
 						},
@@ -13096,30 +13096,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5082, col: 1, offset: 154099},
+			pos:  position{line: 5107, col: 1, offset: 154809},
 			expr: &actionExpr{
-				pos: position{line: 5082, col: 22, offset: 154120},
+				pos: position{line: 5107, col: 22, offset: 154830},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5082, col: 22, offset: 154120},
+					pos:   position{line: 5107, col: 22, offset: 154830},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5082, col: 41, offset: 154139},
+						pos: position{line: 5107, col: 41, offset: 154849},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5082, col: 41, offset: 154139},
+								pos:  position{line: 5107, col: 41, offset: 154849},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5082, col: 67, offset: 154165},
+								pos:  position{line: 5107, col: 67, offset: 154875},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5082, col: 93, offset: 154191},
+								pos:  position{line: 5107, col: 93, offset: 154901},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5082, col: 118, offset: 154216},
+								pos:  position{line: 5107, col: 118, offset: 154926},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13129,35 +13129,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5086, col: 1, offset: 154277},
+			pos:  position{line: 5111, col: 1, offset: 154987},
 			expr: &actionExpr{
-				pos: position{line: 5086, col: 26, offset: 154302},
+				pos: position{line: 5111, col: 26, offset: 155012},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5086, col: 26, offset: 154302},
+					pos: position{line: 5111, col: 26, offset: 155012},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5086, col: 26, offset: 154302},
+							pos:   position{line: 5111, col: 26, offset: 155012},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5086, col: 34, offset: 154310},
+								pos:  position{line: 5111, col: 34, offset: 155020},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5086, col: 53, offset: 154329},
+							pos:   position{line: 5111, col: 53, offset: 155039},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5086, col: 58, offset: 154334},
+								pos: position{line: 5111, col: 58, offset: 155044},
 								expr: &seqExpr{
-									pos: position{line: 5086, col: 59, offset: 154335},
+									pos: position{line: 5111, col: 59, offset: 155045},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5086, col: 59, offset: 154335},
+											pos:  position{line: 5111, col: 59, offset: 155045},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5086, col: 65, offset: 154341},
+											pos:  position{line: 5111, col: 65, offset: 155051},
 											name: "InputLookupOption",
 										},
 									},
@@ -13170,35 +13170,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5128, col: 1, offset: 155787},
+			pos:  position{line: 5153, col: 1, offset: 156497},
 			expr: &actionExpr{
-				pos: position{line: 5128, col: 21, offset: 155807},
+				pos: position{line: 5153, col: 21, offset: 156517},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5128, col: 21, offset: 155807},
+					pos: position{line: 5153, col: 21, offset: 156517},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5128, col: 21, offset: 155807},
+							pos:  position{line: 5153, col: 21, offset: 156517},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5128, col: 26, offset: 155812},
+							pos:  position{line: 5153, col: 26, offset: 156522},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5128, col: 42, offset: 155828},
+							pos:   position{line: 5153, col: 42, offset: 156538},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5128, col: 60, offset: 155846},
+								pos: position{line: 5153, col: 60, offset: 156556},
 								expr: &seqExpr{
-									pos: position{line: 5128, col: 61, offset: 155847},
+									pos: position{line: 5153, col: 61, offset: 156557},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5128, col: 61, offset: 155847},
+											pos:  position{line: 5153, col: 61, offset: 156557},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5128, col: 83, offset: 155869},
+											pos:  position{line: 5153, col: 83, offset: 156579},
 											name: "SPACE",
 										},
 									},
@@ -13206,20 +13206,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5128, col: 91, offset: 155877},
+							pos:   position{line: 5153, col: 91, offset: 156587},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5128, col: 101, offset: 155887},
+								pos:  position{line: 5153, col: 101, offset: 156597},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5128, col: 109, offset: 155895},
+							pos:   position{line: 5153, col: 109, offset: 156605},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5128, col: 121, offset: 155907},
+								pos: position{line: 5153, col: 121, offset: 156617},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5128, col: 122, offset: 155908},
+									pos:  position{line: 5153, col: 122, offset: 156618},
 									name: "WhereClause",
 								},
 							},
@@ -13230,15 +13230,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5151, col: 1, offset: 156596},
+			pos:  position{line: 5176, col: 1, offset: 157306},
 			expr: &actionExpr{
-				pos: position{line: 5151, col: 24, offset: 156619},
+				pos: position{line: 5176, col: 24, offset: 157329},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5151, col: 24, offset: 156619},
+					pos:   position{line: 5176, col: 24, offset: 157329},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5151, col: 41, offset: 156636},
+						pos:  position{line: 5176, col: 41, offset: 157346},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13246,26 +13246,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5162, col: 1, offset: 157035},
+			pos:  position{line: 5187, col: 1, offset: 157745},
 			expr: &actionExpr{
-				pos: position{line: 5162, col: 20, offset: 157054},
+				pos: position{line: 5187, col: 20, offset: 157764},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5162, col: 20, offset: 157054},
+					pos:   position{line: 5187, col: 20, offset: 157764},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5162, col: 28, offset: 157062},
+						pos: position{line: 5187, col: 28, offset: 157772},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5162, col: 28, offset: 157062},
+								pos:  position{line: 5187, col: 28, offset: 157772},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5162, col: 52, offset: 157086},
+								pos:  position{line: 5187, col: 52, offset: 157796},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5162, col: 68, offset: 157102},
+								pos:  position{line: 5187, col: 68, offset: 157812},
 								name: "MaxOutOption",
 							},
 						},
@@ -13275,28 +13275,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5167, col: 1, offset: 157200},
+			pos:  position{line: 5192, col: 1, offset: 157910},
 			expr: &actionExpr{
-				pos: position{line: 5167, col: 26, offset: 157225},
+				pos: position{line: 5192, col: 26, offset: 157935},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5167, col: 26, offset: 157225},
+					pos: position{line: 5192, col: 26, offset: 157935},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5167, col: 26, offset: 157225},
+							pos:        position{line: 5192, col: 26, offset: 157935},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5167, col: 44, offset: 157243},
+							pos:  position{line: 5192, col: 44, offset: 157953},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5167, col: 50, offset: 157249},
+							pos:   position{line: 5192, col: 50, offset: 157959},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5167, col: 58, offset: 157257},
+								pos:  position{line: 5192, col: 58, offset: 157967},
 								name: "Boolean",
 							},
 						},
@@ -13306,28 +13306,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5174, col: 1, offset: 157396},
+			pos:  position{line: 5199, col: 1, offset: 158106},
 			expr: &actionExpr{
-				pos: position{line: 5174, col: 18, offset: 157413},
+				pos: position{line: 5199, col: 18, offset: 158123},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5174, col: 18, offset: 157413},
+					pos: position{line: 5199, col: 18, offset: 158123},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5174, col: 18, offset: 157413},
+							pos:        position{line: 5199, col: 18, offset: 158123},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5174, col: 28, offset: 157423},
+							pos:  position{line: 5199, col: 28, offset: 158133},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5174, col: 34, offset: 157429},
+							pos:   position{line: 5199, col: 34, offset: 158139},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5174, col: 39, offset: 157434},
+								pos:  position{line: 5199, col: 39, offset: 158144},
 								name: "IntegerAsString",
 							},
 						},
@@ -13337,28 +13337,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5185, col: 1, offset: 157735},
+			pos:  position{line: 5210, col: 1, offset: 158445},
 			expr: &actionExpr{
-				pos: position{line: 5185, col: 17, offset: 157751},
+				pos: position{line: 5210, col: 17, offset: 158461},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5185, col: 17, offset: 157751},
+					pos: position{line: 5210, col: 17, offset: 158461},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5185, col: 17, offset: 157751},
+							pos:        position{line: 5210, col: 17, offset: 158461},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5185, col: 26, offset: 157760},
+							pos:  position{line: 5210, col: 26, offset: 158470},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5185, col: 32, offset: 157766},
+							pos:   position{line: 5210, col: 32, offset: 158476},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5185, col: 36, offset: 157770},
+								pos:  position{line: 5210, col: 36, offset: 158480},
 								name: "IntegerAsString",
 							},
 						},
@@ -13368,43 +13368,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5197, col: 1, offset: 158125},
+			pos:  position{line: 5222, col: 1, offset: 158835},
 			expr: &actionExpr{
-				pos: position{line: 5197, col: 14, offset: 158138},
+				pos: position{line: 5222, col: 14, offset: 158848},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5197, col: 14, offset: 158138},
+					pos: position{line: 5222, col: 14, offset: 158848},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5197, col: 14, offset: 158138},
+							pos:        position{line: 5222, col: 14, offset: 158848},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5197, col: 18, offset: 158142},
+							pos: position{line: 5222, col: 18, offset: 158852},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5197, col: 18, offset: 158142},
+								pos:  position{line: 5222, col: 18, offset: 158852},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5197, col: 25, offset: 158149},
+							pos:   position{line: 5222, col: 25, offset: 158859},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5197, col: 32, offset: 158156},
+								pos:  position{line: 5222, col: 32, offset: 158866},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5197, col: 44, offset: 158168},
+							pos: position{line: 5222, col: 44, offset: 158878},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5197, col: 44, offset: 158168},
+								pos:  position{line: 5222, col: 44, offset: 158878},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5197, col: 51, offset: 158175},
+							pos:        position{line: 5222, col: 51, offset: 158885},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13415,35 +13415,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5202, col: 1, offset: 158264},
+			pos:  position{line: 5227, col: 1, offset: 158974},
 			expr: &actionExpr{
-				pos: position{line: 5202, col: 25, offset: 158288},
+				pos: position{line: 5227, col: 25, offset: 158998},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5202, col: 25, offset: 158288},
+					pos: position{line: 5227, col: 25, offset: 158998},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5202, col: 25, offset: 158288},
+							pos:   position{line: 5227, col: 25, offset: 158998},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5202, col: 31, offset: 158294},
+								pos:  position{line: 5227, col: 31, offset: 159004},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5202, col: 47, offset: 158310},
+							pos:   position{line: 5227, col: 47, offset: 159020},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5202, col: 52, offset: 158315},
+								pos: position{line: 5227, col: 52, offset: 159025},
 								expr: &seqExpr{
-									pos: position{line: 5202, col: 53, offset: 158316},
+									pos: position{line: 5227, col: 53, offset: 159026},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5202, col: 53, offset: 158316},
+											pos:  position{line: 5227, col: 53, offset: 159026},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5202, col: 59, offset: 158322},
+											pos:  position{line: 5227, col: 59, offset: 159032},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13456,37 +13456,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5229, col: 1, offset: 159132},
+			pos:  position{line: 5254, col: 1, offset: 159842},
 			expr: &actionExpr{
-				pos: position{line: 5229, col: 16, offset: 159147},
+				pos: position{line: 5254, col: 16, offset: 159857},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5229, col: 16, offset: 159147},
+					pos: position{line: 5254, col: 16, offset: 159857},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5229, col: 16, offset: 159147},
+							pos:  position{line: 5254, col: 16, offset: 159857},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5229, col: 21, offset: 159152},
+							pos:  position{line: 5254, col: 21, offset: 159862},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5229, col: 32, offset: 159163},
+							pos:   position{line: 5254, col: 32, offset: 159873},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5229, col: 40, offset: 159171},
+								pos: position{line: 5254, col: 40, offset: 159881},
 								expr: &seqExpr{
-									pos: position{line: 5229, col: 41, offset: 159172},
+									pos: position{line: 5254, col: 41, offset: 159882},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5229, col: 41, offset: 159172},
+											pos:  position{line: 5254, col: 41, offset: 159882},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5229, col: 57, offset: 159188},
+											pos: position{line: 5254, col: 57, offset: 159898},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5229, col: 57, offset: 159188},
+												pos:  position{line: 5254, col: 57, offset: 159898},
 												name: "SPACE",
 											},
 										},
@@ -13495,10 +13495,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5229, col: 66, offset: 159197},
+							pos:   position{line: 5254, col: 66, offset: 159907},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5229, col: 76, offset: 159207},
+								pos:  position{line: 5254, col: 76, offset: 159917},
 								name: "Subsearch",
 							},
 						},
@@ -13508,128 +13508,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5273, col: 1, offset: 160779},
+			pos:  position{line: 5298, col: 1, offset: 161489},
 			expr: &choiceExpr{
-				pos: position{line: 5273, col: 12, offset: 160790},
+				pos: position{line: 5298, col: 12, offset: 161500},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 12, offset: 160790},
+						pos:  position{line: 5298, col: 12, offset: 161500},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 24, offset: 160802},
+						pos:  position{line: 5298, col: 24, offset: 161512},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 36, offset: 160814},
+						pos:  position{line: 5298, col: 36, offset: 161524},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 49, offset: 160827},
+						pos:  position{line: 5298, col: 49, offset: 161537},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 61, offset: 160839},
+						pos:  position{line: 5298, col: 61, offset: 161549},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 81, offset: 160859},
+						pos:  position{line: 5298, col: 81, offset: 161569},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 92, offset: 160870},
+						pos:  position{line: 5298, col: 92, offset: 161580},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 112, offset: 160890},
+						pos:  position{line: 5298, col: 112, offset: 161600},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 123, offset: 160901},
+						pos:  position{line: 5298, col: 123, offset: 161611},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 134, offset: 160912},
+						pos:  position{line: 5298, col: 134, offset: 161622},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 144, offset: 160922},
+						pos:  position{line: 5298, col: 144, offset: 161632},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 154, offset: 160932},
+						pos:  position{line: 5298, col: 154, offset: 161642},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 165, offset: 160943},
+						pos:  position{line: 5298, col: 165, offset: 161653},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 178, offset: 160956},
+						pos:  position{line: 5298, col: 178, offset: 161666},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 194, offset: 160972},
+						pos:  position{line: 5298, col: 194, offset: 161682},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 212, offset: 160990},
+						pos:  position{line: 5298, col: 212, offset: 161700},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 224, offset: 161002},
+						pos:  position{line: 5298, col: 224, offset: 161712},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 235, offset: 161013},
+						pos:  position{line: 5298, col: 235, offset: 161723},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 248, offset: 161026},
+						pos:  position{line: 5298, col: 248, offset: 161736},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 260, offset: 161038},
+						pos:  position{line: 5298, col: 260, offset: 161748},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 273, offset: 161051},
+						pos:  position{line: 5298, col: 273, offset: 161761},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 288, offset: 161066},
+						pos:  position{line: 5298, col: 288, offset: 161776},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 301, offset: 161079},
+						pos:  position{line: 5298, col: 301, offset: 161789},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 318, offset: 161096},
+						pos:  position{line: 5298, col: 318, offset: 161806},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 328, offset: 161106},
+						pos:  position{line: 5298, col: 328, offset: 161816},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 346, offset: 161124},
+						pos:  position{line: 5298, col: 346, offset: 161834},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 361, offset: 161139},
+						pos:  position{line: 5298, col: 361, offset: 161849},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 376, offset: 161154},
+						pos:  position{line: 5298, col: 376, offset: 161864},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 391, offset: 161169},
+						pos:  position{line: 5298, col: 391, offset: 161879},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5273, col: 409, offset: 161187},
+						pos:  position{line: 5298, col: 409, offset: 161897},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13637,18 +13637,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5274, col: 1, offset: 161199},
+			pos:  position{line: 5299, col: 1, offset: 161909},
 			expr: &seqExpr{
-				pos: position{line: 5274, col: 15, offset: 161213},
+				pos: position{line: 5299, col: 15, offset: 161923},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5274, col: 15, offset: 161213},
+						pos:        position{line: 5299, col: 15, offset: 161923},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5274, col: 24, offset: 161222},
+						pos:  position{line: 5299, col: 24, offset: 161932},
 						name: "SPACE",
 					},
 				},
@@ -13656,18 +13656,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5275, col: 1, offset: 161228},
+			pos:  position{line: 5300, col: 1, offset: 161938},
 			expr: &seqExpr{
-				pos: position{line: 5275, col: 14, offset: 161241},
+				pos: position{line: 5300, col: 14, offset: 161951},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5275, col: 14, offset: 161241},
+						pos:        position{line: 5300, col: 14, offset: 161951},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5275, col: 22, offset: 161249},
+						pos:  position{line: 5300, col: 22, offset: 161959},
 						name: "SPACE",
 					},
 				},
@@ -13675,18 +13675,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5276, col: 1, offset: 161255},
+			pos:  position{line: 5301, col: 1, offset: 161965},
 			expr: &seqExpr{
-				pos: position{line: 5276, col: 14, offset: 161268},
+				pos: position{line: 5301, col: 14, offset: 161978},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5276, col: 14, offset: 161268},
+						pos:        position{line: 5301, col: 14, offset: 161978},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5276, col: 22, offset: 161276},
+						pos:  position{line: 5301, col: 22, offset: 161986},
 						name: "SPACE",
 					},
 				},
@@ -13694,18 +13694,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5277, col: 1, offset: 161282},
+			pos:  position{line: 5302, col: 1, offset: 161992},
 			expr: &seqExpr{
-				pos: position{line: 5277, col: 20, offset: 161301},
+				pos: position{line: 5302, col: 20, offset: 162011},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5277, col: 20, offset: 161301},
+						pos:        position{line: 5302, col: 20, offset: 162011},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5277, col: 34, offset: 161315},
+						pos:  position{line: 5302, col: 34, offset: 162025},
 						name: "SPACE",
 					},
 				},
@@ -13713,18 +13713,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5278, col: 1, offset: 161321},
+			pos:  position{line: 5303, col: 1, offset: 162031},
 			expr: &seqExpr{
-				pos: position{line: 5278, col: 15, offset: 161335},
+				pos: position{line: 5303, col: 15, offset: 162045},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5278, col: 15, offset: 161335},
+						pos:        position{line: 5303, col: 15, offset: 162045},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5278, col: 24, offset: 161344},
+						pos:  position{line: 5303, col: 24, offset: 162054},
 						name: "SPACE",
 					},
 				},
@@ -13732,18 +13732,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5279, col: 1, offset: 161350},
+			pos:  position{line: 5304, col: 1, offset: 162060},
 			expr: &seqExpr{
-				pos: position{line: 5279, col: 14, offset: 161363},
+				pos: position{line: 5304, col: 14, offset: 162073},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5279, col: 14, offset: 161363},
+						pos:        position{line: 5304, col: 14, offset: 162073},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5279, col: 22, offset: 161371},
+						pos:  position{line: 5304, col: 22, offset: 162081},
 						name: "SPACE",
 					},
 				},
@@ -13751,9 +13751,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5280, col: 1, offset: 161377},
+			pos:  position{line: 5305, col: 1, offset: 162087},
 			expr: &litMatcher{
-				pos:        position{line: 5280, col: 22, offset: 161398},
+				pos:        position{line: 5305, col: 22, offset: 162108},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13761,16 +13761,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5281, col: 1, offset: 161405},
+			pos:  position{line: 5306, col: 1, offset: 162115},
 			expr: &seqExpr{
-				pos: position{line: 5281, col: 13, offset: 161417},
+				pos: position{line: 5306, col: 13, offset: 162127},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5281, col: 13, offset: 161417},
+						pos:  position{line: 5306, col: 13, offset: 162127},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5281, col: 31, offset: 161435},
+						pos:  position{line: 5306, col: 31, offset: 162145},
 						name: "SPACE",
 					},
 				},
@@ -13778,9 +13778,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5282, col: 1, offset: 161441},
+			pos:  position{line: 5307, col: 1, offset: 162151},
 			expr: &litMatcher{
-				pos:        position{line: 5282, col: 22, offset: 161462},
+				pos:        position{line: 5307, col: 22, offset: 162172},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13788,16 +13788,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5283, col: 1, offset: 161469},
+			pos:  position{line: 5308, col: 1, offset: 162179},
 			expr: &seqExpr{
-				pos: position{line: 5283, col: 13, offset: 161481},
+				pos: position{line: 5308, col: 13, offset: 162191},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5283, col: 13, offset: 161481},
+						pos:  position{line: 5308, col: 13, offset: 162191},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5283, col: 31, offset: 161499},
+						pos:  position{line: 5308, col: 31, offset: 162209},
 						name: "SPACE",
 					},
 				},
@@ -13805,18 +13805,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5284, col: 1, offset: 161505},
+			pos:  position{line: 5309, col: 1, offset: 162215},
 			expr: &seqExpr{
-				pos: position{line: 5284, col: 13, offset: 161517},
+				pos: position{line: 5309, col: 13, offset: 162227},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5284, col: 13, offset: 161517},
+						pos:        position{line: 5309, col: 13, offset: 162227},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5284, col: 20, offset: 161524},
+						pos:  position{line: 5309, col: 20, offset: 162234},
 						name: "SPACE",
 					},
 				},
@@ -13824,18 +13824,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5285, col: 1, offset: 161530},
+			pos:  position{line: 5310, col: 1, offset: 162240},
 			expr: &seqExpr{
-				pos: position{line: 5285, col: 12, offset: 161541},
+				pos: position{line: 5310, col: 12, offset: 162251},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5285, col: 12, offset: 161541},
+						pos:        position{line: 5310, col: 12, offset: 162251},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5285, col: 18, offset: 161547},
+						pos:  position{line: 5310, col: 18, offset: 162257},
 						name: "SPACE",
 					},
 				},
@@ -13843,18 +13843,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5286, col: 1, offset: 161553},
+			pos:  position{line: 5311, col: 1, offset: 162263},
 			expr: &seqExpr{
-				pos: position{line: 5286, col: 13, offset: 161565},
+				pos: position{line: 5311, col: 13, offset: 162275},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5286, col: 13, offset: 161565},
+						pos:        position{line: 5311, col: 13, offset: 162275},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5286, col: 20, offset: 161572},
+						pos:  position{line: 5311, col: 20, offset: 162282},
 						name: "SPACE",
 					},
 				},
@@ -13862,9 +13862,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5287, col: 1, offset: 161578},
+			pos:  position{line: 5312, col: 1, offset: 162288},
 			expr: &litMatcher{
-				pos:        position{line: 5287, col: 12, offset: 161589},
+				pos:        position{line: 5312, col: 12, offset: 162299},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13872,9 +13872,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5288, col: 1, offset: 161595},
+			pos:  position{line: 5313, col: 1, offset: 162305},
 			expr: &litMatcher{
-				pos:        position{line: 5288, col: 13, offset: 161607},
+				pos:        position{line: 5313, col: 13, offset: 162317},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13882,18 +13882,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5289, col: 1, offset: 161614},
+			pos:  position{line: 5314, col: 1, offset: 162324},
 			expr: &seqExpr{
-				pos: position{line: 5289, col: 15, offset: 161628},
+				pos: position{line: 5314, col: 15, offset: 162338},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5289, col: 15, offset: 161628},
+						pos:        position{line: 5314, col: 15, offset: 162338},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5289, col: 24, offset: 161637},
+						pos:  position{line: 5314, col: 24, offset: 162347},
 						name: "SPACE",
 					},
 				},
@@ -13901,18 +13901,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5290, col: 1, offset: 161643},
+			pos:  position{line: 5315, col: 1, offset: 162353},
 			expr: &seqExpr{
-				pos: position{line: 5290, col: 18, offset: 161660},
+				pos: position{line: 5315, col: 18, offset: 162370},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5290, col: 18, offset: 161660},
+						pos:        position{line: 5315, col: 18, offset: 162370},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5290, col: 30, offset: 161672},
+						pos:  position{line: 5315, col: 30, offset: 162382},
 						name: "SPACE",
 					},
 				},
@@ -13920,18 +13920,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5291, col: 1, offset: 161678},
+			pos:  position{line: 5316, col: 1, offset: 162388},
 			expr: &seqExpr{
-				pos: position{line: 5291, col: 12, offset: 161689},
+				pos: position{line: 5316, col: 12, offset: 162399},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5291, col: 12, offset: 161689},
+						pos:        position{line: 5316, col: 12, offset: 162399},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5291, col: 18, offset: 161695},
+						pos:  position{line: 5316, col: 18, offset: 162405},
 						name: "SPACE",
 					},
 				},
@@ -13939,9 +13939,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5292, col: 1, offset: 161701},
+			pos:  position{line: 5317, col: 1, offset: 162411},
 			expr: &litMatcher{
-				pos:        position{line: 5292, col: 13, offset: 161713},
+				pos:        position{line: 5317, col: 13, offset: 162423},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13949,18 +13949,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5293, col: 1, offset: 161720},
+			pos:  position{line: 5318, col: 1, offset: 162430},
 			expr: &seqExpr{
-				pos: position{line: 5293, col: 20, offset: 161739},
+				pos: position{line: 5318, col: 20, offset: 162449},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5293, col: 20, offset: 161739},
+						pos:        position{line: 5318, col: 20, offset: 162449},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5293, col: 34, offset: 161753},
+						pos:  position{line: 5318, col: 34, offset: 162463},
 						name: "SPACE",
 					},
 				},
@@ -13968,9 +13968,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5294, col: 1, offset: 161759},
+			pos:  position{line: 5319, col: 1, offset: 162469},
 			expr: &litMatcher{
-				pos:        position{line: 5294, col: 14, offset: 161772},
+				pos:        position{line: 5319, col: 14, offset: 162482},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13978,22 +13978,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5295, col: 1, offset: 161780},
+			pos:  position{line: 5320, col: 1, offset: 162490},
 			expr: &seqExpr{
-				pos: position{line: 5295, col: 21, offset: 161800},
+				pos: position{line: 5320, col: 21, offset: 162510},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5295, col: 21, offset: 161800},
+						pos:  position{line: 5320, col: 21, offset: 162510},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5295, col: 27, offset: 161806},
+						pos:        position{line: 5320, col: 27, offset: 162516},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5295, col: 36, offset: 161815},
+						pos:  position{line: 5320, col: 36, offset: 162525},
 						name: "SPACE",
 					},
 				},
@@ -14001,9 +14001,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5296, col: 1, offset: 161821},
+			pos:  position{line: 5321, col: 1, offset: 162531},
 			expr: &litMatcher{
-				pos:        position{line: 5296, col: 15, offset: 161835},
+				pos:        position{line: 5321, col: 15, offset: 162545},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14011,9 +14011,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5297, col: 1, offset: 161844},
+			pos:  position{line: 5322, col: 1, offset: 162554},
 			expr: &litMatcher{
-				pos:        position{line: 5297, col: 14, offset: 161857},
+				pos:        position{line: 5322, col: 14, offset: 162567},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14021,9 +14021,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5298, col: 1, offset: 161865},
+			pos:  position{line: 5323, col: 1, offset: 162575},
 			expr: &litMatcher{
-				pos:        position{line: 5298, col: 15, offset: 161879},
+				pos:        position{line: 5323, col: 15, offset: 162589},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14031,9 +14031,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5299, col: 1, offset: 161888},
+			pos:  position{line: 5324, col: 1, offset: 162598},
 			expr: &litMatcher{
-				pos:        position{line: 5299, col: 17, offset: 161904},
+				pos:        position{line: 5324, col: 17, offset: 162614},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14041,9 +14041,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5300, col: 1, offset: 161915},
+			pos:  position{line: 5325, col: 1, offset: 162625},
 			expr: &litMatcher{
-				pos:        position{line: 5300, col: 15, offset: 161929},
+				pos:        position{line: 5325, col: 15, offset: 162639},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14051,9 +14051,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5301, col: 1, offset: 161938},
+			pos:  position{line: 5326, col: 1, offset: 162648},
 			expr: &litMatcher{
-				pos:        position{line: 5301, col: 19, offset: 161956},
+				pos:        position{line: 5326, col: 19, offset: 162666},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14061,9 +14061,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5302, col: 1, offset: 161969},
+			pos:  position{line: 5327, col: 1, offset: 162679},
 			expr: &litMatcher{
-				pos:        position{line: 5302, col: 17, offset: 161985},
+				pos:        position{line: 5327, col: 17, offset: 162695},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14071,9 +14071,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5303, col: 1, offset: 161996},
+			pos:  position{line: 5328, col: 1, offset: 162706},
 			expr: &litMatcher{
-				pos:        position{line: 5303, col: 17, offset: 162012},
+				pos:        position{line: 5328, col: 17, offset: 162722},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14081,18 +14081,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5304, col: 1, offset: 162023},
+			pos:  position{line: 5329, col: 1, offset: 162733},
 			expr: &seqExpr{
-				pos: position{line: 5304, col: 20, offset: 162042},
+				pos: position{line: 5329, col: 20, offset: 162752},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5304, col: 20, offset: 162042},
+						pos:        position{line: 5329, col: 20, offset: 162752},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5304, col: 34, offset: 162056},
+						pos:  position{line: 5329, col: 34, offset: 162766},
 						name: "SPACE",
 					},
 				},
@@ -14100,28 +14100,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5305, col: 1, offset: 162062},
+			pos:  position{line: 5330, col: 1, offset: 162772},
 			expr: &seqExpr{
-				pos: position{line: 5305, col: 16, offset: 162077},
+				pos: position{line: 5330, col: 16, offset: 162787},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5305, col: 16, offset: 162077},
+						pos: position{line: 5330, col: 16, offset: 162787},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5305, col: 16, offset: 162077},
+							pos:  position{line: 5330, col: 16, offset: 162787},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5305, col: 24, offset: 162085},
+						pos: position{line: 5330, col: 24, offset: 162795},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5305, col: 24, offset: 162085},
+								pos:        position{line: 5330, col: 24, offset: 162795},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5305, col: 30, offset: 162091},
+								pos:        position{line: 5330, col: 30, offset: 162801},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14129,9 +14129,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5305, col: 35, offset: 162096},
+						pos: position{line: 5330, col: 35, offset: 162806},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5305, col: 35, offset: 162096},
+							pos:  position{line: 5330, col: 35, offset: 162806},
 							name: "SPACE",
 						},
 					},
@@ -14140,9 +14140,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5306, col: 1, offset: 162103},
+			pos:  position{line: 5331, col: 1, offset: 162813},
 			expr: &litMatcher{
-				pos:        position{line: 5306, col: 17, offset: 162119},
+				pos:        position{line: 5331, col: 17, offset: 162829},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14150,18 +14150,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5307, col: 1, offset: 162130},
+			pos:  position{line: 5332, col: 1, offset: 162840},
 			expr: &seqExpr{
-				pos: position{line: 5307, col: 15, offset: 162144},
+				pos: position{line: 5332, col: 15, offset: 162854},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5307, col: 15, offset: 162144},
+						pos:        position{line: 5332, col: 15, offset: 162854},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5307, col: 24, offset: 162153},
+						pos:  position{line: 5332, col: 24, offset: 162863},
 						name: "SPACE",
 					},
 				},
@@ -14169,115 +14169,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5310, col: 1, offset: 162263},
+			pos:  position{line: 5335, col: 1, offset: 162973},
 			expr: &choiceExpr{
-				pos: position{line: 5310, col: 16, offset: 162278},
+				pos: position{line: 5335, col: 16, offset: 162988},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5310, col: 16, offset: 162278},
+						pos:        position{line: 5335, col: 16, offset: 162988},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5310, col: 47, offset: 162309},
+						pos:        position{line: 5335, col: 47, offset: 163019},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5310, col: 55, offset: 162317},
+						pos:        position{line: 5335, col: 55, offset: 163027},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 16, offset: 162340},
+						pos:        position{line: 5336, col: 16, offset: 163050},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 26, offset: 162350},
+						pos:        position{line: 5336, col: 26, offset: 163060},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 34, offset: 162358},
+						pos:        position{line: 5336, col: 34, offset: 163068},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 42, offset: 162366},
+						pos:        position{line: 5336, col: 42, offset: 163076},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 50, offset: 162374},
+						pos:        position{line: 5336, col: 50, offset: 163084},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 58, offset: 162382},
+						pos:        position{line: 5336, col: 58, offset: 163092},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5311, col: 66, offset: 162390},
+						pos:        position{line: 5336, col: 66, offset: 163100},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 16, offset: 162412},
+						pos:        position{line: 5337, col: 16, offset: 163122},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 26, offset: 162422},
+						pos:        position{line: 5337, col: 26, offset: 163132},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 34, offset: 162430},
+						pos:        position{line: 5337, col: 34, offset: 163140},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 42, offset: 162438},
+						pos:        position{line: 5337, col: 42, offset: 163148},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 50, offset: 162446},
+						pos:        position{line: 5337, col: 50, offset: 163156},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 58, offset: 162454},
+						pos:        position{line: 5337, col: 58, offset: 163164},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 66, offset: 162462},
+						pos:        position{line: 5337, col: 66, offset: 163172},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5312, col: 74, offset: 162470},
+						pos:        position{line: 5337, col: 74, offset: 163180},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14287,25 +14287,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5313, col: 1, offset: 162476},
+			pos:  position{line: 5338, col: 1, offset: 163186},
 			expr: &choiceExpr{
-				pos: position{line: 5313, col: 16, offset: 162491},
+				pos: position{line: 5338, col: 16, offset: 163201},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5313, col: 16, offset: 162491},
+						pos:        position{line: 5338, col: 16, offset: 163201},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5313, col: 30, offset: 162505},
+						pos:        position{line: 5338, col: 30, offset: 163215},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5313, col: 36, offset: 162511},
+						pos:        position{line: 5338, col: 36, offset: 163221},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14315,18 +14315,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5317, col: 1, offset: 162667},
+			pos:  position{line: 5342, col: 1, offset: 163377},
 			expr: &seqExpr{
-				pos: position{line: 5317, col: 8, offset: 162674},
+				pos: position{line: 5342, col: 8, offset: 163384},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5317, col: 8, offset: 162674},
+						pos:        position{line: 5342, col: 8, offset: 163384},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5317, col: 14, offset: 162680},
+						pos:  position{line: 5342, col: 14, offset: 163390},
 						name: "SPACE",
 					},
 				},
@@ -14334,22 +14334,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5318, col: 1, offset: 162686},
+			pos:  position{line: 5343, col: 1, offset: 163396},
 			expr: &seqExpr{
-				pos: position{line: 5318, col: 7, offset: 162692},
+				pos: position{line: 5343, col: 7, offset: 163402},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5318, col: 7, offset: 162692},
+						pos:  position{line: 5343, col: 7, offset: 163402},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5318, col: 13, offset: 162698},
+						pos:        position{line: 5343, col: 13, offset: 163408},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5318, col: 18, offset: 162703},
+						pos:  position{line: 5343, col: 18, offset: 163413},
 						name: "SPACE",
 					},
 				},
@@ -14357,22 +14357,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5319, col: 1, offset: 162709},
+			pos:  position{line: 5344, col: 1, offset: 163419},
 			expr: &seqExpr{
-				pos: position{line: 5319, col: 8, offset: 162716},
+				pos: position{line: 5344, col: 8, offset: 163426},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5319, col: 8, offset: 162716},
+						pos:  position{line: 5344, col: 8, offset: 163426},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5319, col: 14, offset: 162722},
+						pos:        position{line: 5344, col: 14, offset: 163432},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5319, col: 20, offset: 162728},
+						pos:  position{line: 5344, col: 20, offset: 163438},
 						name: "SPACE",
 					},
 				},
@@ -14380,22 +14380,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5320, col: 1, offset: 162734},
+			pos:  position{line: 5345, col: 1, offset: 163444},
 			expr: &seqExpr{
-				pos: position{line: 5320, col: 9, offset: 162742},
+				pos: position{line: 5345, col: 9, offset: 163452},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5320, col: 9, offset: 162742},
+						pos:  position{line: 5345, col: 9, offset: 163452},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5320, col: 24, offset: 162757},
+						pos:        position{line: 5345, col: 24, offset: 163467},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5320, col: 28, offset: 162761},
+						pos:  position{line: 5345, col: 28, offset: 163471},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14403,22 +14403,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5321, col: 1, offset: 162776},
+			pos:  position{line: 5346, col: 1, offset: 163486},
 			expr: &seqExpr{
-				pos: position{line: 5321, col: 7, offset: 162782},
+				pos: position{line: 5346, col: 7, offset: 163492},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5321, col: 7, offset: 162782},
+						pos:  position{line: 5346, col: 7, offset: 163492},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5321, col: 13, offset: 162788},
+						pos:        position{line: 5346, col: 13, offset: 163498},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5321, col: 19, offset: 162794},
+						pos:  position{line: 5346, col: 19, offset: 163504},
 						name: "SPACE",
 					},
 				},
@@ -14426,22 +14426,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5322, col: 1, offset: 162820},
+			pos:  position{line: 5347, col: 1, offset: 163530},
 			expr: &seqExpr{
-				pos: position{line: 5322, col: 7, offset: 162826},
+				pos: position{line: 5347, col: 7, offset: 163536},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5322, col: 7, offset: 162826},
+						pos:  position{line: 5347, col: 7, offset: 163536},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5322, col: 13, offset: 162832},
+						pos:        position{line: 5347, col: 13, offset: 163542},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5322, col: 19, offset: 162838},
+						pos:  position{line: 5347, col: 19, offset: 163548},
 						name: "SPACE",
 					},
 				},
@@ -14449,22 +14449,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5324, col: 1, offset: 162865},
+			pos:  position{line: 5349, col: 1, offset: 163575},
 			expr: &seqExpr{
-				pos: position{line: 5324, col: 10, offset: 162874},
+				pos: position{line: 5349, col: 10, offset: 163584},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5324, col: 10, offset: 162874},
+						pos:  position{line: 5349, col: 10, offset: 163584},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5324, col: 25, offset: 162889},
+						pos:        position{line: 5349, col: 25, offset: 163599},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5324, col: 29, offset: 162893},
+						pos:  position{line: 5349, col: 29, offset: 163603},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14472,22 +14472,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5325, col: 1, offset: 162908},
+			pos:  position{line: 5350, col: 1, offset: 163618},
 			expr: &seqExpr{
-				pos: position{line: 5325, col: 10, offset: 162917},
+				pos: position{line: 5350, col: 10, offset: 163627},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5325, col: 10, offset: 162917},
+						pos:  position{line: 5350, col: 10, offset: 163627},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5325, col: 25, offset: 162932},
+						pos:        position{line: 5350, col: 25, offset: 163642},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5325, col: 29, offset: 162936},
+						pos:  position{line: 5350, col: 29, offset: 163646},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14495,9 +14495,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5326, col: 1, offset: 162951},
+			pos:  position{line: 5351, col: 1, offset: 163661},
 			expr: &litMatcher{
-				pos:        position{line: 5326, col: 10, offset: 162960},
+				pos:        position{line: 5351, col: 10, offset: 163670},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14505,18 +14505,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5327, col: 1, offset: 162964},
+			pos:  position{line: 5352, col: 1, offset: 163674},
 			expr: &seqExpr{
-				pos: position{line: 5327, col: 12, offset: 162975},
+				pos: position{line: 5352, col: 12, offset: 163685},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5327, col: 12, offset: 162975},
+						pos:        position{line: 5352, col: 12, offset: 163685},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 16, offset: 162979},
+						pos:  position{line: 5352, col: 16, offset: 163689},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14524,16 +14524,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5328, col: 1, offset: 162994},
+			pos:  position{line: 5353, col: 1, offset: 163704},
 			expr: &seqExpr{
-				pos: position{line: 5328, col: 12, offset: 163005},
+				pos: position{line: 5353, col: 12, offset: 163715},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5328, col: 12, offset: 163005},
+						pos:  position{line: 5353, col: 12, offset: 163715},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5328, col: 27, offset: 163020},
+						pos:        position{line: 5353, col: 27, offset: 163730},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14543,40 +14543,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5330, col: 1, offset: 163025},
+			pos:  position{line: 5355, col: 1, offset: 163735},
 			expr: &notExpr{
-				pos: position{line: 5330, col: 8, offset: 163032},
+				pos: position{line: 5355, col: 8, offset: 163742},
 				expr: &anyMatcher{
-					line: 5330, col: 9, offset: 163033,
+					line: 5355, col: 9, offset: 163743,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5331, col: 1, offset: 163035},
+			pos:  position{line: 5356, col: 1, offset: 163745},
 			expr: &choiceExpr{
-				pos: position{line: 5331, col: 15, offset: 163049},
+				pos: position{line: 5356, col: 15, offset: 163759},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5331, col: 15, offset: 163049},
+						pos:        position{line: 5356, col: 15, offset: 163759},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5331, col: 21, offset: 163055},
+						pos:        position{line: 5356, col: 21, offset: 163765},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5331, col: 28, offset: 163062},
+						pos:        position{line: 5356, col: 28, offset: 163772},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5331, col: 35, offset: 163069},
+						pos:        position{line: 5356, col: 35, offset: 163779},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14586,37 +14586,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5332, col: 1, offset: 163074},
+			pos:  position{line: 5357, col: 1, offset: 163784},
 			expr: &choiceExpr{
-				pos: position{line: 5332, col: 10, offset: 163083},
+				pos: position{line: 5357, col: 10, offset: 163793},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5332, col: 11, offset: 163084},
+						pos: position{line: 5357, col: 11, offset: 163794},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5332, col: 11, offset: 163084},
+								pos: position{line: 5357, col: 11, offset: 163794},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5332, col: 11, offset: 163084},
+									pos:  position{line: 5357, col: 11, offset: 163794},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5332, col: 23, offset: 163096},
+								pos:  position{line: 5357, col: 23, offset: 163806},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5332, col: 31, offset: 163104},
+								pos: position{line: 5357, col: 31, offset: 163814},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5332, col: 31, offset: 163104},
+									pos:  position{line: 5357, col: 31, offset: 163814},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5332, col: 46, offset: 163119},
+						pos: position{line: 5357, col: 46, offset: 163829},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5332, col: 46, offset: 163119},
+							pos:  position{line: 5357, col: 46, offset: 163829},
 							name: "WHITESPACE",
 						},
 					},
@@ -14625,38 +14625,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5333, col: 1, offset: 163131},
+			pos:  position{line: 5358, col: 1, offset: 163841},
 			expr: &seqExpr{
-				pos: position{line: 5333, col: 12, offset: 163142},
+				pos: position{line: 5358, col: 12, offset: 163852},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5333, col: 12, offset: 163142},
+						pos:        position{line: 5358, col: 12, offset: 163852},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5333, col: 18, offset: 163148},
+						pos: position{line: 5358, col: 18, offset: 163858},
 						expr: &seqExpr{
-							pos: position{line: 5333, col: 19, offset: 163149},
+							pos: position{line: 5358, col: 19, offset: 163859},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5333, col: 19, offset: 163149},
+									pos: position{line: 5358, col: 19, offset: 163859},
 									expr: &litMatcher{
-										pos:        position{line: 5333, col: 21, offset: 163151},
+										pos:        position{line: 5358, col: 21, offset: 163861},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5333, col: 28, offset: 163158,
+									line: 5358, col: 28, offset: 163868,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5333, col: 32, offset: 163162},
+						pos:        position{line: 5358, col: 32, offset: 163872},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14666,16 +14666,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5334, col: 1, offset: 163168},
+			pos:  position{line: 5359, col: 1, offset: 163878},
 			expr: &choiceExpr{
-				pos: position{line: 5334, col: 20, offset: 163187},
+				pos: position{line: 5359, col: 20, offset: 163897},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5334, col: 20, offset: 163187},
+						pos:  position{line: 5359, col: 20, offset: 163897},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5334, col: 28, offset: 163195},
+						pos:        position{line: 5359, col: 28, offset: 163905},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14685,16 +14685,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5335, col: 1, offset: 163198},
+			pos:  position{line: 5360, col: 1, offset: 163908},
 			expr: &choiceExpr{
-				pos: position{line: 5335, col: 19, offset: 163216},
+				pos: position{line: 5360, col: 19, offset: 163926},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 19, offset: 163216},
+						pos:  position{line: 5360, col: 19, offset: 163926},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 27, offset: 163224},
+						pos:  position{line: 5360, col: 27, offset: 163934},
 						name: "SPACE",
 					},
 				},
@@ -16672,8 +16672,10 @@ func (p *parser) callonByClause7() (any, error) {
 
 func (c *current) onDedupBlock1(dedupExpr any) (any, error) {
 
+	dedupExp := dedupExpr.(*structs.DedupExpr)
+
 	letColReq := &structs.LetColumnsRequest{
-		DedupColRequest: dedupExpr.(*structs.DedupExpr),
+		DedupColRequest: dedupExp,
 	}
 
 	root := &structs.QueryAggregators{
@@ -16681,7 +16683,30 @@ func (c *current) onDedupBlock1(dedupExpr any) (any, error) {
 		OutputTransforms: &structs.OutputTransforms{
 			LetColumns: letColReq,
 		},
-		DedupExpr: dedupExpr.(*structs.DedupExpr),
+		DedupExpr: dedupExp,
+	}
+
+	if len(dedupExp.DedupSortEles) > 0 {
+		sortExpr := &structs.SortExpr{
+			SortEles:      dedupExp.DedupSortEles,
+			SortAscending: dedupExp.DedupSortAscending,
+			Limit:         1000000,
+		}
+		dedupExp.DedupSortEles = nil
+		dedupExp.DedupSortAscending = nil
+
+		sortAgg := &structs.QueryAggregators{
+			PipeCommandType: structs.OutputTransformType,
+			OutputTransforms: &structs.OutputTransforms{
+				LetColumns: &structs.LetColumnsRequest{
+					SortColRequest: sortExpr,
+				},
+			},
+			SortExpr: sortExpr,
+		}
+
+		sortAgg.Next = root
+		return sortAgg, nil
 	}
 
 	return root, nil

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -1977,8 +1977,10 @@ ByClause <- BY fieldList:FieldNameList {
 
 DedupBlock <- PIPE CMD_DEDUP dedupExpr:DedupExpr {
 
+    dedupExp := dedupExpr.(*structs.DedupExpr)
+
     letColReq := &structs.LetColumnsRequest {
-        DedupColRequest: dedupExpr.(*structs.DedupExpr),
+        DedupColRequest: dedupExp,
     }
 
     root := &structs.QueryAggregators {
@@ -1986,7 +1988,30 @@ DedupBlock <- PIPE CMD_DEDUP dedupExpr:DedupExpr {
         OutputTransforms: &structs.OutputTransforms {
             LetColumns: letColReq,
         },
-        DedupExpr: dedupExpr.(*structs.DedupExpr),
+        DedupExpr: dedupExp,
+    }
+
+    if len(dedupExp.DedupSortEles) > 0 {
+        sortExpr := &structs.SortExpr {
+            SortEles: dedupExp.DedupSortEles,
+            SortAscending: dedupExp.DedupSortAscending,
+            Limit: 1000000,
+        }
+        dedupExp.DedupSortEles = nil
+        dedupExp.DedupSortAscending = nil
+
+        sortAgg := &structs.QueryAggregators {
+            PipeCommandType: structs.OutputTransformType,
+            OutputTransforms: &structs.OutputTransforms {
+                LetColumns: &structs.LetColumnsRequest{
+                    SortColRequest: sortExpr,
+                },
+            },
+            SortExpr: sortExpr,
+        }
+
+        sortAgg.Next = root
+        return sortAgg, nil
     }
 
     return root, nil

--- a/pkg/segment/query/processor/dataprocessor_test.go
+++ b/pkg/segment/query/processor/dataprocessor_test.go
@@ -59,13 +59,21 @@ type mockStreamer struct {
 }
 
 func (ms *mockStreamer) Fetch() (*iqr.IQR, error) {
-	if ms.numSent >= len(ms.allRecords["col1"]) {
+	colName := "col1"
+	for col := range ms.allRecords {
+		colName = col
+		break
+	}
+
+	if ms.numSent >= len(ms.allRecords[colName]) {
 		return nil, io.EOF
 	}
 
 	// Send one at a time.
-	knownValues := map[string][]utils.CValueEnclosure{
-		"col1": {ms.allRecords["col1"][ms.numSent]},
+	knownValues := map[string][]utils.CValueEnclosure{}
+
+	for col, values := range ms.allRecords {
+		knownValues[col] = []utils.CValueEnclosure{values[ms.numSent]}
 	}
 
 	iqr := iqr.NewIQR(ms.qid)

--- a/pkg/segment/query/processor/dedupcommand_test.go
+++ b/pkg/segment/query/processor/dedupcommand_test.go
@@ -323,3 +323,76 @@ func Test_Dedup_multipleCols(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedCol2, actualCol2)
 }
+
+func Test_Dedup_WithSort(t *testing.T) {
+	stream := &mockStreamer{
+		allRecords: map[string][]utils.CValueEnclosure{
+			"col1": {
+				{Dtype: utils.SS_DT_STRING, CVal: "a"},
+				{Dtype: utils.SS_DT_STRING, CVal: "a"},
+				{Dtype: utils.SS_DT_STRING, CVal: "a"},
+				{Dtype: utils.SS_DT_STRING, CVal: "b"},
+				{Dtype: utils.SS_DT_STRING, CVal: "b"},
+				{Dtype: utils.SS_DT_STRING, CVal: "b"},
+				{Dtype: utils.SS_DT_STRING, CVal: "c"},
+				{Dtype: utils.SS_DT_STRING, CVal: "c"},
+			},
+			"col2": {
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(0)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(1)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(3)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(2)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(4)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(5)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(6)},
+				{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(7)},
+			},
+		},
+		qid: 0,
+	}
+
+	sortProcessor := NewSortDP(&structs.SortExpr{
+		SortEles: []*structs.SortElement{
+			{Field: "col2", SortByAsc: true, Op: "num"},
+		},
+		Limit: 1000,
+	})
+	sortProcessor.streams = []*cachedStream{{stream, nil, false}}
+
+	dedupProcessor := NewDedupDP(&structs.DedupExpr{
+		DedupOptions: &structs.DedupOptions{
+			Consecutive: true,
+		},
+		FieldList: []string{"col1"},
+	})
+
+	dedupProcessor.streams = []*cachedStream{{sortProcessor, nil, false}}
+
+	result, err := dedupProcessor.Fetch()
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	expectedCol1 := []utils.CValueEnclosure{
+		{Dtype: utils.SS_DT_STRING, CVal: "a"},
+		{Dtype: utils.SS_DT_STRING, CVal: "b"},
+		{Dtype: utils.SS_DT_STRING, CVal: "a"},
+		{Dtype: utils.SS_DT_STRING, CVal: "b"},
+		{Dtype: utils.SS_DT_STRING, CVal: "c"},
+	}
+
+	expectedCol2 := []utils.CValueEnclosure{
+		{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(0)},
+		{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(2)},
+		{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(3)},
+		{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(4)},
+		{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(6)},
+	}
+
+	actualCol1, err := result.ReadColumn("col1")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedCol1, actualCol1)
+
+	actualCol2, err := result.ReadColumn("col2")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedCol2, actualCol2)
+}

--- a/tools/sigclient/functionalQueries/dedup_sortby.json
+++ b/tools/sigclient/functionalQueries/dedup_sortby.json
@@ -1,0 +1,38 @@
+{
+    "queryText": "app_name=Companyhave | fields city, bool_col, http_status, app_name | dedup bool_col sortby http_status",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 2,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "records": [
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Miami",
+                "http_status": 200,
+                "timestamp": 1730926796005
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Stockton",
+                "http_status": 301,
+                "timestamp": 1730926771592
+            }
+        ],
+        "allColumns": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name"
+        ],
+        "columnsOrder": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name"
+        ]
+    }
+}

--- a/tools/sigclient/functionalQueries/dedup_sortby_consecutive.json
+++ b/tools/sigclient/functionalQueries/dedup_sortby_consecutive.json
@@ -1,0 +1,78 @@
+{
+    "queryText": "app_name=Companyhave | fields city, bool_col, http_status, app_name | dedup consecutive=true bool_col sortby http_status",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 9,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "records": [
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Miami",
+                "http_status": 200
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Stockton",
+                "http_status": 301
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Chula Vista",
+                "http_status": 301
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Cincinnati",
+                "http_status": 302
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Indianapolis",
+                "http_status": 400
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Chandler",
+                "http_status": 404
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Louisville/Jefferson",
+                "http_status": 500
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "San Antonio",
+                "http_status": 500
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Mesa",
+                "http_status": 500
+            }
+        ],
+        "allColumns": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name"
+        ],
+        "columnsOrder": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name"
+        ]
+    }
+}

--- a/tools/sigclient/functionalQueries/functionalQueries.yml
+++ b/tools/sigclient/functionalQueries/functionalQueries.yml
@@ -33,6 +33,8 @@ search_timechart_no_groupby.json
 tail.json
 sort_tail_eval_newField.json
 tail_stats.json
+dedup_sortby_consecutive.json
+dedup_sortby.json
 
 ## Uncomment when implemented for new pipline
 # rare.json

--- a/tools/sigclient/longerFunctionalQueries/dedup_sortby.json
+++ b/tools/sigclient/longerFunctionalQueries/dedup_sortby.json
@@ -1,0 +1,40 @@
+{
+    "queryText": "app_name=Companyhave AND city=Boston | fields city, bool_col, http_status, app_name, country | dedup bool_col sortby http_status",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 2,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "records": [
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Lesotho",
+                "http_status": 200
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "American Samoa",
+                "http_status": 200
+            }
+        ],
+        "allColumns": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name",
+            "country"
+        ],
+        "columnsOrder": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name",
+            "country"
+        ]
+    }
+}

--- a/tools/sigclient/longerFunctionalQueries/dedup_sortby_consecutive.json
+++ b/tools/sigclient/longerFunctionalQueries/dedup_sortby_consecutive.json
@@ -1,0 +1,96 @@
+{
+    "queryText": "app_name=Companyhave AND city=Boston | fields city, bool_col, http_status, app_name, country | dedup consecutive=true bool_col sortby http_status, country",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 13,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "records": [
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "American Samoa",
+                "http_status": 200
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Lesotho",
+                "http_status": 200
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "Costa Rica",
+                "http_status": 301
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Syrian Arab Republic",
+                "http_status": 301
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "Trinidad and Tobago",
+                "http_status": 301
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Bahamas",
+                "http_status": 302
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "Burundi",
+                "http_status": 302
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Tokelau",
+                "http_status": 302
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": true,
+                "city": "Boston",
+                "country": "Belize",
+                "http_status": 400
+            },
+            {
+                "app_name": "Companyhave",
+                "bool_col": false,
+                "city": "Boston",
+                "country": "Tokelau",
+                "http_status": 400
+            }
+        ],
+        "allColumns": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name",
+            "country"
+        ],
+        "columnsOrder": [
+            "city",
+            "bool_col",
+            "http_status",
+            "app_name",
+            "country"
+        ]
+    }
+}

--- a/tools/sigclient/longerFunctionalQueries/longerFunctionalQueries.yml
+++ b/tools/sigclient/longerFunctionalQueries/longerFunctionalQueries.yml
@@ -33,6 +33,8 @@ mvexpand.json
 tail.json
 sort_tail_eval_newField.json
 tail_stats.json
+dedup_sortby_consecutive.json
+dedup_sortby.json
 
 ## Uncomment when implemented for new pipline
 # rare.json


### PR DESCRIPTION
# Description
Summarize the change.
- Current implementation in the old pipeline for dedup with sortby is incorrect because it accounts for the existing record order and not the sort order to perform dedup.
- If a sortby clause is present in dedup, the dedup should be performed as if dedup is getting performed on the data that is sorted according to the sortby clause.
- Look at the unit test for more details.
- Have also added functional and longer functional test for this.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
