### PR TITLE
Fix rex log flood

### DIFF
--- a/pkg/segment/query/processor/rexcommand.go
+++ b/pkg/segment/query/processor/rexcommand.go
@@ -69,7 +69,7 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 	for _, rexColName := range p.options.RexColNames {
 		newColValues[rexColName] = toputils.ResizeSliceWithDefault(newColValues[rexColName], len(values), segutils.CValueEnclosure{
 			Dtype: segutils.SS_DT_BACKFILL,
-			CVal: nil,
+			CVal:  nil,
 		})
 	}
 

--- a/pkg/segment/query/processor/rexcommand.go
+++ b/pkg/segment/query/processor/rexcommand.go
@@ -67,7 +67,10 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 
 	newColValues := make(map[string][]segutils.CValueEnclosure, len(p.options.RexColNames))
 	for _, rexColName := range p.options.RexColNames {
-		newColValues[rexColName] = make([]segutils.CValueEnclosure, len(values))
+		newColValues[rexColName] = toputils.ResizeSliceWithDefault(newColValues[rexColName], len(values), segutils.CValueEnclosure{
+			Dtype: segutils.SS_DT_BACKFILL,
+			CVal: nil,
+		})
 	}
 
 	for i, value := range values {
@@ -80,8 +83,7 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 
 		rexResultMap, err := structs.MatchAndExtractGroups(valueStr, p.compiledRegex)
 		if err != nil {
-			log.Warnf("rex.Process: cannot match and extract groups for value=%s; err=%v",
-				valueStr, err)
+			// If there are no matches we will skip this row
 			continue
 		}
 


### PR DESCRIPTION
# Description
Summarize the change.
- If there are no matches `MatchAndExtractGroups` will return an error. We should not log warnings for these cases, rather just ignore the record. By default initialize all the values for newly created columns to be BACKFILLED. 
- The required column values will be overwritten based on the match.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
`Referer != "" | rex field=Referer "^https?://(?:www\.)?(?<k>[^/]+)" | fields k | stats count as cnt by k | sort -cnt` query for clickbench dataset was causing log flood.
After this fix, the warnings on no match should not be logged.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
