### PR TITLE
Dashboard creation time

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -10,11 +10,18 @@
     request: http://localhost:5122/api/dashboards/listall
     response: 
         {
-            "1546954169045081977": "dashboard-y",
-            "4729811385114799544": "dashboard-2",
-            "5025894940373832739": "new-dashboard",
-            "9089097379643921334": "test-dashboard",
-            "9352623799225230043": "test-new"
+            "53cb3dde-fd78-4253-808c-18e4077ef0f1": {
+                "createdAt": 0,
+                "isDefault": true,
+                "isFavorite": false,
+                "name": "Sample Dashboard"
+            },
+            "634674be-84f9-493c-b1b4-be23909b09d4": {
+                "createdAt": 1731994980586,
+                "isDefault": false,
+                "isFavorite": true,
+                "name": "2"
+            }
         }
 
 ### Get dashboard by id

--- a/pkg/dashboards/dashboard_test.go
+++ b/pkg/dashboards/dashboard_test.go
@@ -96,64 +96,17 @@ func Test_dashboard_storage_methods(t *testing.T) {
 	assert.Equal(t, eDashboardDetails["description"], aDashBoardDetails["description"])
 	assert.Equal(t, eDashboardDetails["note"], aDashBoardDetails["note"])
 
-	// Test toggleFavorite with non-existing dashboard
-	_, err = toggleFavorite("non-existing-id")
-	assert.NotNil(t, err)
+	initialFavoriteStatus := eDashboardDetails["isFavorite"]
 
-	// Test isDashboardFavorite with non-existing dashboard
-	_, err = isDashboardFavorite("non-existing-id")
-	assert.NotNil(t, err)
-
-	isFavorite, err := toggleFavorite(expected[0])
+	updatedFavoriteStatus, err := toggleFavorite(expected[0])
 	assert.Nil(t, err)
-	assert.True(t, isFavorite)
 
-	// Test isDashboardFavorite
-	isFavorite, err = isDashboardFavorite(expected[0])
-	assert.Nil(t, err)
-	assert.True(t, isFavorite)
+	assert.NotEqual(t, initialFavoriteStatus, updatedFavoriteStatus)
 
-	// Test isDashboardFavorite for non-favorite dashboard
-	isFavorite, err = isDashboardFavorite(expected[1])
+	revertedFavoriteStatus, err := toggleFavorite(expected[0])
 	assert.Nil(t, err)
-	assert.False(t, isFavorite)
 
-	// Test getAllFavoriteDashboardIds
-	favoriteDashboards, err := getAllFavoriteDashboardIds(0)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(favoriteDashboards))
-	assert.Contains(t, favoriteDashboards, expected[0])
-
-	// Toggle favorite off
-	isFavorite, err = toggleFavorite(expected[0])
-	assert.Nil(t, err)
-	assert.False(t, isFavorite)
-
-	// Test isDashboardFavorite
-	isFavorite, err = isDashboardFavorite(expected[0])
-	assert.Nil(t, err)
-	assert.False(t, isFavorite)
-
-	// Test getAllFavoriteDashboardIds
-	favoriteDashboards, err = getAllFavoriteDashboardIds(0)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(favoriteDashboards))
-
-	// Test toggleFavorite with multiple dashboards
-	isFavorite, err = toggleFavorite(expected[0])
-	assert.Nil(t, err)
-	assert.True(t, isFavorite)
-
-	isFavorite, err = toggleFavorite(expected[1])
-	assert.Nil(t, err)
-	assert.True(t, isFavorite)
-
-	// Test getAllFavoriteDashboardIds with multiple favorite dashboards
-	favoriteDashboards, err = getAllFavoriteDashboardIds(0)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(favoriteDashboards))
-	assert.Contains(t, favoriteDashboards, expected[0])
-	assert.Contains(t, favoriteDashboards, expected[1])
+	assert.Equal(t, initialFavoriteStatus, revertedFavoriteStatus)
 
 	err = deleteDashboard(expected[0], 0)
 	assert.Nil(t, err)

--- a/pkg/dashboards/dashboards.go
+++ b/pkg/dashboards/dashboards.go
@@ -83,36 +83,6 @@ func readSavedDashboards(orgid uint64) ([]byte, error) {
 	return dashboardData, nil
 }
 
