### PR TITLE
fix: processing panic on cleanup

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -303,6 +303,14 @@ func (iqr *IQR) readColumnInternal(cname string) ([]utils.CValueEnclosure, error
 
 	switch iqr.mode {
 	case withRRCs:
+		// Check if the column was renamed and use the old name
+		// for reading it from the RRCs.
+		for oldName, newName := range iqr.renamedColumns {
+			if newName == cname {
+				cname = oldName
+				break
+			}
+		}
 		return iqr.readColumnWithRRCs(cname)
 	case withoutRRCs:
 		// We don't have RRCs, so we can't read the column. Since we got here
@@ -455,8 +463,14 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 			len(iqr.rrcs), len(results))
 	}
 
+	finalCname := cname
+	// Check if the column was renamed and use the new Cname for the results.
+	if newColName, ok := iqr.renamedColumns[cname]; ok {
+		finalCname = newColName
+	}
+
 	// TODO: should we have an option to disable this caching?
-	iqr.knownValues[cname] = results
+	iqr.knownValues[finalCname] = results
 
 	return results, nil
 }

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -115,11 +115,10 @@ func (dp *DataProcessor) Fetch() (*iqr.IQR, error) {
 				return nil, utils.TeeErrorf("DP.Fetch: failed to fetch input: %v", err)
 			}
 
+			dp.processorLock.Lock()
 			if dp.isCleanupCalled {
 				return nil, io.EOF
 			}
-
-			dp.processorLock.Lock()
 			output, err = dp.processor.Process(input)
 			dp.processorLock.Unlock()
 

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -56,7 +56,7 @@ type QueryProcessor struct {
 
 func (qp *QueryProcessor) Cleanup() {
 	for _, dp := range qp.chain {
-		dp.processor.Cleanup()
+		dp.Cleanup()
 	}
 }
 

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -56,7 +56,7 @@ type QueryProcessor struct {
 
 func (qp *QueryProcessor) Cleanup() {
 	for _, dp := range qp.chain {
-		dp.Cleanup()
+		go dp.Cleanup()
 	}
 }
 

--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -20,6 +20,7 @@ package processor
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/query/iqr"
@@ -40,19 +41,27 @@ type ErrorData struct {
 }
 
 type statsProcessor struct {
-	options             *structs.StatsExpr
-	bucketKeyWorkingBuf []byte
-	byteBuffer          *bbp.ByteBuffer
-	searchResults       *segresults.SearchResults
-	qid                 uint64
-	processorType       structs.QueryType
-	errorData           *ErrorData
-	hasFinalResult      bool
+	options                  *structs.StatsExpr
+	bucketKeyWorkingBuf      []byte
+	byteBuffer               *bbp.ByteBuffer
+	searchResults            *segresults.SearchResults
+	qid                      uint64
+	processorType            structs.QueryType
+	errorData                *ErrorData
+	hasFinalResult           bool
+	shouldContinueProcessing bool
+	inExecution              bool
 }
 
 func NewStatsProcessor(options *structs.StatsExpr) *statsProcessor {
 	processor := &statsProcessor{
-		options: options,
+		options:                  options,
+		shouldContinueProcessing: true,
+		errorData: &ErrorData{
+			readColumns:           make(map[string]error),
+			cValueGetStringErr:    make(map[string]error),
+			notSupportedStatsType: make(map[string]struct{}),
+		},
 	}
 
 	if options != nil {
@@ -67,6 +76,9 @@ func NewStatsProcessor(options *structs.StatsExpr) *statsProcessor {
 }
 
 func (p *statsProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
+	p.inExecution = true
+	defer func() { p.inExecution = false }()
+
 	// Initialize error data
 	if p.errorData == nil {
 		p.errorData = &ErrorData{
@@ -98,6 +110,22 @@ func (p *statsProcessor) Rewind() {
 }
 
 func (p *statsProcessor) Cleanup() {
+	p.shouldContinueProcessing = false
+
+	if p.inExecution {
+		go func() {
+			for p.inExecution {
+				// wait for the current execution to finish
+				time.Sleep(10 * time.Millisecond)
+			}
+			p.cleanupResources()
+		}()
+	} else {
+		p.cleanupResources()
+	}
+}
+
+func (p *statsProcessor) cleanupResources() {
 	p.bucketKeyWorkingBuf = nil
 	if p.byteBuffer != nil {
 		bbp.Put(p.byteBuffer)
@@ -164,6 +192,10 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 	measureResults := make([]utils.CValueEnclosure, len(internalMops))
 
 	for i := 0; i < numOfRecords; i++ {
+		if !p.shouldContinueProcessing {
+			return nil, nil
+		}
+
 		record := inputIQR.GetRecord(i)
 
 		// Bucket Key index
@@ -250,6 +282,10 @@ func (p *statsProcessor) processMeasureOperations(inputIQR *iqr.IQR) (*iqr.IQR, 
 		}
 
 		for i := range values {
+			if !p.shouldContinueProcessing {
+				return nil, nil
+			}
+
 			hasValuesFunc := valuesUsage[colName]
 			hasListFunc := listUsage[colName]
 
@@ -303,6 +339,10 @@ func (p *statsProcessor) extractSegmentStatsResults(iqr *iqr.IQR) (*iqr.IQR, err
 }
 
 func (p *statsProcessor) logErrorsAndWarnings(qid uint64) {
+	if p.errorData == nil {
+		return
+	}
+
 	if len(p.errorData.readColumns) > 0 {
 		log.Warnf("qid=%v, statsProcessor.logErrorsAndWarnings: failed to read columns: %v", qid, p.errorData.readColumns)
 	}


### PR DESCRIPTION
# Description
- The stats command was panicing because: when we call cancel when a query is in still execution, it would call cleanup and the cleanup would remove the resources, but the actual command processing is still using those resources, which causes the panic.
- And this type of panic can happen to any command data processor during execution.
- Now I have made a flag to know whether to remove the resources or wait and remove the resources.

**UPDATE:**
- I have reverted my previous commit and added a new fields called `processorLock` in the `DataProcessor` struct and call `processorLock.Lock()` before calling `dp.Process()` and also again acquire lock before calling `dp.Cleanup()`.


# Testing
- Tested by executing this command which will panic on develop branch but will not on this PR.
```
CounterID = 38 AND IsRefresh = 0 | where strptime(EventDate,"%Y-%m-%d") >= strptime("2013-07-01", "%Y-%m-%d") AND strptime(EventDate,"%Y-%m-%d") <= strptime("2013-07-31", "%Y-%m-%d") | eval Src=if(SearchEngineID=0 AND AdvEngineID=0, Referer, "") | rename URL as Dst | stats count as PageViews by TrafficSourceID, SearchEngineID, AdvEngineID, Src, Dst | sort -PageViews | head 1010 | tail 10 | tail 10
```

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
