### PR TITLE
Spl perf improvements

### DIFF
--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -26,7 +26,6 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	putils "github.com/siglens/siglens/pkg/utils"
-	bbp "github.com/valyala/bytebufferpool"
 )
 
 type RunningBucketResults struct {
@@ -140,16 +139,12 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 			i += step
 		case utils.Cardinality:
 			if rr.currStats[i].ValueColRequest == nil {
-				rawVal, err := measureResults[i].GetString()
+				rawValStr, err := measureResults[i].GetString()
 				if err != nil {
 					batchErr.AddError("RunningBucketResults.AddMeasureResults:Cardinality", err)
 					continue
 				}
-				bb := bbp.Get()
-				defer bbp.Put(bb)
-				bb.Reset()
-				_, _ = bb.WriteString(rawVal)
-				(*runningStats)[i].hll.AddRaw(xxhash.Sum64(bb.B))
+				(*runningStats)[i].hll.AddRaw(xxhash.Sum64String(rawValStr))
 				continue
 			}
 			fallthrough


### PR DESCRIPTION
# Description
1. Use the xxhash.Sum64String version and avoid getting mem from bufpool.
2. Reuse sfmData struct when doing cluster stats handling. When there are lot of columns (7800+), this would cause a mem spike of 1.5 GB

with #1 this query now `* | stats dc(UserID) as u BY RegionID | sort -u | head 10` now completes in `8 s` as opposed to `13 s`

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
