### PR TITLE
Fix bug for stats if a groupBy column has Backfill value.

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -1276,7 +1276,7 @@ func (iqr *IQR) getFinalStatsResults() ([]*structs.BucketHolder, []string, []str
 			colValue := knownValues[aggGroupByCol][i]
 			bucketHolderArr[i].IGroupByValues[idx] = colValue
 
-			convertedValue, err := colValue.GetString()
+			convertedValue, err := colValue.GetStringForGroupByCol()
 			if err != nil {
 				return nil, nil, nil, 0, fmt.Errorf("IQR.getFinalStatsResults: conversion error for aggGroupByCol %v with value:%v. Error=%v", aggGroupByCol, colValue, err)
 			}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -936,6 +936,7 @@ func (e *CValueEnclosure) GetValue() (interface{}, error) {
 	}
 }
 
+// TODO: After evaluation is fixed, merge GetString and GetStringForGroupByCol
 func (e *CValueEnclosure) GetString() (string, error) {
 	switch e.Dtype {
 	case SS_DT_STRING:
@@ -952,6 +953,29 @@ func (e *CValueEnclosure) GetString() (string, error) {
 		return fmt.Sprintf("%f", e.CVal.(float64)), nil
 	default:
 		return "", fmt.Errorf("CValueEnclosure GetString: unsupported Dtype: %v", e.Dtype)
+	}
+}
+
+func (e *CValueEnclosure) GetStringForGroupByCol() (string, error) {
+	switch e.Dtype {
+	case SS_DT_STRING:
+		return e.CVal.(string), nil
+	case SS_DT_STRING_SLICE:
+		return fmt.Sprintf("%v", e.CVal.([]string)), nil
+	case SS_DT_STRING_SET:
+		return fmt.Sprintf("%v", e.CVal.(map[string]struct{})), nil
+	case SS_DT_BOOL:
+		return strconv.FormatBool(e.CVal.(bool)), nil
+	case SS_DT_UNSIGNED_NUM:
+		return strconv.FormatUint(e.CVal.(uint64), 10), nil
+	case SS_DT_SIGNED_NUM:
+		return strconv.FormatInt(e.CVal.(int64), 10), nil
+	case SS_DT_FLOAT:
+		return fmt.Sprintf("%f", e.CVal.(float64)), nil
+	case SS_DT_BACKFILL:
+		return "", nil
+	default:
+		return "", fmt.Errorf("CValueEnclosure.GetStringForGroupByCol: unsupported Dtype: %v", e.Dtype)
 	}
 }
 


### PR DESCRIPTION
# Description
Summarize the change.
If a column has some backfilled values and if we groupBy on it, we get the following error
```
GetStreamedResult: failed to get WSResult from iqr; err: IQR.AsWSResult: error getting result: qid=1, IQR.AsResult: error getting final result for GroupBy: IQR.getFinalStatsResults: conversion error for aggGroupByCol variable_col_0 with value:{8 }. Error=CValueEnclosure GetString: unsupported Dtype: 8
```
This is because `CValueEnclosure.GetString` method does not have a way to get string for backfilled value. Changing this method is causing evaluation to break (We often expect errors and assume it as NULL value in evaluation). So, have created a new method to return string for all the types explicitly. When we fix the evaluation to use concrete data types, we will merge these 2 methods.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Ingest functionalTest data.
- Run query `* | stats count(variable_col_3) as cnt by variable_col_0 | sort -cnt`
- Earlier it was showing an error, now it should return the results appropriately with groupBy value being shown as empty string.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
