### PR TITLE
Fix metadata size calculation

### DIFF
--- a/pkg/segment/metadata/segmentmicroindex.go
+++ b/pkg/segment/metadata/segmentmicroindex.go
@@ -106,8 +106,8 @@ func (sm *SegmentMicroIndex) initMetadataSize() {
 		sumColSize += uint64(len(cname))
 	}
 
-	blockHolderSize := sumColSize * (8 + 4)
-	blockHolderSize += 2 + 6 + 8 + 8 // blockNum, padding, 2 map pointers
+	blockHolderSize := sumColSize * (8 + 4) // int64 value + uint32 value
+	blockHolderSize += 2 + 6 + 8 + 8        // blockNum, padding, 2 map pointers
 	searchMetadataSize += uint64(sm.NumBlocks) * blockHolderSize
 
 	sm.SearchMetadataSize = searchMetadataSize

--- a/pkg/segment/metadata/segmentmicroindex.go
+++ b/pkg/segment/metadata/segmentmicroindex.go
@@ -91,12 +91,24 @@ func InitSegmentMicroIndex(segMetaInfo *structs.SegMeta, loadSsm bool) *SegmentM
 // Initializes sm.searchMetadaSize
 func (sm *SegmentMicroIndex) initMetadataSize() {
 	searchMetadataSize := uint64(0)
+
+	// The list of BlockSummary structs
 	searchMetadataSize += uint64(sm.NumBlocks * structs.SIZE_OF_BSUM) // block summaries
-	// for values of the BlockMetadataHolder
-	searchMetadataSize += uint64(sm.NumBlocks * uint16(len(sm.ColumnNames)) * structs.SIZE_OF_BlockInfo)
-	// for keys of BlockMetadataHolder
-	// 2 ==> two maps, 10 ==> avg colnamesize
-	searchMetadataSize += uint64(sm.NumBlocks) * 2 * 10 * uint64(len(sm.ColumnNames))
+
+	// The map of blockNum to BlockMetadataHolder structs
+	// type BlockMetadataHolder struct {
+	// 	BlkNum            uint16
+	// 	ColumnBlockOffset map[string]int64
+	// 	ColumnBlockLen    map[string]uint32
+	// }
+	sumColSize := uint64(0)
+	for cname := range sm.ColumnNames {
+		sumColSize += uint64(len(cname))
+	}
+
+	blockHolderSize := sumColSize * (8 + 4)
+	blockHolderSize += 2 + 6 + 8 + 8 // blockNum, padding, 2 map pointers
+	searchMetadataSize += uint64(sm.NumBlocks) * blockHolderSize
 
 	sm.SearchMetadataSize = searchMetadataSize
 }

--- a/pkg/segment/structs/segmeta.go
+++ b/pkg/segment/structs/segmeta.go
@@ -126,21 +126,13 @@ type SegSetDataWithStrFname struct {
    ***********************************************************
 */
 
-const SIZE_OF_BSUM = 18
+const SIZE_OF_BSUM = 24 // 8 + 8 + 2 + 6 (padding)
 
 // If new member is added to BlockSum, make sure to reset it's value in resetwipblock()
 type BlockSummary struct {
 	HighTs   uint64
 	LowTs    uint64
 	RecCount uint16
-}
-
-const SIZE_OF_BlockInfo = 14 // 2 + 4 + 8 bytes
-type BlockInfo struct {
-	BlkNum    uint16
-	BlkLen    uint32
-	BlkOffset int64
-	// if you add a element here make sure to update the SIZE_OF_BlockInfo
 }
 
 type HostMetaData struct {


### PR DESCRIPTION
# Description
We have configurable limits to reduce how much memory siglens can use for various tasks. The `rebalanceSsm()` function was using too much memory because it's estimate for the memory of one segment was too low. This PR fixes that.

# Testing
Similar to https://github.com/siglens/siglens/pull/1924, but I also reduced the memory allowed for SSM down to 17 MB

Without this fix, `ReadBlockSummaries()` was taking more memory that it should.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
