### PR TITLE
fix: panic on bucket key buffer for Stats Group By CMD

### DIFF
--- a/pkg/segment/query/processor/statscommand_test.go
+++ b/pkg/segment/query/processor/statscommand_test.go
@@ -408,7 +408,7 @@ func Test_ProcessGroupByRequestFullBuffer(t *testing.T) {
 	_, err = processor.Process(iqr1)
 	assert.NoError(t, err)
 
-	// value of col1 at eaach record is utils.MAX_RECORD_SIZE bytes
+	// value of col1 at each record is utils.MAX_RECORD_SIZE * factor bytes
 	// +
 	// value of col3 at each record is 1 byte
 	estimatedSizeOfBuffer := (utils.MAX_RECORD_SIZE * factorSize) + 1

--- a/pkg/segment/query/processor/statscommand_test.go
+++ b/pkg/segment/query/processor/statscommand_test.go
@@ -379,3 +379,40 @@ func Test_ProcessSegmentStats(t *testing.T) {
 	assert.Equal(t, 1, len(actualAvgRes))
 	assert.Equal(t, expectedAvgRes, actualAvgRes)
 }
+
+func Test_ProcessGroupByRequestFullBuffer(t *testing.T) {
+	config.InitializeTestingConfig(t.TempDir())
+	config.GetRunningConfig().UseNewPipelineConverted = true
+
+	knownValues := getTestData()
+	processor := getGroupByProcessor()
+	assert.Equal(t, 0, len(processor.bucketKeyWorkingBuf))
+
+	col1Values := knownValues["col1"]
+	factorSize := 5
+
+	for i := 0; i < len(col1Values); i++ {
+		byteVal := make([]byte, utils.MAX_RECORD_SIZE*3)
+
+		for j := 0; j < utils.MAX_RECORD_SIZE; j++ {
+			byteVal[j] = byte(col1Values[i].CVal.(string)[0])
+		}
+
+		knownValues["col1"][i].CVal = string(byteVal)
+	}
+
+	iqr1 := iqr.NewIQR(0)
+	err := iqr1.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr1)
+	assert.NoError(t, err)
+
+	// value of col1 at eaach record is utils.MAX_RECORD_SIZE bytes
+	// +
+	// value of col3 at each record is 1 byte
+	estimatedSizeOfBuffer := (utils.MAX_RECORD_SIZE * factorSize) + 1
+
+	// the p.bucketKeyWorkingBuf should be at least the size of the estimated buffer
+	assert.GreaterOrEqual(t, len(processor.bucketKeyWorkingBuf), estimatedSizeOfBuffer, "bucketKeyWorkingBuf size is less than estimated buffer size")
+}

