### PR TITLE
stats command panic fix on logging of empty search results

### DIFF
--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -319,12 +319,14 @@ func (p *statsProcessor) logErrorsAndWarnings(qid uint64) {
 		log.Errorf("qid=%v, statsProcessor.logErrorsAndWarnings: not supported stats type: %v", qid, p.errorData.notSupportedStatsType)
 	}
 
-	allErrorsLen := len(p.searchResults.AllErrors)
-	if allErrorsLen > 0 {
-		size := allErrorsLen
-		if allErrorsLen > utils.MAX_SIMILAR_ERRORS_TO_LOG {
-			size = utils.MAX_SIMILAR_ERRORS_TO_LOG
+	if p.searchResults != nil {
+		allErrorsLen := len(p.searchResults.AllErrors)
+		if allErrorsLen > 0 {
+			size := allErrorsLen
+			if allErrorsLen > utils.MAX_SIMILAR_ERRORS_TO_LOG {
+				size = utils.MAX_SIMILAR_ERRORS_TO_LOG
+			}
+			log.Errorf("qid=%v, statsProcessor.logErrorsAndWarnings: search results errors: %v", qid, p.searchResults.AllErrors[:size])
 		}
-		log.Errorf("qid=%v, statsProcessor.logErrorsAndWarnings: search results errors: %v", qid, p.searchResults.AllErrors[:size])
 	}
 }


### PR DESCRIPTION
# Description
- Added safety to log search result errors only when `searchResults != nil`


# Testing
- tested by running the ci/cd queries

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
