### PR TITLE
Reduce ingestion memory via new Buffer type

### DIFF
--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -226,8 +226,7 @@ func Test_packUnpackDictEnc(t *testing.T) {
 		}
 		recNum += recCounts / deCount
 	}
-	err := colWip.CopyWipForTestOnly(tempWipCbuf, wipIdx)
-	assert.NoError(t, err)
+	colWip.CopyWipForTestOnly(tempWipCbuf, wipIdx)
 	colWip.SetDeDataForTest(deCount, deMap)
 
 	writer.PackDictEnc(colWip)

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -226,7 +226,8 @@ func Test_packUnpackDictEnc(t *testing.T) {
 		}
 		recNum += recCounts / deCount
 	}
-	colWip.CopyWipForTestOnly(tempWipCbuf, wipIdx)
+	err := colWip.CopyWipForTestOnly(tempWipCbuf, wipIdx)
+	assert.NoError(t, err)
 	colWip.SetDeDataForTest(deCount, deMap)
 
 	writer.PackDictEnc(colWip)

--- a/pkg/segment/writer/agiletree.go
+++ b/pkg/segment/writer/agiletree.go
@@ -595,7 +595,7 @@ func (stb *StarTreeBuilder) creatEnc(wip *WipBlock) error {
 		// read the non-dict way
 		idx := uint32(0)
 		for recNum := uint16(0); recNum < numRecs; recNum++ {
-			cValBytes, endIdx, err := getColByteSlice(cwip.cbuf[idx:], 0) // todo pass qid here
+			cValBytes, endIdx, err := getColByteSlice(cwip.cbuf, int(idx), 0) // todo pass qid here
 			if err != nil {
 				log.Errorf("populateLeafsWithMeasVals: Could not extract val for cname: %v, idx: %v",
 					colName, idx)
@@ -760,7 +760,9 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 		for dword, recNumsArr := range deData.deMap {
 
 			if toputils.BinarySearchUint16(recNum, recNumsArr) {
-				_, err := GetNumValFromRec([]byte(dword)[0:], 0, num)
+				buffer := &toputils.Buffer{}
+				buffer.Append([]byte(dword))
+				_, err := GetNumValFromRec(buffer, 0, 0, num)
 				if err != nil {
 					log.Errorf("getMeasCval: Could not extract val for cname: %v, dword: %v",
 						colName, dword)
@@ -772,7 +774,7 @@ func getMeasCval(cwip *ColWip, recNum uint16, cIdx []uint32, colNum int,
 		return fmt.Errorf("could not find recNum: %v", recNum)
 	}
 
-	endIdx, err := GetNumValFromRec(cwip.cbuf[cIdx[colNum]:], 0, num) // todo pass qid
+	endIdx, err := GetNumValFromRec(cwip.cbuf, int(cIdx[colNum]), 0, num) // todo pass qid
 	if err != nil {
 		log.Errorf("getMeasCval: Could not extract val for cname: %v, idx: %v",
 			colName, cIdx[colNum])

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1694,7 +1694,7 @@ func getColByteSlice(rec *utils.Buffer, offset int, qid uint64) ([]byte, uint16,
 
 	switch typeByte {
 	case VALTYPE_ENC_SMALL_STRING[0]:
-		strlen := utils.BytesToUint16LittleEndian(rec.Slice(1, 3))
+		strlen := utils.BytesToUint16LittleEndian(rec.Slice(offset+1, offset+3))
 		endIdx = strlen + 3
 	case VALTYPE_ENC_BOOL[0], VALTYPE_ENC_INT8[0], VALTYPE_ENC_UINT8[0]:
 		endIdx = 2
@@ -1716,6 +1716,6 @@ func getColByteSlice(rec *utils.Buffer, offset int, qid uint64) ([]byte, uint16,
 
 func (colWip *ColWip) CopyWipForTestOnly(cbuf []byte, cbufIdx uint32) {
 	colWip.cbuf.Reset()
-	colWip.cbuf.Append(cbuf)
+	colWip.cbuf.Append(cbuf[:cbufIdx])
 	colWip.cbufidx = cbufIdx
 }

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -298,7 +298,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 	s := colWip.cbufidx
 	colWip.cbuf.Append(VALTYPE_DICT_ARRAY[:])
 	colWip.cbufidx += 1
-	utils.Uint16ToBytesLittleEndianInplace(0, colWip.cbuf[colWip.cbufidx:]) //placeholder for encoding length of array
+	colWip.cbuf.AppendAsUint16(0) // Placeholder for encoding length of array
 	colWip.cbufidx += 2
 	_, aErr := jp.ArrayEach(data, func(value []byte, valueType jp.ValueType, offset int, err error) {
 		switch valueType {
@@ -315,7 +315,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 			}
 			//encode and copy keyName
 			n := uint16(len(keyName))
-			utils.Uint16ToBytesLittleEndianInplace(n, colWip.cbuf[colWip.cbufidx:])
+			colWip.cbuf.AppendAsUint16(n)
 			colWip.cbufidx += 2
 			colWip.cbuf.Append(keyName)
 			colWip.cbufidx += uint32(n)
@@ -364,7 +364,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 			}
 			// get the copied key value bytes from the ColWip buffer,
 			// As the keyVal bytes are converted to lower case while adding to Bloom above.
-			keyValBytes := colWip.cbuf[colWip.cbufidx-uint32(keyValLen):]
+			keyValBytes := colWip.cbuf.Slice(int(colWip.cbufidx-uint32(keyValLen)), colWip.cbuf.Len())
 			addSegStatsStrIngestion(ss.AllSst, keyNameStr, keyValBytes)
 		default:
 			finalErr = fmt.Errorf("encodeSingleDictArray : received unknown type of %+s", valueType)
@@ -429,7 +429,7 @@ func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte,
 	colWip.cbuf.Append(VALTYPE_RAW_JSON[:])
 	colWip.cbufidx += 1
 	n := uint16(len(value))
-	utils.Uint16ToBytesLittleEndianInplace(n, colWip.cbuf[colWip.cbufidx:])
+	colWip.cbuf.AppendAsUint16(n)
 	colWip.cbufidx += 2
 	colWip.cbuf.Append(value)
 	colWip.cbufidx += uint32(n)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -464,10 +464,10 @@ func (ss *SegStore) encodeSingleString(key string,
 	ss.updateColValueSizeInAllSeenColumns(key, recLen)
 
 	if !ss.skipDe {
-		ss.checkAddDictEnc(colWip, colWip.cbuf[s:colWip.cbufidx], recNum, s, false)
+		ss.checkAddDictEnc(colWip, colWip.cbuf.Slice(int(s), int(colWip.cbufidx)), recNum, s, false)
 	}
 	valueLen := uint32(len(valBytes))
-	addSegStatsStrIngestion(ss.AllSst, key, colWip.cbuf[colWip.cbufidx-valueLen:colWip.cbufidx])
+	addSegStatsStrIngestion(ss.AllSst, key, colWip.cbuf.Slice(int(colWip.cbufidx-valueLen), int(colWip.cbufidx)))
 	return matchedCol
 }
 
@@ -533,7 +533,7 @@ func (ss *SegStore) encodeSingleNumber(key string, value interface{},
 	colWip, recNum, matchedCol = ss.initAndBackFillColumn(key, numType, matchedCol)
 	colRis := ss.wipBlock.columnRangeIndexes
 	segstats := ss.AllSst
-	retLen := ss.encSingleNumber(key, value, colWip.cbuf[:], colWip.cbufidx, colRis, recNum, segstats,
+	retLen := ss.encSingleNumber(key, value, colWip.cbuf.ReadAll(), colWip.cbufidx, colRis, recNum, segstats,
 		ss.wipBlock.bb, colWip, valBytes)
 	colWip.cbufidx += retLen
 	ss.updateColValueSizeInAllSeenColumns(key, retLen)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -1512,30 +1512,32 @@ func SetCardinalityLimit(val uint16) {
 func PackDictEnc(colWip *ColWip) {
 
 	localIdx := 0
+	colWip.dePackingBuf.Reset()
 
 	// copy num of dict words
-	utils.Uint16ToBytesLittleEndianInplace(colWip.deData.deCount, colWip.dePackingBuf[localIdx:])
+	colWip.dePackingBuf.AppendUint16LittleEndian(colWip.deData.deCount)
 	localIdx += 2
 
 	for dword, recNumsArr := range colWip.deData.deMap {
 
 		// copy the actual dict word , the TLV is packed inside the dword
-		copy(colWip.dePackingBuf[localIdx:], []byte(dword))
+		colWip.dePackingBuf.Append([]byte(dword))
+
 		localIdx += len(dword)
 
 		// copy num of records, by finding how many bits are set
 		numRecs := uint16(len(recNumsArr))
-		utils.Uint16ToBytesLittleEndianInplace(numRecs, colWip.dePackingBuf[localIdx:])
+		colWip.dePackingBuf.AppendUint16LittleEndian(numRecs)
 		localIdx += 2
 
 		for i := uint16(0); i < numRecs; i++ {
 			// copy the recNum
-			utils.Uint16ToBytesLittleEndianInplace(recNumsArr[i], colWip.dePackingBuf[localIdx:])
+			colWip.dePackingBuf.AppendUint16LittleEndian(recNumsArr[i])
 			localIdx += 2
 		}
 	}
 	colWip.cbuf.Reset()
-	colWip.cbuf.Append(colWip.dePackingBuf[:localIdx])
+	colWip.cbuf.Append(colWip.dePackingBuf.Slice(0, localIdx))
 	colWip.cbufidx = uint32(localIdx)
 }
 

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -298,7 +298,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 	s := colWip.cbufidx
 	colWip.cbuf.Append(VALTYPE_DICT_ARRAY[:])
 	colWip.cbufidx += 1
-	colWip.cbuf.AppendAsUint16(0) // Placeholder for encoding length of array
+	colWip.cbuf.AppendUint16LittleEndian(0) // Placeholder for encoding length of array
 	colWip.cbufidx += 2
 	_, aErr := jp.ArrayEach(data, func(value []byte, valueType jp.ValueType, offset int, err error) {
 		switch valueType {
@@ -315,7 +315,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 			}
 			//encode and copy keyName
 			n := uint16(len(keyName))
-			colWip.cbuf.AppendAsUint16(n)
+			colWip.cbuf.AppendUint16LittleEndian(n)
 			colWip.cbufidx += 2
 			colWip.cbuf.Append(keyName)
 			colWip.cbufidx += uint32(n)
@@ -436,7 +436,7 @@ func (ss *SegStore) encodeSingleRawBuffer(key string, value []byte,
 	colWip.cbuf.Append(VALTYPE_RAW_JSON[:])
 	colWip.cbufidx += 1
 	n := uint16(len(value))
-	colWip.cbuf.AppendAsUint16(n)
+	colWip.cbuf.AppendUint16LittleEndian(n)
 	colWip.cbufidx += 2
 	colWip.cbuf.Append(value)
 	colWip.cbufidx += uint32(n)
@@ -662,15 +662,15 @@ func encJsonNumber(key string, numType SS_IntUintFloatTypes, intVal int64, uintV
 	switch numType {
 	case SS_INT64:
 		wipbuf.Append(VALTYPE_ENC_INT64[:])
-		wipbuf.AppendAsInt64(intVal)
+		wipbuf.AppendInt64LittleEndian(intVal)
 		valSize = 1 + 8
 	case SS_UINT64:
 		wipbuf.Append(VALTYPE_ENC_UINT64[:])
-		wipbuf.AppendAsUint64(uintVal)
+		wipbuf.AppendUint64LittleEndian(uintVal)
 		valSize = 1 + 8
 	case SS_FLOAT64:
 		wipbuf.Append(VALTYPE_ENC_FLOAT64[:])
-		wipbuf.AppendAsFloat64(fltVal)
+		wipbuf.AppendFloat64LittleEndian(fltVal)
 		valSize = 1 + 8
 	default:
 		log.Errorf("encJsonNumber: unknown numType: %v", numType)

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -373,7 +373,12 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 	})
 	bytes := [2]byte{}
 	utils.Uint16ToBytesLittleEndianInplace(uint16(colWip.cbufidx-s-3), bytes[:])
-	colWip.cbuf.CopyFrom(bytes[:], int(s+1))
+	err := colWip.cbuf.CopyFrom(bytes[:], int(s+1))
+	if err != nil {
+		log.Errorf("encodeSingleDictArray: failed to copy length of array to buffer; err=%v", err)
+		return matchedCol, err
+	}
+
 	if aErr != nil {
 		finalErr = aErr
 	}

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -371,7 +371,9 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 			return
 		}
 	})
-	utils.Uint16ToBytesLittleEndianInplace(uint16(colWip.cbufidx-s-3), colWip.cbuf[s+1:])
+	bytes := [2]byte{}
+	utils.Uint16ToBytesLittleEndianInplace(uint16(colWip.cbufidx-s-3), bytes[:])
+	colWip.cbuf.CopyFrom(bytes[:], int(s+1))
 	if aErr != nil {
 		finalErr = aErr
 	}

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -860,7 +860,7 @@ func GetNumValFromRec(rec *utils.Buffer, offset int, qid uint64, retVal *Number)
 
 	retVal.SetInvalidType()
 
-	if rec == nil {
+	if rec.Len() == 0 {
 		return 0, errors.New("column value is empty")
 	}
 
@@ -1681,7 +1681,7 @@ func processStats(stats *SegStats, inNumType SS_IntUintFloatTypes, intVal int64,
 
 func getColByteSlice(rec *utils.Buffer, offset int, qid uint64) ([]byte, uint16, error) {
 
-	if rec == nil {
+	if rec.Len() == 0 {
 		return []byte{}, 0, errors.New("column value is empty")
 	}
 

--- a/pkg/segment/writer/packer.go
+++ b/pkg/segment/writer/packer.go
@@ -373,7 +373,7 @@ func (ss *SegStore) encodeSingleDictArray(arraykey string, data []byte,
 	})
 	bytes := [2]byte{}
 	utils.Uint16ToBytesLittleEndianInplace(uint16(colWip.cbufidx-s-3), bytes[:])
-	err := colWip.cbuf.CopyFrom(bytes[:], int(s+1))
+	err := colWip.cbuf.WriteAt(bytes[:], int(s+1))
 	if err != nil {
 		log.Errorf("encodeSingleDictArray: failed to copy length of array to buffer; err=%v", err)
 		return matchedCol, err

--- a/pkg/segment/writer/packer_test.go
+++ b/pkg/segment/writer/packer_test.go
@@ -160,7 +160,7 @@ func TestRecordEncodeDecode(t *testing.T) {
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
 			var val CValueEnclosure
-			_, _ = GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29, &val)
+			_, _ = GetCvalFromRec(colwip.cbuf.Slice(int(colwip.cstartidx), int(colwip.cbufidx)), 29, &val)
 			log.Infof("recNum %+v col %+v:%+v. type %+v", i, key, val, val.Dtype)
 		}
 	}
@@ -272,7 +272,7 @@ func TestJaegerRecordEncodeDecode(t *testing.T) {
 		colWips := allSegStores[sId].wipBlock.colWips
 		for key, colwip := range colWips {
 			var val CValueEnclosure
-			_, _ = GetCvalFromRec(colwip.cbuf[colwip.cstartidx:colwip.cbufidx], 29, &val)
+			_, _ = GetCvalFromRec(colwip.cbuf.Slice(int(colwip.cstartidx), int(colwip.cbufidx)), 29, &val)
 			log.Infof("recNum %+v col %+v:%+v. type %+v", i, key, val, val.Dtype)
 		}
 	}

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -81,7 +81,10 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 		}
 
 		var found bool
-		for _, colWip := range colWips {
+		for cname, colWip := range colWips {
+			if cname == tsKey {
+				continue
+			}
 			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf.ReadAll(), nil, false)
 			assert.Nil(t, err)
 			found = result

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -197,8 +197,8 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		t.Logf("doing equals search for haystack in cstr")
 		qValDte, _ = CreateDtypeEnclosure("haystack", 0)
 		qValDte.AddStringAsByteSlice()
-		var eOff uint16 = 3 + utils.BytesToUint16LittleEndian(colWips["cstr"].cbuf[1:3]) // 2 bytes stored for string type
-		result, err := ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cstr"].cbuf[:eOff], false, holderDte, false)
+		var eOff uint16 = 3 + utils.BytesToUint16LittleEndian(colWips["cstr"].cbuf.Slice(1, 3)) // 2 bytes stored for string type
+		result, err := ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cstr"].cbuf.Slice(0, int(eOff)), false, holderDte, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		qValDte.Reset()

--- a/pkg/segment/writer/rawchecker_test.go
+++ b/pkg/segment/writer/rawchecker_test.go
@@ -82,7 +82,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 
 		var found bool
 		for _, colWip := range colWips {
-			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf[:], nil, false)
+			result, err := ApplySearchToMatchFilterRawCsg(&mf, colWip.cbuf.ReadAll(), nil, false)
 			assert.Nil(t, err)
 			found = result
 			if found {
@@ -99,7 +99,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err := ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf.ReadAll(), nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for val2 in column-a worked")
@@ -110,7 +110,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: Or,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf.ReadAll(), nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for val2 in column-d worked (should not be found)")
@@ -121,7 +121,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf.ReadAll(), nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, false, result)
 		t.Logf("searching for two values in column-a worked (should not be found)")
@@ -132,7 +132,7 @@ func Test_ApplySearchToMatchFilterRaw(t *testing.T) {
 			MatchOperator: And,
 		}
 
-		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf[:], nil, false)
+		result, err = ApplySearchToMatchFilterRawCsg(&mf, colWips[mf.MatchColumn].cbuf.ReadAll(), nil, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, result)
 		t.Logf("searching for multiple values in column-a worked (all should be found)")
@@ -206,21 +206,21 @@ func Test_applySearchToExpressionFilterSimpleHelper(t *testing.T) {
 		t.Logf("doing equals search for haystack for col that is not string")
 		qValDte, _ = CreateDtypeEnclosure("haystack", 0)
 		qValDte.AddStringAsByteSlice()
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte, false)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf.ReadAll(), false, holderDte, false)
 		assert.Equal(t, false, result)
 		qValDte.Reset()
 
 		//TODO: uncomment when ApplySearchToExpressionFilterSimpleCsg for numbers is implemented
 		t.Logf("doing equals search for float ")
-		t.Logf("cbuf:%s", string(colWips["cfloat"].cbuf[:]))
+		t.Logf("cbuf:%s", string(colWips["cfloat"].cbuf.ReadAll()))
 		qValDte, _ = CreateDtypeEnclosure(-2345.35, 0)
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf[:], false, holderDte, false)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cfloat"].cbuf.ReadAll(), false, holderDte, false)
 		assert.Equal(t, true, result)
 		qValDte.Reset()
 
 		t.Logf("doing equals search for unsigned ")
 		qValDte, _ = CreateDtypeEnclosure(2345, 0)
-		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cunsigned"].cbuf[:], false, holderDte, false)
+		result, _ = ApplySearchToExpressionFilterSimpleCsg(qValDte, Equals, colWips["cunsigned"].cbuf.ReadAll(), false, holderDte, false)
 		assert.Equal(t, true, result)
 		qValDte.Reset()
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -211,6 +211,7 @@ func (segstore *SegStore) resetWipBlock(forceRotate bool) error {
 		for _, cwip := range segstore.wipBlock.colWips {
 			cwip.cbufidx = 0
 			cwip.cstartidx = 0
+			cwip.cbuf.Reset()
 
 			for dword := range cwip.deData.deMap {
 				delete(cwip.deData.deMap, dword)

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -395,7 +395,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 			if err == nil {
 				// Conversion succeeded.
 				newColWip.cbuf.Append(utils.VALTYPE_ENC_INT64[:])
-				toputils.Int64ToBytesLittleEndianInplace(intVal, newColWip.cbuf[newColWip.cbufidx+1:])
+				newColWip.cbuf.AppendAsInt64(intVal)
 				newColWip.cbufidx += 1 + 8
 				addIntToRangeIndex(colName, intVal, rangeIndex)
 				continue
@@ -406,7 +406,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 			if err == nil {
 				// Conversion succeeded.
 				newColWip.cbuf.Append(utils.VALTYPE_ENC_FLOAT64[:])
-				toputils.Float64ToBytesLittleEndianInplace(floatVal, newColWip.cbuf[newColWip.cbufidx+1:])
+				newColWip.cbuf.AppendAsFloat64(floatVal)
 				newColWip.cbufidx += 1 + 8
 				addFloatToRangeIndex(colName, floatVal, rangeIndex)
 				continue
@@ -1276,7 +1276,7 @@ func (wipBlock *WipBlock) encodeTimestamps() ([]byte, error) {
 	// store TS_TYPE and lowTs for reconstruction needs
 	tsWip.cbuf.Append([]byte{uint8(tsType)})
 	tsWip.cbufidx += 1
-	toputils.Uint64ToBytesLittleEndianInplace(lowTs, tsWip.cbuf[tsWip.cbufidx:])
+	tsWip.cbuf.AppendAsUint64(lowTs)
 	tsWip.cbufidx += 8
 
 	switch tsType {
@@ -1291,21 +1291,21 @@ func (wipBlock *WipBlock) encodeTimestamps() ([]byte, error) {
 		var tsVal uint16
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = uint16(wipBlock.blockTs[i] - lowTs)
-			toputils.Uint16ToBytesLittleEndianInplace(tsVal, tsWip.cbuf[tsWip.cbufidx:])
+			tsWip.cbuf.AppendAsUint16(tsVal)
 			tsWip.cbufidx += 2
 		}
 	case structs.TS_Type32:
 		var tsVal uint32
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = uint32(wipBlock.blockTs[i] - lowTs)
-			toputils.Uint32ToBytesLittleEndianInplace(tsVal, tsWip.cbuf[tsWip.cbufidx:])
+			tsWip.cbuf.AppendAsUint32(tsVal)
 			tsWip.cbufidx += 4
 		}
 	case structs.TS_Type64:
 		var tsVal uint64
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = wipBlock.blockTs[i] - lowTs
-			toputils.Uint64ToBytesLittleEndianInplace(tsVal, tsWip.cbuf[tsWip.cbufidx:])
+			tsWip.cbuf.AppendAsUint64(tsVal)
 			tsWip.cbufidx += 8
 		}
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -559,7 +559,7 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 		}
 
 		//readjust workBufComp size based on num of columns in this wip
-		flushParallelism := runtime.GOMAXPROCS(0)
+		flushParallelism := runtime.GOMAXPROCS(0) * 2
 		segstore.workBufForCompression = toputils.ResizeSlice(segstore.workBufForCompression,
 			flushParallelism)
 		// now make each of these bufs of atleast WIP_SIZE

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -409,7 +409,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 			if err == nil {
 				// Conversion succeeded.
 				newColWip.cbuf.Append(utils.VALTYPE_ENC_INT64[:])
-				newColWip.cbuf.AppendAsInt64(intVal)
+				newColWip.cbuf.AppendInt64LittleEndian(intVal)
 				newColWip.cbufidx += 1 + 8
 				addIntToRangeIndex(colName, intVal, rangeIndex)
 				continue
@@ -420,7 +420,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 			if err == nil {
 				// Conversion succeeded.
 				newColWip.cbuf.Append(utils.VALTYPE_ENC_FLOAT64[:])
-				newColWip.cbuf.AppendAsFloat64(floatVal)
+				newColWip.cbuf.AppendFloat64LittleEndian(floatVal)
 				newColWip.cbufidx += 1 + 8
 				addFloatToRangeIndex(colName, floatVal, rangeIndex)
 				continue
@@ -1305,7 +1305,7 @@ func (wipBlock *WipBlock) encodeTimestamps() ([]byte, error) {
 	// store TS_TYPE and lowTs for reconstruction needs
 	tsWip.cbuf.Append([]byte{uint8(tsType)})
 	tsWip.cbufidx += 1
-	tsWip.cbuf.AppendAsUint64(lowTs)
+	tsWip.cbuf.AppendUint64LittleEndian(lowTs)
 	tsWip.cbufidx += 8
 
 	switch tsType {
@@ -1320,21 +1320,21 @@ func (wipBlock *WipBlock) encodeTimestamps() ([]byte, error) {
 		var tsVal uint16
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = uint16(wipBlock.blockTs[i] - lowTs)
-			tsWip.cbuf.AppendAsUint16(tsVal)
+			tsWip.cbuf.AppendUint16LittleEndian(tsVal)
 			tsWip.cbufidx += 2
 		}
 	case structs.TS_Type32:
 		var tsVal uint32
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = uint32(wipBlock.blockTs[i] - lowTs)
-			tsWip.cbuf.AppendAsUint32(tsVal)
+			tsWip.cbuf.AppendUint32LittleEndian(tsVal)
 			tsWip.cbufidx += 4
 		}
 	case structs.TS_Type64:
 		var tsVal uint64
 		for i := uint16(0); i < wipBlock.blockSummary.RecCount; i++ {
 			tsVal = wipBlock.blockTs[i] - lowTs
-			tsWip.cbuf.AppendAsUint64(tsVal)
+			tsWip.cbuf.AppendUint64LittleEndian(tsVal)
 			tsWip.cbufidx += 8
 		}
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -294,7 +294,7 @@ func (segstore *SegStore) resetSegStore(streamid string, virtualTableName string
 
 	for _, cwip := range segstore.wipBlock.colWips {
 		cwip.cbuf.Reset()
-		wipCbufPool.Put(&cwip.dePackingBuf)
+		cwip.dePackingBuf.Reset()
 	}
 
 	segstore.wipBlock.colWips = make(map[string]*ColWip)
@@ -444,7 +444,7 @@ func convertColumnToNumbers(wipBlock *WipBlock, colName string, segmentKey strin
 	// Conversion succeeded, so replace the column with the new one.
 	wipBlock.colWips[colName] = newColWip
 	oldColWip.cbuf.Reset()
-	wipCbufPool.Put(&oldColWip.dePackingBuf)
+	oldColWip.dePackingBuf.Reset()
 	delete(wipBlock.columnBlooms, colName)
 	return true, nil
 }
@@ -523,7 +523,7 @@ func convertColumnToStrings(wipBlock *WipBlock, colName string, segmentKey strin
 	// Replace the old column.
 	wipBlock.colWips[colName] = newColWip
 	oldColWip.cbuf.Reset()
-	wipCbufPool.Put(&oldColWip.dePackingBuf)
+	oldColWip.dePackingBuf.Reset()
 	delete(wipBlock.columnRangeIndexes, colName)
 
 	return nil

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -544,7 +544,12 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 	// If there's columns that had both strings and numbers in them, we need to
 	// try converting them all to numbers, but if that doesn't work we'll
 	// convert them all to strings.
-	consolidateColumnTypes(&segstore.wipBlock, segstore.SegmentKey)
+	err := consolidateColumnTypes(&segstore.wipBlock, segstore.SegmentKey)
+	if err != nil {
+		log.Errorf("AppendWipToSegfile: error consolidating column types; err=%v", err)
+		return err
+	}
+
 	if segstore.wipBlock.maxIdx > 0 {
 		var totalBytesWritten uint64 = 0
 		var totalMetadata uint64 = 0

--- a/pkg/segment/writer/segstream.go
+++ b/pkg/segment/writer/segstream.go
@@ -216,5 +216,5 @@ func (segStore *SegStore) addRecordToMatchedResults(recNum uint16, pqid string) 
 }
 
 func (colWip *ColWip) getLastRecord() []byte {
-	return colWip.cbuf[colWip.cstartidx:colWip.cbufidx]
+	return colWip.cbuf.Slice(int(colWip.cstartidx), int(colWip.cbufidx))
 }

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1192,7 +1192,7 @@ func (cw *ColWip) WriteSingleStringBytes(value []byte) {
 	cw.cbuf.Append(VALTYPE_ENC_SMALL_STRING[:])
 	cw.cbufidx += 1
 	n := uint16(len(value))
-	utils.Uint16ToBytesLittleEndianInplace(n, cw.cbuf[cw.cbufidx:])
+	cw.cbuf.AppendAsUint16(n)
 	cw.cbufidx += 2
 	cw.cbuf.Append(value)
 	cw.cbufidx += uint32(n)

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -73,16 +73,6 @@ var plePool = sync.Pool{
 var encoder, _ = zstd.NewWriter(nil)
 var decoder, _ = zstd.NewReader(nil)
 
-var wipCbufPool = sync.Pool{
-	New: func() interface{} {
-		// The Pool's New function should generally only return pointer
-		// types, since a pointer can be put into the return interface
-		// value without an allocation:
-		slice := make([]byte, WIP_SIZE)
-		return &slice
-	},
-}
-
 func InitKibanaInternalData() {
 	KibanaInternalBaseDir = config.GetDataPath() + "common/kibanainternaldata/"
 	err := os.MkdirAll(KibanaInternalBaseDir, 0764)
@@ -108,7 +98,7 @@ type ColWip struct {
 	cbuf         *utils.Buffer
 	csgFname     string // file name of csg file
 	deData       *DeData
-	dePackingBuf []byte
+	dePackingBuf *utils.Buffer
 }
 
 type RangeIndex struct {
@@ -720,13 +710,11 @@ func InitColWip(segKey string, colName string) *ColWip {
 		deCount: 0,
 	}
 
-	dePack := *wipCbufPool.Get().(*[]byte)
-
 	return &ColWip{
 		csgFname:     fmt.Sprintf("%v_%v.csg", segKey, xxhash.Sum64String(colName)),
 		deData:       &deData,
 		cbuf:         &utils.Buffer{},
-		dePackingBuf: dePack,
+		dePackingBuf: &utils.Buffer{},
 	}
 }
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -1192,7 +1192,7 @@ func (cw *ColWip) WriteSingleStringBytes(value []byte) {
 	cw.cbuf.Append(VALTYPE_ENC_SMALL_STRING[:])
 	cw.cbufidx += 1
 	n := uint16(len(value))
-	cw.cbuf.AppendAsUint16(n)
+	cw.cbuf.AppendUint16LittleEndian(n)
 	cw.cbufidx += 2
 	cw.cbuf.Append(value)
 	cw.cbufidx += uint32(n)

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -150,7 +150,7 @@ func (b *Buffer) Slice(start int, end int) []byte {
 	numSkippedChunks := start / chunkSize
 	copy(buf, b.chunks[numSkippedChunks][start%chunkSize:])
 	offset := chunkSize - (start % chunkSize)
-	for i := numSkippedChunks + 1; i <= end/chunkSize; i++ {
+	for i := numSkippedChunks + 1; i <= end/chunkSize && i < len(b.chunks); i++ {
 		// Note: on the last iteration, we generally don't wnat to copy the
 		// whole chunk, but since copy() copies the minimum of the two slice
 		// lengths, we don't need to do anything special.

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -19,12 +19,18 @@ package utils
 
 const chunkSize = 1024
 
-type Buffer struct{}
+type Buffer struct {
+	chunks [][]byte
+}
+
+func (b *Buffer) Append(data []byte) error {
+	return nil
+}
 
 func (b *Buffer) Read(start int, end int) ([]byte, error) {
 	return nil, nil
 }
 
-func (b *Buffer) Append(data []byte) error {
+func (b *Buffer) ReadAll() []byte {
 	return nil
 }

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -88,6 +88,38 @@ func (b *Buffer) Append(data []byte) {
 	}
 }
 
+// TODO: check if optimizing this (and similar) functions by avoiding the
+// temporary buffer is worthwhile.
+func (b *Buffer) AppendAsUint16(val uint16) {
+	buf := [2]byte{}
+	Uint16ToBytesLittleEndianInplace(val, buf[:])
+	b.Append(buf[:])
+}
+
+func (b *Buffer) AppendAsUint32(val uint32) {
+	buf := [4]byte{}
+	Uint32ToBytesLittleEndianInplace(val, buf[:])
+	b.Append(buf[:])
+}
+
+func (b *Buffer) AppendAsUint64(val uint64) {
+	buf := [8]byte{}
+	Uint64ToBytesLittleEndianInplace(val, buf[:])
+	b.Append(buf[:])
+}
+
+func (b *Buffer) AppendAsInt64(val int64) {
+	buf := [8]byte{}
+	Int64ToBytesLittleEndianInplace(val, buf[:])
+	b.Append(buf[:])
+}
+
+func (b *Buffer) AppendAsFloat64(val float64) {
+	buf := [8]byte{}
+	Float64ToBytesLittleEndianInplace(val, buf[:])
+	b.Append(buf[:])
+}
+
 // If Buffer was a normal contiguous slice, Slice(start, end) would be
 // equivalent to Buffer[start:end].
 func (b *Buffer) Slice(start int, end int) []byte {

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -123,7 +123,7 @@ func (b *Buffer) AppendAsFloat64(val float64) {
 // If Buffer was a normal contiguous slice, Slice(start, end) would be
 // equivalent to Buffer[start:end].
 func (b *Buffer) Slice(start int, end int) []byte {
-	if b == nil || b.chunks == nil {
+	if b == nil {
 		return nil
 	}
 

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -23,7 +23,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const chunkSize = 1024
+const chunkSize = 16 * 1024
 
 var chunkPool = sync.Pool{
 	New: func() interface{} {

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -195,17 +195,17 @@ func (b *Buffer) CopyTo(dst []byte) error {
 	return nil
 }
 
-func (b *Buffer) CopyFrom(src []byte, start int) error {
+func (b *Buffer) WriteAt(src []byte, start int) error {
 	if b == nil {
-		return TeeErrorf("Buffer.CopyFrom: nil buffer")
+		return TeeErrorf("Buffer.WriteAt: nil buffer")
 	}
 
 	if start < 0 || start > b.Len() {
-		return TeeErrorf("Buffer.CopyFrom: invalid start position %v; len=%v", start, b.Len())
+		return TeeErrorf("Buffer.WriteAt: invalid start position %v; len=%v", start, b.Len())
 	}
 
 	if start+len(src) > b.Len() {
-		return TeeErrorf("Buffer.CopyFrom: src has %v bytes but needs %v bytes",
+		return TeeErrorf("Buffer.WriteAt: src has %v bytes but needs %v bytes",
 			len(src), b.Len()-start)
 	}
 

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -90,31 +90,31 @@ func (b *Buffer) Append(data []byte) {
 
 // TODO: check if optimizing this (and similar) functions by avoiding the
 // temporary buffer is worthwhile.
-func (b *Buffer) AppendAsUint16(val uint16) {
+func (b *Buffer) AppendUint16LittleEndian(val uint16) {
 	buf := [2]byte{}
 	Uint16ToBytesLittleEndianInplace(val, buf[:])
 	b.Append(buf[:])
 }
 
-func (b *Buffer) AppendAsUint32(val uint32) {
+func (b *Buffer) AppendUint32LittleEndian(val uint32) {
 	buf := [4]byte{}
 	Uint32ToBytesLittleEndianInplace(val, buf[:])
 	b.Append(buf[:])
 }
 
-func (b *Buffer) AppendAsUint64(val uint64) {
+func (b *Buffer) AppendUint64LittleEndian(val uint64) {
 	buf := [8]byte{}
 	Uint64ToBytesLittleEndianInplace(val, buf[:])
 	b.Append(buf[:])
 }
 
-func (b *Buffer) AppendAsInt64(val int64) {
+func (b *Buffer) AppendInt64LittleEndian(val int64) {
 	buf := [8]byte{}
 	Int64ToBytesLittleEndianInplace(val, buf[:])
 	b.Append(buf[:])
 }
 
-func (b *Buffer) AppendAsFloat64(val float64) {
+func (b *Buffer) AppendFloat64LittleEndian(val float64) {
 	buf := [8]byte{}
 	Float64ToBytesLittleEndianInplace(val, buf[:])
 	b.Append(buf[:])

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -25,6 +25,14 @@ type Buffer struct {
 }
 
 func (b *Buffer) Len() int {
+	if b == nil {
+		return 0
+	}
+
+	if len(b.chunks) == 0 {
+		return b.offset
+	}
+
 	return b.offset + (len(b.chunks)-1)*chunkSize
 }
 
@@ -54,6 +62,7 @@ func (b *Buffer) Append(data []byte) {
 
 		copy(b.chunks[len(b.chunks)-1][b.offset:], data[:availableBytes])
 		data = data[availableBytes:]
+		b.offset = 0
 	}
 }
 

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -125,6 +125,15 @@ func (b *Buffer) Slice(start int, end int) []byte {
 	return buf
 }
 
+func (b *Buffer) At(pos int) (byte, error) {
+	slice := b.Slice(pos, pos+1)
+	if slice == nil {
+		return 0, TeeErrorf("Buffer.At: invalid position %v; len=%v", pos, b.Len())
+	}
+
+	return slice[0], nil
+}
+
 func (b *Buffer) ReadAll() ([]byte, error) {
 	if b == nil {
 		return nil, TeeErrorf("Buffer.ReadAll: nil buffer")

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+const chunkSize = 1024
+
+type Buffer struct{}
+
+func (b *Buffer) Read(start int, end int) ([]byte, error) {
+	return nil, nil
+}
+
+func (b *Buffer) Append(data []byte) error {
+	return nil
+}

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -166,23 +166,8 @@ func (b *Buffer) At(pos int) (byte, error) {
 	return slice[0], nil
 }
 
-func (b *Buffer) ReadAll() ([]byte, error) {
-	if b == nil {
-		return nil, TeeErrorf("Buffer.ReadAll: nil buffer")
-	}
-
-	if len(b.chunks) == 0 {
-		return nil, nil
-	}
-
-	buf := make([]byte, b.Len())
-	err := b.CopyTo(buf)
-	if err != nil {
-		log.Errorf("Buffer.ReadAll: failed to copy; err=%v", err)
-		return nil, err
-	}
-
-	return buf, nil
+func (b *Buffer) ReadAll() []byte {
+	return b.Slice(0, b.Len())
 }
 
 func (b *Buffer) CopyTo(dst []byte) error {

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -131,6 +131,10 @@ func (b *Buffer) Slice(start int, end int) []byte {
 		return nil
 	}
 
+	if start == end {
+		return []byte{}
+	}
+
 	if start/chunkSize == (end-1)/chunkSize {
 		// This range is entirely within a single chunk.
 		chunkStart := start % chunkSize

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -33,24 +33,27 @@ func (b *Buffer) Append(data []byte) {
 		return
 	}
 
-	if len(data) == 0 {
-		return
-	}
+	for {
+		if len(data) == 0 {
+			return
+		}
 
-	var availableBytes int
-	if b.offset > 0 {
-		availableBytes = chunkSize - b.offset
-	} else {
-		b.chunks = append(b.chunks, make([]byte, chunkSize))
-		availableBytes = chunkSize
-	}
+		var availableBytes int
+		if b.offset > 0 {
+			availableBytes = chunkSize - b.offset
+		} else {
+			b.chunks = append(b.chunks, make([]byte, chunkSize))
+			availableBytes = chunkSize
+		}
 
-	if len(data) <= availableBytes {
-		copy(b.chunks[len(b.chunks)-1][b.offset:], data)
-		b.offset += len(data)
-	} else {
-		// TODO
-		panic("not implemented")
+		if len(data) <= availableBytes {
+			copy(b.chunks[len(b.chunks)-1][b.offset:], data)
+			b.offset += len(data)
+			return
+		}
+
+		copy(b.chunks[len(b.chunks)-1][b.offset:], data[:availableBytes])
+		data = data[availableBytes:]
 	}
 }
 

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -32,6 +32,7 @@ func testAppendAndRead(t *testing.T, buffer *Buffer, data ...[]byte) {
 
 		readData, err := buffer.ReadAll()
 		assert.NoError(t, err)
+		assert.Equal(t, len(readData), buffer.Len())
 		assert.Equal(t, joinedData, readData)
 	}
 }
@@ -75,4 +76,29 @@ func Test_CopyTo(t *testing.T) {
 	err = buffer.CopyTo(bytes)
 	assert.NoError(t, err)
 	assert.Equal(t, data, bytes)
+}
+
+func Test_Len(t *testing.T) {
+	buffer := &Buffer{}
+	assert.Equal(t, 0, buffer.Len())
+
+	seed := 42
+	data1 := RandomBuffer(chunkSize*0+10, seed)
+	data2 := RandomBuffer(chunkSize*1+10, seed+1)
+	testAppendAndRead(t, buffer, data1, data2)
+
+	assert.Equal(t, len(data1)+len(data2), buffer.Len())
+}
+
+func Test_Reset(t *testing.T) {
+	seed := 42
+	data1 := RandomBuffer(chunkSize*3+10, seed)
+	data2 := RandomBuffer(chunkSize*2+10, seed+1)
+	buffer := &Buffer{}
+	testAppendAndRead(t, buffer, data1, data2)
+
+	buffer.Reset()
+	assert.Equal(t, 0, buffer.Len())
+	data3 := RandomBuffer(chunkSize*1+10, seed+2)
+	testAppendAndRead(t, buffer, data3)
 }

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -145,3 +145,28 @@ func Test_Slice(t *testing.T) {
 	assert.Equal(t, data[0:0], buffer.Slice(0, 0))
 	assert.Equal(t, []byte{}, buffer.Slice(buffer.Len(), buffer.Len()))
 }
+
+func Test_AppendLittleEndian(t *testing.T) {
+	buffer := &Buffer{}
+	buffer.AppendUint16LittleEndian(1)
+	assert.Equal(t, 2, buffer.Len())
+
+	buffer.AppendUint32LittleEndian(2)
+	assert.Equal(t, 6, buffer.Len())
+
+	buffer.AppendUint64LittleEndian(3)
+	assert.Equal(t, 14, buffer.Len())
+
+	buffer.AppendInt64LittleEndian(-4)
+	assert.Equal(t, 22, buffer.Len())
+
+	buffer.AppendFloat64LittleEndian(5.5)
+	assert.Equal(t, 30, buffer.Len())
+
+	bytes := buffer.ReadAll()
+	assert.Equal(t, uint16(1), BytesToUint16LittleEndian(bytes[0:2]))
+	assert.Equal(t, uint32(2), BytesToUint32LittleEndian(bytes[2:6]))
+	assert.Equal(t, uint64(3), BytesToUint64LittleEndian(bytes[6:14]))
+	assert.Equal(t, int64(-4), BytesToInt64LittleEndian(bytes[14:22]))
+	assert.Equal(t, float64(5.5), BytesToFloat64LittleEndian(bytes[22:30]))
+}

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -83,23 +83,23 @@ func Test_CopyFrom(t *testing.T) {
 	buffer.Append(data)
 
 	newData := []byte("hello")
-	err := buffer.CopyFrom(newData, 0)
+	err := buffer.WriteAt(newData, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, newData, buffer.Slice(0, len(newData)))
 
-	err = buffer.CopyFrom(newData, chunkSize-len(newData))
+	err = buffer.WriteAt(newData, chunkSize-len(newData))
 	assert.NoError(t, err)
 	assert.Equal(t, newData, buffer.Slice(chunkSize-len(newData), chunkSize))
 
-	err = buffer.CopyFrom(newData, chunkSize-1)
+	err = buffer.WriteAt(newData, chunkSize-1)
 	assert.NoError(t, err)
 	assert.Equal(t, newData, buffer.Slice(chunkSize-1, chunkSize+len(newData)-1))
 
 	// Invalid start
-	err = buffer.CopyFrom(newData, chunkSize*2-1)
+	err = buffer.WriteAt(newData, chunkSize*2-1)
 	assert.Error(t, err)
 
-	err = buffer.CopyFrom(newData, -1)
+	err = buffer.WriteAt(newData, -1)
 	assert.Error(t, err)
 }
 

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -78,6 +78,32 @@ func Test_CopyTo(t *testing.T) {
 	assert.Equal(t, data, bytes)
 }
 
+func Test_CopyFrom(t *testing.T) {
+	data := make([]byte, chunkSize*2)
+	buffer := &Buffer{}
+	buffer.Append(data)
+
+	newData := []byte("hello")
+	err := buffer.CopyFrom(newData, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, newData, buffer.Slice(0, len(newData)))
+
+	err = buffer.CopyFrom(newData, chunkSize-len(newData))
+	assert.NoError(t, err)
+	assert.Equal(t, newData, buffer.Slice(chunkSize-len(newData), chunkSize))
+
+	err = buffer.CopyFrom(newData, chunkSize-1)
+	assert.NoError(t, err)
+	assert.Equal(t, newData, buffer.Slice(chunkSize-1, chunkSize+len(newData)-1))
+
+	// Invalid start
+	err = buffer.CopyFrom(newData, chunkSize*2-1)
+	assert.Error(t, err)
+
+	err = buffer.CopyFrom(newData, -1)
+	assert.Error(t, err)
+}
+
 func Test_Len(t *testing.T) {
 	buffer := &Buffer{}
 	assert.Equal(t, 0, buffer.Len())

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -137,6 +137,10 @@ func Test_Slice(t *testing.T) {
 	assert.Equal(t, data[:10], buffer.Slice(0, 10))
 	assert.Equal(t, data[chunkSize*3:], buffer.Slice(chunkSize*3, buffer.Len()))
 	assert.Equal(t, data[chunkSize-5:chunkSize], buffer.Slice(chunkSize-5, chunkSize))
+	assert.Equal(t, data[chunkSize-5:chunkSize+1], buffer.Slice(chunkSize-5, chunkSize+1))
+	assert.Equal(t, data[chunkSize-1:chunkSize+1], buffer.Slice(chunkSize-1, chunkSize+1))
 	assert.Equal(t, data[chunkSize-5:chunkSize+5], buffer.Slice(chunkSize-5, chunkSize+5))
 	assert.Equal(t, data, buffer.Slice(0, buffer.Len()))
+	assert.Equal(t, data[0:0], buffer.Slice(0, 0))
+	assert.Equal(t, []byte{}, buffer.Slice(buffer.Len(), buffer.Len()))
 }

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -30,7 +30,8 @@ func testAppendAndRead(t *testing.T, buffer *Buffer, data ...[]byte) {
 		joinedData = append(joinedData, d...)
 		assert.Equal(t, len(joinedData), buffer.Len())
 
-		readData := buffer.ReadAll()
+		readData, err := buffer.ReadAll()
+		assert.NoError(t, err)
 		assert.Equal(t, joinedData, readData)
 	}
 }
@@ -56,4 +57,22 @@ func Test_Append_multiple(t *testing.T) {
 	data1 := RandomBuffer(chunkSize*1+50, seed)
 	data2 := RandomBuffer(chunkSize*2+10, seed+1)
 	testAppendAndRead(t, &Buffer{}, data1, data2)
+}
+
+func Test_CopyTo(t *testing.T) {
+	seed := 42
+	data := RandomBuffer(chunkSize*3+10, seed)
+	buffer := &Buffer{}
+	buffer.Append(data)
+
+	// Insufficient space
+	bytes := make([]byte, 10)
+	err := buffer.CopyTo(bytes)
+	assert.Error(t, err)
+
+	// Sufficient space
+	bytes = make([]byte, buffer.Len())
+	err = buffer.CopyTo(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, data, bytes)
 }

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -48,3 +48,16 @@ func Test_Append_spanningMultipleChunks(t *testing.T) {
 	readData := buffer.ReadAll()
 	assert.Equal(t, data, readData)
 }
+
+func Test_Append_multiple(t *testing.T) {
+	seed := 42
+	data1 := RandomBuffer(chunkSize*1+50, seed)
+	data2 := RandomBuffer(chunkSize*2+10, seed+1)
+	buffer := Buffer{}
+	buffer.Append(data1)
+	buffer.Append(data2)
+
+	assert.Equal(t, len(data1)+len(data2), buffer.Len())
+	readData := buffer.ReadAll()
+	assert.Equal(t, append(data1, data2...), readData)
+}

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -102,3 +102,16 @@ func Test_Reset(t *testing.T) {
 	data3 := RandomBuffer(chunkSize*1+10, seed+2)
 	testAppendAndRead(t, buffer, data3)
 }
+
+func Test_Read(t *testing.T) {
+	seed := 42
+	data := RandomBuffer(chunkSize*3+10, seed)
+	buffer := &Buffer{}
+	buffer.Append(data)
+
+	assert.Equal(t, data[:10], buffer.Read(0, 10))
+	assert.Equal(t, data[chunkSize*3:], buffer.Read(chunkSize*3, buffer.Len()))
+	assert.Equal(t, data[chunkSize-5:chunkSize], buffer.Read(chunkSize-5, chunkSize))
+	assert.Equal(t, data[chunkSize-5:chunkSize+5], buffer.Read(chunkSize-5, chunkSize+5))
+	assert.Equal(t, data, buffer.Read(0, buffer.Len()))
+}

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -132,6 +132,7 @@ func Test_Slice(t *testing.T) {
 	seed := 42
 	data := RandomBuffer(chunkSize*3+10, seed)
 	buffer := &Buffer{}
+	assert.Equal(t, []byte{}, buffer.Slice(0, 0))
 	buffer.Append(data)
 
 	assert.Equal(t, data[:10], buffer.Slice(0, 10))

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -146,6 +146,15 @@ func Test_Slice(t *testing.T) {
 	assert.Equal(t, []byte{}, buffer.Slice(buffer.Len(), buffer.Len()))
 }
 
+func Test_Slice_fullLastChunk(t *testing.T) {
+	seed := 42
+	data := RandomBuffer(chunkSize*3, seed)
+	buffer := &Buffer{}
+	buffer.Append(data)
+
+	assert.Equal(t, data, buffer.Slice(0, buffer.Len()))
+}
+
 func Test_AppendLittleEndian(t *testing.T) {
 	buffer := &Buffer{}
 	buffer.AppendUint16LittleEndian(1)

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -16,3 +16,17 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Append_toEmpty(t *testing.T) {
+	data := []byte("hello")
+	buffer := Buffer{}
+	buffer.Append(data)
+	readData := buffer.ReadAll()
+	assert.Equal(t, data, readData)
+}

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -103,15 +103,15 @@ func Test_Reset(t *testing.T) {
 	testAppendAndRead(t, buffer, data3)
 }
 
-func Test_Read(t *testing.T) {
+func Test_Slice(t *testing.T) {
 	seed := 42
 	data := RandomBuffer(chunkSize*3+10, seed)
 	buffer := &Buffer{}
 	buffer.Append(data)
 
-	assert.Equal(t, data[:10], buffer.Read(0, 10))
-	assert.Equal(t, data[chunkSize*3:], buffer.Read(chunkSize*3, buffer.Len()))
-	assert.Equal(t, data[chunkSize-5:chunkSize], buffer.Read(chunkSize-5, chunkSize))
-	assert.Equal(t, data[chunkSize-5:chunkSize+5], buffer.Read(chunkSize-5, chunkSize+5))
-	assert.Equal(t, data, buffer.Read(0, buffer.Len()))
+	assert.Equal(t, data[:10], buffer.Slice(0, 10))
+	assert.Equal(t, data[chunkSize*3:], buffer.Slice(chunkSize*3, buffer.Len()))
+	assert.Equal(t, data[chunkSize-5:chunkSize], buffer.Slice(chunkSize-5, chunkSize))
+	assert.Equal(t, data[chunkSize-5:chunkSize+5], buffer.Slice(chunkSize-5, chunkSize+5))
+	assert.Equal(t, data, buffer.Slice(0, buffer.Len()))
 }

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -23,41 +23,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func testAppendAndRead(t *testing.T, buffer *Buffer, data ...[]byte) {
+	joinedData := []byte{}
+	for _, d := range data {
+		buffer.Append(d)
+		joinedData = append(joinedData, d...)
+		assert.Equal(t, len(joinedData), buffer.Len())
+
+		readData := buffer.ReadAll()
+		assert.Equal(t, joinedData, readData)
+	}
+}
+
 func Test_Append_toEmpty(t *testing.T) {
-	data := []byte("hello")
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
+	testAppendAndRead(t, &Buffer{}, []byte("hello"))
 }
 
 func Test_Append_spanningChunk(t *testing.T) {
 	seed := 42
 	data := RandomBuffer(chunkSize+10, seed)
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
+	testAppendAndRead(t, &Buffer{}, data)
 }
 
 func Test_Append_spanningMultipleChunks(t *testing.T) {
 	seed := 42
 	data := RandomBuffer(chunkSize*3+10, seed)
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
+	testAppendAndRead(t, &Buffer{}, data)
 }
 
 func Test_Append_multiple(t *testing.T) {
 	seed := 42
 	data1 := RandomBuffer(chunkSize*1+50, seed)
 	data2 := RandomBuffer(chunkSize*2+10, seed+1)
-	buffer := Buffer{}
-	buffer.Append(data1)
-	buffer.Append(data2)
-
-	assert.Equal(t, len(data1)+len(data2), buffer.Len())
-	readData := buffer.ReadAll()
-	assert.Equal(t, append(data1, data2...), readData)
+	testAppendAndRead(t, &Buffer{}, data1, data2)
 }

--- a/pkg/utils/buffer_test.go
+++ b/pkg/utils/buffer_test.go
@@ -30,8 +30,7 @@ func testAppendAndRead(t *testing.T, buffer *Buffer, data ...[]byte) {
 		joinedData = append(joinedData, d...)
 		assert.Equal(t, len(joinedData), buffer.Len())
 
-		readData, err := buffer.ReadAll()
-		assert.NoError(t, err)
+		readData := buffer.ReadAll()
 		assert.Equal(t, len(readData), buffer.Len())
 		assert.Equal(t, joinedData, readData)
 	}

--- a/pkg/utils/randutils.go
+++ b/pkg/utils/randutils.go
@@ -17,34 +17,16 @@
 
 package utils
 
-import (
-	"testing"
+import "math/rand"
 
-	"github.com/stretchr/testify/assert"
-)
+func RandomBuffer(size int, seed int) []byte {
+	source := rand.NewSource(int64(seed))
+	rand := rand.New(source)
+	buf := make([]byte, size)
 
-func Test_Append_toEmpty(t *testing.T) {
-	data := []byte("hello")
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
-}
+	for i := 0; i < size; i++ {
+		buf[i] = byte(rand.Intn(256))
+	}
 
-func Test_Append_spanningChunk(t *testing.T) {
-	seed := 42
-	data := RandomBuffer(chunkSize+10, seed)
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
-}
-
-func Test_Append_spanningMultipleChunks(t *testing.T) {
-	seed := 42
-	data := RandomBuffer(chunkSize*3+10, seed)
-	buffer := Buffer{}
-	buffer.Append(data)
-	readData := buffer.ReadAll()
-	assert.Equal(t, data, readData)
+	return buf
 }

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -81,20 +81,22 @@ func CreateUniqueIndentifier() string {
 	return UUID_GENERATOR.Hex128()
 }
 
-func Max(x, y uint64) uint64 {
+func Max[T ~int | ~uint64](x, y T) T {
 	if x < y {
 		return y
 	}
 	return x
 }
 
-func Min(x, y uint64) uint64 {
+func Min[T ~int | ~uint64](x, y T) T {
 	if x > y {
 		return y
 	}
 	return x
 }
 
+// TODO: delete these functions (and all similar in the codebase). Use the
+// generic min/max functions instead.
 func MaxInt64(x, y int64) int64 {
 	if x < y {
 		return y


### PR DESCRIPTION
# Description
1. Make a new `Buffer` type that's useful for large buffers that get appended to a lot. Instead of resizing the buffer (and potentially copying all the data to the new buffer), the `Buffer` uses fixed-size chunks of data; when the `Buffer` needs more space it gets a new chunk and updates its internal data structure so it acts like that next chunk is contiguous.
2. Use the `Buffer` instead of `[]byte` during ingestion for the `cbuf` and `dePackingBuf` which store compressed ingestion data
3. Limit the parallelism of flushing columns in a block to files. Each column uses a 2MB `[]byte`, so limiting the parallelism to the number of CPUs greatly reduces the memory usage.

# Testing
## Correctness
New unit tests, and existing unit/E2E tests

## Performance
The below ingestion task would OOM my 16GB machine (because it creates a lot of columns and each column was using a fixed amount of memory even if it didn't contain much data). Now it runs fine and uses about 2.5GB:
```
go run main.go ingest esbulk -n 1 -g dynamic-user -d http://localhost:8081/elastic -p 20 -t 20_000_000 -i bidx -b 100   --enableVariableNumColumns true --maxColumns 100  --minColumns 100 --uniqColumns 3900
```

This PR slows ingestion by about 15%. I tested with these on my 12-CPU machine
```
go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 1_000_000 -p 1
go run main.go ingest esbulk -n 12 -g benchmark -d http://localhost:8081/elastic -t 1_000_000 -p 12
```
On develop, they were about 19k events/s and 56k events/s. On this branch they're about 17k events/s and 45.5k events/s

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