--- a/pkg/segment/query/processor/statscommand_test.go
+++ b/pkg/segment/query/processor/statscommand_test.go
@@ -389,10 +389,10 @@ func Test_ProcessGroupByRequestFullBuffer(t *testing.T) {
 	assert.Equal(t, 0, len(processor.bucketKeyWorkingBuf))
 
 	col1Values := knownValues["col1"]
-	factorSize := 5
+	factorSize := 5 // should be greater than len(groupByCols)
 
 	for i := 0; i < len(col1Values); i++ {
-		byteVal := make([]byte, utils.MAX_RECORD_SIZE*3)
+		byteVal := make([]byte, utils.MAX_RECORD_SIZE*factorSize)
 
 		for j := 0; j < utils.MAX_RECORD_SIZE; j++ {
 			byteVal[j] = byte(col1Values[i].CVal.(string)[0])

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1033,8 +1033,59 @@ func (e *CValueEnclosure) GetIntValue() (int64, error) {
 	}
 }
 
-func (e *CValueEnclosure) WriteToBytesWithType(buf []byte) int {
-	bufIdx := 0
+func (e *CValueEnclosure) getWriteTotalBytesSize() int {
+	size := 0
+	switch e.Dtype {
+	case SS_DT_BOOL:
+		size += 1 // for the type
+		size += 1 // for the value
+	case SS_DT_UNSIGNED_NUM:
+		size += 1 // for the type
+		size += 8 // for the value
+	case SS_DT_SIGNED_NUM:
+		size += 1 // for the type
+		size += 8 // for the value
+	case SS_DT_FLOAT:
+		size += 1 // for the type
+		size += 8 // for the value
+	case SS_DT_STRING:
+		size += 1 // for the type
+		strLen := len(e.CVal.(string))
+		sizeOfStrLen := 2    // 2 bytes
+		size += sizeOfStrLen // for the length of the string
+		size += strLen       // for the string
+	case SS_DT_BACKFILL:
+		size += 1 // for the type
+	default:
+		str := fmt.Sprintf("%v", e.CVal)
+		strBytes := []byte(str)
+		strLen := len(strBytes)
+		if strLen <= math.MaxUint16 {
+			size += 1 // for the type
+			sizeOfStrLen := 2
+			size += sizeOfStrLen // for the length of the string
+		} else {
+			size += 1 // for the type
+			sizeOfStrLen := 4
+			size += sizeOfStrLen // for the length of the string
+		}
+		size += strLen // for the string
+	}
+
+	return size
+}
+
+// WriteToBytesWithType writes the CValueEnclosure to a byte slice with the type
+// The byte slice is resized if required
+func (e *CValueEnclosure) WriteToBytesWithType(buf []byte, bufIdx int) ([]byte, int) {
+	requiredSize := e.getWriteTotalBytesSize()
+	availableSize := len(buf) - bufIdx
+
+	// Resize the buffer if required
+	if requiredSize > availableSize {
+		buf = toputils.ResizeSlice(buf, len(buf)+requiredSize+MAX_RECORD_SIZE)
+	}
+
 	switch e.Dtype {
 	case SS_DT_BOOL:
 		copy(buf[bufIdx:], VALTYPE_ENC_BOOL)
@@ -1045,28 +1096,24 @@ func (e *CValueEnclosure) WriteToBytesWithType(buf []byte) int {
 			buf[bufIdx] = 0
 		}
 		bufIdx += 1
-		return bufIdx
 	case SS_DT_UNSIGNED_NUM:
 		copy(buf[bufIdx:], VALTYPE_ENC_UINT64)
 		bufIdx += 1
 		bytesVal := toputils.Uint64ToBytesLittleEndian(e.CVal.(uint64))
 		copy(buf[bufIdx:], bytesVal)
 		bufIdx += 8
-		return bufIdx
 	case SS_DT_SIGNED_NUM:
 		copy(buf[bufIdx:], VALTYPE_ENC_INT64)
 		bufIdx += 1
 		bytesVal := toputils.Int64ToBytesLittleEndian(e.CVal.(int64))
 		copy(buf[bufIdx:], bytesVal)
 		bufIdx += 8
-		return bufIdx
 	case SS_DT_FLOAT:
 		copy(buf[bufIdx:], VALTYPE_ENC_FLOAT64)
 		bufIdx += 1
 		bytesVal := toputils.Float64ToBytesLittleEndian(e.CVal.(float64))
 		copy(buf[bufIdx:], bytesVal)
 		bufIdx += 8
-		return bufIdx
 	case SS_DT_STRING:
 		copy(buf[bufIdx:], VALTYPE_ENC_SMALL_STRING)
 		bufIdx += 1
@@ -1076,11 +1123,9 @@ func (e *CValueEnclosure) WriteToBytesWithType(buf []byte) int {
 		bufIdx += 2
 		copy(buf[bufIdx:], strBytes)
 		bufIdx += strLen
-		return bufIdx
 	case SS_DT_BACKFILL:
 		copy(buf[bufIdx:], VALTYPE_ENC_BACKFILL)
 		bufIdx += 1
-		return bufIdx
 	default:
 		str := fmt.Sprintf("%v", e.CVal)
 		strBytes := []byte(str)
@@ -1098,8 +1143,9 @@ func (e *CValueEnclosure) WriteToBytesWithType(buf []byte) int {
 		}
 		copy(buf[bufIdx:], strBytes)
 		bufIdx += strLen
-		return bufIdx
 	}
+
+	return buf, bufIdx
 }
 
 func (e *CValueEnclosure) IsNull() bool {


### PR DESCRIPTION
# Description
- The bucket key on the group by is paniced because the buffer allocated for the bucket key is not enough.
- In this PR, it will check the size being written and if that size is not enough then it will increment the buffer.

# Testing
- Tested by making a new unit test that checked whether the buffer size is being incremented according to column sizes.
- All unit and functional test cases pass.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
