### PR TITLE
Added New err utils to manage Errors and fixed some log flooding with Stats Group By Queries

### DIFF
--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -235,6 +235,8 @@ func StartQuery(qid uint64, async bool, cleanupCallback func()) (*RunningQuerySt
 
 // Removes reference to qid. If qid does not exist this is a noop
 func DeleteQuery(qid uint64) {
+	// Can remove the LogGlobalSearchErrors after we fully migrate
+	// to the putils.BatchError
 	LogGlobalSearchErrors(qid)
 	putils.LogAllErrorsWithQidAndDelete(qid)
 	arqMapLock.Lock()

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -625,206 +625,255 @@ func (gb *GroupByBuckets) AddResultToStatRes(req *structs.GroupByRequest, bucket
 		var hllToMerge *toputils.GobbableHll
 		var strSetToMerge map[string]struct{}
 		var eVal utils.CValueEnclosure
-		switch mInfo.MeasureFunc {
-		case utils.Count:
-			if mInfo.ValueColRequest != nil || usedByTimechart {
-				if !usedByTimechart && len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for count: %v", mInfoStr)
-					continue
-				}
 
-				countIdx := gb.reverseMeasureIndex[idx]
-				countVal, err := runningStats[countIdx].rawVal.GetUIntValue()
-				if err != nil {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-				eVal = utils.CValueEnclosure{CVal: countVal, Dtype: utils.SS_DT_UNSIGNED_NUM}
-			} else {
-				eVal = utils.CValueEnclosure{CVal: bucket.count, Dtype: utils.SS_DT_UNSIGNED_NUM}
-			}
-			idx++
-		case utils.Avg:
-			var avg float64
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Avg: %v", mInfoStr)
-					continue
-				}
-				valIdx := gb.reverseMeasureIndex[idx]
-				if runningStats[valIdx].avgStat != nil {
-					sumVal := runningStats[valIdx].avgStat.Sum
-					countVal := runningStats[valIdx].avgStat.Count
-					if countVal == 0 {
-						avg = 0
-					} else {
-						avg = sumVal / float64(countVal)
-					}
-				} else {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-				eVal = utils.CValueEnclosure{CVal: avg, Dtype: utils.SS_DT_FLOAT}
-				idx++
-			} else {
-				sumIdx := gb.reverseMeasureIndex[idx]
-				sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
-				if err != nil {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
+		gb.updateEValFromRunningBuckets(mInfo, runningStats, usedByTimechart, mInfoStr, currRes, bucket, &idx, &eVal, &hllToMerge, &strSetToMerge)
 
-				if usedByTimechart {
-					sumIdx := gb.reverseMeasureIndex[idx]
-					sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
-					if err != nil {
-						currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-						continue
-					}
-
-					countIdx := gb.reverseMeasureIndex[idx+1]
-					countRawVal, err := runningStats[countIdx].rawVal.GetFloatValue()
-					if err != nil {
-						currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-						continue
-					}
-					eVal = utils.CValueEnclosure{CVal: sumRawVal / countRawVal, Dtype: utils.SS_DT_FLOAT}
-					idx += 2
-				} else {
-					if bucket.count == 0 {
-						avg = 0
-					} else {
-						avg = sumRawVal / float64(bucket.count)
-					}
-					eVal = utils.CValueEnclosure{CVal: avg, Dtype: utils.SS_DT_FLOAT}
-					idx++
-				}
-			}
-		case utils.Range:
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Range: %v", mInfoStr)
-					continue
-				}
-				valIdx := gb.reverseMeasureIndex[idx]
-				rangeVal := 0.0
-				if runningStats[valIdx].rangeStat != nil {
-					minVal := runningStats[valIdx].rangeStat.Min
-					maxVal := runningStats[valIdx].rangeStat.Max
-					rangeVal = maxVal - minVal
-				} else {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-				eVal = utils.CValueEnclosure{CVal: rangeVal, Dtype: utils.SS_DT_FLOAT}
-				idx++
-			} else {
-				minIdx := gb.reverseMeasureIndex[idx]
-				minRawVal, err := runningStats[minIdx].rawVal.GetFloatValue()
-				if err != nil {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-
-				maxIdx := gb.reverseMeasureIndex[idx+1]
-				maxRawVal, err := runningStats[maxIdx].rawVal.GetFloatValue()
-				if err != nil {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-
-				eVal = utils.CValueEnclosure{CVal: maxRawVal - minRawVal, Dtype: utils.SS_DT_FLOAT}
-				idx += 2
-			}
-		case utils.Cardinality:
-			valIdx := gb.reverseMeasureIndex[idx]
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for cardinality: %v", mInfoStr)
-					continue
-				}
-				strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
-				if !ok {
-					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-					continue
-				}
-				eVal = utils.CValueEnclosure{CVal: uint64(len(strSet)), Dtype: utils.SS_DT_UNSIGNED_NUM}
-			} else {
-				finalVal := runningStats[valIdx].hll.Cardinality()
-				eVal = utils.CValueEnclosure{CVal: finalVal, Dtype: utils.SS_DT_UNSIGNED_NUM}
-				hllToMerge = runningStats[valIdx].hll
-			}
-
-			idx++
-		case utils.Values:
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for values: %v", mInfoStr)
-					continue
-				}
-			}
-
-			valIdx := gb.reverseMeasureIndex[idx]
-			strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
-			if !ok {
-				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-				continue
-			}
-			strSetToMerge = strSet
-
-			uniqueStrings := make([]string, 0)
-			for str := range strSet {
-				uniqueStrings = append(uniqueStrings, str)
-			}
-
-			sort.Strings(uniqueStrings)
-
-			eVal = utils.CValueEnclosure{
-				Dtype: utils.SS_DT_STRING_SLICE,
-				CVal:  uniqueStrings,
-			}
-
-			idx++
-		case utils.List:
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for values: %v", mInfoStr)
-					continue
-				}
-			}
-			valIdx := gb.reverseMeasureIndex[idx]
-			strList, ok := runningStats[valIdx].rawVal.CVal.([]string)
-			if !ok {
-				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
-				continue
-			}
-			if len(strList) > utils.MAX_SPL_LIST_SIZE {
-				strList = strList[:utils.MAX_SPL_LIST_SIZE]
-			}
-			eVal = utils.CValueEnclosure{
-				Dtype: utils.SS_DT_STRING_SLICE,
-				CVal:  strList,
-			}
-			idx++
-		case utils.Sum, utils.Max, utils.Min:
-			if mInfo.ValueColRequest != nil {
-				if len(mInfo.ValueColRequest.GetFields()) == 0 {
-					log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Range: %v", mInfoStr)
-					continue
-				}
-			}
-			valIdx := gb.reverseMeasureIndex[idx]
-			eVal = runningStats[valIdx].rawVal
-			idx++
-		default:
-			valIdx := gb.reverseMeasureIndex[idx]
-			eVal = runningStats[valIdx].rawVal
-			idx++
-		}
 		shouldAddRes := aggregations.ShouldAddRes(timechart, tmLimitResult, index, eVal, hllToMerge, strSetToMerge, mInfo.MeasureFunc, groupByColVal, isOtherCol)
 		if shouldAddRes {
 			currRes[mInfoStr] = eVal
 		}
