### PR TITLE
Fix stats panic

### DIFF
--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -365,7 +365,8 @@ func (sr *SearchResults) UpdateSegmentStats(sstMap map[string]*structs.SegStats,
 			// If the measure is not an eval statement, then update the segment stats
 			resSegStat, err := sr.UpdateNonEvalSegStats(sr.runningSegStat[idx], currSst, measureAgg)
 			if err != nil {
-				return fmt.Errorf("UpdateSegmentStats: qid=%v, err: %v", sr.qid, err)
+				log.Errorf("UpdateSegmentStats: qid=%v, err: %v", sr.qid, err)
+				continue
 			}
 			sr.runningSegStat[idx] = resSegStat
 			continue

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -943,6 +943,9 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 				if !exists {
 					hasListFunc = false
 				}
+				if cValEnc.Dtype == utils.SS_DT_BACKFILL {
+					continue
+				}
 
 				if cValEnc.Dtype == utils.SS_DT_STRING {
 					str, err := cValEnc.GetString()

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -774,6 +774,9 @@ func (ss *SegStats) Merge(other *SegStats) {
 }
 
 func (ss *StringStats) Merge(other *StringStats) {
+	if other == nil {
+		return
+	}
 	if ss.StrSet != nil {
 		for key, value := range other.StrSet {
 			ss.StrSet[key] = value
@@ -802,6 +805,9 @@ func (ss *StringStats) Merge(other *StringStats) {
 }
 
 func (ss *NumericStats) Merge(other *NumericStats) {
+	if other == nil {
+		return
+	}
 	switch ss.Min.Ntype {
 	case utils.SS_DT_FLOAT:
 		if other.Dtype == utils.SS_DT_FLOAT {

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -29,6 +29,18 @@ import (
 	bbp "github.com/valyala/bytebufferpool"
 )
 
+func getDefaultNumStats() *NumericStats {
+	return &NumericStats{
+		Min: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
+			IntgrVal: math.MaxInt64},
+		Max: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
+			IntgrVal: math.MinInt64},
+		Sum: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
+			IntgrVal: 0},
+		Dtype: SS_DT_SIGNED_NUM,
+	}
+}
+
 func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 	inNumType SS_IntUintFloatTypes, intVal int64, uintVal uint64,
 	fltVal float64, numstr string, bb *bbp.ByteBuffer, aggColUsage map[string]AggColUsageMode, hasValuesFunc bool, hasListFunc bool) {
@@ -36,24 +48,19 @@ func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 	var stats *SegStats
 	var ok bool
 	stats, ok = segstats[cname]
-	if !ok || !stats.IsNumeric {
-		numStats := &NumericStats{
-			Min: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
-				IntgrVal: math.MaxInt64},
-			Max: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
-				IntgrVal: math.MinInt64},
-			Sum: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
-				IntgrVal: 0},
-			Dtype: SS_DT_SIGNED_NUM,
-		}
+	if !ok {
 		stats = &SegStats{
 			IsNumeric: true,
 			Count:     0,
-			NumStats:  numStats,
+			NumStats:  getDefaultNumStats(),
 			Records:   make([]*CValueEnclosure, 0),
 		}
 		stats.CreateNewHll()
 		segstats[cname] = stats
+	}
+	if !stats.IsNumeric {
+		stats.IsNumeric = true
+		stats.NumStats = getDefaultNumStats()
 	}
 
 	colUsage := NoEvalUsage
@@ -239,9 +246,6 @@ func AddSegStatsStr(segstats map[string]*SegStats, cname string, strVal string,
 		stats.CreateNewHll()
 
 		segstats[cname] = stats
-	}
-	if stats.IsNumeric {
-		return
 	}
 	stats.Count++
 

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -36,7 +36,7 @@ func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 	var stats *SegStats
 	var ok bool
 	stats, ok = segstats[cname]
-	if !ok {
+	if !ok || !stats.IsNumeric {
 		numStats := &NumericStats{
 			Min: NumTypeEnclosure{Ntype: SS_DT_SIGNED_NUM,
 				IntgrVal: math.MaxInt64},
@@ -239,6 +239,9 @@ func AddSegStatsStr(segstats map[string]*SegStats, cname string, strVal string,
 		stats.CreateNewHll()
 
 		segstats[cname] = stats
+	}
+	if stats.IsNumeric {
+		return
 	}
 	stats.Count++
 


### PR DESCRIPTION
# Description
Summarize the change.
The below mentioned queries were panicking because of merging on `nil` segstats.
```
* | stats avg(variable_col_4), max(variable_col_18), sum(variable_col_17) | eval temp_value = 1
* | eval n = 1 | stats avg(variable_col_4), max(variable_col_18), sum(variable_col_17) | eval temp_value = 1
variable_col_7=Human http_method != "POST" gender=ma* | stats avg(variable_col_4) as avg, max(variable_col_15), min(variable_col_18), sum(variable_col_17), range(variable_col_19), count, values(variable_col_3), dc(variable_col_2) as distinct_count, list(variable_col_16)
city=Boston | stats count(eval(2)) as cnt_const, count(eval(variable_col_4 > 400)) as cnt_bool, count(eval(variable_col_4+10)) as cnt_exp, count(eval(if(variable_col_4 > 300, 1, 0))) as cnt_if, sum(eval(2)) as sum_const, sum(eval(variable_col_4 > 300)) as sum_bool, sum(eval(variable_col_4+20)) as sum_exp, sum(eval(if(variable_col_4 > 300, 2, 1))) as sum_if, avg(eval(3)) as avg_const, avg(eval(variable_col_4 > 400)) as avg_bool, avg(eval(variable_col_4+30)) as avg_exp, avg(eval(if(variable_col_4 > 301, 20, 10))) as avg_if, min(eval(1000)) as min_const, min(eval(variable_col_4 >= 201)) as min_bool, min(eval(variable_col_4+10)) as min_exp, min(eval(if(variable_col_4 > 300, 2, "abc"))) as min_if, max(eval(-2)) as max_const, max(eval(variable_col_4 < 500)) as max_bool, max(eval(variable_col_4-10)) as max_exp, max(eval(if(variable_col_4 > 300, 2, "abc"))) as max_if, range(eval(-1)) as range_const, range(eval(variable_col_4 > 400)) as range_bool, range(eval(variable_col_4+10)) as range_exp, range(eval(if(variable_col_4 > 300, 100, -100))) as range_if, dc(eval(1)) as dc_const, dc(eval(variable_col_4 > 400)) as dc_bool, dc(eval(variable_col_4+20)) as dc_exp, dc(eval(if(variable_col_4 > 300, "abc", "def"))) as dc_if, values(eval(100)) as values_const, values(eval(variable_col_4 > 400)) as values_bool, values(eval(variable_col_4+30)) as values_exp, values(eval(if(variable_col_4 > 300, 2, "abc"))) as values_if, list(eval(-100)) as list_const, list(eval(if(variable_col_4 > 300, 2, 2))) as list_if
```

- We should return partially when error is encountered in UpdateSegment stats because other stats won't be computed correctly.
- Have fixed the code to prioritize numeric stats if a number is added to a stats having string stats (Refer `AddSegStatsNums ` and `AddSegStatsStr `)
- Fixed the log flood having error `segmentStatsWorker failed to extract numerical value for type` by ignoring backfilled value in `segmentStatsWorker `

TODO: Handle average to give consistent results for the cases where the columns have both numbers and strings.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
