### PR TITLE
UI : Add First Byte and Elapsed Time to Query Response Info

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -651,7 +651,7 @@ function processLiveTailQueryUpdate(res, eventType, totalEventsSearched, timeToF
         segStatsRowData = [];
         renderMeasuresGrid(columnOrder, res);
     }
-    let totalTime = new Date().getTime() - startQueryTime;
+    let totalTime = Number(new Date().getTime() - startQueryTime).toLocaleString();
     let percentComplete = res.percent_complete;
     let totalPossibleEvents = res.total_possible_events;
     renderTotalHits(totalHits, totalTime, percentComplete, eventType, totalEventsSearched, timeToFirstByte, '', res.qtype, totalPossibleEvents);
@@ -714,7 +714,7 @@ function processQueryUpdate(res, eventType, totalEventsSearched, timeToFirstByte
         renderMeasuresGrid(columnOrder, res);
     }
     timeChart(res.qtype);
-    let totalTime = new Date().getTime() - startQueryTime;
+    let totalTime = Number(new Date().getTime() - startQueryTime).toLocaleString();
     let percentComplete = res.percent_complete;
     let totalPossibleEvents = res.total_possible_events;
     renderTotalHits(totalHits, totalTime, percentComplete, eventType, totalEventsSearched, timeToFirstByte, '', res.qtype, totalPossibleEvents, columnCount);
@@ -763,7 +763,7 @@ function processLiveTailCompleteUpdate(res, eventType, totalEventsSearched, time
         }
     }
 
-    let totalTime = new Date().getTime() - startQueryTime;
+    let totalTime = Number(new Date().getTime() - startQueryTime).toLocaleString();
     let percentComplete = res.percent_complete;
     if (res.total_rrc_count > 0) {
         totalRrcCount += res.total_rrc_count;
@@ -820,7 +820,7 @@ function processCompleteUpdate(res, eventType, totalEventsSearched, timeToFirstB
     isTimechart = res.isTimechart;
     lastQType = res.qtype;
     timeChart(res.qtype);
-    let totalTime = new Date().getTime() - startQueryTime;
+    let totalTime = Number(new Date().getTime() - startQueryTime).toLocaleString();
     let percentComplete = res.percent_complete;
     if (res.total_rrc_count > 0) {
         totalRrcCount += res.total_rrc_count;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -900,17 +900,18 @@ function renderTotalHits(totalHits, elapedTimeMS, percentComplete, eventType, to
     if (eventType === 'QUERY_UPDATE') {
         if (totalHits > 0) {
             $('#hits-summary').html(`
-            <div><span class="total-hits">${totalHitsFormatted} </span><span>of ${totalEventsSearched} Records Matched</span> </div>
-
-            <div class="text-center">${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
-            <div class="text-end">Response: ${timeToFirstByte} ms</div>
+            <div><span class="total-hits"><b>${totalHitsFormatted}</b> </span><span>of <b>${totalEventsSearched}</b> Records Matched</span> </div>
+            <div>First Byte Response Time: <b>${timeToFirstByte} ms</b></div>
+            <div>Elapsed Time: <b>${elapedTimeMS} ms</b></div>
+            <div>${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
         `);
             $('#record-searched').html(`<div><span class="total-hits"><b>${totalHitsFormatted}</b> </span><span>of <b>${totalEventsSearched}</b> Records Matched (out of <b>${totalPossibleEvents}</b> Possible Records)</span> </div>`);
         } else {
-            $('#hits-summary').html(`<div><span> ${totalEventsSearched} Records Searched</span> </div>
+            $('#hits-summary').html(`<div><span> <b>${totalEventsSearched} </b>Records Searched</span> </div>
 
-            <div class="text-center">${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
-            <div class="text-end">Response: ${timeToFirstByte} ms</div>
+            <div>First Byte Response Time:<b> ${timeToFirstByte} ms</b></div>
+            <div>Elapsed Time: <b>${elapedTimeMS} ms</b></div>
+            <div>${dateFns.format(startDate, timestampDateFmt)} &mdash; ${dateFns.format(endDate, timestampDateFmt)}</div>
         `);
             $('#record-searched').html(`<div><span><b>${totalEventsSearched}</b></span> of <span><b>${totalPossibleEvents}</b> Records Searched</span> </div>`);
         }


### PR DESCRIPTION
# Description
First Byte Response Time: Displays the time in milliseconds it took to receive the first byte of the response.
Elapsed Time: Shows the total time taken from the start of the query to its completion.

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/c6fd0b2c-8861-4f45-a522-d27acafec2fd">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