+	}
+}
+
+func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAggregator, runningStats []runningStats, usedByTimechart bool, mInfoStr string,
+	currRes map[string]utils.CValueEnclosure, bucket *RunningBucketResults, idxPtr *int, eVal *utils.CValueEnclosure, hllToMerge **toputils.GobbableHll,
+	strSetToMerge *map[string]struct{}) {
+	if hllToMerge == nil || strSetToMerge == nil {
+		// This should never happen
+		log.Errorf("GroupByBuckets.AddResultToStatRes: hllToMerge or strSetToMerge is nil")
+		return
+	}
+
+	incrementIdxBy := 1
+
+	defer func() {
+		*idxPtr += incrementIdxBy
+	}()
+
+	idx := *idxPtr
+
+	switch mInfo.MeasureFunc {
+	case utils.Count:
+		incrementIdxBy = 1
+		if mInfo.ValueColRequest != nil || usedByTimechart {
+			if !usedByTimechart && len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for count: %v", mInfoStr)
+				return
+			}
+
+			countIdx := gb.reverseMeasureIndex[idx]
+			countVal, err := runningStats[countIdx].rawVal.GetUIntValue()
+			if err != nil {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			eVal.CVal = countVal
+			eVal.Dtype = utils.SS_DT_UNSIGNED_NUM
+		} else {
+
+			eVal.CVal = bucket.count
+			eVal.Dtype = utils.SS_DT_UNSIGNED_NUM
+		}
+	case utils.Avg:
+		var avg float64
+		if mInfo.ValueColRequest != nil {
+			incrementIdxBy = 1
+
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Avg: %v", mInfoStr)
+				return
+			}
+			valIdx := gb.reverseMeasureIndex[idx]
+			if runningStats[valIdx].avgStat != nil {
+				sumVal := runningStats[valIdx].avgStat.Sum
+				countVal := runningStats[valIdx].avgStat.Count
+				if countVal == 0 {
+					avg = 0
+				} else {
+					avg = sumVal / float64(countVal)
+				}
+			} else {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			eVal.CVal = avg
+			eVal.Dtype = utils.SS_DT_FLOAT
+		} else {
+			if usedByTimechart {
+				incrementIdxBy = 2
+			} else {
+				incrementIdxBy = 1
+			}
+
+			sumIdx := gb.reverseMeasureIndex[idx]
+			sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
+			if err != nil {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			if usedByTimechart {
+				sumIdx := gb.reverseMeasureIndex[idx]
+				sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
+				if err != nil {
+					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+					return
+				}
+
+				countIdx := gb.reverseMeasureIndex[idx+1]
+				countRawVal, err := runningStats[countIdx].rawVal.GetFloatValue()
+				if err != nil {
+					currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+					return
+				}
+
+				eVal.CVal = sumRawVal / countRawVal
+				eVal.Dtype = utils.SS_DT_FLOAT
+			} else {
+				if bucket.count == 0 {
+					avg = 0
+				} else {
+					avg = sumRawVal / float64(bucket.count)
+				}
+
+				eVal.CVal = avg
+				eVal.Dtype = utils.SS_DT_FLOAT
+			}
+		}
+	case utils.Range:
+		if mInfo.ValueColRequest != nil {
+			incrementIdxBy = 1
+
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Range: %v", mInfoStr)
+				return
+			}
+			valIdx := gb.reverseMeasureIndex[idx]
+			rangeVal := 0.0
+			if runningStats[valIdx].rangeStat != nil {
+				minVal := runningStats[valIdx].rangeStat.Min
+				maxVal := runningStats[valIdx].rangeStat.Max
+				rangeVal = maxVal - minVal
+			} else {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			eVal.CVal = rangeVal
+			eVal.Dtype = utils.SS_DT_FLOAT
+		} else {
+			incrementIdxBy = 2
+
+			minIdx := gb.reverseMeasureIndex[idx]
+			minRawVal, err := runningStats[minIdx].rawVal.GetFloatValue()
+			if err != nil {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			maxIdx := gb.reverseMeasureIndex[idx+1]
+			maxRawVal, err := runningStats[maxIdx].rawVal.GetFloatValue()
+			if err != nil {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+
+			eVal.CVal = maxRawVal - minRawVal
+			eVal.Dtype = utils.SS_DT_FLOAT
+		}
+	case utils.Cardinality:
+		incrementIdxBy = 1
+
+		valIdx := gb.reverseMeasureIndex[idx]
+		if mInfo.ValueColRequest != nil {
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for cardinality: %v", mInfoStr)
+				return
+			}
+			strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
+			if !ok {
+				currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+				return
+			}
+			eVal.CVal = uint64(len(strSet))
+			eVal.Dtype = utils.SS_DT_UNSIGNED_NUM
+		} else {
+			finalVal := runningStats[valIdx].hll.Cardinality()
+			eVal.CVal = finalVal
+			eVal.Dtype = utils.SS_DT_UNSIGNED_NUM
+
+			*hllToMerge = runningStats[valIdx].hll
+		}
+	case utils.Values:
+		incrementIdxBy = 1
+
+		if mInfo.ValueColRequest != nil {
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for values: %v", mInfoStr)
+				return
+			}
+		}
+
+		valIdx := gb.reverseMeasureIndex[idx]
+		strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
+		if !ok {
+			currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+			return
+		}
+		*strSetToMerge = strSet
+
+		uniqueStrings := make([]string, 0)
+		for str := range strSet {
+			uniqueStrings = append(uniqueStrings, str)
+		}
+
+		sort.Strings(uniqueStrings)
+
+		eVal.Dtype = utils.SS_DT_STRING_SLICE
+		eVal.CVal = uniqueStrings
+	case utils.List:
+		incrementIdxBy = 1
+
+		if mInfo.ValueColRequest != nil {
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for values: %v", mInfoStr)
+				return
+			}
+		}
+		valIdx := gb.reverseMeasureIndex[idx]
+		strList, ok := runningStats[valIdx].rawVal.CVal.([]string)
+		if !ok {
+			currRes[mInfoStr] = utils.CValueEnclosure{CVal: nil, Dtype: utils.SS_INVALID}
+			return
+		}
+		if len(strList) > utils.MAX_SPL_LIST_SIZE {
+			strList = strList[:utils.MAX_SPL_LIST_SIZE]
+		}
+
+		eVal.Dtype = utils.SS_DT_STRING_SLICE
+		eVal.CVal = strList
+	case utils.Sum, utils.Max, utils.Min:
+		incrementIdxBy = 1
+
+		if mInfo.ValueColRequest != nil {
+			if len(mInfo.ValueColRequest.GetFields()) == 0 {
+				log.Errorf("GroupByBuckets.AddResultToStatRes: Zero fields of ValueColRequest for Range: %v", mInfoStr)
+				return
+			}
+		}
+		valIdx := gb.reverseMeasureIndex[idx]
+		cTypeVal := runningStats[valIdx].rawVal
+		eVal.CVal = cTypeVal.CVal
+		eVal.Dtype = cTypeVal.Dtype
+	default:
+		incrementIdxBy = 1
+
+		valIdx := gb.reverseMeasureIndex[idx]
+		cTypeVal := runningStats[valIdx].rawVal
+		eVal.CVal = cTypeVal.CVal
+		eVal.Dtype = cTypeVal.Dtype
 	}
 }
 

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -389,7 +389,7 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 		if nBuckets >= b.GroupByAggregation.maxBuckets {
 			return
 		}
