### PR TITLE
better estimation of cwip.cbuf size and increase active col limit to 20k

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ const DEFAULT_METADATA_MEM_PERCENT = 20
 const DEFAULT_SEG_SEARCH_MEM_PERCENT = 15 // minimum percent allocated for segsearch
 const DEFAULT_METRICS_MEM_PERCENT = 2
 
-const DEFAULT_MAX_OPEN_COLUMNS = 1000 // Max concurrent unrotated columns across all indexes
+const DEFAULT_MAX_OPEN_COLUMNS = 20_000 // Max concurrent unrotated columns across all indexes
 
 var configFileLastModified uint64
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -219,7 +219,10 @@ func (wp *WipBlock) getSize() uint64 {
 	}
 	size += wp.blockSummary.GetSize()
 	size += uint64(24 * len(wp.columnRangeIndexes))
-	size += uint64(WIP_SIZE * len(wp.colWips))
+
+	for _, cwip := range wp.colWips {
+		size += uint64(cwip.cbuf.Cap())
+	}
 
 	return size
 }
@@ -255,8 +258,7 @@ func GetInMemorySize() uint64 {
 	if numOpenCols > int(maxOpenCols) {
 		log.Errorf("GetInMemorySize: numOpenCols=%v exceeds maxOpenCols=%v", numOpenCols, maxOpenCols)
 	} else if numOpenCols > 0 {
-		multiplier := float64(maxOpenCols) / float64(numOpenCols)
-		totalSize = uint64(float64(totalSize) * multiplier)
+		totalSize = uint64(float64(totalSize) * 1.1)
 	}
 
 	totalSize += metrics.GetTotalEncodedSize()

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -52,6 +52,14 @@ func (b *Buffer) Len() int {
 	return b.offset + (len(b.chunks)-1)*chunkSize
 }
 
+func (b *Buffer) Cap() int {
+	if b == nil {
+		return 0
+	}
+
+	return len(b.chunks) * chunkSize
+}
+
 func (b *Buffer) Append(data []byte) {
 	if b == nil {
 		return

--- a/tools/sigclient/pkg/query/functional.go
+++ b/tools/sigclient/pkg/query/functional.go
@@ -101,7 +101,7 @@ func RunQuery(filePath string, qid int, dest string) {
 		log.Fatalf("RunQuery: Error reading and validating query file: %v, err: %v", filePath, err)
 	}
 
-	log.Infof("RunQuery: qid=%v, Running query=%v", qid, query)
+	log.Infof("RunQuery: qid=%v, Running file: %v, query: %v", qid, filePath, query)
 	queryReq["searchText"] = query
 
 	err = EvaluateQueryForWebSocket(dest, queryReq, qid, expRes)


### PR DESCRIPTION
# Description
1. Increase active cols to 20K across all indices
2. Fix the memory size estimation for segwriter

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
