### PR TITLE
Add uniqColumns for esbulk ingest

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -63,7 +63,13 @@ var esBulkCmd = &cobra.Command{
 		eventsPerDay, _ := cmd.Flags().GetUint64("eventsPerDay")
 		maxColumns, _ := cmd.Flags().GetUint32("maxColumns")
 		minColumns, _ := cmd.Flags().GetUint32("minColumns")
+		uniqColumns, _ := cmd.Flags().GetUint32("uniqColumns")
 		enableVariableNumColumns, _ := cmd.Flags().GetBool("enableVariableNumColumns")
+
+		if uniqColumns < maxColumns {
+			log.Fatalf("uniqColumns must be greater than or equal to maxColumns")
+			return
+		}
 
 		if eventsPerDay > 0 {
 			if cmd.Flags().Changed("totalEvents") {
@@ -79,7 +85,7 @@ var esBulkCmd = &cobra.Command{
 				log.Fatalf("maxColumns must be greater than 0")
 				return
 			}
-			dataGeneratorConfig = ingest.GetGeneratorDataConfig(int(maxColumns), enableVariableNumColumns, int(minColumns))
+			dataGeneratorConfig = ingest.GetGeneratorDataConfig(int(maxColumns), enableVariableNumColumns, int(minColumns), int(uniqColumns))
 		}
 
 		log.Infof("processCount : %+v\n", processCount)
@@ -478,6 +484,7 @@ func init() {
 	esBulkCmd.PersistentFlags().StringP("filePath", "x", "", "path to json file to use as logs")
 	esBulkCmd.PersistentFlags().Uint32P("maxColumns", "", 100, "maximum number of columns to generate. Default is 100")
 	esBulkCmd.PersistentFlags().Uint32P("minColumns", "", 0, "minimum number of columns to generate. Default is 0. if 0, it will be set to maxColumns")
+	esBulkCmd.PersistentFlags().Uint32P("uniqColumns", "", 0, "unique column names to generate")
 	esBulkCmd.PersistentFlags().BoolP("enableVariableNumColumns", "", false, "generate a variable number of columns per record. Each record will have a random number of columns between minColumns and maxColumns")
 
 	functionalTestCmd.PersistentFlags().StringP("queryDest", "q", "", "Query Server Address, format is IP:PORT")

--- a/tools/sigclient/pkg/ingest/ingest.go
+++ b/tools/sigclient/pkg/ingest/ingest.go
@@ -389,8 +389,8 @@ func getReaderFromArgs(iType IngestType, nummetrics int, gentype string, str str
 	return rdr, err
 }
 
-func GetGeneratorDataConfig(maxColumns int, variableColums bool, minColumns int) *utils.GeneratorDataConfig {
-	return utils.InitGeneratorDataConfig(maxColumns, variableColums, minColumns)
+func GetGeneratorDataConfig(maxColumns int, variableColums bool, minColumns int, uniqColumns int) *utils.GeneratorDataConfig {
+	return utils.InitGeneratorDataConfig(maxColumns, variableColums, minColumns, uniqColumns)
 }
 
 func StartIngestion(iType IngestType, generatorType, dataFile string, totalEvents int, continuous bool,


### PR DESCRIPTION
# Description
Summarize the change.
- uniqColumns can be used to vary the number of columns across the whole ingest. It is different from maxColumns in a way that maxColumns is supposed to dictate the maximum number of columns in a records. Whereas this parameter is used to manage how many unique columns would be present in the dataset after complete ingestion.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
This command generates 123 unique columns with no more than 30 values in a record.
`go run main.go ingest esbulk -a "test" -g benchmark -d http://localhost:8081/elastic -t 100_000 -p 1 --enableVariableNumColumns true --maxColumns 30 --minColumns 20 --uniqColumns 123`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