-		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns)
+		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns, qid)
 		b.GroupByAggregation.AllRunningBuckets = append(b.GroupByAggregation.AllRunningBuckets, bucket)
 		// only make a copy if this is the first time we are inserting it
 		// so that the caller may free up the backing space for this currKey/bKey
@@ -428,7 +428,7 @@ func (b *BlockResults) AddMeasureResultsToKeyAgileTree(bKey string,
 		if nBuckets >= b.GroupByAggregation.maxBuckets {
 			return
 		}
-		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns)
+		bucket = initRunningGroupByBucket(b.GroupByAggregation.internalMeasureFns, qid)
 		b.GroupByAggregation.AllRunningBuckets = append(b.GroupByAggregation.AllRunningBuckets, bucket)
 		b.GroupByAggregation.StringBucketIdx[bKey] = nBuckets
 	} else {

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -402,14 +402,12 @@ func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStat
 	}
 	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
 	if err != nil {
-		// return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to populate field to value, err: %v", err)
 		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:POPULATE_FIELD_TO_VALUE", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
 	result, err := agg.PerformEvalAggForSum(rr.currStats[i], 1, exists, (*runningStats)[i].rawVal, fieldToValue)
 	if err != nil {
-		// return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to evaluate ValueColRequest, err: %v", err)
 		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:PerformEvalAggForSum", err)
 	}
 	(*runningStats)[i].rawVal = result

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -26,7 +26,6 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	putils "github.com/siglens/siglens/pkg/utils"
-	log "github.com/sirupsen/logrus"
 	bbp "github.com/valyala/bytebufferpool"
 )
 