-func readDefaultDashboards(orgid uint64) ([]byte, error) {
-	var dashboardData []byte
-	allidsFname := getDefaultDashboardFileName()
-
-	dashboardData, err := os.ReadFile(allidsFname)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, nil
-		}
-		log.Errorf("readDefaultDashboards: Failed to read allidsFname file fname=%v, err=%v", allidsFname, err)
-		return nil, err
-	}
-
-	allDashboardsIdsLock.Lock()
-	if _, ok := allDashboardsIds[orgid]; !ok {
-		allDashboardsIds[orgid] = make(map[string]string)
-	}
-	var allDashboardNames map[string]string
-	err = json.Unmarshal(dashboardData, &allDashboardNames)
-	if err != nil {
-		allDashboardsIdsLock.Unlock()
-		log.Errorf("readDefaultDashboards: Failed to unmarshall allidsFname file fname=%v, err=%v, dashboardData=%v",
-			allidsFname, err, dashboardData)
-		return nil, err
-	}
-	allDashboardsIds[orgid] = allDashboardNames
-	latestDashboardReadTimeMillis[orgid] = utils.GetCurrentTimeInMs()
-	allDashboardsIdsLock.Unlock()
-	return dashboardData, nil
-}
 
 func getAllIdsFileName(orgid uint64) string {
 	var allidsFname string
@@ -209,20 +179,6 @@ func getAllDashboardIds(orgid uint64) (map[string]string, error) {
 	if err != nil {
 		releaseLock(orgid)
 		log.Errorf("getAllDashboardIds: failed to read, orgid=%v, err=%v", orgid, err)
-		return nil, err
-	}
-	releaseLock(orgid)
-	allDashboardsIdsLock.RLock()
-	defer allDashboardsIdsLock.RUnlock()
-	return allDashboardsIds[orgid], nil
-}
-
-func getAllDefaultDashboardIds(orgid uint64) (map[string]string, error) {
-	createOrAcquireLock(orgid)
-	_, err := readDefaultDashboards(orgid)
-	if err != nil {
-		releaseLock(orgid)
-		log.Errorf("getAllDefaultDashboardIds: failed to read, orgid=%v,  err=%v", orgid, err)
 		return nil, err
 	}
 	releaseLock(orgid)
@@ -432,6 +388,10 @@ func updateDashboard(id string, dName string, dashboardDetails map[string]interf
 		return errors.New("updateDashboard: Error fetching dashboard details")
 	}
 
+	if currentCreatedAt, exists := currentDashboardDetails["createdAt"]; exists {
+		dashboardDetails["createdAt"] = currentCreatedAt
+	}
+
 	// Check if isFavorite is provided in the update
 	if _, exists := currentDashboardDetails["isFavorite"]; !exists {
 		// If isFavorite does not exist in currentDashboardDetails, set it to false
@@ -613,85 +573,11 @@ func ProcessFavoriteRequest(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }
 
-func ProcessListFavoritesRequest(ctx *fasthttp.RequestCtx, myid uint64) {
-	dIds, err := getAllFavoriteDashboardIds(myid)
-
-	if err != nil {
-		log.Errorf("ProcessListFavoritesRequest: could not get favorite dashboard ids, err=%v", err)
-		utils.SetBadMsg(ctx, "")
-		return
-	}
-	utils.WriteJsonResponse(ctx, dIds)
-	ctx.SetStatusCode(fasthttp.StatusOK)
-}
-
-func getAllFavoriteDashboardIds(orgId uint64) (map[string]string, error) {
-	allDashboards, err := getAllDashboardIds(orgId)
-	if err != nil {
-		return nil, err
-	}
-
-	favoriteDashboards := make(map[string]string)
-	for id, name := range allDashboards {
-		isFavorite, err := isDashboardFavorite(id)
-		if err != nil {
-			return nil, err
-		}
-
-		if isFavorite {
-			favoriteDashboards[id] = name
-		}
-	}
-
-	return favoriteDashboards, nil
-}
-
-func isDashboardFavorite(id string) (bool, error) {
-	var dashboardDetailsFname string
-
-	if isDefaultDashboard(id) {
-		dashboardDetailsFname = "defaultDBs/details/" + id + ".json"
-	} else {
-		dashboardDetailsFname = config.GetDataPath() + "querynodes/" + config.GetHostID() + "/dashboards/details/" + id + ".json"
-	}
-
-	dashboardJson, err := os.ReadFile(dashboardDetailsFname)
-	if err != nil {
-		return false, err
-	}
-
-	var dashboard map[string]interface{}
-	err = json.Unmarshal(dashboardJson, &dashboard)
-	if err != nil {
-		log.Errorf("isDashboardFavorite: Failed to unmarshal json: %v, err=%v", dashboardJson, err)
-		return false, err
-	}
-
-	isFav, ok := dashboard["isFavorite"].(bool)
-	if !ok {
-		isFav = false
-	}
-
-	return isFav, nil
-}
-
 func ProcessListAllRequest(ctx *fasthttp.RequestCtx, myid uint64) {
-	dIds, err := getAllDashboardIds(myid)
+	dIds, err := getDashboardsWithMetadata(myid)
 
 	if err != nil {
 		log.Errorf("ProcessListAllRequest: could not get dashboard ids, err=%v", err)
-		utils.SetBadMsg(ctx, "")
-		return
-	}
-	utils.WriteJsonResponse(ctx, dIds)
-	ctx.SetStatusCode(fasthttp.StatusOK)
-}
-
-func ProcessListAllDefaultDBRequest(ctx *fasthttp.RequestCtx, myid uint64) {
-	dIds, err := getAllDefaultDashboardIds(myid)
-
-	if err != nil {
-		log.Errorf("ProcessListAllDefaultDBRequest: could not get dashboard ids, err=%v", err)
 		utils.SetBadMsg(ctx, "")
 		return
 	}
@@ -844,4 +730,67 @@ func ProcessDeleteDashboardsByOrgId(orgid uint64) error {
 		log.Warnf("ProcessDeleteDashboardsByOrgId: Failed to delete the dashboard allids file: %v", dashboardAllIdsFilename)
 	}
 	return nil
+}
+
+func getDashboardsWithMetadata(orgid uint64) (map[string]interface{}, error) {
+	dashboardIds, err := getAllDashboardIds(orgid)
+	if err != nil {
+		return nil, err
+	}
+
+	dashboardDetails := make(map[string]interface{})
+	for id, name := range dashboardIds {
+		dashboardInfo, err := getDashboardMetadata(id, name)
+		if err != nil {
+			log.Errorf("Error getting metadata for dashboard %s: %v", id, err)
+			continue
+		}
+		dashboardDetails[id] = dashboardInfo
+	}
+
+	return dashboardDetails, nil
+}
+
+func getDashboardMetadata(id string, name string) (map[string]interface{}, error) {
+	dashboardInfo := map[string]interface{}{
+		"name":       name,
+		"isFavorite": false,
+		"isDefault":  isDefaultDashboard(id),
+	}
+
+	var detailsFname string
+	if dashboardInfo["isDefault"].(bool) {
+		detailsFname = "defaultDBs/details/" + id + ".json"
+		dashboardInfo["createdAt"] = 0 // Default dashboards always have 0
+	} else {
+		detailsFname = config.GetDataPath() + "querynodes/" + config.GetHostID() + "/dashboards/details/" + id + ".json"
+	}
+
+	details, err := os.ReadFile(detailsFname)
+	if err != nil {
+		return dashboardInfo, nil
+	}
+
+	var dashboardDetails map[string]interface{}
+	if err := json.Unmarshal(details, &dashboardDetails); err != nil {
+		return dashboardInfo, nil
+	}
+
+	// For non-default dashboards
+	if !dashboardInfo["isDefault"].(bool) {
+		if createdAt, exists := dashboardDetails["createdAt"]; exists {
+			dashboardInfo["createdAt"] = createdAt
+		} else {
+			// Legacy case only
+			if fileInfo, err := os.Stat(detailsFname); err == nil {
+				dashboardInfo["createdAt"] = fileInfo.ModTime().UnixMilli()
+			}
+		}
+	}
+
+	if favorite, exists := dashboardDetails["isFavorite"].(bool); exists {
+		dashboardInfo["isFavorite"] = favorite
+	}
+
+	return dashboardInfo, nil
 }

--- a/pkg/dashboards/dashboards.go
+++ b/pkg/dashboards/dashboards.go
@@ -83,7 +83,6 @@ func readSavedDashboards(orgid uint64) ([]byte, error) {
 	return dashboardData, nil
 }
 
-
 func getAllIdsFileName(orgid uint64) string {
 	var allidsFname string
 	if orgid == 0 {

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -443,20 +443,9 @@ func favoriteDashboardHandler() fasthttp.RequestHandler {
 	}
 }
 
-func getFavoriteDashboardIdsHandler() func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		serverutils.CallWithOrgIdQuery(dashboards.ProcessListFavoritesRequest, ctx)
-	}
-}
 func getDashboardIdsHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		serverutils.CallWithOrgIdQuery(dashboards.ProcessListAllRequest, ctx)
-	}
-}
-
-func getDefaultDashboardIdsHandler() func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		serverutils.CallWithOrgIdQuery(dashboards.ProcessListAllDefaultDBRequest, ctx)
 	}
 }
 

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -220,13 +220,11 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.GET(server_utils.API_PREFIX+"/pqs", tracing.TraceMiddleware(hs.Recovery(getPqsHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/pqs/{pqid}", tracing.TraceMiddleware(hs.Recovery(getPqsByIdHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/dashboards/create", tracing.TraceMiddleware(hs.Recovery(createDashboardHandler())))
-	hs.Router.GET(server_utils.API_PREFIX+"/dashboards/defaultlistall", tracing.TraceMiddleware(hs.Recovery(getDefaultDashboardIdsHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/dashboards/listall", tracing.TraceMiddleware(hs.Recovery(getDashboardIdsHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/dashboards/update", tracing.TraceMiddleware(hs.Recovery(updateDashboardHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/dashboards/{dashboard-id}", tracing.TraceMiddleware(hs.Recovery(getDashboardIdHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/dashboards/delete/{dashboard-id}", tracing.TraceMiddleware(hs.Recovery(deleteDashboardHandler())))
 	hs.Router.PUT(server_utils.API_PREFIX+"/dashboards/favorite/{dashboard-id}", tracing.TraceMiddleware(hs.Recovery(favoriteDashboardHandler())))
-	hs.Router.GET(server_utils.API_PREFIX+"/dashboards/listfavorites", tracing.TraceMiddleware(hs.Recovery(getFavoriteDashboardIdsHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/version/info", tracing.TraceMiddleware(hs.Recovery(getVersionHandler())))
 
 	// alerting api endpoints

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2023,7 +2023,7 @@ div.dts div.dataTables_scrollBody table {
     background-color: transparent;
     border-width: 0;
     margin-left: 15px;
-    background-size: contain;
+    background-size: cover;
 }
 #favbutton{
     background-image: url(../assets/star-outline.svg);
@@ -3530,7 +3530,7 @@ float: right;
 }
 #dashboard-grid .ag-cell{
     display: flex !important;
-    padding: 0px 15px !important;
+    padding: 0px 0px 0px 15px !important;
     cursor: pointer;
     font-size: 14px;
     text-decoration-line: none;

--- a/static/js/dashboard-from-logs-metrics.js
+++ b/static/js/dashboard-from-logs-metrics.js
@@ -224,10 +224,10 @@ function displayExistingDashboards() {
                 // Add empty list item when there are no additional dashboards
                 dropdown.html(`<li class="dashboard"></li>`);
             } else {
-                $.each(res, function (id, dashboardName) {
+                $.each(res, function (id, dashboardDetails) {
                     // exclude default dashboards
                     if (!defaultDashboardIds.includes(id) && !existingDashboards.includes(id)) {
-                        dropdown.append(`<li class="dashboard" id="${id}">${dashboardName}</li>`);
+                        dropdown.append(`<li class="dashboard" id="${id}">${dashboardDetails.name}</li>`);
                         existingDashboards.push(id);
                     }
                 });

--- a/static/js/dashboards-home.js
+++ b/static/js/dashboards-home.js
@@ -365,7 +365,7 @@ let dashboardColumnDefs = [
         headerName: 'Created At',
         field: 'createdAt',
         sortable: true,
-        cellStyle: { justifyContent: 'flex-end'},
+        cellStyle: { justifyContent: 'flex-end' },
         headerClass: 'ag-right-aligned-header',
         cellRenderer: (params) => {
             if (!params.value) return '-';

--- a/static/js/dashboards-home.js
+++ b/static/js/dashboards-home.js
@@ -262,7 +262,7 @@ class btnRenderer {
                                 {
                                     dbname: duplicatedDBName,
                                     uniqId: uniqIDdb,
-                                    createdAt: utils.GetCurrentTimeInMs(),
+                                    createdAt: Date.now(),
                                     favorite: false,
                                     isDefault: false,
                                 },

--- a/static/js/dashboards-home.js
+++ b/static/js/dashboards-home.js
@@ -20,44 +20,32 @@
 let dbgridDiv = null;
 let dbRowData = [];
 
+let initialDashboards = null;
+
+$(document).ready(async function () {
+    $('.theme-btn').on('click', themePickerHandler);
+
+    initialDashboards = await getAllDashboards();
+    displayDashboards(initialDashboards);
+
+    $('#create-db-btn').click(createDashboard);
+    $('.search-db-input').on('input', searchDB);
+    $('.search-db-input').on('keyup', function (e) {
+        if (e.target.value === '') {
+            displayOriginalDashboards();
+        }
+    });
+
+    let stDate = 'now-1h';
+    let endDate = 'now';
+    datePickerHandler(stDate, endDate, stDate);
+});
+
 async function getAllDashboards() {
     let serverResponse = [];
     await $.ajax({
         method: 'get',
         url: 'api/dashboards/listall',
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            Accept: '*/*',
-        },
-        crossDomain: true,
-        dataType: 'json',
-    }).then(function (res) {
-        serverResponse = res;
-    });
-    return serverResponse;
-}
-
-async function getAllDefaultDashboards() {
-    let serverResponse = [];
-    await $.ajax({
-        method: 'get',
-        url: 'api/dashboards/defaultlistall',
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            Accept: '*/*',
-        },
-        crossDomain: true,
-        dataType: 'json',
-    }).then(function (res) {
-        serverResponse = res;
-    });
-    return serverResponse;
-}
-async function getAllFavoriteDashboards() {
-    let serverResponse = [];
-    await $.ajax({
-        method: 'get',
-        url: 'api/dashboards/listfavorites',
         headers: {
             'Content-Type': 'application/json; charset=utf-8',
             Accept: '*/*',
@@ -185,10 +173,10 @@ class btnRenderer {
         this.dButton.style.marginRight = '5px';
         this.duplicateButton = this.eGui.querySelector('.btn-duplicate');
         this.starIcon = this.eGui.querySelector('.star-icon');
-        this.starIcon.style.backgroundImage = favoriteDBsSet.has(params.data.uniqId) ? starFilledURL : starOutlineURL;
+        this.starIcon.style.backgroundImage = params.data.favorite ? starFilledURL : starOutlineURL;
 
         //Disable delete for default dashboards and show "Default" label
-        if (defaultDashboardIds.includes(params.data.uniqId)) {
+        if (params.data.isDefault) {
             const defaultLabel = document.createElement('span');
             defaultLabel.className = 'default-label';
             defaultLabel.innerText = 'Default';
@@ -274,6 +262,9 @@ class btnRenderer {
                                 {
                                     dbname: duplicatedDBName,
                                     uniqId: uniqIDdb,
+                                    createdAt: utils.GetCurrentTimeInMs(),
+                                    favorite: false,
+                                    isDefault: false,
                                 },
                             ],
                         });
@@ -291,13 +282,8 @@ class btnRenderer {
                 },
                 crossDomain: true,
             }).then((response) => {
-                // Update the favorite status based on the response
                 params.data.favorite = response.isFavorite;
-                if (params.data.favorite) {
-                    this.starIcon.style.backgroundImage = starFilledURL;
-                } else {
-                    this.starIcon.style.backgroundImage = starOutlineURL;
-                }
+                this.starIcon.style.backgroundImage = params.data.favorite ? starFilledURL : starOutlineURL;
             });
         }
 
@@ -331,10 +317,8 @@ class btnRenderer {
     }
 
     refresh(params) {
-        // Use the URL of the SVG files for star icons
         const starOutlineURL = 'url("../assets/star-outline.svg")';
         const starFilledURL = 'url("../assets/star-filled.svg")';
-
         this.starIcon.style.backgroundImage = params.data.favorite ? starFilledURL : starOutlineURL;
         return false;
     }
@@ -378,8 +362,27 @@ let dashboardColumnDefs = [
         },
     },
     {
+        headerName: 'Created At',
+        field: 'createdAt',
+        sortable: true,
+        cellStyle: { justifyContent: 'flex-end'},
+        headerClass: 'ag-right-aligned-header',
+        cellRenderer: (params) => {
+            if (!params.value) return '-';
+            const date = new Date(params.value);
+            return date.toLocaleDateString([], {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+            });
+        },
+        width: 50,
+    },
+    {
         cellRenderer: btnRenderer,
-        width: 40,
+        width: 50,
     },
 ];
 
@@ -409,18 +412,28 @@ function displayDashboards(res, flag) {
     let nonFavorites = [];
 
     for (let [key, value] of Object.entries(res)) {
-        if (favoriteDBsSet.has(key)) {
+        // Check if the dashboard is a favorite from the response itself
+        if (value.isFavorite) {
             favorites.push([key, value]);
         } else {
             nonFavorites.push([key, value]);
         }
     }
-    favorites.sort((a, b) => b[1].localeCompare(a[1]));
-    nonFavorites.sort((a, b) => b[1].localeCompare(a[1]));
+
+    // Sort favorites and non-favorites by creation time (newest first)
+    const sortByTime = (a, b) => {
+        const timeA = a[1].createdAt || 0;
+        const timeB = b[1].createdAt || 0;
+        return timeB - timeA;
+    };
+
+    favorites.sort(sortByTime);
+    nonFavorites.sort(sortByTime);
+
     let resArray = [...favorites, ...nonFavorites];
-    res = Object.fromEntries(resArray);
+
     if (flag == -1) {
-        // show search results
+        // Show search results
         let dbFilteredRowData = [];
         if (dbgridDiv === null) {
             dbgridDiv = document.querySelector('#dashboard-grid');
@@ -428,16 +441,19 @@ function displayDashboards(res, flag) {
             new agGrid.Grid(dbgridDiv, dbgridOptions);
         }
         dbgridOptions.api.setColumnDefs(dashboardColumnDefs);
-        let idx = 0;
-        let newRow = new Map();
-        $.each(res, function (key, value) {
-            newRow.set('rowId', idx);
-            newRow.set('uniqId', key);
-            newRow.set('dbname', value);
 
-            dbFilteredRowData = _.concat(dbFilteredRowData, Object.fromEntries(newRow));
-            idx = idx + 1;
+        resArray.forEach((item, idx) => {
+            const [key, dashboardInfo] = item;
+            dbFilteredRowData.push({
+                rowId: idx,
+                uniqId: key,
+                dbname: dashboardInfo.name,
+                createdAt: dashboardInfo.createdAt,
+                favorite: dashboardInfo.isFavorite,
+                isDefault: dashboardInfo.isDefault,
+            });
         });
+
         dbgridOptions.api.setRowData(dbFilteredRowData);
         dbgridOptions.api.sizeColumnsToFit();
     } else {
@@ -447,16 +463,19 @@ function displayDashboards(res, flag) {
             new agGrid.Grid(dbgridDiv, dbgridOptions);
         }
         dbgridOptions.api.setColumnDefs(dashboardColumnDefs);
-        let idx = 0;
-        let newRow = new Map();
-        $.each(res, function (key, value) {
-            newRow.set('rowId', idx);
-            newRow.set('uniqId', key);
-            newRow.set('dbname', value);
 
-            dbRowData = _.concat(dbRowData, Object.fromEntries(newRow));
-            idx = idx + 1;
+        dbRowData = resArray.map((item, idx) => {
+            const [key, dashboardInfo] = item;
+            return {
+                rowId: idx,
+                uniqId: key,
+                dbname: dashboardInfo.name,
+                createdAt: dashboardInfo.createdAt,
+                favorite: dashboardInfo.isFavorite,
+                isDefault: dashboardInfo.isDefault,
+            };
         });
+
         dbgridOptions.api.setRowData(dbRowData);
         dbgridOptions.api.sizeColumnsToFit();
     }
@@ -464,6 +483,13 @@ function displayDashboards(res, flag) {
 
 function searchDB() {
     let searchText = $('.search-db-input').val();
+
+    // If search is empty, restore original dashboards
+    if (!searchText.trim()) {
+        displayOriginalDashboards();
+        return;
+    }
+
     var tokens = searchText
         .toLowerCase()
         .split(' ')
@@ -471,29 +497,29 @@ function searchDB() {
             return token.trim() !== '';
         });
 
-    let dbNames = [];
-    dbRowData.forEach((rowData) => {
-        dbNames.push(rowData.dbname);
-    });
-
-    let dbFilteredRowsObject = {};
     if (tokens.length) {
         var searchTermRegex = new RegExp(tokens.join('|'), 'gi');
-        dbNames.filter(function (dbName, i) {
-            if (dbName.match(searchTermRegex)) {
-                let uniqIdDB = dbRowData[i].uniqId;
-                dbFilteredRowsObject[`${uniqIdDB}`] = dbRowData[i].dbname;
+
+        // Filter the original dbRowData
+        let filteredDashboards = {};
+        dbRowData.forEach((rowData) => {
+            if (rowData.dbname.match(searchTermRegex)) {
+                filteredDashboards[rowData.uniqId] = {
+                    name: rowData.dbname,
+                    createdAt: rowData.createdAt,
+                    isFavorite: rowData.favorite,
+                    isDefault: rowData.isDefault,
+                };
             }
-            return dbName.match(searchTermRegex);
         });
 
-        if (Object.keys(dbFilteredRowsObject).length === 0) {
-            displayDashboards(dbFilteredRowsObject, -1);
+        if (Object.keys(filteredDashboards).length === 0) {
+            displayDashboards(filteredDashboards, -1);
             showDBNotFoundMsg();
         } else {
             $('#dashboard-grid-container').show();
             $('#empty-response').hide();
-            displayDashboards(dbFilteredRowsObject, -1);
+            displayDashboards(filteredDashboards, -1);
         }
     }
 }
@@ -509,34 +535,12 @@ function displayOriginalDashboards() {
         }
         $('#dashboard-grid-container').show();
         $('#empty-response').hide();
-        dbgridOptions.api.setColumnDefs(dashboardColumnDefs);
-        dbgridOptions.api.setRowData(dbRowData);
-        dbgridOptions.api.sizeColumnsToFit();
+
+        // Use the initial dashboard data to reset
+        displayDashboards(initialDashboards);
     }
 }
-
 function showDBNotFoundMsg() {
     $('#dashboard-grid-container').hide();
     $('#empty-response').show();
 }
-let favoriteDBsSet;
-
-$(document).ready(async function () {
-    $('.theme-btn').on('click', themePickerHandler);
-
-    let normalDBs = await getAllDashboards();
-    let allDefaultDBs = await getAllDefaultDashboards();
-    let allDBs = { ...normalDBs, ...allDefaultDBs };
-    let favoriteDBs = await getAllFavoriteDashboards();
-    // Convert the array of favorite dashboards to a Set for faster lookup
-    favoriteDBsSet = new Set(Object.keys(favoriteDBs));
-    displayDashboards(allDBs);
-
-    $('#create-db-btn').click(createDashboard);
-    $('.search-db-input').on('input', searchDB);
-    $('.search-db-input').on('keyup', displayOriginalDashboards);
-
-    let stDate = 'now-1h';
-    let endDate = 'now';
-    datePickerHandler(stDate, endDate, stDate);
-});


### PR DESCRIPTION
# Description
Backend Update:
- Previously, three separate API calls were made to fetch dashboards, favorites, and default dashboards.
- Now consolidated into a single API call, with metadata updates to include createdAt, isFavorite, and isDefault, simplifying the dashboard data retrieval process.

Frontend Update:

- Dashboards are now displayed with favorites at the top, sorted by createdAt (most recent first).
- Other dashboards are also sorted by creation time.
- For legacy dashboards (created before this change), the createdAt will default to the last modification time.
- For default dashboards, the createdAt is set to 0.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/5595dc00-4206-4256-99d0-8f054a7bdd8b">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
