### PR TITLE
Run dummy CircleCI instead of skipping 

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Check if tests should be run
           command: |
-            if [ "${{ parameters.run-tests }}" = false ]; then
+            if [ "<< pipeline.parameters.run-tests >>" = "false" ]; then
               echo "Skipping tests"
               circleci-agent step halt
             else
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: Check if tests should be run
           command: |
-            if [ "${{ parameters.run-tests }}" = false ]; then
+            if [ "<< pipeline.parameters.run-tests >>" = "false" ]; then
               echo "Skipping tests"
               circleci-agent step halt
             else

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -17,6 +17,15 @@ jobs:
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:
+      - run:
+          name: Check if tests should be run
+          command: |
+            if [ "${{ parameters.run-tests }}" = false ]; then
+              echo "Skipping tests"
+              circleci-agent step halt
+            else
+              echo "Running tests"
+            fi
       - checkout
       - setup_remote_docker:
           version: docker23
@@ -69,6 +78,15 @@ jobs:
     docker:
       - image: cimg/go:1.19
     steps:
+      - run:
+          name: Check if tests should be run
+          command: |
+            if [ "${{ parameters.run-tests }}" = false ]; then
+              echo "Skipping tests"
+              circleci-agent step halt
+            else
+              echo "Running tests"
+            fi
       - checkout
       - setup_remote_docker:
           version: docker23
@@ -96,7 +114,6 @@ jobs:
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
   test_and_lint:
-    when: << pipeline.parameters.run-tests >>
     jobs:
       - functional-test
       - e2e-server


### PR DESCRIPTION
# Description
The CircleCI test is required for PRs to merge, so we need to actually run some test; otherwise, CircleCI won't tell GitHub the test was skipped, so GitHub hangs waiting for the test.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