@@ -35,6 +34,7 @@ type RunningBucketResults struct {
 	currStats           []*structs.MeasureAggregator // measure aggregators in result
 	groupedRunningStats map[string][]runningStats    // maps timechart group by col's vals to corresponding running stats
 	count               uint64                       // total number of elements belonging to the bucket
+	qid                 uint64                       // query id
 }
 
 type runningStats struct {
@@ -67,13 +67,14 @@ func initRunningStats(internalMeasureFns []*structs.MeasureAggregator) []running
 	return retVal
 }
 
-func initRunningGroupByBucket(internalMeasureFns []*structs.MeasureAggregator) *RunningBucketResults {
+func initRunningGroupByBucket(internalMeasureFns []*structs.MeasureAggregator, qid uint64) *RunningBucketResults {
 
 	return &RunningBucketResults{
 		count:               0,
 		runningStats:        initRunningStats(internalMeasureFns),
 		currStats:           internalMeasureFns,
 		groupedRunningStats: make(map[string][]runningStats),
+		qid:                 qid,
 	}
 }
 
@@ -97,46 +98,51 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 		runningStats = &rr.runningStats
 	}
 
+	batchErr := putils.GetOrCreateBatchErrorWithQid(qid)
+
 	for i := 0; i < len(*runningStats); i++ {
-		switch rr.currStats[i].MeasureFunc {
+		measureFunc := rr.currStats[i].MeasureFunc
+		// TODO: Change All the Eval functions to return error
+		// of type *ErrorWithCode
+		switch measureFunc {
 		case utils.Sum:
 			step, err := rr.AddEvalResultsForSum(runningStats, measureResults, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for sum, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:Sum", err)
 			}
 			i += step
 		case utils.Avg:
 			step, err := rr.AddEvalResultsForAvg(runningStats, measureResults, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for avg, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:Avg", err)
 			}
 			i += step
 		case utils.Max:
 			fallthrough
 		case utils.Min:
-			isMin := rr.currStats[i].MeasureFunc == utils.Min
+			isMin := measureFunc == utils.Min
 			step, err := rr.AddEvalResultsForMinMax(runningStats, measureResults, i, isMin)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for min/max, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:MinMax", err)
 			}
 			i += step
 		case utils.Range:
 			step, err := rr.AddEvalResultsForRange(runningStats, measureResults, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for range, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:Range", err)
 			}
 			i += step
 		case utils.Count:
 			step, err := rr.AddEvalResultsForCount(runningStats, measureResults, i, usedByTimechart, cnt)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for count, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:Count", err)
 			}
 			i += step
 		case utils.Cardinality:
 			if rr.currStats[i].ValueColRequest == nil {
 				rawVal, err := measureResults[i].GetString()
 				if err != nil {
-					log.Errorf("RunningBucketResults.AddMeasureResults: failed to add measurement to running stats: %v", err)
+					batchErr.AddError("RunningBucketResults.AddMeasureResults:Cardinality", err)
 					continue
 				}
 				bb := bbp.Get()
@@ -150,19 +156,19 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 		case utils.Values:
 			step, err := rr.AddEvalResultsForValuesOrCardinality(runningStats, measureResults, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for values/cardinality, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:Values", err)
 			}
 			i += step
 		case utils.List:
 			step, err := rr.AddEvalResultsForList(runningStats, measureResults, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: failed to add eval results for list, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:List", err)
 			}
 			i += step
 		default:
 			err := rr.ProcessReduce(runningStats, measureResults[i], i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.AddMeasureResults: Error while ProcessReduce, err: %v", err)
+				batchErr.AddError("RunningBucketResults.AddMeasureResults:ProcessReduce", err)
 			}
 		}
 	}
