### PR TITLE
Optimize batchError passing

### DIFF
--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -410,9 +410,9 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 			bucket.groupedRunningStats[groupByColVal] = gRunningStats
 		}
 		gRunningStats = bucket.groupedRunningStats[groupByColVal]
-		bucket.AddMeasureResults(&gRunningStats, measureResults, qid, 1, true)
+		bucket.AddMeasureResults(&gRunningStats, measureResults, qid, 1, true, b.batchErr)
 	} else {
-		bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, 1, false)
+		bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, 1, false, b.batchErr)
 	}
 
 }
@@ -436,7 +436,7 @@ func (b *BlockResults) AddMeasureResultsToKeyAgileTree(bKey string,
 	} else {
 		bucket = b.GroupByAggregation.AllRunningBuckets[bucketIdx]
 	}
-	bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, cnt, false)
+	bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, cnt, false, b.batchErr)
 }
 
 func (b *BlockResults) AddKeyToTimeBucket(bucketKey uint64, count uint16) {

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -90,15 +90,13 @@ func (rr *RunningBucketResults) AddTimeToBucketStats(count uint16) {
 }
 
 func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, qid uint64,
-	cnt uint64, usedByTimechart bool) {
+	cnt uint64, usedByTimechart bool, batchErr *putils.BatchError) {
 	if runningStats == nil {
 		if rr.runningStats == nil {
 			return
 		}
 		runningStats = &rr.runningStats
 	}
-
-	batchErr := putils.GetOrCreateBatchErrorWithQid(qid)
 
 	for i := 0; i < len(*runningStats); i++ {
 		measureFunc := rr.currStats[i].MeasureFunc


### PR DESCRIPTION
# Description
Summarize the change.
- We already [set](https://github.com/siglens/siglens/blob/e31a15b3d719ab6fd7a75474cb93c1c214ca489b/pkg/segment/results/blockresults/blockresult.go#L119) the batchErr in Blockresults, we do not need to retrieve it using the `GetOrCreateBatchErrorWithQid` function while Adding measure results to the block.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Reduces the execution time of this query `* | stats dc(UserID) as u BY RegionID | sort -u | head 10` on 100M Clickbench dataset by 2s.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
