### PR TITLE
Fix GetString for rex

### DIFF
--- a/pkg/segment/query/processor/rexcommand.go
+++ b/pkg/segment/query/processor/rexcommand.go
@@ -71,7 +71,7 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 	}
 
 	for i, value := range values {
-		valueStr, err := value.GetString()
+		valueStr, err := value.GetStringForGroupByCol()
 		if err != nil {
 			log.Errorf("rex.Process: cannot convert value %v to string; err=%v",
 				value, err)


### PR DESCRIPTION
# Description
Summarize the change.

Earlier a query like this was not working because `GetString` is not working for BACKFILLED values. Use `GetStringForGroupByCol` to get the string value.
```
city=Boston | rex field=variable_col_5 "(?:https?://)(?<uri_segment>[^/]+)" | fields uri_segment, variable_col_18, variable_col_5, variable_col_19 | stats count, avg(variable_col_18) as avg_response, max(variable_col_19) as max_response by variable_col_3 | eval response_category = case( avg_response < 500000, "Fast", avg_response < 1000000, "Medium", avg_response >= 1000000, "Slow") | stats count, avg(avg_response) as avg_response by response_category | sort response_category
```


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Earlier this query was giving out errors, after this fix its working.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