@@ -201,19 +207,21 @@ func (rr *RunningBucketResults) MergeRunningBuckets(toJoin *RunningBucketResults
 }
 
 func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, toJoinRunningStats []runningStats) {
+	batchErr := putils.GetOrCreateBatchErrorWithQid(rr.qid)
+
 	for i := 0; i < len(toJoinRunningStats); i++ {
 		switch rr.currStats[i].MeasureFunc {
 		case utils.Sum, utils.Min, utils.Max:
 			if rr.currStats[i].ValueColRequest == nil {
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for %v while ValueColRequest is nil, err: %v", rr.currStats[i].MeasureFunc, err)
+					batchErr.AddError(fmt.Sprintf("RunningBucketResults.mergeRunningStats:%s", rr.currStats[i].MeasureFunc), err)
 				}
 			} else {
 				fields := rr.currStats[i].ValueColRequest.GetFields()
 				err := rr.ProcessReduceForEval(runningStats, toJoinRunningStats[i].rawVal, i, rr.currStats[i].MeasureFunc)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for %v err: %v", rr.currStats[i].MeasureFunc, err)
+					batchErr.AddError(fmt.Sprintf("RunningBucketResults.mergeRunningStats:%s", rr.currStats[i].MeasureFunc), err)
 				}
 				i += (len(fields) - 1)
 			}
@@ -223,7 +231,7 @@ func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, 
 				(*runningStats)[i].avgStat = ReduceAvg((*runningStats)[i].avgStat, toJoinRunningStats[i].avgStat)
 				i += (len(fields) - 1)
 			} else {
-				log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'avg' while ValueColRequest is nil")
+				batchErr.AddError("RunningBucketResults.mergeRunningStats:Avg", fmt.Errorf("ValueColRequest is nil"))
 			}
 		case utils.Range:
 			if rr.currStats[i].ValueColRequest != nil {
@@ -231,19 +239,19 @@ func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, 
 				(*runningStats)[i].rangeStat = ReduceRange((*runningStats)[i].rangeStat, toJoinRunningStats[i].rangeStat)
 				i += (len(fields) - 1)
 			} else {
-				log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'range' while ValueColRequest is nil")
+				batchErr.AddError("RunningBucketResults.mergeRunningStats:Range", fmt.Errorf("ValueColRequest is nil"))
 			}
 		case utils.Values:
 			if rr.currStats[i].ValueColRequest == nil {
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'values' while ValueColRequest is nil, err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Values", err)
 				}
 			} else {
 				fields := rr.currStats[i].ValueColRequest.GetFields()
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'values' err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Values", err)
 				}
 				i += (len(fields) - 1)
 			}
