### PR TITLE
Cleanup for the Input Streams and Set IQR sorting function

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -110,7 +110,7 @@ type Hooks struct {
 	ShouldAddDistributedInfoHook func() bool
 
 	// Distributed query
-	InitDistributedQueryServiceHook func(querySummary interface{}, allSegFileResults interface{}) interface{}
+	InitDistributedQueryServiceHook func(querySummary interface{}, allSegFileResults interface{}, distQueryId string) interface{}
 	FilterQsrsHook                  func(qsrs interface{}, isRotated bool) (interface{}, error)
 	GetDistributedStreamsHook       func(chainedDp interface{}, searcher interface{}, queryInfo interface{}, shouldDistribute bool) interface{}
 

--- a/pkg/segment/query/distributedquery.go
+++ b/pkg/segment/query/distributedquery.go
@@ -32,7 +32,7 @@ type DistributedQueryService struct {
 	isDistributed bool // whether or not this is a distributed query
 }
 
-func InitDistQueryService(querySummary *summary.QuerySummary, allSegFileResults *segresults.SearchResults) *DistributedQueryService {
+func InitDistQueryService(querySummary *summary.QuerySummary, allSegFileResults *segresults.SearchResults, dqid string) *DistributedQueryService {
 
 	return &DistributedQueryService{
 		isDistributed: false,

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -694,7 +694,7 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 
 	iqr, err := mergeMetadata(iqrs)
 	if err != nil {
-		log.Errorf("qid=%v, MergeIQRs: error merging metadata: %v", iqr.qid, err)
+		log.Errorf("MergeIQRs: error merging metadata: %v", err)
 		return nil, 0, err
 	}
 
@@ -1347,6 +1347,10 @@ func (iqr *IQR) GetBucketCount(qType structs.QueryType) int {
 }
 
 func (iqr *IQR) GobEncode() ([]byte, error) {
+	if iqr == nil {
+		return nil, nil
+	}
+
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 
@@ -1381,6 +1385,10 @@ func (iqr *IQR) GobEncode() ([]byte, error) {
 
 // GobDecode deserializes bytes back to IQR struct
 func (iqr *IQR) GobDecode(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
 	// Register types with gob
 	gob.Register(map[string][]utils.CValueEnclosure{})
 	gob.Register(map[string]struct{}{})

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -75,13 +75,13 @@ func (dp *DataProcessor) SetStreams(streams []*CachedStream) {
 
 // SetLessFunc sets the less function to be used for sorting the input records.
 // The default less function sorts by timestamp.
-func (dp *DataProcessor) SetDefaultLessFunc() {
+func (dp *DataProcessor) setDefaultLessFunc() {
 	dp.less = sortByTimestampLess
 }
 
 func (dp *DataProcessor) SetLessFuncBasedOnStream(stream Streamer) {
 	if stream == nil {
-		dp.SetDefaultLessFunc()
+		dp.setDefaultLessFunc()
 		return
 	}
 
@@ -90,13 +90,13 @@ func (dp *DataProcessor) SetLessFuncBasedOnStream(stream Streamer) {
 		case *sortProcessor:
 			dp.less = streamDP.processor.(*sortProcessor).less
 		default:
-			dp.SetDefaultLessFunc()
+			dp.setDefaultLessFunc()
 		}
 
 		return
 	}
 
-	dp.SetDefaultLessFunc()
+	dp.setDefaultLessFunc()
 }
 
 func (dp *DataProcessor) Cleanup() {

--- a/pkg/segment/query/processor/dataprocessor_test.go
+++ b/pkg/segment/query/processor/dataprocessor_test.go
@@ -93,6 +93,8 @@ func (ms *mockStreamer) Rewind() {
 	ms.numSent = 0
 }
 
+func (ms *mockStreamer) Cleanup() {}
+
 func Test_Fetch_nonBottleneck(t *testing.T) {
 	stream := &mockStreamer{
 		allRecords: map[string][]utils.CValueEnclosure{

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -54,7 +54,20 @@ type QueryProcessor struct {
 	startTime    time.Time
 }
 
+func (qp *QueryProcessor) cleanupInputStreamForFirstDP() {
+	if len(qp.chain) == 0 {
+		return
+	}
+
+	streams := qp.chain[0].streams
+	for _, CachedStream := range streams {
+		go CachedStream.Cleanup()
+	}
+}
+
 func (qp *QueryProcessor) Cleanup() {
+	go qp.cleanupInputStreamForFirstDP()
+
 	for _, dp := range qp.chain {
 		go dp.Cleanup()
 	}

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -98,6 +98,10 @@ func (s *Searcher) Rewind() {
 	s.segEncToKey = toputils.NewTwoWayMap[uint16, string]()
 }
 
+func (s *Searcher) Cleanup() {
+	// Nothing to do.
+}
+
 func getNumRecords(blocks []*block) uint64 {
 	var totalRecords uint64
 	for _, block := range blocks {

--- a/pkg/segment/query/processor/streamer.go
+++ b/pkg/segment/query/processor/streamer.go
@@ -26,6 +26,7 @@ import (
 type Streamer interface {
 	Fetch() (*iqr.IQR, error)
 	Rewind()
+	Cleanup()
 }
 
 type CachedStream struct {
@@ -74,4 +75,8 @@ func (cs *CachedStream) SetUnusedDataFromLastFetch(iqr *iqr.IQR) {
 
 func (cs *CachedStream) IsExhausted() bool {
 	return cs.isExhausted
+}
+
+func (cs *CachedStream) Cleanup() {
+	cs.stream.Cleanup()
 }

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/uuid"
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
@@ -188,7 +189,7 @@ func GenerateEvents(aggs *structs.QueryAggregators, qid uint64) *structs.NodeRes
 }
 
 func InitQueryInfoAndSummary(searchNode *structs.SearchNode, timeRange *dtu.TimeRange, aggs *structs.QueryAggregators,
-	qid uint64, qc *structs.QueryContext) (*QueryInformation, *summary.QuerySummary, string, bool, []string, *segresults.SearchResults, int64, error) {
+	qid uint64, qc *structs.QueryContext, dqid string) (*QueryInformation, *summary.QuerySummary, string, bool, []string, *segresults.SearchResults, int64, error) {
 
 	kibanaIndices := qc.TableInfo.GetKibanaIndices()
 	nonKibanaIndices := qc.TableInfo.GetQueryTables()
@@ -212,10 +213,10 @@ func InitQueryInfoAndSummary(searchNode *structs.SearchNode, timeRange *dtu.Time
 
 	var dqs DistributedQueryServiceInterface
 	if hook := hooks.GlobalHooks.InitDistributedQueryServiceHook; hook != nil {
-		result := hook(querySummary, allSegFileResults)
+		result := hook(querySummary, allSegFileResults, dqid)
 		dqs = result.(DistributedQueryServiceInterface)
 	} else {
-		dqs = InitDistQueryService(querySummary, allSegFileResults)
+		dqs = InitDistQueryService(querySummary, allSegFileResults, dqid)
 	}
 
 	queryInfo, err := InitQueryInformation(searchNode, aggs, timeRange, qc.TableInfo,
@@ -249,9 +250,10 @@ func PrepareToRunQuery(node *structs.ASTNode, timeRange *dtu.TimeRange, aggs *st
 		startTime = time.Now()
 	}
 	searchNode := ConvertASTNodeToSearchNode(node, qid)
+	dqid := uuid.New().String()
 
 	queryInfo, querySummary, pqid, containsKibana, kibanaIndices,
-		allSegFileResults, parallelismPerFile, err := InitQueryInfoAndSummary(searchNode, timeRange, aggs, qid, qc)
+		allSegFileResults, parallelismPerFile, err := InitQueryInfoAndSummary(searchNode, timeRange, aggs, qid, qc, dqid)
 	if err != nil {
 		log.Errorf("qid=%d, PrepareToRunQuery: Failed to init query info and summary! Error: %+v", qid, err)
 		return nil, nil, nil, "", nil, nil, 0, false, nil, err


### PR DESCRIPTION
# Description
- Calls cleanup for the input stream in the first DP. Based on how the `chainedDp` is set up, we are not initiating cleanup for the input stream of first DP. Now this PR initiates that.
- Also set up less functions for DP.

# Testing
- All unit tests passed

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
