### PR TITLE
Fix log flood

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -1037,6 +1037,10 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 					}
 				}
 
+				if rawVal == nil {
+					continue
+				}
+
 				hasValuesFunc, exists := valuesUsage[colName]
 				if !exists {
 					hasValuesFunc = false


### PR DESCRIPTION
# Description
Summarize the change.
Query: `variable_col_7=Human http_method != "POST" gender=ma* | stats avg(variable_col_4) as avg, max(variable_col_15), min(variable_col_18), sum(variable_col_17), range(variable_col_19), count, values(variable_col_3), dc(variable_col_2) as distinct_count, list(variable_col_16)` 
was causing this log flood 
`segmentStatsWorker found a non string or non-numeric in a dict encoded segment. CName variable_col_3`

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