@@ -251,13 +259,13 @@ func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, 
 			if rr.currStats[i].ValueColRequest == nil {
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'list' while ValueColRequest is nil, err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:List", err)
 				}
 			} else {
 				fields := rr.currStats[i].ValueColRequest.GetFields()
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'list' err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:List", err)
 				}
 				i += (len(fields) - 1)
 			}
@@ -265,13 +273,13 @@ func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, 
 			if rr.currStats[i].ValueColRequest == nil {
 				err := (*runningStats)[i].hll.StrictUnion(toJoinRunningStats[i].hll.Hll)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: failed merge HLL!: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Cardinality", putils.NewErrorWithCode("HLL_UNION", err))
 				}
 			} else {
 				fields := rr.currStats[i].ValueColRequest.GetFields()
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'cardinality', err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Cardinality", err)
 				}
 				i += (len(fields) - 1)
 			}
@@ -279,20 +287,20 @@ func (rr *RunningBucketResults) mergeRunningStats(runningStats *[]runningStats, 
 			if rr.currStats[i].ValueColRequest == nil {
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: Error merging running stats for 'count', err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Count", err)
 				}
 			} else {
 				fields := rr.currStats[i].ValueColRequest.GetFields()
 				err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 				if err != nil {
-					log.Errorf("RunningBucketResults.mergeRunningStats: failed to add measurement to running stats, err: %v", err)
+					batchErr.AddError("RunningBucketResults.mergeRunningStats:Count", err)
 				}
 				i += (len(fields) - 1)
 			}
 		default:
 			err := rr.ProcessReduce(runningStats, toJoinRunningStats[i].rawVal, i)
 			if err != nil {
-				log.Errorf("RunningBucketResults.mergeRunningStats: err: %v", err)
+				batchErr.AddError("RunningBucketResults.mergeRunningStats:ProcessReduce", err)
 			}
 		}
 	}
@@ -389,17 +397,20 @@ func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStat
 	}
 	fields := rr.currStats[i].ValueColRequest.GetFields()
 	if len(fields) == 0 {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: Need non zero number of fields in expression for eval stats for sum for aggCol: %v", rr.currStats[i].String())
+		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:NON_ZERO_FIELDS",
+			fmt.Errorf("need non zero number of fields in expression for eval stats for sum for aggCol: %v", rr.currStats[i].String()))
 	}
 	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
 	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to populate field to value, err: %v", err)
+		// return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to populate field to value, err: %v", err)
+		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:POPULATE_FIELD_TO_VALUE", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
 	result, err := agg.PerformEvalAggForSum(rr.currStats[i], 1, exists, (*runningStats)[i].rawVal, fieldToValue)
 	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to evaluate ValueColRequest, err: %v", err)
