### PR TITLE
Fix issue saturating block results

### DIFF
--- a/pkg/utils/sliceutils.go
+++ b/pkg/utils/sliceutils.go
@@ -81,6 +81,22 @@ func ResizeSliceWithDefault[T any](slice []T, newLength int, defaultValue T) []T
 	return newSlice
 }
 
+func GrowSliceInChunks[T any](slice []T, minSize int, chunkSize int) ([]T, error) {
+	if minSize < 0 {
+		return nil, TeeErrorf("GrowSliceInChunks: minSize must be non-negative; found %v", minSize)
+	}
+	if chunkSize <= 0 {
+		return nil, TeeErrorf("GrowSliceInChunks: chunkSize must be positive; found %v", chunkSize)
+	}
+
+	numChunksToAdd := (minSize - len(slice) + chunkSize - 1) / chunkSize
+	if numChunksToAdd <= 0 {
+		return slice, nil
+	}
+
+	return append(slice, make([]T, numChunksToAdd*chunkSize)...), nil
+}
+
 func IsArrayOrSlice(val interface{}) (bool, reflect.Value, string) {
 	v := reflect.ValueOf(val)
 	switch v.Kind() {

--- a/pkg/utils/sliceutils_test.go
+++ b/pkg/utils/sliceutils_test.go
@@ -48,6 +48,26 @@ func Test_ResizeSliceWithDefault(t *testing.T) {
 	assert.Equal(t, newSlice[5:], []int{42, 42, 42, 42, 42})
 }
 
+func Test_GrowSliceInChunks(t *testing.T) {
+	slice, err := GrowSliceInChunks(make([]int, 10), 5, 5)
+	assert.NoError(t, err)
+	assert.Len(t, slice, 10)
+
+	slice, err = GrowSliceInChunks(make([]int, 10), 15, 5)
+	assert.NoError(t, err)
+	assert.Len(t, slice, 15)
+
+	slice, err = GrowSliceInChunks(make([]int, 10), 15, 3)
+	assert.NoError(t, err)
+	assert.Len(t, slice, 16)
+
+	_, err = GrowSliceInChunks(make([]int, 10), 15, -1)
+	assert.Error(t, err)
+
+	_, err = GrowSliceInChunks(make([]int, 10), -1, 3)
+	assert.Error(t, err)
+}
+
 func Test_ConvertSliceToMap_EmptySlice(t *testing.T) {
 	emptySlice := []string{}
 	result := ConvertSliceToMap(emptySlice, func(s string) string {


### PR DESCRIPTION
# Description
The `BlockResults` type was storing at most `MAX_RECS_PER_WIP` results. This caused some issues because sometimes we use one `BlockResults` to store results from many blocks, in particular `SearchResults` uses one  `BlockResults`. Now `BlockResults` can store more records.

# Testing
```
go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 200_000
```
Then query:
```
* | eval n=1 | stats count
```
Without this PR, I was getting 84606 on my machine instead of 200k. Now I get 200k.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