+		// return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForSum: failed to evaluate ValueColRequest, err: %v", err)
+		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:PerformEvalAggForSum", err)
 	}
 	(*runningStats)[i].rawVal = result
 

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -879,6 +879,9 @@ func (sr *StatsResults) GetSegStats() map[string]*structs.SegStats {
 
 func CreateMeasResultsFromAggResults(limit int,
 	aggRes map[string]*structs.AggregationResult) ([]*structs.BucketHolder, []string, int) {
+	batchErr := putils.NewBatchError()
+	defer batchErr.LogAllErrors()
+
 	newQueryPipeline := config.IsNewQueryPipelineEnabled()
 
 	bucketHolderArr := make([]*structs.BucketHolder, 0)
@@ -892,7 +895,7 @@ func CreateMeasResultsFromAggResults(limit int,
 			for mName, mVal := range aggVal.StatRes {
 				rawVal, err := mVal.GetValue()
 				if err != nil {
-					log.Errorf("CreateMeasResultsFromAggResults: failed to get raw value for measurement %+v", err)
+					batchErr.AddError("CreateMeasResultsFromAggResults:RAW_VALUE_ERR", err)
 					continue
 				}
 				internalMFuncs[mName] = true
@@ -906,14 +909,14 @@ func CreateMeasResultsFromAggResults(limit int,
 			if newQueryPipeline {
 				bucketKeySlice, ok := aggVal.BucketKey.([]interface{})
 				if !ok {
-					log.Errorf("CreateMeasResultsFromAggResults: Received an unknown type for bucket keyType! %T", aggVal.BucketKey)
+					batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("expected []interface{} got bucket Key Type as %T", aggVal.BucketKey))
 					continue
 				}
 				for _, bk := range bucketKeySlice {
 					cValue := utils.CValueEnclosure{}
 					err := cValue.ConvertValue(bk)
 					if err != nil {
-						log.Errorf("CreateMeasResultsFromAggResults: failed to convert bucket key %+v", err)
+						batchErr.AddError("CreateMeasResultsFromAggResults:CONVERT_BUCKET_KEY_ERR", err)
 						cValue = utils.CValueEnclosure{
 							Dtype: utils.SS_DT_STRING,
 							CVal:  fmt.Sprintf("%+v", bk),
@@ -940,7 +943,7 @@ func CreateMeasResultsFromAggResults(limit int,
 				}
 				added++
 			default:
-				log.Errorf("CreateMeasResultsFromAggResults: Received an unknown type for bucket keyType! %T", bKey)
+				batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("got bucket Key Type as %T", bKey))
 			}
 			bucketHolder := &structs.BucketHolder{
 				IGroupByValues: iGroupByValues,

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1657,7 +1657,7 @@ func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
 	return qa.HasInChain(statsAggPresentInCur)
 }
 
-// use toputils.BatchError instead
+// TODO: use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -485,7 +485,7 @@ type Progress struct {
 type NodeResult struct {
 	AllRecords                  []*utils.RecordResultContainer
 	ErrList                     []error                     // Need to eventually replace ErrList with GlobalSearchErrors to prevent duplicate errors
-	GlobalSearchErrors          map[string]*SearchErrorInfo // maps global error from error message -> error info
+	GlobalSearchErrors          map[string]*SearchErrorInfo // maps global error from error message -> error info  (Deprecated: use toputils.BatchError)
 	Histogram                   map[string]*AggregationResult
 	TotalResults                *QueryCount
 	VectorResultValue           float64
@@ -1657,6 +1657,7 @@ func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
 	return qa.HasInChain(statsAggPresentInCur)
 }
 
+// Deprecated: use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1657,7 +1657,7 @@ func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
 	return qa.HasInChain(statsAggPresentInCur)
 }
 
-// Deprecated: use toputils.BatchError instead
+// use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)
 }

--- a/pkg/utils/errorutils.go
+++ b/pkg/utils/errorutils.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const MAX_SIMILAR_ERRORS_TO_LOG = 5 // Maximum number of similar errors to store
+
+var qidToBatchErrorMap map[uint64]*BatchError
+var qidToBatchErrorMapLock *sync.RWMutex
+
+// BatchErrorData holds error information for a specific error key
+type BatchErrorData struct {
+	errors  []error
+	counter uint32
+}
+
+// BatchError manages batched errors with thread safety
+type BatchError struct {
+	beMap *sync.Map
+	qid   int64
+}
+
+// ErrorWithCode combines an error with a standardized error code
+type ErrorWithCode struct {
+	code string
+	err  error
+}
+
+func init() {
+	qidToBatchErrorMap = make(map[uint64]*BatchError)
+	qidToBatchErrorMapLock = &sync.RWMutex{}
+}
+
+// NewBatchError creates a new BatchError instance
+func NewBatchError() *BatchError {
+	return &BatchError{
+		beMap: &sync.Map{},
+		qid:   -1,
+	}
+}
+
+// AddError adds an error to the batch with thread safety using sync.Map
+func (be *BatchError) AddError(errKey string, err error) {
+	if err == nil {
+		return
+	}
+
+	if errorWithCode, ok := err.(*ErrorWithCode); ok {
+		errKey = fmt.Sprintf("%s:%s", errKey, errorWithCode.code)
+	}
+
+	// Get or create BatchErrorData atomically
+	value, _ := be.beMap.LoadOrStore(errKey, &BatchErrorData{
+		errors: make([]error, 0, MAX_SIMILAR_ERRORS_TO_LOG),
+	})
+	data := value.(*BatchErrorData)
+
+	atomic.AddUint32(&data.counter, 1)
+
+	// Only store error if we haven't reached the limit
+	if len(data.errors) < MAX_SIMILAR_ERRORS_TO_LOG {
+		data.errors = append(data.errors, err)
+	}
+}
+
+// LogAllErrors logs all accumulated errors
+// Send qid as -1 if qid is not available
+func (be *BatchError) LogAllErrors() {
+	qidMsg := ""
+	if be.qid >= 0 {
+		qidMsg = fmt.Sprintf("qid=%v, ", be.qid)
+	}
+
+	be.beMap.Range(func(key, value interface{}) bool {
+		data := value.(*BatchErrorData)
+		log.WithFields(log.Fields{
+			"count":   data.counter,
+			"samples": data.errors,
+		}).Errorf("%s ErrorKey=%v", qidMsg, key)
+		return true
+	})
+}
+
+// Reset clears all stored errors
+func (be *BatchError) Reset() {
+	be.beMap = &sync.Map{}
+}
+
+// HasErrors returns true if there are any stored errors
+func (be *BatchError) HasErrors() bool {
+	hasErrors := false
+	be.beMap.Range(func(_, _ interface{}) bool {
+		hasErrors = true
+		return false // Stop iteration once we find any entry
+	})
+	return hasErrors
+}
+
+// NewErrorWithCode creates a new error with a code
+func NewErrorWithCode(code string, err error) *ErrorWithCode {
+	return &ErrorWithCode{
+		code: code,
+		err:  err,
+	}
+}
+
+// Error implements the error interface
+func (ewc *ErrorWithCode) Error() string {
+	return fmt.Sprintf("ErrorCode=%s; err=%v", ewc.code, ewc.err)
+}
+
+// Unwrap returns the underlying error
+func (ewc *ErrorWithCode) Unwrap() error {
+	return ewc.err
+}
+
+// String implements the stringer interface
+func (ewc *ErrorWithCode) String() string {
+	return ewc.Error()
+}
+
+func NewBatchErrorWithQid(qid uint64) *BatchError {
+	qidToBatchErrorMapLock.Lock()
+	defer qidToBatchErrorMapLock.Unlock()
+	be := &BatchError{
+		beMap: &sync.Map{},
+		qid:   int64(qid),
+	}
+	qidToBatchErrorMap[qid] = be
+	return be
+}
+
+func GetBatchErrorWithQid(qid uint64) (*BatchError, bool) {
+	qidToBatchErrorMapLock.RLock()
+	defer qidToBatchErrorMapLock.RUnlock()
+	be, exists := qidToBatchErrorMap[qid]
+	return be, exists
+}
+
+func DeleteBatchErrorWithQid(qid uint64) {
+	qidToBatchErrorMapLock.Lock()
+	defer qidToBatchErrorMapLock.Unlock()
+	delete(qidToBatchErrorMap, qid)
+}
+
+func GetOrCreateBatchErrorWithQid(qid uint64) *BatchError {
+	if be, exists := GetBatchErrorWithQid(qid); exists {
+		return be
+	}
+	return NewBatchErrorWithQid(qid)
+}
+
+func LogAllErrorsWithQidAndDelete(qid uint64) {
+	if be, exists := GetBatchErrorWithQid(qid); exists {
+		be.LogAllErrors()
+		DeleteBatchErrorWithQid(qid)
+	}
+}

--- a/pkg/utils/errorutils.go
+++ b/pkg/utils/errorutils.go
@@ -53,7 +53,6 @@ func init() {
 	qidToBatchErrorMapLock = &sync.RWMutex{}
 }
 
-// NewBatchError creates a new BatchError instance
 func NewBatchError() *BatchError {
 	return &BatchError{
 		beMap: &sync.Map{},
@@ -103,12 +102,12 @@ func (be *BatchError) LogAllErrors() {
 	})
 }
 
-// Reset clears all stored errors
+// Reset clears all errors and qid
 func (be *BatchError) Reset() {
 	be.beMap = &sync.Map{}
+	be.qid = -1
 }
 
-// HasErrors returns true if there are any stored errors
 func (be *BatchError) HasErrors() bool {
 	hasErrors := false
 	be.beMap.Range(func(_, _ interface{}) bool {


### PR DESCRIPTION
# Description
- PR: #1905 Needs to be Merged First.
- Added New Error utils, that is initialized at the start of the query and logs the errors at the end. 
- The Error use a `sync.Map` to avoid locking for every update for performance, but also safe from concurrent map write errors.
- Added `ErrorWithCode` type that is compatible with `error` interface. 

# Testing
- All unit test cases pass
- And ran the below query and verified that the there is no any log flooding
```
variable_col_3=male AND (app_name=Bracecould OR variable_col_7=C*) | regex variable_col_8=".*s" | stats avg(variable_col_4), max(variable_col_19) as max, min(variable_col_18) as min, sum(variable_col_17) as sum, range(variable_col_15), count as cnt, values(variable_col_9), dc(variable_col_6) as distinct_count, list(variable_col_2) BY variable_col_16, bool_col
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
