### PR TITLE
Clean up parsing some commands

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -2366,35 +2366,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1358, col: 1, offset: 42038},
+			pos:  position{line: 1360, col: 1, offset: 42119},
 			expr: &actionExpr{
-				pos: position{line: 1358, col: 27, offset: 42064},
+				pos: position{line: 1360, col: 27, offset: 42145},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1358, col: 27, offset: 42064},
+					pos: position{line: 1360, col: 27, offset: 42145},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1358, col: 27, offset: 42064},
+							pos:   position{line: 1360, col: 27, offset: 42145},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1358, col: 33, offset: 42070},
+								pos:  position{line: 1360, col: 33, offset: 42151},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1358, col: 51, offset: 42088},
+							pos:   position{line: 1360, col: 51, offset: 42169},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1358, col: 56, offset: 42093},
+								pos: position{line: 1360, col: 56, offset: 42174},
 								expr: &seqExpr{
-									pos: position{line: 1358, col: 57, offset: 42094},
+									pos: position{line: 1360, col: 57, offset: 42175},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1358, col: 57, offset: 42094},
+											pos:  position{line: 1360, col: 57, offset: 42175},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1358, col: 63, offset: 42100},
+											pos:  position{line: 1360, col: 63, offset: 42181},
 											name: "TimechartArgument",
 										},
 									},
@@ -2407,22 +2407,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1387, col: 1, offset: 42834},
+			pos:  position{line: 1389, col: 1, offset: 42915},
 			expr: &actionExpr{
-				pos: position{line: 1387, col: 22, offset: 42855},
+				pos: position{line: 1389, col: 22, offset: 42936},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1387, col: 22, offset: 42855},
+					pos:   position{line: 1389, col: 22, offset: 42936},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1387, col: 29, offset: 42862},
+						pos: position{line: 1389, col: 29, offset: 42943},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1387, col: 29, offset: 42862},
+								pos:  position{line: 1389, col: 29, offset: 42943},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1387, col: 45, offset: 42878},
+								pos:  position{line: 1389, col: 45, offset: 42959},
 								name: "TcOptions",
 							},
 						},
@@ -2432,28 +2432,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1391, col: 1, offset: 42916},
+			pos:  position{line: 1393, col: 1, offset: 42997},
 			expr: &actionExpr{
-				pos: position{line: 1391, col: 18, offset: 42933},
+				pos: position{line: 1393, col: 18, offset: 43014},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1391, col: 18, offset: 42933},
+					pos: position{line: 1393, col: 18, offset: 43014},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1391, col: 18, offset: 42933},
+							pos:   position{line: 1393, col: 18, offset: 43014},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1391, col: 23, offset: 42938},
+								pos:  position{line: 1393, col: 23, offset: 43019},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1391, col: 39, offset: 42954},
+							pos:   position{line: 1393, col: 39, offset: 43035},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1391, col: 53, offset: 42968},
+								pos: position{line: 1393, col: 53, offset: 43049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1391, col: 53, offset: 42968},
+									pos:  position{line: 1393, col: 53, offset: 43049},
 									name: "SplitByClause",
 								},
 							},
@@ -2464,22 +2464,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1405, col: 1, offset: 43307},
+			pos:  position{line: 1407, col: 1, offset: 43388},
 			expr: &actionExpr{
-				pos: position{line: 1405, col: 18, offset: 43324},
+				pos: position{line: 1407, col: 18, offset: 43405},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1405, col: 18, offset: 43324},
+					pos: position{line: 1407, col: 18, offset: 43405},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1405, col: 18, offset: 43324},
+							pos:  position{line: 1407, col: 18, offset: 43405},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1405, col: 21, offset: 43327},
+							pos:   position{line: 1407, col: 21, offset: 43408},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1405, col: 27, offset: 43333},
+								pos:  position{line: 1407, col: 27, offset: 43414},
 								name: "FieldName",
 							},
 						},
@@ -2489,24 +2489,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1413, col: 1, offset: 43462},
+			pos:  position{line: 1415, col: 1, offset: 43543},
 			expr: &actionExpr{
-				pos: position{line: 1413, col: 14, offset: 43475},
+				pos: position{line: 1415, col: 14, offset: 43556},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1413, col: 14, offset: 43475},
+					pos:   position{line: 1415, col: 14, offset: 43556},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1413, col: 22, offset: 43483},
+						pos: position{line: 1415, col: 22, offset: 43564},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1413, col: 22, offset: 43483},
+								pos:  position{line: 1415, col: 22, offset: 43564},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1413, col: 35, offset: 43496},
+								pos: position{line: 1415, col: 35, offset: 43577},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1413, col: 36, offset: 43497},
+									pos:  position{line: 1415, col: 36, offset: 43578},
 									name: "TcOption",
 								},
 							},
@@ -2517,34 +2517,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1455, col: 1, offset: 45017},
+			pos:  position{line: 1457, col: 1, offset: 45098},
 			expr: &actionExpr{
-				pos: position{line: 1455, col: 13, offset: 45029},
+				pos: position{line: 1457, col: 13, offset: 45110},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1455, col: 13, offset: 45029},
+					pos: position{line: 1457, col: 13, offset: 45110},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1455, col: 13, offset: 45029},
+							pos:  position{line: 1457, col: 13, offset: 45110},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1455, col: 19, offset: 45035},
+							pos:   position{line: 1457, col: 19, offset: 45116},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1455, col: 31, offset: 45047},
+								pos:  position{line: 1457, col: 31, offset: 45128},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1455, col: 43, offset: 45059},
+							pos:  position{line: 1457, col: 43, offset: 45140},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1455, col: 49, offset: 45065},
+							pos:   position{line: 1457, col: 49, offset: 45146},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1455, col: 53, offset: 45069},
+								pos:  position{line: 1457, col: 53, offset: 45150},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2554,36 +2554,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1460, col: 1, offset: 45182},
+			pos:  position{line: 1462, col: 1, offset: 45263},
 			expr: &actionExpr{
-				pos: position{line: 1460, col: 16, offset: 45197},
+				pos: position{line: 1462, col: 16, offset: 45278},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1460, col: 16, offset: 45197},
+					pos:   position{line: 1462, col: 16, offset: 45278},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1460, col: 24, offset: 45205},
+						pos: position{line: 1462, col: 24, offset: 45286},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1460, col: 24, offset: 45205},
+								pos:        position{line: 1462, col: 24, offset: 45286},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1460, col: 36, offset: 45217},
+								pos:        position{line: 1462, col: 36, offset: 45298},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1460, col: 49, offset: 45230},
+								pos:        position{line: 1462, col: 49, offset: 45311},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1460, col: 61, offset: 45242},
+								pos:        position{line: 1462, col: 61, offset: 45323},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2595,50 +2595,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1468, col: 1, offset: 45438},
+			pos:  position{line: 1470, col: 1, offset: 45519},
 			expr: &actionExpr{
-				pos: position{line: 1468, col: 17, offset: 45454},
+				pos: position{line: 1470, col: 17, offset: 45535},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1468, col: 17, offset: 45454},
+					pos:   position{line: 1470, col: 17, offset: 45535},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1468, col: 27, offset: 45464},
+						pos: position{line: 1470, col: 27, offset: 45545},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 27, offset: 45464},
+								pos:  position{line: 1470, col: 27, offset: 45545},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 36, offset: 45473},
+								pos:  position{line: 1470, col: 36, offset: 45554},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 44, offset: 45481},
+								pos:  position{line: 1470, col: 44, offset: 45562},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 57, offset: 45494},
+								pos:  position{line: 1470, col: 57, offset: 45575},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 66, offset: 45503},
+								pos:  position{line: 1470, col: 66, offset: 45584},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 73, offset: 45510},
+								pos:  position{line: 1470, col: 73, offset: 45591},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 79, offset: 45516},
+								pos:  position{line: 1470, col: 79, offset: 45597},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 86, offset: 45523},
+								pos:  position{line: 1470, col: 86, offset: 45604},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1468, col: 96, offset: 45533},
+								pos:  position{line: 1470, col: 96, offset: 45614},
 								name: "Year",
 							},
 						},
@@ -2648,37 +2648,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1472, col: 1, offset: 45569},
+			pos:  position{line: 1474, col: 1, offset: 45650},
 			expr: &actionExpr{
-				pos: position{line: 1472, col: 21, offset: 45589},
+				pos: position{line: 1474, col: 21, offset: 45670},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1472, col: 21, offset: 45589},
+					pos: position{line: 1474, col: 21, offset: 45670},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1472, col: 21, offset: 45589},
+							pos:   position{line: 1474, col: 21, offset: 45670},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1472, col: 29, offset: 45597},
+								pos: position{line: 1474, col: 29, offset: 45678},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1472, col: 29, offset: 45597},
+										pos:  position{line: 1474, col: 29, offset: 45678},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1472, col: 45, offset: 45613},
+										pos:  position{line: 1474, col: 45, offset: 45694},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1472, col: 62, offset: 45630},
+							pos:   position{line: 1474, col: 62, offset: 45711},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1472, col: 72, offset: 45640},
+								pos: position{line: 1474, col: 72, offset: 45721},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1472, col: 73, offset: 45641},
+									pos:  position{line: 1474, col: 73, offset: 45722},
 									name: "AllTimeScale",
 								},
 							},
@@ -2689,28 +2689,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1531, col: 1, offset: 48323},
+			pos:  position{line: 1533, col: 1, offset: 48404},
 			expr: &actionExpr{
-				pos: position{line: 1531, col: 21, offset: 48343},
+				pos: position{line: 1533, col: 21, offset: 48424},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1531, col: 21, offset: 48343},
+					pos: position{line: 1533, col: 21, offset: 48424},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1531, col: 21, offset: 48343},
+							pos:        position{line: 1533, col: 21, offset: 48424},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1531, col: 31, offset: 48353},
+							pos:  position{line: 1533, col: 31, offset: 48434},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1531, col: 37, offset: 48359},
+							pos:   position{line: 1533, col: 37, offset: 48440},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1531, col: 48, offset: 48370},
+								pos:  position{line: 1533, col: 48, offset: 48451},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2720,28 +2720,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1542, col: 1, offset: 48611},
+			pos:  position{line: 1544, col: 1, offset: 48692},
 			expr: &actionExpr{
-				pos: position{line: 1542, col: 21, offset: 48631},
+				pos: position{line: 1544, col: 21, offset: 48712},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1542, col: 21, offset: 48631},
+					pos: position{line: 1544, col: 21, offset: 48712},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1542, col: 21, offset: 48631},
+							pos:        position{line: 1544, col: 21, offset: 48712},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1542, col: 28, offset: 48638},
+							pos:  position{line: 1544, col: 28, offset: 48719},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1542, col: 34, offset: 48644},
+							pos:   position{line: 1544, col: 34, offset: 48725},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1542, col: 43, offset: 48653},
+								pos:  position{line: 1544, col: 43, offset: 48734},
 								name: "IntegerAsString",
 							},
 						},
@@ -2751,31 +2751,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1563, col: 1, offset: 49232},
+			pos:  position{line: 1565, col: 1, offset: 49313},
 			expr: &choiceExpr{
-				pos: position{line: 1563, col: 23, offset: 49254},
+				pos: position{line: 1565, col: 23, offset: 49335},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1563, col: 23, offset: 49254},
+						pos: position{line: 1565, col: 23, offset: 49335},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1563, col: 23, offset: 49254},
+							pos: position{line: 1565, col: 23, offset: 49335},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1563, col: 23, offset: 49254},
+									pos:        position{line: 1565, col: 23, offset: 49335},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1563, col: 35, offset: 49266},
+									pos:  position{line: 1565, col: 35, offset: 49347},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1563, col: 41, offset: 49272},
+									pos:   position{line: 1565, col: 41, offset: 49353},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1563, col: 51, offset: 49282},
+										pos:  position{line: 1565, col: 51, offset: 49363},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2783,33 +2783,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1577, col: 3, offset: 49701},
+						pos: position{line: 1579, col: 3, offset: 49782},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1577, col: 3, offset: 49701},
+							pos: position{line: 1579, col: 3, offset: 49782},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1577, col: 3, offset: 49701},
+									pos:        position{line: 1579, col: 3, offset: 49782},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1577, col: 15, offset: 49713},
+									pos:  position{line: 1579, col: 15, offset: 49794},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1577, col: 21, offset: 49719},
+									pos:   position{line: 1579, col: 21, offset: 49800},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1577, col: 32, offset: 49730},
+										pos: position{line: 1579, col: 32, offset: 49811},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1577, col: 32, offset: 49730},
+												pos:  position{line: 1579, col: 32, offset: 49811},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1577, col: 52, offset: 49750},
+												pos:  position{line: 1579, col: 52, offset: 49831},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2823,35 +2823,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1597, col: 1, offset: 50219},
+			pos:  position{line: 1599, col: 1, offset: 50300},
 			expr: &actionExpr{
-				pos: position{line: 1597, col: 19, offset: 50237},
+				pos: position{line: 1599, col: 19, offset: 50318},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1597, col: 19, offset: 50237},
+					pos: position{line: 1599, col: 19, offset: 50318},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1597, col: 19, offset: 50237},
+							pos:        position{line: 1599, col: 19, offset: 50318},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1597, col: 27, offset: 50245},
+							pos:  position{line: 1599, col: 27, offset: 50326},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1597, col: 33, offset: 50251},
+							pos:   position{line: 1599, col: 33, offset: 50332},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1597, col: 41, offset: 50259},
+								pos: position{line: 1599, col: 41, offset: 50340},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1597, col: 41, offset: 50259},
+										pos:  position{line: 1599, col: 41, offset: 50340},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1597, col: 57, offset: 50275},
+										pos:  position{line: 1599, col: 57, offset: 50356},
 										name: "IntegerAsString",
 									},
 								},
@@ -2863,35 +2863,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1612, col: 1, offset: 50654},
+			pos:  position{line: 1614, col: 1, offset: 50735},
 			expr: &actionExpr{
-				pos: position{line: 1612, col: 17, offset: 50670},
+				pos: position{line: 1614, col: 17, offset: 50751},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1612, col: 17, offset: 50670},
+					pos: position{line: 1614, col: 17, offset: 50751},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1612, col: 17, offset: 50670},
+							pos:        position{line: 1614, col: 17, offset: 50751},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1612, col: 23, offset: 50676},
+							pos:  position{line: 1614, col: 23, offset: 50757},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1612, col: 29, offset: 50682},
+							pos:   position{line: 1614, col: 29, offset: 50763},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1612, col: 37, offset: 50690},
+								pos: position{line: 1614, col: 37, offset: 50771},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1612, col: 37, offset: 50690},
+										pos:  position{line: 1614, col: 37, offset: 50771},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1612, col: 53, offset: 50706},
+										pos:  position{line: 1614, col: 53, offset: 50787},
 										name: "IntegerAsString",
 									},
 								},
@@ -2903,40 +2903,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1627, col: 1, offset: 51077},
+			pos:  position{line: 1629, col: 1, offset: 51158},
 			expr: &choiceExpr{
-				pos: position{line: 1627, col: 18, offset: 51094},
+				pos: position{line: 1629, col: 18, offset: 51175},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1627, col: 18, offset: 51094},
+						pos: position{line: 1629, col: 18, offset: 51175},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1627, col: 18, offset: 51094},
+							pos: position{line: 1629, col: 18, offset: 51175},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1627, col: 18, offset: 51094},
+									pos:        position{line: 1629, col: 18, offset: 51175},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1627, col: 25, offset: 51101},
+									pos:  position{line: 1629, col: 25, offset: 51182},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1627, col: 31, offset: 51107},
+									pos:   position{line: 1629, col: 31, offset: 51188},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1627, col: 36, offset: 51112},
+										pos: position{line: 1629, col: 36, offset: 51193},
 										expr: &choiceExpr{
-											pos: position{line: 1627, col: 37, offset: 51113},
+											pos: position{line: 1629, col: 37, offset: 51194},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1627, col: 37, offset: 51113},
+													pos:  position{line: 1629, col: 37, offset: 51194},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1627, col: 53, offset: 51129},
+													pos:  position{line: 1629, col: 53, offset: 51210},
 													name: "IntegerAsString",
 												},
 											},
@@ -2944,25 +2944,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1627, col: 71, offset: 51147},
+									pos:        position{line: 1629, col: 71, offset: 51228},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1627, col: 77, offset: 51153},
+									pos:   position{line: 1629, col: 77, offset: 51234},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1627, col: 82, offset: 51158},
+										pos: position{line: 1629, col: 82, offset: 51239},
 										expr: &choiceExpr{
-											pos: position{line: 1627, col: 83, offset: 51159},
+											pos: position{line: 1629, col: 83, offset: 51240},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1627, col: 83, offset: 51159},
+													pos:  position{line: 1629, col: 83, offset: 51240},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1627, col: 99, offset: 51175},
+													pos:  position{line: 1629, col: 99, offset: 51256},
 													name: "IntegerAsString",
 												},
 											},
@@ -2973,26 +2973,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1670, col: 3, offset: 52611},
+						pos: position{line: 1672, col: 3, offset: 52692},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1670, col: 3, offset: 52611},
+							pos: position{line: 1672, col: 3, offset: 52692},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1670, col: 3, offset: 52611},
+									pos:        position{line: 1672, col: 3, offset: 52692},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1670, col: 10, offset: 52618},
+									pos:  position{line: 1672, col: 10, offset: 52699},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1670, col: 16, offset: 52624},
+									pos:   position{line: 1672, col: 16, offset: 52705},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1670, col: 24, offset: 52632},
+										pos:  position{line: 1672, col: 24, offset: 52713},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3004,38 +3004,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1685, col: 1, offset: 52963},
+			pos:  position{line: 1687, col: 1, offset: 53044},
 			expr: &actionExpr{
-				pos: position{line: 1685, col: 17, offset: 52979},
+				pos: position{line: 1687, col: 17, offset: 53060},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1685, col: 17, offset: 52979},
+					pos:   position{line: 1687, col: 17, offset: 53060},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1685, col: 25, offset: 52987},
+						pos: position{line: 1687, col: 25, offset: 53068},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 25, offset: 52987},
+								pos:  position{line: 1687, col: 25, offset: 53068},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 46, offset: 53008},
+								pos:  position{line: 1687, col: 46, offset: 53089},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 65, offset: 53027},
+								pos:  position{line: 1687, col: 65, offset: 53108},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 84, offset: 53046},
+								pos:  position{line: 1687, col: 84, offset: 53127},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 101, offset: 53063},
+								pos:  position{line: 1687, col: 101, offset: 53144},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1685, col: 116, offset: 53078},
+								pos:  position{line: 1687, col: 116, offset: 53159},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3045,35 +3045,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1689, col: 1, offset: 53121},
+			pos:  position{line: 1691, col: 1, offset: 53202},
 			expr: &actionExpr{
-				pos: position{line: 1689, col: 22, offset: 53142},
+				pos: position{line: 1691, col: 22, offset: 53223},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1689, col: 22, offset: 53142},
+					pos: position{line: 1691, col: 22, offset: 53223},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1689, col: 22, offset: 53142},
+							pos:   position{line: 1691, col: 22, offset: 53223},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1689, col: 29, offset: 53149},
+								pos:  position{line: 1691, col: 29, offset: 53230},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1689, col: 42, offset: 53162},
+							pos:   position{line: 1691, col: 42, offset: 53243},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1689, col: 48, offset: 53168},
+								pos: position{line: 1691, col: 48, offset: 53249},
 								expr: &seqExpr{
-									pos: position{line: 1689, col: 49, offset: 53169},
+									pos: position{line: 1691, col: 49, offset: 53250},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1689, col: 49, offset: 53169},
+											pos:  position{line: 1691, col: 49, offset: 53250},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1689, col: 55, offset: 53175},
+											pos:  position{line: 1691, col: 55, offset: 53256},
 											name: "BinCmdOption",
 										},
 									},
@@ -3086,51 +3086,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1735, col: 1, offset: 54659},
+			pos:  position{line: 1737, col: 1, offset: 54740},
 			expr: &choiceExpr{
-				pos: position{line: 1735, col: 13, offset: 54671},
+				pos: position{line: 1737, col: 13, offset: 54752},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1735, col: 13, offset: 54671},
+						pos: position{line: 1737, col: 13, offset: 54752},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1735, col: 13, offset: 54671},
+							pos: position{line: 1737, col: 13, offset: 54752},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1735, col: 13, offset: 54671},
+									pos:  position{line: 1737, col: 13, offset: 54752},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1735, col: 18, offset: 54676},
+									pos:  position{line: 1737, col: 18, offset: 54757},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1735, col: 26, offset: 54684},
+									pos:   position{line: 1737, col: 26, offset: 54765},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1735, col: 40, offset: 54698},
+										pos:  position{line: 1737, col: 40, offset: 54779},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1735, col: 59, offset: 54717},
+									pos:  position{line: 1737, col: 59, offset: 54798},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1735, col: 65, offset: 54723},
+									pos:   position{line: 1737, col: 65, offset: 54804},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1735, col: 71, offset: 54729},
+										pos:  position{line: 1737, col: 71, offset: 54810},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1735, col: 81, offset: 54739},
+									pos:   position{line: 1737, col: 81, offset: 54820},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1735, col: 94, offset: 54752},
+										pos: position{line: 1737, col: 94, offset: 54833},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1735, col: 95, offset: 54753},
+											pos:  position{line: 1737, col: 95, offset: 54834},
 											name: "AsField",
 										},
 									},
@@ -3139,34 +3139,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1762, col: 3, offset: 55596},
+						pos: position{line: 1764, col: 3, offset: 55677},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1762, col: 3, offset: 55596},
+							pos: position{line: 1764, col: 3, offset: 55677},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1762, col: 3, offset: 55596},
+									pos:  position{line: 1764, col: 3, offset: 55677},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1762, col: 8, offset: 55601},
+									pos:  position{line: 1764, col: 8, offset: 55682},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1762, col: 16, offset: 55609},
+									pos:   position{line: 1764, col: 16, offset: 55690},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1762, col: 22, offset: 55615},
+										pos:  position{line: 1764, col: 22, offset: 55696},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1762, col: 32, offset: 55625},
+									pos:   position{line: 1764, col: 32, offset: 55706},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1762, col: 45, offset: 55638},
+										pos: position{line: 1764, col: 45, offset: 55719},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1762, col: 46, offset: 55639},
+											pos:  position{line: 1764, col: 46, offset: 55720},
 											name: "AsField",
 										},
 									},
@@ -3179,15 +3179,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1793, col: 1, offset: 56513},
+			pos:  position{line: 1795, col: 1, offset: 56594},
 			expr: &actionExpr{
-				pos: position{line: 1793, col: 15, offset: 56527},
+				pos: position{line: 1795, col: 15, offset: 56608},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1793, col: 15, offset: 56527},
+					pos:   position{line: 1795, col: 15, offset: 56608},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1793, col: 27, offset: 56539},
+						pos:  position{line: 1795, col: 27, offset: 56620},
 						name: "SpanOptions",
 					},
 				},
@@ -3195,26 +3195,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1801, col: 1, offset: 56764},
+			pos:  position{line: 1803, col: 1, offset: 56845},
 			expr: &actionExpr{
-				pos: position{line: 1801, col: 16, offset: 56779},
+				pos: position{line: 1803, col: 16, offset: 56860},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1801, col: 16, offset: 56779},
+					pos: position{line: 1803, col: 16, offset: 56860},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1801, col: 16, offset: 56779},
+							pos:  position{line: 1803, col: 16, offset: 56860},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1801, col: 25, offset: 56788},
+							pos:  position{line: 1803, col: 25, offset: 56869},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1801, col: 31, offset: 56794},
+							pos:   position{line: 1803, col: 31, offset: 56875},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1801, col: 42, offset: 56805},
+								pos:  position{line: 1803, col: 42, offset: 56886},
 								name: "SpanLength",
 							},
 						},
@@ -3224,26 +3224,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1808, col: 1, offset: 56951},
+			pos:  position{line: 1810, col: 1, offset: 57032},
 			expr: &actionExpr{
-				pos: position{line: 1808, col: 15, offset: 56965},
+				pos: position{line: 1810, col: 15, offset: 57046},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1808, col: 15, offset: 56965},
+					pos: position{line: 1810, col: 15, offset: 57046},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1808, col: 15, offset: 56965},
+							pos:   position{line: 1810, col: 15, offset: 57046},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1808, col: 24, offset: 56974},
+								pos:  position{line: 1810, col: 24, offset: 57055},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1808, col: 40, offset: 56990},
+							pos:   position{line: 1810, col: 40, offset: 57071},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1808, col: 50, offset: 57000},
+								pos:  position{line: 1810, col: 50, offset: 57081},
 								name: "AllTimeScale",
 							},
 						},
@@ -3253,43 +3253,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1825, col: 1, offset: 57546},
+			pos:  position{line: 1827, col: 1, offset: 57627},
 			expr: &actionExpr{
-				pos: position{line: 1825, col: 14, offset: 57559},
+				pos: position{line: 1827, col: 14, offset: 57640},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1825, col: 14, offset: 57559},
+					pos: position{line: 1827, col: 14, offset: 57640},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1825, col: 14, offset: 57559},
+							pos:  position{line: 1827, col: 14, offset: 57640},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1825, col: 20, offset: 57565},
+							pos:        position{line: 1827, col: 20, offset: 57646},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1825, col: 28, offset: 57573},
+							pos:  position{line: 1827, col: 28, offset: 57654},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1825, col: 34, offset: 57579},
+							pos:   position{line: 1827, col: 34, offset: 57660},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1825, col: 41, offset: 57586},
+								pos: position{line: 1827, col: 41, offset: 57667},
 								expr: &choiceExpr{
-									pos: position{line: 1825, col: 42, offset: 57587},
+									pos: position{line: 1827, col: 42, offset: 57668},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1825, col: 42, offset: 57587},
+											pos:        position{line: 1827, col: 42, offset: 57668},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1825, col: 50, offset: 57595},
+											pos:        position{line: 1827, col: 50, offset: 57676},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3299,14 +3299,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1825, col: 61, offset: 57606},
+							pos:  position{line: 1827, col: 61, offset: 57687},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1825, col: 76, offset: 57621},
+							pos:   position{line: 1827, col: 76, offset: 57702},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1825, col: 86, offset: 57631},
+								pos:  position{line: 1827, col: 86, offset: 57712},
 								name: "IntegerAsString",
 							},
 						},
@@ -3316,22 +3316,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1849, col: 1, offset: 58212},
+			pos:  position{line: 1851, col: 1, offset: 58293},
 			expr: &actionExpr{
-				pos: position{line: 1849, col: 19, offset: 58230},
+				pos: position{line: 1851, col: 19, offset: 58311},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1849, col: 19, offset: 58230},
+					pos: position{line: 1851, col: 19, offset: 58311},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1849, col: 19, offset: 58230},
+							pos:  position{line: 1851, col: 19, offset: 58311},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1849, col: 24, offset: 58235},
+							pos:   position{line: 1851, col: 24, offset: 58316},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1849, col: 38, offset: 58249},
+								pos:  position{line: 1851, col: 38, offset: 58330},
 								name: "StatisticExpr",
 							},
 						},
@@ -3341,76 +3341,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1889, col: 1, offset: 59460},
+			pos:  position{line: 1891, col: 1, offset: 59541},
 			expr: &actionExpr{
-				pos: position{line: 1889, col: 18, offset: 59477},
+				pos: position{line: 1891, col: 18, offset: 59558},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1889, col: 18, offset: 59477},
+					pos: position{line: 1891, col: 18, offset: 59558},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1889, col: 18, offset: 59477},
+							pos:   position{line: 1891, col: 18, offset: 59558},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1889, col: 23, offset: 59482},
+								pos: position{line: 1891, col: 23, offset: 59563},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1889, col: 23, offset: 59482},
+										pos:  position{line: 1891, col: 23, offset: 59563},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1889, col: 33, offset: 59492},
+										pos:  position{line: 1891, col: 33, offset: 59573},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 43, offset: 59502},
+							pos:   position{line: 1891, col: 43, offset: 59583},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1889, col: 49, offset: 59508},
+								pos: position{line: 1891, col: 49, offset: 59589},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1889, col: 50, offset: 59509},
+									pos:  position{line: 1891, col: 50, offset: 59590},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 67, offset: 59526},
+							pos:   position{line: 1891, col: 67, offset: 59607},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1889, col: 78, offset: 59537},
+								pos: position{line: 1891, col: 78, offset: 59618},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1889, col: 78, offset: 59537},
+										pos:  position{line: 1891, col: 78, offset: 59618},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1889, col: 84, offset: 59543},
+										pos:  position{line: 1891, col: 84, offset: 59624},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 99, offset: 59558},
+							pos:   position{line: 1891, col: 99, offset: 59639},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1889, col: 108, offset: 59567},
+								pos: position{line: 1891, col: 108, offset: 59648},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1889, col: 109, offset: 59568},
+									pos:  position{line: 1891, col: 109, offset: 59649},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1889, col: 120, offset: 59579},
+							pos:   position{line: 1891, col: 120, offset: 59660},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1889, col: 128, offset: 59587},
+								pos: position{line: 1891, col: 128, offset: 59668},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1889, col: 129, offset: 59588},
+									pos:  position{line: 1891, col: 129, offset: 59669},
 									name: "StatisticOptions",
 								},
 							},
@@ -3421,25 +3421,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1931, col: 1, offset: 60673},
+			pos:  position{line: 1933, col: 1, offset: 60754},
 			expr: &choiceExpr{
-				pos: position{line: 1931, col: 19, offset: 60691},
+				pos: position{line: 1933, col: 19, offset: 60772},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1931, col: 19, offset: 60691},
+						pos: position{line: 1933, col: 19, offset: 60772},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1931, col: 19, offset: 60691},
+							pos: position{line: 1933, col: 19, offset: 60772},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1931, col: 19, offset: 60691},
+									pos:  position{line: 1933, col: 19, offset: 60772},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1931, col: 25, offset: 60697},
+									pos:   position{line: 1933, col: 25, offset: 60778},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1931, col: 32, offset: 60704},
+										pos:  position{line: 1933, col: 32, offset: 60785},
 										name: "IntegerAsString",
 									},
 								},
@@ -3447,30 +3447,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1934, col: 3, offset: 60758},
+						pos: position{line: 1936, col: 3, offset: 60839},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1934, col: 3, offset: 60758},
+							pos: position{line: 1936, col: 3, offset: 60839},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1934, col: 3, offset: 60758},
+									pos:  position{line: 1936, col: 3, offset: 60839},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1934, col: 9, offset: 60764},
+									pos:        position{line: 1936, col: 9, offset: 60845},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1934, col: 17, offset: 60772},
+									pos:  position{line: 1936, col: 17, offset: 60853},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1934, col: 23, offset: 60778},
+									pos:   position{line: 1936, col: 23, offset: 60859},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1934, col: 30, offset: 60785},
+										pos:  position{line: 1936, col: 30, offset: 60866},
 										name: "IntegerAsString",
 									},
 								},
@@ -3482,17 +3482,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1939, col: 1, offset: 60883},
+			pos:  position{line: 1941, col: 1, offset: 60964},
 			expr: &actionExpr{
-				pos: position{line: 1939, col: 21, offset: 60903},
+				pos: position{line: 1941, col: 21, offset: 60984},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1939, col: 21, offset: 60903},
+					pos:   position{line: 1941, col: 21, offset: 60984},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1939, col: 28, offset: 60910},
+						pos: position{line: 1941, col: 28, offset: 60991},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1939, col: 29, offset: 60911},
+							pos:  position{line: 1941, col: 29, offset: 60992},
 							name: "StatisticOption",
 						},
 					},
@@ -3501,34 +3501,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1988, col: 1, offset: 62473},
+			pos:  position{line: 1990, col: 1, offset: 62554},
 			expr: &actionExpr{
-				pos: position{line: 1988, col: 20, offset: 62492},
+				pos: position{line: 1990, col: 20, offset: 62573},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1988, col: 20, offset: 62492},
+					pos: position{line: 1990, col: 20, offset: 62573},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1988, col: 20, offset: 62492},
+							pos:  position{line: 1990, col: 20, offset: 62573},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 26, offset: 62498},
+							pos:   position{line: 1990, col: 26, offset: 62579},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 36, offset: 62508},
+								pos:  position{line: 1990, col: 36, offset: 62589},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1988, col: 55, offset: 62527},
+							pos:  position{line: 1990, col: 55, offset: 62608},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1988, col: 61, offset: 62533},
+							pos:   position{line: 1990, col: 61, offset: 62614},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1988, col: 67, offset: 62539},
+								pos:  position{line: 1990, col: 67, offset: 62620},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3538,48 +3538,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1993, col: 1, offset: 62648},
+			pos:  position{line: 1995, col: 1, offset: 62729},
 			expr: &actionExpr{
-				pos: position{line: 1993, col: 23, offset: 62670},
+				pos: position{line: 1995, col: 23, offset: 62751},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1993, col: 23, offset: 62670},
+					pos:   position{line: 1995, col: 23, offset: 62751},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1993, col: 31, offset: 62678},
+						pos: position{line: 1995, col: 31, offset: 62759},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1993, col: 31, offset: 62678},
+								pos:        position{line: 1995, col: 31, offset: 62759},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1993, col: 46, offset: 62693},
+								pos:        position{line: 1995, col: 46, offset: 62774},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1993, col: 60, offset: 62707},
+								pos:        position{line: 1995, col: 60, offset: 62788},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1993, col: 73, offset: 62720},
+								pos:        position{line: 1995, col: 73, offset: 62801},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1993, col: 85, offset: 62732},
+								pos:        position{line: 1995, col: 85, offset: 62813},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1993, col: 102, offset: 62749},
+								pos:        position{line: 1995, col: 102, offset: 62830},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3591,25 +3591,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2001, col: 1, offset: 62936},
+			pos:  position{line: 2003, col: 1, offset: 63017},
 			expr: &choiceExpr{
-				pos: position{line: 2001, col: 13, offset: 62948},
+				pos: position{line: 2003, col: 13, offset: 63029},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2001, col: 13, offset: 62948},
+						pos: position{line: 2003, col: 13, offset: 63029},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2001, col: 13, offset: 62948},
+							pos: position{line: 2003, col: 13, offset: 63029},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2001, col: 13, offset: 62948},
+									pos:  position{line: 2003, col: 13, offset: 63029},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2001, col: 16, offset: 62951},
+									pos:   position{line: 2003, col: 16, offset: 63032},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2001, col: 26, offset: 62961},
+										pos:  position{line: 2003, col: 26, offset: 63042},
 										name: "FieldNameList",
 									},
 								},
@@ -3617,13 +3617,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2004, col: 3, offset: 63018},
+						pos: position{line: 2006, col: 3, offset: 63099},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2004, col: 3, offset: 63018},
+							pos:   position{line: 2006, col: 3, offset: 63099},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2004, col: 16, offset: 63031},
+								pos:  position{line: 2006, col: 16, offset: 63112},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3633,26 +3633,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2008, col: 1, offset: 63089},
+			pos:  position{line: 2010, col: 1, offset: 63170},
 			expr: &actionExpr{
-				pos: position{line: 2008, col: 15, offset: 63103},
+				pos: position{line: 2010, col: 15, offset: 63184},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2008, col: 15, offset: 63103},
+					pos: position{line: 2010, col: 15, offset: 63184},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2008, col: 15, offset: 63103},
+							pos:  position{line: 2010, col: 15, offset: 63184},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2008, col: 20, offset: 63108},
+							pos:  position{line: 2010, col: 20, offset: 63189},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2008, col: 30, offset: 63118},
+							pos:   position{line: 2010, col: 30, offset: 63199},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2008, col: 40, offset: 63128},
+								pos:  position{line: 2010, col: 40, offset: 63209},
 								name: "DedupExpr",
 							},
 						},
@@ -3662,27 +3662,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2054, col: 1, offset: 64457},
+			pos:  position{line: 2056, col: 1, offset: 64538},
 			expr: &actionExpr{
-				pos: position{line: 2054, col: 14, offset: 64470},
+				pos: position{line: 2056, col: 14, offset: 64551},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2054, col: 14, offset: 64470},
+					pos: position{line: 2056, col: 14, offset: 64551},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2054, col: 14, offset: 64470},
+							pos:   position{line: 2056, col: 14, offset: 64551},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2054, col: 23, offset: 64479},
+								pos: position{line: 2056, col: 23, offset: 64560},
 								expr: &seqExpr{
-									pos: position{line: 2054, col: 24, offset: 64480},
+									pos: position{line: 2056, col: 24, offset: 64561},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2054, col: 24, offset: 64480},
+											pos:  position{line: 2056, col: 24, offset: 64561},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2054, col: 30, offset: 64486},
+											pos:  position{line: 2056, col: 30, offset: 64567},
 											name: "IntegerAsString",
 										},
 									},
@@ -3690,45 +3690,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 48, offset: 64504},
+							pos:   position{line: 2056, col: 48, offset: 64585},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2054, col: 57, offset: 64513},
+								pos: position{line: 2056, col: 57, offset: 64594},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2054, col: 58, offset: 64514},
+									pos:  position{line: 2056, col: 58, offset: 64595},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 73, offset: 64529},
+							pos:   position{line: 2056, col: 73, offset: 64610},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2054, col: 83, offset: 64539},
+								pos: position{line: 2056, col: 83, offset: 64620},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2054, col: 84, offset: 64540},
+									pos:  position{line: 2056, col: 84, offset: 64621},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 101, offset: 64557},
+							pos:   position{line: 2056, col: 101, offset: 64638},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2054, col: 110, offset: 64566},
+								pos: position{line: 2056, col: 110, offset: 64647},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2054, col: 111, offset: 64567},
+									pos:  position{line: 2056, col: 111, offset: 64648},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2054, col: 126, offset: 64582},
+							pos:   position{line: 2056, col: 126, offset: 64663},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2054, col: 139, offset: 64595},
+								pos: position{line: 2056, col: 139, offset: 64676},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2054, col: 140, offset: 64596},
+									pos:  position{line: 2056, col: 140, offset: 64677},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3739,27 +3739,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2111, col: 1, offset: 66334},
+			pos:  position{line: 2113, col: 1, offset: 66415},
 			expr: &actionExpr{
-				pos: position{line: 2111, col: 19, offset: 66352},
+				pos: position{line: 2113, col: 19, offset: 66433},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2111, col: 19, offset: 66352},
+					pos: position{line: 2113, col: 19, offset: 66433},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2111, col: 19, offset: 66352},
+							pos: position{line: 2113, col: 19, offset: 66433},
 							expr: &litMatcher{
-								pos:        position{line: 2111, col: 21, offset: 66354},
+								pos:        position{line: 2113, col: 21, offset: 66435},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2111, col: 31, offset: 66364},
+							pos:   position{line: 2113, col: 31, offset: 66445},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2111, col: 37, offset: 66370},
+								pos:  position{line: 2113, col: 37, offset: 66451},
 								name: "FieldName",
 							},
 						},
@@ -3769,48 +3769,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2117, col: 1, offset: 66509},
+			pos:  position{line: 2119, col: 1, offset: 66590},
 			expr: &actionExpr{
-				pos: position{line: 2117, col: 32, offset: 66540},
+				pos: position{line: 2119, col: 32, offset: 66621},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2117, col: 32, offset: 66540},
+					pos: position{line: 2119, col: 32, offset: 66621},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2117, col: 32, offset: 66540},
+							pos:   position{line: 2119, col: 32, offset: 66621},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2117, col: 38, offset: 66546},
+								pos:  position{line: 2119, col: 38, offset: 66627},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2117, col: 48, offset: 66556},
+							pos: position{line: 2119, col: 48, offset: 66637},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2117, col: 50, offset: 66558},
+								pos:  position{line: 2119, col: 50, offset: 66639},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2117, col: 57, offset: 66565},
+							pos:   position{line: 2119, col: 57, offset: 66646},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2117, col: 62, offset: 66570},
+								pos: position{line: 2119, col: 62, offset: 66651},
 								expr: &seqExpr{
-									pos: position{line: 2117, col: 63, offset: 66571},
+									pos: position{line: 2119, col: 63, offset: 66652},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2117, col: 63, offset: 66571},
+											pos:  position{line: 2119, col: 63, offset: 66652},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2117, col: 69, offset: 66577},
+											pos:  position{line: 2119, col: 69, offset: 66658},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2117, col: 79, offset: 66587},
+											pos: position{line: 2119, col: 79, offset: 66668},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2117, col: 81, offset: 66589},
+												pos:  position{line: 2119, col: 81, offset: 66670},
 												name: "EQUAL",
 											},
 										},
@@ -3824,45 +3824,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2128, col: 1, offset: 66864},
+			pos:  position{line: 2130, col: 1, offset: 66945},
 			expr: &actionExpr{
-				pos: position{line: 2128, col: 19, offset: 66882},
+				pos: position{line: 2130, col: 19, offset: 66963},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2128, col: 19, offset: 66882},
+					pos: position{line: 2130, col: 19, offset: 66963},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2128, col: 19, offset: 66882},
+							pos:  position{line: 2130, col: 19, offset: 66963},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2128, col: 25, offset: 66888},
+							pos:   position{line: 2130, col: 25, offset: 66969},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2128, col: 31, offset: 66894},
+								pos:  position{line: 2130, col: 31, offset: 66975},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2128, col: 46, offset: 66909},
+							pos:   position{line: 2130, col: 46, offset: 66990},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2128, col: 51, offset: 66914},
+								pos: position{line: 2130, col: 51, offset: 66995},
 								expr: &seqExpr{
-									pos: position{line: 2128, col: 52, offset: 66915},
+									pos: position{line: 2130, col: 52, offset: 66996},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2128, col: 52, offset: 66915},
+											pos:  position{line: 2130, col: 52, offset: 66996},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2128, col: 58, offset: 66921},
+											pos:  position{line: 2130, col: 58, offset: 67002},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2128, col: 73, offset: 66936},
+											pos: position{line: 2130, col: 73, offset: 67017},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2128, col: 74, offset: 66937},
+												pos:  position{line: 2130, col: 74, offset: 67018},
 												name: "EQUAL",
 											},
 										},
@@ -3876,17 +3876,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2146, col: 1, offset: 67465},
+			pos:  position{line: 2148, col: 1, offset: 67546},
 			expr: &actionExpr{
-				pos: position{line: 2146, col: 17, offset: 67481},
+				pos: position{line: 2148, col: 17, offset: 67562},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2146, col: 17, offset: 67481},
+					pos:   position{line: 2148, col: 17, offset: 67562},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2146, col: 24, offset: 67488},
+						pos: position{line: 2148, col: 24, offset: 67569},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2146, col: 25, offset: 67489},
+							pos:  position{line: 2148, col: 25, offset: 67570},
 							name: "DedupOption",
 						},
 					},
@@ -3895,36 +3895,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2186, col: 1, offset: 68755},
+			pos:  position{line: 2188, col: 1, offset: 68836},
 			expr: &actionExpr{
-				pos: position{line: 2186, col: 16, offset: 68770},
+				pos: position{line: 2188, col: 16, offset: 68851},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2186, col: 16, offset: 68770},
+					pos: position{line: 2188, col: 16, offset: 68851},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2186, col: 16, offset: 68770},
+							pos:  position{line: 2188, col: 16, offset: 68851},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2186, col: 22, offset: 68776},
+							pos:   position{line: 2188, col: 22, offset: 68857},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2186, col: 32, offset: 68786},
+								pos:  position{line: 2188, col: 32, offset: 68867},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2186, col: 47, offset: 68801},
+							pos:        position{line: 2188, col: 47, offset: 68882},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2186, col: 51, offset: 68805},
+							pos:   position{line: 2188, col: 51, offset: 68886},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2186, col: 57, offset: 68811},
+								pos:  position{line: 2188, col: 57, offset: 68892},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3934,30 +3934,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2191, col: 1, offset: 68920},
+			pos:  position{line: 2193, col: 1, offset: 69001},
 			expr: &actionExpr{
-				pos: position{line: 2191, col: 19, offset: 68938},
+				pos: position{line: 2193, col: 19, offset: 69019},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2191, col: 19, offset: 68938},
+					pos:   position{line: 2193, col: 19, offset: 69019},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2191, col: 27, offset: 68946},
+						pos: position{line: 2193, col: 27, offset: 69027},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2191, col: 27, offset: 68946},
+								pos:        position{line: 2193, col: 27, offset: 69027},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2191, col: 43, offset: 68962},
+								pos:        position{line: 2193, col: 43, offset: 69043},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2191, col: 57, offset: 68976},
+								pos:        position{line: 2193, col: 57, offset: 69057},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3969,22 +3969,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2199, col: 1, offset: 69161},
+			pos:  position{line: 2201, col: 1, offset: 69242},
 			expr: &actionExpr{
-				pos: position{line: 2199, col: 22, offset: 69182},
+				pos: position{line: 2201, col: 22, offset: 69263},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2199, col: 22, offset: 69182},
+					pos: position{line: 2201, col: 22, offset: 69263},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2199, col: 22, offset: 69182},
+							pos:  position{line: 2201, col: 22, offset: 69263},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2199, col: 39, offset: 69199},
+							pos:   position{line: 2201, col: 39, offset: 69280},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2199, col: 53, offset: 69213},
+								pos:  position{line: 2201, col: 53, offset: 69294},
 								name: "SortElements",
 							},
 						},
@@ -3994,35 +3994,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2204, col: 1, offset: 69321},
+			pos:  position{line: 2206, col: 1, offset: 69402},
 			expr: &actionExpr{
-				pos: position{line: 2204, col: 17, offset: 69337},
+				pos: position{line: 2206, col: 17, offset: 69418},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2204, col: 17, offset: 69337},
+					pos: position{line: 2206, col: 17, offset: 69418},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2204, col: 17, offset: 69337},
+							pos:   position{line: 2206, col: 17, offset: 69418},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2204, col: 23, offset: 69343},
+								pos:  position{line: 2206, col: 23, offset: 69424},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2204, col: 41, offset: 69361},
+							pos:   position{line: 2206, col: 41, offset: 69442},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2204, col: 46, offset: 69366},
+								pos: position{line: 2206, col: 46, offset: 69447},
 								expr: &seqExpr{
-									pos: position{line: 2204, col: 47, offset: 69367},
+									pos: position{line: 2206, col: 47, offset: 69448},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2204, col: 47, offset: 69367},
+											pos:  position{line: 2206, col: 47, offset: 69448},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2204, col: 62, offset: 69382},
+											pos:  position{line: 2206, col: 62, offset: 69463},
 											name: "SingleSortElement",
 										},
 									},
@@ -4035,22 +4035,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2219, col: 1, offset: 69740},
+			pos:  position{line: 2221, col: 1, offset: 69821},
 			expr: &actionExpr{
-				pos: position{line: 2219, col: 22, offset: 69761},
+				pos: position{line: 2221, col: 22, offset: 69842},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2219, col: 22, offset: 69761},
+					pos:   position{line: 2221, col: 22, offset: 69842},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2219, col: 31, offset: 69770},
+						pos: position{line: 2221, col: 31, offset: 69851},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2219, col: 31, offset: 69770},
+								pos:  position{line: 2221, col: 31, offset: 69851},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2219, col: 59, offset: 69798},
+								pos:  position{line: 2221, col: 59, offset: 69879},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4060,33 +4060,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2223, col: 1, offset: 69857},
+			pos:  position{line: 2225, col: 1, offset: 69938},
 			expr: &actionExpr{
-				pos: position{line: 2223, col: 33, offset: 69889},
+				pos: position{line: 2225, col: 33, offset: 69970},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2223, col: 33, offset: 69889},
+					pos: position{line: 2225, col: 33, offset: 69970},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2223, col: 33, offset: 69889},
+							pos:   position{line: 2225, col: 33, offset: 69970},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2223, col: 47, offset: 69903},
+								pos: position{line: 2225, col: 47, offset: 69984},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2223, col: 47, offset: 69903},
+										pos:        position{line: 2225, col: 47, offset: 69984},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 53, offset: 69909},
+										pos:        position{line: 2225, col: 53, offset: 69990},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 59, offset: 69915},
+										pos:        position{line: 2225, col: 59, offset: 69996},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4095,10 +4095,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 63, offset: 69919},
+							pos:   position{line: 2225, col: 63, offset: 70000},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 69, offset: 69925},
+								pos:  position{line: 2225, col: 69, offset: 70006},
 								name: "FieldName",
 							},
 						},
@@ -4108,33 +4108,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2238, col: 1, offset: 70200},
+			pos:  position{line: 2240, col: 1, offset: 70281},
 			expr: &actionExpr{
-				pos: position{line: 2238, col: 30, offset: 70229},
+				pos: position{line: 2240, col: 30, offset: 70310},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2238, col: 30, offset: 70229},
+					pos: position{line: 2240, col: 30, offset: 70310},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2238, col: 30, offset: 70229},
+							pos:   position{line: 2240, col: 30, offset: 70310},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2238, col: 44, offset: 70243},
+								pos: position{line: 2240, col: 44, offset: 70324},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2238, col: 44, offset: 70243},
+										pos:        position{line: 2240, col: 44, offset: 70324},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2238, col: 50, offset: 70249},
+										pos:        position{line: 2240, col: 50, offset: 70330},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2238, col: 56, offset: 70255},
+										pos:        position{line: 2240, col: 56, offset: 70336},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4143,31 +4143,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2238, col: 60, offset: 70259},
+							pos:   position{line: 2240, col: 60, offset: 70340},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2238, col: 64, offset: 70263},
+								pos: position{line: 2240, col: 64, offset: 70344},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2238, col: 64, offset: 70263},
+										pos:        position{line: 2240, col: 64, offset: 70344},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2238, col: 73, offset: 70272},
+										pos:        position{line: 2240, col: 73, offset: 70353},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2238, col: 81, offset: 70280},
+										pos:        position{line: 2240, col: 81, offset: 70361},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2238, col: 88, offset: 70287},
+										pos:        position{line: 2240, col: 88, offset: 70368},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4176,19 +4176,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2238, col: 95, offset: 70294},
+							pos:  position{line: 2240, col: 95, offset: 70375},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2238, col: 103, offset: 70302},
+							pos:   position{line: 2240, col: 103, offset: 70383},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2238, col: 109, offset: 70308},
+								pos:  position{line: 2240, col: 109, offset: 70389},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2238, col: 119, offset: 70318},
+							pos:  position{line: 2240, col: 119, offset: 70399},
 							name: "R_PAREN",
 						},
 					},
@@ -4197,26 +4197,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2258, col: 1, offset: 70743},
+			pos:  position{line: 2260, col: 1, offset: 70824},
 			expr: &actionExpr{
-				pos: position{line: 2258, col: 16, offset: 70758},
+				pos: position{line: 2260, col: 16, offset: 70839},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2258, col: 16, offset: 70758},
+					pos: position{line: 2260, col: 16, offset: 70839},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2258, col: 16, offset: 70758},
+							pos:  position{line: 2260, col: 16, offset: 70839},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2258, col: 21, offset: 70763},
+							pos:  position{line: 2260, col: 21, offset: 70844},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2258, col: 32, offset: 70774},
+							pos:   position{line: 2260, col: 32, offset: 70855},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2258, col: 43, offset: 70785},
+								pos:  position{line: 2260, col: 43, offset: 70866},
 								name: "RenameExpr",
 							},
 						},
@@ -4226,33 +4226,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2281, col: 1, offset: 71449},
+			pos:  position{line: 2283, col: 1, offset: 71530},
 			expr: &choiceExpr{
-				pos: position{line: 2281, col: 15, offset: 71463},
+				pos: position{line: 2283, col: 15, offset: 71544},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2281, col: 15, offset: 71463},
+						pos: position{line: 2283, col: 15, offset: 71544},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2281, col: 15, offset: 71463},
+							pos: position{line: 2283, col: 15, offset: 71544},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2281, col: 15, offset: 71463},
+									pos:   position{line: 2283, col: 15, offset: 71544},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2281, col: 31, offset: 71479},
+										pos:  position{line: 2283, col: 31, offset: 71560},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2281, col: 45, offset: 71493},
+									pos:  position{line: 2283, col: 45, offset: 71574},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2281, col: 48, offset: 71496},
+									pos:   position{line: 2283, col: 48, offset: 71577},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2281, col: 59, offset: 71507},
+										pos:  position{line: 2283, col: 59, offset: 71588},
 										name: "QuotedString",
 									},
 								},
@@ -4260,28 +4260,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2292, col: 3, offset: 71826},
+						pos: position{line: 2294, col: 3, offset: 71907},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2292, col: 3, offset: 71826},
+							pos: position{line: 2294, col: 3, offset: 71907},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2292, col: 3, offset: 71826},
+									pos:   position{line: 2294, col: 3, offset: 71907},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2292, col: 19, offset: 71842},
+										pos:  position{line: 2294, col: 19, offset: 71923},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2292, col: 33, offset: 71856},
+									pos:  position{line: 2294, col: 33, offset: 71937},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2292, col: 36, offset: 71859},
+									pos:   position{line: 2294, col: 36, offset: 71940},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2292, col: 47, offset: 71870},
+										pos:  position{line: 2294, col: 47, offset: 71951},
 										name: "RenamePattern",
 									},
 								},
@@ -4293,48 +4293,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2314, col: 1, offset: 72436},
+			pos:  position{line: 2316, col: 1, offset: 72517},
 			expr: &actionExpr{
-				pos: position{line: 2314, col: 13, offset: 72448},
+				pos: position{line: 2316, col: 13, offset: 72529},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2314, col: 13, offset: 72448},
+					pos: position{line: 2316, col: 13, offset: 72529},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 13, offset: 72448},
+							pos:  position{line: 2316, col: 13, offset: 72529},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 18, offset: 72453},
+							pos:  position{line: 2316, col: 18, offset: 72534},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2314, col: 26, offset: 72461},
+							pos:        position{line: 2316, col: 26, offset: 72542},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 34, offset: 72469},
+							pos:  position{line: 2316, col: 34, offset: 72550},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2314, col: 40, offset: 72475},
+							pos:   position{line: 2316, col: 40, offset: 72556},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2314, col: 46, offset: 72481},
+								pos:  position{line: 2316, col: 46, offset: 72562},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 62, offset: 72497},
+							pos:  position{line: 2316, col: 62, offset: 72578},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2314, col: 68, offset: 72503},
+							pos:   position{line: 2316, col: 68, offset: 72584},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2314, col: 72, offset: 72507},
+								pos:  position{line: 2316, col: 72, offset: 72588},
 								name: "QuotedString",
 							},
 						},
@@ -4344,37 +4344,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2343, col: 1, offset: 73236},
+			pos:  position{line: 2345, col: 1, offset: 73317},
 			expr: &actionExpr{
-				pos: position{line: 2343, col: 14, offset: 73249},
+				pos: position{line: 2345, col: 14, offset: 73330},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2343, col: 14, offset: 73249},
+					pos: position{line: 2345, col: 14, offset: 73330},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2343, col: 14, offset: 73249},
+							pos:  position{line: 2345, col: 14, offset: 73330},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2343, col: 19, offset: 73254},
+							pos:  position{line: 2345, col: 19, offset: 73335},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2343, col: 28, offset: 73263},
+							pos:   position{line: 2345, col: 28, offset: 73344},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2343, col: 34, offset: 73269},
+								pos: position{line: 2345, col: 34, offset: 73350},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2343, col: 35, offset: 73270},
+									pos:  position{line: 2345, col: 35, offset: 73351},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2343, col: 47, offset: 73282},
+							pos:   position{line: 2345, col: 47, offset: 73363},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2343, col: 58, offset: 73293},
+								pos:  position{line: 2345, col: 58, offset: 73374},
 								name: "SortElements",
 							},
 						},
@@ -4384,41 +4384,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2381, col: 1, offset: 74172},
+			pos:  position{line: 2383, col: 1, offset: 74253},
 			expr: &actionExpr{
-				pos: position{line: 2381, col: 14, offset: 74185},
+				pos: position{line: 2383, col: 14, offset: 74266},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2381, col: 14, offset: 74185},
+					pos: position{line: 2383, col: 14, offset: 74266},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2381, col: 14, offset: 74185},
+							pos: position{line: 2383, col: 14, offset: 74266},
 							expr: &seqExpr{
-								pos: position{line: 2381, col: 15, offset: 74186},
+								pos: position{line: 2383, col: 15, offset: 74267},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2381, col: 15, offset: 74186},
+										pos:        position{line: 2383, col: 15, offset: 74267},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2381, col: 23, offset: 74194},
+										pos:  position{line: 2383, col: 23, offset: 74275},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2381, col: 31, offset: 74202},
+							pos:   position{line: 2383, col: 31, offset: 74283},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2381, col: 40, offset: 74211},
+								pos:  position{line: 2383, col: 40, offset: 74292},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2381, col: 56, offset: 74227},
+							pos:  position{line: 2383, col: 56, offset: 74308},
 							name: "SPACE",
 						},
 					},
@@ -4427,43 +4427,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2395, col: 1, offset: 74526},
+			pos:  position{line: 2397, col: 1, offset: 74607},
 			expr: &actionExpr{
-				pos: position{line: 2395, col: 14, offset: 74539},
+				pos: position{line: 2397, col: 14, offset: 74620},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2395, col: 14, offset: 74539},
+					pos: position{line: 2397, col: 14, offset: 74620},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2395, col: 14, offset: 74539},
+							pos:  position{line: 2397, col: 14, offset: 74620},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2395, col: 19, offset: 74544},
+							pos:  position{line: 2397, col: 19, offset: 74625},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2395, col: 28, offset: 74553},
+							pos:   position{line: 2397, col: 28, offset: 74634},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2395, col: 34, offset: 74559},
+								pos:  position{line: 2397, col: 34, offset: 74640},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2395, col: 45, offset: 74570},
+							pos:   position{line: 2397, col: 45, offset: 74651},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2395, col: 50, offset: 74575},
+								pos: position{line: 2397, col: 50, offset: 74656},
 								expr: &seqExpr{
-									pos: position{line: 2395, col: 51, offset: 74576},
+									pos: position{line: 2397, col: 51, offset: 74657},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2395, col: 51, offset: 74576},
+											pos:  position{line: 2397, col: 51, offset: 74657},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2395, col: 57, offset: 74582},
+											pos:  position{line: 2397, col: 57, offset: 74663},
 											name: "SingleEval",
 										},
 									},
@@ -4476,30 +4476,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2430, col: 1, offset: 75815},
+			pos:  position{line: 2432, col: 1, offset: 75896},
 			expr: &actionExpr{
-				pos: position{line: 2430, col: 15, offset: 75829},
+				pos: position{line: 2432, col: 15, offset: 75910},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2430, col: 15, offset: 75829},
+					pos: position{line: 2432, col: 15, offset: 75910},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2430, col: 15, offset: 75829},
+							pos:   position{line: 2432, col: 15, offset: 75910},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2430, col: 21, offset: 75835},
+								pos:  position{line: 2432, col: 21, offset: 75916},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2430, col: 31, offset: 75845},
+							pos:  position{line: 2432, col: 31, offset: 75926},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2430, col: 37, offset: 75851},
+							pos:   position{line: 2432, col: 37, offset: 75932},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2430, col: 42, offset: 75856},
+								pos:  position{line: 2432, col: 42, offset: 75937},
 								name: "EvalExpression",
 							},
 						},
@@ -4509,15 +4509,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2443, col: 1, offset: 76257},
+			pos:  position{line: 2445, col: 1, offset: 76338},
 			expr: &actionExpr{
-				pos: position{line: 2443, col: 19, offset: 76275},
+				pos: position{line: 2445, col: 19, offset: 76356},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2443, col: 19, offset: 76275},
+					pos:   position{line: 2445, col: 19, offset: 76356},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2443, col: 25, offset: 76281},
+						pos:  position{line: 2445, col: 25, offset: 76362},
 						name: "ValueExpr",
 					},
 				},
@@ -4525,85 +4525,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2452, col: 1, offset: 76505},
+			pos:  position{line: 2454, col: 1, offset: 76586},
 			expr: &choiceExpr{
-				pos: position{line: 2452, col: 18, offset: 76522},
+				pos: position{line: 2454, col: 18, offset: 76603},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2452, col: 18, offset: 76522},
+						pos: position{line: 2454, col: 18, offset: 76603},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2452, col: 18, offset: 76522},
+							pos: position{line: 2454, col: 18, offset: 76603},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2452, col: 18, offset: 76522},
+									pos:        position{line: 2454, col: 18, offset: 76603},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2452, col: 23, offset: 76527},
+									pos:  position{line: 2454, col: 23, offset: 76608},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2452, col: 31, offset: 76535},
+									pos:   position{line: 2454, col: 31, offset: 76616},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2452, col: 41, offset: 76545},
+										pos:  position{line: 2454, col: 41, offset: 76626},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2452, col: 50, offset: 76554},
+									pos:  position{line: 2454, col: 50, offset: 76635},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2452, col: 56, offset: 76560},
+									pos:   position{line: 2454, col: 56, offset: 76641},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2452, col: 66, offset: 76570},
+										pos:  position{line: 2454, col: 66, offset: 76651},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2452, col: 76, offset: 76580},
+									pos:  position{line: 2454, col: 76, offset: 76661},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2452, col: 82, offset: 76586},
+									pos:   position{line: 2454, col: 82, offset: 76667},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2452, col: 93, offset: 76597},
+										pos:  position{line: 2454, col: 93, offset: 76678},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2452, col: 103, offset: 76607},
+									pos:  position{line: 2454, col: 103, offset: 76688},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2463, col: 3, offset: 76858},
+						pos: position{line: 2465, col: 3, offset: 76939},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2463, col: 3, offset: 76858},
+							pos: position{line: 2465, col: 3, offset: 76939},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2463, col: 3, offset: 76858},
+									pos:   position{line: 2465, col: 3, offset: 76939},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2463, col: 11, offset: 76866},
+										pos: position{line: 2465, col: 11, offset: 76947},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2463, col: 11, offset: 76866},
+												pos:        position{line: 2465, col: 11, offset: 76947},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2463, col: 20, offset: 76875},
+												pos:        position{line: 2465, col: 20, offset: 76956},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4612,31 +4612,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2463, col: 32, offset: 76887},
+									pos:  position{line: 2465, col: 32, offset: 76968},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2463, col: 40, offset: 76895},
+									pos:   position{line: 2465, col: 40, offset: 76976},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2463, col: 45, offset: 76900},
+										pos:  position{line: 2465, col: 45, offset: 76981},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2463, col: 64, offset: 76919},
+									pos:   position{line: 2465, col: 64, offset: 77000},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2463, col: 69, offset: 76924},
+										pos: position{line: 2465, col: 69, offset: 77005},
 										expr: &seqExpr{
-											pos: position{line: 2463, col: 70, offset: 76925},
+											pos: position{line: 2465, col: 70, offset: 77006},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2463, col: 70, offset: 76925},
+													pos:  position{line: 2465, col: 70, offset: 77006},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2463, col: 76, offset: 76931},
+													pos:  position{line: 2465, col: 76, offset: 77012},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4644,50 +4644,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2463, col: 97, offset: 76952},
+									pos:  position{line: 2465, col: 97, offset: 77033},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2486, col: 3, offset: 77556},
+						pos: position{line: 2488, col: 3, offset: 77637},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2486, col: 3, offset: 77556},
+							pos: position{line: 2488, col: 3, offset: 77637},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2486, col: 3, offset: 77556},
+									pos:        position{line: 2488, col: 3, offset: 77637},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 14, offset: 77567},
+									pos:  position{line: 2488, col: 14, offset: 77648},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 22, offset: 77575},
+									pos:   position{line: 2488, col: 22, offset: 77656},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2486, col: 32, offset: 77585},
+										pos:  position{line: 2488, col: 32, offset: 77666},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2486, col: 42, offset: 77595},
+									pos:   position{line: 2488, col: 42, offset: 77676},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2486, col: 47, offset: 77600},
+										pos: position{line: 2488, col: 47, offset: 77681},
 										expr: &seqExpr{
-											pos: position{line: 2486, col: 48, offset: 77601},
+											pos: position{line: 2488, col: 48, offset: 77682},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2486, col: 48, offset: 77601},
+													pos:  position{line: 2488, col: 48, offset: 77682},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2486, col: 54, offset: 77607},
+													pos:  position{line: 2488, col: 54, offset: 77688},
 													name: "ValueExpr",
 												},
 											},
@@ -4695,73 +4695,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2486, col: 66, offset: 77619},
+									pos:  position{line: 2488, col: 66, offset: 77700},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2503, col: 3, offset: 78038},
+						pos: position{line: 2505, col: 3, offset: 78119},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2503, col: 3, offset: 78038},
+							pos: position{line: 2505, col: 3, offset: 78119},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2503, col: 3, offset: 78038},
+									pos:        position{line: 2505, col: 3, offset: 78119},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2503, col: 12, offset: 78047},
+									pos:  position{line: 2505, col: 12, offset: 78128},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2503, col: 20, offset: 78055},
+									pos:   position{line: 2505, col: 20, offset: 78136},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2503, col: 30, offset: 78065},
+										pos:  position{line: 2505, col: 30, offset: 78146},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2503, col: 40, offset: 78075},
+									pos:  position{line: 2505, col: 40, offset: 78156},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2503, col: 46, offset: 78081},
+									pos:   position{line: 2505, col: 46, offset: 78162},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2503, col: 57, offset: 78092},
+										pos:  position{line: 2505, col: 57, offset: 78173},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2503, col: 67, offset: 78102},
+									pos:  position{line: 2505, col: 67, offset: 78183},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2515, col: 3, offset: 78382},
+						pos: position{line: 2517, col: 3, offset: 78463},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2515, col: 3, offset: 78382},
+							pos: position{line: 2517, col: 3, offset: 78463},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2515, col: 3, offset: 78382},
+									pos:        position{line: 2517, col: 3, offset: 78463},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2515, col: 10, offset: 78389},
+									pos:  position{line: 2517, col: 10, offset: 78470},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2515, col: 18, offset: 78397},
+									pos:  position{line: 2517, col: 18, offset: 78478},
 									name: "R_PAREN",
 								},
 							},
@@ -4772,30 +4772,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2522, col: 1, offset: 78494},
+			pos:  position{line: 2524, col: 1, offset: 78575},
 			expr: &actionExpr{
-				pos: position{line: 2522, col: 23, offset: 78516},
+				pos: position{line: 2524, col: 23, offset: 78597},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2522, col: 23, offset: 78516},
+					pos: position{line: 2524, col: 23, offset: 78597},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2522, col: 23, offset: 78516},
+							pos:   position{line: 2524, col: 23, offset: 78597},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2522, col: 33, offset: 78526},
+								pos:  position{line: 2524, col: 33, offset: 78607},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2522, col: 42, offset: 78535},
+							pos:  position{line: 2524, col: 42, offset: 78616},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2522, col: 48, offset: 78541},
+							pos:   position{line: 2524, col: 48, offset: 78622},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2522, col: 54, offset: 78547},
+								pos:  position{line: 2524, col: 54, offset: 78628},
 								name: "ValueExpr",
 							},
 						},
@@ -4805,15 +4805,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2530, col: 1, offset: 78752},
+			pos:  position{line: 2532, col: 1, offset: 78833},
 			expr: &actionExpr{
-				pos: position{line: 2530, col: 26, offset: 78777},
+				pos: position{line: 2532, col: 26, offset: 78858},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2530, col: 26, offset: 78777},
+					pos:   position{line: 2532, col: 26, offset: 78858},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2530, col: 37, offset: 78788},
+						pos:  position{line: 2532, col: 37, offset: 78869},
 						name: "StringExpr",
 					},
 				},
@@ -4821,15 +4821,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2540, col: 1, offset: 78997},
+			pos:  position{line: 2542, col: 1, offset: 79078},
 			expr: &actionExpr{
-				pos: position{line: 2540, col: 30, offset: 79026},
+				pos: position{line: 2542, col: 30, offset: 79107},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2540, col: 30, offset: 79026},
+					pos:   position{line: 2542, col: 30, offset: 79107},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2540, col: 45, offset: 79041},
+						pos:  position{line: 2542, col: 45, offset: 79122},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4837,22 +4837,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2549, col: 1, offset: 79247},
+			pos:  position{line: 2551, col: 1, offset: 79328},
 			expr: &actionExpr{
-				pos: position{line: 2549, col: 27, offset: 79273},
+				pos: position{line: 2551, col: 27, offset: 79354},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2549, col: 27, offset: 79273},
+					pos:   position{line: 2551, col: 27, offset: 79354},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2549, col: 40, offset: 79286},
+						pos: position{line: 2551, col: 40, offset: 79367},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2549, col: 40, offset: 79286},
+								pos:  position{line: 2551, col: 40, offset: 79367},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2549, col: 68, offset: 79314},
+								pos:  position{line: 2551, col: 68, offset: 79395},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4862,135 +4862,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2553, col: 1, offset: 79391},
+			pos:  position{line: 2555, col: 1, offset: 79472},
 			expr: &choiceExpr{
-				pos: position{line: 2553, col: 19, offset: 79409},
+				pos: position{line: 2555, col: 19, offset: 79490},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2553, col: 19, offset: 79409},
+						pos: position{line: 2555, col: 19, offset: 79490},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2553, col: 20, offset: 79410},
+							pos: position{line: 2555, col: 20, offset: 79491},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2553, col: 20, offset: 79410},
+									pos:   position{line: 2555, col: 20, offset: 79491},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2553, col: 28, offset: 79418},
+										pos:        position{line: 2555, col: 28, offset: 79499},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2553, col: 37, offset: 79427},
+									pos:  position{line: 2555, col: 37, offset: 79508},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2553, col: 45, offset: 79435},
+									pos:   position{line: 2555, col: 45, offset: 79516},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2553, col: 56, offset: 79446},
+										pos:  position{line: 2555, col: 56, offset: 79527},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2553, col: 67, offset: 79457},
+									pos:  position{line: 2555, col: 67, offset: 79538},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2553, col: 73, offset: 79463},
+									pos:   position{line: 2555, col: 73, offset: 79544},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2553, col: 79, offset: 79469},
+										pos:  position{line: 2555, col: 79, offset: 79550},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2553, col: 90, offset: 79480},
+									pos:  position{line: 2555, col: 90, offset: 79561},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2565, col: 3, offset: 79841},
+						pos: position{line: 2567, col: 3, offset: 79922},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2565, col: 4, offset: 79842},
+							pos: position{line: 2567, col: 4, offset: 79923},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2565, col: 4, offset: 79842},
+									pos:   position{line: 2567, col: 4, offset: 79923},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2565, col: 12, offset: 79850},
+										pos:        position{line: 2567, col: 12, offset: 79931},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2565, col: 23, offset: 79861},
+									pos:  position{line: 2567, col: 23, offset: 79942},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2565, col: 31, offset: 79869},
+									pos:   position{line: 2567, col: 31, offset: 79950},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2565, col: 46, offset: 79884},
+										pos:  position{line: 2567, col: 46, offset: 79965},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2565, col: 61, offset: 79899},
+									pos:  position{line: 2567, col: 61, offset: 79980},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2565, col: 67, offset: 79905},
+									pos:   position{line: 2567, col: 67, offset: 79986},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2565, col: 78, offset: 79916},
+										pos:  position{line: 2567, col: 78, offset: 79997},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2565, col: 90, offset: 79928},
+									pos:   position{line: 2567, col: 90, offset: 80009},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2565, col: 99, offset: 79937},
+										pos: position{line: 2567, col: 99, offset: 80018},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2565, col: 100, offset: 79938},
+											pos:  position{line: 2567, col: 100, offset: 80019},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2565, col: 119, offset: 79957},
+									pos:  position{line: 2567, col: 119, offset: 80038},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2581, col: 3, offset: 80519},
+						pos: position{line: 2583, col: 3, offset: 80600},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2581, col: 4, offset: 80520},
+							pos: position{line: 2583, col: 4, offset: 80601},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2581, col: 4, offset: 80520},
+									pos:   position{line: 2583, col: 4, offset: 80601},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2581, col: 12, offset: 80528},
+										pos: position{line: 2583, col: 12, offset: 80609},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2581, col: 12, offset: 80528},
+												pos:        position{line: 2583, col: 12, offset: 80609},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2581, col: 24, offset: 80540},
+												pos:        position{line: 2583, col: 24, offset: 80621},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4999,222 +4999,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2581, col: 34, offset: 80550},
+									pos:  position{line: 2583, col: 34, offset: 80631},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2581, col: 42, offset: 80558},
+									pos:   position{line: 2583, col: 42, offset: 80639},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2581, col: 57, offset: 80573},
+										pos:  position{line: 2583, col: 57, offset: 80654},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2581, col: 72, offset: 80588},
+									pos:  position{line: 2583, col: 72, offset: 80669},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2593, col: 3, offset: 80936},
+						pos: position{line: 2595, col: 3, offset: 81017},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2593, col: 4, offset: 80937},
+							pos: position{line: 2595, col: 4, offset: 81018},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2593, col: 4, offset: 80937},
+									pos:   position{line: 2595, col: 4, offset: 81018},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2593, col: 12, offset: 80945},
+										pos:        position{line: 2595, col: 12, offset: 81026},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2593, col: 24, offset: 80957},
+									pos:  position{line: 2595, col: 24, offset: 81038},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2593, col: 32, offset: 80965},
+									pos:   position{line: 2595, col: 32, offset: 81046},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2593, col: 42, offset: 80975},
+										pos:  position{line: 2595, col: 42, offset: 81056},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2593, col: 51, offset: 80984},
+									pos:  position{line: 2595, col: 51, offset: 81065},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2606, col: 3, offset: 81331},
+						pos: position{line: 2608, col: 3, offset: 81412},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2606, col: 4, offset: 81332},
+							pos: position{line: 2608, col: 4, offset: 81413},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2606, col: 4, offset: 81332},
+									pos:   position{line: 2608, col: 4, offset: 81413},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2606, col: 12, offset: 81340},
+										pos:        position{line: 2608, col: 12, offset: 81421},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2606, col: 21, offset: 81349},
+									pos:  position{line: 2608, col: 21, offset: 81430},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2606, col: 29, offset: 81357},
+									pos:   position{line: 2608, col: 29, offset: 81438},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2606, col: 44, offset: 81372},
+										pos:  position{line: 2608, col: 44, offset: 81453},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2606, col: 59, offset: 81387},
+									pos:  position{line: 2608, col: 59, offset: 81468},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2606, col: 65, offset: 81393},
+									pos:   position{line: 2608, col: 65, offset: 81474},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2606, col: 70, offset: 81398},
+										pos:  position{line: 2608, col: 70, offset: 81479},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2606, col: 80, offset: 81408},
+									pos:  position{line: 2608, col: 80, offset: 81489},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2619, col: 3, offset: 81830},
+						pos: position{line: 2621, col: 3, offset: 81911},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2619, col: 4, offset: 81831},
+							pos: position{line: 2621, col: 4, offset: 81912},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2619, col: 4, offset: 81831},
+									pos:   position{line: 2621, col: 4, offset: 81912},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2619, col: 12, offset: 81839},
+										pos:        position{line: 2621, col: 12, offset: 81920},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 23, offset: 81850},
+									pos:  position{line: 2621, col: 23, offset: 81931},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 31, offset: 81858},
+									pos:   position{line: 2621, col: 31, offset: 81939},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2619, col: 42, offset: 81869},
+										pos:  position{line: 2621, col: 42, offset: 81950},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 54, offset: 81881},
+									pos:  position{line: 2621, col: 54, offset: 81962},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 60, offset: 81887},
+									pos:   position{line: 2621, col: 60, offset: 81968},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2619, col: 69, offset: 81896},
+										pos:  position{line: 2621, col: 69, offset: 81977},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 81, offset: 81908},
+									pos:  position{line: 2621, col: 81, offset: 81989},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2619, col: 87, offset: 81914},
+									pos:   position{line: 2621, col: 87, offset: 81995},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2619, col: 98, offset: 81925},
+										pos: position{line: 2621, col: 98, offset: 82006},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2619, col: 99, offset: 81926},
+											pos:  position{line: 2621, col: 99, offset: 82007},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2619, col: 112, offset: 81939},
+									pos:  position{line: 2621, col: 112, offset: 82020},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2632, col: 3, offset: 82390},
+						pos: position{line: 2634, col: 3, offset: 82471},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2632, col: 4, offset: 82391},
+							pos: position{line: 2634, col: 4, offset: 82472},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2632, col: 4, offset: 82391},
+									pos:   position{line: 2634, col: 4, offset: 82472},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2632, col: 12, offset: 82399},
+										pos:        position{line: 2634, col: 12, offset: 82480},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 21, offset: 82408},
+									pos:  position{line: 2634, col: 21, offset: 82489},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2632, col: 29, offset: 82416},
+									pos:   position{line: 2634, col: 29, offset: 82497},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2632, col: 36, offset: 82423},
+										pos:  position{line: 2634, col: 36, offset: 82504},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 51, offset: 82438},
+									pos:  position{line: 2634, col: 51, offset: 82519},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2632, col: 57, offset: 82444},
+									pos:   position{line: 2634, col: 57, offset: 82525},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2632, col: 65, offset: 82452},
+										pos:  position{line: 2634, col: 65, offset: 82533},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2632, col: 80, offset: 82467},
+									pos:   position{line: 2634, col: 80, offset: 82548},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2632, col: 85, offset: 82472},
+										pos: position{line: 2634, col: 85, offset: 82553},
 										expr: &seqExpr{
-											pos: position{line: 2632, col: 86, offset: 82473},
+											pos: position{line: 2634, col: 86, offset: 82554},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2632, col: 86, offset: 82473},
+													pos:  position{line: 2634, col: 86, offset: 82554},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2632, col: 92, offset: 82479},
+													pos:  position{line: 2634, col: 92, offset: 82560},
 													name: "StringExpr",
 												},
 											},
@@ -5222,63 +5222,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 105, offset: 82492},
+									pos:  position{line: 2634, col: 105, offset: 82573},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2649, col: 3, offset: 83020},
+						pos: position{line: 2651, col: 3, offset: 83101},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2649, col: 4, offset: 83021},
+							pos: position{line: 2651, col: 4, offset: 83102},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2649, col: 4, offset: 83021},
+									pos:   position{line: 2651, col: 4, offset: 83102},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2649, col: 12, offset: 83029},
+										pos:        position{line: 2651, col: 12, offset: 83110},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 32, offset: 83049},
+									pos:  position{line: 2651, col: 32, offset: 83130},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 40, offset: 83057},
+									pos:   position{line: 2651, col: 40, offset: 83138},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2649, col: 55, offset: 83072},
+										pos:  position{line: 2651, col: 55, offset: 83153},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 70, offset: 83087},
+									pos:   position{line: 2651, col: 70, offset: 83168},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2649, col: 75, offset: 83092},
+										pos: position{line: 2651, col: 75, offset: 83173},
 										expr: &seqExpr{
-											pos: position{line: 2649, col: 76, offset: 83093},
+											pos: position{line: 2651, col: 76, offset: 83174},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2649, col: 76, offset: 83093},
+													pos:  position{line: 2651, col: 76, offset: 83174},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2649, col: 83, offset: 83100},
+													pos: position{line: 2651, col: 83, offset: 83181},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2649, col: 83, offset: 83100},
+															pos:        position{line: 2651, col: 83, offset: 83181},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2649, col: 92, offset: 83109},
+															pos:        position{line: 2651, col: 92, offset: 83190},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5286,7 +5286,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2649, col: 101, offset: 83118},
+													pos:        position{line: 2651, col: 101, offset: 83199},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5296,54 +5296,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 108, offset: 83125},
+									pos:  position{line: 2651, col: 108, offset: 83206},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2674, col: 3, offset: 83828},
+						pos: position{line: 2676, col: 3, offset: 83909},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2674, col: 4, offset: 83829},
+							pos: position{line: 2676, col: 4, offset: 83910},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2674, col: 4, offset: 83829},
+									pos:   position{line: 2676, col: 4, offset: 83910},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2674, col: 12, offset: 83837},
+										pos:        position{line: 2676, col: 12, offset: 83918},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2674, col: 24, offset: 83849},
+									pos:  position{line: 2676, col: 24, offset: 83930},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2674, col: 32, offset: 83857},
+									pos:   position{line: 2676, col: 32, offset: 83938},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2674, col: 41, offset: 83866},
+										pos:  position{line: 2676, col: 41, offset: 83947},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2674, col: 64, offset: 83889},
+									pos:   position{line: 2676, col: 64, offset: 83970},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2674, col: 69, offset: 83894},
+										pos: position{line: 2676, col: 69, offset: 83975},
 										expr: &seqExpr{
-											pos: position{line: 2674, col: 70, offset: 83895},
+											pos: position{line: 2676, col: 70, offset: 83976},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2674, col: 70, offset: 83895},
+													pos:  position{line: 2676, col: 70, offset: 83976},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2674, col: 76, offset: 83901},
+													pos:  position{line: 2676, col: 76, offset: 83982},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5351,57 +5351,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2674, col: 101, offset: 83926},
+									pos:  position{line: 2676, col: 101, offset: 84007},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2694, col: 3, offset: 84514},
+						pos: position{line: 2696, col: 3, offset: 84595},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2694, col: 3, offset: 84514},
+							pos: position{line: 2696, col: 3, offset: 84595},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2694, col: 3, offset: 84514},
+									pos:   position{line: 2696, col: 3, offset: 84595},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2694, col: 9, offset: 84520},
+										pos:  position{line: 2696, col: 9, offset: 84601},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2694, col: 25, offset: 84536},
+									pos: position{line: 2696, col: 25, offset: 84617},
 									expr: &choiceExpr{
-										pos: position{line: 2694, col: 27, offset: 84538},
+										pos: position{line: 2696, col: 27, offset: 84619},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 27, offset: 84538},
+												pos:  position{line: 2696, col: 27, offset: 84619},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 36, offset: 84547},
+												pos:  position{line: 2696, col: 36, offset: 84628},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 46, offset: 84557},
+												pos:  position{line: 2696, col: 46, offset: 84638},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 54, offset: 84565},
+												pos:  position{line: 2696, col: 54, offset: 84646},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 62, offset: 84573},
+												pos:  position{line: 2696, col: 62, offset: 84654},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2694, col: 70, offset: 84581},
+												pos:  position{line: 2696, col: 70, offset: 84662},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2694, col: 84, offset: 84595},
+												pos:        position{line: 2696, col: 84, offset: 84676},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5417,36 +5417,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2706, col: 1, offset: 84990},
+			pos:  position{line: 2708, col: 1, offset: 85071},
 			expr: &choiceExpr{
-				pos: position{line: 2706, col: 13, offset: 85002},
+				pos: position{line: 2708, col: 13, offset: 85083},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2706, col: 13, offset: 85002},
+						pos: position{line: 2708, col: 13, offset: 85083},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2706, col: 14, offset: 85003},
+							pos: position{line: 2708, col: 14, offset: 85084},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2706, col: 14, offset: 85003},
+									pos:   position{line: 2708, col: 14, offset: 85084},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2706, col: 22, offset: 85011},
+										pos: position{line: 2708, col: 22, offset: 85092},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2706, col: 22, offset: 85011},
+												pos:        position{line: 2708, col: 22, offset: 85092},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2706, col: 32, offset: 85021},
+												pos:        position{line: 2708, col: 32, offset: 85102},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2706, col: 42, offset: 85031},
+												pos:        position{line: 2708, col: 42, offset: 85112},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5455,44 +5455,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2706, col: 55, offset: 85044},
+									pos:  position{line: 2708, col: 55, offset: 85125},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2706, col: 63, offset: 85052},
+									pos:   position{line: 2708, col: 63, offset: 85133},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2706, col: 74, offset: 85063},
+										pos:  position{line: 2708, col: 74, offset: 85144},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2706, col: 85, offset: 85074},
+									pos:  position{line: 2708, col: 85, offset: 85155},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2718, col: 3, offset: 85388},
+						pos: position{line: 2720, col: 3, offset: 85469},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2718, col: 4, offset: 85389},
+							pos: position{line: 2720, col: 4, offset: 85470},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2718, col: 4, offset: 85389},
+									pos:   position{line: 2720, col: 4, offset: 85470},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2718, col: 12, offset: 85397},
+										pos: position{line: 2720, col: 12, offset: 85478},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2718, col: 12, offset: 85397},
+												pos:        position{line: 2720, col: 12, offset: 85478},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2718, col: 20, offset: 85405},
+												pos:        position{line: 2720, col: 20, offset: 85486},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5501,31 +5501,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2718, col: 27, offset: 85412},
+									pos:  position{line: 2720, col: 27, offset: 85493},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2718, col: 35, offset: 85420},
+									pos:   position{line: 2720, col: 35, offset: 85501},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2718, col: 44, offset: 85429},
+										pos:  position{line: 2720, col: 44, offset: 85510},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2718, col: 55, offset: 85440},
+									pos:   position{line: 2720, col: 55, offset: 85521},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2718, col: 60, offset: 85445},
+										pos: position{line: 2720, col: 60, offset: 85526},
 										expr: &seqExpr{
-											pos: position{line: 2718, col: 61, offset: 85446},
+											pos: position{line: 2720, col: 61, offset: 85527},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2718, col: 61, offset: 85446},
+													pos:  position{line: 2720, col: 61, offset: 85527},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2718, col: 67, offset: 85452},
+													pos:  position{line: 2720, col: 67, offset: 85533},
 													name: "StringExpr",
 												},
 											},
@@ -5533,195 +5533,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2718, col: 80, offset: 85465},
+									pos:  position{line: 2720, col: 80, offset: 85546},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2740, col: 3, offset: 86065},
+						pos: position{line: 2742, col: 3, offset: 86146},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2740, col: 4, offset: 86066},
+							pos: position{line: 2742, col: 4, offset: 86147},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2740, col: 4, offset: 86066},
+									pos:   position{line: 2742, col: 4, offset: 86147},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2740, col: 12, offset: 86074},
+										pos:        position{line: 2742, col: 12, offset: 86155},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2740, col: 23, offset: 86085},
+									pos:  position{line: 2742, col: 23, offset: 86166},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2740, col: 31, offset: 86093},
+									pos:   position{line: 2742, col: 31, offset: 86174},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2740, col: 46, offset: 86108},
+										pos:  position{line: 2742, col: 46, offset: 86189},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2740, col: 61, offset: 86123},
+									pos:  position{line: 2742, col: 61, offset: 86204},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2751, col: 3, offset: 86425},
+						pos: position{line: 2753, col: 3, offset: 86506},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2751, col: 4, offset: 86426},
+							pos: position{line: 2753, col: 4, offset: 86507},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2751, col: 4, offset: 86426},
+									pos:   position{line: 2753, col: 4, offset: 86507},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2751, col: 12, offset: 86434},
+										pos:        position{line: 2753, col: 12, offset: 86515},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2751, col: 22, offset: 86444},
+									pos:  position{line: 2753, col: 22, offset: 86525},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 30, offset: 86452},
+									pos:   position{line: 2753, col: 30, offset: 86533},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2751, col: 45, offset: 86467},
+										pos:  position{line: 2753, col: 45, offset: 86548},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2751, col: 60, offset: 86482},
+									pos:  position{line: 2753, col: 60, offset: 86563},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2751, col: 66, offset: 86488},
+									pos:   position{line: 2753, col: 66, offset: 86569},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2751, col: 72, offset: 86494},
+										pos:  position{line: 2753, col: 72, offset: 86575},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2751, col: 83, offset: 86505},
+									pos:  position{line: 2753, col: 83, offset: 86586},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2763, col: 3, offset: 86855},
+						pos: position{line: 2765, col: 3, offset: 86936},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2763, col: 4, offset: 86856},
+							pos: position{line: 2765, col: 4, offset: 86937},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2763, col: 4, offset: 86856},
+									pos:   position{line: 2765, col: 4, offset: 86937},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2763, col: 12, offset: 86864},
+										pos:        position{line: 2765, col: 12, offset: 86945},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2763, col: 22, offset: 86874},
+									pos:  position{line: 2765, col: 22, offset: 86955},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2763, col: 30, offset: 86882},
+									pos:   position{line: 2765, col: 30, offset: 86963},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2763, col: 45, offset: 86897},
+										pos:  position{line: 2765, col: 45, offset: 86978},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2763, col: 60, offset: 86912},
+									pos:  position{line: 2765, col: 60, offset: 86993},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2763, col: 66, offset: 86918},
+									pos:   position{line: 2765, col: 66, offset: 86999},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2763, col: 79, offset: 86931},
+										pos:  position{line: 2765, col: 79, offset: 87012},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2763, col: 90, offset: 86942},
+									pos:  position{line: 2765, col: 90, offset: 87023},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2787, col: 3, offset: 87611},
+						pos: position{line: 2789, col: 3, offset: 87692},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2787, col: 4, offset: 87612},
+							pos: position{line: 2789, col: 4, offset: 87693},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2787, col: 4, offset: 87612},
+									pos:   position{line: 2789, col: 4, offset: 87693},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2787, col: 12, offset: 87620},
+										pos:        position{line: 2789, col: 12, offset: 87701},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2787, col: 22, offset: 87630},
+									pos:  position{line: 2789, col: 22, offset: 87711},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2787, col: 30, offset: 87638},
+									pos:   position{line: 2789, col: 30, offset: 87719},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2787, col: 41, offset: 87649},
+										pos:  position{line: 2789, col: 41, offset: 87730},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2787, col: 52, offset: 87660},
+									pos:  position{line: 2789, col: 52, offset: 87741},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2787, col: 58, offset: 87666},
+									pos:   position{line: 2789, col: 58, offset: 87747},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2787, col: 69, offset: 87677},
+										pos:  position{line: 2789, col: 69, offset: 87758},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2787, col: 81, offset: 87689},
+									pos:   position{line: 2789, col: 81, offset: 87770},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2787, col: 93, offset: 87701},
+										pos: position{line: 2789, col: 93, offset: 87782},
 										expr: &seqExpr{
-											pos: position{line: 2787, col: 94, offset: 87702},
+											pos: position{line: 2789, col: 94, offset: 87783},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2787, col: 94, offset: 87702},
+													pos:  position{line: 2789, col: 94, offset: 87783},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2787, col: 100, offset: 87708},
+													pos:  position{line: 2789, col: 100, offset: 87789},
 													name: "NumericExpr",
 												},
 											},
@@ -5729,50 +5729,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2787, col: 114, offset: 87722},
+									pos:  position{line: 2789, col: 114, offset: 87803},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2812, col: 3, offset: 88552},
+						pos: position{line: 2814, col: 3, offset: 88633},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2812, col: 3, offset: 88552},
+							pos: position{line: 2814, col: 3, offset: 88633},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2812, col: 3, offset: 88552},
+									pos:        position{line: 2814, col: 3, offset: 88633},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2812, col: 14, offset: 88563},
+									pos:  position{line: 2814, col: 14, offset: 88644},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2812, col: 22, offset: 88571},
+									pos:   position{line: 2814, col: 22, offset: 88652},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2812, col: 28, offset: 88577},
+										pos:  position{line: 2814, col: 28, offset: 88658},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2812, col: 38, offset: 88587},
+									pos:   position{line: 2814, col: 38, offset: 88668},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2812, col: 45, offset: 88594},
+										pos: position{line: 2814, col: 45, offset: 88675},
 										expr: &seqExpr{
-											pos: position{line: 2812, col: 46, offset: 88595},
+											pos: position{line: 2814, col: 46, offset: 88676},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2812, col: 46, offset: 88595},
+													pos:  position{line: 2814, col: 46, offset: 88676},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2812, col: 52, offset: 88601},
+													pos:  position{line: 2814, col: 52, offset: 88682},
 													name: "StringExpr",
 												},
 											},
@@ -5780,38 +5780,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2812, col: 65, offset: 88614},
+									pos:  position{line: 2814, col: 65, offset: 88695},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2825, col: 3, offset: 88982},
+						pos: position{line: 2827, col: 3, offset: 89063},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2825, col: 4, offset: 88983},
+							pos: position{line: 2827, col: 4, offset: 89064},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2825, col: 4, offset: 88983},
+									pos:   position{line: 2827, col: 4, offset: 89064},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2825, col: 12, offset: 88991},
+										pos: position{line: 2827, col: 12, offset: 89072},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2825, col: 12, offset: 88991},
+												pos:        position{line: 2827, col: 12, offset: 89072},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2825, col: 22, offset: 89001},
+												pos:        position{line: 2827, col: 22, offset: 89082},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2825, col: 32, offset: 89011},
+												pos:        position{line: 2827, col: 32, offset: 89092},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5820,223 +5820,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2825, col: 40, offset: 89019},
+									pos:  position{line: 2827, col: 40, offset: 89100},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2825, col: 48, offset: 89027},
+									pos:   position{line: 2827, col: 48, offset: 89108},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2825, col: 54, offset: 89033},
+										pos:  position{line: 2827, col: 54, offset: 89114},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2825, col: 66, offset: 89045},
+									pos:   position{line: 2827, col: 66, offset: 89126},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2825, col: 82, offset: 89061},
+										pos: position{line: 2827, col: 82, offset: 89142},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2825, col: 83, offset: 89062},
+											pos:  position{line: 2827, col: 83, offset: 89143},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2825, col: 101, offset: 89080},
+									pos:  position{line: 2827, col: 101, offset: 89161},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2844, col: 3, offset: 89520},
+						pos: position{line: 2846, col: 3, offset: 89601},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2844, col: 3, offset: 89520},
+							pos: position{line: 2846, col: 3, offset: 89601},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2844, col: 3, offset: 89520},
+									pos:        position{line: 2846, col: 3, offset: 89601},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2844, col: 11, offset: 89528},
+									pos:  position{line: 2846, col: 11, offset: 89609},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2844, col: 19, offset: 89536},
+									pos:   position{line: 2846, col: 19, offset: 89617},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2844, col: 30, offset: 89547},
+										pos:  position{line: 2846, col: 30, offset: 89628},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2844, col: 50, offset: 89567},
+									pos:  position{line: 2846, col: 50, offset: 89648},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2844, col: 56, offset: 89573},
+									pos:   position{line: 2846, col: 56, offset: 89654},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2844, col: 62, offset: 89579},
+										pos: position{line: 2846, col: 62, offset: 89660},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2844, col: 62, offset: 89579},
+												pos:  position{line: 2846, col: 62, offset: 89660},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2844, col: 81, offset: 89598},
+												pos:  position{line: 2846, col: 81, offset: 89679},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2844, col: 100, offset: 89617},
+									pos:  position{line: 2846, col: 100, offset: 89698},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2855, col: 3, offset: 89922},
+						pos: position{line: 2857, col: 3, offset: 90003},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2855, col: 3, offset: 89922},
+							pos: position{line: 2857, col: 3, offset: 90003},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2855, col: 3, offset: 89922},
+									pos:        position{line: 2857, col: 3, offset: 90003},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 12, offset: 89931},
+									pos:  position{line: 2857, col: 12, offset: 90012},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2855, col: 20, offset: 89939},
+									pos:   position{line: 2857, col: 20, offset: 90020},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2855, col: 25, offset: 89944},
+										pos:  position{line: 2857, col: 25, offset: 90025},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 36, offset: 89955},
+									pos:  position{line: 2857, col: 36, offset: 90036},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2855, col: 42, offset: 89961},
+									pos:   position{line: 2857, col: 42, offset: 90042},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2855, col: 45, offset: 89964},
+										pos:  position{line: 2857, col: 45, offset: 90045},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2855, col: 55, offset: 89974},
+									pos:  position{line: 2857, col: 55, offset: 90055},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2862, col: 3, offset: 90132},
+						pos: position{line: 2864, col: 3, offset: 90213},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2862, col: 3, offset: 90132},
+							pos: position{line: 2864, col: 3, offset: 90213},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2862, col: 3, offset: 90132},
+									pos:        position{line: 2864, col: 3, offset: 90213},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 21, offset: 90150},
+									pos:  position{line: 2864, col: 21, offset: 90231},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2862, col: 29, offset: 90158},
+									pos:   position{line: 2864, col: 29, offset: 90239},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2862, col: 33, offset: 90162},
+										pos:  position{line: 2864, col: 33, offset: 90243},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 43, offset: 90172},
+									pos:  position{line: 2864, col: 43, offset: 90253},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2862, col: 49, offset: 90178},
+									pos:   position{line: 2864, col: 49, offset: 90259},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2862, col: 53, offset: 90182},
+										pos:  position{line: 2864, col: 53, offset: 90263},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 66, offset: 90195},
+									pos:  position{line: 2864, col: 66, offset: 90276},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2862, col: 72, offset: 90201},
+									pos:   position{line: 2864, col: 72, offset: 90282},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2862, col: 78, offset: 90207},
+										pos:  position{line: 2864, col: 78, offset: 90288},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2862, col: 91, offset: 90220},
+									pos:  position{line: 2864, col: 91, offset: 90301},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2873, col: 3, offset: 90528},
+						pos: position{line: 2875, col: 3, offset: 90609},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2873, col: 3, offset: 90528},
+							pos: position{line: 2875, col: 3, offset: 90609},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2873, col: 3, offset: 90528},
+									pos:        position{line: 2875, col: 3, offset: 90609},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2873, col: 12, offset: 90537},
+									pos:  position{line: 2875, col: 12, offset: 90618},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2873, col: 20, offset: 90545},
+									pos:   position{line: 2875, col: 20, offset: 90626},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2873, col: 27, offset: 90552},
+										pos:  position{line: 2875, col: 27, offset: 90633},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2873, col: 38, offset: 90563},
+									pos:   position{line: 2875, col: 38, offset: 90644},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2873, col: 43, offset: 90568},
+										pos: position{line: 2875, col: 43, offset: 90649},
 										expr: &seqExpr{
-											pos: position{line: 2873, col: 44, offset: 90569},
+											pos: position{line: 2875, col: 44, offset: 90650},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2873, col: 44, offset: 90569},
+													pos:  position{line: 2875, col: 44, offset: 90650},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2873, col: 50, offset: 90575},
+													pos:  position{line: 2875, col: 50, offset: 90656},
 													name: "StringExpr",
 												},
 											},
@@ -6044,47 +6044,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2873, col: 63, offset: 90588},
+									pos:  position{line: 2875, col: 63, offset: 90669},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2891, col: 3, offset: 91055},
+						pos: position{line: 2893, col: 3, offset: 91136},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2891, col: 3, offset: 91055},
+							pos: position{line: 2893, col: 3, offset: 91136},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2891, col: 3, offset: 91055},
+									pos:        position{line: 2893, col: 3, offset: 91136},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2891, col: 12, offset: 91064},
+									pos:  position{line: 2893, col: 12, offset: 91145},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2891, col: 20, offset: 91072},
+									pos:   position{line: 2893, col: 20, offset: 91153},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2891, col: 42, offset: 91094},
+										pos: position{line: 2893, col: 42, offset: 91175},
 										expr: &seqExpr{
-											pos: position{line: 2891, col: 43, offset: 91095},
+											pos: position{line: 2893, col: 43, offset: 91176},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2891, col: 44, offset: 91096},
+													pos: position{line: 2893, col: 44, offset: 91177},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2891, col: 44, offset: 91096},
+															pos:        position{line: 2893, col: 44, offset: 91177},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2891, col: 53, offset: 91105},
+															pos:        position{line: 2893, col: 53, offset: 91186},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6092,7 +6092,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2891, col: 62, offset: 91114},
+													pos:        position{line: 2893, col: 62, offset: 91195},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6102,56 +6102,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2891, col: 69, offset: 91121},
+									pos:  position{line: 2893, col: 69, offset: 91202},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2913, col: 3, offset: 91718},
+						pos: position{line: 2915, col: 3, offset: 91799},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2913, col: 3, offset: 91718},
+							pos: position{line: 2915, col: 3, offset: 91799},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2913, col: 3, offset: 91718},
+									pos:        position{line: 2915, col: 3, offset: 91799},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2913, col: 13, offset: 91728},
+									pos:  position{line: 2915, col: 13, offset: 91809},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2913, col: 21, offset: 91736},
+									pos:   position{line: 2915, col: 21, offset: 91817},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2913, col: 27, offset: 91742},
+										pos:  position{line: 2915, col: 27, offset: 91823},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2913, col: 43, offset: 91758},
+									pos:   position{line: 2915, col: 43, offset: 91839},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2913, col: 53, offset: 91768},
+										pos: position{line: 2915, col: 53, offset: 91849},
 										expr: &seqExpr{
-											pos: position{line: 2913, col: 54, offset: 91769},
+											pos: position{line: 2915, col: 54, offset: 91850},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2913, col: 54, offset: 91769},
+													pos:  position{line: 2915, col: 54, offset: 91850},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2913, col: 60, offset: 91775},
+													pos:        position{line: 2915, col: 60, offset: 91856},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2913, col: 73, offset: 91788},
+													pos:  position{line: 2915, col: 73, offset: 91869},
 													name: "FloatAsString",
 												},
 											},
@@ -6159,40 +6159,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2913, col: 89, offset: 91804},
+									pos:   position{line: 2915, col: 89, offset: 91885},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2913, col: 95, offset: 91810},
+										pos: position{line: 2915, col: 95, offset: 91891},
 										expr: &seqExpr{
-											pos: position{line: 2913, col: 96, offset: 91811},
+											pos: position{line: 2915, col: 96, offset: 91892},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2913, col: 96, offset: 91811},
+													pos:  position{line: 2915, col: 96, offset: 91892},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2913, col: 102, offset: 91817},
+													pos:        position{line: 2915, col: 102, offset: 91898},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2913, col: 112, offset: 91827},
+													pos: position{line: 2915, col: 112, offset: 91908},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2913, col: 112, offset: 91827},
+															pos:        position{line: 2915, col: 112, offset: 91908},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2913, col: 125, offset: 91840},
+															pos:        position{line: 2915, col: 125, offset: 91921},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2913, col: 137, offset: 91852},
+															pos:        position{line: 2915, col: 137, offset: 91933},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6204,25 +6204,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2913, col: 151, offset: 91866},
+									pos:   position{line: 2915, col: 151, offset: 91947},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2913, col: 158, offset: 91873},
+										pos: position{line: 2915, col: 158, offset: 91954},
 										expr: &seqExpr{
-											pos: position{line: 2913, col: 159, offset: 91874},
+											pos: position{line: 2915, col: 159, offset: 91955},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2913, col: 159, offset: 91874},
+													pos:  position{line: 2915, col: 159, offset: 91955},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2913, col: 165, offset: 91880},
+													pos:        position{line: 2915, col: 165, offset: 91961},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2913, col: 175, offset: 91890},
+													pos:  position{line: 2915, col: 175, offset: 91971},
 													name: "QuotedString",
 												},
 											},
@@ -6230,213 +6230,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2913, col: 190, offset: 91905},
+									pos:  position{line: 2915, col: 190, offset: 91986},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2953, col: 3, offset: 92900},
+						pos: position{line: 2955, col: 3, offset: 92981},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2953, col: 3, offset: 92900},
+							pos: position{line: 2955, col: 3, offset: 92981},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2953, col: 3, offset: 92900},
+									pos:        position{line: 2955, col: 3, offset: 92981},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2953, col: 15, offset: 92912},
+									pos:  position{line: 2955, col: 15, offset: 92993},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2953, col: 23, offset: 92920},
+									pos:   position{line: 2955, col: 23, offset: 93001},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2953, col: 30, offset: 92927},
+										pos: position{line: 2955, col: 30, offset: 93008},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2953, col: 31, offset: 92928},
+											pos:  position{line: 2955, col: 31, offset: 93009},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2953, col: 44, offset: 92941},
+									pos:  position{line: 2955, col: 44, offset: 93022},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2964, col: 3, offset: 93132},
+						pos: position{line: 2966, col: 3, offset: 93213},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2964, col: 3, offset: 93132},
+							pos: position{line: 2966, col: 3, offset: 93213},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2964, col: 3, offset: 93132},
+									pos:        position{line: 2966, col: 3, offset: 93213},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2964, col: 12, offset: 93141},
+									pos:  position{line: 2966, col: 12, offset: 93222},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2964, col: 20, offset: 93149},
+									pos:   position{line: 2966, col: 20, offset: 93230},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2964, col: 30, offset: 93159},
+										pos:  position{line: 2966, col: 30, offset: 93240},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2964, col: 40, offset: 93169},
+									pos:  position{line: 2966, col: 40, offset: 93250},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2970, col: 3, offset: 93292},
+						pos: position{line: 2972, col: 3, offset: 93373},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2970, col: 3, offset: 93292},
+							pos: position{line: 2972, col: 3, offset: 93373},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2970, col: 3, offset: 93292},
+									pos:        position{line: 2972, col: 3, offset: 93373},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 13, offset: 93302},
+									pos:  position{line: 2972, col: 13, offset: 93383},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2970, col: 21, offset: 93310},
+									pos:   position{line: 2972, col: 21, offset: 93391},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2970, col: 25, offset: 93314},
+										pos:  position{line: 2972, col: 25, offset: 93395},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 35, offset: 93324},
+									pos:  position{line: 2972, col: 35, offset: 93405},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2970, col: 41, offset: 93330},
+									pos:   position{line: 2972, col: 41, offset: 93411},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2970, col: 47, offset: 93336},
+										pos:  position{line: 2972, col: 47, offset: 93417},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 58, offset: 93347},
+									pos:  position{line: 2972, col: 58, offset: 93428},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2970, col: 64, offset: 93353},
+									pos:   position{line: 2972, col: 64, offset: 93434},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2970, col: 76, offset: 93365},
+										pos:  position{line: 2972, col: 76, offset: 93446},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 87, offset: 93376},
+									pos:  position{line: 2972, col: 87, offset: 93457},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2977, col: 3, offset: 93600},
+						pos: position{line: 2979, col: 3, offset: 93681},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2977, col: 3, offset: 93600},
+							pos: position{line: 2979, col: 3, offset: 93681},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2977, col: 3, offset: 93600},
+									pos:        position{line: 2979, col: 3, offset: 93681},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2977, col: 14, offset: 93611},
+									pos:  position{line: 2979, col: 14, offset: 93692},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2977, col: 22, offset: 93619},
+									pos:   position{line: 2979, col: 22, offset: 93700},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2977, col: 26, offset: 93623},
+										pos:  position{line: 2979, col: 26, offset: 93704},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2977, col: 36, offset: 93633},
+									pos:  position{line: 2979, col: 36, offset: 93714},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2977, col: 42, offset: 93639},
+									pos:   position{line: 2979, col: 42, offset: 93720},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2977, col: 49, offset: 93646},
+										pos:  position{line: 2979, col: 49, offset: 93727},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2977, col: 60, offset: 93657},
+									pos:  position{line: 2979, col: 60, offset: 93738},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2985, col: 3, offset: 93821},
+						pos: position{line: 2987, col: 3, offset: 93902},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2985, col: 3, offset: 93821},
+							pos: position{line: 2987, col: 3, offset: 93902},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2985, col: 3, offset: 93821},
+									pos:        position{line: 2987, col: 3, offset: 93902},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2985, col: 14, offset: 93832},
+									pos:  position{line: 2987, col: 14, offset: 93913},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2985, col: 22, offset: 93840},
+									pos:   position{line: 2987, col: 22, offset: 93921},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2985, col: 26, offset: 93844},
+										pos:  position{line: 2987, col: 26, offset: 93925},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2985, col: 36, offset: 93854},
+									pos:  position{line: 2987, col: 36, offset: 93935},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2985, col: 42, offset: 93860},
+									pos:   position{line: 2987, col: 42, offset: 93941},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2985, col: 49, offset: 93867},
+										pos:  position{line: 2987, col: 49, offset: 93948},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2985, col: 60, offset: 93878},
+									pos:  position{line: 2987, col: 60, offset: 93959},
 									name: "R_PAREN",
 								},
 							},
@@ -6447,15 +6447,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2993, col: 1, offset: 94040},
+			pos:  position{line: 2995, col: 1, offset: 94121},
 			expr: &actionExpr{
-				pos: position{line: 2993, col: 21, offset: 94060},
+				pos: position{line: 2995, col: 21, offset: 94141},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2993, col: 21, offset: 94060},
+					pos:   position{line: 2995, col: 21, offset: 94141},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2993, col: 25, offset: 94064},
+						pos:  position{line: 2995, col: 25, offset: 94145},
 						name: "QuotedString",
 					},
 				},
@@ -6463,15 +6463,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3000, col: 1, offset: 94191},
+			pos:  position{line: 3002, col: 1, offset: 94272},
 			expr: &actionExpr{
-				pos: position{line: 3000, col: 22, offset: 94212},
+				pos: position{line: 3002, col: 22, offset: 94293},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3000, col: 22, offset: 94212},
+					pos:   position{line: 3002, col: 22, offset: 94293},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3000, col: 26, offset: 94216},
+						pos:  position{line: 3002, col: 26, offset: 94297},
 						name: "UnquotedString",
 					},
 				},
@@ -6479,22 +6479,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3007, col: 1, offset: 94344},
+			pos:  position{line: 3009, col: 1, offset: 94425},
 			expr: &actionExpr{
-				pos: position{line: 3007, col: 20, offset: 94363},
+				pos: position{line: 3009, col: 20, offset: 94444},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3007, col: 20, offset: 94363},
+					pos: position{line: 3009, col: 20, offset: 94444},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3007, col: 20, offset: 94363},
+							pos:  position{line: 3009, col: 20, offset: 94444},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3007, col: 26, offset: 94369},
+							pos:   position{line: 3009, col: 26, offset: 94450},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3007, col: 38, offset: 94381},
+								pos:  position{line: 3009, col: 38, offset: 94462},
 								name: "String",
 							},
 						},
@@ -6504,27 +6504,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3013, col: 1, offset: 94566},
+			pos:  position{line: 3015, col: 1, offset: 94647},
 			expr: &choiceExpr{
-				pos: position{line: 3013, col: 20, offset: 94585},
+				pos: position{line: 3015, col: 20, offset: 94666},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3013, col: 20, offset: 94585},
+						pos: position{line: 3015, col: 20, offset: 94666},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3013, col: 20, offset: 94585},
+							pos: position{line: 3015, col: 20, offset: 94666},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3013, col: 20, offset: 94585},
+									pos:        position{line: 3015, col: 20, offset: 94666},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3013, col: 28, offset: 94593},
+									pos: position{line: 3015, col: 28, offset: 94674},
 									expr: &charClassMatcher{
-										pos:        position{line: 3013, col: 28, offset: 94593},
+										pos:        position{line: 3015, col: 28, offset: 94674},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6533,9 +6533,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3013, col: 42, offset: 94607},
+									pos: position{line: 3015, col: 42, offset: 94688},
 									expr: &litMatcher{
-										pos:        position{line: 3013, col: 44, offset: 94609},
+										pos:        position{line: 3015, col: 44, offset: 94690},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6545,27 +6545,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3016, col: 3, offset: 94651},
+						pos: position{line: 3018, col: 3, offset: 94732},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3016, col: 3, offset: 94651},
+							pos: position{line: 3018, col: 3, offset: 94732},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3016, col: 3, offset: 94651},
+									pos:        position{line: 3018, col: 3, offset: 94732},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3016, col: 7, offset: 94655},
+									pos:   position{line: 3018, col: 7, offset: 94736},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3016, col: 13, offset: 94661},
+										pos:  position{line: 3018, col: 13, offset: 94742},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3016, col: 23, offset: 94671},
+									pos:        position{line: 3018, col: 23, offset: 94752},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6578,26 +6578,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3021, col: 1, offset: 94739},
+			pos:  position{line: 3023, col: 1, offset: 94820},
 			expr: &actionExpr{
-				pos: position{line: 3021, col: 15, offset: 94753},
+				pos: position{line: 3023, col: 15, offset: 94834},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3021, col: 15, offset: 94753},
+					pos: position{line: 3023, col: 15, offset: 94834},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3021, col: 15, offset: 94753},
+							pos:  position{line: 3023, col: 15, offset: 94834},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3021, col: 20, offset: 94758},
+							pos:  position{line: 3023, col: 20, offset: 94839},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3021, col: 30, offset: 94768},
+							pos:   position{line: 3023, col: 30, offset: 94849},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3021, col: 40, offset: 94778},
+								pos:  position{line: 3023, col: 40, offset: 94859},
 								name: "BoolExpr",
 							},
 						},
@@ -6607,15 +6607,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3034, col: 1, offset: 95121},
+			pos:  position{line: 3036, col: 1, offset: 95202},
 			expr: &actionExpr{
-				pos: position{line: 3034, col: 13, offset: 95133},
+				pos: position{line: 3036, col: 13, offset: 95214},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3034, col: 13, offset: 95133},
+					pos:   position{line: 3036, col: 13, offset: 95214},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3034, col: 18, offset: 95138},
+						pos:  position{line: 3036, col: 18, offset: 95219},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6623,35 +6623,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3039, col: 1, offset: 95208},
+			pos:  position{line: 3041, col: 1, offset: 95289},
 			expr: &actionExpr{
-				pos: position{line: 3039, col: 19, offset: 95226},
+				pos: position{line: 3041, col: 19, offset: 95307},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3039, col: 19, offset: 95226},
+					pos: position{line: 3041, col: 19, offset: 95307},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3039, col: 19, offset: 95226},
+							pos:   position{line: 3041, col: 19, offset: 95307},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3039, col: 25, offset: 95232},
+								pos:  position{line: 3041, col: 25, offset: 95313},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3039, col: 40, offset: 95247},
+							pos:   position{line: 3041, col: 40, offset: 95328},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3039, col: 45, offset: 95252},
+								pos: position{line: 3041, col: 45, offset: 95333},
 								expr: &seqExpr{
-									pos: position{line: 3039, col: 46, offset: 95253},
+									pos: position{line: 3041, col: 46, offset: 95334},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3039, col: 46, offset: 95253},
+											pos:  position{line: 3041, col: 46, offset: 95334},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3039, col: 49, offset: 95256},
+											pos:  position{line: 3041, col: 49, offset: 95337},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6664,35 +6664,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3059, col: 1, offset: 95694},
+			pos:  position{line: 3061, col: 1, offset: 95775},
 			expr: &actionExpr{
-				pos: position{line: 3059, col: 19, offset: 95712},
+				pos: position{line: 3061, col: 19, offset: 95793},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3059, col: 19, offset: 95712},
+					pos: position{line: 3061, col: 19, offset: 95793},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3059, col: 19, offset: 95712},
+							pos:   position{line: 3061, col: 19, offset: 95793},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3059, col: 25, offset: 95718},
+								pos:  position{line: 3061, col: 25, offset: 95799},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3059, col: 40, offset: 95733},
+							pos:   position{line: 3061, col: 40, offset: 95814},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3059, col: 45, offset: 95738},
+								pos: position{line: 3061, col: 45, offset: 95819},
 								expr: &seqExpr{
-									pos: position{line: 3059, col: 46, offset: 95739},
+									pos: position{line: 3061, col: 46, offset: 95820},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3059, col: 46, offset: 95739},
+											pos:  position{line: 3061, col: 46, offset: 95820},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3059, col: 50, offset: 95743},
+											pos:  position{line: 3061, col: 50, offset: 95824},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6705,47 +6705,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3079, col: 1, offset: 96182},
+			pos:  position{line: 3081, col: 1, offset: 96263},
 			expr: &choiceExpr{
-				pos: position{line: 3079, col: 19, offset: 96200},
+				pos: position{line: 3081, col: 19, offset: 96281},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3079, col: 19, offset: 96200},
+						pos: position{line: 3081, col: 19, offset: 96281},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3079, col: 19, offset: 96200},
+							pos: position{line: 3081, col: 19, offset: 96281},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3079, col: 19, offset: 96200},
+									pos:  position{line: 3081, col: 19, offset: 96281},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3079, col: 23, offset: 96204},
+									pos:  position{line: 3081, col: 23, offset: 96285},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3079, col: 31, offset: 96212},
+									pos:   position{line: 3081, col: 31, offset: 96293},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3079, col: 37, offset: 96218},
+										pos:  position{line: 3081, col: 37, offset: 96299},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3079, col: 52, offset: 96233},
+									pos:  position{line: 3081, col: 52, offset: 96314},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3089, col: 3, offset: 96436},
+						pos: position{line: 3091, col: 3, offset: 96517},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3089, col: 3, offset: 96436},
+							pos:   position{line: 3091, col: 3, offset: 96517},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3089, col: 9, offset: 96442},
+								pos:  position{line: 3091, col: 9, offset: 96523},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6755,50 +6755,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3094, col: 1, offset: 96513},
+			pos:  position{line: 3096, col: 1, offset: 96594},
 			expr: &choiceExpr{
-				pos: position{line: 3094, col: 19, offset: 96531},
+				pos: position{line: 3096, col: 19, offset: 96612},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3094, col: 19, offset: 96531},
+						pos: position{line: 3096, col: 19, offset: 96612},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3094, col: 19, offset: 96531},
+							pos: position{line: 3096, col: 19, offset: 96612},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3094, col: 19, offset: 96531},
+									pos:  position{line: 3096, col: 19, offset: 96612},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3094, col: 27, offset: 96539},
+									pos:   position{line: 3096, col: 27, offset: 96620},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3094, col: 33, offset: 96545},
+										pos:  position{line: 3096, col: 33, offset: 96626},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3094, col: 48, offset: 96560},
+									pos:  position{line: 3096, col: 48, offset: 96641},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3097, col: 3, offset: 96596},
+						pos: position{line: 3099, col: 3, offset: 96677},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3097, col: 3, offset: 96596},
+							pos:   position{line: 3099, col: 3, offset: 96677},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3097, col: 10, offset: 96603},
+								pos: position{line: 3099, col: 10, offset: 96684},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3097, col: 10, offset: 96603},
+										pos:  position{line: 3099, col: 10, offset: 96684},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3097, col: 31, offset: 96624},
+										pos:  position{line: 3099, col: 31, offset: 96705},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6810,60 +6810,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3102, col: 1, offset: 96744},
+			pos:  position{line: 3104, col: 1, offset: 96825},
 			expr: &choiceExpr{
-				pos: position{line: 3102, col: 23, offset: 96766},
+				pos: position{line: 3104, col: 23, offset: 96847},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3102, col: 23, offset: 96766},
+						pos: position{line: 3104, col: 23, offset: 96847},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3102, col: 24, offset: 96767},
+							pos: position{line: 3104, col: 24, offset: 96848},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3102, col: 24, offset: 96767},
+									pos:   position{line: 3104, col: 24, offset: 96848},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3102, col: 28, offset: 96771},
+										pos: position{line: 3104, col: 28, offset: 96852},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3102, col: 28, offset: 96771},
+												pos:        position{line: 3104, col: 28, offset: 96852},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 39, offset: 96782},
+												pos:        position{line: 3104, col: 39, offset: 96863},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 49, offset: 96792},
+												pos:        position{line: 3104, col: 49, offset: 96873},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 59, offset: 96802},
+												pos:        position{line: 3104, col: 59, offset: 96883},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 70, offset: 96813},
+												pos:        position{line: 3104, col: 70, offset: 96894},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 84, offset: 96827},
+												pos:        position{line: 3104, col: 84, offset: 96908},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3102, col: 94, offset: 96837},
+												pos:        position{line: 3104, col: 94, offset: 96918},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6872,56 +6872,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3102, col: 109, offset: 96852},
+									pos:  position{line: 3104, col: 109, offset: 96933},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3102, col: 117, offset: 96860},
+									pos:   position{line: 3104, col: 117, offset: 96941},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3102, col: 123, offset: 96866},
+										pos:  position{line: 3104, col: 123, offset: 96947},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3102, col: 133, offset: 96876},
+									pos:  position{line: 3104, col: 133, offset: 96957},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3132, col: 3, offset: 97747},
+						pos: position{line: 3134, col: 3, offset: 97828},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3132, col: 3, offset: 97747},
+							pos: position{line: 3134, col: 3, offset: 97828},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3132, col: 3, offset: 97747},
+									pos:   position{line: 3134, col: 3, offset: 97828},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3132, col: 11, offset: 97755},
+										pos: position{line: 3134, col: 11, offset: 97836},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3132, col: 11, offset: 97755},
+												pos:        position{line: 3134, col: 11, offset: 97836},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3132, col: 20, offset: 97764},
+												pos:        position{line: 3134, col: 20, offset: 97845},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3132, col: 29, offset: 97773},
+												pos:        position{line: 3134, col: 29, offset: 97854},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3132, col: 39, offset: 97783},
+												pos:        position{line: 3134, col: 39, offset: 97864},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6930,86 +6930,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3132, col: 52, offset: 97796},
+									pos:  position{line: 3134, col: 52, offset: 97877},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3132, col: 60, offset: 97804},
+									pos:   position{line: 3134, col: 60, offset: 97885},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3132, col: 70, offset: 97814},
+										pos:  position{line: 3134, col: 70, offset: 97895},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3132, col: 80, offset: 97824},
+									pos:  position{line: 3134, col: 80, offset: 97905},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3132, col: 86, offset: 97830},
+									pos:   position{line: 3134, col: 86, offset: 97911},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3132, col: 97, offset: 97841},
+										pos:  position{line: 3134, col: 97, offset: 97922},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3132, col: 107, offset: 97851},
+									pos:  position{line: 3134, col: 107, offset: 97932},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3145, col: 3, offset: 98221},
+						pos: position{line: 3147, col: 3, offset: 98302},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3145, col: 3, offset: 98221},
+							pos: position{line: 3147, col: 3, offset: 98302},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3145, col: 3, offset: 98221},
+									pos:   position{line: 3147, col: 3, offset: 98302},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3145, col: 8, offset: 98226},
+										pos:  position{line: 3147, col: 8, offset: 98307},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3145, col: 18, offset: 98236},
+									pos:  position{line: 3147, col: 18, offset: 98317},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3145, col: 24, offset: 98242},
+									pos:        position{line: 3147, col: 24, offset: 98323},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3145, col: 29, offset: 98247},
+									pos:  position{line: 3147, col: 29, offset: 98328},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3145, col: 37, offset: 98255},
+									pos:   position{line: 3147, col: 37, offset: 98336},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3145, col: 50, offset: 98268},
+										pos:  position{line: 3147, col: 50, offset: 98349},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3145, col: 60, offset: 98278},
+									pos:   position{line: 3147, col: 60, offset: 98359},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3145, col: 65, offset: 98283},
+										pos: position{line: 3147, col: 65, offset: 98364},
 										expr: &seqExpr{
-											pos: position{line: 3145, col: 66, offset: 98284},
+											pos: position{line: 3147, col: 66, offset: 98365},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3145, col: 66, offset: 98284},
+													pos:  position{line: 3147, col: 66, offset: 98365},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3145, col: 72, offset: 98290},
+													pos:  position{line: 3147, col: 72, offset: 98371},
 													name: "ValueExpr",
 												},
 											},
@@ -7017,50 +7017,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3145, col: 84, offset: 98302},
+									pos:  position{line: 3147, col: 84, offset: 98383},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3164, col: 3, offset: 98853},
+						pos: position{line: 3166, col: 3, offset: 98934},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3164, col: 3, offset: 98853},
+							pos: position{line: 3166, col: 3, offset: 98934},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3164, col: 3, offset: 98853},
+									pos:        position{line: 3166, col: 3, offset: 98934},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3164, col: 8, offset: 98858},
+									pos:  position{line: 3166, col: 8, offset: 98939},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3164, col: 16, offset: 98866},
+									pos:   position{line: 3166, col: 16, offset: 98947},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3164, col: 29, offset: 98879},
+										pos:  position{line: 3166, col: 29, offset: 98960},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3164, col: 39, offset: 98889},
+									pos:   position{line: 3166, col: 39, offset: 98970},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3164, col: 44, offset: 98894},
+										pos: position{line: 3166, col: 44, offset: 98975},
 										expr: &seqExpr{
-											pos: position{line: 3164, col: 45, offset: 98895},
+											pos: position{line: 3166, col: 45, offset: 98976},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3164, col: 45, offset: 98895},
+													pos:  position{line: 3166, col: 45, offset: 98976},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3164, col: 51, offset: 98901},
+													pos:  position{line: 3166, col: 51, offset: 98982},
 													name: "ValueExpr",
 												},
 											},
@@ -7068,7 +7068,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3164, col: 63, offset: 98913},
+									pos:  position{line: 3166, col: 63, offset: 98994},
 									name: "R_PAREN",
 								},
 							},
@@ -7079,34 +7079,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3182, col: 1, offset: 99334},
+			pos:  position{line: 3184, col: 1, offset: 99415},
 			expr: &actionExpr{
-				pos: position{line: 3182, col: 23, offset: 99356},
+				pos: position{line: 3184, col: 23, offset: 99437},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3182, col: 23, offset: 99356},
+					pos: position{line: 3184, col: 23, offset: 99437},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3182, col: 23, offset: 99356},
+							pos:   position{line: 3184, col: 23, offset: 99437},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3182, col: 28, offset: 99361},
+								pos:  position{line: 3184, col: 28, offset: 99442},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3182, col: 38, offset: 99371},
+							pos:   position{line: 3184, col: 38, offset: 99452},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3182, col: 41, offset: 99374},
+								pos:  position{line: 3184, col: 41, offset: 99455},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3182, col: 62, offset: 99395},
+							pos:   position{line: 3184, col: 62, offset: 99476},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3182, col: 68, offset: 99401},
+								pos:  position{line: 3184, col: 68, offset: 99482},
 								name: "ValueExpr",
 							},
 						},
@@ -7116,129 +7116,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3200, col: 1, offset: 99995},
+			pos:  position{line: 3202, col: 1, offset: 100076},
 			expr: &choiceExpr{
-				pos: position{line: 3200, col: 14, offset: 100008},
+				pos: position{line: 3202, col: 14, offset: 100089},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3200, col: 14, offset: 100008},
+						pos: position{line: 3202, col: 14, offset: 100089},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3200, col: 14, offset: 100008},
+							pos:   position{line: 3202, col: 14, offset: 100089},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3200, col: 24, offset: 100018},
+								pos:  position{line: 3202, col: 24, offset: 100099},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3209, col: 3, offset: 100208},
+						pos: position{line: 3211, col: 3, offset: 100289},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3209, col: 3, offset: 100208},
+							pos: position{line: 3211, col: 3, offset: 100289},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3209, col: 3, offset: 100208},
+									pos:  position{line: 3211, col: 3, offset: 100289},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3209, col: 12, offset: 100217},
+									pos:   position{line: 3211, col: 12, offset: 100298},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3209, col: 22, offset: 100227},
+										pos:  position{line: 3211, col: 22, offset: 100308},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3209, col: 37, offset: 100242},
+									pos:  position{line: 3211, col: 37, offset: 100323},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3218, col: 3, offset: 100426},
+						pos: position{line: 3220, col: 3, offset: 100507},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3218, col: 3, offset: 100426},
+							pos:   position{line: 3220, col: 3, offset: 100507},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3218, col: 11, offset: 100434},
+								pos:  position{line: 3220, col: 11, offset: 100515},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3227, col: 3, offset: 100614},
+						pos: position{line: 3229, col: 3, offset: 100695},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3227, col: 3, offset: 100614},
+							pos:   position{line: 3229, col: 3, offset: 100695},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3227, col: 7, offset: 100618},
+								pos:  position{line: 3229, col: 7, offset: 100699},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3236, col: 3, offset: 100790},
+						pos: position{line: 3238, col: 3, offset: 100871},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3236, col: 3, offset: 100790},
+							pos: position{line: 3238, col: 3, offset: 100871},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3236, col: 3, offset: 100790},
+									pos:  position{line: 3238, col: 3, offset: 100871},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3236, col: 12, offset: 100799},
+									pos:   position{line: 3238, col: 12, offset: 100880},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3236, col: 16, offset: 100803},
+										pos:  position{line: 3238, col: 16, offset: 100884},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3236, col: 28, offset: 100815},
+									pos:  position{line: 3238, col: 28, offset: 100896},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3245, col: 3, offset: 100984},
+						pos: position{line: 3247, col: 3, offset: 101065},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3245, col: 3, offset: 100984},
+							pos: position{line: 3247, col: 3, offset: 101065},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3245, col: 3, offset: 100984},
+									pos:  position{line: 3247, col: 3, offset: 101065},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3245, col: 11, offset: 100992},
+									pos:   position{line: 3247, col: 11, offset: 101073},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3245, col: 19, offset: 101000},
+										pos:  position{line: 3247, col: 19, offset: 101081},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3245, col: 28, offset: 101009},
+									pos:  position{line: 3247, col: 28, offset: 101090},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3254, col: 3, offset: 101181},
+						pos: position{line: 3256, col: 3, offset: 101262},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3254, col: 3, offset: 101181},
+							pos:   position{line: 3256, col: 3, offset: 101262},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3254, col: 18, offset: 101196},
+								pos:  position{line: 3256, col: 18, offset: 101277},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7248,28 +7248,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3264, col: 1, offset: 101393},
+			pos:  position{line: 3266, col: 1, offset: 101474},
 			expr: &choiceExpr{
-				pos: position{line: 3264, col: 15, offset: 101407},
+				pos: position{line: 3266, col: 15, offset: 101488},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3264, col: 15, offset: 101407},
+						pos: position{line: 3266, col: 15, offset: 101488},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3264, col: 15, offset: 101407},
+							pos: position{line: 3266, col: 15, offset: 101488},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3264, col: 15, offset: 101407},
+									pos:   position{line: 3266, col: 15, offset: 101488},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3264, col: 20, offset: 101412},
+										pos:  position{line: 3266, col: 20, offset: 101493},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3264, col: 29, offset: 101421},
+									pos: position{line: 3266, col: 29, offset: 101502},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3264, col: 31, offset: 101423},
+										pos:  position{line: 3266, col: 31, offset: 101504},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7277,23 +7277,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3272, col: 3, offset: 101593},
+						pos: position{line: 3274, col: 3, offset: 101674},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3272, col: 3, offset: 101593},
+							pos: position{line: 3274, col: 3, offset: 101674},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3272, col: 3, offset: 101593},
+									pos:   position{line: 3274, col: 3, offset: 101674},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3272, col: 7, offset: 101597},
+										pos:  position{line: 3274, col: 7, offset: 101678},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3272, col: 20, offset: 101610},
+									pos: position{line: 3274, col: 20, offset: 101691},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3272, col: 22, offset: 101612},
+										pos:  position{line: 3274, col: 22, offset: 101693},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7301,50 +7301,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3280, col: 3, offset: 101777},
+						pos: position{line: 3282, col: 3, offset: 101858},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3280, col: 3, offset: 101777},
+							pos: position{line: 3282, col: 3, offset: 101858},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3280, col: 3, offset: 101777},
+									pos:   position{line: 3282, col: 3, offset: 101858},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3280, col: 9, offset: 101783},
+										pos:  position{line: 3282, col: 9, offset: 101864},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3280, col: 25, offset: 101799},
+									pos: position{line: 3282, col: 25, offset: 101880},
 									expr: &choiceExpr{
-										pos: position{line: 3280, col: 27, offset: 101801},
+										pos: position{line: 3282, col: 27, offset: 101882},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 27, offset: 101801},
+												pos:  position{line: 3282, col: 27, offset: 101882},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 36, offset: 101810},
+												pos:  position{line: 3282, col: 36, offset: 101891},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 46, offset: 101820},
+												pos:  position{line: 3282, col: 46, offset: 101901},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 54, offset: 101828},
+												pos:  position{line: 3282, col: 54, offset: 101909},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 62, offset: 101836},
+												pos:  position{line: 3282, col: 62, offset: 101917},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3280, col: 70, offset: 101844},
+												pos:  position{line: 3282, col: 70, offset: 101925},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3280, col: 84, offset: 101858},
+												pos:        position{line: 3282, col: 84, offset: 101939},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7356,13 +7356,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3288, col: 3, offset: 102008},
+						pos: position{line: 3290, col: 3, offset: 102089},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3288, col: 3, offset: 102008},
+							pos:   position{line: 3290, col: 3, offset: 102089},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3288, col: 10, offset: 102015},
+								pos:  position{line: 3290, col: 10, offset: 102096},
 								name: "ConcatExpr",
 							},
 						},
@@ -7372,35 +7372,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3298, col: 1, offset: 102221},
+			pos:  position{line: 3300, col: 1, offset: 102302},
 			expr: &actionExpr{
-				pos: position{line: 3298, col: 15, offset: 102235},
+				pos: position{line: 3300, col: 15, offset: 102316},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3298, col: 15, offset: 102235},
+					pos: position{line: 3300, col: 15, offset: 102316},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3298, col: 15, offset: 102235},
+							pos:   position{line: 3300, col: 15, offset: 102316},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3298, col: 21, offset: 102241},
+								pos:  position{line: 3300, col: 21, offset: 102322},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3298, col: 32, offset: 102252},
+							pos:   position{line: 3300, col: 32, offset: 102333},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3298, col: 37, offset: 102257},
+								pos: position{line: 3300, col: 37, offset: 102338},
 								expr: &seqExpr{
-									pos: position{line: 3298, col: 38, offset: 102258},
+									pos: position{line: 3300, col: 38, offset: 102339},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3298, col: 38, offset: 102258},
+											pos:  position{line: 3300, col: 38, offset: 102339},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3298, col: 50, offset: 102270},
+											pos:  position{line: 3300, col: 50, offset: 102351},
 											name: "ConcatAtom",
 										},
 									},
@@ -7408,28 +7408,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3298, col: 63, offset: 102283},
+							pos: position{line: 3300, col: 63, offset: 102364},
 							expr: &choiceExpr{
-								pos: position{line: 3298, col: 65, offset: 102285},
+								pos: position{line: 3300, col: 65, offset: 102366},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3298, col: 65, offset: 102285},
+										pos:  position{line: 3300, col: 65, offset: 102366},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3298, col: 74, offset: 102294},
+										pos:  position{line: 3300, col: 74, offset: 102375},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3298, col: 84, offset: 102304},
+										pos:  position{line: 3300, col: 84, offset: 102385},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3298, col: 92, offset: 102312},
+										pos:  position{line: 3300, col: 92, offset: 102393},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3298, col: 100, offset: 102320},
+										pos:        position{line: 3300, col: 100, offset: 102401},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7443,54 +7443,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3316, col: 1, offset: 102726},
+			pos:  position{line: 3318, col: 1, offset: 102807},
 			expr: &choiceExpr{
-				pos: position{line: 3316, col: 15, offset: 102740},
+				pos: position{line: 3318, col: 15, offset: 102821},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3316, col: 15, offset: 102740},
+						pos: position{line: 3318, col: 15, offset: 102821},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3316, col: 15, offset: 102740},
+							pos:   position{line: 3318, col: 15, offset: 102821},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3316, col: 20, offset: 102745},
+								pos:  position{line: 3318, col: 20, offset: 102826},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3325, col: 3, offset: 102909},
+						pos: position{line: 3327, col: 3, offset: 102990},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3325, col: 3, offset: 102909},
+							pos:   position{line: 3327, col: 3, offset: 102990},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3325, col: 7, offset: 102913},
+								pos:  position{line: 3327, col: 7, offset: 102994},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3333, col: 3, offset: 103052},
+						pos: position{line: 3335, col: 3, offset: 103133},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3333, col: 3, offset: 103052},
+							pos:   position{line: 3335, col: 3, offset: 103133},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3333, col: 10, offset: 103059},
+								pos:  position{line: 3335, col: 10, offset: 103140},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3341, col: 3, offset: 103198},
+						pos: position{line: 3343, col: 3, offset: 103279},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3341, col: 3, offset: 103198},
+							pos:   position{line: 3343, col: 3, offset: 103279},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3341, col: 9, offset: 103204},
+								pos:  position{line: 3343, col: 9, offset: 103285},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7500,32 +7500,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3351, col: 1, offset: 103373},
+			pos:  position{line: 3353, col: 1, offset: 103454},
 			expr: &actionExpr{
-				pos: position{line: 3351, col: 16, offset: 103388},
+				pos: position{line: 3353, col: 16, offset: 103469},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3351, col: 16, offset: 103388},
+					pos: position{line: 3353, col: 16, offset: 103469},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3351, col: 16, offset: 103388},
+							pos:   position{line: 3353, col: 16, offset: 103469},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3351, col: 21, offset: 103393},
+								pos:  position{line: 3353, col: 21, offset: 103474},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3351, col: 39, offset: 103411},
+							pos: position{line: 3353, col: 39, offset: 103492},
 							expr: &choiceExpr{
-								pos: position{line: 3351, col: 41, offset: 103413},
+								pos: position{line: 3353, col: 41, offset: 103494},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3351, col: 41, offset: 103413},
+										pos:  position{line: 3353, col: 41, offset: 103494},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3351, col: 55, offset: 103427},
+										pos:        position{line: 3353, col: 55, offset: 103508},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7539,44 +7539,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3356, col: 1, offset: 103492},
+			pos:  position{line: 3358, col: 1, offset: 103573},
 			expr: &actionExpr{
-				pos: position{line: 3356, col: 22, offset: 103513},
+				pos: position{line: 3358, col: 22, offset: 103594},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3356, col: 22, offset: 103513},
+					pos: position{line: 3358, col: 22, offset: 103594},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3356, col: 22, offset: 103513},
+							pos:   position{line: 3358, col: 22, offset: 103594},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3356, col: 28, offset: 103519},
+								pos:  position{line: 3358, col: 28, offset: 103600},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3356, col: 46, offset: 103537},
+							pos:   position{line: 3358, col: 46, offset: 103618},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3356, col: 51, offset: 103542},
+								pos: position{line: 3358, col: 51, offset: 103623},
 								expr: &seqExpr{
-									pos: position{line: 3356, col: 52, offset: 103543},
+									pos: position{line: 3358, col: 52, offset: 103624},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3356, col: 53, offset: 103544},
+											pos: position{line: 3358, col: 53, offset: 103625},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3356, col: 53, offset: 103544},
+													pos:  position{line: 3358, col: 53, offset: 103625},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3356, col: 62, offset: 103553},
+													pos:  position{line: 3358, col: 62, offset: 103634},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3356, col: 71, offset: 103562},
+											pos:  position{line: 3358, col: 71, offset: 103643},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7589,48 +7589,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3377, col: 1, offset: 104063},
+			pos:  position{line: 3379, col: 1, offset: 104144},
 			expr: &actionExpr{
-				pos: position{line: 3377, col: 22, offset: 104084},
+				pos: position{line: 3379, col: 22, offset: 104165},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3377, col: 22, offset: 104084},
+					pos: position{line: 3379, col: 22, offset: 104165},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3377, col: 22, offset: 104084},
+							pos:   position{line: 3379, col: 22, offset: 104165},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3377, col: 28, offset: 104090},
+								pos:  position{line: 3379, col: 28, offset: 104171},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3377, col: 46, offset: 104108},
+							pos:   position{line: 3379, col: 46, offset: 104189},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3377, col: 51, offset: 104113},
+								pos: position{line: 3379, col: 51, offset: 104194},
 								expr: &seqExpr{
-									pos: position{line: 3377, col: 52, offset: 104114},
+									pos: position{line: 3379, col: 52, offset: 104195},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3377, col: 53, offset: 104115},
+											pos: position{line: 3379, col: 53, offset: 104196},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3377, col: 53, offset: 104115},
+													pos:  position{line: 3379, col: 53, offset: 104196},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3377, col: 61, offset: 104123},
+													pos:  position{line: 3379, col: 61, offset: 104204},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3377, col: 69, offset: 104131},
+													pos:  position{line: 3379, col: 69, offset: 104212},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3377, col: 76, offset: 104138},
+											pos:  position{line: 3379, col: 76, offset: 104219},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7643,22 +7643,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3397, col: 1, offset: 104607},
+			pos:  position{line: 3399, col: 1, offset: 104688},
 			expr: &actionExpr{
-				pos: position{line: 3397, col: 21, offset: 104627},
+				pos: position{line: 3399, col: 21, offset: 104708},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3397, col: 21, offset: 104627},
+					pos: position{line: 3399, col: 21, offset: 104708},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3397, col: 21, offset: 104627},
+							pos:  position{line: 3399, col: 21, offset: 104708},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3397, col: 27, offset: 104633},
+							pos:   position{line: 3399, col: 27, offset: 104714},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3397, col: 32, offset: 104638},
+								pos:  position{line: 3399, col: 32, offset: 104719},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7668,67 +7668,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3407, col: 1, offset: 104882},
+			pos:  position{line: 3409, col: 1, offset: 104963},
 			expr: &choiceExpr{
-				pos: position{line: 3407, col: 22, offset: 104903},
+				pos: position{line: 3409, col: 22, offset: 104984},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3407, col: 22, offset: 104903},
+						pos: position{line: 3409, col: 22, offset: 104984},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3407, col: 22, offset: 104903},
+							pos: position{line: 3409, col: 22, offset: 104984},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3407, col: 22, offset: 104903},
+									pos:  position{line: 3409, col: 22, offset: 104984},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3407, col: 30, offset: 104911},
+									pos:   position{line: 3409, col: 30, offset: 104992},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3407, col: 35, offset: 104916},
+										pos:  position{line: 3409, col: 35, offset: 104997},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3407, col: 53, offset: 104934},
+									pos:  position{line: 3409, col: 53, offset: 105015},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3410, col: 3, offset: 104969},
+						pos: position{line: 3412, col: 3, offset: 105050},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3410, col: 3, offset: 104969},
+							pos:   position{line: 3412, col: 3, offset: 105050},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3410, col: 20, offset: 104986},
+								pos:  position{line: 3412, col: 20, offset: 105067},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3413, col: 3, offset: 105040},
+						pos: position{line: 3415, col: 3, offset: 105121},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3413, col: 3, offset: 105040},
+							pos:   position{line: 3415, col: 3, offset: 105121},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3413, col: 9, offset: 105046},
+								pos:  position{line: 3415, col: 9, offset: 105127},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3423, col: 3, offset: 105265},
+						pos: position{line: 3425, col: 3, offset: 105346},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3423, col: 3, offset: 105265},
+							pos:   position{line: 3425, col: 3, offset: 105346},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3423, col: 10, offset: 105272},
+								pos:  position{line: 3425, col: 10, offset: 105353},
 								name: "NumberAsString",
 							},
 						},
@@ -7738,144 +7738,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3436, col: 1, offset: 105650},
+			pos:  position{line: 3438, col: 1, offset: 105731},
 			expr: &choiceExpr{
-				pos: position{line: 3436, col: 20, offset: 105669},
+				pos: position{line: 3438, col: 20, offset: 105750},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3436, col: 20, offset: 105669},
+						pos: position{line: 3438, col: 20, offset: 105750},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3436, col: 21, offset: 105670},
+							pos: position{line: 3438, col: 21, offset: 105751},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3436, col: 21, offset: 105670},
+									pos:   position{line: 3438, col: 21, offset: 105751},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3436, col: 29, offset: 105678},
+										pos: position{line: 3438, col: 29, offset: 105759},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3436, col: 29, offset: 105678},
+												pos:        position{line: 3438, col: 29, offset: 105759},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 37, offset: 105686},
+												pos:        position{line: 3438, col: 37, offset: 105767},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 46, offset: 105695},
+												pos:        position{line: 3438, col: 46, offset: 105776},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 58, offset: 105707},
+												pos:        position{line: 3438, col: 58, offset: 105788},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 67, offset: 105716},
+												pos:        position{line: 3438, col: 67, offset: 105797},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 77, offset: 105726},
+												pos:        position{line: 3438, col: 77, offset: 105807},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 85, offset: 105734},
+												pos:        position{line: 3438, col: 85, offset: 105815},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 95, offset: 105744},
+												pos:        position{line: 3438, col: 95, offset: 105825},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 102, offset: 105751},
+												pos:        position{line: 3438, col: 102, offset: 105832},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 113, offset: 105762},
+												pos:        position{line: 3438, col: 113, offset: 105843},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 123, offset: 105772},
+												pos:        position{line: 3438, col: 123, offset: 105853},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 132, offset: 105781},
+												pos:        position{line: 3438, col: 132, offset: 105862},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 142, offset: 105791},
+												pos:        position{line: 3438, col: 142, offset: 105872},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 151, offset: 105800},
+												pos:        position{line: 3438, col: 151, offset: 105881},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 161, offset: 105810},
+												pos:        position{line: 3438, col: 161, offset: 105891},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 170, offset: 105819},
+												pos:        position{line: 3438, col: 170, offset: 105900},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 179, offset: 105828},
+												pos:        position{line: 3438, col: 179, offset: 105909},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 187, offset: 105836},
+												pos:        position{line: 3438, col: 187, offset: 105917},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 196, offset: 105845},
+												pos:        position{line: 3438, col: 196, offset: 105926},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 204, offset: 105853},
+												pos:        position{line: 3438, col: 204, offset: 105934},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3436, col: 213, offset: 105862},
+												pos:        position{line: 3438, col: 213, offset: 105943},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7884,102 +7884,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3436, col: 220, offset: 105869},
+									pos:  position{line: 3438, col: 220, offset: 105950},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3436, col: 228, offset: 105877},
+									pos:   position{line: 3438, col: 228, offset: 105958},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3436, col: 234, offset: 105883},
+										pos:  position{line: 3438, col: 234, offset: 105964},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3436, col: 253, offset: 105902},
+									pos:  position{line: 3438, col: 253, offset: 105983},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3456, col: 3, offset: 106414},
+						pos: position{line: 3458, col: 3, offset: 106495},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3456, col: 3, offset: 106414},
+							pos: position{line: 3458, col: 3, offset: 106495},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3456, col: 3, offset: 106414},
+									pos:   position{line: 3458, col: 3, offset: 106495},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3456, col: 13, offset: 106424},
+										pos:        position{line: 3458, col: 13, offset: 106505},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3456, col: 21, offset: 106432},
+									pos:  position{line: 3458, col: 21, offset: 106513},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3456, col: 29, offset: 106440},
+									pos:   position{line: 3458, col: 29, offset: 106521},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3456, col: 35, offset: 106446},
+										pos:  position{line: 3458, col: 35, offset: 106527},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3456, col: 54, offset: 106465},
+									pos:   position{line: 3458, col: 54, offset: 106546},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3456, col: 69, offset: 106480},
+										pos: position{line: 3458, col: 69, offset: 106561},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3456, col: 70, offset: 106481},
+											pos:  position{line: 3458, col: 70, offset: 106562},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3456, col: 89, offset: 106500},
+									pos:  position{line: 3458, col: 89, offset: 106581},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3477, col: 3, offset: 107118},
+						pos: position{line: 3479, col: 3, offset: 107199},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3477, col: 4, offset: 107119},
+							pos: position{line: 3479, col: 4, offset: 107200},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3477, col: 4, offset: 107119},
+									pos:   position{line: 3479, col: 4, offset: 107200},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3477, col: 12, offset: 107127},
+										pos: position{line: 3479, col: 12, offset: 107208},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3477, col: 12, offset: 107127},
+												pos:        position{line: 3479, col: 12, offset: 107208},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3477, col: 20, offset: 107135},
+												pos:        position{line: 3479, col: 20, offset: 107216},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3477, col: 27, offset: 107142},
+												pos:        position{line: 3479, col: 27, offset: 107223},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3477, col: 38, offset: 107153},
+												pos:        position{line: 3479, col: 38, offset: 107234},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7988,54 +7988,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3477, col: 46, offset: 107161},
+									pos:  position{line: 3479, col: 46, offset: 107242},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3477, col: 54, offset: 107169},
+									pos:  position{line: 3479, col: 54, offset: 107250},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3490, col: 3, offset: 107455},
+						pos: position{line: 3492, col: 3, offset: 107536},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3490, col: 3, offset: 107455},
+							pos: position{line: 3492, col: 3, offset: 107536},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3490, col: 3, offset: 107455},
+									pos:        position{line: 3492, col: 3, offset: 107536},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3490, col: 14, offset: 107466},
+									pos:  position{line: 3492, col: 14, offset: 107547},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3490, col: 22, offset: 107474},
+									pos:   position{line: 3492, col: 22, offset: 107555},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3490, col: 33, offset: 107485},
+										pos:  position{line: 3492, col: 33, offset: 107566},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3490, col: 44, offset: 107496},
+									pos:   position{line: 3492, col: 44, offset: 107577},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3490, col: 53, offset: 107505},
+										pos: position{line: 3492, col: 53, offset: 107586},
 										expr: &seqExpr{
-											pos: position{line: 3490, col: 54, offset: 107506},
+											pos: position{line: 3492, col: 54, offset: 107587},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3490, col: 54, offset: 107506},
+													pos:  position{line: 3492, col: 54, offset: 107587},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3490, col: 60, offset: 107512},
+													pos:  position{line: 3492, col: 60, offset: 107593},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8043,73 +8043,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3490, col: 80, offset: 107532},
+									pos:  position{line: 3492, col: 80, offset: 107613},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3518, col: 3, offset: 108374},
+						pos: position{line: 3520, col: 3, offset: 108455},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3518, col: 3, offset: 108374},
+							pos: position{line: 3520, col: 3, offset: 108455},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3518, col: 3, offset: 108374},
+									pos:   position{line: 3520, col: 3, offset: 108455},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3518, col: 12, offset: 108383},
+										pos:        position{line: 3520, col: 12, offset: 108464},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3518, col: 18, offset: 108389},
+									pos:  position{line: 3520, col: 18, offset: 108470},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3518, col: 26, offset: 108397},
+									pos:   position{line: 3520, col: 26, offset: 108478},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3518, col: 31, offset: 108402},
+										pos:  position{line: 3520, col: 31, offset: 108483},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3518, col: 39, offset: 108410},
+									pos:  position{line: 3520, col: 39, offset: 108491},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3521, col: 3, offset: 108445},
+						pos: position{line: 3523, col: 3, offset: 108526},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3521, col: 4, offset: 108446},
+							pos: position{line: 3523, col: 4, offset: 108527},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3521, col: 4, offset: 108446},
+									pos:   position{line: 3523, col: 4, offset: 108527},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3521, col: 12, offset: 108454},
+										pos: position{line: 3523, col: 12, offset: 108535},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3521, col: 12, offset: 108454},
+												pos:        position{line: 3523, col: 12, offset: 108535},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3521, col: 20, offset: 108462},
+												pos:        position{line: 3523, col: 20, offset: 108543},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3521, col: 30, offset: 108472},
+												pos:        position{line: 3523, col: 30, offset: 108553},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8118,128 +8118,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3521, col: 39, offset: 108481},
+									pos:  position{line: 3523, col: 39, offset: 108562},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3521, col: 47, offset: 108489},
+									pos:   position{line: 3523, col: 47, offset: 108570},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3521, col: 53, offset: 108495},
+										pos:  position{line: 3523, col: 53, offset: 108576},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3521, col: 72, offset: 108514},
+									pos:   position{line: 3523, col: 72, offset: 108595},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3521, col: 79, offset: 108521},
+										pos:  position{line: 3523, col: 79, offset: 108602},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3521, col: 97, offset: 108539},
+									pos:  position{line: 3523, col: 97, offset: 108620},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3551, col: 3, offset: 109378},
+						pos: position{line: 3553, col: 3, offset: 109459},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3551, col: 4, offset: 109379},
+							pos: position{line: 3553, col: 4, offset: 109460},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3551, col: 4, offset: 109379},
+									pos:   position{line: 3553, col: 4, offset: 109460},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3551, col: 11, offset: 109386},
+										pos:        position{line: 3553, col: 11, offset: 109467},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3551, col: 17, offset: 109392},
+									pos:  position{line: 3553, col: 17, offset: 109473},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3551, col: 25, offset: 109400},
+									pos:   position{line: 3553, col: 25, offset: 109481},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3551, col: 31, offset: 109406},
+										pos:  position{line: 3553, col: 31, offset: 109487},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3551, col: 50, offset: 109425},
+									pos:   position{line: 3553, col: 50, offset: 109506},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3551, col: 56, offset: 109431},
+										pos: position{line: 3553, col: 56, offset: 109512},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3551, col: 57, offset: 109432},
+											pos:  position{line: 3553, col: 57, offset: 109513},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3551, col: 76, offset: 109451},
+									pos:  position{line: 3553, col: 76, offset: 109532},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3580, col: 3, offset: 110224},
+						pos: position{line: 3582, col: 3, offset: 110305},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3580, col: 3, offset: 110224},
+							pos: position{line: 3582, col: 3, offset: 110305},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3580, col: 3, offset: 110224},
+									pos:   position{line: 3582, col: 3, offset: 110305},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3580, col: 11, offset: 110232},
+										pos:        position{line: 3582, col: 11, offset: 110313},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 28, offset: 110249},
+									pos:  position{line: 3582, col: 28, offset: 110330},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3580, col: 36, offset: 110257},
+									pos:   position{line: 3582, col: 36, offset: 110338},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3580, col: 42, offset: 110263},
+										pos:  position{line: 3582, col: 42, offset: 110344},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 61, offset: 110282},
+									pos:  position{line: 3582, col: 61, offset: 110363},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 67, offset: 110288},
+									pos:  position{line: 3582, col: 67, offset: 110369},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3580, col: 73, offset: 110294},
+									pos:   position{line: 3582, col: 73, offset: 110375},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3580, col: 84, offset: 110305},
+										pos:  position{line: 3582, col: 84, offset: 110386},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 120, offset: 110341},
+									pos:  position{line: 3582, col: 120, offset: 110422},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3580, col: 126, offset: 110347},
+									pos:  position{line: 3582, col: 126, offset: 110428},
 									name: "R_PAREN",
 								},
 							},
@@ -8250,28 +8250,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3597, col: 1, offset: 110876},
+			pos:  position{line: 3599, col: 1, offset: 110957},
 			expr: &choiceExpr{
-				pos: position{line: 3597, col: 12, offset: 110887},
+				pos: position{line: 3599, col: 12, offset: 110968},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3597, col: 12, offset: 110887},
+						pos: position{line: 3599, col: 12, offset: 110968},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3597, col: 12, offset: 110887},
+							pos: position{line: 3599, col: 12, offset: 110968},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3597, col: 12, offset: 110887},
+									pos:   position{line: 3599, col: 12, offset: 110968},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3597, col: 16, offset: 110891},
+										pos:  position{line: 3599, col: 16, offset: 110972},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3597, col: 29, offset: 110904},
+									pos: position{line: 3599, col: 29, offset: 110985},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3597, col: 31, offset: 110906},
+										pos:  position{line: 3599, col: 31, offset: 110987},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8279,50 +8279,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3613, col: 3, offset: 111267},
+						pos: position{line: 3615, col: 3, offset: 111348},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3613, col: 3, offset: 111267},
+							pos: position{line: 3615, col: 3, offset: 111348},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3613, col: 3, offset: 111267},
+									pos:   position{line: 3615, col: 3, offset: 111348},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3613, col: 9, offset: 111273},
+										pos:  position{line: 3615, col: 9, offset: 111354},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3613, col: 25, offset: 111289},
+									pos: position{line: 3615, col: 25, offset: 111370},
 									expr: &choiceExpr{
-										pos: position{line: 3613, col: 27, offset: 111291},
+										pos: position{line: 3615, col: 27, offset: 111372},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 27, offset: 111291},
+												pos:  position{line: 3615, col: 27, offset: 111372},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 36, offset: 111300},
+												pos:  position{line: 3615, col: 36, offset: 111381},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 46, offset: 111310},
+												pos:  position{line: 3615, col: 46, offset: 111391},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 54, offset: 111318},
+												pos:  position{line: 3615, col: 54, offset: 111399},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 62, offset: 111326},
+												pos:  position{line: 3615, col: 62, offset: 111407},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3613, col: 70, offset: 111334},
+												pos:  position{line: 3615, col: 70, offset: 111415},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3613, col: 84, offset: 111348},
+												pos:        position{line: 3615, col: 84, offset: 111429},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8338,28 +8338,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3630, col: 1, offset: 111699},
+			pos:  position{line: 3632, col: 1, offset: 111780},
 			expr: &actionExpr{
-				pos: position{line: 3630, col: 19, offset: 111717},
+				pos: position{line: 3632, col: 19, offset: 111798},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3630, col: 19, offset: 111717},
+					pos: position{line: 3632, col: 19, offset: 111798},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3630, col: 19, offset: 111717},
+							pos:        position{line: 3632, col: 19, offset: 111798},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3630, col: 26, offset: 111724},
+							pos:  position{line: 3632, col: 26, offset: 111805},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3630, col: 32, offset: 111730},
+							pos:   position{line: 3632, col: 32, offset: 111811},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3630, col: 40, offset: 111738},
+								pos:  position{line: 3632, col: 40, offset: 111819},
 								name: "Boolean",
 							},
 						},
@@ -8369,28 +8369,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3641, col: 1, offset: 111927},
+			pos:  position{line: 3643, col: 1, offset: 112008},
 			expr: &actionExpr{
-				pos: position{line: 3641, col: 23, offset: 111949},
+				pos: position{line: 3643, col: 23, offset: 112030},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3641, col: 23, offset: 111949},
+					pos: position{line: 3643, col: 23, offset: 112030},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3641, col: 23, offset: 111949},
+							pos:        position{line: 3643, col: 23, offset: 112030},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3641, col: 34, offset: 111960},
+							pos:  position{line: 3643, col: 34, offset: 112041},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3641, col: 40, offset: 111966},
+							pos:   position{line: 3643, col: 40, offset: 112047},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3641, col: 48, offset: 111974},
+								pos:  position{line: 3643, col: 48, offset: 112055},
 								name: "Boolean",
 							},
 						},
@@ -8400,28 +8400,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3652, col: 1, offset: 112171},
+			pos:  position{line: 3654, col: 1, offset: 112252},
 			expr: &actionExpr{
-				pos: position{line: 3652, col: 20, offset: 112190},
+				pos: position{line: 3654, col: 20, offset: 112271},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3652, col: 20, offset: 112190},
+					pos: position{line: 3654, col: 20, offset: 112271},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3652, col: 20, offset: 112190},
+							pos:        position{line: 3654, col: 20, offset: 112271},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3652, col: 28, offset: 112198},
+							pos:  position{line: 3654, col: 28, offset: 112279},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3652, col: 34, offset: 112204},
+							pos:   position{line: 3654, col: 34, offset: 112285},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3652, col: 43, offset: 112213},
+								pos:  position{line: 3654, col: 43, offset: 112294},
 								name: "IntegerAsString",
 							},
 						},
@@ -8431,15 +8431,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3667, col: 1, offset: 112575},
+			pos:  position{line: 3669, col: 1, offset: 112656},
 			expr: &actionExpr{
-				pos: position{line: 3667, col: 19, offset: 112593},
+				pos: position{line: 3669, col: 19, offset: 112674},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3667, col: 19, offset: 112593},
+					pos:   position{line: 3669, col: 19, offset: 112674},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3667, col: 28, offset: 112602},
+						pos:  position{line: 3669, col: 28, offset: 112683},
 						name: "BoolExpr",
 					},
 				},
@@ -8447,30 +8447,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3678, col: 1, offset: 112814},
+			pos:  position{line: 3680, col: 1, offset: 112895},
 			expr: &actionExpr{
-				pos: position{line: 3678, col: 15, offset: 112828},
+				pos: position{line: 3680, col: 15, offset: 112909},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3678, col: 15, offset: 112828},
+					pos:   position{line: 3680, col: 15, offset: 112909},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3678, col: 23, offset: 112836},
+						pos: position{line: 3680, col: 23, offset: 112917},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3678, col: 23, offset: 112836},
+								pos:  position{line: 3680, col: 23, offset: 112917},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3678, col: 44, offset: 112857},
+								pos:  position{line: 3680, col: 44, offset: 112938},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3678, col: 61, offset: 112874},
+								pos:  position{line: 3680, col: 61, offset: 112955},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3678, col: 79, offset: 112892},
+								pos:  position{line: 3680, col: 79, offset: 112973},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8480,35 +8480,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3682, col: 1, offset: 112936},
+			pos:  position{line: 3684, col: 1, offset: 113017},
 			expr: &actionExpr{
-				pos: position{line: 3682, col: 19, offset: 112954},
+				pos: position{line: 3684, col: 19, offset: 113035},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3682, col: 19, offset: 112954},
+					pos: position{line: 3684, col: 19, offset: 113035},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3682, col: 19, offset: 112954},
+							pos:   position{line: 3684, col: 19, offset: 113035},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3682, col: 26, offset: 112961},
+								pos:  position{line: 3684, col: 26, offset: 113042},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3682, col: 37, offset: 112972},
+							pos:   position{line: 3684, col: 37, offset: 113053},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3682, col: 43, offset: 112978},
+								pos: position{line: 3684, col: 43, offset: 113059},
 								expr: &seqExpr{
-									pos: position{line: 3682, col: 44, offset: 112979},
+									pos: position{line: 3684, col: 44, offset: 113060},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3682, col: 44, offset: 112979},
+											pos:  position{line: 3684, col: 44, offset: 113060},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3682, col: 50, offset: 112985},
+											pos:  position{line: 3684, col: 50, offset: 113066},
 											name: "HeadOption",
 										},
 									},
@@ -8521,29 +8521,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3739, col: 1, offset: 114785},
+			pos:  position{line: 3741, col: 1, offset: 114866},
 			expr: &choiceExpr{
-				pos: position{line: 3739, col: 14, offset: 114798},
+				pos: position{line: 3741, col: 14, offset: 114879},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3739, col: 14, offset: 114798},
+						pos: position{line: 3741, col: 14, offset: 114879},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3739, col: 14, offset: 114798},
+							pos: position{line: 3741, col: 14, offset: 114879},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3739, col: 14, offset: 114798},
+									pos:  position{line: 3741, col: 14, offset: 114879},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3739, col: 19, offset: 114803},
+									pos:  position{line: 3741, col: 19, offset: 114884},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3739, col: 28, offset: 114812},
+									pos:   position{line: 3741, col: 28, offset: 114893},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3739, col: 37, offset: 114821},
+										pos:  position{line: 3741, col: 37, offset: 114902},
 										name: "HeadOptionList",
 									},
 								},
@@ -8551,24 +8551,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3750, col: 3, offset: 115140},
+						pos: position{line: 3752, col: 3, offset: 115221},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3750, col: 3, offset: 115140},
+							pos: position{line: 3752, col: 3, offset: 115221},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3750, col: 3, offset: 115140},
+									pos:  position{line: 3752, col: 3, offset: 115221},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3750, col: 8, offset: 115145},
+									pos:  position{line: 3752, col: 8, offset: 115226},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3750, col: 17, offset: 115154},
+									pos:   position{line: 3752, col: 17, offset: 115235},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3750, col: 26, offset: 115163},
+										pos:  position{line: 3752, col: 26, offset: 115244},
 										name: "IntegerAsString",
 									},
 								},
@@ -8576,17 +8576,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3770, col: 3, offset: 115680},
+						pos: position{line: 3772, col: 3, offset: 115761},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3770, col: 3, offset: 115680},
+							pos: position{line: 3772, col: 3, offset: 115761},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3770, col: 3, offset: 115680},
+									pos:  position{line: 3772, col: 3, offset: 115761},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3770, col: 8, offset: 115685},
+									pos:  position{line: 3772, col: 8, offset: 115766},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8597,29 +8597,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3788, col: 1, offset: 116155},
+			pos:  position{line: 3790, col: 1, offset: 116236},
 			expr: &choiceExpr{
-				pos: position{line: 3788, col: 14, offset: 116168},
+				pos: position{line: 3790, col: 14, offset: 116249},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3788, col: 14, offset: 116168},
+						pos: position{line: 3790, col: 14, offset: 116249},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3788, col: 14, offset: 116168},
+							pos: position{line: 3790, col: 14, offset: 116249},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3788, col: 14, offset: 116168},
+									pos:  position{line: 3790, col: 14, offset: 116249},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3788, col: 19, offset: 116173},
+									pos:  position{line: 3790, col: 19, offset: 116254},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3788, col: 28, offset: 116182},
+									pos:   position{line: 3790, col: 28, offset: 116263},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3788, col: 37, offset: 116191},
+										pos:  position{line: 3790, col: 37, offset: 116272},
 										name: "IntegerAsString",
 									},
 								},
@@ -8627,17 +8627,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3809, col: 3, offset: 116765},
+						pos: position{line: 3811, col: 3, offset: 116846},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3809, col: 3, offset: 116765},
+							pos: position{line: 3811, col: 3, offset: 116846},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3809, col: 3, offset: 116765},
+									pos:  position{line: 3811, col: 3, offset: 116846},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3809, col: 8, offset: 116770},
+									pos:  position{line: 3811, col: 8, offset: 116851},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8648,44 +8648,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3830, col: 1, offset: 117388},
+			pos:  position{line: 3832, col: 1, offset: 117469},
 			expr: &actionExpr{
-				pos: position{line: 3830, col: 20, offset: 117407},
+				pos: position{line: 3832, col: 20, offset: 117488},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3830, col: 20, offset: 117407},
+					pos: position{line: 3832, col: 20, offset: 117488},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3830, col: 20, offset: 117407},
+							pos:   position{line: 3832, col: 20, offset: 117488},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3830, col: 26, offset: 117413},
+								pos:  position{line: 3832, col: 26, offset: 117494},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3830, col: 37, offset: 117424},
+							pos:   position{line: 3832, col: 37, offset: 117505},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3830, col: 42, offset: 117429},
+								pos: position{line: 3832, col: 42, offset: 117510},
 								expr: &seqExpr{
-									pos: position{line: 3830, col: 43, offset: 117430},
+									pos: position{line: 3832, col: 43, offset: 117511},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3830, col: 44, offset: 117431},
+											pos: position{line: 3832, col: 44, offset: 117512},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3830, col: 44, offset: 117431},
+													pos:  position{line: 3832, col: 44, offset: 117512},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3830, col: 52, offset: 117439},
+													pos:  position{line: 3832, col: 52, offset: 117520},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3830, col: 59, offset: 117446},
+											pos:  position{line: 3832, col: 59, offset: 117527},
 											name: "Aggregator",
 										},
 									},
@@ -8698,28 +8698,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3847, col: 1, offset: 117949},
+			pos:  position{line: 3849, col: 1, offset: 118030},
 			expr: &actionExpr{
-				pos: position{line: 3847, col: 15, offset: 117963},
+				pos: position{line: 3849, col: 15, offset: 118044},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3847, col: 15, offset: 117963},
+					pos: position{line: 3849, col: 15, offset: 118044},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3847, col: 15, offset: 117963},
+							pos:   position{line: 3849, col: 15, offset: 118044},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3847, col: 23, offset: 117971},
+								pos:  position{line: 3849, col: 23, offset: 118052},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3847, col: 35, offset: 117983},
+							pos:   position{line: 3849, col: 35, offset: 118064},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3847, col: 43, offset: 117991},
+								pos: position{line: 3849, col: 43, offset: 118072},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3847, col: 43, offset: 117991},
+									pos:  position{line: 3849, col: 43, offset: 118072},
 									name: "AsField",
 								},
 							},
@@ -8730,26 +8730,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3863, col: 1, offset: 118832},
+			pos:  position{line: 3865, col: 1, offset: 118913},
 			expr: &actionExpr{
-				pos: position{line: 3863, col: 16, offset: 118847},
+				pos: position{line: 3865, col: 16, offset: 118928},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3863, col: 16, offset: 118847},
+					pos:   position{line: 3865, col: 16, offset: 118928},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3863, col: 21, offset: 118852},
+						pos: position{line: 3865, col: 21, offset: 118933},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3863, col: 21, offset: 118852},
+								pos:  position{line: 3865, col: 21, offset: 118933},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3863, col: 32, offset: 118863},
+								pos:  position{line: 3865, col: 32, offset: 118944},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3863, col: 48, offset: 118879},
+								pos:  position{line: 3865, col: 48, offset: 118960},
 								name: "AggCommon",
 							},
 						},
@@ -8759,165 +8759,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3868, col: 1, offset: 119085},
+			pos:  position{line: 3870, col: 1, offset: 119166},
 			expr: &actionExpr{
-				pos: position{line: 3868, col: 18, offset: 119102},
+				pos: position{line: 3870, col: 18, offset: 119183},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3868, col: 19, offset: 119103},
+					pos: position{line: 3870, col: 19, offset: 119184},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3868, col: 19, offset: 119103},
+							pos:        position{line: 3870, col: 19, offset: 119184},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 30, offset: 119114},
+							pos:        position{line: 3870, col: 30, offset: 119195},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 39, offset: 119123},
+							pos:        position{line: 3870, col: 39, offset: 119204},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 47, offset: 119131},
+							pos:        position{line: 3870, col: 47, offset: 119212},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 57, offset: 119141},
+							pos:        position{line: 3870, col: 57, offset: 119222},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 65, offset: 119149},
+							pos:        position{line: 3870, col: 65, offset: 119230},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 76, offset: 119160},
+							pos:        position{line: 3870, col: 76, offset: 119241},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 86, offset: 119170},
+							pos:        position{line: 3870, col: 86, offset: 119251},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 95, offset: 119179},
+							pos:        position{line: 3870, col: 95, offset: 119260},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 105, offset: 119189},
+							pos:        position{line: 3870, col: 105, offset: 119270},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 114, offset: 119198},
+							pos:        position{line: 3870, col: 114, offset: 119279},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 122, offset: 119206},
+							pos:        position{line: 3870, col: 122, offset: 119287},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 133, offset: 119217},
+							pos:        position{line: 3870, col: 133, offset: 119298},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3868, col: 142, offset: 119226},
+							pos:        position{line: 3870, col: 142, offset: 119307},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 1, offset: 119235},
+							pos:        position{line: 3871, col: 1, offset: 119316},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 10, offset: 119244},
+							pos:        position{line: 3871, col: 10, offset: 119325},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 26, offset: 119260},
+							pos:        position{line: 3871, col: 26, offset: 119341},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 37, offset: 119271},
+							pos:        position{line: 3871, col: 37, offset: 119352},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 46, offset: 119280},
+							pos:        position{line: 3871, col: 46, offset: 119361},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 56, offset: 119290},
+							pos:        position{line: 3871, col: 56, offset: 119371},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 72, offset: 119306},
+							pos:        position{line: 3871, col: 72, offset: 119387},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 82, offset: 119316},
+							pos:        position{line: 3871, col: 82, offset: 119397},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 100, offset: 119334},
+							pos:        position{line: 3871, col: 100, offset: 119415},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 113, offset: 119347},
+							pos:        position{line: 3871, col: 113, offset: 119428},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 132, offset: 119366},
+							pos:        position{line: 3871, col: 132, offset: 119447},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3869, col: 139, offset: 119373},
+							pos:        position{line: 3871, col: 139, offset: 119454},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8928,27 +8928,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3873, col: 1, offset: 119416},
+			pos:  position{line: 3875, col: 1, offset: 119497},
 			expr: &actionExpr{
-				pos: position{line: 3873, col: 22, offset: 119437},
+				pos: position{line: 3875, col: 22, offset: 119518},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3873, col: 23, offset: 119438},
+					pos: position{line: 3875, col: 23, offset: 119519},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3873, col: 23, offset: 119438},
+							pos:        position{line: 3875, col: 23, offset: 119519},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3873, col: 37, offset: 119452},
+							pos:        position{line: 3875, col: 37, offset: 119533},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3873, col: 51, offset: 119466},
+							pos:        position{line: 3875, col: 51, offset: 119547},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8959,29 +8959,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3877, col: 1, offset: 119510},
+			pos:  position{line: 3879, col: 1, offset: 119591},
 			expr: &actionExpr{
-				pos: position{line: 3877, col: 12, offset: 119521},
+				pos: position{line: 3879, col: 12, offset: 119602},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3877, col: 12, offset: 119521},
+					pos: position{line: 3879, col: 12, offset: 119602},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3877, col: 12, offset: 119521},
+							pos:  position{line: 3879, col: 12, offset: 119602},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3877, col: 15, offset: 119524},
+							pos:   position{line: 3879, col: 15, offset: 119605},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3877, col: 23, offset: 119532},
+								pos: position{line: 3879, col: 23, offset: 119613},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3877, col: 23, offset: 119532},
+										pos:  position{line: 3879, col: 23, offset: 119613},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3877, col: 35, offset: 119544},
+										pos:  position{line: 3879, col: 35, offset: 119625},
 										name: "String",
 									},
 								},
@@ -8993,27 +8993,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3891, col: 1, offset: 119873},
+			pos:  position{line: 3893, col: 1, offset: 119954},
 			expr: &choiceExpr{
-				pos: position{line: 3891, col: 13, offset: 119885},
+				pos: position{line: 3893, col: 13, offset: 119966},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3891, col: 13, offset: 119885},
+						pos: position{line: 3893, col: 13, offset: 119966},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3891, col: 13, offset: 119885},
+							pos: position{line: 3893, col: 13, offset: 119966},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3891, col: 14, offset: 119886},
+									pos: position{line: 3893, col: 14, offset: 119967},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3891, col: 14, offset: 119886},
+											pos:        position{line: 3893, col: 14, offset: 119967},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3891, col: 24, offset: 119896},
+											pos:        position{line: 3893, col: 24, offset: 119977},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9021,47 +9021,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3891, col: 29, offset: 119901},
+									pos:  position{line: 3893, col: 29, offset: 119982},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3891, col: 37, offset: 119909},
+									pos:        position{line: 3893, col: 37, offset: 119990},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3891, col: 44, offset: 119916},
+									pos:   position{line: 3893, col: 44, offset: 119997},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3891, col: 54, offset: 119926},
+										pos:  position{line: 3893, col: 54, offset: 120007},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3891, col: 64, offset: 119936},
+									pos:  position{line: 3893, col: 64, offset: 120017},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3901, col: 3, offset: 120164},
+						pos: position{line: 3903, col: 3, offset: 120245},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3901, col: 3, offset: 120164},
+							pos: position{line: 3903, col: 3, offset: 120245},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3901, col: 4, offset: 120165},
+									pos: position{line: 3903, col: 4, offset: 120246},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3901, col: 4, offset: 120165},
+											pos:        position{line: 3903, col: 4, offset: 120246},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3901, col: 14, offset: 120175},
+											pos:        position{line: 3903, col: 14, offset: 120256},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9069,38 +9069,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3901, col: 19, offset: 120180},
+									pos:  position{line: 3903, col: 19, offset: 120261},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3901, col: 27, offset: 120188},
+									pos:   position{line: 3903, col: 27, offset: 120269},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3901, col: 33, offset: 120194},
+										pos:  position{line: 3903, col: 33, offset: 120275},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3901, col: 43, offset: 120204},
+									pos:  position{line: 3903, col: 43, offset: 120285},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3908, col: 5, offset: 120355},
+						pos: position{line: 3910, col: 5, offset: 120436},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3908, col: 6, offset: 120356},
+							pos: position{line: 3910, col: 6, offset: 120437},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3908, col: 6, offset: 120356},
+									pos:        position{line: 3910, col: 6, offset: 120437},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3908, col: 16, offset: 120366},
+									pos:        position{line: 3910, col: 16, offset: 120447},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9113,77 +9113,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3917, col: 1, offset: 120502},
+			pos:  position{line: 3919, col: 1, offset: 120583},
 			expr: &choiceExpr{
-				pos: position{line: 3917, col: 14, offset: 120515},
+				pos: position{line: 3919, col: 14, offset: 120596},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3917, col: 14, offset: 120515},
+						pos: position{line: 3919, col: 14, offset: 120596},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3917, col: 14, offset: 120515},
+							pos: position{line: 3919, col: 14, offset: 120596},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3917, col: 14, offset: 120515},
+									pos:   position{line: 3919, col: 14, offset: 120596},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3917, col: 22, offset: 120523},
+										pos:  position{line: 3919, col: 22, offset: 120604},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3917, col: 36, offset: 120537},
+									pos:  position{line: 3919, col: 36, offset: 120618},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3917, col: 44, offset: 120545},
+									pos:        position{line: 3919, col: 44, offset: 120626},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3917, col: 51, offset: 120552},
+									pos:   position{line: 3919, col: 51, offset: 120633},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3917, col: 61, offset: 120562},
+										pos:  position{line: 3919, col: 61, offset: 120643},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3917, col: 71, offset: 120572},
+									pos:  position{line: 3919, col: 71, offset: 120653},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3932, col: 3, offset: 120982},
+						pos: position{line: 3934, col: 3, offset: 121063},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3932, col: 3, offset: 120982},
+							pos: position{line: 3934, col: 3, offset: 121063},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3932, col: 3, offset: 120982},
+									pos:   position{line: 3934, col: 3, offset: 121063},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3932, col: 11, offset: 120990},
+										pos:  position{line: 3934, col: 11, offset: 121071},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3932, col: 25, offset: 121004},
+									pos:  position{line: 3934, col: 25, offset: 121085},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3932, col: 33, offset: 121012},
+									pos:   position{line: 3934, col: 33, offset: 121093},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3932, col: 39, offset: 121018},
+										pos:  position{line: 3934, col: 39, offset: 121099},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3932, col: 49, offset: 121028},
+									pos:  position{line: 3934, col: 49, offset: 121109},
 									name: "R_PAREN",
 								},
 							},
@@ -9194,22 +9194,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3946, col: 1, offset: 121360},
+			pos:  position{line: 3948, col: 1, offset: 121441},
 			expr: &actionExpr{
-				pos: position{line: 3946, col: 18, offset: 121377},
+				pos: position{line: 3948, col: 18, offset: 121458},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3946, col: 18, offset: 121377},
+					pos:   position{line: 3948, col: 18, offset: 121458},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3946, col: 26, offset: 121385},
+						pos: position{line: 3948, col: 26, offset: 121466},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3946, col: 26, offset: 121385},
+								pos:  position{line: 3948, col: 26, offset: 121466},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3946, col: 42, offset: 121401},
+								pos:  position{line: 3948, col: 42, offset: 121482},
 								name: "IntegerAsString",
 							},
 						},
@@ -9219,93 +9219,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3958, col: 1, offset: 121775},
+			pos:  position{line: 3960, col: 1, offset: 121856},
 			expr: &choiceExpr{
-				pos: position{line: 3958, col: 18, offset: 121792},
+				pos: position{line: 3960, col: 18, offset: 121873},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3958, col: 18, offset: 121792},
+						pos: position{line: 3960, col: 18, offset: 121873},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3958, col: 18, offset: 121792},
+							pos: position{line: 3960, col: 18, offset: 121873},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3958, col: 18, offset: 121792},
+									pos:   position{line: 3960, col: 18, offset: 121873},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3958, col: 26, offset: 121800},
+										pos:  position{line: 3960, col: 26, offset: 121881},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3958, col: 44, offset: 121818},
+									pos:   position{line: 3960, col: 44, offset: 121899},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3958, col: 58, offset: 121832},
+										pos:  position{line: 3960, col: 58, offset: 121913},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3958, col: 72, offset: 121846},
+									pos:  position{line: 3960, col: 72, offset: 121927},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3958, col: 80, offset: 121854},
+									pos:        position{line: 3960, col: 80, offset: 121935},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3958, col: 87, offset: 121861},
+									pos:   position{line: 3960, col: 87, offset: 121942},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3958, col: 97, offset: 121871},
+										pos:  position{line: 3960, col: 97, offset: 121952},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3958, col: 107, offset: 121881},
+									pos:  position{line: 3960, col: 107, offset: 121962},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3974, col: 3, offset: 122330},
+						pos: position{line: 3976, col: 3, offset: 122411},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3974, col: 3, offset: 122330},
+							pos: position{line: 3976, col: 3, offset: 122411},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3974, col: 3, offset: 122330},
+									pos:   position{line: 3976, col: 3, offset: 122411},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3974, col: 11, offset: 122338},
+										pos:  position{line: 3976, col: 11, offset: 122419},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3974, col: 29, offset: 122356},
+									pos:   position{line: 3976, col: 29, offset: 122437},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3974, col: 43, offset: 122370},
+										pos:  position{line: 3976, col: 43, offset: 122451},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3974, col: 57, offset: 122384},
+									pos:  position{line: 3976, col: 57, offset: 122465},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3974, col: 65, offset: 122392},
+									pos:   position{line: 3976, col: 65, offset: 122473},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3974, col: 71, offset: 122398},
+										pos:  position{line: 3976, col: 71, offset: 122479},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3974, col: 81, offset: 122408},
+									pos:  position{line: 3976, col: 81, offset: 122489},
 									name: "R_PAREN",
 								},
 							},
@@ -9316,22 +9316,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3990, col: 1, offset: 122780},
+			pos:  position{line: 3992, col: 1, offset: 122861},
 			expr: &actionExpr{
-				pos: position{line: 3990, col: 25, offset: 122804},
+				pos: position{line: 3992, col: 25, offset: 122885},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3990, col: 25, offset: 122804},
+					pos:   position{line: 3992, col: 25, offset: 122885},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3990, col: 39, offset: 122818},
+						pos: position{line: 3992, col: 39, offset: 122899},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3990, col: 39, offset: 122818},
+								pos:  position{line: 3992, col: 39, offset: 122899},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3990, col: 67, offset: 122846},
+								pos:  position{line: 3992, col: 67, offset: 122927},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9341,43 +9341,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3994, col: 1, offset: 122909},
+			pos:  position{line: 3996, col: 1, offset: 122990},
 			expr: &actionExpr{
-				pos: position{line: 3994, col: 30, offset: 122938},
+				pos: position{line: 3996, col: 30, offset: 123019},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3994, col: 30, offset: 122938},
+					pos: position{line: 3996, col: 30, offset: 123019},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3994, col: 30, offset: 122938},
+							pos:   position{line: 3996, col: 30, offset: 123019},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3994, col: 34, offset: 122942},
+								pos:  position{line: 3996, col: 34, offset: 123023},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3994, col: 44, offset: 122952},
+							pos:   position{line: 3996, col: 44, offset: 123033},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3994, col: 48, offset: 122956},
+								pos: position{line: 3996, col: 48, offset: 123037},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3994, col: 48, offset: 122956},
+										pos:  position{line: 3996, col: 48, offset: 123037},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3994, col: 67, offset: 122975},
+										pos:  position{line: 3996, col: 67, offset: 123056},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3994, col: 87, offset: 122995},
+							pos:   position{line: 3996, col: 87, offset: 123076},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3994, col: 93, offset: 123001},
+								pos:  position{line: 3996, col: 93, offset: 123082},
 								name: "Number",
 							},
 						},
@@ -9387,15 +9387,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4007, col: 1, offset: 123235},
+			pos:  position{line: 4009, col: 1, offset: 123316},
 			expr: &actionExpr{
-				pos: position{line: 4007, col: 32, offset: 123266},
+				pos: position{line: 4009, col: 32, offset: 123347},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4007, col: 32, offset: 123266},
+					pos:   position{line: 4009, col: 32, offset: 123347},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4007, col: 38, offset: 123272},
+						pos:  position{line: 4009, col: 38, offset: 123353},
 						name: "Number",
 					},
 				},
@@ -9403,34 +9403,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4020, col: 1, offset: 123489},
+			pos:  position{line: 4022, col: 1, offset: 123570},
 			expr: &actionExpr{
-				pos: position{line: 4020, col: 26, offset: 123514},
+				pos: position{line: 4022, col: 26, offset: 123595},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4020, col: 26, offset: 123514},
+					pos: position{line: 4022, col: 26, offset: 123595},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4020, col: 26, offset: 123514},
+							pos:   position{line: 4022, col: 26, offset: 123595},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4020, col: 30, offset: 123518},
+								pos:  position{line: 4022, col: 30, offset: 123599},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4020, col: 40, offset: 123528},
+							pos:   position{line: 4022, col: 40, offset: 123609},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4020, col: 43, offset: 123531},
+								pos:  position{line: 4022, col: 43, offset: 123612},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4020, col: 60, offset: 123548},
+							pos:   position{line: 4022, col: 60, offset: 123629},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4020, col: 66, offset: 123554},
+								pos:  position{line: 4022, col: 66, offset: 123635},
 								name: "Boolean",
 							},
 						},
@@ -9440,22 +9440,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4033, col: 1, offset: 123789},
+			pos:  position{line: 4035, col: 1, offset: 123870},
 			expr: &actionExpr{
-				pos: position{line: 4033, col: 25, offset: 123813},
+				pos: position{line: 4035, col: 25, offset: 123894},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4033, col: 25, offset: 123813},
+					pos:   position{line: 4035, col: 25, offset: 123894},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4033, col: 39, offset: 123827},
+						pos: position{line: 4035, col: 39, offset: 123908},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4033, col: 39, offset: 123827},
+								pos:  position{line: 4035, col: 39, offset: 123908},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4033, col: 67, offset: 123855},
+								pos:  position{line: 4035, col: 67, offset: 123936},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9465,41 +9465,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4037, col: 1, offset: 123918},
+			pos:  position{line: 4039, col: 1, offset: 123999},
 			expr: &actionExpr{
-				pos: position{line: 4037, col: 30, offset: 123947},
+				pos: position{line: 4039, col: 30, offset: 124028},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4037, col: 30, offset: 123947},
+					pos: position{line: 4039, col: 30, offset: 124028},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4037, col: 30, offset: 123947},
+							pos:   position{line: 4039, col: 30, offset: 124028},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4037, col: 34, offset: 123951},
+								pos:  position{line: 4039, col: 34, offset: 124032},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4037, col: 44, offset: 123961},
+							pos:   position{line: 4039, col: 44, offset: 124042},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4037, col: 47, offset: 123964},
+								pos:  position{line: 4039, col: 47, offset: 124045},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4037, col: 64, offset: 123981},
+							pos:   position{line: 4039, col: 64, offset: 124062},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4037, col: 81, offset: 123998},
+								pos: position{line: 4039, col: 81, offset: 124079},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4037, col: 81, offset: 123998},
+										pos:  position{line: 4039, col: 81, offset: 124079},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4037, col: 103, offset: 124020},
+										pos:  position{line: 4039, col: 103, offset: 124101},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9511,22 +9511,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4052, col: 1, offset: 124420},
+			pos:  position{line: 4054, col: 1, offset: 124501},
 			expr: &actionExpr{
-				pos: position{line: 4052, col: 32, offset: 124451},
+				pos: position{line: 4054, col: 32, offset: 124532},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4052, col: 32, offset: 124451},
+					pos:   position{line: 4054, col: 32, offset: 124532},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4052, col: 49, offset: 124468},
+						pos: position{line: 4054, col: 49, offset: 124549},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4052, col: 49, offset: 124468},
+								pos:  position{line: 4054, col: 49, offset: 124549},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4052, col: 71, offset: 124490},
+								pos:  position{line: 4054, col: 71, offset: 124571},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9536,33 +9536,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4067, col: 1, offset: 124873},
+			pos:  position{line: 4069, col: 1, offset: 124954},
 			expr: &actionExpr{
-				pos: position{line: 4067, col: 24, offset: 124896},
+				pos: position{line: 4069, col: 24, offset: 124977},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4067, col: 24, offset: 124896},
+					pos: position{line: 4069, col: 24, offset: 124977},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4067, col: 24, offset: 124896},
+							pos:        position{line: 4069, col: 24, offset: 124977},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4067, col: 31, offset: 124903},
+							pos:  position{line: 4069, col: 31, offset: 124984},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4067, col: 39, offset: 124911},
+							pos:   position{line: 4069, col: 39, offset: 124992},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4067, col: 45, offset: 124917},
+								pos:  position{line: 4069, col: 45, offset: 124998},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4067, col: 52, offset: 124924},
+							pos:  position{line: 4069, col: 52, offset: 125005},
 							name: "R_PAREN",
 						},
 					},
@@ -9571,15 +9571,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4075, col: 1, offset: 125065},
+			pos:  position{line: 4077, col: 1, offset: 125146},
 			expr: &actionExpr{
-				pos: position{line: 4075, col: 26, offset: 125090},
+				pos: position{line: 4077, col: 26, offset: 125171},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4075, col: 26, offset: 125090},
+					pos:   position{line: 4077, col: 26, offset: 125171},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4075, col: 32, offset: 125096},
+						pos:  position{line: 4077, col: 32, offset: 125177},
 						name: "String",
 					},
 				},
@@ -9587,35 +9587,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4085, col: 1, offset: 125376},
+			pos:  position{line: 4087, col: 1, offset: 125457},
 			expr: &actionExpr{
-				pos: position{line: 4085, col: 18, offset: 125393},
+				pos: position{line: 4087, col: 18, offset: 125474},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4085, col: 18, offset: 125393},
+					pos: position{line: 4087, col: 18, offset: 125474},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4085, col: 18, offset: 125393},
+							pos:   position{line: 4087, col: 18, offset: 125474},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4085, col: 24, offset: 125399},
+								pos:  position{line: 4087, col: 24, offset: 125480},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4085, col: 34, offset: 125409},
+							pos:   position{line: 4087, col: 34, offset: 125490},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4085, col: 39, offset: 125414},
+								pos: position{line: 4087, col: 39, offset: 125495},
 								expr: &seqExpr{
-									pos: position{line: 4085, col: 40, offset: 125415},
+									pos: position{line: 4087, col: 40, offset: 125496},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4085, col: 40, offset: 125415},
+											pos:  position{line: 4087, col: 40, offset: 125496},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4085, col: 46, offset: 125421},
+											pos:  position{line: 4087, col: 46, offset: 125502},
 											name: "FieldName",
 										},
 									},
@@ -9628,16 +9628,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4102, col: 1, offset: 125916},
+			pos:  position{line: 4104, col: 1, offset: 125997},
 			expr: &choiceExpr{
-				pos: position{line: 4102, col: 18, offset: 125933},
+				pos: position{line: 4104, col: 18, offset: 126014},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4102, col: 18, offset: 125933},
+						pos:  position{line: 4104, col: 18, offset: 126014},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4102, col: 38, offset: 125953},
+						pos:  position{line: 4104, col: 38, offset: 126034},
 						name: "EarliestOnly",
 					},
 				},
@@ -9645,62 +9645,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4104, col: 1, offset: 125967},
+			pos:  position{line: 4106, col: 1, offset: 126048},
 			expr: &actionExpr{
-				pos: position{line: 4104, col: 22, offset: 125988},
+				pos: position{line: 4106, col: 22, offset: 126069},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4104, col: 22, offset: 125988},
+					pos: position{line: 4106, col: 22, offset: 126069},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4104, col: 22, offset: 125988},
+							pos:  position{line: 4106, col: 22, offset: 126069},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4104, col: 35, offset: 126001},
+							pos:  position{line: 4106, col: 35, offset: 126082},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4104, col: 41, offset: 126007},
+							pos:   position{line: 4106, col: 41, offset: 126088},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4104, col: 55, offset: 126021},
+								pos: position{line: 4106, col: 55, offset: 126102},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4104, col: 55, offset: 126021},
+										pos:  position{line: 4106, col: 55, offset: 126102},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4104, col: 75, offset: 126041},
+										pos:  position{line: 4106, col: 75, offset: 126122},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4104, col: 94, offset: 126060},
+							pos:  position{line: 4106, col: 94, offset: 126141},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4104, col: 100, offset: 126066},
+							pos:  position{line: 4106, col: 100, offset: 126147},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4104, col: 111, offset: 126077},
+							pos:  position{line: 4106, col: 111, offset: 126158},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4104, col: 117, offset: 126083},
+							pos:   position{line: 4106, col: 117, offset: 126164},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4104, col: 129, offset: 126095},
+								pos: position{line: 4106, col: 129, offset: 126176},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4104, col: 129, offset: 126095},
+										pos:  position{line: 4106, col: 129, offset: 126176},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4104, col: 149, offset: 126115},
+										pos:  position{line: 4106, col: 149, offset: 126196},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9712,33 +9712,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4145, col: 1, offset: 127254},
+			pos:  position{line: 4147, col: 1, offset: 127335},
 			expr: &actionExpr{
-				pos: position{line: 4145, col: 17, offset: 127270},
+				pos: position{line: 4147, col: 17, offset: 127351},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4145, col: 17, offset: 127270},
+					pos: position{line: 4147, col: 17, offset: 127351},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4145, col: 17, offset: 127270},
+							pos:  position{line: 4147, col: 17, offset: 127351},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4145, col: 30, offset: 127283},
+							pos:  position{line: 4147, col: 30, offset: 127364},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4145, col: 36, offset: 127289},
+							pos:   position{line: 4147, col: 36, offset: 127370},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4145, col: 50, offset: 127303},
+								pos: position{line: 4147, col: 50, offset: 127384},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4145, col: 50, offset: 127303},
+										pos:  position{line: 4147, col: 50, offset: 127384},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4145, col: 70, offset: 127323},
+										pos:  position{line: 4147, col: 70, offset: 127404},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9750,24 +9750,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4173, col: 1, offset: 128031},
+			pos:  position{line: 4175, col: 1, offset: 128112},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 23, offset: 128053},
+				pos: position{line: 4175, col: 23, offset: 128134},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4173, col: 23, offset: 128053},
+					pos: position{line: 4175, col: 23, offset: 128134},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4173, col: 23, offset: 128053},
+							pos:        position{line: 4175, col: 23, offset: 128134},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4173, col: 27, offset: 128057},
+							pos: position{line: 4175, col: 27, offset: 128138},
 							expr: &charClassMatcher{
-								pos:        position{line: 4173, col: 27, offset: 128057},
+								pos:        position{line: 4175, col: 27, offset: 128138},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9780,21 +9780,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4177, col: 1, offset: 128100},
+			pos:  position{line: 4179, col: 1, offset: 128181},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 13, offset: 128112},
+				pos: position{line: 4179, col: 13, offset: 128193},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4177, col: 14, offset: 128113},
+					pos: position{line: 4179, col: 14, offset: 128194},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4177, col: 14, offset: 128113},
+							pos:        position{line: 4179, col: 14, offset: 128194},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4177, col: 17, offset: 128116},
+							pos:        position{line: 4179, col: 17, offset: 128197},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9806,15 +9806,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4181, col: 1, offset: 128159},
+			pos:  position{line: 4183, col: 1, offset: 128240},
 			expr: &actionExpr{
-				pos: position{line: 4181, col: 16, offset: 128174},
+				pos: position{line: 4183, col: 16, offset: 128255},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4181, col: 16, offset: 128174},
+					pos:   position{line: 4183, col: 16, offset: 128255},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4181, col: 26, offset: 128184},
+						pos:  position{line: 4183, col: 26, offset: 128265},
 						name: "AllTimeScale",
 					},
 				},
@@ -9822,31 +9822,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4188, col: 1, offset: 128408},
+			pos:  position{line: 4190, col: 1, offset: 128489},
 			expr: &actionExpr{
-				pos: position{line: 4188, col: 9, offset: 128416},
+				pos: position{line: 4190, col: 9, offset: 128497},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4188, col: 9, offset: 128416},
+					pos: position{line: 4190, col: 9, offset: 128497},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4188, col: 9, offset: 128416},
+							pos:        position{line: 4190, col: 9, offset: 128497},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4188, col: 13, offset: 128420},
+							pos:   position{line: 4190, col: 13, offset: 128501},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4188, col: 19, offset: 128426},
+								pos: position{line: 4190, col: 19, offset: 128507},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4188, col: 19, offset: 128426},
+										pos:  position{line: 4190, col: 19, offset: 128507},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4188, col: 30, offset: 128437},
+										pos:  position{line: 4190, col: 30, offset: 128518},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9858,26 +9858,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4192, col: 1, offset: 128485},
+			pos:  position{line: 4194, col: 1, offset: 128566},
 			expr: &actionExpr{
-				pos: position{line: 4192, col: 11, offset: 128495},
+				pos: position{line: 4194, col: 11, offset: 128576},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4192, col: 11, offset: 128495},
+					pos: position{line: 4194, col: 11, offset: 128576},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4192, col: 11, offset: 128495},
+							pos:   position{line: 4194, col: 11, offset: 128576},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4192, col: 16, offset: 128500},
+								pos:  position{line: 4194, col: 16, offset: 128581},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4192, col: 36, offset: 128520},
+							pos:   position{line: 4194, col: 36, offset: 128601},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4192, col: 43, offset: 128527},
+								pos:  position{line: 4194, col: 43, offset: 128608},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9887,44 +9887,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4220, col: 1, offset: 129265},
+			pos:  position{line: 4222, col: 1, offset: 129346},
 			expr: &actionExpr{
-				pos: position{line: 4220, col: 29, offset: 129293},
+				pos: position{line: 4222, col: 29, offset: 129374},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4220, col: 29, offset: 129293},
+					pos: position{line: 4222, col: 29, offset: 129374},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4220, col: 29, offset: 129293},
+							pos:   position{line: 4222, col: 29, offset: 129374},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4220, col: 36, offset: 129300},
+								pos: position{line: 4222, col: 36, offset: 129381},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4220, col: 36, offset: 129300},
+										pos:  position{line: 4222, col: 36, offset: 129381},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4220, col: 45, offset: 129309},
+										pos:  position{line: 4222, col: 45, offset: 129390},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4220, col: 51, offset: 129315},
+							pos:   position{line: 4222, col: 51, offset: 129396},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4220, col: 57, offset: 129321},
+								pos: position{line: 4222, col: 57, offset: 129402},
 								expr: &choiceExpr{
-									pos: position{line: 4220, col: 58, offset: 129322},
+									pos: position{line: 4222, col: 58, offset: 129403},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4220, col: 58, offset: 129322},
+											pos:  position{line: 4222, col: 58, offset: 129403},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4220, col: 67, offset: 129331},
+											pos:  position{line: 4222, col: 67, offset: 129412},
 											name: "Snap",
 										},
 									},
@@ -9937,29 +9937,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4267, col: 1, offset: 130763},
+			pos:  position{line: 4269, col: 1, offset: 130844},
 			expr: &actionExpr{
-				pos: position{line: 4267, col: 22, offset: 130784},
+				pos: position{line: 4269, col: 22, offset: 130865},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4267, col: 22, offset: 130784},
+					pos: position{line: 4269, col: 22, offset: 130865},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4267, col: 22, offset: 130784},
+							pos:   position{line: 4269, col: 22, offset: 130865},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4267, col: 34, offset: 130796},
+								pos: position{line: 4269, col: 34, offset: 130877},
 								expr: &choiceExpr{
-									pos: position{line: 4267, col: 35, offset: 130797},
+									pos: position{line: 4269, col: 35, offset: 130878},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4267, col: 35, offset: 130797},
+											pos:        position{line: 4269, col: 35, offset: 130878},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4267, col: 43, offset: 130805},
+											pos:        position{line: 4269, col: 43, offset: 130886},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9969,12 +9969,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4267, col: 49, offset: 130811},
+							pos:   position{line: 4269, col: 49, offset: 130892},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4267, col: 57, offset: 130819},
+								pos: position{line: 4269, col: 57, offset: 130900},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4267, col: 58, offset: 130820},
+									pos:  position{line: 4269, col: 58, offset: 130901},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9985,31 +9985,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4292, col: 1, offset: 131503},
+			pos:  position{line: 4294, col: 1, offset: 131584},
 			expr: &actionExpr{
-				pos: position{line: 4292, col: 39, offset: 131541},
+				pos: position{line: 4294, col: 39, offset: 131622},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4292, col: 39, offset: 131541},
+					pos: position{line: 4294, col: 39, offset: 131622},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4292, col: 39, offset: 131541},
+							pos:   position{line: 4294, col: 39, offset: 131622},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4292, col: 46, offset: 131548},
+								pos: position{line: 4294, col: 46, offset: 131629},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4292, col: 47, offset: 131549},
+									pos:  position{line: 4294, col: 47, offset: 131630},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4292, col: 56, offset: 131558},
+							pos:   position{line: 4294, col: 56, offset: 131639},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4292, col: 66, offset: 131568},
+								pos: position{line: 4294, col: 66, offset: 131649},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4292, col: 67, offset: 131569},
+									pos:  position{line: 4294, col: 67, offset: 131650},
 									name: "Snap",
 								},
 							},
@@ -10020,136 +10020,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4319, col: 1, offset: 132197},
+			pos:  position{line: 4321, col: 1, offset: 132278},
 			expr: &actionExpr{
-				pos: position{line: 4319, col: 18, offset: 132214},
+				pos: position{line: 4321, col: 18, offset: 132295},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4319, col: 18, offset: 132214},
+					pos: position{line: 4321, col: 18, offset: 132295},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 18, offset: 132214},
+							pos:        position{line: 4321, col: 18, offset: 132295},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 23, offset: 132219},
+							pos:        position{line: 4321, col: 23, offset: 132300},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4319, col: 29, offset: 132225},
+							pos:        position{line: 4321, col: 29, offset: 132306},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 33, offset: 132229},
+							pos:        position{line: 4321, col: 33, offset: 132310},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 38, offset: 132234},
+							pos:        position{line: 4321, col: 38, offset: 132315},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4319, col: 44, offset: 132240},
+							pos:        position{line: 4321, col: 44, offset: 132321},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 48, offset: 132244},
+							pos:        position{line: 4321, col: 48, offset: 132325},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 53, offset: 132249},
+							pos:        position{line: 4321, col: 53, offset: 132330},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 58, offset: 132254},
+							pos:        position{line: 4321, col: 58, offset: 132335},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 63, offset: 132259},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4319, col: 69, offset: 132265},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4319, col: 73, offset: 132269},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4319, col: 78, offset: 132274},
+							pos:        position{line: 4321, col: 63, offset: 132340},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4319, col: 84, offset: 132280},
+							pos:        position{line: 4321, col: 69, offset: 132346},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 88, offset: 132284},
+							pos:        position{line: 4321, col: 73, offset: 132350},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 93, offset: 132289},
+							pos:        position{line: 4321, col: 78, offset: 132355},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4319, col: 99, offset: 132295},
+							pos:        position{line: 4321, col: 84, offset: 132361},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 103, offset: 132299},
+							pos:        position{line: 4321, col: 88, offset: 132365},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 108, offset: 132304},
+							pos:        position{line: 4321, col: 93, offset: 132370},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4321, col: 99, offset: 132376},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4321, col: 103, offset: 132380},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4321, col: 108, offset: 132385},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10161,15 +10161,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4323, col: 1, offset: 132346},
+			pos:  position{line: 4325, col: 1, offset: 132427},
 			expr: &actionExpr{
-				pos: position{line: 4323, col: 22, offset: 132367},
+				pos: position{line: 4325, col: 22, offset: 132448},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4323, col: 22, offset: 132367},
+					pos:   position{line: 4325, col: 22, offset: 132448},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4323, col: 32, offset: 132377},
+						pos:  position{line: 4325, col: 32, offset: 132458},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10177,15 +10177,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4333, col: 1, offset: 132785},
+			pos:  position{line: 4335, col: 1, offset: 132866},
 			expr: &actionExpr{
-				pos: position{line: 4333, col: 14, offset: 132798},
+				pos: position{line: 4335, col: 14, offset: 132879},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4333, col: 14, offset: 132798},
+					pos: position{line: 4335, col: 14, offset: 132879},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4333, col: 14, offset: 132798},
+							pos:        position{line: 4335, col: 14, offset: 132879},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10193,9 +10193,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4333, col: 27, offset: 132811},
+							pos: position{line: 4335, col: 27, offset: 132892},
 							expr: &charClassMatcher{
-								pos:        position{line: 4333, col: 27, offset: 132811},
+								pos:        position{line: 4335, col: 27, offset: 132892},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10209,15 +10209,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4337, col: 1, offset: 132864},
+			pos:  position{line: 4339, col: 1, offset: 132945},
 			expr: &actionExpr{
-				pos: position{line: 4337, col: 24, offset: 132887},
+				pos: position{line: 4339, col: 24, offset: 132968},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4337, col: 24, offset: 132887},
+					pos: position{line: 4339, col: 24, offset: 132968},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4337, col: 24, offset: 132887},
+							pos:        position{line: 4339, col: 24, offset: 132968},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10225,9 +10225,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4337, col: 39, offset: 132902},
+							pos: position{line: 4339, col: 39, offset: 132983},
 							expr: &charClassMatcher{
-								pos:        position{line: 4337, col: 39, offset: 132902},
+								pos:        position{line: 4339, col: 39, offset: 132983},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10241,22 +10241,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4341, col: 1, offset: 132955},
+			pos:  position{line: 4343, col: 1, offset: 133036},
 			expr: &actionExpr{
-				pos: position{line: 4341, col: 11, offset: 132965},
+				pos: position{line: 4343, col: 11, offset: 133046},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4341, col: 11, offset: 132965},
+					pos:   position{line: 4343, col: 11, offset: 133046},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4341, col: 16, offset: 132970},
+						pos: position{line: 4343, col: 16, offset: 133051},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4341, col: 16, offset: 132970},
+								pos:  position{line: 4343, col: 16, offset: 133051},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4341, col: 31, offset: 132985},
+								pos:  position{line: 4343, col: 31, offset: 133066},
 								name: "UnquotedString",
 							},
 						},
@@ -10266,23 +10266,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4345, col: 1, offset: 133026},
+			pos:  position{line: 4347, col: 1, offset: 133107},
 			expr: &actionExpr{
-				pos: position{line: 4345, col: 17, offset: 133042},
+				pos: position{line: 4347, col: 17, offset: 133123},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4345, col: 17, offset: 133042},
+					pos: position{line: 4347, col: 17, offset: 133123},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4345, col: 17, offset: 133042},
+							pos:        position{line: 4347, col: 17, offset: 133123},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4345, col: 21, offset: 133046},
+							pos: position{line: 4347, col: 21, offset: 133127},
 							expr: &charClassMatcher{
-								pos:        position{line: 4345, col: 21, offset: 133046},
+								pos:        position{line: 4347, col: 21, offset: 133127},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10290,7 +10290,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4345, col: 27, offset: 133052},
+							pos:        position{line: 4347, col: 27, offset: 133133},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10301,48 +10301,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4350, col: 1, offset: 133163},
+			pos:  position{line: 4352, col: 1, offset: 133244},
 			expr: &actionExpr{
-				pos: position{line: 4350, col: 19, offset: 133181},
+				pos: position{line: 4352, col: 19, offset: 133262},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4350, col: 19, offset: 133181},
+					pos: position{line: 4352, col: 19, offset: 133262},
 					expr: &choiceExpr{
-						pos: position{line: 4350, col: 20, offset: 133182},
+						pos: position{line: 4352, col: 20, offset: 133263},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4350, col: 20, offset: 133182},
+								pos:        position{line: 4352, col: 20, offset: 133263},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4350, col: 27, offset: 133189},
+								pos: position{line: 4352, col: 27, offset: 133270},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4350, col: 27, offset: 133189},
+										pos: position{line: 4352, col: 27, offset: 133270},
 										expr: &choiceExpr{
-											pos: position{line: 4350, col: 29, offset: 133191},
+											pos: position{line: 4352, col: 29, offset: 133272},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4350, col: 29, offset: 133191},
+													pos:  position{line: 4352, col: 29, offset: 133272},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4350, col: 43, offset: 133205},
+													pos:        position{line: 4352, col: 43, offset: 133286},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4350, col: 49, offset: 133211},
+													pos:  position{line: 4352, col: 49, offset: 133292},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4350, col: 54, offset: 133216,
+										line: 4352, col: 54, offset: 133297,
 									},
 								},
 							},
@@ -10353,12 +10353,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4357, col: 1, offset: 133331},
+			pos:  position{line: 4359, col: 1, offset: 133412},
 			expr: &choiceExpr{
-				pos: position{line: 4357, col: 16, offset: 133346},
+				pos: position{line: 4359, col: 16, offset: 133427},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4357, col: 16, offset: 133346},
+						pos:        position{line: 4359, col: 16, offset: 133427},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10366,18 +10366,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4357, col: 37, offset: 133367},
+						pos: position{line: 4359, col: 37, offset: 133448},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4357, col: 37, offset: 133367},
+								pos:        position{line: 4359, col: 37, offset: 133448},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4357, col: 41, offset: 133371},
+								pos: position{line: 4359, col: 41, offset: 133452},
 								expr: &charClassMatcher{
-									pos:        position{line: 4357, col: 41, offset: 133371},
+									pos:        position{line: 4359, col: 41, offset: 133452},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10385,7 +10385,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4357, col: 48, offset: 133378},
+								pos:        position{line: 4359, col: 48, offset: 133459},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10397,46 +10397,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4359, col: 1, offset: 133384},
+			pos:  position{line: 4361, col: 1, offset: 133465},
 			expr: &actionExpr{
-				pos: position{line: 4359, col: 39, offset: 133422},
+				pos: position{line: 4361, col: 39, offset: 133503},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4359, col: 39, offset: 133422},
+					pos: position{line: 4361, col: 39, offset: 133503},
 					expr: &choiceExpr{
-						pos: position{line: 4359, col: 40, offset: 133423},
+						pos: position{line: 4361, col: 40, offset: 133504},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4359, col: 40, offset: 133423},
+								pos:  position{line: 4361, col: 40, offset: 133504},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4359, col: 54, offset: 133437},
+								pos: position{line: 4361, col: 54, offset: 133518},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4359, col: 54, offset: 133437},
+										pos: position{line: 4361, col: 54, offset: 133518},
 										expr: &choiceExpr{
-											pos: position{line: 4359, col: 56, offset: 133439},
+											pos: position{line: 4361, col: 56, offset: 133520},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4359, col: 56, offset: 133439},
+													pos:  position{line: 4361, col: 56, offset: 133520},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4359, col: 70, offset: 133453},
+													pos:        position{line: 4361, col: 70, offset: 133534},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4359, col: 76, offset: 133459},
+													pos:  position{line: 4361, col: 76, offset: 133540},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4359, col: 81, offset: 133464,
+										line: 4361, col: 81, offset: 133545,
 									},
 								},
 							},
@@ -10447,21 +10447,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4363, col: 1, offset: 133504},
+			pos:  position{line: 4365, col: 1, offset: 133585},
 			expr: &actionExpr{
-				pos: position{line: 4363, col: 12, offset: 133515},
+				pos: position{line: 4365, col: 12, offset: 133596},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4363, col: 13, offset: 133516},
+					pos: position{line: 4365, col: 13, offset: 133597},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4363, col: 13, offset: 133516},
+							pos:        position{line: 4365, col: 13, offset: 133597},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4363, col: 22, offset: 133525},
+							pos:        position{line: 4365, col: 22, offset: 133606},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10472,14 +10472,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4369, col: 1, offset: 133679},
+			pos:  position{line: 4371, col: 1, offset: 133760},
 			expr: &actionExpr{
-				pos: position{line: 4369, col: 18, offset: 133696},
+				pos: position{line: 4371, col: 18, offset: 133777},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4369, col: 18, offset: 133696},
+					pos: position{line: 4371, col: 18, offset: 133777},
 					expr: &charClassMatcher{
-						pos:        position{line: 4369, col: 18, offset: 133696},
+						pos:        position{line: 4371, col: 18, offset: 133777},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10491,15 +10491,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4373, col: 1, offset: 133747},
+			pos:  position{line: 4375, col: 1, offset: 133828},
 			expr: &actionExpr{
-				pos: position{line: 4373, col: 11, offset: 133757},
+				pos: position{line: 4375, col: 11, offset: 133838},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4373, col: 11, offset: 133757},
+					pos:   position{line: 4375, col: 11, offset: 133838},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4373, col: 18, offset: 133764},
+						pos:  position{line: 4375, col: 18, offset: 133845},
 						name: "NumberAsString",
 					},
 				},
@@ -10507,59 +10507,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4379, col: 1, offset: 133953},
+			pos:  position{line: 4381, col: 1, offset: 134034},
 			expr: &actionExpr{
-				pos: position{line: 4379, col: 19, offset: 133971},
+				pos: position{line: 4381, col: 19, offset: 134052},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4379, col: 19, offset: 133971},
+					pos: position{line: 4381, col: 19, offset: 134052},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4379, col: 19, offset: 133971},
+							pos:   position{line: 4381, col: 19, offset: 134052},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4379, col: 27, offset: 133979},
+								pos: position{line: 4381, col: 27, offset: 134060},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4379, col: 27, offset: 133979},
+										pos:  position{line: 4381, col: 27, offset: 134060},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4379, col: 43, offset: 133995},
+										pos:  position{line: 4381, col: 43, offset: 134076},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4379, col: 60, offset: 134012},
+							pos: position{line: 4381, col: 60, offset: 134093},
 							expr: &choiceExpr{
-								pos: position{line: 4379, col: 62, offset: 134014},
+								pos: position{line: 4381, col: 62, offset: 134095},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4379, col: 62, offset: 134014},
+										pos:  position{line: 4381, col: 62, offset: 134095},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4379, col: 70, offset: 134022},
+										pos:        position{line: 4381, col: 70, offset: 134103},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4379, col: 76, offset: 134028},
+										pos:        position{line: 4381, col: 76, offset: 134109},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4379, col: 82, offset: 134034},
+										pos:        position{line: 4381, col: 82, offset: 134115},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4379, col: 88, offset: 134040},
+										pos:  position{line: 4381, col: 88, offset: 134121},
 										name: "EOF",
 									},
 								},
@@ -10571,17 +10571,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4385, col: 1, offset: 134169},
+			pos:  position{line: 4387, col: 1, offset: 134250},
 			expr: &actionExpr{
-				pos: position{line: 4385, col: 18, offset: 134186},
+				pos: position{line: 4387, col: 18, offset: 134267},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4385, col: 18, offset: 134186},
+					pos: position{line: 4387, col: 18, offset: 134267},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4385, col: 18, offset: 134186},
+							pos: position{line: 4387, col: 18, offset: 134267},
 							expr: &charClassMatcher{
-								pos:        position{line: 4385, col: 18, offset: 134186},
+								pos:        position{line: 4387, col: 18, offset: 134267},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10589,9 +10589,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4385, col: 24, offset: 134192},
+							pos: position{line: 4387, col: 24, offset: 134273},
 							expr: &charClassMatcher{
-								pos:        position{line: 4385, col: 24, offset: 134192},
+								pos:        position{line: 4387, col: 24, offset: 134273},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10599,15 +10599,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4385, col: 31, offset: 134199},
+							pos:        position{line: 4387, col: 31, offset: 134280},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4385, col: 35, offset: 134203},
+							pos: position{line: 4387, col: 35, offset: 134284},
 							expr: &charClassMatcher{
-								pos:        position{line: 4385, col: 35, offset: 134203},
+								pos:        position{line: 4387, col: 35, offset: 134284},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10620,17 +10620,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4390, col: 1, offset: 134298},
+			pos:  position{line: 4392, col: 1, offset: 134379},
 			expr: &actionExpr{
-				pos: position{line: 4390, col: 20, offset: 134317},
+				pos: position{line: 4392, col: 20, offset: 134398},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4390, col: 20, offset: 134317},
+					pos: position{line: 4392, col: 20, offset: 134398},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4390, col: 20, offset: 134317},
+							pos: position{line: 4392, col: 20, offset: 134398},
 							expr: &charClassMatcher{
-								pos:        position{line: 4390, col: 20, offset: 134317},
+								pos:        position{line: 4392, col: 20, offset: 134398},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10638,9 +10638,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4390, col: 26, offset: 134323},
+							pos: position{line: 4392, col: 26, offset: 134404},
 							expr: &charClassMatcher{
-								pos:        position{line: 4390, col: 26, offset: 134323},
+								pos:        position{line: 4392, col: 26, offset: 134404},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10653,14 +10653,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4394, col: 1, offset: 134366},
+			pos:  position{line: 4396, col: 1, offset: 134447},
 			expr: &actionExpr{
-				pos: position{line: 4394, col: 28, offset: 134393},
+				pos: position{line: 4396, col: 28, offset: 134474},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4394, col: 28, offset: 134393},
+					pos: position{line: 4396, col: 28, offset: 134474},
 					expr: &charClassMatcher{
-						pos:        position{line: 4394, col: 28, offset: 134393},
+						pos:        position{line: 4396, col: 28, offset: 134474},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10671,15 +10671,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4398, col: 1, offset: 134436},
+			pos:  position{line: 4400, col: 1, offset: 134517},
 			expr: &actionExpr{
-				pos: position{line: 4398, col: 20, offset: 134455},
+				pos: position{line: 4400, col: 20, offset: 134536},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4398, col: 20, offset: 134455},
+					pos:   position{line: 4400, col: 20, offset: 134536},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4398, col: 27, offset: 134462},
+						pos:  position{line: 4400, col: 27, offset: 134543},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10687,31 +10687,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4406, col: 1, offset: 134709},
+			pos:  position{line: 4408, col: 1, offset: 134790},
 			expr: &actionExpr{
-				pos: position{line: 4406, col: 21, offset: 134729},
+				pos: position{line: 4408, col: 21, offset: 134810},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4406, col: 21, offset: 134729},
+					pos: position{line: 4408, col: 21, offset: 134810},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4406, col: 21, offset: 134729},
+							pos:  position{line: 4408, col: 21, offset: 134810},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4406, col: 36, offset: 134744},
+							pos:   position{line: 4408, col: 36, offset: 134825},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4406, col: 40, offset: 134748},
+								pos: position{line: 4408, col: 40, offset: 134829},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4406, col: 40, offset: 134748},
+										pos:        position{line: 4408, col: 40, offset: 134829},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4406, col: 46, offset: 134754},
+										pos:        position{line: 4408, col: 46, offset: 134835},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10720,7 +10720,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4406, col: 52, offset: 134760},
+							pos:  position{line: 4408, col: 52, offset: 134841},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10729,43 +10729,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4414, col: 1, offset: 134941},
+			pos:  position{line: 4416, col: 1, offset: 135022},
 			expr: &actionExpr{
-				pos: position{line: 4414, col: 23, offset: 134963},
+				pos: position{line: 4416, col: 23, offset: 135044},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4414, col: 23, offset: 134963},
+					pos: position{line: 4416, col: 23, offset: 135044},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4414, col: 23, offset: 134963},
+							pos:  position{line: 4416, col: 23, offset: 135044},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4414, col: 38, offset: 134978},
+							pos:   position{line: 4416, col: 38, offset: 135059},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4414, col: 42, offset: 134982},
+								pos: position{line: 4416, col: 42, offset: 135063},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4414, col: 42, offset: 134982},
+										pos:        position{line: 4416, col: 42, offset: 135063},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4414, col: 49, offset: 134989},
+										pos:        position{line: 4416, col: 49, offset: 135070},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4414, col: 55, offset: 134995},
+										pos:        position{line: 4416, col: 55, offset: 135076},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4414, col: 62, offset: 135002},
+										pos:        position{line: 4416, col: 62, offset: 135083},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10774,7 +10774,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4414, col: 67, offset: 135007},
+							pos:  position{line: 4416, col: 67, offset: 135088},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10783,30 +10783,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4422, col: 1, offset: 135190},
+			pos:  position{line: 4424, col: 1, offset: 135271},
 			expr: &choiceExpr{
-				pos: position{line: 4422, col: 25, offset: 135214},
+				pos: position{line: 4424, col: 25, offset: 135295},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4422, col: 25, offset: 135214},
+						pos: position{line: 4424, col: 25, offset: 135295},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4422, col: 25, offset: 135214},
+							pos:   position{line: 4424, col: 25, offset: 135295},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4422, col: 28, offset: 135217},
+								pos:  position{line: 4424, col: 28, offset: 135298},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4425, col: 3, offset: 135259},
+						pos: position{line: 4427, col: 3, offset: 135340},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4425, col: 3, offset: 135259},
+							pos:   position{line: 4427, col: 3, offset: 135340},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4425, col: 6, offset: 135262},
+								pos:  position{line: 4427, col: 6, offset: 135343},
 								name: "InequalityOperator",
 							},
 						},
@@ -10816,25 +10816,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4429, col: 1, offset: 135305},
+			pos:  position{line: 4431, col: 1, offset: 135386},
 			expr: &actionExpr{
-				pos: position{line: 4429, col: 11, offset: 135315},
+				pos: position{line: 4431, col: 11, offset: 135396},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4429, col: 11, offset: 135315},
+					pos: position{line: 4431, col: 11, offset: 135396},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4429, col: 11, offset: 135315},
+							pos:  position{line: 4431, col: 11, offset: 135396},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4429, col: 26, offset: 135330},
+							pos:        position{line: 4431, col: 26, offset: 135411},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4429, col: 30, offset: 135334},
+							pos:  position{line: 4431, col: 30, offset: 135415},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10843,25 +10843,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4433, col: 1, offset: 135374},
+			pos:  position{line: 4435, col: 1, offset: 135455},
 			expr: &actionExpr{
-				pos: position{line: 4433, col: 12, offset: 135385},
+				pos: position{line: 4435, col: 12, offset: 135466},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4433, col: 12, offset: 135385},
+					pos: position{line: 4435, col: 12, offset: 135466},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4433, col: 12, offset: 135385},
+							pos:  position{line: 4435, col: 12, offset: 135466},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4433, col: 27, offset: 135400},
+							pos:        position{line: 4435, col: 27, offset: 135481},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4433, col: 31, offset: 135404},
+							pos:  position{line: 4435, col: 31, offset: 135485},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10870,25 +10870,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4437, col: 1, offset: 135444},
+			pos:  position{line: 4439, col: 1, offset: 135525},
 			expr: &actionExpr{
-				pos: position{line: 4437, col: 10, offset: 135453},
+				pos: position{line: 4439, col: 10, offset: 135534},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4437, col: 10, offset: 135453},
+					pos: position{line: 4439, col: 10, offset: 135534},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4437, col: 10, offset: 135453},
+							pos:  position{line: 4439, col: 10, offset: 135534},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4437, col: 25, offset: 135468},
+							pos:        position{line: 4439, col: 25, offset: 135549},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4437, col: 29, offset: 135472},
+							pos:  position{line: 4439, col: 29, offset: 135553},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10897,25 +10897,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4441, col: 1, offset: 135512},
+			pos:  position{line: 4443, col: 1, offset: 135593},
 			expr: &actionExpr{
-				pos: position{line: 4441, col: 10, offset: 135521},
+				pos: position{line: 4443, col: 10, offset: 135602},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4441, col: 10, offset: 135521},
+					pos: position{line: 4443, col: 10, offset: 135602},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4441, col: 10, offset: 135521},
+							pos:  position{line: 4443, col: 10, offset: 135602},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4441, col: 25, offset: 135536},
+							pos:        position{line: 4443, col: 25, offset: 135617},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4441, col: 29, offset: 135540},
+							pos:  position{line: 4443, col: 29, offset: 135621},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10924,25 +10924,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4445, col: 1, offset: 135580},
+			pos:  position{line: 4447, col: 1, offset: 135661},
 			expr: &actionExpr{
-				pos: position{line: 4445, col: 10, offset: 135589},
+				pos: position{line: 4447, col: 10, offset: 135670},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4445, col: 10, offset: 135589},
+					pos: position{line: 4447, col: 10, offset: 135670},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4445, col: 10, offset: 135589},
+							pos:  position{line: 4447, col: 10, offset: 135670},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4445, col: 25, offset: 135604},
+							pos:        position{line: 4447, col: 25, offset: 135685},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4445, col: 29, offset: 135608},
+							pos:  position{line: 4447, col: 29, offset: 135689},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10951,39 +10951,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4450, col: 1, offset: 135672},
+			pos:  position{line: 4452, col: 1, offset: 135753},
 			expr: &actionExpr{
-				pos: position{line: 4450, col: 11, offset: 135682},
+				pos: position{line: 4452, col: 11, offset: 135763},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4450, col: 12, offset: 135683},
+					pos: position{line: 4452, col: 12, offset: 135764},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4450, col: 12, offset: 135683},
+							pos:        position{line: 4452, col: 12, offset: 135764},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4450, col: 24, offset: 135695},
+							pos:        position{line: 4452, col: 24, offset: 135776},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4450, col: 35, offset: 135706},
+							pos:        position{line: 4452, col: 35, offset: 135787},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4450, col: 44, offset: 135715},
+							pos:        position{line: 4452, col: 44, offset: 135796},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4450, col: 52, offset: 135723},
+							pos:        position{line: 4452, col: 52, offset: 135804},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10994,39 +10994,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4454, col: 1, offset: 135764},
+			pos:  position{line: 4456, col: 1, offset: 135845},
 			expr: &actionExpr{
-				pos: position{line: 4454, col: 11, offset: 135774},
+				pos: position{line: 4456, col: 11, offset: 135855},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4454, col: 12, offset: 135775},
+					pos: position{line: 4456, col: 12, offset: 135856},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4454, col: 12, offset: 135775},
+							pos:        position{line: 4456, col: 12, offset: 135856},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4454, col: 24, offset: 135787},
+							pos:        position{line: 4456, col: 24, offset: 135868},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4454, col: 35, offset: 135798},
+							pos:        position{line: 4456, col: 35, offset: 135879},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4454, col: 44, offset: 135807},
+							pos:        position{line: 4456, col: 44, offset: 135888},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4454, col: 52, offset: 135815},
+							pos:        position{line: 4456, col: 52, offset: 135896},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11037,39 +11037,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4458, col: 1, offset: 135856},
+			pos:  position{line: 4460, col: 1, offset: 135937},
 			expr: &actionExpr{
-				pos: position{line: 4458, col: 9, offset: 135864},
+				pos: position{line: 4460, col: 9, offset: 135945},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4458, col: 10, offset: 135865},
+					pos: position{line: 4460, col: 10, offset: 135946},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4458, col: 10, offset: 135865},
+							pos:        position{line: 4460, col: 10, offset: 135946},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4458, col: 20, offset: 135875},
+							pos:        position{line: 4460, col: 20, offset: 135956},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4458, col: 29, offset: 135884},
+							pos:        position{line: 4460, col: 29, offset: 135965},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4458, col: 37, offset: 135892},
+							pos:        position{line: 4460, col: 37, offset: 135973},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4458, col: 44, offset: 135899},
+							pos:        position{line: 4460, col: 44, offset: 135980},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11080,27 +11080,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4462, col: 1, offset: 135938},
+			pos:  position{line: 4464, col: 1, offset: 136019},
 			expr: &actionExpr{
-				pos: position{line: 4462, col: 8, offset: 135945},
+				pos: position{line: 4464, col: 8, offset: 136026},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4462, col: 9, offset: 135946},
+					pos: position{line: 4464, col: 9, offset: 136027},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4462, col: 9, offset: 135946},
+							pos:        position{line: 4464, col: 9, offset: 136027},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4462, col: 18, offset: 135955},
+							pos:        position{line: 4464, col: 18, offset: 136036},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4462, col: 26, offset: 135963},
+							pos:        position{line: 4464, col: 26, offset: 136044},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11111,27 +11111,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4466, col: 1, offset: 136001},
+			pos:  position{line: 4468, col: 1, offset: 136082},
 			expr: &actionExpr{
-				pos: position{line: 4466, col: 9, offset: 136009},
+				pos: position{line: 4468, col: 9, offset: 136090},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4466, col: 10, offset: 136010},
+					pos: position{line: 4468, col: 10, offset: 136091},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4466, col: 10, offset: 136010},
+							pos:        position{line: 4468, col: 10, offset: 136091},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4466, col: 20, offset: 136020},
+							pos:        position{line: 4468, col: 20, offset: 136101},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4466, col: 29, offset: 136029},
+							pos:        position{line: 4468, col: 29, offset: 136110},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11142,27 +11142,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4470, col: 1, offset: 136068},
+			pos:  position{line: 4472, col: 1, offset: 136149},
 			expr: &actionExpr{
-				pos: position{line: 4470, col: 10, offset: 136077},
+				pos: position{line: 4472, col: 10, offset: 136158},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4470, col: 11, offset: 136078},
+					pos: position{line: 4472, col: 11, offset: 136159},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4470, col: 11, offset: 136078},
+							pos:        position{line: 4472, col: 11, offset: 136159},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4470, col: 22, offset: 136089},
+							pos:        position{line: 4472, col: 22, offset: 136170},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4470, col: 32, offset: 136099},
+							pos:        position{line: 4472, col: 32, offset: 136180},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11173,39 +11173,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4474, col: 1, offset: 136141},
+			pos:  position{line: 4476, col: 1, offset: 136222},
 			expr: &actionExpr{
-				pos: position{line: 4474, col: 12, offset: 136152},
+				pos: position{line: 4476, col: 12, offset: 136233},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4474, col: 13, offset: 136153},
+					pos: position{line: 4476, col: 13, offset: 136234},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4474, col: 13, offset: 136153},
+							pos:        position{line: 4476, col: 13, offset: 136234},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4474, col: 26, offset: 136166},
+							pos:        position{line: 4476, col: 26, offset: 136247},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4474, col: 38, offset: 136178},
+							pos:        position{line: 4476, col: 38, offset: 136259},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4474, col: 47, offset: 136187},
+							pos:        position{line: 4476, col: 47, offset: 136268},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4474, col: 55, offset: 136195},
+							pos:        position{line: 4476, col: 55, offset: 136276},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11216,39 +11216,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4478, col: 1, offset: 136237},
+			pos:  position{line: 4480, col: 1, offset: 136318},
 			expr: &actionExpr{
-				pos: position{line: 4478, col: 9, offset: 136245},
+				pos: position{line: 4480, col: 9, offset: 136326},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4478, col: 10, offset: 136246},
+					pos: position{line: 4480, col: 10, offset: 136327},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4478, col: 10, offset: 136246},
+							pos:        position{line: 4480, col: 10, offset: 136327},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4478, col: 20, offset: 136256},
+							pos:        position{line: 4480, col: 20, offset: 136337},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4478, col: 29, offset: 136265},
+							pos:        position{line: 4480, col: 29, offset: 136346},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4478, col: 37, offset: 136273},
+							pos:        position{line: 4480, col: 37, offset: 136354},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4478, col: 44, offset: 136280},
+							pos:        position{line: 4480, col: 44, offset: 136361},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11259,33 +11259,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4483, col: 1, offset: 136411},
+			pos:  position{line: 4485, col: 1, offset: 136492},
 			expr: &actionExpr{
-				pos: position{line: 4483, col: 15, offset: 136425},
+				pos: position{line: 4485, col: 15, offset: 136506},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4483, col: 16, offset: 136426},
+					pos: position{line: 4485, col: 16, offset: 136507},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4483, col: 16, offset: 136426},
+							pos:        position{line: 4485, col: 16, offset: 136507},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4483, col: 23, offset: 136433},
+							pos:        position{line: 4485, col: 23, offset: 136514},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4483, col: 30, offset: 136440},
+							pos:        position{line: 4485, col: 30, offset: 136521},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4483, col: 37, offset: 136447},
+							pos:        position{line: 4485, col: 37, offset: 136528},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11296,26 +11296,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4492, col: 1, offset: 136670},
+			pos:  position{line: 4494, col: 1, offset: 136751},
 			expr: &actionExpr{
-				pos: position{line: 4492, col: 21, offset: 136690},
+				pos: position{line: 4494, col: 21, offset: 136771},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4492, col: 21, offset: 136690},
+					pos: position{line: 4494, col: 21, offset: 136771},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4492, col: 21, offset: 136690},
+							pos:  position{line: 4494, col: 21, offset: 136771},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4492, col: 26, offset: 136695},
+							pos:  position{line: 4494, col: 26, offset: 136776},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4492, col: 42, offset: 136711},
+							pos:   position{line: 4494, col: 42, offset: 136792},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4492, col: 53, offset: 136722},
+								pos:  position{line: 4494, col: 53, offset: 136803},
 								name: "TransactionOptions",
 							},
 						},
@@ -11325,17 +11325,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4502, col: 1, offset: 137097},
+			pos:  position{line: 4504, col: 1, offset: 137178},
 			expr: &actionExpr{
-				pos: position{line: 4502, col: 23, offset: 137119},
+				pos: position{line: 4504, col: 23, offset: 137200},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4502, col: 23, offset: 137119},
+					pos:   position{line: 4504, col: 23, offset: 137200},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4502, col: 34, offset: 137130},
+						pos: position{line: 4504, col: 34, offset: 137211},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4502, col: 34, offset: 137130},
+							pos:  position{line: 4504, col: 34, offset: 137211},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11344,35 +11344,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4517, col: 1, offset: 137521},
+			pos:  position{line: 4519, col: 1, offset: 137602},
 			expr: &actionExpr{
-				pos: position{line: 4517, col: 37, offset: 137557},
+				pos: position{line: 4519, col: 37, offset: 137638},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4517, col: 37, offset: 137557},
+					pos: position{line: 4519, col: 37, offset: 137638},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4517, col: 37, offset: 137557},
+							pos:   position{line: 4519, col: 37, offset: 137638},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4517, col: 43, offset: 137563},
+								pos:  position{line: 4519, col: 43, offset: 137644},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4517, col: 71, offset: 137591},
+							pos:   position{line: 4519, col: 71, offset: 137672},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4517, col: 76, offset: 137596},
+								pos: position{line: 4519, col: 76, offset: 137677},
 								expr: &seqExpr{
-									pos: position{line: 4517, col: 77, offset: 137597},
+									pos: position{line: 4519, col: 77, offset: 137678},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4517, col: 77, offset: 137597},
+											pos:  position{line: 4519, col: 77, offset: 137678},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4517, col: 83, offset: 137603},
+											pos:  position{line: 4519, col: 83, offset: 137684},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11385,26 +11385,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4552, col: 1, offset: 138592},
+			pos:  position{line: 4554, col: 1, offset: 138673},
 			expr: &actionExpr{
-				pos: position{line: 4552, col: 32, offset: 138623},
+				pos: position{line: 4554, col: 32, offset: 138704},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4552, col: 32, offset: 138623},
+					pos:   position{line: 4554, col: 32, offset: 138704},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4552, col: 40, offset: 138631},
+						pos: position{line: 4554, col: 40, offset: 138712},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4552, col: 40, offset: 138631},
+								pos:  position{line: 4554, col: 40, offset: 138712},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4552, col: 77, offset: 138668},
+								pos:  position{line: 4554, col: 77, offset: 138749},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4552, col: 96, offset: 138687},
+								pos:  position{line: 4554, col: 96, offset: 138768},
 								name: "EndsWithOption",
 							},
 						},
@@ -11414,15 +11414,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4556, col: 1, offset: 138731},
+			pos:  position{line: 4558, col: 1, offset: 138812},
 			expr: &actionExpr{
-				pos: position{line: 4556, col: 39, offset: 138769},
+				pos: position{line: 4558, col: 39, offset: 138850},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4556, col: 39, offset: 138769},
+					pos:   position{line: 4558, col: 39, offset: 138850},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4556, col: 46, offset: 138776},
+						pos:  position{line: 4558, col: 46, offset: 138857},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11430,28 +11430,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4567, col: 1, offset: 138992},
+			pos:  position{line: 4569, col: 1, offset: 139073},
 			expr: &actionExpr{
-				pos: position{line: 4567, col: 21, offset: 139012},
+				pos: position{line: 4569, col: 21, offset: 139093},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4567, col: 21, offset: 139012},
+					pos: position{line: 4569, col: 21, offset: 139093},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4567, col: 21, offset: 139012},
+							pos:        position{line: 4569, col: 21, offset: 139093},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4567, col: 34, offset: 139025},
+							pos:  position{line: 4569, col: 34, offset: 139106},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4567, col: 40, offset: 139031},
+							pos:   position{line: 4569, col: 40, offset: 139112},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4567, col: 48, offset: 139039},
+								pos:  position{line: 4569, col: 48, offset: 139120},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11461,28 +11461,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4577, col: 1, offset: 139277},
+			pos:  position{line: 4579, col: 1, offset: 139358},
 			expr: &actionExpr{
-				pos: position{line: 4577, col: 19, offset: 139295},
+				pos: position{line: 4579, col: 19, offset: 139376},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4577, col: 19, offset: 139295},
+					pos: position{line: 4579, col: 19, offset: 139376},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4577, col: 19, offset: 139295},
+							pos:        position{line: 4579, col: 19, offset: 139376},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4577, col: 30, offset: 139306},
+							pos:  position{line: 4579, col: 30, offset: 139387},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4577, col: 36, offset: 139312},
+							pos:   position{line: 4579, col: 36, offset: 139393},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4577, col: 44, offset: 139320},
+								pos:  position{line: 4579, col: 44, offset: 139401},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11492,26 +11492,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4588, col: 1, offset: 139589},
+			pos:  position{line: 4590, col: 1, offset: 139670},
 			expr: &actionExpr{
-				pos: position{line: 4588, col: 28, offset: 139616},
+				pos: position{line: 4590, col: 28, offset: 139697},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4588, col: 28, offset: 139616},
+					pos:   position{line: 4590, col: 28, offset: 139697},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4588, col: 37, offset: 139625},
+						pos: position{line: 4590, col: 37, offset: 139706},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4588, col: 37, offset: 139625},
+								pos:  position{line: 4590, col: 37, offset: 139706},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4588, col: 63, offset: 139651},
+								pos:  position{line: 4590, col: 63, offset: 139732},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4588, col: 81, offset: 139669},
+								pos:  position{line: 4590, col: 81, offset: 139750},
 								name: "TransactionSearch",
 							},
 						},
@@ -11521,22 +11521,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4592, col: 1, offset: 139717},
+			pos:  position{line: 4594, col: 1, offset: 139798},
 			expr: &actionExpr{
-				pos: position{line: 4592, col: 28, offset: 139744},
+				pos: position{line: 4594, col: 28, offset: 139825},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4592, col: 28, offset: 139744},
+					pos:   position{line: 4594, col: 28, offset: 139825},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4592, col: 33, offset: 139749},
+						pos: position{line: 4594, col: 33, offset: 139830},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4592, col: 33, offset: 139749},
+								pos:  position{line: 4594, col: 33, offset: 139830},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4592, col: 64, offset: 139780},
+								pos:  position{line: 4594, col: 64, offset: 139861},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11546,29 +11546,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4596, col: 1, offset: 139840},
+			pos:  position{line: 4598, col: 1, offset: 139921},
 			expr: &actionExpr{
-				pos: position{line: 4596, col: 38, offset: 139877},
+				pos: position{line: 4598, col: 38, offset: 139958},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4596, col: 38, offset: 139877},
+					pos: position{line: 4598, col: 38, offset: 139958},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4596, col: 38, offset: 139877},
+							pos:        position{line: 4598, col: 38, offset: 139958},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4596, col: 42, offset: 139881},
+							pos:   position{line: 4598, col: 42, offset: 139962},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4596, col: 55, offset: 139894},
+								pos:  position{line: 4598, col: 55, offset: 139975},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4596, col: 68, offset: 139907},
+							pos:        position{line: 4598, col: 68, offset: 139988},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11579,23 +11579,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4604, col: 1, offset: 140046},
+			pos:  position{line: 4606, col: 1, offset: 140127},
 			expr: &actionExpr{
-				pos: position{line: 4604, col: 21, offset: 140066},
+				pos: position{line: 4606, col: 21, offset: 140147},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4604, col: 21, offset: 140066},
+					pos: position{line: 4606, col: 21, offset: 140147},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4604, col: 21, offset: 140066},
+							pos:        position{line: 4606, col: 21, offset: 140147},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4604, col: 25, offset: 140070},
+							pos: position{line: 4606, col: 25, offset: 140151},
 							expr: &charClassMatcher{
-								pos:        position{line: 4604, col: 25, offset: 140070},
+								pos:        position{line: 4606, col: 25, offset: 140151},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11603,7 +11603,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4604, col: 44, offset: 140089},
+							pos:        position{line: 4606, col: 44, offset: 140170},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11614,15 +11614,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4609, col: 1, offset: 140200},
+			pos:  position{line: 4611, col: 1, offset: 140281},
 			expr: &actionExpr{
-				pos: position{line: 4609, col: 33, offset: 140232},
+				pos: position{line: 4611, col: 33, offset: 140313},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4609, col: 33, offset: 140232},
+					pos:   position{line: 4611, col: 33, offset: 140313},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4609, col: 37, offset: 140236},
+						pos:  position{line: 4611, col: 37, offset: 140317},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11630,15 +11630,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4617, col: 1, offset: 140391},
+			pos:  position{line: 4619, col: 1, offset: 140472},
 			expr: &actionExpr{
-				pos: position{line: 4617, col: 22, offset: 140412},
+				pos: position{line: 4619, col: 22, offset: 140493},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4617, col: 22, offset: 140412},
+					pos:   position{line: 4619, col: 22, offset: 140493},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4617, col: 27, offset: 140417},
+						pos:  position{line: 4619, col: 27, offset: 140498},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11646,37 +11646,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4627, col: 1, offset: 140589},
+			pos:  position{line: 4629, col: 1, offset: 140670},
 			expr: &actionExpr{
-				pos: position{line: 4627, col: 20, offset: 140608},
+				pos: position{line: 4629, col: 20, offset: 140689},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4627, col: 20, offset: 140608},
+					pos: position{line: 4629, col: 20, offset: 140689},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4627, col: 20, offset: 140608},
+							pos:        position{line: 4629, col: 20, offset: 140689},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 27, offset: 140615},
+							pos:  position{line: 4629, col: 27, offset: 140696},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 42, offset: 140630},
+							pos:  position{line: 4629, col: 42, offset: 140711},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4627, col: 50, offset: 140638},
+							pos:   position{line: 4629, col: 50, offset: 140719},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4627, col: 60, offset: 140648},
+								pos:  position{line: 4629, col: 60, offset: 140729},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 69, offset: 140657},
+							pos:  position{line: 4629, col: 69, offset: 140738},
 							name: "R_PAREN",
 						},
 					},
@@ -11685,22 +11685,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4637, col: 1, offset: 140960},
+			pos:  position{line: 4639, col: 1, offset: 141041},
 			expr: &actionExpr{
-				pos: position{line: 4637, col: 20, offset: 140979},
+				pos: position{line: 4639, col: 20, offset: 141060},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4637, col: 20, offset: 140979},
+					pos: position{line: 4639, col: 20, offset: 141060},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4637, col: 20, offset: 140979},
+							pos:  position{line: 4639, col: 20, offset: 141060},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4637, col: 25, offset: 140984},
+							pos:   position{line: 4639, col: 25, offset: 141065},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4637, col: 42, offset: 141001},
+								pos:  position{line: 4639, col: 42, offset: 141082},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11710,41 +11710,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4641, col: 1, offset: 141050},
+			pos:  position{line: 4643, col: 1, offset: 141131},
 			expr: &actionExpr{
-				pos: position{line: 4641, col: 16, offset: 141065},
+				pos: position{line: 4643, col: 16, offset: 141146},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4641, col: 16, offset: 141065},
+					pos: position{line: 4643, col: 16, offset: 141146},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4641, col: 16, offset: 141065},
+							pos:  position{line: 4643, col: 16, offset: 141146},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4641, col: 27, offset: 141076},
+							pos:  position{line: 4643, col: 27, offset: 141157},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4641, col: 33, offset: 141082},
+							pos:   position{line: 4643, col: 33, offset: 141163},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4641, col: 50, offset: 141099},
+								pos: position{line: 4643, col: 50, offset: 141180},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4641, col: 50, offset: 141099},
+									pos:  position{line: 4643, col: 50, offset: 141180},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4641, col: 70, offset: 141119},
+							pos:  position{line: 4643, col: 70, offset: 141200},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4641, col: 85, offset: 141134},
+							pos:   position{line: 4643, col: 85, offset: 141215},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4641, col: 91, offset: 141140},
+								pos:  position{line: 4643, col: 91, offset: 141221},
 								name: "FieldName",
 							},
 						},
@@ -11754,35 +11754,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4670, col: 1, offset: 141911},
+			pos:  position{line: 4672, col: 1, offset: 141992},
 			expr: &actionExpr{
-				pos: position{line: 4670, col: 23, offset: 141933},
+				pos: position{line: 4672, col: 23, offset: 142014},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4670, col: 23, offset: 141933},
+					pos: position{line: 4672, col: 23, offset: 142014},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4670, col: 23, offset: 141933},
+							pos:   position{line: 4672, col: 23, offset: 142014},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4670, col: 31, offset: 141941},
+								pos:  position{line: 4672, col: 31, offset: 142022},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4670, col: 46, offset: 141956},
+							pos:   position{line: 4672, col: 46, offset: 142037},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4670, col: 52, offset: 141962},
+								pos: position{line: 4672, col: 52, offset: 142043},
 								expr: &seqExpr{
-									pos: position{line: 4670, col: 53, offset: 141963},
+									pos: position{line: 4672, col: 53, offset: 142044},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4670, col: 53, offset: 141963},
+											pos:  position{line: 4672, col: 53, offset: 142044},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4670, col: 59, offset: 141969},
+											pos:  position{line: 4672, col: 59, offset: 142050},
 											name: "MVBlockOption",
 										},
 									},
@@ -11795,26 +11795,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4704, col: 1, offset: 143025},
+			pos:  position{line: 4706, col: 1, offset: 143106},
 			expr: &actionExpr{
-				pos: position{line: 4704, col: 18, offset: 143042},
+				pos: position{line: 4706, col: 18, offset: 143123},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4704, col: 18, offset: 143042},
+					pos:   position{line: 4706, col: 18, offset: 143123},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4704, col: 27, offset: 143051},
+						pos: position{line: 4706, col: 27, offset: 143132},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4704, col: 27, offset: 143051},
+								pos:  position{line: 4706, col: 27, offset: 143132},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4704, col: 41, offset: 143065},
+								pos:  position{line: 4706, col: 41, offset: 143146},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4704, col: 60, offset: 143084},
+								pos:  position{line: 4706, col: 60, offset: 143165},
 								name: "SetSvOption",
 							},
 						},
@@ -11824,22 +11824,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4708, col: 1, offset: 143125},
+			pos:  position{line: 4710, col: 1, offset: 143206},
 			expr: &actionExpr{
-				pos: position{line: 4708, col: 16, offset: 143140},
+				pos: position{line: 4710, col: 16, offset: 143221},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4708, col: 16, offset: 143140},
+					pos:   position{line: 4710, col: 16, offset: 143221},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4708, col: 28, offset: 143152},
+						pos: position{line: 4710, col: 28, offset: 143233},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4708, col: 28, offset: 143152},
+								pos:  position{line: 4710, col: 28, offset: 143233},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4708, col: 46, offset: 143170},
+								pos:  position{line: 4710, col: 46, offset: 143251},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11849,28 +11849,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4712, col: 1, offset: 143217},
+			pos:  position{line: 4714, col: 1, offset: 143298},
 			expr: &actionExpr{
-				pos: position{line: 4712, col: 20, offset: 143236},
+				pos: position{line: 4714, col: 20, offset: 143317},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4712, col: 20, offset: 143236},
+					pos: position{line: 4714, col: 20, offset: 143317},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4712, col: 20, offset: 143236},
+							pos:        position{line: 4714, col: 20, offset: 143317},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4712, col: 28, offset: 143244},
+							pos:  position{line: 4714, col: 28, offset: 143325},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4712, col: 34, offset: 143250},
+							pos:   position{line: 4714, col: 34, offset: 143331},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4712, col: 38, offset: 143254},
+								pos:  position{line: 4714, col: 38, offset: 143335},
 								name: "QuotedString",
 							},
 						},
@@ -11880,28 +11880,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4723, col: 1, offset: 143505},
+			pos:  position{line: 4725, col: 1, offset: 143586},
 			expr: &actionExpr{
-				pos: position{line: 4723, col: 19, offset: 143523},
+				pos: position{line: 4725, col: 19, offset: 143604},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4723, col: 19, offset: 143523},
+					pos: position{line: 4725, col: 19, offset: 143604},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4723, col: 19, offset: 143523},
+							pos:        position{line: 4725, col: 19, offset: 143604},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4723, col: 31, offset: 143535},
+							pos:  position{line: 4725, col: 31, offset: 143616},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4723, col: 37, offset: 143541},
+							pos:   position{line: 4725, col: 37, offset: 143622},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4723, col: 41, offset: 143545},
+								pos:  position{line: 4725, col: 41, offset: 143626},
 								name: "QuotedString",
 							},
 						},
@@ -11911,28 +11911,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4741, col: 1, offset: 144016},
+			pos:  position{line: 4743, col: 1, offset: 144097},
 			expr: &actionExpr{
-				pos: position{line: 4741, col: 21, offset: 144036},
+				pos: position{line: 4743, col: 21, offset: 144117},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4741, col: 21, offset: 144036},
+					pos: position{line: 4743, col: 21, offset: 144117},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4741, col: 21, offset: 144036},
+							pos:        position{line: 4743, col: 21, offset: 144117},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4741, col: 34, offset: 144049},
+							pos:  position{line: 4743, col: 34, offset: 144130},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4741, col: 40, offset: 144055},
+							pos:   position{line: 4743, col: 40, offset: 144136},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4741, col: 48, offset: 144063},
+								pos:  position{line: 4743, col: 48, offset: 144144},
 								name: "Boolean",
 							},
 						},
@@ -11942,28 +11942,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4753, col: 1, offset: 144303},
+			pos:  position{line: 4755, col: 1, offset: 144384},
 			expr: &actionExpr{
-				pos: position{line: 4753, col: 16, offset: 144318},
+				pos: position{line: 4755, col: 16, offset: 144399},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4753, col: 16, offset: 144318},
+					pos: position{line: 4755, col: 16, offset: 144399},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4753, col: 16, offset: 144318},
+							pos:        position{line: 4755, col: 16, offset: 144399},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4753, col: 24, offset: 144326},
+							pos:  position{line: 4755, col: 24, offset: 144407},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4753, col: 30, offset: 144332},
+							pos:   position{line: 4755, col: 30, offset: 144413},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4753, col: 38, offset: 144340},
+								pos:  position{line: 4755, col: 38, offset: 144421},
 								name: "Boolean",
 							},
 						},
@@ -11973,28 +11973,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4765, col: 1, offset: 144605},
+			pos:  position{line: 4767, col: 1, offset: 144686},
 			expr: &actionExpr{
-				pos: position{line: 4765, col: 15, offset: 144619},
+				pos: position{line: 4767, col: 15, offset: 144700},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4765, col: 15, offset: 144619},
+					pos: position{line: 4767, col: 15, offset: 144700},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4765, col: 15, offset: 144619},
+							pos:  position{line: 4767, col: 15, offset: 144700},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4765, col: 20, offset: 144624},
+							pos:  position{line: 4767, col: 20, offset: 144705},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4765, col: 30, offset: 144634},
+							pos:   position{line: 4767, col: 30, offset: 144715},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4765, col: 40, offset: 144644},
+								pos: position{line: 4767, col: 40, offset: 144725},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4765, col: 40, offset: 144644},
+									pos:  position{line: 4767, col: 40, offset: 144725},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12005,39 +12005,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4772, col: 1, offset: 144770},
+			pos:  position{line: 4774, col: 1, offset: 144851},
 			expr: &actionExpr{
-				pos: position{line: 4772, col: 23, offset: 144792},
+				pos: position{line: 4774, col: 23, offset: 144873},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4772, col: 23, offset: 144792},
+					pos: position{line: 4774, col: 23, offset: 144873},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4772, col: 23, offset: 144792},
+							pos:  position{line: 4774, col: 23, offset: 144873},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4772, col: 29, offset: 144798},
+							pos:   position{line: 4774, col: 29, offset: 144879},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4772, col: 35, offset: 144804},
+								pos:  position{line: 4774, col: 35, offset: 144885},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4772, col: 49, offset: 144818},
+							pos:   position{line: 4774, col: 49, offset: 144899},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4772, col: 54, offset: 144823},
+								pos: position{line: 4774, col: 54, offset: 144904},
 								expr: &seqExpr{
-									pos: position{line: 4772, col: 55, offset: 144824},
+									pos: position{line: 4774, col: 55, offset: 144905},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4772, col: 55, offset: 144824},
+											pos:  position{line: 4774, col: 55, offset: 144905},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4772, col: 61, offset: 144830},
+											pos:  position{line: 4774, col: 61, offset: 144911},
 											name: "SPathArgument",
 										},
 									},
@@ -12050,26 +12050,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4804, col: 1, offset: 145723},
+			pos:  position{line: 4806, col: 1, offset: 145804},
 			expr: &actionExpr{
-				pos: position{line: 4804, col: 18, offset: 145740},
+				pos: position{line: 4806, col: 18, offset: 145821},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4804, col: 18, offset: 145740},
+					pos:   position{line: 4806, col: 18, offset: 145821},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4804, col: 23, offset: 145745},
+						pos: position{line: 4806, col: 23, offset: 145826},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4804, col: 23, offset: 145745},
+								pos:  position{line: 4806, col: 23, offset: 145826},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4804, col: 36, offset: 145758},
+								pos:  position{line: 4806, col: 36, offset: 145839},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4804, col: 50, offset: 145772},
+								pos:  position{line: 4806, col: 50, offset: 145853},
 								name: "PathField",
 							},
 						},
@@ -12079,28 +12079,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4808, col: 1, offset: 145808},
+			pos:  position{line: 4810, col: 1, offset: 145889},
 			expr: &actionExpr{
-				pos: position{line: 4808, col: 15, offset: 145822},
+				pos: position{line: 4810, col: 15, offset: 145903},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4808, col: 15, offset: 145822},
+					pos: position{line: 4810, col: 15, offset: 145903},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4808, col: 15, offset: 145822},
+							pos:        position{line: 4810, col: 15, offset: 145903},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4808, col: 23, offset: 145830},
+							pos:  position{line: 4810, col: 23, offset: 145911},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4808, col: 29, offset: 145836},
+							pos:   position{line: 4810, col: 29, offset: 145917},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4808, col: 35, offset: 145842},
+								pos:  position{line: 4810, col: 35, offset: 145923},
 								name: "FieldName",
 							},
 						},
@@ -12110,28 +12110,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4811, col: 1, offset: 145898},
+			pos:  position{line: 4813, col: 1, offset: 145979},
 			expr: &actionExpr{
-				pos: position{line: 4811, col: 16, offset: 145913},
+				pos: position{line: 4813, col: 16, offset: 145994},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4811, col: 16, offset: 145913},
+					pos: position{line: 4813, col: 16, offset: 145994},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4811, col: 16, offset: 145913},
+							pos:        position{line: 4813, col: 16, offset: 145994},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4811, col: 25, offset: 145922},
+							pos:  position{line: 4813, col: 25, offset: 146003},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4811, col: 31, offset: 145928},
+							pos:   position{line: 4813, col: 31, offset: 146009},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4811, col: 37, offset: 145934},
+								pos:  position{line: 4813, col: 37, offset: 146015},
 								name: "FieldName",
 							},
 						},
@@ -12141,34 +12141,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4814, col: 1, offset: 145991},
+			pos:  position{line: 4816, col: 1, offset: 146072},
 			expr: &actionExpr{
-				pos: position{line: 4814, col: 14, offset: 146004},
+				pos: position{line: 4816, col: 14, offset: 146085},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4814, col: 15, offset: 146005},
+					pos: position{line: 4816, col: 15, offset: 146086},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4814, col: 15, offset: 146005},
+							pos: position{line: 4816, col: 15, offset: 146086},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4814, col: 15, offset: 146005},
+									pos:        position{line: 4816, col: 15, offset: 146086},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4814, col: 22, offset: 146012},
+									pos:  position{line: 4816, col: 22, offset: 146093},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4814, col: 28, offset: 146018},
+									pos:  position{line: 4816, col: 28, offset: 146099},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4814, col: 47, offset: 146037},
+							pos:  position{line: 4816, col: 47, offset: 146118},
 							name: "SPathFieldString",
 						},
 					},
@@ -12177,16 +12177,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4826, col: 1, offset: 146449},
+			pos:  position{line: 4828, col: 1, offset: 146530},
 			expr: &choiceExpr{
-				pos: position{line: 4826, col: 21, offset: 146469},
+				pos: position{line: 4828, col: 21, offset: 146550},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4826, col: 21, offset: 146469},
+						pos:  position{line: 4828, col: 21, offset: 146550},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4826, col: 36, offset: 146484},
+						pos:  position{line: 4828, col: 36, offset: 146565},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12194,28 +12194,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4829, col: 1, offset: 146557},
+			pos:  position{line: 4831, col: 1, offset: 146638},
 			expr: &actionExpr{
-				pos: position{line: 4829, col: 16, offset: 146572},
+				pos: position{line: 4831, col: 16, offset: 146653},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4829, col: 16, offset: 146572},
+					pos: position{line: 4831, col: 16, offset: 146653},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4829, col: 16, offset: 146572},
+							pos:  position{line: 4831, col: 16, offset: 146653},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4829, col: 21, offset: 146577},
+							pos:  position{line: 4831, col: 21, offset: 146658},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4829, col: 32, offset: 146588},
+							pos:   position{line: 4831, col: 32, offset: 146669},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4829, col: 46, offset: 146602},
+								pos: position{line: 4831, col: 46, offset: 146683},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4829, col: 46, offset: 146602},
+									pos:  position{line: 4831, col: 46, offset: 146683},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12226,39 +12226,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4851, col: 1, offset: 147211},
+			pos:  position{line: 4853, col: 1, offset: 147292},
 			expr: &actionExpr{
-				pos: position{line: 4851, col: 24, offset: 147234},
+				pos: position{line: 4853, col: 24, offset: 147315},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4851, col: 24, offset: 147234},
+					pos: position{line: 4853, col: 24, offset: 147315},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4851, col: 24, offset: 147234},
+							pos:  position{line: 4853, col: 24, offset: 147315},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4851, col: 30, offset: 147240},
+							pos:   position{line: 4853, col: 30, offset: 147321},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4851, col: 37, offset: 147247},
+								pos:  position{line: 4853, col: 37, offset: 147328},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4851, col: 52, offset: 147262},
+							pos:   position{line: 4853, col: 52, offset: 147343},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4851, col: 57, offset: 147267},
+								pos: position{line: 4853, col: 57, offset: 147348},
 								expr: &seqExpr{
-									pos: position{line: 4851, col: 58, offset: 147268},
+									pos: position{line: 4853, col: 58, offset: 147349},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4851, col: 58, offset: 147268},
+											pos:  position{line: 4853, col: 58, offset: 147349},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4851, col: 64, offset: 147274},
+											pos:  position{line: 4853, col: 64, offset: 147355},
 											name: "FormatArgument",
 										},
 									},
@@ -12271,30 +12271,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4885, col: 1, offset: 148463},
+			pos:  position{line: 4887, col: 1, offset: 148544},
 			expr: &actionExpr{
-				pos: position{line: 4885, col: 19, offset: 148481},
+				pos: position{line: 4887, col: 19, offset: 148562},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4885, col: 19, offset: 148481},
+					pos:   position{line: 4887, col: 19, offset: 148562},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4885, col: 28, offset: 148490},
+						pos: position{line: 4887, col: 28, offset: 148571},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4885, col: 28, offset: 148490},
+								pos:  position{line: 4887, col: 28, offset: 148571},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4885, col: 46, offset: 148508},
+								pos:  position{line: 4887, col: 46, offset: 148589},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4885, col: 65, offset: 148527},
+								pos:  position{line: 4887, col: 65, offset: 148608},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4885, col: 82, offset: 148544},
+								pos:  position{line: 4887, col: 82, offset: 148625},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12304,28 +12304,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4889, col: 1, offset: 148594},
+			pos:  position{line: 4891, col: 1, offset: 148675},
 			expr: &actionExpr{
-				pos: position{line: 4889, col: 20, offset: 148613},
+				pos: position{line: 4891, col: 20, offset: 148694},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4889, col: 20, offset: 148613},
+					pos: position{line: 4891, col: 20, offset: 148694},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4889, col: 20, offset: 148613},
+							pos:        position{line: 4891, col: 20, offset: 148694},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4889, col: 28, offset: 148621},
+							pos:  position{line: 4891, col: 28, offset: 148702},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4889, col: 34, offset: 148627},
+							pos:   position{line: 4891, col: 34, offset: 148708},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4889, col: 38, offset: 148631},
+								pos:  position{line: 4891, col: 38, offset: 148712},
 								name: "QuotedString",
 							},
 						},
@@ -12335,28 +12335,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4898, col: 1, offset: 148843},
+			pos:  position{line: 4900, col: 1, offset: 148924},
 			expr: &actionExpr{
-				pos: position{line: 4898, col: 21, offset: 148863},
+				pos: position{line: 4900, col: 21, offset: 148944},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4898, col: 21, offset: 148863},
+					pos: position{line: 4900, col: 21, offset: 148944},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4898, col: 21, offset: 148863},
+							pos:        position{line: 4900, col: 21, offset: 148944},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4898, col: 34, offset: 148876},
+							pos:  position{line: 4900, col: 34, offset: 148957},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4898, col: 40, offset: 148882},
+							pos:   position{line: 4900, col: 40, offset: 148963},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4898, col: 47, offset: 148889},
+								pos:  position{line: 4900, col: 47, offset: 148970},
 								name: "IntegerAsString",
 							},
 						},
@@ -12366,28 +12366,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4911, col: 1, offset: 149295},
+			pos:  position{line: 4913, col: 1, offset: 149376},
 			expr: &actionExpr{
-				pos: position{line: 4911, col: 19, offset: 149313},
+				pos: position{line: 4913, col: 19, offset: 149394},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4911, col: 19, offset: 149313},
+					pos: position{line: 4913, col: 19, offset: 149394},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4911, col: 19, offset: 149313},
+							pos:        position{line: 4913, col: 19, offset: 149394},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4911, col: 30, offset: 149324},
+							pos:  position{line: 4913, col: 30, offset: 149405},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4911, col: 36, offset: 149330},
+							pos:   position{line: 4913, col: 36, offset: 149411},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4911, col: 40, offset: 149334},
+								pos:  position{line: 4913, col: 40, offset: 149415},
 								name: "QuotedString",
 							},
 						},
@@ -12397,78 +12397,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4920, col: 1, offset: 149549},
+			pos:  position{line: 4922, col: 1, offset: 149630},
 			expr: &actionExpr{
-				pos: position{line: 4920, col: 24, offset: 149572},
+				pos: position{line: 4922, col: 24, offset: 149653},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4920, col: 24, offset: 149572},
+					pos: position{line: 4922, col: 24, offset: 149653},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4920, col: 24, offset: 149572},
+							pos:   position{line: 4922, col: 24, offset: 149653},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 34, offset: 149582},
+								pos:  position{line: 4922, col: 34, offset: 149663},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 47, offset: 149595},
+							pos:  position{line: 4922, col: 47, offset: 149676},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 53, offset: 149601},
+							pos:   position{line: 4922, col: 53, offset: 149682},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 63, offset: 149611},
+								pos:  position{line: 4922, col: 63, offset: 149692},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 76, offset: 149624},
+							pos:  position{line: 4922, col: 76, offset: 149705},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 82, offset: 149630},
+							pos:   position{line: 4922, col: 82, offset: 149711},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 95, offset: 149643},
+								pos:  position{line: 4922, col: 95, offset: 149724},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 108, offset: 149656},
+							pos:  position{line: 4922, col: 108, offset: 149737},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 114, offset: 149662},
+							pos:   position{line: 4922, col: 114, offset: 149743},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 121, offset: 149669},
+								pos:  position{line: 4922, col: 121, offset: 149750},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 134, offset: 149682},
+							pos:  position{line: 4922, col: 134, offset: 149763},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 140, offset: 149688},
+							pos:   position{line: 4922, col: 140, offset: 149769},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 153, offset: 149701},
+								pos:  position{line: 4922, col: 153, offset: 149782},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4920, col: 166, offset: 149714},
+							pos:  position{line: 4922, col: 166, offset: 149795},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4920, col: 172, offset: 149720},
+							pos:   position{line: 4922, col: 172, offset: 149801},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4920, col: 179, offset: 149727},
+								pos:  position{line: 4922, col: 179, offset: 149808},
 								name: "QuotedString",
 							},
 						},
@@ -12478,28 +12478,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4938, col: 1, offset: 150303},
+			pos:  position{line: 4940, col: 1, offset: 150384},
 			expr: &actionExpr{
-				pos: position{line: 4938, col: 20, offset: 150322},
+				pos: position{line: 4940, col: 20, offset: 150403},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4938, col: 20, offset: 150322},
+					pos: position{line: 4940, col: 20, offset: 150403},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4938, col: 20, offset: 150322},
+							pos:  position{line: 4940, col: 20, offset: 150403},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4938, col: 25, offset: 150327},
+							pos:  position{line: 4940, col: 25, offset: 150408},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4938, col: 40, offset: 150342},
+							pos:   position{line: 4940, col: 40, offset: 150423},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4938, col: 55, offset: 150357},
+								pos: position{line: 4940, col: 55, offset: 150438},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4938, col: 55, offset: 150357},
+									pos:  position{line: 4940, col: 55, offset: 150438},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12510,42 +12510,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4945, col: 1, offset: 150510},
+			pos:  position{line: 4947, col: 1, offset: 150591},
 			expr: &actionExpr{
-				pos: position{line: 4945, col: 28, offset: 150537},
+				pos: position{line: 4947, col: 28, offset: 150618},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4945, col: 28, offset: 150537},
+					pos: position{line: 4947, col: 28, offset: 150618},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4945, col: 28, offset: 150537},
+							pos:  position{line: 4947, col: 28, offset: 150618},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4945, col: 34, offset: 150543},
+							pos:   position{line: 4947, col: 34, offset: 150624},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4945, col: 40, offset: 150549},
+								pos: position{line: 4947, col: 40, offset: 150630},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4945, col: 40, offset: 150549},
+									pos:  position{line: 4947, col: 40, offset: 150630},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4945, col: 60, offset: 150569},
+							pos:   position{line: 4947, col: 60, offset: 150650},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4945, col: 65, offset: 150574},
+								pos: position{line: 4947, col: 65, offset: 150655},
 								expr: &seqExpr{
-									pos: position{line: 4945, col: 66, offset: 150575},
+									pos: position{line: 4947, col: 66, offset: 150656},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4945, col: 66, offset: 150575},
+											pos:  position{line: 4947, col: 66, offset: 150656},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4945, col: 72, offset: 150581},
+											pos:  position{line: 4947, col: 72, offset: 150662},
 											name: "EventCountArgument",
 										},
 									},
@@ -12558,30 +12558,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5001, col: 1, offset: 152458},
+			pos:  position{line: 5003, col: 1, offset: 152539},
 			expr: &actionExpr{
-				pos: position{line: 5001, col: 23, offset: 152480},
+				pos: position{line: 5003, col: 23, offset: 152561},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5001, col: 23, offset: 152480},
+					pos:   position{line: 5003, col: 23, offset: 152561},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5001, col: 28, offset: 152485},
+						pos: position{line: 5003, col: 28, offset: 152566},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5001, col: 28, offset: 152485},
+								pos:  position{line: 5003, col: 28, offset: 152566},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5001, col: 41, offset: 152498},
+								pos:  position{line: 5003, col: 41, offset: 152579},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5001, col: 58, offset: 152515},
+								pos:  position{line: 5003, col: 58, offset: 152596},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5001, col: 76, offset: 152533},
+								pos:  position{line: 5003, col: 76, offset: 152614},
 								name: "ListVixField",
 							},
 						},
@@ -12591,28 +12591,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5005, col: 1, offset: 152572},
+			pos:  position{line: 5007, col: 1, offset: 152653},
 			expr: &actionExpr{
-				pos: position{line: 5005, col: 15, offset: 152586},
+				pos: position{line: 5007, col: 15, offset: 152667},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5005, col: 15, offset: 152586},
+					pos: position{line: 5007, col: 15, offset: 152667},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5005, col: 15, offset: 152586},
+							pos:        position{line: 5007, col: 15, offset: 152667},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5005, col: 23, offset: 152594},
+							pos:  position{line: 5007, col: 23, offset: 152675},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5005, col: 29, offset: 152600},
+							pos:   position{line: 5007, col: 29, offset: 152681},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5005, col: 35, offset: 152606},
+								pos:  position{line: 5007, col: 35, offset: 152687},
 								name: "IndexName",
 							},
 						},
@@ -12622,28 +12622,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5008, col: 1, offset: 152662},
+			pos:  position{line: 5010, col: 1, offset: 152743},
 			expr: &actionExpr{
-				pos: position{line: 5008, col: 19, offset: 152680},
+				pos: position{line: 5010, col: 19, offset: 152761},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5008, col: 19, offset: 152680},
+					pos: position{line: 5010, col: 19, offset: 152761},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5008, col: 19, offset: 152680},
+							pos:        position{line: 5010, col: 19, offset: 152761},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5008, col: 31, offset: 152692},
+							pos:  position{line: 5010, col: 31, offset: 152773},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5008, col: 37, offset: 152698},
+							pos:   position{line: 5010, col: 37, offset: 152779},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5008, col: 43, offset: 152704},
+								pos:  position{line: 5010, col: 43, offset: 152785},
 								name: "Boolean",
 							},
 						},
@@ -12653,28 +12653,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5011, col: 1, offset: 152780},
+			pos:  position{line: 5013, col: 1, offset: 152861},
 			expr: &actionExpr{
-				pos: position{line: 5011, col: 20, offset: 152799},
+				pos: position{line: 5013, col: 20, offset: 152880},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5011, col: 20, offset: 152799},
+					pos: position{line: 5013, col: 20, offset: 152880},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5011, col: 20, offset: 152799},
+							pos:        position{line: 5013, col: 20, offset: 152880},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5011, col: 34, offset: 152813},
+							pos:  position{line: 5013, col: 34, offset: 152894},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5011, col: 40, offset: 152819},
+							pos:   position{line: 5013, col: 40, offset: 152900},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5011, col: 46, offset: 152825},
+								pos:  position{line: 5013, col: 46, offset: 152906},
 								name: "Boolean",
 							},
 						},
@@ -12684,28 +12684,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5014, col: 1, offset: 152903},
+			pos:  position{line: 5016, col: 1, offset: 152984},
 			expr: &actionExpr{
-				pos: position{line: 5014, col: 17, offset: 152919},
+				pos: position{line: 5016, col: 17, offset: 153000},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5014, col: 17, offset: 152919},
+					pos: position{line: 5016, col: 17, offset: 153000},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5014, col: 17, offset: 152919},
+							pos:        position{line: 5016, col: 17, offset: 153000},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 28, offset: 152930},
+							pos:  position{line: 5016, col: 28, offset: 153011},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 34, offset: 152936},
+							pos:   position{line: 5016, col: 34, offset: 153017},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5014, col: 40, offset: 152942},
+								pos:  position{line: 5016, col: 40, offset: 153023},
 								name: "Boolean",
 							},
 						},
@@ -12715,24 +12715,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5018, col: 1, offset: 153018},
+			pos:  position{line: 5020, col: 1, offset: 153099},
 			expr: &actionExpr{
-				pos: position{line: 5018, col: 14, offset: 153031},
+				pos: position{line: 5020, col: 14, offset: 153112},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5018, col: 14, offset: 153031},
+					pos: position{line: 5020, col: 14, offset: 153112},
 					expr: &seqExpr{
-						pos: position{line: 5018, col: 15, offset: 153032},
+						pos: position{line: 5020, col: 15, offset: 153113},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5018, col: 15, offset: 153032},
+								pos: position{line: 5020, col: 15, offset: 153113},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5018, col: 16, offset: 153033},
+									pos:  position{line: 5020, col: 16, offset: 153114},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5018, col: 22, offset: 153039,
+								line: 5020, col: 22, offset: 153120,
 							},
 						},
 					},
@@ -12741,39 +12741,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5023, col: 1, offset: 153112},
+			pos:  position{line: 5025, col: 1, offset: 153193},
 			expr: &actionExpr{
-				pos: position{line: 5023, col: 18, offset: 153129},
+				pos: position{line: 5025, col: 18, offset: 153210},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5023, col: 18, offset: 153129},
+					pos: position{line: 5025, col: 18, offset: 153210},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5023, col: 18, offset: 153129},
+							pos:  position{line: 5025, col: 18, offset: 153210},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5023, col: 23, offset: 153134},
+							pos:  position{line: 5025, col: 23, offset: 153215},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5023, col: 36, offset: 153147},
+							pos:   position{line: 5025, col: 36, offset: 153228},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5023, col: 49, offset: 153160},
+								pos: position{line: 5025, col: 49, offset: 153241},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5023, col: 49, offset: 153160},
+									pos:  position{line: 5025, col: 49, offset: 153241},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5023, col: 70, offset: 153181},
+							pos:   position{line: 5025, col: 70, offset: 153262},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5023, col: 77, offset: 153188},
+								pos: position{line: 5025, col: 77, offset: 153269},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5023, col: 77, offset: 153188},
+									pos:  position{line: 5025, col: 77, offset: 153269},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12784,32 +12784,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5053, col: 1, offset: 153951},
+			pos:  position{line: 5055, col: 1, offset: 154032},
 			expr: &actionExpr{
-				pos: position{line: 5053, col: 24, offset: 153974},
+				pos: position{line: 5055, col: 24, offset: 154055},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5053, col: 24, offset: 153974},
+					pos: position{line: 5055, col: 24, offset: 154055},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5053, col: 24, offset: 153974},
+							pos:  position{line: 5055, col: 24, offset: 154055},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5053, col: 30, offset: 153980},
+							pos:        position{line: 5055, col: 30, offset: 154061},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5053, col: 38, offset: 153988},
+							pos:  position{line: 5055, col: 38, offset: 154069},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5053, col: 44, offset: 153994},
+							pos:   position{line: 5055, col: 44, offset: 154075},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5053, col: 48, offset: 153998},
+								pos:  position{line: 5055, col: 48, offset: 154079},
 								name: "String",
 							},
 						},
@@ -12819,22 +12819,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5057, col: 1, offset: 154044},
+			pos:  position{line: 5059, col: 1, offset: 154125},
 			expr: &actionExpr{
-				pos: position{line: 5057, col: 22, offset: 154065},
+				pos: position{line: 5059, col: 22, offset: 154146},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5057, col: 22, offset: 154065},
+					pos: position{line: 5059, col: 22, offset: 154146},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5057, col: 22, offset: 154065},
+							pos:  position{line: 5059, col: 22, offset: 154146},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5057, col: 28, offset: 154071},
+							pos:   position{line: 5059, col: 28, offset: 154152},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5057, col: 38, offset: 154081},
+								pos:  position{line: 5059, col: 38, offset: 154162},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12844,36 +12844,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5061, col: 1, offset: 154140},
+			pos:  position{line: 5063, col: 1, offset: 154221},
 			expr: &actionExpr{
-				pos: position{line: 5061, col: 18, offset: 154157},
+				pos: position{line: 5063, col: 18, offset: 154238},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5061, col: 18, offset: 154157},
+					pos: position{line: 5063, col: 18, offset: 154238},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5061, col: 18, offset: 154157},
+							pos:  position{line: 5063, col: 18, offset: 154238},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5061, col: 23, offset: 154162},
+							pos:  position{line: 5063, col: 23, offset: 154243},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5061, col: 36, offset: 154175},
+							pos:   position{line: 5063, col: 36, offset: 154256},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5061, col: 42, offset: 154181},
+								pos:  position{line: 5063, col: 42, offset: 154262},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5061, col: 56, offset: 154195},
+							pos:   position{line: 5063, col: 56, offset: 154276},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5061, col: 65, offset: 154204},
+								pos: position{line: 5063, col: 65, offset: 154285},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5061, col: 65, offset: 154204},
+									pos:  position{line: 5063, col: 65, offset: 154285},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12884,22 +12884,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5090, col: 1, offset: 154993},
+			pos:  position{line: 5092, col: 1, offset: 155074},
 			expr: &actionExpr{
-				pos: position{line: 5090, col: 18, offset: 155010},
+				pos: position{line: 5092, col: 18, offset: 155091},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5090, col: 18, offset: 155010},
+					pos: position{line: 5092, col: 18, offset: 155091},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5090, col: 18, offset: 155010},
+							pos:  position{line: 5092, col: 18, offset: 155091},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5090, col: 24, offset: 155016},
+							pos:   position{line: 5092, col: 24, offset: 155097},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5090, col: 34, offset: 155026},
+								pos:  position{line: 5092, col: 34, offset: 155107},
 								name: "FieldName",
 							},
 						},
@@ -12909,32 +12909,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5094, col: 1, offset: 155067},
+			pos:  position{line: 5096, col: 1, offset: 155148},
 			expr: &actionExpr{
-				pos: position{line: 5094, col: 18, offset: 155084},
+				pos: position{line: 5096, col: 18, offset: 155165},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5094, col: 18, offset: 155084},
+					pos: position{line: 5096, col: 18, offset: 155165},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5094, col: 18, offset: 155084},
+							pos:  position{line: 5096, col: 18, offset: 155165},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5094, col: 24, offset: 155090},
+							pos:        position{line: 5096, col: 24, offset: 155171},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5094, col: 32, offset: 155098},
+							pos:  position{line: 5096, col: 32, offset: 155179},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5094, col: 38, offset: 155104},
+							pos:   position{line: 5096, col: 38, offset: 155185},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5094, col: 47, offset: 155113},
+								pos:  position{line: 5096, col: 47, offset: 155194},
 								name: "IntegerAsString",
 							},
 						},
@@ -12944,26 +12944,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5098, col: 1, offset: 155159},
+			pos:  position{line: 5100, col: 1, offset: 155240},
 			expr: &actionExpr{
-				pos: position{line: 5098, col: 16, offset: 155174},
+				pos: position{line: 5100, col: 16, offset: 155255},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5098, col: 16, offset: 155174},
+					pos: position{line: 5100, col: 16, offset: 155255},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5098, col: 16, offset: 155174},
+							pos:  position{line: 5100, col: 16, offset: 155255},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5098, col: 22, offset: 155180},
+							pos:  position{line: 5100, col: 22, offset: 155261},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5098, col: 32, offset: 155190},
+							pos:   position{line: 5100, col: 32, offset: 155271},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5098, col: 42, offset: 155200},
+								pos:  position{line: 5100, col: 42, offset: 155281},
 								name: "BoolExpr",
 							},
 						},
@@ -12973,28 +12973,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5102, col: 1, offset: 155260},
+			pos:  position{line: 5104, col: 1, offset: 155341},
 			expr: &actionExpr{
-				pos: position{line: 5102, col: 28, offset: 155287},
+				pos: position{line: 5104, col: 28, offset: 155368},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5102, col: 28, offset: 155287},
+					pos: position{line: 5104, col: 28, offset: 155368},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5102, col: 28, offset: 155287},
+							pos:        position{line: 5104, col: 28, offset: 155368},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5102, col: 37, offset: 155296},
+							pos:  position{line: 5104, col: 37, offset: 155377},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5102, col: 43, offset: 155302},
+							pos:   position{line: 5104, col: 43, offset: 155383},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5102, col: 51, offset: 155310},
+								pos:  position{line: 5104, col: 51, offset: 155391},
 								name: "Boolean",
 							},
 						},
@@ -13004,28 +13004,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5111, col: 1, offset: 155494},
+			pos:  position{line: 5113, col: 1, offset: 155575},
 			expr: &actionExpr{
-				pos: position{line: 5111, col: 28, offset: 155521},
+				pos: position{line: 5113, col: 28, offset: 155602},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5111, col: 28, offset: 155521},
+					pos: position{line: 5113, col: 28, offset: 155602},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5111, col: 28, offset: 155521},
+							pos:        position{line: 5113, col: 28, offset: 155602},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5111, col: 37, offset: 155530},
+							pos:  position{line: 5113, col: 37, offset: 155611},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5111, col: 43, offset: 155536},
+							pos:   position{line: 5113, col: 43, offset: 155617},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5111, col: 51, offset: 155544},
+								pos:  position{line: 5113, col: 51, offset: 155625},
 								name: "Boolean",
 							},
 						},
@@ -13035,28 +13035,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5120, col: 1, offset: 155728},
+			pos:  position{line: 5122, col: 1, offset: 155809},
 			expr: &actionExpr{
-				pos: position{line: 5120, col: 27, offset: 155754},
+				pos: position{line: 5122, col: 27, offset: 155835},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5120, col: 27, offset: 155754},
+					pos: position{line: 5122, col: 27, offset: 155835},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5120, col: 27, offset: 155754},
+							pos:        position{line: 5122, col: 27, offset: 155835},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5120, col: 35, offset: 155762},
+							pos:  position{line: 5122, col: 35, offset: 155843},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5120, col: 41, offset: 155768},
+							pos:   position{line: 5122, col: 41, offset: 155849},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5120, col: 48, offset: 155775},
+								pos:  position{line: 5122, col: 48, offset: 155856},
 								name: "PositiveInteger",
 							},
 						},
@@ -13066,28 +13066,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5129, col: 1, offset: 155966},
+			pos:  position{line: 5131, col: 1, offset: 156047},
 			expr: &actionExpr{
-				pos: position{line: 5129, col: 25, offset: 155990},
+				pos: position{line: 5131, col: 25, offset: 156071},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5129, col: 25, offset: 155990},
+					pos: position{line: 5131, col: 25, offset: 156071},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5129, col: 25, offset: 155990},
+							pos:        position{line: 5131, col: 25, offset: 156071},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5129, col: 31, offset: 155996},
+							pos:  position{line: 5131, col: 31, offset: 156077},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5129, col: 37, offset: 156002},
+							pos:   position{line: 5131, col: 37, offset: 156083},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5129, col: 44, offset: 156009},
+								pos:  position{line: 5131, col: 44, offset: 156090},
 								name: "PositiveInteger",
 							},
 						},
@@ -13097,30 +13097,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5138, col: 1, offset: 156196},
+			pos:  position{line: 5140, col: 1, offset: 156277},
 			expr: &actionExpr{
-				pos: position{line: 5138, col: 22, offset: 156217},
+				pos: position{line: 5140, col: 22, offset: 156298},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5138, col: 22, offset: 156217},
+					pos:   position{line: 5140, col: 22, offset: 156298},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5138, col: 41, offset: 156236},
+						pos: position{line: 5140, col: 41, offset: 156317},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5138, col: 41, offset: 156236},
+								pos:  position{line: 5140, col: 41, offset: 156317},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5138, col: 67, offset: 156262},
+								pos:  position{line: 5140, col: 67, offset: 156343},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5138, col: 93, offset: 156288},
+								pos:  position{line: 5140, col: 93, offset: 156369},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5138, col: 118, offset: 156313},
+								pos:  position{line: 5140, col: 118, offset: 156394},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13130,35 +13130,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5142, col: 1, offset: 156374},
+			pos:  position{line: 5144, col: 1, offset: 156455},
 			expr: &actionExpr{
-				pos: position{line: 5142, col: 26, offset: 156399},
+				pos: position{line: 5144, col: 26, offset: 156480},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5142, col: 26, offset: 156399},
+					pos: position{line: 5144, col: 26, offset: 156480},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5142, col: 26, offset: 156399},
+							pos:   position{line: 5144, col: 26, offset: 156480},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5142, col: 34, offset: 156407},
+								pos:  position{line: 5144, col: 34, offset: 156488},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5142, col: 53, offset: 156426},
+							pos:   position{line: 5144, col: 53, offset: 156507},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5142, col: 58, offset: 156431},
+								pos: position{line: 5144, col: 58, offset: 156512},
 								expr: &seqExpr{
-									pos: position{line: 5142, col: 59, offset: 156432},
+									pos: position{line: 5144, col: 59, offset: 156513},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5142, col: 59, offset: 156432},
+											pos:  position{line: 5144, col: 59, offset: 156513},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5142, col: 65, offset: 156438},
+											pos:  position{line: 5144, col: 65, offset: 156519},
 											name: "InputLookupOption",
 										},
 									},
@@ -13171,35 +13171,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5184, col: 1, offset: 157884},
+			pos:  position{line: 5186, col: 1, offset: 157965},
 			expr: &actionExpr{
-				pos: position{line: 5184, col: 21, offset: 157904},
+				pos: position{line: 5186, col: 21, offset: 157985},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5184, col: 21, offset: 157904},
+					pos: position{line: 5186, col: 21, offset: 157985},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5184, col: 21, offset: 157904},
+							pos:  position{line: 5186, col: 21, offset: 157985},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5184, col: 26, offset: 157909},
+							pos:  position{line: 5186, col: 26, offset: 157990},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5184, col: 42, offset: 157925},
+							pos:   position{line: 5186, col: 42, offset: 158006},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5184, col: 60, offset: 157943},
+								pos: position{line: 5186, col: 60, offset: 158024},
 								expr: &seqExpr{
-									pos: position{line: 5184, col: 61, offset: 157944},
+									pos: position{line: 5186, col: 61, offset: 158025},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5184, col: 61, offset: 157944},
+											pos:  position{line: 5186, col: 61, offset: 158025},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5184, col: 83, offset: 157966},
+											pos:  position{line: 5186, col: 83, offset: 158047},
 											name: "SPACE",
 										},
 									},
@@ -13207,20 +13207,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5184, col: 91, offset: 157974},
+							pos:   position{line: 5186, col: 91, offset: 158055},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5184, col: 101, offset: 157984},
+								pos:  position{line: 5186, col: 101, offset: 158065},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5184, col: 109, offset: 157992},
+							pos:   position{line: 5186, col: 109, offset: 158073},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5184, col: 121, offset: 158004},
+								pos: position{line: 5186, col: 121, offset: 158085},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5184, col: 122, offset: 158005},
+									pos:  position{line: 5186, col: 122, offset: 158086},
 									name: "WhereClause",
 								},
 							},
@@ -13231,15 +13231,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5207, col: 1, offset: 158693},
+			pos:  position{line: 5209, col: 1, offset: 158774},
 			expr: &actionExpr{
-				pos: position{line: 5207, col: 24, offset: 158716},
+				pos: position{line: 5209, col: 24, offset: 158797},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5207, col: 24, offset: 158716},
+					pos:   position{line: 5209, col: 24, offset: 158797},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5207, col: 41, offset: 158733},
+						pos:  position{line: 5209, col: 41, offset: 158814},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13247,26 +13247,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5218, col: 1, offset: 159132},
+			pos:  position{line: 5220, col: 1, offset: 159213},
 			expr: &actionExpr{
-				pos: position{line: 5218, col: 20, offset: 159151},
+				pos: position{line: 5220, col: 20, offset: 159232},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5218, col: 20, offset: 159151},
+					pos:   position{line: 5220, col: 20, offset: 159232},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5218, col: 28, offset: 159159},
+						pos: position{line: 5220, col: 28, offset: 159240},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5218, col: 28, offset: 159159},
+								pos:  position{line: 5220, col: 28, offset: 159240},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5218, col: 52, offset: 159183},
+								pos:  position{line: 5220, col: 52, offset: 159264},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5218, col: 68, offset: 159199},
+								pos:  position{line: 5220, col: 68, offset: 159280},
 								name: "MaxOutOption",
 							},
 						},
@@ -13276,28 +13276,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5223, col: 1, offset: 159297},
+			pos:  position{line: 5225, col: 1, offset: 159378},
 			expr: &actionExpr{
-				pos: position{line: 5223, col: 26, offset: 159322},
+				pos: position{line: 5225, col: 26, offset: 159403},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5223, col: 26, offset: 159322},
+					pos: position{line: 5225, col: 26, offset: 159403},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5223, col: 26, offset: 159322},
+							pos:        position{line: 5225, col: 26, offset: 159403},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5223, col: 44, offset: 159340},
+							pos:  position{line: 5225, col: 44, offset: 159421},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5223, col: 50, offset: 159346},
+							pos:   position{line: 5225, col: 50, offset: 159427},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5223, col: 58, offset: 159354},
+								pos:  position{line: 5225, col: 58, offset: 159435},
 								name: "Boolean",
 							},
 						},
@@ -13307,28 +13307,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5230, col: 1, offset: 159493},
+			pos:  position{line: 5232, col: 1, offset: 159574},
 			expr: &actionExpr{
-				pos: position{line: 5230, col: 18, offset: 159510},
+				pos: position{line: 5232, col: 18, offset: 159591},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5230, col: 18, offset: 159510},
+					pos: position{line: 5232, col: 18, offset: 159591},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5230, col: 18, offset: 159510},
+							pos:        position{line: 5232, col: 18, offset: 159591},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5230, col: 28, offset: 159520},
+							pos:  position{line: 5232, col: 28, offset: 159601},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5230, col: 34, offset: 159526},
+							pos:   position{line: 5232, col: 34, offset: 159607},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5230, col: 39, offset: 159531},
+								pos:  position{line: 5232, col: 39, offset: 159612},
 								name: "IntegerAsString",
 							},
 						},
@@ -13338,28 +13338,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5241, col: 1, offset: 159832},
+			pos:  position{line: 5243, col: 1, offset: 159913},
 			expr: &actionExpr{
-				pos: position{line: 5241, col: 17, offset: 159848},
+				pos: position{line: 5243, col: 17, offset: 159929},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5241, col: 17, offset: 159848},
+					pos: position{line: 5243, col: 17, offset: 159929},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5241, col: 17, offset: 159848},
+							pos:        position{line: 5243, col: 17, offset: 159929},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5241, col: 26, offset: 159857},
+							pos:  position{line: 5243, col: 26, offset: 159938},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5241, col: 32, offset: 159863},
+							pos:   position{line: 5243, col: 32, offset: 159944},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5241, col: 36, offset: 159867},
+								pos:  position{line: 5243, col: 36, offset: 159948},
 								name: "IntegerAsString",
 							},
 						},
@@ -13369,43 +13369,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5253, col: 1, offset: 160222},
+			pos:  position{line: 5255, col: 1, offset: 160303},
 			expr: &actionExpr{
-				pos: position{line: 5253, col: 14, offset: 160235},
+				pos: position{line: 5255, col: 14, offset: 160316},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5253, col: 14, offset: 160235},
+					pos: position{line: 5255, col: 14, offset: 160316},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5253, col: 14, offset: 160235},
+							pos:        position{line: 5255, col: 14, offset: 160316},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5253, col: 18, offset: 160239},
+							pos: position{line: 5255, col: 18, offset: 160320},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5253, col: 18, offset: 160239},
+								pos:  position{line: 5255, col: 18, offset: 160320},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5253, col: 25, offset: 160246},
+							pos:   position{line: 5255, col: 25, offset: 160327},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5253, col: 32, offset: 160253},
+								pos:  position{line: 5255, col: 32, offset: 160334},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5253, col: 44, offset: 160265},
+							pos: position{line: 5255, col: 44, offset: 160346},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5253, col: 44, offset: 160265},
+								pos:  position{line: 5255, col: 44, offset: 160346},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5253, col: 51, offset: 160272},
+							pos:        position{line: 5255, col: 51, offset: 160353},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13416,35 +13416,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5258, col: 1, offset: 160361},
+			pos:  position{line: 5260, col: 1, offset: 160442},
 			expr: &actionExpr{
-				pos: position{line: 5258, col: 25, offset: 160385},
+				pos: position{line: 5260, col: 25, offset: 160466},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5258, col: 25, offset: 160385},
+					pos: position{line: 5260, col: 25, offset: 160466},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5258, col: 25, offset: 160385},
+							pos:   position{line: 5260, col: 25, offset: 160466},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5258, col: 31, offset: 160391},
+								pos:  position{line: 5260, col: 31, offset: 160472},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5258, col: 47, offset: 160407},
+							pos:   position{line: 5260, col: 47, offset: 160488},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5258, col: 52, offset: 160412},
+								pos: position{line: 5260, col: 52, offset: 160493},
 								expr: &seqExpr{
-									pos: position{line: 5258, col: 53, offset: 160413},
+									pos: position{line: 5260, col: 53, offset: 160494},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5258, col: 53, offset: 160413},
+											pos:  position{line: 5260, col: 53, offset: 160494},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5258, col: 59, offset: 160419},
+											pos:  position{line: 5260, col: 59, offset: 160500},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13457,37 +13457,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5285, col: 1, offset: 161229},
+			pos:  position{line: 5287, col: 1, offset: 161310},
 			expr: &actionExpr{
-				pos: position{line: 5285, col: 16, offset: 161244},
+				pos: position{line: 5287, col: 16, offset: 161325},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5285, col: 16, offset: 161244},
+					pos: position{line: 5287, col: 16, offset: 161325},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5285, col: 16, offset: 161244},
+							pos:  position{line: 5287, col: 16, offset: 161325},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5285, col: 21, offset: 161249},
+							pos:  position{line: 5287, col: 21, offset: 161330},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5285, col: 32, offset: 161260},
+							pos:   position{line: 5287, col: 32, offset: 161341},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5285, col: 40, offset: 161268},
+								pos: position{line: 5287, col: 40, offset: 161349},
 								expr: &seqExpr{
-									pos: position{line: 5285, col: 41, offset: 161269},
+									pos: position{line: 5287, col: 41, offset: 161350},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5285, col: 41, offset: 161269},
+											pos:  position{line: 5287, col: 41, offset: 161350},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5285, col: 57, offset: 161285},
+											pos: position{line: 5287, col: 57, offset: 161366},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5285, col: 57, offset: 161285},
+												pos:  position{line: 5287, col: 57, offset: 161366},
 												name: "SPACE",
 											},
 										},
@@ -13496,10 +13496,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5285, col: 66, offset: 161294},
+							pos:   position{line: 5287, col: 66, offset: 161375},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5285, col: 76, offset: 161304},
+								pos:  position{line: 5287, col: 76, offset: 161385},
 								name: "Subsearch",
 							},
 						},
@@ -13509,128 +13509,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5329, col: 1, offset: 162876},
+			pos:  position{line: 5331, col: 1, offset: 162957},
 			expr: &choiceExpr{
-				pos: position{line: 5329, col: 12, offset: 162887},
+				pos: position{line: 5331, col: 12, offset: 162968},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 12, offset: 162887},
+						pos:  position{line: 5331, col: 12, offset: 162968},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 24, offset: 162899},
+						pos:  position{line: 5331, col: 24, offset: 162980},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 36, offset: 162911},
+						pos:  position{line: 5331, col: 36, offset: 162992},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 49, offset: 162924},
+						pos:  position{line: 5331, col: 49, offset: 163005},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 61, offset: 162936},
+						pos:  position{line: 5331, col: 61, offset: 163017},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 81, offset: 162956},
+						pos:  position{line: 5331, col: 81, offset: 163037},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 92, offset: 162967},
+						pos:  position{line: 5331, col: 92, offset: 163048},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 112, offset: 162987},
+						pos:  position{line: 5331, col: 112, offset: 163068},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 123, offset: 162998},
+						pos:  position{line: 5331, col: 123, offset: 163079},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 134, offset: 163009},
+						pos:  position{line: 5331, col: 134, offset: 163090},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 144, offset: 163019},
+						pos:  position{line: 5331, col: 144, offset: 163100},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 154, offset: 163029},
+						pos:  position{line: 5331, col: 154, offset: 163110},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 165, offset: 163040},
+						pos:  position{line: 5331, col: 165, offset: 163121},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 178, offset: 163053},
+						pos:  position{line: 5331, col: 178, offset: 163134},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 194, offset: 163069},
+						pos:  position{line: 5331, col: 194, offset: 163150},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 212, offset: 163087},
+						pos:  position{line: 5331, col: 212, offset: 163168},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 224, offset: 163099},
+						pos:  position{line: 5331, col: 224, offset: 163180},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 235, offset: 163110},
+						pos:  position{line: 5331, col: 235, offset: 163191},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 248, offset: 163123},
+						pos:  position{line: 5331, col: 248, offset: 163204},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 260, offset: 163135},
+						pos:  position{line: 5331, col: 260, offset: 163216},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 273, offset: 163148},
+						pos:  position{line: 5331, col: 273, offset: 163229},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 288, offset: 163163},
+						pos:  position{line: 5331, col: 288, offset: 163244},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 301, offset: 163176},
+						pos:  position{line: 5331, col: 301, offset: 163257},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 318, offset: 163193},
+						pos:  position{line: 5331, col: 318, offset: 163274},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 328, offset: 163203},
+						pos:  position{line: 5331, col: 328, offset: 163284},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 346, offset: 163221},
+						pos:  position{line: 5331, col: 346, offset: 163302},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 361, offset: 163236},
+						pos:  position{line: 5331, col: 361, offset: 163317},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 376, offset: 163251},
+						pos:  position{line: 5331, col: 376, offset: 163332},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 391, offset: 163266},
+						pos:  position{line: 5331, col: 391, offset: 163347},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 409, offset: 163284},
+						pos:  position{line: 5331, col: 409, offset: 163365},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13638,18 +13638,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5330, col: 1, offset: 163296},
+			pos:  position{line: 5332, col: 1, offset: 163377},
 			expr: &seqExpr{
-				pos: position{line: 5330, col: 15, offset: 163310},
+				pos: position{line: 5332, col: 15, offset: 163391},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5330, col: 15, offset: 163310},
+						pos:        position{line: 5332, col: 15, offset: 163391},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5330, col: 24, offset: 163319},
+						pos:  position{line: 5332, col: 24, offset: 163400},
 						name: "SPACE",
 					},
 				},
@@ -13657,18 +13657,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5331, col: 1, offset: 163325},
+			pos:  position{line: 5333, col: 1, offset: 163406},
 			expr: &seqExpr{
-				pos: position{line: 5331, col: 14, offset: 163338},
+				pos: position{line: 5333, col: 14, offset: 163419},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5331, col: 14, offset: 163338},
+						pos:        position{line: 5333, col: 14, offset: 163419},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5331, col: 22, offset: 163346},
+						pos:  position{line: 5333, col: 22, offset: 163427},
 						name: "SPACE",
 					},
 				},
@@ -13676,18 +13676,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5332, col: 1, offset: 163352},
+			pos:  position{line: 5334, col: 1, offset: 163433},
 			expr: &seqExpr{
-				pos: position{line: 5332, col: 14, offset: 163365},
+				pos: position{line: 5334, col: 14, offset: 163446},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5332, col: 14, offset: 163365},
+						pos:        position{line: 5334, col: 14, offset: 163446},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5332, col: 22, offset: 163373},
+						pos:  position{line: 5334, col: 22, offset: 163454},
 						name: "SPACE",
 					},
 				},
@@ -13695,18 +13695,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5333, col: 1, offset: 163379},
+			pos:  position{line: 5335, col: 1, offset: 163460},
 			expr: &seqExpr{
-				pos: position{line: 5333, col: 20, offset: 163398},
+				pos: position{line: 5335, col: 20, offset: 163479},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5333, col: 20, offset: 163398},
+						pos:        position{line: 5335, col: 20, offset: 163479},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5333, col: 34, offset: 163412},
+						pos:  position{line: 5335, col: 34, offset: 163493},
 						name: "SPACE",
 					},
 				},
@@ -13714,18 +13714,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5334, col: 1, offset: 163418},
+			pos:  position{line: 5336, col: 1, offset: 163499},
 			expr: &seqExpr{
-				pos: position{line: 5334, col: 15, offset: 163432},
+				pos: position{line: 5336, col: 15, offset: 163513},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5334, col: 15, offset: 163432},
+						pos:        position{line: 5336, col: 15, offset: 163513},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5334, col: 24, offset: 163441},
+						pos:  position{line: 5336, col: 24, offset: 163522},
 						name: "SPACE",
 					},
 				},
@@ -13733,18 +13733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5335, col: 1, offset: 163447},
+			pos:  position{line: 5337, col: 1, offset: 163528},
 			expr: &seqExpr{
-				pos: position{line: 5335, col: 14, offset: 163460},
+				pos: position{line: 5337, col: 14, offset: 163541},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5335, col: 14, offset: 163460},
+						pos:        position{line: 5337, col: 14, offset: 163541},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 22, offset: 163468},
+						pos:  position{line: 5337, col: 22, offset: 163549},
 						name: "SPACE",
 					},
 				},
@@ -13752,9 +13752,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5336, col: 1, offset: 163474},
+			pos:  position{line: 5338, col: 1, offset: 163555},
 			expr: &litMatcher{
-				pos:        position{line: 5336, col: 22, offset: 163495},
+				pos:        position{line: 5338, col: 22, offset: 163576},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13762,16 +13762,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5337, col: 1, offset: 163502},
+			pos:  position{line: 5339, col: 1, offset: 163583},
 			expr: &seqExpr{
-				pos: position{line: 5337, col: 13, offset: 163514},
+				pos: position{line: 5339, col: 13, offset: 163595},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 13, offset: 163514},
+						pos:  position{line: 5339, col: 13, offset: 163595},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 31, offset: 163532},
+						pos:  position{line: 5339, col: 31, offset: 163613},
 						name: "SPACE",
 					},
 				},
@@ -13779,9 +13779,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5338, col: 1, offset: 163538},
+			pos:  position{line: 5340, col: 1, offset: 163619},
 			expr: &litMatcher{
-				pos:        position{line: 5338, col: 22, offset: 163559},
+				pos:        position{line: 5340, col: 22, offset: 163640},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13789,16 +13789,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5339, col: 1, offset: 163566},
+			pos:  position{line: 5341, col: 1, offset: 163647},
 			expr: &seqExpr{
-				pos: position{line: 5339, col: 13, offset: 163578},
+				pos: position{line: 5341, col: 13, offset: 163659},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5339, col: 13, offset: 163578},
+						pos:  position{line: 5341, col: 13, offset: 163659},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5339, col: 31, offset: 163596},
+						pos:  position{line: 5341, col: 31, offset: 163677},
 						name: "SPACE",
 					},
 				},
@@ -13806,18 +13806,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5340, col: 1, offset: 163602},
+			pos:  position{line: 5342, col: 1, offset: 163683},
 			expr: &seqExpr{
-				pos: position{line: 5340, col: 13, offset: 163614},
+				pos: position{line: 5342, col: 13, offset: 163695},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5340, col: 13, offset: 163614},
+						pos:        position{line: 5342, col: 13, offset: 163695},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5340, col: 20, offset: 163621},
+						pos:  position{line: 5342, col: 20, offset: 163702},
 						name: "SPACE",
 					},
 				},
@@ -13825,18 +13825,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5341, col: 1, offset: 163627},
+			pos:  position{line: 5343, col: 1, offset: 163708},
 			expr: &seqExpr{
-				pos: position{line: 5341, col: 12, offset: 163638},
+				pos: position{line: 5343, col: 12, offset: 163719},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5341, col: 12, offset: 163638},
+						pos:        position{line: 5343, col: 12, offset: 163719},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5341, col: 18, offset: 163644},
+						pos:  position{line: 5343, col: 18, offset: 163725},
 						name: "SPACE",
 					},
 				},
@@ -13844,18 +13844,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5342, col: 1, offset: 163650},
+			pos:  position{line: 5344, col: 1, offset: 163731},
 			expr: &seqExpr{
-				pos: position{line: 5342, col: 13, offset: 163662},
+				pos: position{line: 5344, col: 13, offset: 163743},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5342, col: 13, offset: 163662},
+						pos:        position{line: 5344, col: 13, offset: 163743},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5342, col: 20, offset: 163669},
+						pos:  position{line: 5344, col: 20, offset: 163750},
 						name: "SPACE",
 					},
 				},
@@ -13863,9 +13863,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5343, col: 1, offset: 163675},
+			pos:  position{line: 5345, col: 1, offset: 163756},
 			expr: &litMatcher{
-				pos:        position{line: 5343, col: 12, offset: 163686},
+				pos:        position{line: 5345, col: 12, offset: 163767},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13873,9 +13873,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5344, col: 1, offset: 163692},
+			pos:  position{line: 5346, col: 1, offset: 163773},
 			expr: &litMatcher{
-				pos:        position{line: 5344, col: 13, offset: 163704},
+				pos:        position{line: 5346, col: 13, offset: 163785},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13883,18 +13883,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5345, col: 1, offset: 163711},
+			pos:  position{line: 5347, col: 1, offset: 163792},
 			expr: &seqExpr{
-				pos: position{line: 5345, col: 15, offset: 163725},
+				pos: position{line: 5347, col: 15, offset: 163806},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5345, col: 15, offset: 163725},
+						pos:        position{line: 5347, col: 15, offset: 163806},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5345, col: 24, offset: 163734},
+						pos:  position{line: 5347, col: 24, offset: 163815},
 						name: "SPACE",
 					},
 				},
@@ -13902,18 +13902,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5346, col: 1, offset: 163740},
+			pos:  position{line: 5348, col: 1, offset: 163821},
 			expr: &seqExpr{
-				pos: position{line: 5346, col: 18, offset: 163757},
+				pos: position{line: 5348, col: 18, offset: 163838},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5346, col: 18, offset: 163757},
+						pos:        position{line: 5348, col: 18, offset: 163838},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5346, col: 30, offset: 163769},
+						pos:  position{line: 5348, col: 30, offset: 163850},
 						name: "SPACE",
 					},
 				},
@@ -13921,18 +13921,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5347, col: 1, offset: 163775},
+			pos:  position{line: 5349, col: 1, offset: 163856},
 			expr: &seqExpr{
-				pos: position{line: 5347, col: 12, offset: 163786},
+				pos: position{line: 5349, col: 12, offset: 163867},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5347, col: 12, offset: 163786},
+						pos:        position{line: 5349, col: 12, offset: 163867},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5347, col: 18, offset: 163792},
+						pos:  position{line: 5349, col: 18, offset: 163873},
 						name: "SPACE",
 					},
 				},
@@ -13940,9 +13940,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5348, col: 1, offset: 163798},
+			pos:  position{line: 5350, col: 1, offset: 163879},
 			expr: &litMatcher{
-				pos:        position{line: 5348, col: 13, offset: 163810},
+				pos:        position{line: 5350, col: 13, offset: 163891},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13950,18 +13950,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5349, col: 1, offset: 163817},
+			pos:  position{line: 5351, col: 1, offset: 163898},
 			expr: &seqExpr{
-				pos: position{line: 5349, col: 20, offset: 163836},
+				pos: position{line: 5351, col: 20, offset: 163917},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5349, col: 20, offset: 163836},
+						pos:        position{line: 5351, col: 20, offset: 163917},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5349, col: 34, offset: 163850},
+						pos:  position{line: 5351, col: 34, offset: 163931},
 						name: "SPACE",
 					},
 				},
@@ -13969,9 +13969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5350, col: 1, offset: 163856},
+			pos:  position{line: 5352, col: 1, offset: 163937},
 			expr: &litMatcher{
-				pos:        position{line: 5350, col: 14, offset: 163869},
+				pos:        position{line: 5352, col: 14, offset: 163950},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13979,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5351, col: 1, offset: 163877},
+			pos:  position{line: 5353, col: 1, offset: 163958},
 			expr: &seqExpr{
-				pos: position{line: 5351, col: 21, offset: 163897},
+				pos: position{line: 5353, col: 21, offset: 163978},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5351, col: 21, offset: 163897},
+						pos:  position{line: 5353, col: 21, offset: 163978},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 27, offset: 163903},
+						pos:        position{line: 5353, col: 27, offset: 163984},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5351, col: 36, offset: 163912},
+						pos:  position{line: 5353, col: 36, offset: 163993},
 						name: "SPACE",
 					},
 				},
@@ -14002,9 +14002,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5352, col: 1, offset: 163918},
+			pos:  position{line: 5354, col: 1, offset: 163999},
 			expr: &litMatcher{
-				pos:        position{line: 5352, col: 15, offset: 163932},
+				pos:        position{line: 5354, col: 15, offset: 164013},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14012,9 +14012,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5353, col: 1, offset: 163941},
+			pos:  position{line: 5355, col: 1, offset: 164022},
 			expr: &litMatcher{
-				pos:        position{line: 5353, col: 14, offset: 163954},
+				pos:        position{line: 5355, col: 14, offset: 164035},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14022,9 +14022,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5354, col: 1, offset: 163962},
+			pos:  position{line: 5356, col: 1, offset: 164043},
 			expr: &litMatcher{
-				pos:        position{line: 5354, col: 15, offset: 163976},
+				pos:        position{line: 5356, col: 15, offset: 164057},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14032,9 +14032,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5355, col: 1, offset: 163985},
+			pos:  position{line: 5357, col: 1, offset: 164066},
 			expr: &litMatcher{
-				pos:        position{line: 5355, col: 17, offset: 164001},
+				pos:        position{line: 5357, col: 17, offset: 164082},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14042,9 +14042,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5356, col: 1, offset: 164012},
+			pos:  position{line: 5358, col: 1, offset: 164093},
 			expr: &litMatcher{
-				pos:        position{line: 5356, col: 15, offset: 164026},
+				pos:        position{line: 5358, col: 15, offset: 164107},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14052,9 +14052,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5357, col: 1, offset: 164035},
+			pos:  position{line: 5359, col: 1, offset: 164116},
 			expr: &litMatcher{
-				pos:        position{line: 5357, col: 19, offset: 164053},
+				pos:        position{line: 5359, col: 19, offset: 164134},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14062,9 +14062,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5358, col: 1, offset: 164066},
+			pos:  position{line: 5360, col: 1, offset: 164147},
 			expr: &litMatcher{
-				pos:        position{line: 5358, col: 17, offset: 164082},
+				pos:        position{line: 5360, col: 17, offset: 164163},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14072,9 +14072,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5359, col: 1, offset: 164093},
+			pos:  position{line: 5361, col: 1, offset: 164174},
 			expr: &litMatcher{
-				pos:        position{line: 5359, col: 17, offset: 164109},
+				pos:        position{line: 5361, col: 17, offset: 164190},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14082,18 +14082,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5360, col: 1, offset: 164120},
+			pos:  position{line: 5362, col: 1, offset: 164201},
 			expr: &seqExpr{
-				pos: position{line: 5360, col: 20, offset: 164139},
+				pos: position{line: 5362, col: 20, offset: 164220},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5360, col: 20, offset: 164139},
+						pos:        position{line: 5362, col: 20, offset: 164220},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5360, col: 34, offset: 164153},
+						pos:  position{line: 5362, col: 34, offset: 164234},
 						name: "SPACE",
 					},
 				},
@@ -14101,28 +14101,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5361, col: 1, offset: 164159},
+			pos:  position{line: 5363, col: 1, offset: 164240},
 			expr: &seqExpr{
-				pos: position{line: 5361, col: 16, offset: 164174},
+				pos: position{line: 5363, col: 16, offset: 164255},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5361, col: 16, offset: 164174},
+						pos: position{line: 5363, col: 16, offset: 164255},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5361, col: 16, offset: 164174},
+							pos:  position{line: 5363, col: 16, offset: 164255},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5361, col: 24, offset: 164182},
+						pos: position{line: 5363, col: 24, offset: 164263},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5361, col: 24, offset: 164182},
+								pos:        position{line: 5363, col: 24, offset: 164263},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5361, col: 30, offset: 164188},
+								pos:        position{line: 5363, col: 30, offset: 164269},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14130,9 +14130,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5361, col: 35, offset: 164193},
+						pos: position{line: 5363, col: 35, offset: 164274},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5361, col: 35, offset: 164193},
+							pos:  position{line: 5363, col: 35, offset: 164274},
 							name: "SPACE",
 						},
 					},
@@ -14141,9 +14141,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5362, col: 1, offset: 164200},
+			pos:  position{line: 5364, col: 1, offset: 164281},
 			expr: &litMatcher{
-				pos:        position{line: 5362, col: 17, offset: 164216},
+				pos:        position{line: 5364, col: 17, offset: 164297},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14151,18 +14151,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5363, col: 1, offset: 164227},
+			pos:  position{line: 5365, col: 1, offset: 164308},
 			expr: &seqExpr{
-				pos: position{line: 5363, col: 15, offset: 164241},
+				pos: position{line: 5365, col: 15, offset: 164322},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5363, col: 15, offset: 164241},
+						pos:        position{line: 5365, col: 15, offset: 164322},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5363, col: 24, offset: 164250},
+						pos:  position{line: 5365, col: 24, offset: 164331},
 						name: "SPACE",
 					},
 				},
@@ -14170,115 +14170,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5366, col: 1, offset: 164360},
+			pos:  position{line: 5368, col: 1, offset: 164441},
 			expr: &choiceExpr{
-				pos: position{line: 5366, col: 16, offset: 164375},
+				pos: position{line: 5368, col: 16, offset: 164456},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5366, col: 16, offset: 164375},
+						pos:        position{line: 5368, col: 16, offset: 164456},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 47, offset: 164406},
+						pos:        position{line: 5368, col: 47, offset: 164487},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 55, offset: 164414},
+						pos:        position{line: 5368, col: 55, offset: 164495},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 16, offset: 164437},
+						pos:        position{line: 5369, col: 16, offset: 164518},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 26, offset: 164447},
+						pos:        position{line: 5369, col: 26, offset: 164528},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 34, offset: 164455},
+						pos:        position{line: 5369, col: 34, offset: 164536},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 42, offset: 164463},
+						pos:        position{line: 5369, col: 42, offset: 164544},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 50, offset: 164471},
+						pos:        position{line: 5369, col: 50, offset: 164552},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 58, offset: 164479},
+						pos:        position{line: 5369, col: 58, offset: 164560},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 66, offset: 164487},
+						pos:        position{line: 5369, col: 66, offset: 164568},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 16, offset: 164509},
+						pos:        position{line: 5370, col: 16, offset: 164590},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 26, offset: 164519},
+						pos:        position{line: 5370, col: 26, offset: 164600},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 34, offset: 164527},
+						pos:        position{line: 5370, col: 34, offset: 164608},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 42, offset: 164535},
+						pos:        position{line: 5370, col: 42, offset: 164616},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 50, offset: 164543},
+						pos:        position{line: 5370, col: 50, offset: 164624},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 58, offset: 164551},
+						pos:        position{line: 5370, col: 58, offset: 164632},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 66, offset: 164559},
+						pos:        position{line: 5370, col: 66, offset: 164640},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 74, offset: 164567},
+						pos:        position{line: 5370, col: 74, offset: 164648},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14288,25 +14288,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5369, col: 1, offset: 164573},
+			pos:  position{line: 5371, col: 1, offset: 164654},
 			expr: &choiceExpr{
-				pos: position{line: 5369, col: 16, offset: 164588},
+				pos: position{line: 5371, col: 16, offset: 164669},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5369, col: 16, offset: 164588},
+						pos:        position{line: 5371, col: 16, offset: 164669},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5369, col: 30, offset: 164602},
+						pos:        position{line: 5371, col: 30, offset: 164683},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5369, col: 36, offset: 164608},
+						pos:        position{line: 5371, col: 36, offset: 164689},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14316,18 +14316,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5373, col: 1, offset: 164764},
+			pos:  position{line: 5375, col: 1, offset: 164845},
 			expr: &seqExpr{
-				pos: position{line: 5373, col: 8, offset: 164771},
+				pos: position{line: 5375, col: 8, offset: 164852},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5373, col: 8, offset: 164771},
+						pos:        position{line: 5375, col: 8, offset: 164852},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5373, col: 14, offset: 164777},
+						pos:  position{line: 5375, col: 14, offset: 164858},
 						name: "SPACE",
 					},
 				},
@@ -14335,22 +14335,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5374, col: 1, offset: 164783},
+			pos:  position{line: 5376, col: 1, offset: 164864},
 			expr: &seqExpr{
-				pos: position{line: 5374, col: 7, offset: 164789},
+				pos: position{line: 5376, col: 7, offset: 164870},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5374, col: 7, offset: 164789},
+						pos:  position{line: 5376, col: 7, offset: 164870},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5374, col: 13, offset: 164795},
+						pos:        position{line: 5376, col: 13, offset: 164876},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5374, col: 18, offset: 164800},
+						pos:  position{line: 5376, col: 18, offset: 164881},
 						name: "SPACE",
 					},
 				},
@@ -14358,22 +14358,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5375, col: 1, offset: 164806},
+			pos:  position{line: 5377, col: 1, offset: 164887},
 			expr: &seqExpr{
-				pos: position{line: 5375, col: 8, offset: 164813},
+				pos: position{line: 5377, col: 8, offset: 164894},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 8, offset: 164813},
+						pos:  position{line: 5377, col: 8, offset: 164894},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5375, col: 14, offset: 164819},
+						pos:        position{line: 5377, col: 14, offset: 164900},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 20, offset: 164825},
+						pos:  position{line: 5377, col: 20, offset: 164906},
 						name: "SPACE",
 					},
 				},
@@ -14381,22 +14381,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5376, col: 1, offset: 164831},
+			pos:  position{line: 5378, col: 1, offset: 164912},
 			expr: &seqExpr{
-				pos: position{line: 5376, col: 9, offset: 164839},
+				pos: position{line: 5378, col: 9, offset: 164920},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5376, col: 9, offset: 164839},
+						pos:  position{line: 5378, col: 9, offset: 164920},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5376, col: 24, offset: 164854},
+						pos:        position{line: 5378, col: 24, offset: 164935},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5376, col: 28, offset: 164858},
+						pos:  position{line: 5378, col: 28, offset: 164939},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14404,22 +14404,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5377, col: 1, offset: 164873},
+			pos:  position{line: 5379, col: 1, offset: 164954},
 			expr: &seqExpr{
-				pos: position{line: 5377, col: 7, offset: 164879},
+				pos: position{line: 5379, col: 7, offset: 164960},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5377, col: 7, offset: 164879},
+						pos:  position{line: 5379, col: 7, offset: 164960},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5377, col: 13, offset: 164885},
+						pos:        position{line: 5379, col: 13, offset: 164966},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5377, col: 19, offset: 164891},
+						pos:  position{line: 5379, col: 19, offset: 164972},
 						name: "SPACE",
 					},
 				},
@@ -14427,22 +14427,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5378, col: 1, offset: 164917},
+			pos:  position{line: 5380, col: 1, offset: 164998},
 			expr: &seqExpr{
-				pos: position{line: 5378, col: 7, offset: 164923},
+				pos: position{line: 5380, col: 7, offset: 165004},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5378, col: 7, offset: 164923},
+						pos:  position{line: 5380, col: 7, offset: 165004},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5378, col: 13, offset: 164929},
+						pos:        position{line: 5380, col: 13, offset: 165010},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5378, col: 19, offset: 164935},
+						pos:  position{line: 5380, col: 19, offset: 165016},
 						name: "SPACE",
 					},
 				},
@@ -14450,22 +14450,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5380, col: 1, offset: 164962},
+			pos:  position{line: 5382, col: 1, offset: 165043},
 			expr: &seqExpr{
-				pos: position{line: 5380, col: 10, offset: 164971},
+				pos: position{line: 5382, col: 10, offset: 165052},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5380, col: 10, offset: 164971},
+						pos:  position{line: 5382, col: 10, offset: 165052},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5380, col: 25, offset: 164986},
+						pos:        position{line: 5382, col: 25, offset: 165067},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5380, col: 29, offset: 164990},
+						pos:  position{line: 5382, col: 29, offset: 165071},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14473,22 +14473,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5381, col: 1, offset: 165005},
+			pos:  position{line: 5383, col: 1, offset: 165086},
 			expr: &seqExpr{
-				pos: position{line: 5381, col: 10, offset: 165014},
+				pos: position{line: 5383, col: 10, offset: 165095},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5381, col: 10, offset: 165014},
+						pos:  position{line: 5383, col: 10, offset: 165095},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5381, col: 25, offset: 165029},
+						pos:        position{line: 5383, col: 25, offset: 165110},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5381, col: 29, offset: 165033},
+						pos:  position{line: 5383, col: 29, offset: 165114},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14496,9 +14496,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5382, col: 1, offset: 165048},
+			pos:  position{line: 5384, col: 1, offset: 165129},
 			expr: &litMatcher{
-				pos:        position{line: 5382, col: 10, offset: 165057},
+				pos:        position{line: 5384, col: 10, offset: 165138},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14506,18 +14506,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5383, col: 1, offset: 165061},
+			pos:  position{line: 5385, col: 1, offset: 165142},
 			expr: &seqExpr{
-				pos: position{line: 5383, col: 12, offset: 165072},
+				pos: position{line: 5385, col: 12, offset: 165153},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5383, col: 12, offset: 165072},
+						pos:        position{line: 5385, col: 12, offset: 165153},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5383, col: 16, offset: 165076},
+						pos:  position{line: 5385, col: 16, offset: 165157},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14525,16 +14525,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5384, col: 1, offset: 165091},
+			pos:  position{line: 5386, col: 1, offset: 165172},
 			expr: &seqExpr{
-				pos: position{line: 5384, col: 12, offset: 165102},
+				pos: position{line: 5386, col: 12, offset: 165183},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5384, col: 12, offset: 165102},
+						pos:  position{line: 5386, col: 12, offset: 165183},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5384, col: 27, offset: 165117},
+						pos:        position{line: 5386, col: 27, offset: 165198},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14544,40 +14544,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5386, col: 1, offset: 165122},
+			pos:  position{line: 5388, col: 1, offset: 165203},
 			expr: &notExpr{
-				pos: position{line: 5386, col: 8, offset: 165129},
+				pos: position{line: 5388, col: 8, offset: 165210},
 				expr: &anyMatcher{
-					line: 5386, col: 9, offset: 165130,
+					line: 5388, col: 9, offset: 165211,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5387, col: 1, offset: 165132},
+			pos:  position{line: 5389, col: 1, offset: 165213},
 			expr: &choiceExpr{
-				pos: position{line: 5387, col: 15, offset: 165146},
+				pos: position{line: 5389, col: 15, offset: 165227},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5387, col: 15, offset: 165146},
+						pos:        position{line: 5389, col: 15, offset: 165227},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5387, col: 21, offset: 165152},
+						pos:        position{line: 5389, col: 21, offset: 165233},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5387, col: 28, offset: 165159},
+						pos:        position{line: 5389, col: 28, offset: 165240},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5387, col: 35, offset: 165166},
+						pos:        position{line: 5389, col: 35, offset: 165247},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14587,37 +14587,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5388, col: 1, offset: 165171},
+			pos:  position{line: 5390, col: 1, offset: 165252},
 			expr: &choiceExpr{
-				pos: position{line: 5388, col: 10, offset: 165180},
+				pos: position{line: 5390, col: 10, offset: 165261},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5388, col: 11, offset: 165181},
+						pos: position{line: 5390, col: 11, offset: 165262},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5388, col: 11, offset: 165181},
+								pos: position{line: 5390, col: 11, offset: 165262},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5388, col: 11, offset: 165181},
+									pos:  position{line: 5390, col: 11, offset: 165262},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5388, col: 23, offset: 165193},
+								pos:  position{line: 5390, col: 23, offset: 165274},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5388, col: 31, offset: 165201},
+								pos: position{line: 5390, col: 31, offset: 165282},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5388, col: 31, offset: 165201},
+									pos:  position{line: 5390, col: 31, offset: 165282},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5388, col: 46, offset: 165216},
+						pos: position{line: 5390, col: 46, offset: 165297},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5388, col: 46, offset: 165216},
+							pos:  position{line: 5390, col: 46, offset: 165297},
 							name: "WHITESPACE",
 						},
 					},
@@ -14626,38 +14626,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5389, col: 1, offset: 165228},
+			pos:  position{line: 5391, col: 1, offset: 165309},
 			expr: &seqExpr{
-				pos: position{line: 5389, col: 12, offset: 165239},
+				pos: position{line: 5391, col: 12, offset: 165320},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5389, col: 12, offset: 165239},
+						pos:        position{line: 5391, col: 12, offset: 165320},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5389, col: 18, offset: 165245},
+						pos: position{line: 5391, col: 18, offset: 165326},
 						expr: &seqExpr{
-							pos: position{line: 5389, col: 19, offset: 165246},
+							pos: position{line: 5391, col: 19, offset: 165327},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5389, col: 19, offset: 165246},
+									pos: position{line: 5391, col: 19, offset: 165327},
 									expr: &litMatcher{
-										pos:        position{line: 5389, col: 21, offset: 165248},
+										pos:        position{line: 5391, col: 21, offset: 165329},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5389, col: 28, offset: 165255,
+									line: 5391, col: 28, offset: 165336,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5389, col: 32, offset: 165259},
+						pos:        position{line: 5391, col: 32, offset: 165340},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14667,16 +14667,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5390, col: 1, offset: 165265},
+			pos:  position{line: 5392, col: 1, offset: 165346},
 			expr: &choiceExpr{
-				pos: position{line: 5390, col: 20, offset: 165284},
+				pos: position{line: 5392, col: 20, offset: 165365},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5390, col: 20, offset: 165284},
+						pos:  position{line: 5392, col: 20, offset: 165365},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5390, col: 28, offset: 165292},
+						pos:        position{line: 5392, col: 28, offset: 165373},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14686,16 +14686,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5391, col: 1, offset: 165295},
+			pos:  position{line: 5393, col: 1, offset: 165376},
 			expr: &choiceExpr{
-				pos: position{line: 5391, col: 19, offset: 165313},
+				pos: position{line: 5393, col: 19, offset: 165394},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5391, col: 19, offset: 165313},
+						pos:  position{line: 5393, col: 19, offset: 165394},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5391, col: 27, offset: 165321},
+						pos:  position{line: 5393, col: 27, offset: 165402},
 						name: "SPACE",
 					},
 				},
@@ -15845,6 +15845,8 @@ func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
 
 	timeBucket := aggregations.InitTimeBucket(bOptions.SpanOptions.SpanLength.Num, bOptions.SpanOptions.SpanLength.TimeScalr, byField, limitExprTmp, len(measureAggs))
 	aggNode.TimeHistogram = timeBucket
+	timechartExpr.TimeHistogram = timeBucket
+	timechartExpr.ByField = byField
 
 	return aggNode, nil
 }

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -3341,76 +3341,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1874, col: 1, offset: 58760},
+			pos:  position{line: 1875, col: 1, offset: 58828},
 			expr: &actionExpr{
-				pos: position{line: 1874, col: 18, offset: 58777},
+				pos: position{line: 1875, col: 18, offset: 58845},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1874, col: 18, offset: 58777},
+					pos: position{line: 1875, col: 18, offset: 58845},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1874, col: 18, offset: 58777},
+							pos:   position{line: 1875, col: 18, offset: 58845},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1874, col: 23, offset: 58782},
+								pos: position{line: 1875, col: 23, offset: 58850},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1874, col: 23, offset: 58782},
+										pos:  position{line: 1875, col: 23, offset: 58850},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1874, col: 33, offset: 58792},
+										pos:  position{line: 1875, col: 33, offset: 58860},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1874, col: 43, offset: 58802},
+							pos:   position{line: 1875, col: 43, offset: 58870},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1874, col: 49, offset: 58808},
+								pos: position{line: 1875, col: 49, offset: 58876},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1874, col: 50, offset: 58809},
+									pos:  position{line: 1875, col: 50, offset: 58877},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1874, col: 67, offset: 58826},
+							pos:   position{line: 1875, col: 67, offset: 58894},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1874, col: 78, offset: 58837},
+								pos: position{line: 1875, col: 78, offset: 58905},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1874, col: 78, offset: 58837},
+										pos:  position{line: 1875, col: 78, offset: 58905},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1874, col: 84, offset: 58843},
+										pos:  position{line: 1875, col: 84, offset: 58911},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1874, col: 99, offset: 58858},
+							pos:   position{line: 1875, col: 99, offset: 58926},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1874, col: 108, offset: 58867},
+								pos: position{line: 1875, col: 108, offset: 58935},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1874, col: 109, offset: 58868},
+									pos:  position{line: 1875, col: 109, offset: 58936},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1874, col: 120, offset: 58879},
+							pos:   position{line: 1875, col: 120, offset: 58947},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1874, col: 128, offset: 58887},
+								pos: position{line: 1875, col: 128, offset: 58955},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1874, col: 129, offset: 58888},
+									pos:  position{line: 1875, col: 129, offset: 58956},
 									name: "StatisticOptions",
 								},
 							},
@@ -3421,25 +3421,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1916, col: 1, offset: 59973},
+			pos:  position{line: 1917, col: 1, offset: 60041},
 			expr: &choiceExpr{
-				pos: position{line: 1916, col: 19, offset: 59991},
+				pos: position{line: 1917, col: 19, offset: 60059},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1916, col: 19, offset: 59991},
+						pos: position{line: 1917, col: 19, offset: 60059},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1916, col: 19, offset: 59991},
+							pos: position{line: 1917, col: 19, offset: 60059},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1916, col: 19, offset: 59991},
+									pos:  position{line: 1917, col: 19, offset: 60059},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1916, col: 25, offset: 59997},
+									pos:   position{line: 1917, col: 25, offset: 60065},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1916, col: 32, offset: 60004},
+										pos:  position{line: 1917, col: 32, offset: 60072},
 										name: "IntegerAsString",
 									},
 								},
@@ -3447,30 +3447,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1919, col: 3, offset: 60058},
+						pos: position{line: 1920, col: 3, offset: 60126},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1919, col: 3, offset: 60058},
+							pos: position{line: 1920, col: 3, offset: 60126},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 3, offset: 60058},
+									pos:  position{line: 1920, col: 3, offset: 60126},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1919, col: 9, offset: 60064},
+									pos:        position{line: 1920, col: 9, offset: 60132},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1919, col: 17, offset: 60072},
+									pos:  position{line: 1920, col: 17, offset: 60140},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1919, col: 23, offset: 60078},
+									pos:   position{line: 1920, col: 23, offset: 60146},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1919, col: 30, offset: 60085},
+										pos:  position{line: 1920, col: 30, offset: 60153},
 										name: "IntegerAsString",
 									},
 								},
@@ -3482,17 +3482,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1924, col: 1, offset: 60183},
+			pos:  position{line: 1925, col: 1, offset: 60251},
 			expr: &actionExpr{
-				pos: position{line: 1924, col: 21, offset: 60203},
+				pos: position{line: 1925, col: 21, offset: 60271},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1924, col: 21, offset: 60203},
+					pos:   position{line: 1925, col: 21, offset: 60271},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1924, col: 28, offset: 60210},
+						pos: position{line: 1925, col: 28, offset: 60278},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1924, col: 29, offset: 60211},
+							pos:  position{line: 1925, col: 29, offset: 60279},
 							name: "StatisticOption",
 						},
 					},
@@ -3501,34 +3501,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1973, col: 1, offset: 61773},
+			pos:  position{line: 1974, col: 1, offset: 61841},
 			expr: &actionExpr{
-				pos: position{line: 1973, col: 20, offset: 61792},
+				pos: position{line: 1974, col: 20, offset: 61860},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1973, col: 20, offset: 61792},
+					pos: position{line: 1974, col: 20, offset: 61860},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1973, col: 20, offset: 61792},
+							pos:  position{line: 1974, col: 20, offset: 61860},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1973, col: 26, offset: 61798},
+							pos:   position{line: 1974, col: 26, offset: 61866},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1973, col: 36, offset: 61808},
+								pos:  position{line: 1974, col: 36, offset: 61876},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1973, col: 55, offset: 61827},
+							pos:  position{line: 1974, col: 55, offset: 61895},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1973, col: 61, offset: 61833},
+							pos:   position{line: 1974, col: 61, offset: 61901},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1973, col: 67, offset: 61839},
+								pos:  position{line: 1974, col: 67, offset: 61907},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3538,48 +3538,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1978, col: 1, offset: 61948},
+			pos:  position{line: 1979, col: 1, offset: 62016},
 			expr: &actionExpr{
-				pos: position{line: 1978, col: 23, offset: 61970},
+				pos: position{line: 1979, col: 23, offset: 62038},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1978, col: 23, offset: 61970},
+					pos:   position{line: 1979, col: 23, offset: 62038},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1978, col: 31, offset: 61978},
+						pos: position{line: 1979, col: 31, offset: 62046},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1978, col: 31, offset: 61978},
+								pos:        position{line: 1979, col: 31, offset: 62046},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1978, col: 46, offset: 61993},
+								pos:        position{line: 1979, col: 46, offset: 62061},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1978, col: 60, offset: 62007},
+								pos:        position{line: 1979, col: 60, offset: 62075},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1978, col: 73, offset: 62020},
+								pos:        position{line: 1979, col: 73, offset: 62088},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1978, col: 85, offset: 62032},
+								pos:        position{line: 1979, col: 85, offset: 62100},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1978, col: 102, offset: 62049},
+								pos:        position{line: 1979, col: 102, offset: 62117},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3591,25 +3591,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1986, col: 1, offset: 62236},
+			pos:  position{line: 1987, col: 1, offset: 62304},
 			expr: &choiceExpr{
-				pos: position{line: 1986, col: 13, offset: 62248},
+				pos: position{line: 1987, col: 13, offset: 62316},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1986, col: 13, offset: 62248},
+						pos: position{line: 1987, col: 13, offset: 62316},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1986, col: 13, offset: 62248},
+							pos: position{line: 1987, col: 13, offset: 62316},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1986, col: 13, offset: 62248},
+									pos:  position{line: 1987, col: 13, offset: 62316},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1986, col: 16, offset: 62251},
+									pos:   position{line: 1987, col: 16, offset: 62319},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1986, col: 26, offset: 62261},
+										pos:  position{line: 1987, col: 26, offset: 62329},
 										name: "FieldNameList",
 									},
 								},
@@ -3617,13 +3617,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1989, col: 3, offset: 62318},
+						pos: position{line: 1990, col: 3, offset: 62386},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1989, col: 3, offset: 62318},
+							pos:   position{line: 1990, col: 3, offset: 62386},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1989, col: 16, offset: 62331},
+								pos:  position{line: 1990, col: 16, offset: 62399},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3633,26 +3633,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1993, col: 1, offset: 62389},
+			pos:  position{line: 1994, col: 1, offset: 62457},
 			expr: &actionExpr{
-				pos: position{line: 1993, col: 15, offset: 62403},
+				pos: position{line: 1994, col: 15, offset: 62471},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1993, col: 15, offset: 62403},
+					pos: position{line: 1994, col: 15, offset: 62471},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1993, col: 15, offset: 62403},
+							pos:  position{line: 1994, col: 15, offset: 62471},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1993, col: 20, offset: 62408},
+							pos:  position{line: 1994, col: 20, offset: 62476},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1993, col: 30, offset: 62418},
+							pos:   position{line: 1994, col: 30, offset: 62486},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1993, col: 40, offset: 62428},
+								pos:  position{line: 1994, col: 40, offset: 62496},
 								name: "DedupExpr",
 							},
 						},
@@ -3662,27 +3662,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2039, col: 1, offset: 63757},
+			pos:  position{line: 2040, col: 1, offset: 63825},
 			expr: &actionExpr{
-				pos: position{line: 2039, col: 14, offset: 63770},
+				pos: position{line: 2040, col: 14, offset: 63838},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2039, col: 14, offset: 63770},
+					pos: position{line: 2040, col: 14, offset: 63838},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2039, col: 14, offset: 63770},
+							pos:   position{line: 2040, col: 14, offset: 63838},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2039, col: 23, offset: 63779},
+								pos: position{line: 2040, col: 23, offset: 63847},
 								expr: &seqExpr{
-									pos: position{line: 2039, col: 24, offset: 63780},
+									pos: position{line: 2040, col: 24, offset: 63848},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2039, col: 24, offset: 63780},
+											pos:  position{line: 2040, col: 24, offset: 63848},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2039, col: 30, offset: 63786},
+											pos:  position{line: 2040, col: 30, offset: 63854},
 											name: "IntegerAsString",
 										},
 									},
@@ -3690,45 +3690,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 48, offset: 63804},
+							pos:   position{line: 2040, col: 48, offset: 63872},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2039, col: 57, offset: 63813},
+								pos: position{line: 2040, col: 57, offset: 63881},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2039, col: 58, offset: 63814},
+									pos:  position{line: 2040, col: 58, offset: 63882},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 73, offset: 63829},
+							pos:   position{line: 2040, col: 73, offset: 63897},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2039, col: 83, offset: 63839},
+								pos: position{line: 2040, col: 83, offset: 63907},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2039, col: 84, offset: 63840},
+									pos:  position{line: 2040, col: 84, offset: 63908},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 101, offset: 63857},
+							pos:   position{line: 2040, col: 101, offset: 63925},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2039, col: 110, offset: 63866},
+								pos: position{line: 2040, col: 110, offset: 63934},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2039, col: 111, offset: 63867},
+									pos:  position{line: 2040, col: 111, offset: 63935},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2039, col: 126, offset: 63882},
+							pos:   position{line: 2040, col: 126, offset: 63950},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2039, col: 139, offset: 63895},
+								pos: position{line: 2040, col: 139, offset: 63963},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2039, col: 140, offset: 63896},
+									pos:  position{line: 2040, col: 140, offset: 63964},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3739,27 +3739,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2096, col: 1, offset: 65634},
+			pos:  position{line: 2097, col: 1, offset: 65702},
 			expr: &actionExpr{
-				pos: position{line: 2096, col: 19, offset: 65652},
+				pos: position{line: 2097, col: 19, offset: 65720},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2096, col: 19, offset: 65652},
+					pos: position{line: 2097, col: 19, offset: 65720},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2096, col: 19, offset: 65652},
+							pos: position{line: 2097, col: 19, offset: 65720},
 							expr: &litMatcher{
-								pos:        position{line: 2096, col: 21, offset: 65654},
+								pos:        position{line: 2097, col: 21, offset: 65722},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2096, col: 31, offset: 65664},
+							pos:   position{line: 2097, col: 31, offset: 65732},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2096, col: 37, offset: 65670},
+								pos:  position{line: 2097, col: 37, offset: 65738},
 								name: "FieldName",
 							},
 						},
@@ -3769,48 +3769,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2102, col: 1, offset: 65809},
+			pos:  position{line: 2103, col: 1, offset: 65877},
 			expr: &actionExpr{
-				pos: position{line: 2102, col: 32, offset: 65840},
+				pos: position{line: 2103, col: 32, offset: 65908},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2102, col: 32, offset: 65840},
+					pos: position{line: 2103, col: 32, offset: 65908},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2102, col: 32, offset: 65840},
+							pos:   position{line: 2103, col: 32, offset: 65908},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2102, col: 38, offset: 65846},
+								pos:  position{line: 2103, col: 38, offset: 65914},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2102, col: 48, offset: 65856},
+							pos: position{line: 2103, col: 48, offset: 65924},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2102, col: 50, offset: 65858},
+								pos:  position{line: 2103, col: 50, offset: 65926},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2102, col: 57, offset: 65865},
+							pos:   position{line: 2103, col: 57, offset: 65933},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2102, col: 62, offset: 65870},
+								pos: position{line: 2103, col: 62, offset: 65938},
 								expr: &seqExpr{
-									pos: position{line: 2102, col: 63, offset: 65871},
+									pos: position{line: 2103, col: 63, offset: 65939},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2102, col: 63, offset: 65871},
+											pos:  position{line: 2103, col: 63, offset: 65939},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2102, col: 69, offset: 65877},
+											pos:  position{line: 2103, col: 69, offset: 65945},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2102, col: 79, offset: 65887},
+											pos: position{line: 2103, col: 79, offset: 65955},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2102, col: 81, offset: 65889},
+												pos:  position{line: 2103, col: 81, offset: 65957},
 												name: "EQUAL",
 											},
 										},
@@ -3824,45 +3824,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2113, col: 1, offset: 66164},
+			pos:  position{line: 2114, col: 1, offset: 66232},
 			expr: &actionExpr{
-				pos: position{line: 2113, col: 19, offset: 66182},
+				pos: position{line: 2114, col: 19, offset: 66250},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2113, col: 19, offset: 66182},
+					pos: position{line: 2114, col: 19, offset: 66250},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2113, col: 19, offset: 66182},
+							pos:  position{line: 2114, col: 19, offset: 66250},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2113, col: 25, offset: 66188},
+							pos:   position{line: 2114, col: 25, offset: 66256},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2113, col: 31, offset: 66194},
+								pos:  position{line: 2114, col: 31, offset: 66262},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2113, col: 46, offset: 66209},
+							pos:   position{line: 2114, col: 46, offset: 66277},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2113, col: 51, offset: 66214},
+								pos: position{line: 2114, col: 51, offset: 66282},
 								expr: &seqExpr{
-									pos: position{line: 2113, col: 52, offset: 66215},
+									pos: position{line: 2114, col: 52, offset: 66283},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2113, col: 52, offset: 66215},
+											pos:  position{line: 2114, col: 52, offset: 66283},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2113, col: 58, offset: 66221},
+											pos:  position{line: 2114, col: 58, offset: 66289},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2113, col: 73, offset: 66236},
+											pos: position{line: 2114, col: 73, offset: 66304},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2113, col: 74, offset: 66237},
+												pos:  position{line: 2114, col: 74, offset: 66305},
 												name: "EQUAL",
 											},
 										},
@@ -3876,17 +3876,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2131, col: 1, offset: 66765},
+			pos:  position{line: 2132, col: 1, offset: 66833},
 			expr: &actionExpr{
-				pos: position{line: 2131, col: 17, offset: 66781},
+				pos: position{line: 2132, col: 17, offset: 66849},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2131, col: 17, offset: 66781},
+					pos:   position{line: 2132, col: 17, offset: 66849},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2131, col: 24, offset: 66788},
+						pos: position{line: 2132, col: 24, offset: 66856},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2131, col: 25, offset: 66789},
+							pos:  position{line: 2132, col: 25, offset: 66857},
 							name: "DedupOption",
 						},
 					},
@@ -3895,36 +3895,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2171, col: 1, offset: 68055},
+			pos:  position{line: 2172, col: 1, offset: 68123},
 			expr: &actionExpr{
-				pos: position{line: 2171, col: 16, offset: 68070},
+				pos: position{line: 2172, col: 16, offset: 68138},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2171, col: 16, offset: 68070},
+					pos: position{line: 2172, col: 16, offset: 68138},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2171, col: 16, offset: 68070},
+							pos:  position{line: 2172, col: 16, offset: 68138},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 22, offset: 68076},
+							pos:   position{line: 2172, col: 22, offset: 68144},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2171, col: 32, offset: 68086},
+								pos:  position{line: 2172, col: 32, offset: 68154},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2171, col: 47, offset: 68101},
+							pos:        position{line: 2172, col: 47, offset: 68169},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2171, col: 51, offset: 68105},
+							pos:   position{line: 2172, col: 51, offset: 68173},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2171, col: 57, offset: 68111},
+								pos:  position{line: 2172, col: 57, offset: 68179},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3934,30 +3934,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2176, col: 1, offset: 68220},
+			pos:  position{line: 2177, col: 1, offset: 68288},
 			expr: &actionExpr{
-				pos: position{line: 2176, col: 19, offset: 68238},
+				pos: position{line: 2177, col: 19, offset: 68306},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2176, col: 19, offset: 68238},
+					pos:   position{line: 2177, col: 19, offset: 68306},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2176, col: 27, offset: 68246},
+						pos: position{line: 2177, col: 27, offset: 68314},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2176, col: 27, offset: 68246},
+								pos:        position{line: 2177, col: 27, offset: 68314},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2176, col: 43, offset: 68262},
+								pos:        position{line: 2177, col: 43, offset: 68330},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2176, col: 57, offset: 68276},
+								pos:        position{line: 2177, col: 57, offset: 68344},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3969,22 +3969,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2184, col: 1, offset: 68461},
+			pos:  position{line: 2185, col: 1, offset: 68529},
 			expr: &actionExpr{
-				pos: position{line: 2184, col: 22, offset: 68482},
+				pos: position{line: 2185, col: 22, offset: 68550},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2184, col: 22, offset: 68482},
+					pos: position{line: 2185, col: 22, offset: 68550},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 22, offset: 68482},
+							pos:  position{line: 2185, col: 22, offset: 68550},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 39, offset: 68499},
+							pos:   position{line: 2185, col: 39, offset: 68567},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 53, offset: 68513},
+								pos:  position{line: 2185, col: 53, offset: 68581},
 								name: "SortElements",
 							},
 						},
@@ -3994,35 +3994,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2189, col: 1, offset: 68621},
+			pos:  position{line: 2190, col: 1, offset: 68689},
 			expr: &actionExpr{
-				pos: position{line: 2189, col: 17, offset: 68637},
+				pos: position{line: 2190, col: 17, offset: 68705},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2189, col: 17, offset: 68637},
+					pos: position{line: 2190, col: 17, offset: 68705},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2189, col: 17, offset: 68637},
+							pos:   position{line: 2190, col: 17, offset: 68705},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2189, col: 23, offset: 68643},
+								pos:  position{line: 2190, col: 23, offset: 68711},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2189, col: 41, offset: 68661},
+							pos:   position{line: 2190, col: 41, offset: 68729},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2189, col: 46, offset: 68666},
+								pos: position{line: 2190, col: 46, offset: 68734},
 								expr: &seqExpr{
-									pos: position{line: 2189, col: 47, offset: 68667},
+									pos: position{line: 2190, col: 47, offset: 68735},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2189, col: 47, offset: 68667},
+											pos:  position{line: 2190, col: 47, offset: 68735},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2189, col: 62, offset: 68682},
+											pos:  position{line: 2190, col: 62, offset: 68750},
 											name: "SingleSortElement",
 										},
 									},
@@ -4035,22 +4035,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2204, col: 1, offset: 69040},
+			pos:  position{line: 2205, col: 1, offset: 69108},
 			expr: &actionExpr{
-				pos: position{line: 2204, col: 22, offset: 69061},
+				pos: position{line: 2205, col: 22, offset: 69129},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2204, col: 22, offset: 69061},
+					pos:   position{line: 2205, col: 22, offset: 69129},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2204, col: 31, offset: 69070},
+						pos: position{line: 2205, col: 31, offset: 69138},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2204, col: 31, offset: 69070},
+								pos:  position{line: 2205, col: 31, offset: 69138},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2204, col: 59, offset: 69098},
+								pos:  position{line: 2205, col: 59, offset: 69166},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4060,33 +4060,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2208, col: 1, offset: 69157},
+			pos:  position{line: 2209, col: 1, offset: 69225},
 			expr: &actionExpr{
-				pos: position{line: 2208, col: 33, offset: 69189},
+				pos: position{line: 2209, col: 33, offset: 69257},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2208, col: 33, offset: 69189},
+					pos: position{line: 2209, col: 33, offset: 69257},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2208, col: 33, offset: 69189},
+							pos:   position{line: 2209, col: 33, offset: 69257},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2208, col: 47, offset: 69203},
+								pos: position{line: 2209, col: 47, offset: 69271},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2208, col: 47, offset: 69203},
+										pos:        position{line: 2209, col: 47, offset: 69271},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2208, col: 53, offset: 69209},
+										pos:        position{line: 2209, col: 53, offset: 69277},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2208, col: 59, offset: 69215},
+										pos:        position{line: 2209, col: 59, offset: 69283},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4095,10 +4095,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2208, col: 63, offset: 69219},
+							pos:   position{line: 2209, col: 63, offset: 69287},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2208, col: 69, offset: 69225},
+								pos:  position{line: 2209, col: 69, offset: 69293},
 								name: "FieldName",
 							},
 						},
@@ -4108,33 +4108,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2223, col: 1, offset: 69500},
+			pos:  position{line: 2224, col: 1, offset: 69568},
 			expr: &actionExpr{
-				pos: position{line: 2223, col: 30, offset: 69529},
+				pos: position{line: 2224, col: 30, offset: 69597},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2223, col: 30, offset: 69529},
+					pos: position{line: 2224, col: 30, offset: 69597},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2223, col: 30, offset: 69529},
+							pos:   position{line: 2224, col: 30, offset: 69597},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2223, col: 44, offset: 69543},
+								pos: position{line: 2224, col: 44, offset: 69611},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2223, col: 44, offset: 69543},
+										pos:        position{line: 2224, col: 44, offset: 69611},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 50, offset: 69549},
+										pos:        position{line: 2224, col: 50, offset: 69617},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 56, offset: 69555},
+										pos:        position{line: 2224, col: 56, offset: 69623},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4143,31 +4143,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 60, offset: 69559},
+							pos:   position{line: 2224, col: 60, offset: 69627},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2223, col: 64, offset: 69563},
+								pos: position{line: 2224, col: 64, offset: 69631},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2223, col: 64, offset: 69563},
+										pos:        position{line: 2224, col: 64, offset: 69631},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 73, offset: 69572},
+										pos:        position{line: 2224, col: 73, offset: 69640},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 81, offset: 69580},
+										pos:        position{line: 2224, col: 81, offset: 69648},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2223, col: 88, offset: 69587},
+										pos:        position{line: 2224, col: 88, offset: 69655},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4176,19 +4176,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2223, col: 95, offset: 69594},
+							pos:  position{line: 2224, col: 95, offset: 69662},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2223, col: 103, offset: 69602},
+							pos:   position{line: 2224, col: 103, offset: 69670},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2223, col: 109, offset: 69608},
+								pos:  position{line: 2224, col: 109, offset: 69676},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2223, col: 119, offset: 69618},
+							pos:  position{line: 2224, col: 119, offset: 69686},
 							name: "R_PAREN",
 						},
 					},
@@ -4197,26 +4197,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2243, col: 1, offset: 70043},
+			pos:  position{line: 2244, col: 1, offset: 70111},
 			expr: &actionExpr{
-				pos: position{line: 2243, col: 16, offset: 70058},
+				pos: position{line: 2244, col: 16, offset: 70126},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2243, col: 16, offset: 70058},
+					pos: position{line: 2244, col: 16, offset: 70126},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2243, col: 16, offset: 70058},
+							pos:  position{line: 2244, col: 16, offset: 70126},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2243, col: 21, offset: 70063},
+							pos:  position{line: 2244, col: 21, offset: 70131},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2243, col: 32, offset: 70074},
+							pos:   position{line: 2244, col: 32, offset: 70142},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2243, col: 43, offset: 70085},
+								pos:  position{line: 2244, col: 43, offset: 70153},
 								name: "RenameExpr",
 							},
 						},
@@ -4226,33 +4226,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2266, col: 1, offset: 70749},
+			pos:  position{line: 2267, col: 1, offset: 70817},
 			expr: &choiceExpr{
-				pos: position{line: 2266, col: 15, offset: 70763},
+				pos: position{line: 2267, col: 15, offset: 70831},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2266, col: 15, offset: 70763},
+						pos: position{line: 2267, col: 15, offset: 70831},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2266, col: 15, offset: 70763},
+							pos: position{line: 2267, col: 15, offset: 70831},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2266, col: 15, offset: 70763},
+									pos:   position{line: 2267, col: 15, offset: 70831},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2266, col: 31, offset: 70779},
+										pos:  position{line: 2267, col: 31, offset: 70847},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2266, col: 45, offset: 70793},
+									pos:  position{line: 2267, col: 45, offset: 70861},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2266, col: 48, offset: 70796},
+									pos:   position{line: 2267, col: 48, offset: 70864},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2266, col: 59, offset: 70807},
+										pos:  position{line: 2267, col: 59, offset: 70875},
 										name: "QuotedString",
 									},
 								},
@@ -4260,28 +4260,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2277, col: 3, offset: 71126},
+						pos: position{line: 2278, col: 3, offset: 71194},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2277, col: 3, offset: 71126},
+							pos: position{line: 2278, col: 3, offset: 71194},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2277, col: 3, offset: 71126},
+									pos:   position{line: 2278, col: 3, offset: 71194},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2277, col: 19, offset: 71142},
+										pos:  position{line: 2278, col: 19, offset: 71210},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2277, col: 33, offset: 71156},
+									pos:  position{line: 2278, col: 33, offset: 71224},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2277, col: 36, offset: 71159},
+									pos:   position{line: 2278, col: 36, offset: 71227},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2277, col: 47, offset: 71170},
+										pos:  position{line: 2278, col: 47, offset: 71238},
 										name: "RenamePattern",
 									},
 								},
@@ -4293,48 +4293,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2299, col: 1, offset: 71736},
+			pos:  position{line: 2300, col: 1, offset: 71804},
 			expr: &actionExpr{
-				pos: position{line: 2299, col: 13, offset: 71748},
+				pos: position{line: 2300, col: 13, offset: 71816},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2299, col: 13, offset: 71748},
+					pos: position{line: 2300, col: 13, offset: 71816},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 13, offset: 71748},
+							pos:  position{line: 2300, col: 13, offset: 71816},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 18, offset: 71753},
+							pos:  position{line: 2300, col: 18, offset: 71821},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2299, col: 26, offset: 71761},
+							pos:        position{line: 2300, col: 26, offset: 71829},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 34, offset: 71769},
+							pos:  position{line: 2300, col: 34, offset: 71837},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2299, col: 40, offset: 71775},
+							pos:   position{line: 2300, col: 40, offset: 71843},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2299, col: 46, offset: 71781},
+								pos:  position{line: 2300, col: 46, offset: 71849},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 62, offset: 71797},
+							pos:  position{line: 2300, col: 62, offset: 71865},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2299, col: 68, offset: 71803},
+							pos:   position{line: 2300, col: 68, offset: 71871},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2299, col: 72, offset: 71807},
+								pos:  position{line: 2300, col: 72, offset: 71875},
 								name: "QuotedString",
 							},
 						},
@@ -4344,37 +4344,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2328, col: 1, offset: 72536},
+			pos:  position{line: 2329, col: 1, offset: 72604},
 			expr: &actionExpr{
-				pos: position{line: 2328, col: 14, offset: 72549},
+				pos: position{line: 2329, col: 14, offset: 72617},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2328, col: 14, offset: 72549},
+					pos: position{line: 2329, col: 14, offset: 72617},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 14, offset: 72549},
+							pos:  position{line: 2329, col: 14, offset: 72617},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2328, col: 19, offset: 72554},
+							pos:  position{line: 2329, col: 19, offset: 72622},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2328, col: 28, offset: 72563},
+							pos:   position{line: 2329, col: 28, offset: 72631},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2328, col: 34, offset: 72569},
+								pos: position{line: 2329, col: 34, offset: 72637},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2328, col: 35, offset: 72570},
+									pos:  position{line: 2329, col: 35, offset: 72638},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2328, col: 47, offset: 72582},
+							pos:   position{line: 2329, col: 47, offset: 72650},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2328, col: 58, offset: 72593},
+								pos:  position{line: 2329, col: 58, offset: 72661},
 								name: "SortElements",
 							},
 						},
@@ -4384,41 +4384,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2366, col: 1, offset: 73472},
+			pos:  position{line: 2367, col: 1, offset: 73540},
 			expr: &actionExpr{
-				pos: position{line: 2366, col: 14, offset: 73485},
+				pos: position{line: 2367, col: 14, offset: 73553},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2366, col: 14, offset: 73485},
+					pos: position{line: 2367, col: 14, offset: 73553},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2366, col: 14, offset: 73485},
+							pos: position{line: 2367, col: 14, offset: 73553},
 							expr: &seqExpr{
-								pos: position{line: 2366, col: 15, offset: 73486},
+								pos: position{line: 2367, col: 15, offset: 73554},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2366, col: 15, offset: 73486},
+										pos:        position{line: 2367, col: 15, offset: 73554},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2366, col: 23, offset: 73494},
+										pos:  position{line: 2367, col: 23, offset: 73562},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2366, col: 31, offset: 73502},
+							pos:   position{line: 2367, col: 31, offset: 73570},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2366, col: 40, offset: 73511},
+								pos:  position{line: 2367, col: 40, offset: 73579},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2366, col: 56, offset: 73527},
+							pos:  position{line: 2367, col: 56, offset: 73595},
 							name: "SPACE",
 						},
 					},
@@ -4427,43 +4427,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2380, col: 1, offset: 73826},
+			pos:  position{line: 2381, col: 1, offset: 73894},
 			expr: &actionExpr{
-				pos: position{line: 2380, col: 14, offset: 73839},
+				pos: position{line: 2381, col: 14, offset: 73907},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2380, col: 14, offset: 73839},
+					pos: position{line: 2381, col: 14, offset: 73907},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2380, col: 14, offset: 73839},
+							pos:  position{line: 2381, col: 14, offset: 73907},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2380, col: 19, offset: 73844},
+							pos:  position{line: 2381, col: 19, offset: 73912},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2380, col: 28, offset: 73853},
+							pos:   position{line: 2381, col: 28, offset: 73921},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2380, col: 34, offset: 73859},
+								pos:  position{line: 2381, col: 34, offset: 73927},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2380, col: 45, offset: 73870},
+							pos:   position{line: 2381, col: 45, offset: 73938},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2380, col: 50, offset: 73875},
+								pos: position{line: 2381, col: 50, offset: 73943},
 								expr: &seqExpr{
-									pos: position{line: 2380, col: 51, offset: 73876},
+									pos: position{line: 2381, col: 51, offset: 73944},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2380, col: 51, offset: 73876},
+											pos:  position{line: 2381, col: 51, offset: 73944},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2380, col: 57, offset: 73882},
+											pos:  position{line: 2381, col: 57, offset: 73950},
 											name: "SingleEval",
 										},
 									},
@@ -4476,30 +4476,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2415, col: 1, offset: 75115},
+			pos:  position{line: 2416, col: 1, offset: 75183},
 			expr: &actionExpr{
-				pos: position{line: 2415, col: 15, offset: 75129},
+				pos: position{line: 2416, col: 15, offset: 75197},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2415, col: 15, offset: 75129},
+					pos: position{line: 2416, col: 15, offset: 75197},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2415, col: 15, offset: 75129},
+							pos:   position{line: 2416, col: 15, offset: 75197},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2415, col: 21, offset: 75135},
+								pos:  position{line: 2416, col: 21, offset: 75203},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2415, col: 31, offset: 75145},
+							pos:  position{line: 2416, col: 31, offset: 75213},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2415, col: 37, offset: 75151},
+							pos:   position{line: 2416, col: 37, offset: 75219},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2415, col: 42, offset: 75156},
+								pos:  position{line: 2416, col: 42, offset: 75224},
 								name: "EvalExpression",
 							},
 						},
@@ -4509,15 +4509,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2428, col: 1, offset: 75557},
+			pos:  position{line: 2429, col: 1, offset: 75625},
 			expr: &actionExpr{
-				pos: position{line: 2428, col: 19, offset: 75575},
+				pos: position{line: 2429, col: 19, offset: 75643},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2428, col: 19, offset: 75575},
+					pos:   position{line: 2429, col: 19, offset: 75643},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2428, col: 25, offset: 75581},
+						pos:  position{line: 2429, col: 25, offset: 75649},
 						name: "ValueExpr",
 					},
 				},
@@ -4525,85 +4525,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2437, col: 1, offset: 75805},
+			pos:  position{line: 2438, col: 1, offset: 75873},
 			expr: &choiceExpr{
-				pos: position{line: 2437, col: 18, offset: 75822},
+				pos: position{line: 2438, col: 18, offset: 75890},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2437, col: 18, offset: 75822},
+						pos: position{line: 2438, col: 18, offset: 75890},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2437, col: 18, offset: 75822},
+							pos: position{line: 2438, col: 18, offset: 75890},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2437, col: 18, offset: 75822},
+									pos:        position{line: 2438, col: 18, offset: 75890},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2437, col: 23, offset: 75827},
+									pos:  position{line: 2438, col: 23, offset: 75895},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2437, col: 31, offset: 75835},
+									pos:   position{line: 2438, col: 31, offset: 75903},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2437, col: 41, offset: 75845},
+										pos:  position{line: 2438, col: 41, offset: 75913},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2437, col: 50, offset: 75854},
+									pos:  position{line: 2438, col: 50, offset: 75922},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2437, col: 56, offset: 75860},
+									pos:   position{line: 2438, col: 56, offset: 75928},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2437, col: 66, offset: 75870},
+										pos:  position{line: 2438, col: 66, offset: 75938},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2437, col: 76, offset: 75880},
+									pos:  position{line: 2438, col: 76, offset: 75948},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2437, col: 82, offset: 75886},
+									pos:   position{line: 2438, col: 82, offset: 75954},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2437, col: 93, offset: 75897},
+										pos:  position{line: 2438, col: 93, offset: 75965},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2437, col: 103, offset: 75907},
+									pos:  position{line: 2438, col: 103, offset: 75975},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2448, col: 3, offset: 76158},
+						pos: position{line: 2449, col: 3, offset: 76226},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2448, col: 3, offset: 76158},
+							pos: position{line: 2449, col: 3, offset: 76226},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2448, col: 3, offset: 76158},
+									pos:   position{line: 2449, col: 3, offset: 76226},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2448, col: 11, offset: 76166},
+										pos: position{line: 2449, col: 11, offset: 76234},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2448, col: 11, offset: 76166},
+												pos:        position{line: 2449, col: 11, offset: 76234},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2448, col: 20, offset: 76175},
+												pos:        position{line: 2449, col: 20, offset: 76243},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4612,31 +4612,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2448, col: 32, offset: 76187},
+									pos:  position{line: 2449, col: 32, offset: 76255},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2448, col: 40, offset: 76195},
+									pos:   position{line: 2449, col: 40, offset: 76263},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2448, col: 45, offset: 76200},
+										pos:  position{line: 2449, col: 45, offset: 76268},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2448, col: 64, offset: 76219},
+									pos:   position{line: 2449, col: 64, offset: 76287},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2448, col: 69, offset: 76224},
+										pos: position{line: 2449, col: 69, offset: 76292},
 										expr: &seqExpr{
-											pos: position{line: 2448, col: 70, offset: 76225},
+											pos: position{line: 2449, col: 70, offset: 76293},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2448, col: 70, offset: 76225},
+													pos:  position{line: 2449, col: 70, offset: 76293},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2448, col: 76, offset: 76231},
+													pos:  position{line: 2449, col: 76, offset: 76299},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4644,50 +4644,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2448, col: 97, offset: 76252},
+									pos:  position{line: 2449, col: 97, offset: 76320},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2471, col: 3, offset: 76856},
+						pos: position{line: 2472, col: 3, offset: 76924},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2471, col: 3, offset: 76856},
+							pos: position{line: 2472, col: 3, offset: 76924},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2471, col: 3, offset: 76856},
+									pos:        position{line: 2472, col: 3, offset: 76924},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2471, col: 14, offset: 76867},
+									pos:  position{line: 2472, col: 14, offset: 76935},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2471, col: 22, offset: 76875},
+									pos:   position{line: 2472, col: 22, offset: 76943},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2471, col: 32, offset: 76885},
+										pos:  position{line: 2472, col: 32, offset: 76953},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2471, col: 42, offset: 76895},
+									pos:   position{line: 2472, col: 42, offset: 76963},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2471, col: 47, offset: 76900},
+										pos: position{line: 2472, col: 47, offset: 76968},
 										expr: &seqExpr{
-											pos: position{line: 2471, col: 48, offset: 76901},
+											pos: position{line: 2472, col: 48, offset: 76969},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2471, col: 48, offset: 76901},
+													pos:  position{line: 2472, col: 48, offset: 76969},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2471, col: 54, offset: 76907},
+													pos:  position{line: 2472, col: 54, offset: 76975},
 													name: "ValueExpr",
 												},
 											},
@@ -4695,73 +4695,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2471, col: 66, offset: 76919},
+									pos:  position{line: 2472, col: 66, offset: 76987},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2488, col: 3, offset: 77338},
+						pos: position{line: 2489, col: 3, offset: 77406},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2488, col: 3, offset: 77338},
+							pos: position{line: 2489, col: 3, offset: 77406},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2488, col: 3, offset: 77338},
+									pos:        position{line: 2489, col: 3, offset: 77406},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2488, col: 12, offset: 77347},
+									pos:  position{line: 2489, col: 12, offset: 77415},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2488, col: 20, offset: 77355},
+									pos:   position{line: 2489, col: 20, offset: 77423},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2488, col: 30, offset: 77365},
+										pos:  position{line: 2489, col: 30, offset: 77433},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2488, col: 40, offset: 77375},
+									pos:  position{line: 2489, col: 40, offset: 77443},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2488, col: 46, offset: 77381},
+									pos:   position{line: 2489, col: 46, offset: 77449},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2488, col: 57, offset: 77392},
+										pos:  position{line: 2489, col: 57, offset: 77460},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2488, col: 67, offset: 77402},
+									pos:  position{line: 2489, col: 67, offset: 77470},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2500, col: 3, offset: 77682},
+						pos: position{line: 2501, col: 3, offset: 77750},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2500, col: 3, offset: 77682},
+							pos: position{line: 2501, col: 3, offset: 77750},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2500, col: 3, offset: 77682},
+									pos:        position{line: 2501, col: 3, offset: 77750},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2500, col: 10, offset: 77689},
+									pos:  position{line: 2501, col: 10, offset: 77757},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2500, col: 18, offset: 77697},
+									pos:  position{line: 2501, col: 18, offset: 77765},
 									name: "R_PAREN",
 								},
 							},
@@ -4772,30 +4772,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2507, col: 1, offset: 77794},
+			pos:  position{line: 2508, col: 1, offset: 77862},
 			expr: &actionExpr{
-				pos: position{line: 2507, col: 23, offset: 77816},
+				pos: position{line: 2508, col: 23, offset: 77884},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2507, col: 23, offset: 77816},
+					pos: position{line: 2508, col: 23, offset: 77884},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2507, col: 23, offset: 77816},
+							pos:   position{line: 2508, col: 23, offset: 77884},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2507, col: 33, offset: 77826},
+								pos:  position{line: 2508, col: 33, offset: 77894},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2507, col: 42, offset: 77835},
+							pos:  position{line: 2508, col: 42, offset: 77903},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2507, col: 48, offset: 77841},
+							pos:   position{line: 2508, col: 48, offset: 77909},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2507, col: 54, offset: 77847},
+								pos:  position{line: 2508, col: 54, offset: 77915},
 								name: "ValueExpr",
 							},
 						},
@@ -4805,15 +4805,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2515, col: 1, offset: 78052},
+			pos:  position{line: 2516, col: 1, offset: 78120},
 			expr: &actionExpr{
-				pos: position{line: 2515, col: 26, offset: 78077},
+				pos: position{line: 2516, col: 26, offset: 78145},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2515, col: 26, offset: 78077},
+					pos:   position{line: 2516, col: 26, offset: 78145},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2515, col: 37, offset: 78088},
+						pos:  position{line: 2516, col: 37, offset: 78156},
 						name: "StringExpr",
 					},
 				},
@@ -4821,15 +4821,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2525, col: 1, offset: 78297},
+			pos:  position{line: 2526, col: 1, offset: 78365},
 			expr: &actionExpr{
-				pos: position{line: 2525, col: 30, offset: 78326},
+				pos: position{line: 2526, col: 30, offset: 78394},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2525, col: 30, offset: 78326},
+					pos:   position{line: 2526, col: 30, offset: 78394},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2525, col: 45, offset: 78341},
+						pos:  position{line: 2526, col: 45, offset: 78409},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4837,22 +4837,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2534, col: 1, offset: 78547},
+			pos:  position{line: 2535, col: 1, offset: 78615},
 			expr: &actionExpr{
-				pos: position{line: 2534, col: 27, offset: 78573},
+				pos: position{line: 2535, col: 27, offset: 78641},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2534, col: 27, offset: 78573},
+					pos:   position{line: 2535, col: 27, offset: 78641},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2534, col: 40, offset: 78586},
+						pos: position{line: 2535, col: 40, offset: 78654},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2534, col: 40, offset: 78586},
+								pos:  position{line: 2535, col: 40, offset: 78654},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2534, col: 68, offset: 78614},
+								pos:  position{line: 2535, col: 68, offset: 78682},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4862,135 +4862,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2538, col: 1, offset: 78691},
+			pos:  position{line: 2539, col: 1, offset: 78759},
 			expr: &choiceExpr{
-				pos: position{line: 2538, col: 19, offset: 78709},
+				pos: position{line: 2539, col: 19, offset: 78777},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2538, col: 19, offset: 78709},
+						pos: position{line: 2539, col: 19, offset: 78777},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2538, col: 20, offset: 78710},
+							pos: position{line: 2539, col: 20, offset: 78778},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2538, col: 20, offset: 78710},
+									pos:   position{line: 2539, col: 20, offset: 78778},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2538, col: 28, offset: 78718},
+										pos:        position{line: 2539, col: 28, offset: 78786},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 37, offset: 78727},
+									pos:  position{line: 2539, col: 37, offset: 78795},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2538, col: 45, offset: 78735},
+									pos:   position{line: 2539, col: 45, offset: 78803},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2538, col: 56, offset: 78746},
+										pos:  position{line: 2539, col: 56, offset: 78814},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 67, offset: 78757},
+									pos:  position{line: 2539, col: 67, offset: 78825},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2538, col: 73, offset: 78763},
+									pos:   position{line: 2539, col: 73, offset: 78831},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2538, col: 79, offset: 78769},
+										pos:  position{line: 2539, col: 79, offset: 78837},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2538, col: 90, offset: 78780},
+									pos:  position{line: 2539, col: 90, offset: 78848},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2550, col: 3, offset: 79141},
+						pos: position{line: 2551, col: 3, offset: 79209},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2550, col: 4, offset: 79142},
+							pos: position{line: 2551, col: 4, offset: 79210},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2550, col: 4, offset: 79142},
+									pos:   position{line: 2551, col: 4, offset: 79210},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2550, col: 12, offset: 79150},
+										pos:        position{line: 2551, col: 12, offset: 79218},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2550, col: 23, offset: 79161},
+									pos:  position{line: 2551, col: 23, offset: 79229},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2550, col: 31, offset: 79169},
+									pos:   position{line: 2551, col: 31, offset: 79237},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2550, col: 46, offset: 79184},
+										pos:  position{line: 2551, col: 46, offset: 79252},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2550, col: 61, offset: 79199},
+									pos:  position{line: 2551, col: 61, offset: 79267},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2550, col: 67, offset: 79205},
+									pos:   position{line: 2551, col: 67, offset: 79273},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2550, col: 78, offset: 79216},
+										pos:  position{line: 2551, col: 78, offset: 79284},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2550, col: 90, offset: 79228},
+									pos:   position{line: 2551, col: 90, offset: 79296},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2550, col: 99, offset: 79237},
+										pos: position{line: 2551, col: 99, offset: 79305},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2550, col: 100, offset: 79238},
+											pos:  position{line: 2551, col: 100, offset: 79306},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2550, col: 119, offset: 79257},
+									pos:  position{line: 2551, col: 119, offset: 79325},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2566, col: 3, offset: 79819},
+						pos: position{line: 2567, col: 3, offset: 79887},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2566, col: 4, offset: 79820},
+							pos: position{line: 2567, col: 4, offset: 79888},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2566, col: 4, offset: 79820},
+									pos:   position{line: 2567, col: 4, offset: 79888},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2566, col: 12, offset: 79828},
+										pos: position{line: 2567, col: 12, offset: 79896},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2566, col: 12, offset: 79828},
+												pos:        position{line: 2567, col: 12, offset: 79896},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2566, col: 24, offset: 79840},
+												pos:        position{line: 2567, col: 24, offset: 79908},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4999,222 +4999,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2566, col: 34, offset: 79850},
+									pos:  position{line: 2567, col: 34, offset: 79918},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2566, col: 42, offset: 79858},
+									pos:   position{line: 2567, col: 42, offset: 79926},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2566, col: 57, offset: 79873},
+										pos:  position{line: 2567, col: 57, offset: 79941},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2566, col: 72, offset: 79888},
+									pos:  position{line: 2567, col: 72, offset: 79956},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2578, col: 3, offset: 80236},
+						pos: position{line: 2579, col: 3, offset: 80304},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2578, col: 4, offset: 80237},
+							pos: position{line: 2579, col: 4, offset: 80305},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2578, col: 4, offset: 80237},
+									pos:   position{line: 2579, col: 4, offset: 80305},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2578, col: 12, offset: 80245},
+										pos:        position{line: 2579, col: 12, offset: 80313},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2578, col: 24, offset: 80257},
+									pos:  position{line: 2579, col: 24, offset: 80325},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2578, col: 32, offset: 80265},
+									pos:   position{line: 2579, col: 32, offset: 80333},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2578, col: 42, offset: 80275},
+										pos:  position{line: 2579, col: 42, offset: 80343},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2578, col: 51, offset: 80284},
+									pos:  position{line: 2579, col: 51, offset: 80352},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2591, col: 3, offset: 80631},
+						pos: position{line: 2592, col: 3, offset: 80699},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2591, col: 4, offset: 80632},
+							pos: position{line: 2592, col: 4, offset: 80700},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2591, col: 4, offset: 80632},
+									pos:   position{line: 2592, col: 4, offset: 80700},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2591, col: 12, offset: 80640},
+										pos:        position{line: 2592, col: 12, offset: 80708},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 21, offset: 80649},
+									pos:  position{line: 2592, col: 21, offset: 80717},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2591, col: 29, offset: 80657},
+									pos:   position{line: 2592, col: 29, offset: 80725},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2591, col: 44, offset: 80672},
+										pos:  position{line: 2592, col: 44, offset: 80740},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 59, offset: 80687},
+									pos:  position{line: 2592, col: 59, offset: 80755},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2591, col: 65, offset: 80693},
+									pos:   position{line: 2592, col: 65, offset: 80761},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2591, col: 70, offset: 80698},
+										pos:  position{line: 2592, col: 70, offset: 80766},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 80, offset: 80708},
+									pos:  position{line: 2592, col: 80, offset: 80776},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2604, col: 3, offset: 81130},
+						pos: position{line: 2605, col: 3, offset: 81198},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2604, col: 4, offset: 81131},
+							pos: position{line: 2605, col: 4, offset: 81199},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2604, col: 4, offset: 81131},
+									pos:   position{line: 2605, col: 4, offset: 81199},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2604, col: 12, offset: 81139},
+										pos:        position{line: 2605, col: 12, offset: 81207},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 23, offset: 81150},
+									pos:  position{line: 2605, col: 23, offset: 81218},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2604, col: 31, offset: 81158},
+									pos:   position{line: 2605, col: 31, offset: 81226},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2604, col: 42, offset: 81169},
+										pos:  position{line: 2605, col: 42, offset: 81237},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 54, offset: 81181},
+									pos:  position{line: 2605, col: 54, offset: 81249},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2604, col: 60, offset: 81187},
+									pos:   position{line: 2605, col: 60, offset: 81255},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2604, col: 69, offset: 81196},
+										pos:  position{line: 2605, col: 69, offset: 81264},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 81, offset: 81208},
+									pos:  position{line: 2605, col: 81, offset: 81276},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2604, col: 87, offset: 81214},
+									pos:   position{line: 2605, col: 87, offset: 81282},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2604, col: 98, offset: 81225},
+										pos: position{line: 2605, col: 98, offset: 81293},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2604, col: 99, offset: 81226},
+											pos:  position{line: 2605, col: 99, offset: 81294},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 112, offset: 81239},
+									pos:  position{line: 2605, col: 112, offset: 81307},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2617, col: 3, offset: 81690},
+						pos: position{line: 2618, col: 3, offset: 81758},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2617, col: 4, offset: 81691},
+							pos: position{line: 2618, col: 4, offset: 81759},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2617, col: 4, offset: 81691},
+									pos:   position{line: 2618, col: 4, offset: 81759},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2617, col: 12, offset: 81699},
+										pos:        position{line: 2618, col: 12, offset: 81767},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 21, offset: 81708},
+									pos:  position{line: 2618, col: 21, offset: 81776},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 29, offset: 81716},
+									pos:   position{line: 2618, col: 29, offset: 81784},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2617, col: 36, offset: 81723},
+										pos:  position{line: 2618, col: 36, offset: 81791},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 51, offset: 81738},
+									pos:  position{line: 2618, col: 51, offset: 81806},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 57, offset: 81744},
+									pos:   position{line: 2618, col: 57, offset: 81812},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2617, col: 65, offset: 81752},
+										pos:  position{line: 2618, col: 65, offset: 81820},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 80, offset: 81767},
+									pos:   position{line: 2618, col: 80, offset: 81835},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2617, col: 85, offset: 81772},
+										pos: position{line: 2618, col: 85, offset: 81840},
 										expr: &seqExpr{
-											pos: position{line: 2617, col: 86, offset: 81773},
+											pos: position{line: 2618, col: 86, offset: 81841},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2617, col: 86, offset: 81773},
+													pos:  position{line: 2618, col: 86, offset: 81841},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2617, col: 92, offset: 81779},
+													pos:  position{line: 2618, col: 92, offset: 81847},
 													name: "StringExpr",
 												},
 											},
@@ -5222,63 +5222,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 105, offset: 81792},
+									pos:  position{line: 2618, col: 105, offset: 81860},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2634, col: 3, offset: 82320},
+						pos: position{line: 2635, col: 3, offset: 82388},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2634, col: 4, offset: 82321},
+							pos: position{line: 2635, col: 4, offset: 82389},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2634, col: 4, offset: 82321},
+									pos:   position{line: 2635, col: 4, offset: 82389},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2634, col: 12, offset: 82329},
+										pos:        position{line: 2635, col: 12, offset: 82397},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2634, col: 32, offset: 82349},
+									pos:  position{line: 2635, col: 32, offset: 82417},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2634, col: 40, offset: 82357},
+									pos:   position{line: 2635, col: 40, offset: 82425},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2634, col: 55, offset: 82372},
+										pos:  position{line: 2635, col: 55, offset: 82440},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2634, col: 70, offset: 82387},
+									pos:   position{line: 2635, col: 70, offset: 82455},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2634, col: 75, offset: 82392},
+										pos: position{line: 2635, col: 75, offset: 82460},
 										expr: &seqExpr{
-											pos: position{line: 2634, col: 76, offset: 82393},
+											pos: position{line: 2635, col: 76, offset: 82461},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2634, col: 76, offset: 82393},
+													pos:  position{line: 2635, col: 76, offset: 82461},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2634, col: 83, offset: 82400},
+													pos: position{line: 2635, col: 83, offset: 82468},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2634, col: 83, offset: 82400},
+															pos:        position{line: 2635, col: 83, offset: 82468},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2634, col: 92, offset: 82409},
+															pos:        position{line: 2635, col: 92, offset: 82477},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5286,7 +5286,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2634, col: 101, offset: 82418},
+													pos:        position{line: 2635, col: 101, offset: 82486},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5296,54 +5296,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2634, col: 108, offset: 82425},
+									pos:  position{line: 2635, col: 108, offset: 82493},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2659, col: 3, offset: 83128},
+						pos: position{line: 2660, col: 3, offset: 83196},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2659, col: 4, offset: 83129},
+							pos: position{line: 2660, col: 4, offset: 83197},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2659, col: 4, offset: 83129},
+									pos:   position{line: 2660, col: 4, offset: 83197},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2659, col: 12, offset: 83137},
+										pos:        position{line: 2660, col: 12, offset: 83205},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2659, col: 24, offset: 83149},
+									pos:  position{line: 2660, col: 24, offset: 83217},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2659, col: 32, offset: 83157},
+									pos:   position{line: 2660, col: 32, offset: 83225},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2659, col: 41, offset: 83166},
+										pos:  position{line: 2660, col: 41, offset: 83234},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2659, col: 64, offset: 83189},
+									pos:   position{line: 2660, col: 64, offset: 83257},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2659, col: 69, offset: 83194},
+										pos: position{line: 2660, col: 69, offset: 83262},
 										expr: &seqExpr{
-											pos: position{line: 2659, col: 70, offset: 83195},
+											pos: position{line: 2660, col: 70, offset: 83263},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2659, col: 70, offset: 83195},
+													pos:  position{line: 2660, col: 70, offset: 83263},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2659, col: 76, offset: 83201},
+													pos:  position{line: 2660, col: 76, offset: 83269},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5351,57 +5351,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2659, col: 101, offset: 83226},
+									pos:  position{line: 2660, col: 101, offset: 83294},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2679, col: 3, offset: 83814},
+						pos: position{line: 2680, col: 3, offset: 83882},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2679, col: 3, offset: 83814},
+							pos: position{line: 2680, col: 3, offset: 83882},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2679, col: 3, offset: 83814},
+									pos:   position{line: 2680, col: 3, offset: 83882},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2679, col: 9, offset: 83820},
+										pos:  position{line: 2680, col: 9, offset: 83888},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2679, col: 25, offset: 83836},
+									pos: position{line: 2680, col: 25, offset: 83904},
 									expr: &choiceExpr{
-										pos: position{line: 2679, col: 27, offset: 83838},
+										pos: position{line: 2680, col: 27, offset: 83906},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 27, offset: 83838},
+												pos:  position{line: 2680, col: 27, offset: 83906},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 36, offset: 83847},
+												pos:  position{line: 2680, col: 36, offset: 83915},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 46, offset: 83857},
+												pos:  position{line: 2680, col: 46, offset: 83925},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 54, offset: 83865},
+												pos:  position{line: 2680, col: 54, offset: 83933},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 62, offset: 83873},
+												pos:  position{line: 2680, col: 62, offset: 83941},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2679, col: 70, offset: 83881},
+												pos:  position{line: 2680, col: 70, offset: 83949},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2679, col: 84, offset: 83895},
+												pos:        position{line: 2680, col: 84, offset: 83963},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5417,36 +5417,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2691, col: 1, offset: 84290},
+			pos:  position{line: 2692, col: 1, offset: 84358},
 			expr: &choiceExpr{
-				pos: position{line: 2691, col: 13, offset: 84302},
+				pos: position{line: 2692, col: 13, offset: 84370},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2691, col: 13, offset: 84302},
+						pos: position{line: 2692, col: 13, offset: 84370},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2691, col: 14, offset: 84303},
+							pos: position{line: 2692, col: 14, offset: 84371},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2691, col: 14, offset: 84303},
+									pos:   position{line: 2692, col: 14, offset: 84371},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2691, col: 22, offset: 84311},
+										pos: position{line: 2692, col: 22, offset: 84379},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2691, col: 22, offset: 84311},
+												pos:        position{line: 2692, col: 22, offset: 84379},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2691, col: 32, offset: 84321},
+												pos:        position{line: 2692, col: 32, offset: 84389},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2691, col: 42, offset: 84331},
+												pos:        position{line: 2692, col: 42, offset: 84399},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5455,44 +5455,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2691, col: 55, offset: 84344},
+									pos:  position{line: 2692, col: 55, offset: 84412},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2691, col: 63, offset: 84352},
+									pos:   position{line: 2692, col: 63, offset: 84420},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2691, col: 74, offset: 84363},
+										pos:  position{line: 2692, col: 74, offset: 84431},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2691, col: 85, offset: 84374},
+									pos:  position{line: 2692, col: 85, offset: 84442},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2703, col: 3, offset: 84688},
+						pos: position{line: 2704, col: 3, offset: 84756},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2703, col: 4, offset: 84689},
+							pos: position{line: 2704, col: 4, offset: 84757},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2703, col: 4, offset: 84689},
+									pos:   position{line: 2704, col: 4, offset: 84757},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2703, col: 12, offset: 84697},
+										pos: position{line: 2704, col: 12, offset: 84765},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2703, col: 12, offset: 84697},
+												pos:        position{line: 2704, col: 12, offset: 84765},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2703, col: 20, offset: 84705},
+												pos:        position{line: 2704, col: 20, offset: 84773},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5501,31 +5501,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2703, col: 27, offset: 84712},
+									pos:  position{line: 2704, col: 27, offset: 84780},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2703, col: 35, offset: 84720},
+									pos:   position{line: 2704, col: 35, offset: 84788},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2703, col: 44, offset: 84729},
+										pos:  position{line: 2704, col: 44, offset: 84797},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2703, col: 55, offset: 84740},
+									pos:   position{line: 2704, col: 55, offset: 84808},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2703, col: 60, offset: 84745},
+										pos: position{line: 2704, col: 60, offset: 84813},
 										expr: &seqExpr{
-											pos: position{line: 2703, col: 61, offset: 84746},
+											pos: position{line: 2704, col: 61, offset: 84814},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2703, col: 61, offset: 84746},
+													pos:  position{line: 2704, col: 61, offset: 84814},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2703, col: 67, offset: 84752},
+													pos:  position{line: 2704, col: 67, offset: 84820},
 													name: "StringExpr",
 												},
 											},
@@ -5533,195 +5533,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2703, col: 80, offset: 84765},
+									pos:  position{line: 2704, col: 80, offset: 84833},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2725, col: 3, offset: 85365},
+						pos: position{line: 2726, col: 3, offset: 85433},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2725, col: 4, offset: 85366},
+							pos: position{line: 2726, col: 4, offset: 85434},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2725, col: 4, offset: 85366},
+									pos:   position{line: 2726, col: 4, offset: 85434},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2725, col: 12, offset: 85374},
+										pos:        position{line: 2726, col: 12, offset: 85442},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2725, col: 23, offset: 85385},
+									pos:  position{line: 2726, col: 23, offset: 85453},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2725, col: 31, offset: 85393},
+									pos:   position{line: 2726, col: 31, offset: 85461},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2725, col: 46, offset: 85408},
+										pos:  position{line: 2726, col: 46, offset: 85476},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2725, col: 61, offset: 85423},
+									pos:  position{line: 2726, col: 61, offset: 85491},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2736, col: 3, offset: 85725},
+						pos: position{line: 2737, col: 3, offset: 85793},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2736, col: 4, offset: 85726},
+							pos: position{line: 2737, col: 4, offset: 85794},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2736, col: 4, offset: 85726},
+									pos:   position{line: 2737, col: 4, offset: 85794},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2736, col: 12, offset: 85734},
+										pos:        position{line: 2737, col: 12, offset: 85802},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 22, offset: 85744},
+									pos:  position{line: 2737, col: 22, offset: 85812},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2736, col: 30, offset: 85752},
+									pos:   position{line: 2737, col: 30, offset: 85820},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2736, col: 45, offset: 85767},
+										pos:  position{line: 2737, col: 45, offset: 85835},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 60, offset: 85782},
+									pos:  position{line: 2737, col: 60, offset: 85850},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2736, col: 66, offset: 85788},
+									pos:   position{line: 2737, col: 66, offset: 85856},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2736, col: 72, offset: 85794},
+										pos:  position{line: 2737, col: 72, offset: 85862},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 83, offset: 85805},
+									pos:  position{line: 2737, col: 83, offset: 85873},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2748, col: 3, offset: 86155},
+						pos: position{line: 2749, col: 3, offset: 86223},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2748, col: 4, offset: 86156},
+							pos: position{line: 2749, col: 4, offset: 86224},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2748, col: 4, offset: 86156},
+									pos:   position{line: 2749, col: 4, offset: 86224},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2748, col: 12, offset: 86164},
+										pos:        position{line: 2749, col: 12, offset: 86232},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2748, col: 22, offset: 86174},
+									pos:  position{line: 2749, col: 22, offset: 86242},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2748, col: 30, offset: 86182},
+									pos:   position{line: 2749, col: 30, offset: 86250},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2748, col: 45, offset: 86197},
+										pos:  position{line: 2749, col: 45, offset: 86265},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2748, col: 60, offset: 86212},
+									pos:  position{line: 2749, col: 60, offset: 86280},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2748, col: 66, offset: 86218},
+									pos:   position{line: 2749, col: 66, offset: 86286},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2748, col: 79, offset: 86231},
+										pos:  position{line: 2749, col: 79, offset: 86299},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2748, col: 90, offset: 86242},
+									pos:  position{line: 2749, col: 90, offset: 86310},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2772, col: 3, offset: 86911},
+						pos: position{line: 2773, col: 3, offset: 86979},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2772, col: 4, offset: 86912},
+							pos: position{line: 2773, col: 4, offset: 86980},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2772, col: 4, offset: 86912},
+									pos:   position{line: 2773, col: 4, offset: 86980},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2772, col: 12, offset: 86920},
+										pos:        position{line: 2773, col: 12, offset: 86988},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2772, col: 22, offset: 86930},
+									pos:  position{line: 2773, col: 22, offset: 86998},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2772, col: 30, offset: 86938},
+									pos:   position{line: 2773, col: 30, offset: 87006},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2772, col: 41, offset: 86949},
+										pos:  position{line: 2773, col: 41, offset: 87017},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2772, col: 52, offset: 86960},
+									pos:  position{line: 2773, col: 52, offset: 87028},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2772, col: 58, offset: 86966},
+									pos:   position{line: 2773, col: 58, offset: 87034},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2772, col: 69, offset: 86977},
+										pos:  position{line: 2773, col: 69, offset: 87045},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2772, col: 81, offset: 86989},
+									pos:   position{line: 2773, col: 81, offset: 87057},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2772, col: 93, offset: 87001},
+										pos: position{line: 2773, col: 93, offset: 87069},
 										expr: &seqExpr{
-											pos: position{line: 2772, col: 94, offset: 87002},
+											pos: position{line: 2773, col: 94, offset: 87070},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2772, col: 94, offset: 87002},
+													pos:  position{line: 2773, col: 94, offset: 87070},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2772, col: 100, offset: 87008},
+													pos:  position{line: 2773, col: 100, offset: 87076},
 													name: "NumericExpr",
 												},
 											},
@@ -5729,50 +5729,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2772, col: 114, offset: 87022},
+									pos:  position{line: 2773, col: 114, offset: 87090},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2797, col: 3, offset: 87852},
+						pos: position{line: 2798, col: 3, offset: 87920},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2797, col: 3, offset: 87852},
+							pos: position{line: 2798, col: 3, offset: 87920},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2797, col: 3, offset: 87852},
+									pos:        position{line: 2798, col: 3, offset: 87920},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 14, offset: 87863},
+									pos:  position{line: 2798, col: 14, offset: 87931},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 22, offset: 87871},
+									pos:   position{line: 2798, col: 22, offset: 87939},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2797, col: 28, offset: 87877},
+										pos:  position{line: 2798, col: 28, offset: 87945},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 38, offset: 87887},
+									pos:   position{line: 2798, col: 38, offset: 87955},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2797, col: 45, offset: 87894},
+										pos: position{line: 2798, col: 45, offset: 87962},
 										expr: &seqExpr{
-											pos: position{line: 2797, col: 46, offset: 87895},
+											pos: position{line: 2798, col: 46, offset: 87963},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2797, col: 46, offset: 87895},
+													pos:  position{line: 2798, col: 46, offset: 87963},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2797, col: 52, offset: 87901},
+													pos:  position{line: 2798, col: 52, offset: 87969},
 													name: "StringExpr",
 												},
 											},
@@ -5780,38 +5780,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 65, offset: 87914},
+									pos:  position{line: 2798, col: 65, offset: 87982},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2810, col: 3, offset: 88282},
+						pos: position{line: 2811, col: 3, offset: 88350},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2810, col: 4, offset: 88283},
+							pos: position{line: 2811, col: 4, offset: 88351},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2810, col: 4, offset: 88283},
+									pos:   position{line: 2811, col: 4, offset: 88351},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2810, col: 12, offset: 88291},
+										pos: position{line: 2811, col: 12, offset: 88359},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2810, col: 12, offset: 88291},
+												pos:        position{line: 2811, col: 12, offset: 88359},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2810, col: 22, offset: 88301},
+												pos:        position{line: 2811, col: 22, offset: 88369},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2810, col: 32, offset: 88311},
+												pos:        position{line: 2811, col: 32, offset: 88379},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5820,223 +5820,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 40, offset: 88319},
+									pos:  position{line: 2811, col: 40, offset: 88387},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 48, offset: 88327},
+									pos:   position{line: 2811, col: 48, offset: 88395},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 54, offset: 88333},
+										pos:  position{line: 2811, col: 54, offset: 88401},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 66, offset: 88345},
+									pos:   position{line: 2811, col: 66, offset: 88413},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2810, col: 82, offset: 88361},
+										pos: position{line: 2811, col: 82, offset: 88429},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2810, col: 83, offset: 88362},
+											pos:  position{line: 2811, col: 83, offset: 88430},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 101, offset: 88380},
+									pos:  position{line: 2811, col: 101, offset: 88448},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2829, col: 3, offset: 88820},
+						pos: position{line: 2830, col: 3, offset: 88888},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2829, col: 3, offset: 88820},
+							pos: position{line: 2830, col: 3, offset: 88888},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2829, col: 3, offset: 88820},
+									pos:        position{line: 2830, col: 3, offset: 88888},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2829, col: 11, offset: 88828},
+									pos:  position{line: 2830, col: 11, offset: 88896},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2829, col: 19, offset: 88836},
+									pos:   position{line: 2830, col: 19, offset: 88904},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2829, col: 30, offset: 88847},
+										pos:  position{line: 2830, col: 30, offset: 88915},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2829, col: 50, offset: 88867},
+									pos:  position{line: 2830, col: 50, offset: 88935},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2829, col: 56, offset: 88873},
+									pos:   position{line: 2830, col: 56, offset: 88941},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2829, col: 62, offset: 88879},
+										pos: position{line: 2830, col: 62, offset: 88947},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2829, col: 62, offset: 88879},
+												pos:  position{line: 2830, col: 62, offset: 88947},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2829, col: 81, offset: 88898},
+												pos:  position{line: 2830, col: 81, offset: 88966},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2829, col: 100, offset: 88917},
+									pos:  position{line: 2830, col: 100, offset: 88985},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2840, col: 3, offset: 89222},
+						pos: position{line: 2841, col: 3, offset: 89290},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2840, col: 3, offset: 89222},
+							pos: position{line: 2841, col: 3, offset: 89290},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2840, col: 3, offset: 89222},
+									pos:        position{line: 2841, col: 3, offset: 89290},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2840, col: 12, offset: 89231},
+									pos:  position{line: 2841, col: 12, offset: 89299},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2840, col: 20, offset: 89239},
+									pos:   position{line: 2841, col: 20, offset: 89307},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2840, col: 25, offset: 89244},
+										pos:  position{line: 2841, col: 25, offset: 89312},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2840, col: 36, offset: 89255},
+									pos:  position{line: 2841, col: 36, offset: 89323},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2840, col: 42, offset: 89261},
+									pos:   position{line: 2841, col: 42, offset: 89329},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2840, col: 45, offset: 89264},
+										pos:  position{line: 2841, col: 45, offset: 89332},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2840, col: 55, offset: 89274},
+									pos:  position{line: 2841, col: 55, offset: 89342},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2847, col: 3, offset: 89432},
+						pos: position{line: 2848, col: 3, offset: 89500},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2847, col: 3, offset: 89432},
+							pos: position{line: 2848, col: 3, offset: 89500},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2847, col: 3, offset: 89432},
+									pos:        position{line: 2848, col: 3, offset: 89500},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2847, col: 21, offset: 89450},
+									pos:  position{line: 2848, col: 21, offset: 89518},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2847, col: 29, offset: 89458},
+									pos:   position{line: 2848, col: 29, offset: 89526},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2847, col: 33, offset: 89462},
+										pos:  position{line: 2848, col: 33, offset: 89530},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2847, col: 43, offset: 89472},
+									pos:  position{line: 2848, col: 43, offset: 89540},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2847, col: 49, offset: 89478},
+									pos:   position{line: 2848, col: 49, offset: 89546},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2847, col: 53, offset: 89482},
+										pos:  position{line: 2848, col: 53, offset: 89550},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2847, col: 66, offset: 89495},
+									pos:  position{line: 2848, col: 66, offset: 89563},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2847, col: 72, offset: 89501},
+									pos:   position{line: 2848, col: 72, offset: 89569},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2847, col: 78, offset: 89507},
+										pos:  position{line: 2848, col: 78, offset: 89575},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2847, col: 91, offset: 89520},
+									pos:  position{line: 2848, col: 91, offset: 89588},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2858, col: 3, offset: 89828},
+						pos: position{line: 2859, col: 3, offset: 89896},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2858, col: 3, offset: 89828},
+							pos: position{line: 2859, col: 3, offset: 89896},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2858, col: 3, offset: 89828},
+									pos:        position{line: 2859, col: 3, offset: 89896},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 12, offset: 89837},
+									pos:  position{line: 2859, col: 12, offset: 89905},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 20, offset: 89845},
+									pos:   position{line: 2859, col: 20, offset: 89913},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2858, col: 27, offset: 89852},
+										pos:  position{line: 2859, col: 27, offset: 89920},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 38, offset: 89863},
+									pos:   position{line: 2859, col: 38, offset: 89931},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2858, col: 43, offset: 89868},
+										pos: position{line: 2859, col: 43, offset: 89936},
 										expr: &seqExpr{
-											pos: position{line: 2858, col: 44, offset: 89869},
+											pos: position{line: 2859, col: 44, offset: 89937},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 44, offset: 89869},
+													pos:  position{line: 2859, col: 44, offset: 89937},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 50, offset: 89875},
+													pos:  position{line: 2859, col: 50, offset: 89943},
 													name: "StringExpr",
 												},
 											},
@@ -6044,47 +6044,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 63, offset: 89888},
+									pos:  position{line: 2859, col: 63, offset: 89956},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2876, col: 3, offset: 90355},
+						pos: position{line: 2877, col: 3, offset: 90423},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2876, col: 3, offset: 90355},
+							pos: position{line: 2877, col: 3, offset: 90423},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2876, col: 3, offset: 90355},
+									pos:        position{line: 2877, col: 3, offset: 90423},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2876, col: 12, offset: 90364},
+									pos:  position{line: 2877, col: 12, offset: 90432},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2876, col: 20, offset: 90372},
+									pos:   position{line: 2877, col: 20, offset: 90440},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2876, col: 42, offset: 90394},
+										pos: position{line: 2877, col: 42, offset: 90462},
 										expr: &seqExpr{
-											pos: position{line: 2876, col: 43, offset: 90395},
+											pos: position{line: 2877, col: 43, offset: 90463},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2876, col: 44, offset: 90396},
+													pos: position{line: 2877, col: 44, offset: 90464},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2876, col: 44, offset: 90396},
+															pos:        position{line: 2877, col: 44, offset: 90464},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2876, col: 53, offset: 90405},
+															pos:        position{line: 2877, col: 53, offset: 90473},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6092,7 +6092,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2876, col: 62, offset: 90414},
+													pos:        position{line: 2877, col: 62, offset: 90482},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6102,56 +6102,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2876, col: 69, offset: 90421},
+									pos:  position{line: 2877, col: 69, offset: 90489},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2898, col: 3, offset: 91018},
+						pos: position{line: 2899, col: 3, offset: 91086},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2898, col: 3, offset: 91018},
+							pos: position{line: 2899, col: 3, offset: 91086},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2898, col: 3, offset: 91018},
+									pos:        position{line: 2899, col: 3, offset: 91086},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2898, col: 13, offset: 91028},
+									pos:  position{line: 2899, col: 13, offset: 91096},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2898, col: 21, offset: 91036},
+									pos:   position{line: 2899, col: 21, offset: 91104},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2898, col: 27, offset: 91042},
+										pos:  position{line: 2899, col: 27, offset: 91110},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2898, col: 43, offset: 91058},
+									pos:   position{line: 2899, col: 43, offset: 91126},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2898, col: 53, offset: 91068},
+										pos: position{line: 2899, col: 53, offset: 91136},
 										expr: &seqExpr{
-											pos: position{line: 2898, col: 54, offset: 91069},
+											pos: position{line: 2899, col: 54, offset: 91137},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2898, col: 54, offset: 91069},
+													pos:  position{line: 2899, col: 54, offset: 91137},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2898, col: 60, offset: 91075},
+													pos:        position{line: 2899, col: 60, offset: 91143},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2898, col: 73, offset: 91088},
+													pos:  position{line: 2899, col: 73, offset: 91156},
 													name: "FloatAsString",
 												},
 											},
@@ -6159,40 +6159,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2898, col: 89, offset: 91104},
+									pos:   position{line: 2899, col: 89, offset: 91172},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2898, col: 95, offset: 91110},
+										pos: position{line: 2899, col: 95, offset: 91178},
 										expr: &seqExpr{
-											pos: position{line: 2898, col: 96, offset: 91111},
+											pos: position{line: 2899, col: 96, offset: 91179},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2898, col: 96, offset: 91111},
+													pos:  position{line: 2899, col: 96, offset: 91179},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2898, col: 102, offset: 91117},
+													pos:        position{line: 2899, col: 102, offset: 91185},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2898, col: 112, offset: 91127},
+													pos: position{line: 2899, col: 112, offset: 91195},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2898, col: 112, offset: 91127},
+															pos:        position{line: 2899, col: 112, offset: 91195},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2898, col: 125, offset: 91140},
+															pos:        position{line: 2899, col: 125, offset: 91208},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2898, col: 137, offset: 91152},
+															pos:        position{line: 2899, col: 137, offset: 91220},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6204,25 +6204,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2898, col: 151, offset: 91166},
+									pos:   position{line: 2899, col: 151, offset: 91234},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2898, col: 158, offset: 91173},
+										pos: position{line: 2899, col: 158, offset: 91241},
 										expr: &seqExpr{
-											pos: position{line: 2898, col: 159, offset: 91174},
+											pos: position{line: 2899, col: 159, offset: 91242},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2898, col: 159, offset: 91174},
+													pos:  position{line: 2899, col: 159, offset: 91242},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2898, col: 165, offset: 91180},
+													pos:        position{line: 2899, col: 165, offset: 91248},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2898, col: 175, offset: 91190},
+													pos:  position{line: 2899, col: 175, offset: 91258},
 													name: "QuotedString",
 												},
 											},
@@ -6230,213 +6230,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2898, col: 190, offset: 91205},
+									pos:  position{line: 2899, col: 190, offset: 91273},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2938, col: 3, offset: 92200},
+						pos: position{line: 2939, col: 3, offset: 92268},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2938, col: 3, offset: 92200},
+							pos: position{line: 2939, col: 3, offset: 92268},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2938, col: 3, offset: 92200},
+									pos:        position{line: 2939, col: 3, offset: 92268},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 15, offset: 92212},
+									pos:  position{line: 2939, col: 15, offset: 92280},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2938, col: 23, offset: 92220},
+									pos:   position{line: 2939, col: 23, offset: 92288},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2938, col: 30, offset: 92227},
+										pos: position{line: 2939, col: 30, offset: 92295},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2938, col: 31, offset: 92228},
+											pos:  position{line: 2939, col: 31, offset: 92296},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2938, col: 44, offset: 92241},
+									pos:  position{line: 2939, col: 44, offset: 92309},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2949, col: 3, offset: 92432},
+						pos: position{line: 2950, col: 3, offset: 92500},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2949, col: 3, offset: 92432},
+							pos: position{line: 2950, col: 3, offset: 92500},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2949, col: 3, offset: 92432},
+									pos:        position{line: 2950, col: 3, offset: 92500},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2949, col: 12, offset: 92441},
+									pos:  position{line: 2950, col: 12, offset: 92509},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2949, col: 20, offset: 92449},
+									pos:   position{line: 2950, col: 20, offset: 92517},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2949, col: 30, offset: 92459},
+										pos:  position{line: 2950, col: 30, offset: 92527},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2949, col: 40, offset: 92469},
+									pos:  position{line: 2950, col: 40, offset: 92537},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2955, col: 3, offset: 92592},
+						pos: position{line: 2956, col: 3, offset: 92660},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2955, col: 3, offset: 92592},
+							pos: position{line: 2956, col: 3, offset: 92660},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2955, col: 3, offset: 92592},
+									pos:        position{line: 2956, col: 3, offset: 92660},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2955, col: 13, offset: 92602},
+									pos:  position{line: 2956, col: 13, offset: 92670},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2955, col: 21, offset: 92610},
+									pos:   position{line: 2956, col: 21, offset: 92678},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2955, col: 25, offset: 92614},
+										pos:  position{line: 2956, col: 25, offset: 92682},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2955, col: 35, offset: 92624},
+									pos:  position{line: 2956, col: 35, offset: 92692},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2955, col: 41, offset: 92630},
+									pos:   position{line: 2956, col: 41, offset: 92698},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2955, col: 47, offset: 92636},
+										pos:  position{line: 2956, col: 47, offset: 92704},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2955, col: 58, offset: 92647},
+									pos:  position{line: 2956, col: 58, offset: 92715},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2955, col: 64, offset: 92653},
+									pos:   position{line: 2956, col: 64, offset: 92721},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2955, col: 76, offset: 92665},
+										pos:  position{line: 2956, col: 76, offset: 92733},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2955, col: 87, offset: 92676},
+									pos:  position{line: 2956, col: 87, offset: 92744},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2962, col: 3, offset: 92900},
+						pos: position{line: 2963, col: 3, offset: 92968},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2962, col: 3, offset: 92900},
+							pos: position{line: 2963, col: 3, offset: 92968},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2962, col: 3, offset: 92900},
+									pos:        position{line: 2963, col: 3, offset: 92968},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2962, col: 14, offset: 92911},
+									pos:  position{line: 2963, col: 14, offset: 92979},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2962, col: 22, offset: 92919},
+									pos:   position{line: 2963, col: 22, offset: 92987},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2962, col: 26, offset: 92923},
+										pos:  position{line: 2963, col: 26, offset: 92991},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2962, col: 36, offset: 92933},
+									pos:  position{line: 2963, col: 36, offset: 93001},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2962, col: 42, offset: 92939},
+									pos:   position{line: 2963, col: 42, offset: 93007},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2962, col: 49, offset: 92946},
+										pos:  position{line: 2963, col: 49, offset: 93014},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2962, col: 60, offset: 92957},
+									pos:  position{line: 2963, col: 60, offset: 93025},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2970, col: 3, offset: 93121},
+						pos: position{line: 2971, col: 3, offset: 93189},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2970, col: 3, offset: 93121},
+							pos: position{line: 2971, col: 3, offset: 93189},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2970, col: 3, offset: 93121},
+									pos:        position{line: 2971, col: 3, offset: 93189},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 14, offset: 93132},
+									pos:  position{line: 2971, col: 14, offset: 93200},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2970, col: 22, offset: 93140},
+									pos:   position{line: 2971, col: 22, offset: 93208},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2970, col: 26, offset: 93144},
+										pos:  position{line: 2971, col: 26, offset: 93212},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 36, offset: 93154},
+									pos:  position{line: 2971, col: 36, offset: 93222},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2970, col: 42, offset: 93160},
+									pos:   position{line: 2971, col: 42, offset: 93228},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2970, col: 49, offset: 93167},
+										pos:  position{line: 2971, col: 49, offset: 93235},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2970, col: 60, offset: 93178},
+									pos:  position{line: 2971, col: 60, offset: 93246},
 									name: "R_PAREN",
 								},
 							},
@@ -6447,15 +6447,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2978, col: 1, offset: 93340},
+			pos:  position{line: 2979, col: 1, offset: 93408},
 			expr: &actionExpr{
-				pos: position{line: 2978, col: 21, offset: 93360},
+				pos: position{line: 2979, col: 21, offset: 93428},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2978, col: 21, offset: 93360},
+					pos:   position{line: 2979, col: 21, offset: 93428},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2978, col: 25, offset: 93364},
+						pos:  position{line: 2979, col: 25, offset: 93432},
 						name: "QuotedString",
 					},
 				},
@@ -6463,15 +6463,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2985, col: 1, offset: 93491},
+			pos:  position{line: 2986, col: 1, offset: 93559},
 			expr: &actionExpr{
-				pos: position{line: 2985, col: 22, offset: 93512},
+				pos: position{line: 2986, col: 22, offset: 93580},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2985, col: 22, offset: 93512},
+					pos:   position{line: 2986, col: 22, offset: 93580},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2985, col: 26, offset: 93516},
+						pos:  position{line: 2986, col: 26, offset: 93584},
 						name: "UnquotedString",
 					},
 				},
@@ -6479,22 +6479,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2992, col: 1, offset: 93644},
+			pos:  position{line: 2993, col: 1, offset: 93712},
 			expr: &actionExpr{
-				pos: position{line: 2992, col: 20, offset: 93663},
+				pos: position{line: 2993, col: 20, offset: 93731},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2992, col: 20, offset: 93663},
+					pos: position{line: 2993, col: 20, offset: 93731},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2992, col: 20, offset: 93663},
+							pos:  position{line: 2993, col: 20, offset: 93731},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2992, col: 26, offset: 93669},
+							pos:   position{line: 2993, col: 26, offset: 93737},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2992, col: 38, offset: 93681},
+								pos:  position{line: 2993, col: 38, offset: 93749},
 								name: "String",
 							},
 						},
@@ -6504,27 +6504,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2998, col: 1, offset: 93866},
+			pos:  position{line: 2999, col: 1, offset: 93934},
 			expr: &choiceExpr{
-				pos: position{line: 2998, col: 20, offset: 93885},
+				pos: position{line: 2999, col: 20, offset: 93953},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2998, col: 20, offset: 93885},
+						pos: position{line: 2999, col: 20, offset: 93953},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2998, col: 20, offset: 93885},
+							pos: position{line: 2999, col: 20, offset: 93953},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 2998, col: 20, offset: 93885},
+									pos:        position{line: 2999, col: 20, offset: 93953},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 2998, col: 28, offset: 93893},
+									pos: position{line: 2999, col: 28, offset: 93961},
 									expr: &charClassMatcher{
-										pos:        position{line: 2998, col: 28, offset: 93893},
+										pos:        position{line: 2999, col: 28, offset: 93961},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6533,9 +6533,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2998, col: 42, offset: 93907},
+									pos: position{line: 2999, col: 42, offset: 93975},
 									expr: &litMatcher{
-										pos:        position{line: 2998, col: 44, offset: 93909},
+										pos:        position{line: 2999, col: 44, offset: 93977},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6545,27 +6545,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3001, col: 3, offset: 93951},
+						pos: position{line: 3002, col: 3, offset: 94019},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3001, col: 3, offset: 93951},
+							pos: position{line: 3002, col: 3, offset: 94019},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3001, col: 3, offset: 93951},
+									pos:        position{line: 3002, col: 3, offset: 94019},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3001, col: 7, offset: 93955},
+									pos:   position{line: 3002, col: 7, offset: 94023},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3001, col: 13, offset: 93961},
+										pos:  position{line: 3002, col: 13, offset: 94029},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3001, col: 23, offset: 93971},
+									pos:        position{line: 3002, col: 23, offset: 94039},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6578,26 +6578,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3006, col: 1, offset: 94039},
+			pos:  position{line: 3007, col: 1, offset: 94107},
 			expr: &actionExpr{
-				pos: position{line: 3006, col: 15, offset: 94053},
+				pos: position{line: 3007, col: 15, offset: 94121},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3006, col: 15, offset: 94053},
+					pos: position{line: 3007, col: 15, offset: 94121},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3006, col: 15, offset: 94053},
+							pos:  position{line: 3007, col: 15, offset: 94121},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3006, col: 20, offset: 94058},
+							pos:  position{line: 3007, col: 20, offset: 94126},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3006, col: 30, offset: 94068},
+							pos:   position{line: 3007, col: 30, offset: 94136},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3006, col: 40, offset: 94078},
+								pos:  position{line: 3007, col: 40, offset: 94146},
 								name: "BoolExpr",
 							},
 						},
@@ -6607,15 +6607,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3019, col: 1, offset: 94421},
+			pos:  position{line: 3020, col: 1, offset: 94489},
 			expr: &actionExpr{
-				pos: position{line: 3019, col: 13, offset: 94433},
+				pos: position{line: 3020, col: 13, offset: 94501},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3019, col: 13, offset: 94433},
+					pos:   position{line: 3020, col: 13, offset: 94501},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3019, col: 18, offset: 94438},
+						pos:  position{line: 3020, col: 18, offset: 94506},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6623,35 +6623,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3024, col: 1, offset: 94508},
+			pos:  position{line: 3025, col: 1, offset: 94576},
 			expr: &actionExpr{
-				pos: position{line: 3024, col: 19, offset: 94526},
+				pos: position{line: 3025, col: 19, offset: 94594},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3024, col: 19, offset: 94526},
+					pos: position{line: 3025, col: 19, offset: 94594},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3024, col: 19, offset: 94526},
+							pos:   position{line: 3025, col: 19, offset: 94594},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3024, col: 25, offset: 94532},
+								pos:  position{line: 3025, col: 25, offset: 94600},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3024, col: 40, offset: 94547},
+							pos:   position{line: 3025, col: 40, offset: 94615},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3024, col: 45, offset: 94552},
+								pos: position{line: 3025, col: 45, offset: 94620},
 								expr: &seqExpr{
-									pos: position{line: 3024, col: 46, offset: 94553},
+									pos: position{line: 3025, col: 46, offset: 94621},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3024, col: 46, offset: 94553},
+											pos:  position{line: 3025, col: 46, offset: 94621},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3024, col: 49, offset: 94556},
+											pos:  position{line: 3025, col: 49, offset: 94624},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6664,35 +6664,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3044, col: 1, offset: 94994},
+			pos:  position{line: 3045, col: 1, offset: 95062},
 			expr: &actionExpr{
-				pos: position{line: 3044, col: 19, offset: 95012},
+				pos: position{line: 3045, col: 19, offset: 95080},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3044, col: 19, offset: 95012},
+					pos: position{line: 3045, col: 19, offset: 95080},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3044, col: 19, offset: 95012},
+							pos:   position{line: 3045, col: 19, offset: 95080},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3044, col: 25, offset: 95018},
+								pos:  position{line: 3045, col: 25, offset: 95086},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3044, col: 40, offset: 95033},
+							pos:   position{line: 3045, col: 40, offset: 95101},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3044, col: 45, offset: 95038},
+								pos: position{line: 3045, col: 45, offset: 95106},
 								expr: &seqExpr{
-									pos: position{line: 3044, col: 46, offset: 95039},
+									pos: position{line: 3045, col: 46, offset: 95107},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3044, col: 46, offset: 95039},
+											pos:  position{line: 3045, col: 46, offset: 95107},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3044, col: 50, offset: 95043},
+											pos:  position{line: 3045, col: 50, offset: 95111},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6705,47 +6705,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3064, col: 1, offset: 95482},
+			pos:  position{line: 3065, col: 1, offset: 95550},
 			expr: &choiceExpr{
-				pos: position{line: 3064, col: 19, offset: 95500},
+				pos: position{line: 3065, col: 19, offset: 95568},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3064, col: 19, offset: 95500},
+						pos: position{line: 3065, col: 19, offset: 95568},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3064, col: 19, offset: 95500},
+							pos: position{line: 3065, col: 19, offset: 95568},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3064, col: 19, offset: 95500},
+									pos:  position{line: 3065, col: 19, offset: 95568},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3064, col: 23, offset: 95504},
+									pos:  position{line: 3065, col: 23, offset: 95572},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3064, col: 31, offset: 95512},
+									pos:   position{line: 3065, col: 31, offset: 95580},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3064, col: 37, offset: 95518},
+										pos:  position{line: 3065, col: 37, offset: 95586},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3064, col: 52, offset: 95533},
+									pos:  position{line: 3065, col: 52, offset: 95601},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3074, col: 3, offset: 95736},
+						pos: position{line: 3075, col: 3, offset: 95804},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3074, col: 3, offset: 95736},
+							pos:   position{line: 3075, col: 3, offset: 95804},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3074, col: 9, offset: 95742},
+								pos:  position{line: 3075, col: 9, offset: 95810},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6755,50 +6755,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3079, col: 1, offset: 95813},
+			pos:  position{line: 3080, col: 1, offset: 95881},
 			expr: &choiceExpr{
-				pos: position{line: 3079, col: 19, offset: 95831},
+				pos: position{line: 3080, col: 19, offset: 95899},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3079, col: 19, offset: 95831},
+						pos: position{line: 3080, col: 19, offset: 95899},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3079, col: 19, offset: 95831},
+							pos: position{line: 3080, col: 19, offset: 95899},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3079, col: 19, offset: 95831},
+									pos:  position{line: 3080, col: 19, offset: 95899},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3079, col: 27, offset: 95839},
+									pos:   position{line: 3080, col: 27, offset: 95907},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3079, col: 33, offset: 95845},
+										pos:  position{line: 3080, col: 33, offset: 95913},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3079, col: 48, offset: 95860},
+									pos:  position{line: 3080, col: 48, offset: 95928},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3082, col: 3, offset: 95896},
+						pos: position{line: 3083, col: 3, offset: 95964},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3082, col: 3, offset: 95896},
+							pos:   position{line: 3083, col: 3, offset: 95964},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3082, col: 10, offset: 95903},
+								pos: position{line: 3083, col: 10, offset: 95971},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3082, col: 10, offset: 95903},
+										pos:  position{line: 3083, col: 10, offset: 95971},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3082, col: 31, offset: 95924},
+										pos:  position{line: 3083, col: 31, offset: 95992},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6810,60 +6810,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3087, col: 1, offset: 96044},
+			pos:  position{line: 3088, col: 1, offset: 96112},
 			expr: &choiceExpr{
-				pos: position{line: 3087, col: 23, offset: 96066},
+				pos: position{line: 3088, col: 23, offset: 96134},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3087, col: 23, offset: 96066},
+						pos: position{line: 3088, col: 23, offset: 96134},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3087, col: 24, offset: 96067},
+							pos: position{line: 3088, col: 24, offset: 96135},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3087, col: 24, offset: 96067},
+									pos:   position{line: 3088, col: 24, offset: 96135},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3087, col: 28, offset: 96071},
+										pos: position{line: 3088, col: 28, offset: 96139},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3087, col: 28, offset: 96071},
+												pos:        position{line: 3088, col: 28, offset: 96139},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 39, offset: 96082},
+												pos:        position{line: 3088, col: 39, offset: 96150},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 49, offset: 96092},
+												pos:        position{line: 3088, col: 49, offset: 96160},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 59, offset: 96102},
+												pos:        position{line: 3088, col: 59, offset: 96170},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 70, offset: 96113},
+												pos:        position{line: 3088, col: 70, offset: 96181},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 84, offset: 96127},
+												pos:        position{line: 3088, col: 84, offset: 96195},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3087, col: 94, offset: 96137},
+												pos:        position{line: 3088, col: 94, offset: 96205},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6872,56 +6872,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3087, col: 109, offset: 96152},
+									pos:  position{line: 3088, col: 109, offset: 96220},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3087, col: 117, offset: 96160},
+									pos:   position{line: 3088, col: 117, offset: 96228},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3087, col: 123, offset: 96166},
+										pos:  position{line: 3088, col: 123, offset: 96234},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3087, col: 133, offset: 96176},
+									pos:  position{line: 3088, col: 133, offset: 96244},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3117, col: 3, offset: 97047},
+						pos: position{line: 3118, col: 3, offset: 97115},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3117, col: 3, offset: 97047},
+							pos: position{line: 3118, col: 3, offset: 97115},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3117, col: 3, offset: 97047},
+									pos:   position{line: 3118, col: 3, offset: 97115},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3117, col: 11, offset: 97055},
+										pos: position{line: 3118, col: 11, offset: 97123},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3117, col: 11, offset: 97055},
+												pos:        position{line: 3118, col: 11, offset: 97123},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3117, col: 20, offset: 97064},
+												pos:        position{line: 3118, col: 20, offset: 97132},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3117, col: 29, offset: 97073},
+												pos:        position{line: 3118, col: 29, offset: 97141},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3117, col: 39, offset: 97083},
+												pos:        position{line: 3118, col: 39, offset: 97151},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6930,86 +6930,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3117, col: 52, offset: 97096},
+									pos:  position{line: 3118, col: 52, offset: 97164},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3117, col: 60, offset: 97104},
+									pos:   position{line: 3118, col: 60, offset: 97172},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3117, col: 70, offset: 97114},
+										pos:  position{line: 3118, col: 70, offset: 97182},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3117, col: 80, offset: 97124},
+									pos:  position{line: 3118, col: 80, offset: 97192},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3117, col: 86, offset: 97130},
+									pos:   position{line: 3118, col: 86, offset: 97198},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3117, col: 97, offset: 97141},
+										pos:  position{line: 3118, col: 97, offset: 97209},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3117, col: 107, offset: 97151},
+									pos:  position{line: 3118, col: 107, offset: 97219},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3130, col: 3, offset: 97521},
+						pos: position{line: 3131, col: 3, offset: 97589},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3130, col: 3, offset: 97521},
+							pos: position{line: 3131, col: 3, offset: 97589},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3130, col: 3, offset: 97521},
+									pos:   position{line: 3131, col: 3, offset: 97589},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3130, col: 8, offset: 97526},
+										pos:  position{line: 3131, col: 8, offset: 97594},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 18, offset: 97536},
+									pos:  position{line: 3131, col: 18, offset: 97604},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3130, col: 24, offset: 97542},
+									pos:        position{line: 3131, col: 24, offset: 97610},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 29, offset: 97547},
+									pos:  position{line: 3131, col: 29, offset: 97615},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3130, col: 37, offset: 97555},
+									pos:   position{line: 3131, col: 37, offset: 97623},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3130, col: 50, offset: 97568},
+										pos:  position{line: 3131, col: 50, offset: 97636},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3130, col: 60, offset: 97578},
+									pos:   position{line: 3131, col: 60, offset: 97646},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3130, col: 65, offset: 97583},
+										pos: position{line: 3131, col: 65, offset: 97651},
 										expr: &seqExpr{
-											pos: position{line: 3130, col: 66, offset: 97584},
+											pos: position{line: 3131, col: 66, offset: 97652},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3130, col: 66, offset: 97584},
+													pos:  position{line: 3131, col: 66, offset: 97652},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3130, col: 72, offset: 97590},
+													pos:  position{line: 3131, col: 72, offset: 97658},
 													name: "ValueExpr",
 												},
 											},
@@ -7017,50 +7017,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 84, offset: 97602},
+									pos:  position{line: 3131, col: 84, offset: 97670},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3149, col: 3, offset: 98153},
+						pos: position{line: 3150, col: 3, offset: 98221},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3149, col: 3, offset: 98153},
+							pos: position{line: 3150, col: 3, offset: 98221},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3149, col: 3, offset: 98153},
+									pos:        position{line: 3150, col: 3, offset: 98221},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3149, col: 8, offset: 98158},
+									pos:  position{line: 3150, col: 8, offset: 98226},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3149, col: 16, offset: 98166},
+									pos:   position{line: 3150, col: 16, offset: 98234},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3149, col: 29, offset: 98179},
+										pos:  position{line: 3150, col: 29, offset: 98247},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3149, col: 39, offset: 98189},
+									pos:   position{line: 3150, col: 39, offset: 98257},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3149, col: 44, offset: 98194},
+										pos: position{line: 3150, col: 44, offset: 98262},
 										expr: &seqExpr{
-											pos: position{line: 3149, col: 45, offset: 98195},
+											pos: position{line: 3150, col: 45, offset: 98263},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3149, col: 45, offset: 98195},
+													pos:  position{line: 3150, col: 45, offset: 98263},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3149, col: 51, offset: 98201},
+													pos:  position{line: 3150, col: 51, offset: 98269},
 													name: "ValueExpr",
 												},
 											},
@@ -7068,7 +7068,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3149, col: 63, offset: 98213},
+									pos:  position{line: 3150, col: 63, offset: 98281},
 									name: "R_PAREN",
 								},
 							},
@@ -7079,34 +7079,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3167, col: 1, offset: 98634},
+			pos:  position{line: 3168, col: 1, offset: 98702},
 			expr: &actionExpr{
-				pos: position{line: 3167, col: 23, offset: 98656},
+				pos: position{line: 3168, col: 23, offset: 98724},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3167, col: 23, offset: 98656},
+					pos: position{line: 3168, col: 23, offset: 98724},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3167, col: 23, offset: 98656},
+							pos:   position{line: 3168, col: 23, offset: 98724},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3167, col: 28, offset: 98661},
+								pos:  position{line: 3168, col: 28, offset: 98729},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3167, col: 38, offset: 98671},
+							pos:   position{line: 3168, col: 38, offset: 98739},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3167, col: 41, offset: 98674},
+								pos:  position{line: 3168, col: 41, offset: 98742},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3167, col: 62, offset: 98695},
+							pos:   position{line: 3168, col: 62, offset: 98763},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3167, col: 68, offset: 98701},
+								pos:  position{line: 3168, col: 68, offset: 98769},
 								name: "ValueExpr",
 							},
 						},
@@ -7116,129 +7116,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3185, col: 1, offset: 99295},
+			pos:  position{line: 3186, col: 1, offset: 99363},
 			expr: &choiceExpr{
-				pos: position{line: 3185, col: 14, offset: 99308},
+				pos: position{line: 3186, col: 14, offset: 99376},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3185, col: 14, offset: 99308},
+						pos: position{line: 3186, col: 14, offset: 99376},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3185, col: 14, offset: 99308},
+							pos:   position{line: 3186, col: 14, offset: 99376},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3185, col: 24, offset: 99318},
+								pos:  position{line: 3186, col: 24, offset: 99386},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3194, col: 3, offset: 99508},
+						pos: position{line: 3195, col: 3, offset: 99576},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3194, col: 3, offset: 99508},
+							pos: position{line: 3195, col: 3, offset: 99576},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3194, col: 3, offset: 99508},
+									pos:  position{line: 3195, col: 3, offset: 99576},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3194, col: 12, offset: 99517},
+									pos:   position{line: 3195, col: 12, offset: 99585},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3194, col: 22, offset: 99527},
+										pos:  position{line: 3195, col: 22, offset: 99595},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3194, col: 37, offset: 99542},
+									pos:  position{line: 3195, col: 37, offset: 99610},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3203, col: 3, offset: 99726},
+						pos: position{line: 3204, col: 3, offset: 99794},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3203, col: 3, offset: 99726},
+							pos:   position{line: 3204, col: 3, offset: 99794},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3203, col: 11, offset: 99734},
+								pos:  position{line: 3204, col: 11, offset: 99802},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3212, col: 3, offset: 99914},
+						pos: position{line: 3213, col: 3, offset: 99982},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3212, col: 3, offset: 99914},
+							pos:   position{line: 3213, col: 3, offset: 99982},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3212, col: 7, offset: 99918},
+								pos:  position{line: 3213, col: 7, offset: 99986},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3221, col: 3, offset: 100090},
+						pos: position{line: 3222, col: 3, offset: 100158},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3221, col: 3, offset: 100090},
+							pos: position{line: 3222, col: 3, offset: 100158},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3221, col: 3, offset: 100090},
+									pos:  position{line: 3222, col: 3, offset: 100158},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3221, col: 12, offset: 100099},
+									pos:   position{line: 3222, col: 12, offset: 100167},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3221, col: 16, offset: 100103},
+										pos:  position{line: 3222, col: 16, offset: 100171},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3221, col: 28, offset: 100115},
+									pos:  position{line: 3222, col: 28, offset: 100183},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3230, col: 3, offset: 100284},
+						pos: position{line: 3231, col: 3, offset: 100352},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3230, col: 3, offset: 100284},
+							pos: position{line: 3231, col: 3, offset: 100352},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3230, col: 3, offset: 100284},
+									pos:  position{line: 3231, col: 3, offset: 100352},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3230, col: 11, offset: 100292},
+									pos:   position{line: 3231, col: 11, offset: 100360},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3230, col: 19, offset: 100300},
+										pos:  position{line: 3231, col: 19, offset: 100368},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3230, col: 28, offset: 100309},
+									pos:  position{line: 3231, col: 28, offset: 100377},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3239, col: 3, offset: 100481},
+						pos: position{line: 3240, col: 3, offset: 100549},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3239, col: 3, offset: 100481},
+							pos:   position{line: 3240, col: 3, offset: 100549},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3239, col: 18, offset: 100496},
+								pos:  position{line: 3240, col: 18, offset: 100564},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7248,28 +7248,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3249, col: 1, offset: 100693},
+			pos:  position{line: 3250, col: 1, offset: 100761},
 			expr: &choiceExpr{
-				pos: position{line: 3249, col: 15, offset: 100707},
+				pos: position{line: 3250, col: 15, offset: 100775},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3249, col: 15, offset: 100707},
+						pos: position{line: 3250, col: 15, offset: 100775},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3249, col: 15, offset: 100707},
+							pos: position{line: 3250, col: 15, offset: 100775},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3249, col: 15, offset: 100707},
+									pos:   position{line: 3250, col: 15, offset: 100775},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3249, col: 20, offset: 100712},
+										pos:  position{line: 3250, col: 20, offset: 100780},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3249, col: 29, offset: 100721},
+									pos: position{line: 3250, col: 29, offset: 100789},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3249, col: 31, offset: 100723},
+										pos:  position{line: 3250, col: 31, offset: 100791},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7277,23 +7277,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3257, col: 3, offset: 100893},
+						pos: position{line: 3258, col: 3, offset: 100961},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3257, col: 3, offset: 100893},
+							pos: position{line: 3258, col: 3, offset: 100961},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3257, col: 3, offset: 100893},
+									pos:   position{line: 3258, col: 3, offset: 100961},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3257, col: 7, offset: 100897},
+										pos:  position{line: 3258, col: 7, offset: 100965},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3257, col: 20, offset: 100910},
+									pos: position{line: 3258, col: 20, offset: 100978},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3257, col: 22, offset: 100912},
+										pos:  position{line: 3258, col: 22, offset: 100980},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7301,50 +7301,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3265, col: 3, offset: 101077},
+						pos: position{line: 3266, col: 3, offset: 101145},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3265, col: 3, offset: 101077},
+							pos: position{line: 3266, col: 3, offset: 101145},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3265, col: 3, offset: 101077},
+									pos:   position{line: 3266, col: 3, offset: 101145},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3265, col: 9, offset: 101083},
+										pos:  position{line: 3266, col: 9, offset: 101151},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3265, col: 25, offset: 101099},
+									pos: position{line: 3266, col: 25, offset: 101167},
 									expr: &choiceExpr{
-										pos: position{line: 3265, col: 27, offset: 101101},
+										pos: position{line: 3266, col: 27, offset: 101169},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 27, offset: 101101},
+												pos:  position{line: 3266, col: 27, offset: 101169},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 36, offset: 101110},
+												pos:  position{line: 3266, col: 36, offset: 101178},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 46, offset: 101120},
+												pos:  position{line: 3266, col: 46, offset: 101188},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 54, offset: 101128},
+												pos:  position{line: 3266, col: 54, offset: 101196},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 62, offset: 101136},
+												pos:  position{line: 3266, col: 62, offset: 101204},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3265, col: 70, offset: 101144},
+												pos:  position{line: 3266, col: 70, offset: 101212},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3265, col: 84, offset: 101158},
+												pos:        position{line: 3266, col: 84, offset: 101226},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7356,13 +7356,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3273, col: 3, offset: 101308},
+						pos: position{line: 3274, col: 3, offset: 101376},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3273, col: 3, offset: 101308},
+							pos:   position{line: 3274, col: 3, offset: 101376},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3273, col: 10, offset: 101315},
+								pos:  position{line: 3274, col: 10, offset: 101383},
 								name: "ConcatExpr",
 							},
 						},
@@ -7372,35 +7372,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3283, col: 1, offset: 101521},
+			pos:  position{line: 3284, col: 1, offset: 101589},
 			expr: &actionExpr{
-				pos: position{line: 3283, col: 15, offset: 101535},
+				pos: position{line: 3284, col: 15, offset: 101603},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3283, col: 15, offset: 101535},
+					pos: position{line: 3284, col: 15, offset: 101603},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3283, col: 15, offset: 101535},
+							pos:   position{line: 3284, col: 15, offset: 101603},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3283, col: 21, offset: 101541},
+								pos:  position{line: 3284, col: 21, offset: 101609},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3283, col: 32, offset: 101552},
+							pos:   position{line: 3284, col: 32, offset: 101620},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3283, col: 37, offset: 101557},
+								pos: position{line: 3284, col: 37, offset: 101625},
 								expr: &seqExpr{
-									pos: position{line: 3283, col: 38, offset: 101558},
+									pos: position{line: 3284, col: 38, offset: 101626},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3283, col: 38, offset: 101558},
+											pos:  position{line: 3284, col: 38, offset: 101626},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3283, col: 50, offset: 101570},
+											pos:  position{line: 3284, col: 50, offset: 101638},
 											name: "ConcatAtom",
 										},
 									},
@@ -7408,28 +7408,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3283, col: 63, offset: 101583},
+							pos: position{line: 3284, col: 63, offset: 101651},
 							expr: &choiceExpr{
-								pos: position{line: 3283, col: 65, offset: 101585},
+								pos: position{line: 3284, col: 65, offset: 101653},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3283, col: 65, offset: 101585},
+										pos:  position{line: 3284, col: 65, offset: 101653},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3283, col: 74, offset: 101594},
+										pos:  position{line: 3284, col: 74, offset: 101662},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3283, col: 84, offset: 101604},
+										pos:  position{line: 3284, col: 84, offset: 101672},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3283, col: 92, offset: 101612},
+										pos:  position{line: 3284, col: 92, offset: 101680},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3283, col: 100, offset: 101620},
+										pos:        position{line: 3284, col: 100, offset: 101688},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7443,54 +7443,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3301, col: 1, offset: 102026},
+			pos:  position{line: 3302, col: 1, offset: 102094},
 			expr: &choiceExpr{
-				pos: position{line: 3301, col: 15, offset: 102040},
+				pos: position{line: 3302, col: 15, offset: 102108},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3301, col: 15, offset: 102040},
+						pos: position{line: 3302, col: 15, offset: 102108},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3301, col: 15, offset: 102040},
+							pos:   position{line: 3302, col: 15, offset: 102108},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3301, col: 20, offset: 102045},
+								pos:  position{line: 3302, col: 20, offset: 102113},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3310, col: 3, offset: 102209},
+						pos: position{line: 3311, col: 3, offset: 102277},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3310, col: 3, offset: 102209},
+							pos:   position{line: 3311, col: 3, offset: 102277},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3310, col: 7, offset: 102213},
+								pos:  position{line: 3311, col: 7, offset: 102281},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3318, col: 3, offset: 102352},
+						pos: position{line: 3319, col: 3, offset: 102420},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3318, col: 3, offset: 102352},
+							pos:   position{line: 3319, col: 3, offset: 102420},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3318, col: 10, offset: 102359},
+								pos:  position{line: 3319, col: 10, offset: 102427},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3326, col: 3, offset: 102498},
+						pos: position{line: 3327, col: 3, offset: 102566},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3326, col: 3, offset: 102498},
+							pos:   position{line: 3327, col: 3, offset: 102566},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3326, col: 9, offset: 102504},
+								pos:  position{line: 3327, col: 9, offset: 102572},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7500,32 +7500,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3336, col: 1, offset: 102673},
+			pos:  position{line: 3337, col: 1, offset: 102741},
 			expr: &actionExpr{
-				pos: position{line: 3336, col: 16, offset: 102688},
+				pos: position{line: 3337, col: 16, offset: 102756},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3336, col: 16, offset: 102688},
+					pos: position{line: 3337, col: 16, offset: 102756},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3336, col: 16, offset: 102688},
+							pos:   position{line: 3337, col: 16, offset: 102756},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3336, col: 21, offset: 102693},
+								pos:  position{line: 3337, col: 21, offset: 102761},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3336, col: 39, offset: 102711},
+							pos: position{line: 3337, col: 39, offset: 102779},
 							expr: &choiceExpr{
-								pos: position{line: 3336, col: 41, offset: 102713},
+								pos: position{line: 3337, col: 41, offset: 102781},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3336, col: 41, offset: 102713},
+										pos:  position{line: 3337, col: 41, offset: 102781},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3336, col: 55, offset: 102727},
+										pos:        position{line: 3337, col: 55, offset: 102795},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7539,44 +7539,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3341, col: 1, offset: 102792},
+			pos:  position{line: 3342, col: 1, offset: 102860},
 			expr: &actionExpr{
-				pos: position{line: 3341, col: 22, offset: 102813},
+				pos: position{line: 3342, col: 22, offset: 102881},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3341, col: 22, offset: 102813},
+					pos: position{line: 3342, col: 22, offset: 102881},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3341, col: 22, offset: 102813},
+							pos:   position{line: 3342, col: 22, offset: 102881},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3341, col: 28, offset: 102819},
+								pos:  position{line: 3342, col: 28, offset: 102887},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3341, col: 46, offset: 102837},
+							pos:   position{line: 3342, col: 46, offset: 102905},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3341, col: 51, offset: 102842},
+								pos: position{line: 3342, col: 51, offset: 102910},
 								expr: &seqExpr{
-									pos: position{line: 3341, col: 52, offset: 102843},
+									pos: position{line: 3342, col: 52, offset: 102911},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3341, col: 53, offset: 102844},
+											pos: position{line: 3342, col: 53, offset: 102912},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3341, col: 53, offset: 102844},
+													pos:  position{line: 3342, col: 53, offset: 102912},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3341, col: 62, offset: 102853},
+													pos:  position{line: 3342, col: 62, offset: 102921},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3341, col: 71, offset: 102862},
+											pos:  position{line: 3342, col: 71, offset: 102930},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7589,48 +7589,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3362, col: 1, offset: 103363},
+			pos:  position{line: 3363, col: 1, offset: 103431},
 			expr: &actionExpr{
-				pos: position{line: 3362, col: 22, offset: 103384},
+				pos: position{line: 3363, col: 22, offset: 103452},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3362, col: 22, offset: 103384},
+					pos: position{line: 3363, col: 22, offset: 103452},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3362, col: 22, offset: 103384},
+							pos:   position{line: 3363, col: 22, offset: 103452},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3362, col: 28, offset: 103390},
+								pos:  position{line: 3363, col: 28, offset: 103458},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3362, col: 46, offset: 103408},
+							pos:   position{line: 3363, col: 46, offset: 103476},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3362, col: 51, offset: 103413},
+								pos: position{line: 3363, col: 51, offset: 103481},
 								expr: &seqExpr{
-									pos: position{line: 3362, col: 52, offset: 103414},
+									pos: position{line: 3363, col: 52, offset: 103482},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3362, col: 53, offset: 103415},
+											pos: position{line: 3363, col: 53, offset: 103483},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3362, col: 53, offset: 103415},
+													pos:  position{line: 3363, col: 53, offset: 103483},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3362, col: 61, offset: 103423},
+													pos:  position{line: 3363, col: 61, offset: 103491},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3362, col: 69, offset: 103431},
+													pos:  position{line: 3363, col: 69, offset: 103499},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3362, col: 76, offset: 103438},
+											pos:  position{line: 3363, col: 76, offset: 103506},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7643,22 +7643,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3382, col: 1, offset: 103907},
+			pos:  position{line: 3383, col: 1, offset: 103975},
 			expr: &actionExpr{
-				pos: position{line: 3382, col: 21, offset: 103927},
+				pos: position{line: 3383, col: 21, offset: 103995},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3382, col: 21, offset: 103927},
+					pos: position{line: 3383, col: 21, offset: 103995},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3382, col: 21, offset: 103927},
+							pos:  position{line: 3383, col: 21, offset: 103995},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3382, col: 27, offset: 103933},
+							pos:   position{line: 3383, col: 27, offset: 104001},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3382, col: 32, offset: 103938},
+								pos:  position{line: 3383, col: 32, offset: 104006},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7668,67 +7668,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3392, col: 1, offset: 104182},
+			pos:  position{line: 3393, col: 1, offset: 104250},
 			expr: &choiceExpr{
-				pos: position{line: 3392, col: 22, offset: 104203},
+				pos: position{line: 3393, col: 22, offset: 104271},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3392, col: 22, offset: 104203},
+						pos: position{line: 3393, col: 22, offset: 104271},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3392, col: 22, offset: 104203},
+							pos: position{line: 3393, col: 22, offset: 104271},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3392, col: 22, offset: 104203},
+									pos:  position{line: 3393, col: 22, offset: 104271},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3392, col: 30, offset: 104211},
+									pos:   position{line: 3393, col: 30, offset: 104279},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3392, col: 35, offset: 104216},
+										pos:  position{line: 3393, col: 35, offset: 104284},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3392, col: 53, offset: 104234},
+									pos:  position{line: 3393, col: 53, offset: 104302},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3395, col: 3, offset: 104269},
+						pos: position{line: 3396, col: 3, offset: 104337},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3395, col: 3, offset: 104269},
+							pos:   position{line: 3396, col: 3, offset: 104337},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3395, col: 20, offset: 104286},
+								pos:  position{line: 3396, col: 20, offset: 104354},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3398, col: 3, offset: 104340},
+						pos: position{line: 3399, col: 3, offset: 104408},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3398, col: 3, offset: 104340},
+							pos:   position{line: 3399, col: 3, offset: 104408},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3398, col: 9, offset: 104346},
+								pos:  position{line: 3399, col: 9, offset: 104414},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3408, col: 3, offset: 104565},
+						pos: position{line: 3409, col: 3, offset: 104633},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3408, col: 3, offset: 104565},
+							pos:   position{line: 3409, col: 3, offset: 104633},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3408, col: 10, offset: 104572},
+								pos:  position{line: 3409, col: 10, offset: 104640},
 								name: "NumberAsString",
 							},
 						},
@@ -7738,144 +7738,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3421, col: 1, offset: 104950},
+			pos:  position{line: 3422, col: 1, offset: 105018},
 			expr: &choiceExpr{
-				pos: position{line: 3421, col: 20, offset: 104969},
+				pos: position{line: 3422, col: 20, offset: 105037},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3421, col: 20, offset: 104969},
+						pos: position{line: 3422, col: 20, offset: 105037},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3421, col: 21, offset: 104970},
+							pos: position{line: 3422, col: 21, offset: 105038},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3421, col: 21, offset: 104970},
+									pos:   position{line: 3422, col: 21, offset: 105038},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3421, col: 29, offset: 104978},
+										pos: position{line: 3422, col: 29, offset: 105046},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3421, col: 29, offset: 104978},
+												pos:        position{line: 3422, col: 29, offset: 105046},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 37, offset: 104986},
+												pos:        position{line: 3422, col: 37, offset: 105054},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 46, offset: 104995},
+												pos:        position{line: 3422, col: 46, offset: 105063},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 58, offset: 105007},
+												pos:        position{line: 3422, col: 58, offset: 105075},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 67, offset: 105016},
+												pos:        position{line: 3422, col: 67, offset: 105084},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 77, offset: 105026},
+												pos:        position{line: 3422, col: 77, offset: 105094},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 85, offset: 105034},
+												pos:        position{line: 3422, col: 85, offset: 105102},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 95, offset: 105044},
+												pos:        position{line: 3422, col: 95, offset: 105112},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 102, offset: 105051},
+												pos:        position{line: 3422, col: 102, offset: 105119},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 113, offset: 105062},
+												pos:        position{line: 3422, col: 113, offset: 105130},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 123, offset: 105072},
+												pos:        position{line: 3422, col: 123, offset: 105140},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 132, offset: 105081},
+												pos:        position{line: 3422, col: 132, offset: 105149},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 142, offset: 105091},
+												pos:        position{line: 3422, col: 142, offset: 105159},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 151, offset: 105100},
+												pos:        position{line: 3422, col: 151, offset: 105168},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 161, offset: 105110},
+												pos:        position{line: 3422, col: 161, offset: 105178},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 170, offset: 105119},
+												pos:        position{line: 3422, col: 170, offset: 105187},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 179, offset: 105128},
+												pos:        position{line: 3422, col: 179, offset: 105196},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 187, offset: 105136},
+												pos:        position{line: 3422, col: 187, offset: 105204},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 196, offset: 105145},
+												pos:        position{line: 3422, col: 196, offset: 105213},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 204, offset: 105153},
+												pos:        position{line: 3422, col: 204, offset: 105221},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3421, col: 213, offset: 105162},
+												pos:        position{line: 3422, col: 213, offset: 105230},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7884,102 +7884,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3421, col: 220, offset: 105169},
+									pos:  position{line: 3422, col: 220, offset: 105237},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3421, col: 228, offset: 105177},
+									pos:   position{line: 3422, col: 228, offset: 105245},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3421, col: 234, offset: 105183},
+										pos:  position{line: 3422, col: 234, offset: 105251},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3421, col: 253, offset: 105202},
+									pos:  position{line: 3422, col: 253, offset: 105270},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3441, col: 3, offset: 105714},
+						pos: position{line: 3442, col: 3, offset: 105782},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3441, col: 3, offset: 105714},
+							pos: position{line: 3442, col: 3, offset: 105782},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3441, col: 3, offset: 105714},
+									pos:   position{line: 3442, col: 3, offset: 105782},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3441, col: 13, offset: 105724},
+										pos:        position{line: 3442, col: 13, offset: 105792},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3441, col: 21, offset: 105732},
+									pos:  position{line: 3442, col: 21, offset: 105800},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3441, col: 29, offset: 105740},
+									pos:   position{line: 3442, col: 29, offset: 105808},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3441, col: 35, offset: 105746},
+										pos:  position{line: 3442, col: 35, offset: 105814},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3441, col: 54, offset: 105765},
+									pos:   position{line: 3442, col: 54, offset: 105833},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3441, col: 69, offset: 105780},
+										pos: position{line: 3442, col: 69, offset: 105848},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3441, col: 70, offset: 105781},
+											pos:  position{line: 3442, col: 70, offset: 105849},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3441, col: 89, offset: 105800},
+									pos:  position{line: 3442, col: 89, offset: 105868},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3462, col: 3, offset: 106418},
+						pos: position{line: 3463, col: 3, offset: 106486},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3462, col: 4, offset: 106419},
+							pos: position{line: 3463, col: 4, offset: 106487},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3462, col: 4, offset: 106419},
+									pos:   position{line: 3463, col: 4, offset: 106487},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3462, col: 12, offset: 106427},
+										pos: position{line: 3463, col: 12, offset: 106495},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3462, col: 12, offset: 106427},
+												pos:        position{line: 3463, col: 12, offset: 106495},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3462, col: 20, offset: 106435},
+												pos:        position{line: 3463, col: 20, offset: 106503},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3462, col: 27, offset: 106442},
+												pos:        position{line: 3463, col: 27, offset: 106510},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3462, col: 38, offset: 106453},
+												pos:        position{line: 3463, col: 38, offset: 106521},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7988,54 +7988,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3462, col: 46, offset: 106461},
+									pos:  position{line: 3463, col: 46, offset: 106529},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3462, col: 54, offset: 106469},
+									pos:  position{line: 3463, col: 54, offset: 106537},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3475, col: 3, offset: 106755},
+						pos: position{line: 3476, col: 3, offset: 106823},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3475, col: 3, offset: 106755},
+							pos: position{line: 3476, col: 3, offset: 106823},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3475, col: 3, offset: 106755},
+									pos:        position{line: 3476, col: 3, offset: 106823},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 14, offset: 106766},
+									pos:  position{line: 3476, col: 14, offset: 106834},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3475, col: 22, offset: 106774},
+									pos:   position{line: 3476, col: 22, offset: 106842},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3475, col: 33, offset: 106785},
+										pos:  position{line: 3476, col: 33, offset: 106853},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3475, col: 44, offset: 106796},
+									pos:   position{line: 3476, col: 44, offset: 106864},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3475, col: 53, offset: 106805},
+										pos: position{line: 3476, col: 53, offset: 106873},
 										expr: &seqExpr{
-											pos: position{line: 3475, col: 54, offset: 106806},
+											pos: position{line: 3476, col: 54, offset: 106874},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3475, col: 54, offset: 106806},
+													pos:  position{line: 3476, col: 54, offset: 106874},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3475, col: 60, offset: 106812},
+													pos:  position{line: 3476, col: 60, offset: 106880},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8043,73 +8043,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 80, offset: 106832},
+									pos:  position{line: 3476, col: 80, offset: 106900},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3503, col: 3, offset: 107674},
+						pos: position{line: 3504, col: 3, offset: 107742},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3503, col: 3, offset: 107674},
+							pos: position{line: 3504, col: 3, offset: 107742},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3503, col: 3, offset: 107674},
+									pos:   position{line: 3504, col: 3, offset: 107742},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3503, col: 12, offset: 107683},
+										pos:        position{line: 3504, col: 12, offset: 107751},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3503, col: 18, offset: 107689},
+									pos:  position{line: 3504, col: 18, offset: 107757},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3503, col: 26, offset: 107697},
+									pos:   position{line: 3504, col: 26, offset: 107765},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3503, col: 31, offset: 107702},
+										pos:  position{line: 3504, col: 31, offset: 107770},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3503, col: 39, offset: 107710},
+									pos:  position{line: 3504, col: 39, offset: 107778},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3506, col: 3, offset: 107745},
+						pos: position{line: 3507, col: 3, offset: 107813},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3506, col: 4, offset: 107746},
+							pos: position{line: 3507, col: 4, offset: 107814},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3506, col: 4, offset: 107746},
+									pos:   position{line: 3507, col: 4, offset: 107814},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3506, col: 12, offset: 107754},
+										pos: position{line: 3507, col: 12, offset: 107822},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3506, col: 12, offset: 107754},
+												pos:        position{line: 3507, col: 12, offset: 107822},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3506, col: 20, offset: 107762},
+												pos:        position{line: 3507, col: 20, offset: 107830},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3506, col: 30, offset: 107772},
+												pos:        position{line: 3507, col: 30, offset: 107840},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8118,128 +8118,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3506, col: 39, offset: 107781},
+									pos:  position{line: 3507, col: 39, offset: 107849},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3506, col: 47, offset: 107789},
+									pos:   position{line: 3507, col: 47, offset: 107857},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3506, col: 53, offset: 107795},
+										pos:  position{line: 3507, col: 53, offset: 107863},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3506, col: 72, offset: 107814},
+									pos:   position{line: 3507, col: 72, offset: 107882},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3506, col: 79, offset: 107821},
+										pos:  position{line: 3507, col: 79, offset: 107889},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3506, col: 97, offset: 107839},
+									pos:  position{line: 3507, col: 97, offset: 107907},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3536, col: 3, offset: 108678},
+						pos: position{line: 3537, col: 3, offset: 108746},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3536, col: 4, offset: 108679},
+							pos: position{line: 3537, col: 4, offset: 108747},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3536, col: 4, offset: 108679},
+									pos:   position{line: 3537, col: 4, offset: 108747},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3536, col: 11, offset: 108686},
+										pos:        position{line: 3537, col: 11, offset: 108754},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3536, col: 17, offset: 108692},
+									pos:  position{line: 3537, col: 17, offset: 108760},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3536, col: 25, offset: 108700},
+									pos:   position{line: 3537, col: 25, offset: 108768},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3536, col: 31, offset: 108706},
+										pos:  position{line: 3537, col: 31, offset: 108774},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3536, col: 50, offset: 108725},
+									pos:   position{line: 3537, col: 50, offset: 108793},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3536, col: 56, offset: 108731},
+										pos: position{line: 3537, col: 56, offset: 108799},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3536, col: 57, offset: 108732},
+											pos:  position{line: 3537, col: 57, offset: 108800},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3536, col: 76, offset: 108751},
+									pos:  position{line: 3537, col: 76, offset: 108819},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3565, col: 3, offset: 109524},
+						pos: position{line: 3566, col: 3, offset: 109592},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3565, col: 3, offset: 109524},
+							pos: position{line: 3566, col: 3, offset: 109592},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3565, col: 3, offset: 109524},
+									pos:   position{line: 3566, col: 3, offset: 109592},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3565, col: 11, offset: 109532},
+										pos:        position{line: 3566, col: 11, offset: 109600},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3565, col: 28, offset: 109549},
+									pos:  position{line: 3566, col: 28, offset: 109617},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3565, col: 36, offset: 109557},
+									pos:   position{line: 3566, col: 36, offset: 109625},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3565, col: 42, offset: 109563},
+										pos:  position{line: 3566, col: 42, offset: 109631},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3565, col: 61, offset: 109582},
+									pos:  position{line: 3566, col: 61, offset: 109650},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3565, col: 67, offset: 109588},
+									pos:  position{line: 3566, col: 67, offset: 109656},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3565, col: 73, offset: 109594},
+									pos:   position{line: 3566, col: 73, offset: 109662},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3565, col: 84, offset: 109605},
+										pos:  position{line: 3566, col: 84, offset: 109673},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3565, col: 120, offset: 109641},
+									pos:  position{line: 3566, col: 120, offset: 109709},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3565, col: 126, offset: 109647},
+									pos:  position{line: 3566, col: 126, offset: 109715},
 									name: "R_PAREN",
 								},
 							},
@@ -8250,28 +8250,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3582, col: 1, offset: 110176},
+			pos:  position{line: 3583, col: 1, offset: 110244},
 			expr: &choiceExpr{
-				pos: position{line: 3582, col: 12, offset: 110187},
+				pos: position{line: 3583, col: 12, offset: 110255},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3582, col: 12, offset: 110187},
+						pos: position{line: 3583, col: 12, offset: 110255},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3582, col: 12, offset: 110187},
+							pos: position{line: 3583, col: 12, offset: 110255},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3582, col: 12, offset: 110187},
+									pos:   position{line: 3583, col: 12, offset: 110255},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3582, col: 16, offset: 110191},
+										pos:  position{line: 3583, col: 16, offset: 110259},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3582, col: 29, offset: 110204},
+									pos: position{line: 3583, col: 29, offset: 110272},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3582, col: 31, offset: 110206},
+										pos:  position{line: 3583, col: 31, offset: 110274},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8279,50 +8279,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3598, col: 3, offset: 110567},
+						pos: position{line: 3599, col: 3, offset: 110635},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3598, col: 3, offset: 110567},
+							pos: position{line: 3599, col: 3, offset: 110635},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3598, col: 3, offset: 110567},
+									pos:   position{line: 3599, col: 3, offset: 110635},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3598, col: 9, offset: 110573},
+										pos:  position{line: 3599, col: 9, offset: 110641},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3598, col: 25, offset: 110589},
+									pos: position{line: 3599, col: 25, offset: 110657},
 									expr: &choiceExpr{
-										pos: position{line: 3598, col: 27, offset: 110591},
+										pos: position{line: 3599, col: 27, offset: 110659},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 27, offset: 110591},
+												pos:  position{line: 3599, col: 27, offset: 110659},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 36, offset: 110600},
+												pos:  position{line: 3599, col: 36, offset: 110668},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 46, offset: 110610},
+												pos:  position{line: 3599, col: 46, offset: 110678},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 54, offset: 110618},
+												pos:  position{line: 3599, col: 54, offset: 110686},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 62, offset: 110626},
+												pos:  position{line: 3599, col: 62, offset: 110694},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3598, col: 70, offset: 110634},
+												pos:  position{line: 3599, col: 70, offset: 110702},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3598, col: 84, offset: 110648},
+												pos:        position{line: 3599, col: 84, offset: 110716},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8338,28 +8338,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3615, col: 1, offset: 110999},
+			pos:  position{line: 3616, col: 1, offset: 111067},
 			expr: &actionExpr{
-				pos: position{line: 3615, col: 19, offset: 111017},
+				pos: position{line: 3616, col: 19, offset: 111085},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3615, col: 19, offset: 111017},
+					pos: position{line: 3616, col: 19, offset: 111085},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3615, col: 19, offset: 111017},
+							pos:        position{line: 3616, col: 19, offset: 111085},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3615, col: 26, offset: 111024},
+							pos:  position{line: 3616, col: 26, offset: 111092},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3615, col: 32, offset: 111030},
+							pos:   position{line: 3616, col: 32, offset: 111098},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3615, col: 40, offset: 111038},
+								pos:  position{line: 3616, col: 40, offset: 111106},
 								name: "Boolean",
 							},
 						},
@@ -8369,28 +8369,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3626, col: 1, offset: 111227},
+			pos:  position{line: 3627, col: 1, offset: 111295},
 			expr: &actionExpr{
-				pos: position{line: 3626, col: 23, offset: 111249},
+				pos: position{line: 3627, col: 23, offset: 111317},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3626, col: 23, offset: 111249},
+					pos: position{line: 3627, col: 23, offset: 111317},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3626, col: 23, offset: 111249},
+							pos:        position{line: 3627, col: 23, offset: 111317},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3626, col: 34, offset: 111260},
+							pos:  position{line: 3627, col: 34, offset: 111328},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3626, col: 40, offset: 111266},
+							pos:   position{line: 3627, col: 40, offset: 111334},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3626, col: 48, offset: 111274},
+								pos:  position{line: 3627, col: 48, offset: 111342},
 								name: "Boolean",
 							},
 						},
@@ -8400,28 +8400,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3637, col: 1, offset: 111471},
+			pos:  position{line: 3638, col: 1, offset: 111539},
 			expr: &actionExpr{
-				pos: position{line: 3637, col: 20, offset: 111490},
+				pos: position{line: 3638, col: 20, offset: 111558},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3637, col: 20, offset: 111490},
+					pos: position{line: 3638, col: 20, offset: 111558},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3637, col: 20, offset: 111490},
+							pos:        position{line: 3638, col: 20, offset: 111558},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3637, col: 28, offset: 111498},
+							pos:  position{line: 3638, col: 28, offset: 111566},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3637, col: 34, offset: 111504},
+							pos:   position{line: 3638, col: 34, offset: 111572},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3637, col: 43, offset: 111513},
+								pos:  position{line: 3638, col: 43, offset: 111581},
 								name: "IntegerAsString",
 							},
 						},
@@ -8431,15 +8431,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3652, col: 1, offset: 111875},
+			pos:  position{line: 3653, col: 1, offset: 111943},
 			expr: &actionExpr{
-				pos: position{line: 3652, col: 19, offset: 111893},
+				pos: position{line: 3653, col: 19, offset: 111961},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3652, col: 19, offset: 111893},
+					pos:   position{line: 3653, col: 19, offset: 111961},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3652, col: 28, offset: 111902},
+						pos:  position{line: 3653, col: 28, offset: 111970},
 						name: "BoolExpr",
 					},
 				},
@@ -8447,30 +8447,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3663, col: 1, offset: 112114},
+			pos:  position{line: 3664, col: 1, offset: 112182},
 			expr: &actionExpr{
-				pos: position{line: 3663, col: 15, offset: 112128},
+				pos: position{line: 3664, col: 15, offset: 112196},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3663, col: 15, offset: 112128},
+					pos:   position{line: 3664, col: 15, offset: 112196},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3663, col: 23, offset: 112136},
+						pos: position{line: 3664, col: 23, offset: 112204},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3663, col: 23, offset: 112136},
+								pos:  position{line: 3664, col: 23, offset: 112204},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3663, col: 44, offset: 112157},
+								pos:  position{line: 3664, col: 44, offset: 112225},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3663, col: 61, offset: 112174},
+								pos:  position{line: 3664, col: 61, offset: 112242},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3663, col: 79, offset: 112192},
+								pos:  position{line: 3664, col: 79, offset: 112260},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8480,35 +8480,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3667, col: 1, offset: 112236},
+			pos:  position{line: 3668, col: 1, offset: 112304},
 			expr: &actionExpr{
-				pos: position{line: 3667, col: 19, offset: 112254},
+				pos: position{line: 3668, col: 19, offset: 112322},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3667, col: 19, offset: 112254},
+					pos: position{line: 3668, col: 19, offset: 112322},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3667, col: 19, offset: 112254},
+							pos:   position{line: 3668, col: 19, offset: 112322},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3667, col: 26, offset: 112261},
+								pos:  position{line: 3668, col: 26, offset: 112329},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3667, col: 37, offset: 112272},
+							pos:   position{line: 3668, col: 37, offset: 112340},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3667, col: 43, offset: 112278},
+								pos: position{line: 3668, col: 43, offset: 112346},
 								expr: &seqExpr{
-									pos: position{line: 3667, col: 44, offset: 112279},
+									pos: position{line: 3668, col: 44, offset: 112347},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3667, col: 44, offset: 112279},
+											pos:  position{line: 3668, col: 44, offset: 112347},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3667, col: 50, offset: 112285},
+											pos:  position{line: 3668, col: 50, offset: 112353},
 											name: "HeadOption",
 										},
 									},
@@ -8521,29 +8521,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3724, col: 1, offset: 114085},
+			pos:  position{line: 3725, col: 1, offset: 114153},
 			expr: &choiceExpr{
-				pos: position{line: 3724, col: 14, offset: 114098},
+				pos: position{line: 3725, col: 14, offset: 114166},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3724, col: 14, offset: 114098},
+						pos: position{line: 3725, col: 14, offset: 114166},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3724, col: 14, offset: 114098},
+							pos: position{line: 3725, col: 14, offset: 114166},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3724, col: 14, offset: 114098},
+									pos:  position{line: 3725, col: 14, offset: 114166},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3724, col: 19, offset: 114103},
+									pos:  position{line: 3725, col: 19, offset: 114171},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3724, col: 28, offset: 114112},
+									pos:   position{line: 3725, col: 28, offset: 114180},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3724, col: 37, offset: 114121},
+										pos:  position{line: 3725, col: 37, offset: 114189},
 										name: "HeadOptionList",
 									},
 								},
@@ -8551,24 +8551,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3735, col: 3, offset: 114440},
+						pos: position{line: 3736, col: 3, offset: 114508},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3735, col: 3, offset: 114440},
+							pos: position{line: 3736, col: 3, offset: 114508},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3735, col: 3, offset: 114440},
+									pos:  position{line: 3736, col: 3, offset: 114508},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3735, col: 8, offset: 114445},
+									pos:  position{line: 3736, col: 8, offset: 114513},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3735, col: 17, offset: 114454},
+									pos:   position{line: 3736, col: 17, offset: 114522},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3735, col: 26, offset: 114463},
+										pos:  position{line: 3736, col: 26, offset: 114531},
 										name: "IntegerAsString",
 									},
 								},
@@ -8576,17 +8576,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3755, col: 3, offset: 114980},
+						pos: position{line: 3756, col: 3, offset: 115048},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3755, col: 3, offset: 114980},
+							pos: position{line: 3756, col: 3, offset: 115048},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3755, col: 3, offset: 114980},
+									pos:  position{line: 3756, col: 3, offset: 115048},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3755, col: 8, offset: 114985},
+									pos:  position{line: 3756, col: 8, offset: 115053},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8597,29 +8597,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3773, col: 1, offset: 115455},
+			pos:  position{line: 3774, col: 1, offset: 115523},
 			expr: &choiceExpr{
-				pos: position{line: 3773, col: 14, offset: 115468},
+				pos: position{line: 3774, col: 14, offset: 115536},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3773, col: 14, offset: 115468},
+						pos: position{line: 3774, col: 14, offset: 115536},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3773, col: 14, offset: 115468},
+							pos: position{line: 3774, col: 14, offset: 115536},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3773, col: 14, offset: 115468},
+									pos:  position{line: 3774, col: 14, offset: 115536},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3773, col: 19, offset: 115473},
+									pos:  position{line: 3774, col: 19, offset: 115541},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3773, col: 28, offset: 115482},
+									pos:   position{line: 3774, col: 28, offset: 115550},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3773, col: 37, offset: 115491},
+										pos:  position{line: 3774, col: 37, offset: 115559},
 										name: "IntegerAsString",
 									},
 								},
@@ -8627,17 +8627,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3794, col: 3, offset: 116065},
+						pos: position{line: 3795, col: 3, offset: 116133},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3794, col: 3, offset: 116065},
+							pos: position{line: 3795, col: 3, offset: 116133},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3794, col: 3, offset: 116065},
+									pos:  position{line: 3795, col: 3, offset: 116133},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3794, col: 8, offset: 116070},
+									pos:  position{line: 3795, col: 8, offset: 116138},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8648,44 +8648,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3815, col: 1, offset: 116688},
+			pos:  position{line: 3816, col: 1, offset: 116756},
 			expr: &actionExpr{
-				pos: position{line: 3815, col: 20, offset: 116707},
+				pos: position{line: 3816, col: 20, offset: 116775},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3815, col: 20, offset: 116707},
+					pos: position{line: 3816, col: 20, offset: 116775},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3815, col: 20, offset: 116707},
+							pos:   position{line: 3816, col: 20, offset: 116775},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3815, col: 26, offset: 116713},
+								pos:  position{line: 3816, col: 26, offset: 116781},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3815, col: 37, offset: 116724},
+							pos:   position{line: 3816, col: 37, offset: 116792},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3815, col: 42, offset: 116729},
+								pos: position{line: 3816, col: 42, offset: 116797},
 								expr: &seqExpr{
-									pos: position{line: 3815, col: 43, offset: 116730},
+									pos: position{line: 3816, col: 43, offset: 116798},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3815, col: 44, offset: 116731},
+											pos: position{line: 3816, col: 44, offset: 116799},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3815, col: 44, offset: 116731},
+													pos:  position{line: 3816, col: 44, offset: 116799},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3815, col: 52, offset: 116739},
+													pos:  position{line: 3816, col: 52, offset: 116807},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3815, col: 59, offset: 116746},
+											pos:  position{line: 3816, col: 59, offset: 116814},
 											name: "Aggregator",
 										},
 									},
@@ -8698,28 +8698,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3832, col: 1, offset: 117249},
+			pos:  position{line: 3833, col: 1, offset: 117317},
 			expr: &actionExpr{
-				pos: position{line: 3832, col: 15, offset: 117263},
+				pos: position{line: 3833, col: 15, offset: 117331},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3832, col: 15, offset: 117263},
+					pos: position{line: 3833, col: 15, offset: 117331},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3832, col: 15, offset: 117263},
+							pos:   position{line: 3833, col: 15, offset: 117331},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3832, col: 23, offset: 117271},
+								pos:  position{line: 3833, col: 23, offset: 117339},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3832, col: 35, offset: 117283},
+							pos:   position{line: 3833, col: 35, offset: 117351},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3832, col: 43, offset: 117291},
+								pos: position{line: 3833, col: 43, offset: 117359},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3832, col: 43, offset: 117291},
+									pos:  position{line: 3833, col: 43, offset: 117359},
 									name: "AsField",
 								},
 							},
@@ -8730,26 +8730,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3848, col: 1, offset: 118132},
+			pos:  position{line: 3849, col: 1, offset: 118200},
 			expr: &actionExpr{
-				pos: position{line: 3848, col: 16, offset: 118147},
+				pos: position{line: 3849, col: 16, offset: 118215},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3848, col: 16, offset: 118147},
+					pos:   position{line: 3849, col: 16, offset: 118215},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3848, col: 21, offset: 118152},
+						pos: position{line: 3849, col: 21, offset: 118220},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3848, col: 21, offset: 118152},
+								pos:  position{line: 3849, col: 21, offset: 118220},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3848, col: 32, offset: 118163},
+								pos:  position{line: 3849, col: 32, offset: 118231},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3848, col: 48, offset: 118179},
+								pos:  position{line: 3849, col: 48, offset: 118247},
 								name: "AggCommon",
 							},
 						},
@@ -8759,165 +8759,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3853, col: 1, offset: 118385},
+			pos:  position{line: 3854, col: 1, offset: 118453},
 			expr: &actionExpr{
-				pos: position{line: 3853, col: 18, offset: 118402},
+				pos: position{line: 3854, col: 18, offset: 118470},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3853, col: 19, offset: 118403},
+					pos: position{line: 3854, col: 19, offset: 118471},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3853, col: 19, offset: 118403},
+							pos:        position{line: 3854, col: 19, offset: 118471},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 30, offset: 118414},
+							pos:        position{line: 3854, col: 30, offset: 118482},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 39, offset: 118423},
+							pos:        position{line: 3854, col: 39, offset: 118491},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 47, offset: 118431},
+							pos:        position{line: 3854, col: 47, offset: 118499},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 57, offset: 118441},
+							pos:        position{line: 3854, col: 57, offset: 118509},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 65, offset: 118449},
+							pos:        position{line: 3854, col: 65, offset: 118517},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 76, offset: 118460},
+							pos:        position{line: 3854, col: 76, offset: 118528},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 86, offset: 118470},
+							pos:        position{line: 3854, col: 86, offset: 118538},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 95, offset: 118479},
+							pos:        position{line: 3854, col: 95, offset: 118547},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 105, offset: 118489},
+							pos:        position{line: 3854, col: 105, offset: 118557},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 114, offset: 118498},
+							pos:        position{line: 3854, col: 114, offset: 118566},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 122, offset: 118506},
+							pos:        position{line: 3854, col: 122, offset: 118574},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 133, offset: 118517},
+							pos:        position{line: 3854, col: 133, offset: 118585},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3853, col: 142, offset: 118526},
+							pos:        position{line: 3854, col: 142, offset: 118594},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 1, offset: 118535},
+							pos:        position{line: 3855, col: 1, offset: 118603},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 10, offset: 118544},
+							pos:        position{line: 3855, col: 10, offset: 118612},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 26, offset: 118560},
+							pos:        position{line: 3855, col: 26, offset: 118628},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 37, offset: 118571},
+							pos:        position{line: 3855, col: 37, offset: 118639},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 46, offset: 118580},
+							pos:        position{line: 3855, col: 46, offset: 118648},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 56, offset: 118590},
+							pos:        position{line: 3855, col: 56, offset: 118658},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 72, offset: 118606},
+							pos:        position{line: 3855, col: 72, offset: 118674},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 82, offset: 118616},
+							pos:        position{line: 3855, col: 82, offset: 118684},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 100, offset: 118634},
+							pos:        position{line: 3855, col: 100, offset: 118702},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 113, offset: 118647},
+							pos:        position{line: 3855, col: 113, offset: 118715},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 132, offset: 118666},
+							pos:        position{line: 3855, col: 132, offset: 118734},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 139, offset: 118673},
+							pos:        position{line: 3855, col: 139, offset: 118741},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8928,27 +8928,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3858, col: 1, offset: 118716},
+			pos:  position{line: 3859, col: 1, offset: 118784},
 			expr: &actionExpr{
-				pos: position{line: 3858, col: 22, offset: 118737},
+				pos: position{line: 3859, col: 22, offset: 118805},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3858, col: 23, offset: 118738},
+					pos: position{line: 3859, col: 23, offset: 118806},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3858, col: 23, offset: 118738},
+							pos:        position{line: 3859, col: 23, offset: 118806},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3858, col: 37, offset: 118752},
+							pos:        position{line: 3859, col: 37, offset: 118820},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3858, col: 51, offset: 118766},
+							pos:        position{line: 3859, col: 51, offset: 118834},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8959,29 +8959,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3862, col: 1, offset: 118810},
+			pos:  position{line: 3863, col: 1, offset: 118878},
 			expr: &actionExpr{
-				pos: position{line: 3862, col: 12, offset: 118821},
+				pos: position{line: 3863, col: 12, offset: 118889},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3862, col: 12, offset: 118821},
+					pos: position{line: 3863, col: 12, offset: 118889},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3862, col: 12, offset: 118821},
+							pos:  position{line: 3863, col: 12, offset: 118889},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3862, col: 15, offset: 118824},
+							pos:   position{line: 3863, col: 15, offset: 118892},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3862, col: 23, offset: 118832},
+								pos: position{line: 3863, col: 23, offset: 118900},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3862, col: 23, offset: 118832},
+										pos:  position{line: 3863, col: 23, offset: 118900},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3862, col: 35, offset: 118844},
+										pos:  position{line: 3863, col: 35, offset: 118912},
 										name: "String",
 									},
 								},
@@ -8993,27 +8993,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3876, col: 1, offset: 119173},
+			pos:  position{line: 3877, col: 1, offset: 119241},
 			expr: &choiceExpr{
-				pos: position{line: 3876, col: 13, offset: 119185},
+				pos: position{line: 3877, col: 13, offset: 119253},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3876, col: 13, offset: 119185},
+						pos: position{line: 3877, col: 13, offset: 119253},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3876, col: 13, offset: 119185},
+							pos: position{line: 3877, col: 13, offset: 119253},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3876, col: 14, offset: 119186},
+									pos: position{line: 3877, col: 14, offset: 119254},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3876, col: 14, offset: 119186},
+											pos:        position{line: 3877, col: 14, offset: 119254},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3876, col: 24, offset: 119196},
+											pos:        position{line: 3877, col: 24, offset: 119264},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9021,47 +9021,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3876, col: 29, offset: 119201},
+									pos:  position{line: 3877, col: 29, offset: 119269},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3876, col: 37, offset: 119209},
+									pos:        position{line: 3877, col: 37, offset: 119277},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3876, col: 44, offset: 119216},
+									pos:   position{line: 3877, col: 44, offset: 119284},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3876, col: 54, offset: 119226},
+										pos:  position{line: 3877, col: 54, offset: 119294},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3876, col: 64, offset: 119236},
+									pos:  position{line: 3877, col: 64, offset: 119304},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3886, col: 3, offset: 119464},
+						pos: position{line: 3887, col: 3, offset: 119532},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3886, col: 3, offset: 119464},
+							pos: position{line: 3887, col: 3, offset: 119532},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3886, col: 4, offset: 119465},
+									pos: position{line: 3887, col: 4, offset: 119533},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3886, col: 4, offset: 119465},
+											pos:        position{line: 3887, col: 4, offset: 119533},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3886, col: 14, offset: 119475},
+											pos:        position{line: 3887, col: 14, offset: 119543},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9069,38 +9069,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3886, col: 19, offset: 119480},
+									pos:  position{line: 3887, col: 19, offset: 119548},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3886, col: 27, offset: 119488},
+									pos:   position{line: 3887, col: 27, offset: 119556},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3886, col: 33, offset: 119494},
+										pos:  position{line: 3887, col: 33, offset: 119562},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3886, col: 43, offset: 119504},
+									pos:  position{line: 3887, col: 43, offset: 119572},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3893, col: 5, offset: 119655},
+						pos: position{line: 3894, col: 5, offset: 119723},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3893, col: 6, offset: 119656},
+							pos: position{line: 3894, col: 6, offset: 119724},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3893, col: 6, offset: 119656},
+									pos:        position{line: 3894, col: 6, offset: 119724},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3893, col: 16, offset: 119666},
+									pos:        position{line: 3894, col: 16, offset: 119734},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9113,77 +9113,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3902, col: 1, offset: 119802},
+			pos:  position{line: 3903, col: 1, offset: 119870},
 			expr: &choiceExpr{
-				pos: position{line: 3902, col: 14, offset: 119815},
+				pos: position{line: 3903, col: 14, offset: 119883},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3902, col: 14, offset: 119815},
+						pos: position{line: 3903, col: 14, offset: 119883},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3902, col: 14, offset: 119815},
+							pos: position{line: 3903, col: 14, offset: 119883},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3902, col: 14, offset: 119815},
+									pos:   position{line: 3903, col: 14, offset: 119883},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3902, col: 22, offset: 119823},
+										pos:  position{line: 3903, col: 22, offset: 119891},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3902, col: 36, offset: 119837},
+									pos:  position{line: 3903, col: 36, offset: 119905},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3902, col: 44, offset: 119845},
+									pos:        position{line: 3903, col: 44, offset: 119913},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3902, col: 51, offset: 119852},
+									pos:   position{line: 3903, col: 51, offset: 119920},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3902, col: 61, offset: 119862},
+										pos:  position{line: 3903, col: 61, offset: 119930},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3902, col: 71, offset: 119872},
+									pos:  position{line: 3903, col: 71, offset: 119940},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3917, col: 3, offset: 120282},
+						pos: position{line: 3918, col: 3, offset: 120350},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3917, col: 3, offset: 120282},
+							pos: position{line: 3918, col: 3, offset: 120350},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3917, col: 3, offset: 120282},
+									pos:   position{line: 3918, col: 3, offset: 120350},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3917, col: 11, offset: 120290},
+										pos:  position{line: 3918, col: 11, offset: 120358},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3917, col: 25, offset: 120304},
+									pos:  position{line: 3918, col: 25, offset: 120372},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3917, col: 33, offset: 120312},
+									pos:   position{line: 3918, col: 33, offset: 120380},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3917, col: 39, offset: 120318},
+										pos:  position{line: 3918, col: 39, offset: 120386},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3917, col: 49, offset: 120328},
+									pos:  position{line: 3918, col: 49, offset: 120396},
 									name: "R_PAREN",
 								},
 							},
@@ -9194,22 +9194,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3931, col: 1, offset: 120660},
+			pos:  position{line: 3932, col: 1, offset: 120728},
 			expr: &actionExpr{
-				pos: position{line: 3931, col: 18, offset: 120677},
+				pos: position{line: 3932, col: 18, offset: 120745},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3931, col: 18, offset: 120677},
+					pos:   position{line: 3932, col: 18, offset: 120745},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3931, col: 26, offset: 120685},
+						pos: position{line: 3932, col: 26, offset: 120753},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3931, col: 26, offset: 120685},
+								pos:  position{line: 3932, col: 26, offset: 120753},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3931, col: 42, offset: 120701},
+								pos:  position{line: 3932, col: 42, offset: 120769},
 								name: "IntegerAsString",
 							},
 						},
@@ -9219,93 +9219,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3943, col: 1, offset: 121075},
+			pos:  position{line: 3944, col: 1, offset: 121143},
 			expr: &choiceExpr{
-				pos: position{line: 3943, col: 18, offset: 121092},
+				pos: position{line: 3944, col: 18, offset: 121160},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3943, col: 18, offset: 121092},
+						pos: position{line: 3944, col: 18, offset: 121160},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3943, col: 18, offset: 121092},
+							pos: position{line: 3944, col: 18, offset: 121160},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3943, col: 18, offset: 121092},
+									pos:   position{line: 3944, col: 18, offset: 121160},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3943, col: 26, offset: 121100},
+										pos:  position{line: 3944, col: 26, offset: 121168},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3943, col: 44, offset: 121118},
+									pos:   position{line: 3944, col: 44, offset: 121186},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3943, col: 58, offset: 121132},
+										pos:  position{line: 3944, col: 58, offset: 121200},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3943, col: 72, offset: 121146},
+									pos:  position{line: 3944, col: 72, offset: 121214},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3943, col: 80, offset: 121154},
+									pos:        position{line: 3944, col: 80, offset: 121222},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3943, col: 87, offset: 121161},
+									pos:   position{line: 3944, col: 87, offset: 121229},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3943, col: 97, offset: 121171},
+										pos:  position{line: 3944, col: 97, offset: 121239},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3943, col: 107, offset: 121181},
+									pos:  position{line: 3944, col: 107, offset: 121249},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3959, col: 3, offset: 121630},
+						pos: position{line: 3960, col: 3, offset: 121698},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3959, col: 3, offset: 121630},
+							pos: position{line: 3960, col: 3, offset: 121698},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3959, col: 3, offset: 121630},
+									pos:   position{line: 3960, col: 3, offset: 121698},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3959, col: 11, offset: 121638},
+										pos:  position{line: 3960, col: 11, offset: 121706},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3959, col: 29, offset: 121656},
+									pos:   position{line: 3960, col: 29, offset: 121724},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3959, col: 43, offset: 121670},
+										pos:  position{line: 3960, col: 43, offset: 121738},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3959, col: 57, offset: 121684},
+									pos:  position{line: 3960, col: 57, offset: 121752},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3959, col: 65, offset: 121692},
+									pos:   position{line: 3960, col: 65, offset: 121760},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3959, col: 71, offset: 121698},
+										pos:  position{line: 3960, col: 71, offset: 121766},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3959, col: 81, offset: 121708},
+									pos:  position{line: 3960, col: 81, offset: 121776},
 									name: "R_PAREN",
 								},
 							},
@@ -9316,22 +9316,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3975, col: 1, offset: 122080},
+			pos:  position{line: 3976, col: 1, offset: 122148},
 			expr: &actionExpr{
-				pos: position{line: 3975, col: 25, offset: 122104},
+				pos: position{line: 3976, col: 25, offset: 122172},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3975, col: 25, offset: 122104},
+					pos:   position{line: 3976, col: 25, offset: 122172},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3975, col: 39, offset: 122118},
+						pos: position{line: 3976, col: 39, offset: 122186},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3975, col: 39, offset: 122118},
+								pos:  position{line: 3976, col: 39, offset: 122186},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3975, col: 67, offset: 122146},
+								pos:  position{line: 3976, col: 67, offset: 122214},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9341,43 +9341,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3979, col: 1, offset: 122209},
+			pos:  position{line: 3980, col: 1, offset: 122277},
 			expr: &actionExpr{
-				pos: position{line: 3979, col: 30, offset: 122238},
+				pos: position{line: 3980, col: 30, offset: 122306},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3979, col: 30, offset: 122238},
+					pos: position{line: 3980, col: 30, offset: 122306},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3979, col: 30, offset: 122238},
+							pos:   position{line: 3980, col: 30, offset: 122306},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3979, col: 34, offset: 122242},
+								pos:  position{line: 3980, col: 34, offset: 122310},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3979, col: 44, offset: 122252},
+							pos:   position{line: 3980, col: 44, offset: 122320},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3979, col: 48, offset: 122256},
+								pos: position{line: 3980, col: 48, offset: 122324},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3979, col: 48, offset: 122256},
+										pos:  position{line: 3980, col: 48, offset: 122324},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3979, col: 67, offset: 122275},
+										pos:  position{line: 3980, col: 67, offset: 122343},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3979, col: 87, offset: 122295},
+							pos:   position{line: 3980, col: 87, offset: 122363},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3979, col: 93, offset: 122301},
+								pos:  position{line: 3980, col: 93, offset: 122369},
 								name: "Number",
 							},
 						},
@@ -9387,15 +9387,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3992, col: 1, offset: 122535},
+			pos:  position{line: 3993, col: 1, offset: 122603},
 			expr: &actionExpr{
-				pos: position{line: 3992, col: 32, offset: 122566},
+				pos: position{line: 3993, col: 32, offset: 122634},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3992, col: 32, offset: 122566},
+					pos:   position{line: 3993, col: 32, offset: 122634},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3992, col: 38, offset: 122572},
+						pos:  position{line: 3993, col: 38, offset: 122640},
 						name: "Number",
 					},
 				},
@@ -9403,34 +9403,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4005, col: 1, offset: 122789},
+			pos:  position{line: 4006, col: 1, offset: 122857},
 			expr: &actionExpr{
-				pos: position{line: 4005, col: 26, offset: 122814},
+				pos: position{line: 4006, col: 26, offset: 122882},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4005, col: 26, offset: 122814},
+					pos: position{line: 4006, col: 26, offset: 122882},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4005, col: 26, offset: 122814},
+							pos:   position{line: 4006, col: 26, offset: 122882},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4005, col: 30, offset: 122818},
+								pos:  position{line: 4006, col: 30, offset: 122886},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4005, col: 40, offset: 122828},
+							pos:   position{line: 4006, col: 40, offset: 122896},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4005, col: 43, offset: 122831},
+								pos:  position{line: 4006, col: 43, offset: 122899},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4005, col: 60, offset: 122848},
+							pos:   position{line: 4006, col: 60, offset: 122916},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4005, col: 66, offset: 122854},
+								pos:  position{line: 4006, col: 66, offset: 122922},
 								name: "Boolean",
 							},
 						},
@@ -9440,22 +9440,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4018, col: 1, offset: 123089},
+			pos:  position{line: 4019, col: 1, offset: 123157},
 			expr: &actionExpr{
-				pos: position{line: 4018, col: 25, offset: 123113},
+				pos: position{line: 4019, col: 25, offset: 123181},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4018, col: 25, offset: 123113},
+					pos:   position{line: 4019, col: 25, offset: 123181},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4018, col: 39, offset: 123127},
+						pos: position{line: 4019, col: 39, offset: 123195},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4018, col: 39, offset: 123127},
+								pos:  position{line: 4019, col: 39, offset: 123195},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4018, col: 67, offset: 123155},
+								pos:  position{line: 4019, col: 67, offset: 123223},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9465,41 +9465,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4022, col: 1, offset: 123218},
+			pos:  position{line: 4023, col: 1, offset: 123286},
 			expr: &actionExpr{
-				pos: position{line: 4022, col: 30, offset: 123247},
+				pos: position{line: 4023, col: 30, offset: 123315},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4022, col: 30, offset: 123247},
+					pos: position{line: 4023, col: 30, offset: 123315},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4022, col: 30, offset: 123247},
+							pos:   position{line: 4023, col: 30, offset: 123315},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4022, col: 34, offset: 123251},
+								pos:  position{line: 4023, col: 34, offset: 123319},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4022, col: 44, offset: 123261},
+							pos:   position{line: 4023, col: 44, offset: 123329},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4022, col: 47, offset: 123264},
+								pos:  position{line: 4023, col: 47, offset: 123332},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4022, col: 64, offset: 123281},
+							pos:   position{line: 4023, col: 64, offset: 123349},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4022, col: 81, offset: 123298},
+								pos: position{line: 4023, col: 81, offset: 123366},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4022, col: 81, offset: 123298},
+										pos:  position{line: 4023, col: 81, offset: 123366},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4022, col: 103, offset: 123320},
+										pos:  position{line: 4023, col: 103, offset: 123388},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9511,22 +9511,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4037, col: 1, offset: 123720},
+			pos:  position{line: 4038, col: 1, offset: 123788},
 			expr: &actionExpr{
-				pos: position{line: 4037, col: 32, offset: 123751},
+				pos: position{line: 4038, col: 32, offset: 123819},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4037, col: 32, offset: 123751},
+					pos:   position{line: 4038, col: 32, offset: 123819},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4037, col: 49, offset: 123768},
+						pos: position{line: 4038, col: 49, offset: 123836},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4037, col: 49, offset: 123768},
+								pos:  position{line: 4038, col: 49, offset: 123836},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4037, col: 71, offset: 123790},
+								pos:  position{line: 4038, col: 71, offset: 123858},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9536,33 +9536,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4052, col: 1, offset: 124173},
+			pos:  position{line: 4053, col: 1, offset: 124241},
 			expr: &actionExpr{
-				pos: position{line: 4052, col: 24, offset: 124196},
+				pos: position{line: 4053, col: 24, offset: 124264},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4052, col: 24, offset: 124196},
+					pos: position{line: 4053, col: 24, offset: 124264},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4052, col: 24, offset: 124196},
+							pos:        position{line: 4053, col: 24, offset: 124264},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4052, col: 31, offset: 124203},
+							pos:  position{line: 4053, col: 31, offset: 124271},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4052, col: 39, offset: 124211},
+							pos:   position{line: 4053, col: 39, offset: 124279},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4052, col: 45, offset: 124217},
+								pos:  position{line: 4053, col: 45, offset: 124285},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4052, col: 52, offset: 124224},
+							pos:  position{line: 4053, col: 52, offset: 124292},
 							name: "R_PAREN",
 						},
 					},
@@ -9571,15 +9571,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4060, col: 1, offset: 124365},
+			pos:  position{line: 4061, col: 1, offset: 124433},
 			expr: &actionExpr{
-				pos: position{line: 4060, col: 26, offset: 124390},
+				pos: position{line: 4061, col: 26, offset: 124458},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4060, col: 26, offset: 124390},
+					pos:   position{line: 4061, col: 26, offset: 124458},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4060, col: 32, offset: 124396},
+						pos:  position{line: 4061, col: 32, offset: 124464},
 						name: "String",
 					},
 				},
@@ -9587,35 +9587,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4070, col: 1, offset: 124676},
+			pos:  position{line: 4071, col: 1, offset: 124744},
 			expr: &actionExpr{
-				pos: position{line: 4070, col: 18, offset: 124693},
+				pos: position{line: 4071, col: 18, offset: 124761},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4070, col: 18, offset: 124693},
+					pos: position{line: 4071, col: 18, offset: 124761},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4070, col: 18, offset: 124693},
+							pos:   position{line: 4071, col: 18, offset: 124761},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4070, col: 24, offset: 124699},
+								pos:  position{line: 4071, col: 24, offset: 124767},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4070, col: 34, offset: 124709},
+							pos:   position{line: 4071, col: 34, offset: 124777},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4070, col: 39, offset: 124714},
+								pos: position{line: 4071, col: 39, offset: 124782},
 								expr: &seqExpr{
-									pos: position{line: 4070, col: 40, offset: 124715},
+									pos: position{line: 4071, col: 40, offset: 124783},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4070, col: 40, offset: 124715},
+											pos:  position{line: 4071, col: 40, offset: 124783},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4070, col: 46, offset: 124721},
+											pos:  position{line: 4071, col: 46, offset: 124789},
 											name: "FieldName",
 										},
 									},
@@ -9628,16 +9628,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4087, col: 1, offset: 125216},
+			pos:  position{line: 4088, col: 1, offset: 125284},
 			expr: &choiceExpr{
-				pos: position{line: 4087, col: 18, offset: 125233},
+				pos: position{line: 4088, col: 18, offset: 125301},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4087, col: 18, offset: 125233},
+						pos:  position{line: 4088, col: 18, offset: 125301},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4087, col: 38, offset: 125253},
+						pos:  position{line: 4088, col: 38, offset: 125321},
 						name: "EarliestOnly",
 					},
 				},
@@ -9645,62 +9645,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4089, col: 1, offset: 125267},
+			pos:  position{line: 4090, col: 1, offset: 125335},
 			expr: &actionExpr{
-				pos: position{line: 4089, col: 22, offset: 125288},
+				pos: position{line: 4090, col: 22, offset: 125356},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4089, col: 22, offset: 125288},
+					pos: position{line: 4090, col: 22, offset: 125356},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4089, col: 22, offset: 125288},
+							pos:  position{line: 4090, col: 22, offset: 125356},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4089, col: 35, offset: 125301},
+							pos:  position{line: 4090, col: 35, offset: 125369},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4089, col: 41, offset: 125307},
+							pos:   position{line: 4090, col: 41, offset: 125375},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4089, col: 55, offset: 125321},
+								pos: position{line: 4090, col: 55, offset: 125389},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 55, offset: 125321},
+										pos:  position{line: 4090, col: 55, offset: 125389},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 75, offset: 125341},
+										pos:  position{line: 4090, col: 75, offset: 125409},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4089, col: 94, offset: 125360},
+							pos:  position{line: 4090, col: 94, offset: 125428},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4089, col: 100, offset: 125366},
+							pos:  position{line: 4090, col: 100, offset: 125434},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4089, col: 111, offset: 125377},
+							pos:  position{line: 4090, col: 111, offset: 125445},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4089, col: 117, offset: 125383},
+							pos:   position{line: 4090, col: 117, offset: 125451},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4089, col: 129, offset: 125395},
+								pos: position{line: 4090, col: 129, offset: 125463},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 129, offset: 125395},
+										pos:  position{line: 4090, col: 129, offset: 125463},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 149, offset: 125415},
+										pos:  position{line: 4090, col: 149, offset: 125483},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9712,33 +9712,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4130, col: 1, offset: 126554},
+			pos:  position{line: 4131, col: 1, offset: 126622},
 			expr: &actionExpr{
-				pos: position{line: 4130, col: 17, offset: 126570},
+				pos: position{line: 4131, col: 17, offset: 126638},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4130, col: 17, offset: 126570},
+					pos: position{line: 4131, col: 17, offset: 126638},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4130, col: 17, offset: 126570},
+							pos:  position{line: 4131, col: 17, offset: 126638},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4130, col: 30, offset: 126583},
+							pos:  position{line: 4131, col: 30, offset: 126651},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4130, col: 36, offset: 126589},
+							pos:   position{line: 4131, col: 36, offset: 126657},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4130, col: 50, offset: 126603},
+								pos: position{line: 4131, col: 50, offset: 126671},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4130, col: 50, offset: 126603},
+										pos:  position{line: 4131, col: 50, offset: 126671},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4130, col: 70, offset: 126623},
+										pos:  position{line: 4131, col: 70, offset: 126691},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9750,24 +9750,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4158, col: 1, offset: 127331},
+			pos:  position{line: 4159, col: 1, offset: 127399},
 			expr: &actionExpr{
-				pos: position{line: 4158, col: 23, offset: 127353},
+				pos: position{line: 4159, col: 23, offset: 127421},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4158, col: 23, offset: 127353},
+					pos: position{line: 4159, col: 23, offset: 127421},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4158, col: 23, offset: 127353},
+							pos:        position{line: 4159, col: 23, offset: 127421},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4158, col: 27, offset: 127357},
+							pos: position{line: 4159, col: 27, offset: 127425},
 							expr: &charClassMatcher{
-								pos:        position{line: 4158, col: 27, offset: 127357},
+								pos:        position{line: 4159, col: 27, offset: 127425},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9780,21 +9780,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4162, col: 1, offset: 127400},
+			pos:  position{line: 4163, col: 1, offset: 127468},
 			expr: &actionExpr{
-				pos: position{line: 4162, col: 13, offset: 127412},
+				pos: position{line: 4163, col: 13, offset: 127480},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4162, col: 14, offset: 127413},
+					pos: position{line: 4163, col: 14, offset: 127481},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4162, col: 14, offset: 127413},
+							pos:        position{line: 4163, col: 14, offset: 127481},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4162, col: 17, offset: 127416},
+							pos:        position{line: 4163, col: 17, offset: 127484},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9806,15 +9806,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4166, col: 1, offset: 127459},
+			pos:  position{line: 4167, col: 1, offset: 127527},
 			expr: &actionExpr{
-				pos: position{line: 4166, col: 16, offset: 127474},
+				pos: position{line: 4167, col: 16, offset: 127542},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4166, col: 16, offset: 127474},
+					pos:   position{line: 4167, col: 16, offset: 127542},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4166, col: 26, offset: 127484},
+						pos:  position{line: 4167, col: 26, offset: 127552},
 						name: "AllTimeScale",
 					},
 				},
@@ -9822,31 +9822,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4173, col: 1, offset: 127708},
+			pos:  position{line: 4174, col: 1, offset: 127776},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 9, offset: 127716},
+				pos: position{line: 4174, col: 9, offset: 127784},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4173, col: 9, offset: 127716},
+					pos: position{line: 4174, col: 9, offset: 127784},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4173, col: 9, offset: 127716},
+							pos:        position{line: 4174, col: 9, offset: 127784},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4173, col: 13, offset: 127720},
+							pos:   position{line: 4174, col: 13, offset: 127788},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4173, col: 19, offset: 127726},
+								pos: position{line: 4174, col: 19, offset: 127794},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4173, col: 19, offset: 127726},
+										pos:  position{line: 4174, col: 19, offset: 127794},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4173, col: 30, offset: 127737},
+										pos:  position{line: 4174, col: 30, offset: 127805},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9858,26 +9858,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4177, col: 1, offset: 127785},
+			pos:  position{line: 4178, col: 1, offset: 127853},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 11, offset: 127795},
+				pos: position{line: 4178, col: 11, offset: 127863},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4177, col: 11, offset: 127795},
+					pos: position{line: 4178, col: 11, offset: 127863},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4177, col: 11, offset: 127795},
+							pos:   position{line: 4178, col: 11, offset: 127863},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4177, col: 16, offset: 127800},
+								pos:  position{line: 4178, col: 16, offset: 127868},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4177, col: 36, offset: 127820},
+							pos:   position{line: 4178, col: 36, offset: 127888},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4177, col: 43, offset: 127827},
+								pos:  position{line: 4178, col: 43, offset: 127895},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9887,44 +9887,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4205, col: 1, offset: 128565},
+			pos:  position{line: 4206, col: 1, offset: 128633},
 			expr: &actionExpr{
-				pos: position{line: 4205, col: 29, offset: 128593},
+				pos: position{line: 4206, col: 29, offset: 128661},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4205, col: 29, offset: 128593},
+					pos: position{line: 4206, col: 29, offset: 128661},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4205, col: 29, offset: 128593},
+							pos:   position{line: 4206, col: 29, offset: 128661},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4205, col: 36, offset: 128600},
+								pos: position{line: 4206, col: 36, offset: 128668},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4205, col: 36, offset: 128600},
+										pos:  position{line: 4206, col: 36, offset: 128668},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4205, col: 45, offset: 128609},
+										pos:  position{line: 4206, col: 45, offset: 128677},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4205, col: 51, offset: 128615},
+							pos:   position{line: 4206, col: 51, offset: 128683},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4205, col: 57, offset: 128621},
+								pos: position{line: 4206, col: 57, offset: 128689},
 								expr: &choiceExpr{
-									pos: position{line: 4205, col: 58, offset: 128622},
+									pos: position{line: 4206, col: 58, offset: 128690},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4205, col: 58, offset: 128622},
+											pos:  position{line: 4206, col: 58, offset: 128690},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4205, col: 67, offset: 128631},
+											pos:  position{line: 4206, col: 67, offset: 128699},
 											name: "Snap",
 										},
 									},
@@ -9937,29 +9937,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4252, col: 1, offset: 130063},
+			pos:  position{line: 4253, col: 1, offset: 130131},
 			expr: &actionExpr{
-				pos: position{line: 4252, col: 22, offset: 130084},
+				pos: position{line: 4253, col: 22, offset: 130152},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4252, col: 22, offset: 130084},
+					pos: position{line: 4253, col: 22, offset: 130152},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4252, col: 22, offset: 130084},
+							pos:   position{line: 4253, col: 22, offset: 130152},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4252, col: 34, offset: 130096},
+								pos: position{line: 4253, col: 34, offset: 130164},
 								expr: &choiceExpr{
-									pos: position{line: 4252, col: 35, offset: 130097},
+									pos: position{line: 4253, col: 35, offset: 130165},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4252, col: 35, offset: 130097},
+											pos:        position{line: 4253, col: 35, offset: 130165},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4252, col: 43, offset: 130105},
+											pos:        position{line: 4253, col: 43, offset: 130173},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9969,12 +9969,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4252, col: 49, offset: 130111},
+							pos:   position{line: 4253, col: 49, offset: 130179},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4252, col: 57, offset: 130119},
+								pos: position{line: 4253, col: 57, offset: 130187},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4252, col: 58, offset: 130120},
+									pos:  position{line: 4253, col: 58, offset: 130188},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9985,31 +9985,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4277, col: 1, offset: 130803},
+			pos:  position{line: 4278, col: 1, offset: 130871},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 39, offset: 130841},
+				pos: position{line: 4278, col: 39, offset: 130909},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4277, col: 39, offset: 130841},
+					pos: position{line: 4278, col: 39, offset: 130909},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4277, col: 39, offset: 130841},
+							pos:   position{line: 4278, col: 39, offset: 130909},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4277, col: 46, offset: 130848},
+								pos: position{line: 4278, col: 46, offset: 130916},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4277, col: 47, offset: 130849},
+									pos:  position{line: 4278, col: 47, offset: 130917},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4277, col: 56, offset: 130858},
+							pos:   position{line: 4278, col: 56, offset: 130926},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4277, col: 66, offset: 130868},
+								pos: position{line: 4278, col: 66, offset: 130936},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4277, col: 67, offset: 130869},
+									pos:  position{line: 4278, col: 67, offset: 130937},
 									name: "Snap",
 								},
 							},
@@ -10020,136 +10020,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4304, col: 1, offset: 131497},
+			pos:  position{line: 4305, col: 1, offset: 131565},
 			expr: &actionExpr{
-				pos: position{line: 4304, col: 18, offset: 131514},
+				pos: position{line: 4305, col: 18, offset: 131582},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4304, col: 18, offset: 131514},
+					pos: position{line: 4305, col: 18, offset: 131582},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 18, offset: 131514},
+							pos:        position{line: 4305, col: 18, offset: 131582},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 23, offset: 131519},
+							pos:        position{line: 4305, col: 23, offset: 131587},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4304, col: 29, offset: 131525},
+							pos:        position{line: 4305, col: 29, offset: 131593},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 33, offset: 131529},
+							pos:        position{line: 4305, col: 33, offset: 131597},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 38, offset: 131534},
+							pos:        position{line: 4305, col: 38, offset: 131602},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4304, col: 44, offset: 131540},
+							pos:        position{line: 4305, col: 44, offset: 131608},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 48, offset: 131544},
+							pos:        position{line: 4305, col: 48, offset: 131612},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 53, offset: 131549},
+							pos:        position{line: 4305, col: 53, offset: 131617},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 58, offset: 131554},
+							pos:        position{line: 4305, col: 58, offset: 131622},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 63, offset: 131559},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4304, col: 69, offset: 131565},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4304, col: 73, offset: 131569},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4304, col: 78, offset: 131574},
+							pos:        position{line: 4305, col: 63, offset: 131627},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4304, col: 84, offset: 131580},
+							pos:        position{line: 4305, col: 69, offset: 131633},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 88, offset: 131584},
+							pos:        position{line: 4305, col: 73, offset: 131637},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 93, offset: 131589},
+							pos:        position{line: 4305, col: 78, offset: 131642},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4304, col: 99, offset: 131595},
+							pos:        position{line: 4305, col: 84, offset: 131648},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 103, offset: 131599},
+							pos:        position{line: 4305, col: 88, offset: 131652},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4304, col: 108, offset: 131604},
+							pos:        position{line: 4305, col: 93, offset: 131657},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4305, col: 99, offset: 131663},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4305, col: 103, offset: 131667},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4305, col: 108, offset: 131672},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10161,15 +10161,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4308, col: 1, offset: 131646},
+			pos:  position{line: 4309, col: 1, offset: 131714},
 			expr: &actionExpr{
-				pos: position{line: 4308, col: 22, offset: 131667},
+				pos: position{line: 4309, col: 22, offset: 131735},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4308, col: 22, offset: 131667},
+					pos:   position{line: 4309, col: 22, offset: 131735},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4308, col: 32, offset: 131677},
+						pos:  position{line: 4309, col: 32, offset: 131745},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10177,15 +10177,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4318, col: 1, offset: 132085},
+			pos:  position{line: 4319, col: 1, offset: 132153},
 			expr: &actionExpr{
-				pos: position{line: 4318, col: 14, offset: 132098},
+				pos: position{line: 4319, col: 14, offset: 132166},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4318, col: 14, offset: 132098},
+					pos: position{line: 4319, col: 14, offset: 132166},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4318, col: 14, offset: 132098},
+							pos:        position{line: 4319, col: 14, offset: 132166},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10193,9 +10193,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4318, col: 27, offset: 132111},
+							pos: position{line: 4319, col: 27, offset: 132179},
 							expr: &charClassMatcher{
-								pos:        position{line: 4318, col: 27, offset: 132111},
+								pos:        position{line: 4319, col: 27, offset: 132179},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10209,15 +10209,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4322, col: 1, offset: 132164},
+			pos:  position{line: 4323, col: 1, offset: 132232},
 			expr: &actionExpr{
-				pos: position{line: 4322, col: 24, offset: 132187},
+				pos: position{line: 4323, col: 24, offset: 132255},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4322, col: 24, offset: 132187},
+					pos: position{line: 4323, col: 24, offset: 132255},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4322, col: 24, offset: 132187},
+							pos:        position{line: 4323, col: 24, offset: 132255},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10225,9 +10225,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4322, col: 39, offset: 132202},
+							pos: position{line: 4323, col: 39, offset: 132270},
 							expr: &charClassMatcher{
-								pos:        position{line: 4322, col: 39, offset: 132202},
+								pos:        position{line: 4323, col: 39, offset: 132270},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10241,22 +10241,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4326, col: 1, offset: 132255},
+			pos:  position{line: 4327, col: 1, offset: 132323},
 			expr: &actionExpr{
-				pos: position{line: 4326, col: 11, offset: 132265},
+				pos: position{line: 4327, col: 11, offset: 132333},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4326, col: 11, offset: 132265},
+					pos:   position{line: 4327, col: 11, offset: 132333},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4326, col: 16, offset: 132270},
+						pos: position{line: 4327, col: 16, offset: 132338},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4326, col: 16, offset: 132270},
+								pos:  position{line: 4327, col: 16, offset: 132338},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4326, col: 31, offset: 132285},
+								pos:  position{line: 4327, col: 31, offset: 132353},
 								name: "UnquotedString",
 							},
 						},
@@ -10266,23 +10266,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4330, col: 1, offset: 132326},
+			pos:  position{line: 4331, col: 1, offset: 132394},
 			expr: &actionExpr{
-				pos: position{line: 4330, col: 17, offset: 132342},
+				pos: position{line: 4331, col: 17, offset: 132410},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4330, col: 17, offset: 132342},
+					pos: position{line: 4331, col: 17, offset: 132410},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4330, col: 17, offset: 132342},
+							pos:        position{line: 4331, col: 17, offset: 132410},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4330, col: 21, offset: 132346},
+							pos: position{line: 4331, col: 21, offset: 132414},
 							expr: &charClassMatcher{
-								pos:        position{line: 4330, col: 21, offset: 132346},
+								pos:        position{line: 4331, col: 21, offset: 132414},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10290,7 +10290,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4330, col: 27, offset: 132352},
+							pos:        position{line: 4331, col: 27, offset: 132420},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10301,48 +10301,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4335, col: 1, offset: 132463},
+			pos:  position{line: 4336, col: 1, offset: 132531},
 			expr: &actionExpr{
-				pos: position{line: 4335, col: 19, offset: 132481},
+				pos: position{line: 4336, col: 19, offset: 132549},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4335, col: 19, offset: 132481},
+					pos: position{line: 4336, col: 19, offset: 132549},
 					expr: &choiceExpr{
-						pos: position{line: 4335, col: 20, offset: 132482},
+						pos: position{line: 4336, col: 20, offset: 132550},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4335, col: 20, offset: 132482},
+								pos:        position{line: 4336, col: 20, offset: 132550},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4335, col: 27, offset: 132489},
+								pos: position{line: 4336, col: 27, offset: 132557},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4335, col: 27, offset: 132489},
+										pos: position{line: 4336, col: 27, offset: 132557},
 										expr: &choiceExpr{
-											pos: position{line: 4335, col: 29, offset: 132491},
+											pos: position{line: 4336, col: 29, offset: 132559},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4335, col: 29, offset: 132491},
+													pos:  position{line: 4336, col: 29, offset: 132559},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4335, col: 43, offset: 132505},
+													pos:        position{line: 4336, col: 43, offset: 132573},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4335, col: 49, offset: 132511},
+													pos:  position{line: 4336, col: 49, offset: 132579},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4335, col: 54, offset: 132516,
+										line: 4336, col: 54, offset: 132584,
 									},
 								},
 							},
@@ -10353,12 +10353,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4342, col: 1, offset: 132631},
+			pos:  position{line: 4343, col: 1, offset: 132699},
 			expr: &choiceExpr{
-				pos: position{line: 4342, col: 16, offset: 132646},
+				pos: position{line: 4343, col: 16, offset: 132714},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4342, col: 16, offset: 132646},
+						pos:        position{line: 4343, col: 16, offset: 132714},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10366,18 +10366,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4342, col: 37, offset: 132667},
+						pos: position{line: 4343, col: 37, offset: 132735},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4342, col: 37, offset: 132667},
+								pos:        position{line: 4343, col: 37, offset: 132735},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4342, col: 41, offset: 132671},
+								pos: position{line: 4343, col: 41, offset: 132739},
 								expr: &charClassMatcher{
-									pos:        position{line: 4342, col: 41, offset: 132671},
+									pos:        position{line: 4343, col: 41, offset: 132739},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10385,7 +10385,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4342, col: 48, offset: 132678},
+								pos:        position{line: 4343, col: 48, offset: 132746},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10397,46 +10397,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4344, col: 1, offset: 132684},
+			pos:  position{line: 4345, col: 1, offset: 132752},
 			expr: &actionExpr{
-				pos: position{line: 4344, col: 39, offset: 132722},
+				pos: position{line: 4345, col: 39, offset: 132790},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4344, col: 39, offset: 132722},
+					pos: position{line: 4345, col: 39, offset: 132790},
 					expr: &choiceExpr{
-						pos: position{line: 4344, col: 40, offset: 132723},
+						pos: position{line: 4345, col: 40, offset: 132791},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4344, col: 40, offset: 132723},
+								pos:  position{line: 4345, col: 40, offset: 132791},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4344, col: 54, offset: 132737},
+								pos: position{line: 4345, col: 54, offset: 132805},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4344, col: 54, offset: 132737},
+										pos: position{line: 4345, col: 54, offset: 132805},
 										expr: &choiceExpr{
-											pos: position{line: 4344, col: 56, offset: 132739},
+											pos: position{line: 4345, col: 56, offset: 132807},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4344, col: 56, offset: 132739},
+													pos:  position{line: 4345, col: 56, offset: 132807},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4344, col: 70, offset: 132753},
+													pos:        position{line: 4345, col: 70, offset: 132821},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4344, col: 76, offset: 132759},
+													pos:  position{line: 4345, col: 76, offset: 132827},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4344, col: 81, offset: 132764,
+										line: 4345, col: 81, offset: 132832,
 									},
 								},
 							},
@@ -10447,21 +10447,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4348, col: 1, offset: 132804},
+			pos:  position{line: 4349, col: 1, offset: 132872},
 			expr: &actionExpr{
-				pos: position{line: 4348, col: 12, offset: 132815},
+				pos: position{line: 4349, col: 12, offset: 132883},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4348, col: 13, offset: 132816},
+					pos: position{line: 4349, col: 13, offset: 132884},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4348, col: 13, offset: 132816},
+							pos:        position{line: 4349, col: 13, offset: 132884},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4348, col: 22, offset: 132825},
+							pos:        position{line: 4349, col: 22, offset: 132893},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10472,14 +10472,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4354, col: 1, offset: 132979},
+			pos:  position{line: 4355, col: 1, offset: 133047},
 			expr: &actionExpr{
-				pos: position{line: 4354, col: 18, offset: 132996},
+				pos: position{line: 4355, col: 18, offset: 133064},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4354, col: 18, offset: 132996},
+					pos: position{line: 4355, col: 18, offset: 133064},
 					expr: &charClassMatcher{
-						pos:        position{line: 4354, col: 18, offset: 132996},
+						pos:        position{line: 4355, col: 18, offset: 133064},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10491,15 +10491,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4358, col: 1, offset: 133047},
+			pos:  position{line: 4359, col: 1, offset: 133115},
 			expr: &actionExpr{
-				pos: position{line: 4358, col: 11, offset: 133057},
+				pos: position{line: 4359, col: 11, offset: 133125},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4358, col: 11, offset: 133057},
+					pos:   position{line: 4359, col: 11, offset: 133125},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4358, col: 18, offset: 133064},
+						pos:  position{line: 4359, col: 18, offset: 133132},
 						name: "NumberAsString",
 					},
 				},
@@ -10507,59 +10507,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4364, col: 1, offset: 133253},
+			pos:  position{line: 4365, col: 1, offset: 133321},
 			expr: &actionExpr{
-				pos: position{line: 4364, col: 19, offset: 133271},
+				pos: position{line: 4365, col: 19, offset: 133339},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4364, col: 19, offset: 133271},
+					pos: position{line: 4365, col: 19, offset: 133339},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4364, col: 19, offset: 133271},
+							pos:   position{line: 4365, col: 19, offset: 133339},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4364, col: 27, offset: 133279},
+								pos: position{line: 4365, col: 27, offset: 133347},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4364, col: 27, offset: 133279},
+										pos:  position{line: 4365, col: 27, offset: 133347},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4364, col: 43, offset: 133295},
+										pos:  position{line: 4365, col: 43, offset: 133363},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4364, col: 60, offset: 133312},
+							pos: position{line: 4365, col: 60, offset: 133380},
 							expr: &choiceExpr{
-								pos: position{line: 4364, col: 62, offset: 133314},
+								pos: position{line: 4365, col: 62, offset: 133382},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4364, col: 62, offset: 133314},
+										pos:  position{line: 4365, col: 62, offset: 133382},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4364, col: 70, offset: 133322},
+										pos:        position{line: 4365, col: 70, offset: 133390},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4364, col: 76, offset: 133328},
+										pos:        position{line: 4365, col: 76, offset: 133396},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4364, col: 82, offset: 133334},
+										pos:        position{line: 4365, col: 82, offset: 133402},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4364, col: 88, offset: 133340},
+										pos:  position{line: 4365, col: 88, offset: 133408},
 										name: "EOF",
 									},
 								},
@@ -10571,17 +10571,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4370, col: 1, offset: 133469},
+			pos:  position{line: 4371, col: 1, offset: 133537},
 			expr: &actionExpr{
-				pos: position{line: 4370, col: 18, offset: 133486},
+				pos: position{line: 4371, col: 18, offset: 133554},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4370, col: 18, offset: 133486},
+					pos: position{line: 4371, col: 18, offset: 133554},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4370, col: 18, offset: 133486},
+							pos: position{line: 4371, col: 18, offset: 133554},
 							expr: &charClassMatcher{
-								pos:        position{line: 4370, col: 18, offset: 133486},
+								pos:        position{line: 4371, col: 18, offset: 133554},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10589,9 +10589,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4370, col: 24, offset: 133492},
+							pos: position{line: 4371, col: 24, offset: 133560},
 							expr: &charClassMatcher{
-								pos:        position{line: 4370, col: 24, offset: 133492},
+								pos:        position{line: 4371, col: 24, offset: 133560},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10599,15 +10599,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4370, col: 31, offset: 133499},
+							pos:        position{line: 4371, col: 31, offset: 133567},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4370, col: 35, offset: 133503},
+							pos: position{line: 4371, col: 35, offset: 133571},
 							expr: &charClassMatcher{
-								pos:        position{line: 4370, col: 35, offset: 133503},
+								pos:        position{line: 4371, col: 35, offset: 133571},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10620,17 +10620,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4375, col: 1, offset: 133598},
+			pos:  position{line: 4376, col: 1, offset: 133666},
 			expr: &actionExpr{
-				pos: position{line: 4375, col: 20, offset: 133617},
+				pos: position{line: 4376, col: 20, offset: 133685},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4375, col: 20, offset: 133617},
+					pos: position{line: 4376, col: 20, offset: 133685},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4375, col: 20, offset: 133617},
+							pos: position{line: 4376, col: 20, offset: 133685},
 							expr: &charClassMatcher{
-								pos:        position{line: 4375, col: 20, offset: 133617},
+								pos:        position{line: 4376, col: 20, offset: 133685},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10638,9 +10638,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4375, col: 26, offset: 133623},
+							pos: position{line: 4376, col: 26, offset: 133691},
 							expr: &charClassMatcher{
-								pos:        position{line: 4375, col: 26, offset: 133623},
+								pos:        position{line: 4376, col: 26, offset: 133691},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10653,14 +10653,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4379, col: 1, offset: 133666},
+			pos:  position{line: 4380, col: 1, offset: 133734},
 			expr: &actionExpr{
-				pos: position{line: 4379, col: 28, offset: 133693},
+				pos: position{line: 4380, col: 28, offset: 133761},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4379, col: 28, offset: 133693},
+					pos: position{line: 4380, col: 28, offset: 133761},
 					expr: &charClassMatcher{
-						pos:        position{line: 4379, col: 28, offset: 133693},
+						pos:        position{line: 4380, col: 28, offset: 133761},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10671,15 +10671,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4383, col: 1, offset: 133736},
+			pos:  position{line: 4384, col: 1, offset: 133804},
 			expr: &actionExpr{
-				pos: position{line: 4383, col: 20, offset: 133755},
+				pos: position{line: 4384, col: 20, offset: 133823},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4383, col: 20, offset: 133755},
+					pos:   position{line: 4384, col: 20, offset: 133823},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4383, col: 27, offset: 133762},
+						pos:  position{line: 4384, col: 27, offset: 133830},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10687,31 +10687,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4391, col: 1, offset: 134009},
+			pos:  position{line: 4392, col: 1, offset: 134077},
 			expr: &actionExpr{
-				pos: position{line: 4391, col: 21, offset: 134029},
+				pos: position{line: 4392, col: 21, offset: 134097},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4391, col: 21, offset: 134029},
+					pos: position{line: 4392, col: 21, offset: 134097},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4391, col: 21, offset: 134029},
+							pos:  position{line: 4392, col: 21, offset: 134097},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4391, col: 36, offset: 134044},
+							pos:   position{line: 4392, col: 36, offset: 134112},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4391, col: 40, offset: 134048},
+								pos: position{line: 4392, col: 40, offset: 134116},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4391, col: 40, offset: 134048},
+										pos:        position{line: 4392, col: 40, offset: 134116},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4391, col: 46, offset: 134054},
+										pos:        position{line: 4392, col: 46, offset: 134122},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10720,7 +10720,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4391, col: 52, offset: 134060},
+							pos:  position{line: 4392, col: 52, offset: 134128},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10729,43 +10729,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4399, col: 1, offset: 134241},
+			pos:  position{line: 4400, col: 1, offset: 134309},
 			expr: &actionExpr{
-				pos: position{line: 4399, col: 23, offset: 134263},
+				pos: position{line: 4400, col: 23, offset: 134331},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4399, col: 23, offset: 134263},
+					pos: position{line: 4400, col: 23, offset: 134331},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4399, col: 23, offset: 134263},
+							pos:  position{line: 4400, col: 23, offset: 134331},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4399, col: 38, offset: 134278},
+							pos:   position{line: 4400, col: 38, offset: 134346},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4399, col: 42, offset: 134282},
+								pos: position{line: 4400, col: 42, offset: 134350},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4399, col: 42, offset: 134282},
+										pos:        position{line: 4400, col: 42, offset: 134350},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4399, col: 49, offset: 134289},
+										pos:        position{line: 4400, col: 49, offset: 134357},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4399, col: 55, offset: 134295},
+										pos:        position{line: 4400, col: 55, offset: 134363},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4399, col: 62, offset: 134302},
+										pos:        position{line: 4400, col: 62, offset: 134370},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10774,7 +10774,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4399, col: 67, offset: 134307},
+							pos:  position{line: 4400, col: 67, offset: 134375},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10783,30 +10783,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4407, col: 1, offset: 134490},
+			pos:  position{line: 4408, col: 1, offset: 134558},
 			expr: &choiceExpr{
-				pos: position{line: 4407, col: 25, offset: 134514},
+				pos: position{line: 4408, col: 25, offset: 134582},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4407, col: 25, offset: 134514},
+						pos: position{line: 4408, col: 25, offset: 134582},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4407, col: 25, offset: 134514},
+							pos:   position{line: 4408, col: 25, offset: 134582},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4407, col: 28, offset: 134517},
+								pos:  position{line: 4408, col: 28, offset: 134585},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4410, col: 3, offset: 134559},
+						pos: position{line: 4411, col: 3, offset: 134627},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4410, col: 3, offset: 134559},
+							pos:   position{line: 4411, col: 3, offset: 134627},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4410, col: 6, offset: 134562},
+								pos:  position{line: 4411, col: 6, offset: 134630},
 								name: "InequalityOperator",
 							},
 						},
@@ -10816,25 +10816,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4414, col: 1, offset: 134605},
+			pos:  position{line: 4415, col: 1, offset: 134673},
 			expr: &actionExpr{
-				pos: position{line: 4414, col: 11, offset: 134615},
+				pos: position{line: 4415, col: 11, offset: 134683},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4414, col: 11, offset: 134615},
+					pos: position{line: 4415, col: 11, offset: 134683},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4414, col: 11, offset: 134615},
+							pos:  position{line: 4415, col: 11, offset: 134683},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4414, col: 26, offset: 134630},
+							pos:        position{line: 4415, col: 26, offset: 134698},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4414, col: 30, offset: 134634},
+							pos:  position{line: 4415, col: 30, offset: 134702},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10843,25 +10843,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4418, col: 1, offset: 134674},
+			pos:  position{line: 4419, col: 1, offset: 134742},
 			expr: &actionExpr{
-				pos: position{line: 4418, col: 12, offset: 134685},
+				pos: position{line: 4419, col: 12, offset: 134753},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4418, col: 12, offset: 134685},
+					pos: position{line: 4419, col: 12, offset: 134753},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4418, col: 12, offset: 134685},
+							pos:  position{line: 4419, col: 12, offset: 134753},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4418, col: 27, offset: 134700},
+							pos:        position{line: 4419, col: 27, offset: 134768},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4418, col: 31, offset: 134704},
+							pos:  position{line: 4419, col: 31, offset: 134772},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10870,25 +10870,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4422, col: 1, offset: 134744},
+			pos:  position{line: 4423, col: 1, offset: 134812},
 			expr: &actionExpr{
-				pos: position{line: 4422, col: 10, offset: 134753},
+				pos: position{line: 4423, col: 10, offset: 134821},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4422, col: 10, offset: 134753},
+					pos: position{line: 4423, col: 10, offset: 134821},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4422, col: 10, offset: 134753},
+							pos:  position{line: 4423, col: 10, offset: 134821},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4422, col: 25, offset: 134768},
+							pos:        position{line: 4423, col: 25, offset: 134836},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4422, col: 29, offset: 134772},
+							pos:  position{line: 4423, col: 29, offset: 134840},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10897,25 +10897,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4426, col: 1, offset: 134812},
+			pos:  position{line: 4427, col: 1, offset: 134880},
 			expr: &actionExpr{
-				pos: position{line: 4426, col: 10, offset: 134821},
+				pos: position{line: 4427, col: 10, offset: 134889},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4426, col: 10, offset: 134821},
+					pos: position{line: 4427, col: 10, offset: 134889},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4426, col: 10, offset: 134821},
+							pos:  position{line: 4427, col: 10, offset: 134889},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4426, col: 25, offset: 134836},
+							pos:        position{line: 4427, col: 25, offset: 134904},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4426, col: 29, offset: 134840},
+							pos:  position{line: 4427, col: 29, offset: 134908},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10924,25 +10924,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4430, col: 1, offset: 134880},
+			pos:  position{line: 4431, col: 1, offset: 134948},
 			expr: &actionExpr{
-				pos: position{line: 4430, col: 10, offset: 134889},
+				pos: position{line: 4431, col: 10, offset: 134957},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4430, col: 10, offset: 134889},
+					pos: position{line: 4431, col: 10, offset: 134957},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4430, col: 10, offset: 134889},
+							pos:  position{line: 4431, col: 10, offset: 134957},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4430, col: 25, offset: 134904},
+							pos:        position{line: 4431, col: 25, offset: 134972},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4430, col: 29, offset: 134908},
+							pos:  position{line: 4431, col: 29, offset: 134976},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10951,39 +10951,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4435, col: 1, offset: 134972},
+			pos:  position{line: 4436, col: 1, offset: 135040},
 			expr: &actionExpr{
-				pos: position{line: 4435, col: 11, offset: 134982},
+				pos: position{line: 4436, col: 11, offset: 135050},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4435, col: 12, offset: 134983},
+					pos: position{line: 4436, col: 12, offset: 135051},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4435, col: 12, offset: 134983},
+							pos:        position{line: 4436, col: 12, offset: 135051},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 24, offset: 134995},
+							pos:        position{line: 4436, col: 24, offset: 135063},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 35, offset: 135006},
+							pos:        position{line: 4436, col: 35, offset: 135074},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 44, offset: 135015},
+							pos:        position{line: 4436, col: 44, offset: 135083},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 52, offset: 135023},
+							pos:        position{line: 4436, col: 52, offset: 135091},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10994,39 +10994,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4439, col: 1, offset: 135064},
+			pos:  position{line: 4440, col: 1, offset: 135132},
 			expr: &actionExpr{
-				pos: position{line: 4439, col: 11, offset: 135074},
+				pos: position{line: 4440, col: 11, offset: 135142},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4439, col: 12, offset: 135075},
+					pos: position{line: 4440, col: 12, offset: 135143},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4439, col: 12, offset: 135075},
+							pos:        position{line: 4440, col: 12, offset: 135143},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 24, offset: 135087},
+							pos:        position{line: 4440, col: 24, offset: 135155},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 35, offset: 135098},
+							pos:        position{line: 4440, col: 35, offset: 135166},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 44, offset: 135107},
+							pos:        position{line: 4440, col: 44, offset: 135175},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 52, offset: 135115},
+							pos:        position{line: 4440, col: 52, offset: 135183},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11037,39 +11037,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4443, col: 1, offset: 135156},
+			pos:  position{line: 4444, col: 1, offset: 135224},
 			expr: &actionExpr{
-				pos: position{line: 4443, col: 9, offset: 135164},
+				pos: position{line: 4444, col: 9, offset: 135232},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4443, col: 10, offset: 135165},
+					pos: position{line: 4444, col: 10, offset: 135233},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4443, col: 10, offset: 135165},
+							pos:        position{line: 4444, col: 10, offset: 135233},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4443, col: 20, offset: 135175},
+							pos:        position{line: 4444, col: 20, offset: 135243},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4443, col: 29, offset: 135184},
+							pos:        position{line: 4444, col: 29, offset: 135252},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4443, col: 37, offset: 135192},
+							pos:        position{line: 4444, col: 37, offset: 135260},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4443, col: 44, offset: 135199},
+							pos:        position{line: 4444, col: 44, offset: 135267},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11080,27 +11080,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4447, col: 1, offset: 135238},
+			pos:  position{line: 4448, col: 1, offset: 135306},
 			expr: &actionExpr{
-				pos: position{line: 4447, col: 8, offset: 135245},
+				pos: position{line: 4448, col: 8, offset: 135313},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4447, col: 9, offset: 135246},
+					pos: position{line: 4448, col: 9, offset: 135314},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4447, col: 9, offset: 135246},
+							pos:        position{line: 4448, col: 9, offset: 135314},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4447, col: 18, offset: 135255},
+							pos:        position{line: 4448, col: 18, offset: 135323},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4447, col: 26, offset: 135263},
+							pos:        position{line: 4448, col: 26, offset: 135331},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11111,27 +11111,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4451, col: 1, offset: 135301},
+			pos:  position{line: 4452, col: 1, offset: 135369},
 			expr: &actionExpr{
-				pos: position{line: 4451, col: 9, offset: 135309},
+				pos: position{line: 4452, col: 9, offset: 135377},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4451, col: 10, offset: 135310},
+					pos: position{line: 4452, col: 10, offset: 135378},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4451, col: 10, offset: 135310},
+							pos:        position{line: 4452, col: 10, offset: 135378},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4451, col: 20, offset: 135320},
+							pos:        position{line: 4452, col: 20, offset: 135388},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4451, col: 29, offset: 135329},
+							pos:        position{line: 4452, col: 29, offset: 135397},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11142,27 +11142,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4455, col: 1, offset: 135368},
+			pos:  position{line: 4456, col: 1, offset: 135436},
 			expr: &actionExpr{
-				pos: position{line: 4455, col: 10, offset: 135377},
+				pos: position{line: 4456, col: 10, offset: 135445},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4455, col: 11, offset: 135378},
+					pos: position{line: 4456, col: 11, offset: 135446},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4455, col: 11, offset: 135378},
+							pos:        position{line: 4456, col: 11, offset: 135446},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4455, col: 22, offset: 135389},
+							pos:        position{line: 4456, col: 22, offset: 135457},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4455, col: 32, offset: 135399},
+							pos:        position{line: 4456, col: 32, offset: 135467},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11173,39 +11173,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4459, col: 1, offset: 135441},
+			pos:  position{line: 4460, col: 1, offset: 135509},
 			expr: &actionExpr{
-				pos: position{line: 4459, col: 12, offset: 135452},
+				pos: position{line: 4460, col: 12, offset: 135520},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4459, col: 13, offset: 135453},
+					pos: position{line: 4460, col: 13, offset: 135521},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4459, col: 13, offset: 135453},
+							pos:        position{line: 4460, col: 13, offset: 135521},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4459, col: 26, offset: 135466},
+							pos:        position{line: 4460, col: 26, offset: 135534},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4459, col: 38, offset: 135478},
+							pos:        position{line: 4460, col: 38, offset: 135546},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4459, col: 47, offset: 135487},
+							pos:        position{line: 4460, col: 47, offset: 135555},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4459, col: 55, offset: 135495},
+							pos:        position{line: 4460, col: 55, offset: 135563},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11216,39 +11216,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4463, col: 1, offset: 135537},
+			pos:  position{line: 4464, col: 1, offset: 135605},
 			expr: &actionExpr{
-				pos: position{line: 4463, col: 9, offset: 135545},
+				pos: position{line: 4464, col: 9, offset: 135613},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4463, col: 10, offset: 135546},
+					pos: position{line: 4464, col: 10, offset: 135614},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4463, col: 10, offset: 135546},
+							pos:        position{line: 4464, col: 10, offset: 135614},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4463, col: 20, offset: 135556},
+							pos:        position{line: 4464, col: 20, offset: 135624},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4463, col: 29, offset: 135565},
+							pos:        position{line: 4464, col: 29, offset: 135633},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4463, col: 37, offset: 135573},
+							pos:        position{line: 4464, col: 37, offset: 135641},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4463, col: 44, offset: 135580},
+							pos:        position{line: 4464, col: 44, offset: 135648},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11259,33 +11259,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4468, col: 1, offset: 135711},
+			pos:  position{line: 4469, col: 1, offset: 135779},
 			expr: &actionExpr{
-				pos: position{line: 4468, col: 15, offset: 135725},
+				pos: position{line: 4469, col: 15, offset: 135793},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4468, col: 16, offset: 135726},
+					pos: position{line: 4469, col: 16, offset: 135794},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4468, col: 16, offset: 135726},
+							pos:        position{line: 4469, col: 16, offset: 135794},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4468, col: 23, offset: 135733},
+							pos:        position{line: 4469, col: 23, offset: 135801},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4468, col: 30, offset: 135740},
+							pos:        position{line: 4469, col: 30, offset: 135808},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4468, col: 37, offset: 135747},
+							pos:        position{line: 4469, col: 37, offset: 135815},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11296,26 +11296,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4477, col: 1, offset: 135970},
+			pos:  position{line: 4478, col: 1, offset: 136038},
 			expr: &actionExpr{
-				pos: position{line: 4477, col: 21, offset: 135990},
+				pos: position{line: 4478, col: 21, offset: 136058},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4477, col: 21, offset: 135990},
+					pos: position{line: 4478, col: 21, offset: 136058},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4477, col: 21, offset: 135990},
+							pos:  position{line: 4478, col: 21, offset: 136058},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4477, col: 26, offset: 135995},
+							pos:  position{line: 4478, col: 26, offset: 136063},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4477, col: 42, offset: 136011},
+							pos:   position{line: 4478, col: 42, offset: 136079},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4477, col: 53, offset: 136022},
+								pos:  position{line: 4478, col: 53, offset: 136090},
 								name: "TransactionOptions",
 							},
 						},
@@ -11325,17 +11325,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4486, col: 1, offset: 136328},
+			pos:  position{line: 4488, col: 1, offset: 136465},
 			expr: &actionExpr{
-				pos: position{line: 4486, col: 23, offset: 136350},
+				pos: position{line: 4488, col: 23, offset: 136487},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4486, col: 23, offset: 136350},
+					pos:   position{line: 4488, col: 23, offset: 136487},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4486, col: 34, offset: 136361},
+						pos: position{line: 4488, col: 34, offset: 136498},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4486, col: 34, offset: 136361},
+							pos:  position{line: 4488, col: 34, offset: 136498},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11344,35 +11344,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4501, col: 1, offset: 136752},
+			pos:  position{line: 4503, col: 1, offset: 136889},
 			expr: &actionExpr{
-				pos: position{line: 4501, col: 37, offset: 136788},
+				pos: position{line: 4503, col: 37, offset: 136925},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4501, col: 37, offset: 136788},
+					pos: position{line: 4503, col: 37, offset: 136925},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4501, col: 37, offset: 136788},
+							pos:   position{line: 4503, col: 37, offset: 136925},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4501, col: 43, offset: 136794},
+								pos:  position{line: 4503, col: 43, offset: 136931},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4501, col: 71, offset: 136822},
+							pos:   position{line: 4503, col: 71, offset: 136959},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4501, col: 76, offset: 136827},
+								pos: position{line: 4503, col: 76, offset: 136964},
 								expr: &seqExpr{
-									pos: position{line: 4501, col: 77, offset: 136828},
+									pos: position{line: 4503, col: 77, offset: 136965},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4501, col: 77, offset: 136828},
+											pos:  position{line: 4503, col: 77, offset: 136965},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4501, col: 83, offset: 136834},
+											pos:  position{line: 4503, col: 83, offset: 136971},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11385,26 +11385,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4536, col: 1, offset: 137823},
+			pos:  position{line: 4538, col: 1, offset: 137960},
 			expr: &actionExpr{
-				pos: position{line: 4536, col: 32, offset: 137854},
+				pos: position{line: 4538, col: 32, offset: 137991},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4536, col: 32, offset: 137854},
+					pos:   position{line: 4538, col: 32, offset: 137991},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4536, col: 40, offset: 137862},
+						pos: position{line: 4538, col: 40, offset: 137999},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 40, offset: 137862},
+								pos:  position{line: 4538, col: 40, offset: 137999},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 77, offset: 137899},
+								pos:  position{line: 4538, col: 77, offset: 138036},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 96, offset: 137918},
+								pos:  position{line: 4538, col: 96, offset: 138055},
 								name: "EndsWithOption",
 							},
 						},
@@ -11414,15 +11414,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4540, col: 1, offset: 137962},
+			pos:  position{line: 4542, col: 1, offset: 138099},
 			expr: &actionExpr{
-				pos: position{line: 4540, col: 39, offset: 138000},
+				pos: position{line: 4542, col: 39, offset: 138137},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4540, col: 39, offset: 138000},
+					pos:   position{line: 4542, col: 39, offset: 138137},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4540, col: 46, offset: 138007},
+						pos:  position{line: 4542, col: 46, offset: 138144},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11430,28 +11430,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4551, col: 1, offset: 138223},
+			pos:  position{line: 4553, col: 1, offset: 138360},
 			expr: &actionExpr{
-				pos: position{line: 4551, col: 21, offset: 138243},
+				pos: position{line: 4553, col: 21, offset: 138380},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4551, col: 21, offset: 138243},
+					pos: position{line: 4553, col: 21, offset: 138380},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4551, col: 21, offset: 138243},
+							pos:        position{line: 4553, col: 21, offset: 138380},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4551, col: 34, offset: 138256},
+							pos:  position{line: 4553, col: 34, offset: 138393},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4551, col: 40, offset: 138262},
+							pos:   position{line: 4553, col: 40, offset: 138399},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4551, col: 48, offset: 138270},
+								pos:  position{line: 4553, col: 48, offset: 138407},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11461,28 +11461,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4561, col: 1, offset: 138508},
+			pos:  position{line: 4563, col: 1, offset: 138645},
 			expr: &actionExpr{
-				pos: position{line: 4561, col: 19, offset: 138526},
+				pos: position{line: 4563, col: 19, offset: 138663},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4561, col: 19, offset: 138526},
+					pos: position{line: 4563, col: 19, offset: 138663},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4561, col: 19, offset: 138526},
+							pos:        position{line: 4563, col: 19, offset: 138663},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4561, col: 30, offset: 138537},
+							pos:  position{line: 4563, col: 30, offset: 138674},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4561, col: 36, offset: 138543},
+							pos:   position{line: 4563, col: 36, offset: 138680},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4561, col: 44, offset: 138551},
+								pos:  position{line: 4563, col: 44, offset: 138688},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11492,26 +11492,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4572, col: 1, offset: 138820},
+			pos:  position{line: 4574, col: 1, offset: 138957},
 			expr: &actionExpr{
-				pos: position{line: 4572, col: 28, offset: 138847},
+				pos: position{line: 4574, col: 28, offset: 138984},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4572, col: 28, offset: 138847},
+					pos:   position{line: 4574, col: 28, offset: 138984},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4572, col: 37, offset: 138856},
+						pos: position{line: 4574, col: 37, offset: 138993},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4572, col: 37, offset: 138856},
+								pos:  position{line: 4574, col: 37, offset: 138993},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4572, col: 63, offset: 138882},
+								pos:  position{line: 4574, col: 63, offset: 139019},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4572, col: 81, offset: 138900},
+								pos:  position{line: 4574, col: 81, offset: 139037},
 								name: "TransactionSearch",
 							},
 						},
@@ -11521,22 +11521,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4576, col: 1, offset: 138948},
+			pos:  position{line: 4578, col: 1, offset: 139085},
 			expr: &actionExpr{
-				pos: position{line: 4576, col: 28, offset: 138975},
+				pos: position{line: 4578, col: 28, offset: 139112},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4576, col: 28, offset: 138975},
+					pos:   position{line: 4578, col: 28, offset: 139112},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4576, col: 33, offset: 138980},
+						pos: position{line: 4578, col: 33, offset: 139117},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4576, col: 33, offset: 138980},
+								pos:  position{line: 4578, col: 33, offset: 139117},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4576, col: 64, offset: 139011},
+								pos:  position{line: 4578, col: 64, offset: 139148},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11546,29 +11546,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4580, col: 1, offset: 139071},
+			pos:  position{line: 4582, col: 1, offset: 139208},
 			expr: &actionExpr{
-				pos: position{line: 4580, col: 38, offset: 139108},
+				pos: position{line: 4582, col: 38, offset: 139245},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4580, col: 38, offset: 139108},
+					pos: position{line: 4582, col: 38, offset: 139245},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4580, col: 38, offset: 139108},
+							pos:        position{line: 4582, col: 38, offset: 139245},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4580, col: 42, offset: 139112},
+							pos:   position{line: 4582, col: 42, offset: 139249},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4580, col: 55, offset: 139125},
+								pos:  position{line: 4582, col: 55, offset: 139262},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4580, col: 68, offset: 139138},
+							pos:        position{line: 4582, col: 68, offset: 139275},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11579,23 +11579,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4588, col: 1, offset: 139277},
+			pos:  position{line: 4590, col: 1, offset: 139414},
 			expr: &actionExpr{
-				pos: position{line: 4588, col: 21, offset: 139297},
+				pos: position{line: 4590, col: 21, offset: 139434},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4588, col: 21, offset: 139297},
+					pos: position{line: 4590, col: 21, offset: 139434},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4588, col: 21, offset: 139297},
+							pos:        position{line: 4590, col: 21, offset: 139434},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4588, col: 25, offset: 139301},
+							pos: position{line: 4590, col: 25, offset: 139438},
 							expr: &charClassMatcher{
-								pos:        position{line: 4588, col: 25, offset: 139301},
+								pos:        position{line: 4590, col: 25, offset: 139438},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11603,7 +11603,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4588, col: 44, offset: 139320},
+							pos:        position{line: 4590, col: 44, offset: 139457},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11614,15 +11614,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4593, col: 1, offset: 139431},
+			pos:  position{line: 4595, col: 1, offset: 139568},
 			expr: &actionExpr{
-				pos: position{line: 4593, col: 33, offset: 139463},
+				pos: position{line: 4595, col: 33, offset: 139600},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4593, col: 33, offset: 139463},
+					pos:   position{line: 4595, col: 33, offset: 139600},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4593, col: 37, offset: 139467},
+						pos:  position{line: 4595, col: 37, offset: 139604},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11630,15 +11630,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4601, col: 1, offset: 139622},
+			pos:  position{line: 4603, col: 1, offset: 139759},
 			expr: &actionExpr{
-				pos: position{line: 4601, col: 22, offset: 139643},
+				pos: position{line: 4603, col: 22, offset: 139780},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4601, col: 22, offset: 139643},
+					pos:   position{line: 4603, col: 22, offset: 139780},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4601, col: 27, offset: 139648},
+						pos:  position{line: 4603, col: 27, offset: 139785},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11646,37 +11646,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4611, col: 1, offset: 139820},
+			pos:  position{line: 4613, col: 1, offset: 139957},
 			expr: &actionExpr{
-				pos: position{line: 4611, col: 20, offset: 139839},
+				pos: position{line: 4613, col: 20, offset: 139976},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4611, col: 20, offset: 139839},
+					pos: position{line: 4613, col: 20, offset: 139976},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4611, col: 20, offset: 139839},
+							pos:        position{line: 4613, col: 20, offset: 139976},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4611, col: 27, offset: 139846},
+							pos:  position{line: 4613, col: 27, offset: 139983},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4611, col: 42, offset: 139861},
+							pos:  position{line: 4613, col: 42, offset: 139998},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4611, col: 50, offset: 139869},
+							pos:   position{line: 4613, col: 50, offset: 140006},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4611, col: 60, offset: 139879},
+								pos:  position{line: 4613, col: 60, offset: 140016},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4611, col: 69, offset: 139888},
+							pos:  position{line: 4613, col: 69, offset: 140025},
 							name: "R_PAREN",
 						},
 					},
@@ -11685,22 +11685,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4621, col: 1, offset: 140191},
+			pos:  position{line: 4623, col: 1, offset: 140328},
 			expr: &actionExpr{
-				pos: position{line: 4621, col: 20, offset: 140210},
+				pos: position{line: 4623, col: 20, offset: 140347},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4621, col: 20, offset: 140210},
+					pos: position{line: 4623, col: 20, offset: 140347},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4621, col: 20, offset: 140210},
+							pos:  position{line: 4623, col: 20, offset: 140347},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4621, col: 25, offset: 140215},
+							pos:   position{line: 4623, col: 25, offset: 140352},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4621, col: 42, offset: 140232},
+								pos:  position{line: 4623, col: 42, offset: 140369},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11710,41 +11710,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4625, col: 1, offset: 140281},
+			pos:  position{line: 4627, col: 1, offset: 140418},
 			expr: &actionExpr{
-				pos: position{line: 4625, col: 16, offset: 140296},
+				pos: position{line: 4627, col: 16, offset: 140433},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4625, col: 16, offset: 140296},
+					pos: position{line: 4627, col: 16, offset: 140433},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 16, offset: 140296},
+							pos:  position{line: 4627, col: 16, offset: 140433},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 27, offset: 140307},
+							pos:  position{line: 4627, col: 27, offset: 140444},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4625, col: 33, offset: 140313},
+							pos:   position{line: 4627, col: 33, offset: 140450},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4625, col: 50, offset: 140330},
+								pos: position{line: 4627, col: 50, offset: 140467},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4625, col: 50, offset: 140330},
+									pos:  position{line: 4627, col: 50, offset: 140467},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 70, offset: 140350},
+							pos:  position{line: 4627, col: 70, offset: 140487},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4625, col: 85, offset: 140365},
+							pos:   position{line: 4627, col: 85, offset: 140502},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4625, col: 91, offset: 140371},
+								pos:  position{line: 4627, col: 91, offset: 140508},
 								name: "FieldName",
 							},
 						},
@@ -11754,35 +11754,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4654, col: 1, offset: 141142},
+			pos:  position{line: 4656, col: 1, offset: 141279},
 			expr: &actionExpr{
-				pos: position{line: 4654, col: 23, offset: 141164},
+				pos: position{line: 4656, col: 23, offset: 141301},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4654, col: 23, offset: 141164},
+					pos: position{line: 4656, col: 23, offset: 141301},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4654, col: 23, offset: 141164},
+							pos:   position{line: 4656, col: 23, offset: 141301},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4654, col: 31, offset: 141172},
+								pos:  position{line: 4656, col: 31, offset: 141309},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4654, col: 46, offset: 141187},
+							pos:   position{line: 4656, col: 46, offset: 141324},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4654, col: 52, offset: 141193},
+								pos: position{line: 4656, col: 52, offset: 141330},
 								expr: &seqExpr{
-									pos: position{line: 4654, col: 53, offset: 141194},
+									pos: position{line: 4656, col: 53, offset: 141331},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4654, col: 53, offset: 141194},
+											pos:  position{line: 4656, col: 53, offset: 141331},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4654, col: 59, offset: 141200},
+											pos:  position{line: 4656, col: 59, offset: 141337},
 											name: "MVBlockOption",
 										},
 									},
@@ -11795,26 +11795,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4688, col: 1, offset: 142256},
+			pos:  position{line: 4690, col: 1, offset: 142393},
 			expr: &actionExpr{
-				pos: position{line: 4688, col: 18, offset: 142273},
+				pos: position{line: 4690, col: 18, offset: 142410},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4688, col: 18, offset: 142273},
+					pos:   position{line: 4690, col: 18, offset: 142410},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4688, col: 27, offset: 142282},
+						pos: position{line: 4690, col: 27, offset: 142419},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4688, col: 27, offset: 142282},
+								pos:  position{line: 4690, col: 27, offset: 142419},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4688, col: 41, offset: 142296},
+								pos:  position{line: 4690, col: 41, offset: 142433},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4688, col: 60, offset: 142315},
+								pos:  position{line: 4690, col: 60, offset: 142452},
 								name: "SetSvOption",
 							},
 						},
@@ -11824,22 +11824,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4692, col: 1, offset: 142356},
+			pos:  position{line: 4694, col: 1, offset: 142493},
 			expr: &actionExpr{
-				pos: position{line: 4692, col: 16, offset: 142371},
+				pos: position{line: 4694, col: 16, offset: 142508},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4692, col: 16, offset: 142371},
+					pos:   position{line: 4694, col: 16, offset: 142508},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4692, col: 28, offset: 142383},
+						pos: position{line: 4694, col: 28, offset: 142520},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4692, col: 28, offset: 142383},
+								pos:  position{line: 4694, col: 28, offset: 142520},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4692, col: 46, offset: 142401},
+								pos:  position{line: 4694, col: 46, offset: 142538},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11849,28 +11849,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4696, col: 1, offset: 142448},
+			pos:  position{line: 4698, col: 1, offset: 142585},
 			expr: &actionExpr{
-				pos: position{line: 4696, col: 20, offset: 142467},
+				pos: position{line: 4698, col: 20, offset: 142604},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4696, col: 20, offset: 142467},
+					pos: position{line: 4698, col: 20, offset: 142604},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4696, col: 20, offset: 142467},
+							pos:        position{line: 4698, col: 20, offset: 142604},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4696, col: 28, offset: 142475},
+							pos:  position{line: 4698, col: 28, offset: 142612},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4696, col: 34, offset: 142481},
+							pos:   position{line: 4698, col: 34, offset: 142618},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4696, col: 38, offset: 142485},
+								pos:  position{line: 4698, col: 38, offset: 142622},
 								name: "QuotedString",
 							},
 						},
@@ -11880,28 +11880,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4707, col: 1, offset: 142736},
+			pos:  position{line: 4709, col: 1, offset: 142873},
 			expr: &actionExpr{
-				pos: position{line: 4707, col: 19, offset: 142754},
+				pos: position{line: 4709, col: 19, offset: 142891},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4707, col: 19, offset: 142754},
+					pos: position{line: 4709, col: 19, offset: 142891},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4707, col: 19, offset: 142754},
+							pos:        position{line: 4709, col: 19, offset: 142891},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4707, col: 31, offset: 142766},
+							pos:  position{line: 4709, col: 31, offset: 142903},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4707, col: 37, offset: 142772},
+							pos:   position{line: 4709, col: 37, offset: 142909},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4707, col: 41, offset: 142776},
+								pos:  position{line: 4709, col: 41, offset: 142913},
 								name: "QuotedString",
 							},
 						},
@@ -11911,28 +11911,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4725, col: 1, offset: 143247},
+			pos:  position{line: 4727, col: 1, offset: 143384},
 			expr: &actionExpr{
-				pos: position{line: 4725, col: 21, offset: 143267},
+				pos: position{line: 4727, col: 21, offset: 143404},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4725, col: 21, offset: 143267},
+					pos: position{line: 4727, col: 21, offset: 143404},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4725, col: 21, offset: 143267},
+							pos:        position{line: 4727, col: 21, offset: 143404},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4725, col: 34, offset: 143280},
+							pos:  position{line: 4727, col: 34, offset: 143417},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4725, col: 40, offset: 143286},
+							pos:   position{line: 4727, col: 40, offset: 143423},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4725, col: 48, offset: 143294},
+								pos:  position{line: 4727, col: 48, offset: 143431},
 								name: "Boolean",
 							},
 						},
@@ -11942,28 +11942,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4737, col: 1, offset: 143534},
+			pos:  position{line: 4739, col: 1, offset: 143671},
 			expr: &actionExpr{
-				pos: position{line: 4737, col: 16, offset: 143549},
+				pos: position{line: 4739, col: 16, offset: 143686},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4737, col: 16, offset: 143549},
+					pos: position{line: 4739, col: 16, offset: 143686},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4737, col: 16, offset: 143549},
+							pos:        position{line: 4739, col: 16, offset: 143686},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4737, col: 24, offset: 143557},
+							pos:  position{line: 4739, col: 24, offset: 143694},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4737, col: 30, offset: 143563},
+							pos:   position{line: 4739, col: 30, offset: 143700},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4737, col: 38, offset: 143571},
+								pos:  position{line: 4739, col: 38, offset: 143708},
 								name: "Boolean",
 							},
 						},
@@ -11973,28 +11973,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4749, col: 1, offset: 143836},
+			pos:  position{line: 4751, col: 1, offset: 143973},
 			expr: &actionExpr{
-				pos: position{line: 4749, col: 15, offset: 143850},
+				pos: position{line: 4751, col: 15, offset: 143987},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4749, col: 15, offset: 143850},
+					pos: position{line: 4751, col: 15, offset: 143987},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4749, col: 15, offset: 143850},
+							pos:  position{line: 4751, col: 15, offset: 143987},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4749, col: 20, offset: 143855},
+							pos:  position{line: 4751, col: 20, offset: 143992},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4749, col: 30, offset: 143865},
+							pos:   position{line: 4751, col: 30, offset: 144002},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4749, col: 40, offset: 143875},
+								pos: position{line: 4751, col: 40, offset: 144012},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4749, col: 40, offset: 143875},
+									pos:  position{line: 4751, col: 40, offset: 144012},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12005,39 +12005,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4756, col: 1, offset: 144001},
+			pos:  position{line: 4758, col: 1, offset: 144138},
 			expr: &actionExpr{
-				pos: position{line: 4756, col: 23, offset: 144023},
+				pos: position{line: 4758, col: 23, offset: 144160},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4756, col: 23, offset: 144023},
+					pos: position{line: 4758, col: 23, offset: 144160},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4756, col: 23, offset: 144023},
+							pos:  position{line: 4758, col: 23, offset: 144160},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4756, col: 29, offset: 144029},
+							pos:   position{line: 4758, col: 29, offset: 144166},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4756, col: 35, offset: 144035},
+								pos:  position{line: 4758, col: 35, offset: 144172},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4756, col: 49, offset: 144049},
+							pos:   position{line: 4758, col: 49, offset: 144186},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4756, col: 54, offset: 144054},
+								pos: position{line: 4758, col: 54, offset: 144191},
 								expr: &seqExpr{
-									pos: position{line: 4756, col: 55, offset: 144055},
+									pos: position{line: 4758, col: 55, offset: 144192},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4756, col: 55, offset: 144055},
+											pos:  position{line: 4758, col: 55, offset: 144192},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4756, col: 61, offset: 144061},
+											pos:  position{line: 4758, col: 61, offset: 144198},
 											name: "SPathArgument",
 										},
 									},
@@ -12050,26 +12050,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4788, col: 1, offset: 144954},
+			pos:  position{line: 4790, col: 1, offset: 145091},
 			expr: &actionExpr{
-				pos: position{line: 4788, col: 18, offset: 144971},
+				pos: position{line: 4790, col: 18, offset: 145108},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4788, col: 18, offset: 144971},
+					pos:   position{line: 4790, col: 18, offset: 145108},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4788, col: 23, offset: 144976},
+						pos: position{line: 4790, col: 23, offset: 145113},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4788, col: 23, offset: 144976},
+								pos:  position{line: 4790, col: 23, offset: 145113},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4788, col: 36, offset: 144989},
+								pos:  position{line: 4790, col: 36, offset: 145126},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4788, col: 50, offset: 145003},
+								pos:  position{line: 4790, col: 50, offset: 145140},
 								name: "PathField",
 							},
 						},
@@ -12079,28 +12079,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4792, col: 1, offset: 145039},
+			pos:  position{line: 4794, col: 1, offset: 145176},
 			expr: &actionExpr{
-				pos: position{line: 4792, col: 15, offset: 145053},
+				pos: position{line: 4794, col: 15, offset: 145190},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4792, col: 15, offset: 145053},
+					pos: position{line: 4794, col: 15, offset: 145190},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4792, col: 15, offset: 145053},
+							pos:        position{line: 4794, col: 15, offset: 145190},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4792, col: 23, offset: 145061},
+							pos:  position{line: 4794, col: 23, offset: 145198},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4792, col: 29, offset: 145067},
+							pos:   position{line: 4794, col: 29, offset: 145204},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4792, col: 35, offset: 145073},
+								pos:  position{line: 4794, col: 35, offset: 145210},
 								name: "FieldName",
 							},
 						},
@@ -12110,28 +12110,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4795, col: 1, offset: 145129},
+			pos:  position{line: 4797, col: 1, offset: 145266},
 			expr: &actionExpr{
-				pos: position{line: 4795, col: 16, offset: 145144},
+				pos: position{line: 4797, col: 16, offset: 145281},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4795, col: 16, offset: 145144},
+					pos: position{line: 4797, col: 16, offset: 145281},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4795, col: 16, offset: 145144},
+							pos:        position{line: 4797, col: 16, offset: 145281},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4795, col: 25, offset: 145153},
+							pos:  position{line: 4797, col: 25, offset: 145290},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4795, col: 31, offset: 145159},
+							pos:   position{line: 4797, col: 31, offset: 145296},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4795, col: 37, offset: 145165},
+								pos:  position{line: 4797, col: 37, offset: 145302},
 								name: "FieldName",
 							},
 						},
@@ -12141,34 +12141,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4798, col: 1, offset: 145222},
+			pos:  position{line: 4800, col: 1, offset: 145359},
 			expr: &actionExpr{
-				pos: position{line: 4798, col: 14, offset: 145235},
+				pos: position{line: 4800, col: 14, offset: 145372},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4798, col: 15, offset: 145236},
+					pos: position{line: 4800, col: 15, offset: 145373},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4798, col: 15, offset: 145236},
+							pos: position{line: 4800, col: 15, offset: 145373},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4798, col: 15, offset: 145236},
+									pos:        position{line: 4800, col: 15, offset: 145373},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4798, col: 22, offset: 145243},
+									pos:  position{line: 4800, col: 22, offset: 145380},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4798, col: 28, offset: 145249},
+									pos:  position{line: 4800, col: 28, offset: 145386},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4798, col: 47, offset: 145268},
+							pos:  position{line: 4800, col: 47, offset: 145405},
 							name: "SPathFieldString",
 						},
 					},
@@ -12177,16 +12177,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4810, col: 1, offset: 145680},
+			pos:  position{line: 4812, col: 1, offset: 145817},
 			expr: &choiceExpr{
-				pos: position{line: 4810, col: 21, offset: 145700},
+				pos: position{line: 4812, col: 21, offset: 145837},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4810, col: 21, offset: 145700},
+						pos:  position{line: 4812, col: 21, offset: 145837},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4810, col: 36, offset: 145715},
+						pos:  position{line: 4812, col: 36, offset: 145852},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12194,28 +12194,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4813, col: 1, offset: 145788},
+			pos:  position{line: 4815, col: 1, offset: 145925},
 			expr: &actionExpr{
-				pos: position{line: 4813, col: 16, offset: 145803},
+				pos: position{line: 4815, col: 16, offset: 145940},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4813, col: 16, offset: 145803},
+					pos: position{line: 4815, col: 16, offset: 145940},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4813, col: 16, offset: 145803},
+							pos:  position{line: 4815, col: 16, offset: 145940},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4813, col: 21, offset: 145808},
+							pos:  position{line: 4815, col: 21, offset: 145945},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4813, col: 32, offset: 145819},
+							pos:   position{line: 4815, col: 32, offset: 145956},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4813, col: 46, offset: 145833},
+								pos: position{line: 4815, col: 46, offset: 145970},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4813, col: 46, offset: 145833},
+									pos:  position{line: 4815, col: 46, offset: 145970},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12226,39 +12226,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4835, col: 1, offset: 146442},
+			pos:  position{line: 4837, col: 1, offset: 146579},
 			expr: &actionExpr{
-				pos: position{line: 4835, col: 24, offset: 146465},
+				pos: position{line: 4837, col: 24, offset: 146602},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4835, col: 24, offset: 146465},
+					pos: position{line: 4837, col: 24, offset: 146602},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4835, col: 24, offset: 146465},
+							pos:  position{line: 4837, col: 24, offset: 146602},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4835, col: 30, offset: 146471},
+							pos:   position{line: 4837, col: 30, offset: 146608},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4835, col: 37, offset: 146478},
+								pos:  position{line: 4837, col: 37, offset: 146615},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4835, col: 52, offset: 146493},
+							pos:   position{line: 4837, col: 52, offset: 146630},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4835, col: 57, offset: 146498},
+								pos: position{line: 4837, col: 57, offset: 146635},
 								expr: &seqExpr{
-									pos: position{line: 4835, col: 58, offset: 146499},
+									pos: position{line: 4837, col: 58, offset: 146636},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4835, col: 58, offset: 146499},
+											pos:  position{line: 4837, col: 58, offset: 146636},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4835, col: 64, offset: 146505},
+											pos:  position{line: 4837, col: 64, offset: 146642},
 											name: "FormatArgument",
 										},
 									},
@@ -12271,30 +12271,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4869, col: 1, offset: 147694},
+			pos:  position{line: 4871, col: 1, offset: 147831},
 			expr: &actionExpr{
-				pos: position{line: 4869, col: 19, offset: 147712},
+				pos: position{line: 4871, col: 19, offset: 147849},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4869, col: 19, offset: 147712},
+					pos:   position{line: 4871, col: 19, offset: 147849},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4869, col: 28, offset: 147721},
+						pos: position{line: 4871, col: 28, offset: 147858},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4869, col: 28, offset: 147721},
+								pos:  position{line: 4871, col: 28, offset: 147858},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4869, col: 46, offset: 147739},
+								pos:  position{line: 4871, col: 46, offset: 147876},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4869, col: 65, offset: 147758},
+								pos:  position{line: 4871, col: 65, offset: 147895},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4869, col: 82, offset: 147775},
+								pos:  position{line: 4871, col: 82, offset: 147912},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12304,28 +12304,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4873, col: 1, offset: 147825},
+			pos:  position{line: 4875, col: 1, offset: 147962},
 			expr: &actionExpr{
-				pos: position{line: 4873, col: 20, offset: 147844},
+				pos: position{line: 4875, col: 20, offset: 147981},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4873, col: 20, offset: 147844},
+					pos: position{line: 4875, col: 20, offset: 147981},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4873, col: 20, offset: 147844},
+							pos:        position{line: 4875, col: 20, offset: 147981},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4873, col: 28, offset: 147852},
+							pos:  position{line: 4875, col: 28, offset: 147989},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4873, col: 34, offset: 147858},
+							pos:   position{line: 4875, col: 34, offset: 147995},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4873, col: 38, offset: 147862},
+								pos:  position{line: 4875, col: 38, offset: 147999},
 								name: "QuotedString",
 							},
 						},
@@ -12335,28 +12335,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4882, col: 1, offset: 148074},
+			pos:  position{line: 4884, col: 1, offset: 148211},
 			expr: &actionExpr{
-				pos: position{line: 4882, col: 21, offset: 148094},
+				pos: position{line: 4884, col: 21, offset: 148231},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4882, col: 21, offset: 148094},
+					pos: position{line: 4884, col: 21, offset: 148231},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4882, col: 21, offset: 148094},
+							pos:        position{line: 4884, col: 21, offset: 148231},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4882, col: 34, offset: 148107},
+							pos:  position{line: 4884, col: 34, offset: 148244},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4882, col: 40, offset: 148113},
+							pos:   position{line: 4884, col: 40, offset: 148250},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4882, col: 47, offset: 148120},
+								pos:  position{line: 4884, col: 47, offset: 148257},
 								name: "IntegerAsString",
 							},
 						},
@@ -12366,28 +12366,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4895, col: 1, offset: 148526},
+			pos:  position{line: 4897, col: 1, offset: 148663},
 			expr: &actionExpr{
-				pos: position{line: 4895, col: 19, offset: 148544},
+				pos: position{line: 4897, col: 19, offset: 148681},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4895, col: 19, offset: 148544},
+					pos: position{line: 4897, col: 19, offset: 148681},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4895, col: 19, offset: 148544},
+							pos:        position{line: 4897, col: 19, offset: 148681},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4895, col: 30, offset: 148555},
+							pos:  position{line: 4897, col: 30, offset: 148692},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4895, col: 36, offset: 148561},
+							pos:   position{line: 4897, col: 36, offset: 148698},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4895, col: 40, offset: 148565},
+								pos:  position{line: 4897, col: 40, offset: 148702},
 								name: "QuotedString",
 							},
 						},
@@ -12397,78 +12397,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4904, col: 1, offset: 148780},
+			pos:  position{line: 4906, col: 1, offset: 148917},
 			expr: &actionExpr{
-				pos: position{line: 4904, col: 24, offset: 148803},
+				pos: position{line: 4906, col: 24, offset: 148940},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4904, col: 24, offset: 148803},
+					pos: position{line: 4906, col: 24, offset: 148940},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4904, col: 24, offset: 148803},
+							pos:   position{line: 4906, col: 24, offset: 148940},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 34, offset: 148813},
+								pos:  position{line: 4906, col: 34, offset: 148950},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 47, offset: 148826},
+							pos:  position{line: 4906, col: 47, offset: 148963},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 53, offset: 148832},
+							pos:   position{line: 4906, col: 53, offset: 148969},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 63, offset: 148842},
+								pos:  position{line: 4906, col: 63, offset: 148979},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 76, offset: 148855},
+							pos:  position{line: 4906, col: 76, offset: 148992},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 82, offset: 148861},
+							pos:   position{line: 4906, col: 82, offset: 148998},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 95, offset: 148874},
+								pos:  position{line: 4906, col: 95, offset: 149011},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 108, offset: 148887},
+							pos:  position{line: 4906, col: 108, offset: 149024},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 114, offset: 148893},
+							pos:   position{line: 4906, col: 114, offset: 149030},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 121, offset: 148900},
+								pos:  position{line: 4906, col: 121, offset: 149037},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 134, offset: 148913},
+							pos:  position{line: 4906, col: 134, offset: 149050},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 140, offset: 148919},
+							pos:   position{line: 4906, col: 140, offset: 149056},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 153, offset: 148932},
+								pos:  position{line: 4906, col: 153, offset: 149069},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4904, col: 166, offset: 148945},
+							pos:  position{line: 4906, col: 166, offset: 149082},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4904, col: 172, offset: 148951},
+							pos:   position{line: 4906, col: 172, offset: 149088},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4904, col: 179, offset: 148958},
+								pos:  position{line: 4906, col: 179, offset: 149095},
 								name: "QuotedString",
 							},
 						},
@@ -12478,28 +12478,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4922, col: 1, offset: 149534},
+			pos:  position{line: 4924, col: 1, offset: 149671},
 			expr: &actionExpr{
-				pos: position{line: 4922, col: 20, offset: 149553},
+				pos: position{line: 4924, col: 20, offset: 149690},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4922, col: 20, offset: 149553},
+					pos: position{line: 4924, col: 20, offset: 149690},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4922, col: 20, offset: 149553},
+							pos:  position{line: 4924, col: 20, offset: 149690},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4922, col: 25, offset: 149558},
+							pos:  position{line: 4924, col: 25, offset: 149695},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4922, col: 40, offset: 149573},
+							pos:   position{line: 4924, col: 40, offset: 149710},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4922, col: 55, offset: 149588},
+								pos: position{line: 4924, col: 55, offset: 149725},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4922, col: 55, offset: 149588},
+									pos:  position{line: 4924, col: 55, offset: 149725},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12510,42 +12510,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4929, col: 1, offset: 149741},
+			pos:  position{line: 4931, col: 1, offset: 149878},
 			expr: &actionExpr{
-				pos: position{line: 4929, col: 28, offset: 149768},
+				pos: position{line: 4931, col: 28, offset: 149905},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4929, col: 28, offset: 149768},
+					pos: position{line: 4931, col: 28, offset: 149905},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4929, col: 28, offset: 149768},
+							pos:  position{line: 4931, col: 28, offset: 149905},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4929, col: 34, offset: 149774},
+							pos:   position{line: 4931, col: 34, offset: 149911},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4929, col: 40, offset: 149780},
+								pos: position{line: 4931, col: 40, offset: 149917},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4929, col: 40, offset: 149780},
+									pos:  position{line: 4931, col: 40, offset: 149917},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4929, col: 60, offset: 149800},
+							pos:   position{line: 4931, col: 60, offset: 149937},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4929, col: 65, offset: 149805},
+								pos: position{line: 4931, col: 65, offset: 149942},
 								expr: &seqExpr{
-									pos: position{line: 4929, col: 66, offset: 149806},
+									pos: position{line: 4931, col: 66, offset: 149943},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4929, col: 66, offset: 149806},
+											pos:  position{line: 4931, col: 66, offset: 149943},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4929, col: 72, offset: 149812},
+											pos:  position{line: 4931, col: 72, offset: 149949},
 											name: "EventCountArgument",
 										},
 									},
@@ -12558,30 +12558,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4985, col: 1, offset: 151689},
+			pos:  position{line: 4987, col: 1, offset: 151826},
 			expr: &actionExpr{
-				pos: position{line: 4985, col: 23, offset: 151711},
+				pos: position{line: 4987, col: 23, offset: 151848},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4985, col: 23, offset: 151711},
+					pos:   position{line: 4987, col: 23, offset: 151848},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4985, col: 28, offset: 151716},
+						pos: position{line: 4987, col: 28, offset: 151853},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4985, col: 28, offset: 151716},
+								pos:  position{line: 4987, col: 28, offset: 151853},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4985, col: 41, offset: 151729},
+								pos:  position{line: 4987, col: 41, offset: 151866},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4985, col: 58, offset: 151746},
+								pos:  position{line: 4987, col: 58, offset: 151883},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4985, col: 76, offset: 151764},
+								pos:  position{line: 4987, col: 76, offset: 151901},
 								name: "ListVixField",
 							},
 						},
@@ -12591,28 +12591,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4989, col: 1, offset: 151803},
+			pos:  position{line: 4991, col: 1, offset: 151940},
 			expr: &actionExpr{
-				pos: position{line: 4989, col: 15, offset: 151817},
+				pos: position{line: 4991, col: 15, offset: 151954},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4989, col: 15, offset: 151817},
+					pos: position{line: 4991, col: 15, offset: 151954},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4989, col: 15, offset: 151817},
+							pos:        position{line: 4991, col: 15, offset: 151954},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4989, col: 23, offset: 151825},
+							pos:  position{line: 4991, col: 23, offset: 151962},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4989, col: 29, offset: 151831},
+							pos:   position{line: 4991, col: 29, offset: 151968},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4989, col: 35, offset: 151837},
+								pos:  position{line: 4991, col: 35, offset: 151974},
 								name: "IndexName",
 							},
 						},
@@ -12622,28 +12622,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4992, col: 1, offset: 151893},
+			pos:  position{line: 4994, col: 1, offset: 152030},
 			expr: &actionExpr{
-				pos: position{line: 4992, col: 19, offset: 151911},
+				pos: position{line: 4994, col: 19, offset: 152048},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4992, col: 19, offset: 151911},
+					pos: position{line: 4994, col: 19, offset: 152048},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4992, col: 19, offset: 151911},
+							pos:        position{line: 4994, col: 19, offset: 152048},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4992, col: 31, offset: 151923},
+							pos:  position{line: 4994, col: 31, offset: 152060},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4992, col: 37, offset: 151929},
+							pos:   position{line: 4994, col: 37, offset: 152066},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4992, col: 43, offset: 151935},
+								pos:  position{line: 4994, col: 43, offset: 152072},
 								name: "Boolean",
 							},
 						},
@@ -12653,28 +12653,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4995, col: 1, offset: 152011},
+			pos:  position{line: 4997, col: 1, offset: 152148},
 			expr: &actionExpr{
-				pos: position{line: 4995, col: 20, offset: 152030},
+				pos: position{line: 4997, col: 20, offset: 152167},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4995, col: 20, offset: 152030},
+					pos: position{line: 4997, col: 20, offset: 152167},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4995, col: 20, offset: 152030},
+							pos:        position{line: 4997, col: 20, offset: 152167},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4995, col: 34, offset: 152044},
+							pos:  position{line: 4997, col: 34, offset: 152181},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4995, col: 40, offset: 152050},
+							pos:   position{line: 4997, col: 40, offset: 152187},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4995, col: 46, offset: 152056},
+								pos:  position{line: 4997, col: 46, offset: 152193},
 								name: "Boolean",
 							},
 						},
@@ -12684,28 +12684,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 4998, col: 1, offset: 152134},
+			pos:  position{line: 5000, col: 1, offset: 152271},
 			expr: &actionExpr{
-				pos: position{line: 4998, col: 17, offset: 152150},
+				pos: position{line: 5000, col: 17, offset: 152287},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 4998, col: 17, offset: 152150},
+					pos: position{line: 5000, col: 17, offset: 152287},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4998, col: 17, offset: 152150},
+							pos:        position{line: 5000, col: 17, offset: 152287},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4998, col: 28, offset: 152161},
+							pos:  position{line: 5000, col: 28, offset: 152298},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4998, col: 34, offset: 152167},
+							pos:   position{line: 5000, col: 34, offset: 152304},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4998, col: 40, offset: 152173},
+								pos:  position{line: 5000, col: 40, offset: 152310},
 								name: "Boolean",
 							},
 						},
@@ -12715,24 +12715,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5002, col: 1, offset: 152249},
+			pos:  position{line: 5004, col: 1, offset: 152386},
 			expr: &actionExpr{
-				pos: position{line: 5002, col: 14, offset: 152262},
+				pos: position{line: 5004, col: 14, offset: 152399},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5002, col: 14, offset: 152262},
+					pos: position{line: 5004, col: 14, offset: 152399},
 					expr: &seqExpr{
-						pos: position{line: 5002, col: 15, offset: 152263},
+						pos: position{line: 5004, col: 15, offset: 152400},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5002, col: 15, offset: 152263},
+								pos: position{line: 5004, col: 15, offset: 152400},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5002, col: 16, offset: 152264},
+									pos:  position{line: 5004, col: 16, offset: 152401},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5002, col: 22, offset: 152270,
+								line: 5004, col: 22, offset: 152407,
 							},
 						},
 					},
@@ -12741,39 +12741,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5007, col: 1, offset: 152343},
+			pos:  position{line: 5009, col: 1, offset: 152480},
 			expr: &actionExpr{
-				pos: position{line: 5007, col: 18, offset: 152360},
+				pos: position{line: 5009, col: 18, offset: 152497},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5007, col: 18, offset: 152360},
+					pos: position{line: 5009, col: 18, offset: 152497},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5007, col: 18, offset: 152360},
+							pos:  position{line: 5009, col: 18, offset: 152497},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5007, col: 23, offset: 152365},
+							pos:  position{line: 5009, col: 23, offset: 152502},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5007, col: 36, offset: 152378},
+							pos:   position{line: 5009, col: 36, offset: 152515},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5007, col: 49, offset: 152391},
+								pos: position{line: 5009, col: 49, offset: 152528},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5007, col: 49, offset: 152391},
+									pos:  position{line: 5009, col: 49, offset: 152528},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5007, col: 70, offset: 152412},
+							pos:   position{line: 5009, col: 70, offset: 152549},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5007, col: 77, offset: 152419},
+								pos: position{line: 5009, col: 77, offset: 152556},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5007, col: 77, offset: 152419},
+									pos:  position{line: 5009, col: 77, offset: 152556},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12784,32 +12784,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5037, col: 1, offset: 153182},
+			pos:  position{line: 5039, col: 1, offset: 153319},
 			expr: &actionExpr{
-				pos: position{line: 5037, col: 24, offset: 153205},
+				pos: position{line: 5039, col: 24, offset: 153342},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5037, col: 24, offset: 153205},
+					pos: position{line: 5039, col: 24, offset: 153342},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5037, col: 24, offset: 153205},
+							pos:  position{line: 5039, col: 24, offset: 153342},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5037, col: 30, offset: 153211},
+							pos:        position{line: 5039, col: 30, offset: 153348},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5037, col: 38, offset: 153219},
+							pos:  position{line: 5039, col: 38, offset: 153356},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5037, col: 44, offset: 153225},
+							pos:   position{line: 5039, col: 44, offset: 153362},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5037, col: 48, offset: 153229},
+								pos:  position{line: 5039, col: 48, offset: 153366},
 								name: "String",
 							},
 						},
@@ -12819,22 +12819,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5041, col: 1, offset: 153275},
+			pos:  position{line: 5043, col: 1, offset: 153412},
 			expr: &actionExpr{
-				pos: position{line: 5041, col: 22, offset: 153296},
+				pos: position{line: 5043, col: 22, offset: 153433},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5041, col: 22, offset: 153296},
+					pos: position{line: 5043, col: 22, offset: 153433},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5041, col: 22, offset: 153296},
+							pos:  position{line: 5043, col: 22, offset: 153433},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5041, col: 28, offset: 153302},
+							pos:   position{line: 5043, col: 28, offset: 153439},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5041, col: 38, offset: 153312},
+								pos:  position{line: 5043, col: 38, offset: 153449},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12844,36 +12844,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5045, col: 1, offset: 153371},
+			pos:  position{line: 5047, col: 1, offset: 153508},
 			expr: &actionExpr{
-				pos: position{line: 5045, col: 18, offset: 153388},
+				pos: position{line: 5047, col: 18, offset: 153525},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5045, col: 18, offset: 153388},
+					pos: position{line: 5047, col: 18, offset: 153525},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5045, col: 18, offset: 153388},
+							pos:  position{line: 5047, col: 18, offset: 153525},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5045, col: 23, offset: 153393},
+							pos:  position{line: 5047, col: 23, offset: 153530},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5045, col: 36, offset: 153406},
+							pos:   position{line: 5047, col: 36, offset: 153543},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5045, col: 42, offset: 153412},
+								pos:  position{line: 5047, col: 42, offset: 153549},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5045, col: 56, offset: 153426},
+							pos:   position{line: 5047, col: 56, offset: 153563},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5045, col: 65, offset: 153435},
+								pos: position{line: 5047, col: 65, offset: 153572},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5045, col: 65, offset: 153435},
+									pos:  position{line: 5047, col: 65, offset: 153572},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12884,22 +12884,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5074, col: 1, offset: 154224},
+			pos:  position{line: 5076, col: 1, offset: 154361},
 			expr: &actionExpr{
-				pos: position{line: 5074, col: 18, offset: 154241},
+				pos: position{line: 5076, col: 18, offset: 154378},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5074, col: 18, offset: 154241},
+					pos: position{line: 5076, col: 18, offset: 154378},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5074, col: 18, offset: 154241},
+							pos:  position{line: 5076, col: 18, offset: 154378},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5074, col: 24, offset: 154247},
+							pos:   position{line: 5076, col: 24, offset: 154384},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5074, col: 34, offset: 154257},
+								pos:  position{line: 5076, col: 34, offset: 154394},
 								name: "FieldName",
 							},
 						},
@@ -12909,32 +12909,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5078, col: 1, offset: 154298},
+			pos:  position{line: 5080, col: 1, offset: 154435},
 			expr: &actionExpr{
-				pos: position{line: 5078, col: 18, offset: 154315},
+				pos: position{line: 5080, col: 18, offset: 154452},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5078, col: 18, offset: 154315},
+					pos: position{line: 5080, col: 18, offset: 154452},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5078, col: 18, offset: 154315},
+							pos:  position{line: 5080, col: 18, offset: 154452},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5078, col: 24, offset: 154321},
+							pos:        position{line: 5080, col: 24, offset: 154458},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5078, col: 32, offset: 154329},
+							pos:  position{line: 5080, col: 32, offset: 154466},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5078, col: 38, offset: 154335},
+							pos:   position{line: 5080, col: 38, offset: 154472},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5078, col: 47, offset: 154344},
+								pos:  position{line: 5080, col: 47, offset: 154481},
 								name: "IntegerAsString",
 							},
 						},
@@ -12944,26 +12944,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5082, col: 1, offset: 154390},
+			pos:  position{line: 5084, col: 1, offset: 154527},
 			expr: &actionExpr{
-				pos: position{line: 5082, col: 16, offset: 154405},
+				pos: position{line: 5084, col: 16, offset: 154542},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5082, col: 16, offset: 154405},
+					pos: position{line: 5084, col: 16, offset: 154542},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5082, col: 16, offset: 154405},
+							pos:  position{line: 5084, col: 16, offset: 154542},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5082, col: 22, offset: 154411},
+							pos:  position{line: 5084, col: 22, offset: 154548},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5082, col: 32, offset: 154421},
+							pos:   position{line: 5084, col: 32, offset: 154558},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5082, col: 42, offset: 154431},
+								pos:  position{line: 5084, col: 42, offset: 154568},
 								name: "BoolExpr",
 							},
 						},
@@ -12973,28 +12973,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5086, col: 1, offset: 154491},
+			pos:  position{line: 5088, col: 1, offset: 154628},
 			expr: &actionExpr{
-				pos: position{line: 5086, col: 28, offset: 154518},
+				pos: position{line: 5088, col: 28, offset: 154655},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5086, col: 28, offset: 154518},
+					pos: position{line: 5088, col: 28, offset: 154655},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5086, col: 28, offset: 154518},
+							pos:        position{line: 5088, col: 28, offset: 154655},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5086, col: 37, offset: 154527},
+							pos:  position{line: 5088, col: 37, offset: 154664},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5086, col: 43, offset: 154533},
+							pos:   position{line: 5088, col: 43, offset: 154670},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5086, col: 51, offset: 154541},
+								pos:  position{line: 5088, col: 51, offset: 154678},
 								name: "Boolean",
 							},
 						},
@@ -13004,28 +13004,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5095, col: 1, offset: 154725},
+			pos:  position{line: 5097, col: 1, offset: 154862},
 			expr: &actionExpr{
-				pos: position{line: 5095, col: 28, offset: 154752},
+				pos: position{line: 5097, col: 28, offset: 154889},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5095, col: 28, offset: 154752},
+					pos: position{line: 5097, col: 28, offset: 154889},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5095, col: 28, offset: 154752},
+							pos:        position{line: 5097, col: 28, offset: 154889},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5095, col: 37, offset: 154761},
+							pos:  position{line: 5097, col: 37, offset: 154898},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5095, col: 43, offset: 154767},
+							pos:   position{line: 5097, col: 43, offset: 154904},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5095, col: 51, offset: 154775},
+								pos:  position{line: 5097, col: 51, offset: 154912},
 								name: "Boolean",
 							},
 						},
@@ -13035,28 +13035,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5104, col: 1, offset: 154959},
+			pos:  position{line: 5106, col: 1, offset: 155096},
 			expr: &actionExpr{
-				pos: position{line: 5104, col: 27, offset: 154985},
+				pos: position{line: 5106, col: 27, offset: 155122},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5104, col: 27, offset: 154985},
+					pos: position{line: 5106, col: 27, offset: 155122},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5104, col: 27, offset: 154985},
+							pos:        position{line: 5106, col: 27, offset: 155122},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5104, col: 35, offset: 154993},
+							pos:  position{line: 5106, col: 35, offset: 155130},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5104, col: 41, offset: 154999},
+							pos:   position{line: 5106, col: 41, offset: 155136},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5104, col: 48, offset: 155006},
+								pos:  position{line: 5106, col: 48, offset: 155143},
 								name: "PositiveInteger",
 							},
 						},
@@ -13066,28 +13066,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5113, col: 1, offset: 155197},
+			pos:  position{line: 5115, col: 1, offset: 155334},
 			expr: &actionExpr{
-				pos: position{line: 5113, col: 25, offset: 155221},
+				pos: position{line: 5115, col: 25, offset: 155358},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5113, col: 25, offset: 155221},
+					pos: position{line: 5115, col: 25, offset: 155358},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5113, col: 25, offset: 155221},
+							pos:        position{line: 5115, col: 25, offset: 155358},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5113, col: 31, offset: 155227},
+							pos:  position{line: 5115, col: 31, offset: 155364},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5113, col: 37, offset: 155233},
+							pos:   position{line: 5115, col: 37, offset: 155370},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5113, col: 44, offset: 155240},
+								pos:  position{line: 5115, col: 44, offset: 155377},
 								name: "PositiveInteger",
 							},
 						},
@@ -13097,30 +13097,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5122, col: 1, offset: 155427},
+			pos:  position{line: 5124, col: 1, offset: 155564},
 			expr: &actionExpr{
-				pos: position{line: 5122, col: 22, offset: 155448},
+				pos: position{line: 5124, col: 22, offset: 155585},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5122, col: 22, offset: 155448},
+					pos:   position{line: 5124, col: 22, offset: 155585},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5122, col: 41, offset: 155467},
+						pos: position{line: 5124, col: 41, offset: 155604},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5122, col: 41, offset: 155467},
+								pos:  position{line: 5124, col: 41, offset: 155604},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5122, col: 67, offset: 155493},
+								pos:  position{line: 5124, col: 67, offset: 155630},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5122, col: 93, offset: 155519},
+								pos:  position{line: 5124, col: 93, offset: 155656},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5122, col: 118, offset: 155544},
+								pos:  position{line: 5124, col: 118, offset: 155681},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13130,35 +13130,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5126, col: 1, offset: 155605},
+			pos:  position{line: 5128, col: 1, offset: 155742},
 			expr: &actionExpr{
-				pos: position{line: 5126, col: 26, offset: 155630},
+				pos: position{line: 5128, col: 26, offset: 155767},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5126, col: 26, offset: 155630},
+					pos: position{line: 5128, col: 26, offset: 155767},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5126, col: 26, offset: 155630},
+							pos:   position{line: 5128, col: 26, offset: 155767},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5126, col: 34, offset: 155638},
+								pos:  position{line: 5128, col: 34, offset: 155775},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5126, col: 53, offset: 155657},
+							pos:   position{line: 5128, col: 53, offset: 155794},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5126, col: 58, offset: 155662},
+								pos: position{line: 5128, col: 58, offset: 155799},
 								expr: &seqExpr{
-									pos: position{line: 5126, col: 59, offset: 155663},
+									pos: position{line: 5128, col: 59, offset: 155800},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5126, col: 59, offset: 155663},
+											pos:  position{line: 5128, col: 59, offset: 155800},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5126, col: 65, offset: 155669},
+											pos:  position{line: 5128, col: 65, offset: 155806},
 											name: "InputLookupOption",
 										},
 									},
@@ -13171,35 +13171,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5168, col: 1, offset: 157115},
+			pos:  position{line: 5170, col: 1, offset: 157252},
 			expr: &actionExpr{
-				pos: position{line: 5168, col: 21, offset: 157135},
+				pos: position{line: 5170, col: 21, offset: 157272},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5168, col: 21, offset: 157135},
+					pos: position{line: 5170, col: 21, offset: 157272},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5168, col: 21, offset: 157135},
+							pos:  position{line: 5170, col: 21, offset: 157272},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5168, col: 26, offset: 157140},
+							pos:  position{line: 5170, col: 26, offset: 157277},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5168, col: 42, offset: 157156},
+							pos:   position{line: 5170, col: 42, offset: 157293},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5168, col: 60, offset: 157174},
+								pos: position{line: 5170, col: 60, offset: 157311},
 								expr: &seqExpr{
-									pos: position{line: 5168, col: 61, offset: 157175},
+									pos: position{line: 5170, col: 61, offset: 157312},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5168, col: 61, offset: 157175},
+											pos:  position{line: 5170, col: 61, offset: 157312},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5168, col: 83, offset: 157197},
+											pos:  position{line: 5170, col: 83, offset: 157334},
 											name: "SPACE",
 										},
 									},
@@ -13207,20 +13207,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5168, col: 91, offset: 157205},
+							pos:   position{line: 5170, col: 91, offset: 157342},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5168, col: 101, offset: 157215},
+								pos:  position{line: 5170, col: 101, offset: 157352},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5168, col: 109, offset: 157223},
+							pos:   position{line: 5170, col: 109, offset: 157360},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5168, col: 121, offset: 157235},
+								pos: position{line: 5170, col: 121, offset: 157372},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5168, col: 122, offset: 157236},
+									pos:  position{line: 5170, col: 122, offset: 157373},
 									name: "WhereClause",
 								},
 							},
@@ -13231,15 +13231,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5191, col: 1, offset: 157924},
+			pos:  position{line: 5193, col: 1, offset: 158061},
 			expr: &actionExpr{
-				pos: position{line: 5191, col: 24, offset: 157947},
+				pos: position{line: 5193, col: 24, offset: 158084},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5191, col: 24, offset: 157947},
+					pos:   position{line: 5193, col: 24, offset: 158084},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5191, col: 41, offset: 157964},
+						pos:  position{line: 5193, col: 41, offset: 158101},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13247,26 +13247,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5202, col: 1, offset: 158363},
+			pos:  position{line: 5204, col: 1, offset: 158500},
 			expr: &actionExpr{
-				pos: position{line: 5202, col: 20, offset: 158382},
+				pos: position{line: 5204, col: 20, offset: 158519},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5202, col: 20, offset: 158382},
+					pos:   position{line: 5204, col: 20, offset: 158519},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5202, col: 28, offset: 158390},
+						pos: position{line: 5204, col: 28, offset: 158527},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 28, offset: 158390},
+								pos:  position{line: 5204, col: 28, offset: 158527},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 52, offset: 158414},
+								pos:  position{line: 5204, col: 52, offset: 158551},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 68, offset: 158430},
+								pos:  position{line: 5204, col: 68, offset: 158567},
 								name: "MaxOutOption",
 							},
 						},
@@ -13276,28 +13276,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5207, col: 1, offset: 158528},
+			pos:  position{line: 5209, col: 1, offset: 158665},
 			expr: &actionExpr{
-				pos: position{line: 5207, col: 26, offset: 158553},
+				pos: position{line: 5209, col: 26, offset: 158690},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5207, col: 26, offset: 158553},
+					pos: position{line: 5209, col: 26, offset: 158690},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5207, col: 26, offset: 158553},
+							pos:        position{line: 5209, col: 26, offset: 158690},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5207, col: 44, offset: 158571},
+							pos:  position{line: 5209, col: 44, offset: 158708},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5207, col: 50, offset: 158577},
+							pos:   position{line: 5209, col: 50, offset: 158714},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5207, col: 58, offset: 158585},
+								pos:  position{line: 5209, col: 58, offset: 158722},
 								name: "Boolean",
 							},
 						},
@@ -13307,28 +13307,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5214, col: 1, offset: 158724},
+			pos:  position{line: 5216, col: 1, offset: 158861},
 			expr: &actionExpr{
-				pos: position{line: 5214, col: 18, offset: 158741},
+				pos: position{line: 5216, col: 18, offset: 158878},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5214, col: 18, offset: 158741},
+					pos: position{line: 5216, col: 18, offset: 158878},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5214, col: 18, offset: 158741},
+							pos:        position{line: 5216, col: 18, offset: 158878},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5214, col: 28, offset: 158751},
+							pos:  position{line: 5216, col: 28, offset: 158888},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5214, col: 34, offset: 158757},
+							pos:   position{line: 5216, col: 34, offset: 158894},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5214, col: 39, offset: 158762},
+								pos:  position{line: 5216, col: 39, offset: 158899},
 								name: "IntegerAsString",
 							},
 						},
@@ -13338,28 +13338,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5225, col: 1, offset: 159063},
+			pos:  position{line: 5227, col: 1, offset: 159200},
 			expr: &actionExpr{
-				pos: position{line: 5225, col: 17, offset: 159079},
+				pos: position{line: 5227, col: 17, offset: 159216},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5225, col: 17, offset: 159079},
+					pos: position{line: 5227, col: 17, offset: 159216},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5225, col: 17, offset: 159079},
+							pos:        position{line: 5227, col: 17, offset: 159216},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5225, col: 26, offset: 159088},
+							pos:  position{line: 5227, col: 26, offset: 159225},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5225, col: 32, offset: 159094},
+							pos:   position{line: 5227, col: 32, offset: 159231},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5225, col: 36, offset: 159098},
+								pos:  position{line: 5227, col: 36, offset: 159235},
 								name: "IntegerAsString",
 							},
 						},
@@ -13369,43 +13369,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5237, col: 1, offset: 159453},
+			pos:  position{line: 5239, col: 1, offset: 159590},
 			expr: &actionExpr{
-				pos: position{line: 5237, col: 14, offset: 159466},
+				pos: position{line: 5239, col: 14, offset: 159603},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5237, col: 14, offset: 159466},
+					pos: position{line: 5239, col: 14, offset: 159603},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5237, col: 14, offset: 159466},
+							pos:        position{line: 5239, col: 14, offset: 159603},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5237, col: 18, offset: 159470},
+							pos: position{line: 5239, col: 18, offset: 159607},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5237, col: 18, offset: 159470},
+								pos:  position{line: 5239, col: 18, offset: 159607},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5237, col: 25, offset: 159477},
+							pos:   position{line: 5239, col: 25, offset: 159614},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5237, col: 32, offset: 159484},
+								pos:  position{line: 5239, col: 32, offset: 159621},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5237, col: 44, offset: 159496},
+							pos: position{line: 5239, col: 44, offset: 159633},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5237, col: 44, offset: 159496},
+								pos:  position{line: 5239, col: 44, offset: 159633},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5237, col: 51, offset: 159503},
+							pos:        position{line: 5239, col: 51, offset: 159640},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13416,35 +13416,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5242, col: 1, offset: 159592},
+			pos:  position{line: 5244, col: 1, offset: 159729},
 			expr: &actionExpr{
-				pos: position{line: 5242, col: 25, offset: 159616},
+				pos: position{line: 5244, col: 25, offset: 159753},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5242, col: 25, offset: 159616},
+					pos: position{line: 5244, col: 25, offset: 159753},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5242, col: 25, offset: 159616},
+							pos:   position{line: 5244, col: 25, offset: 159753},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5242, col: 31, offset: 159622},
+								pos:  position{line: 5244, col: 31, offset: 159759},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5242, col: 47, offset: 159638},
+							pos:   position{line: 5244, col: 47, offset: 159775},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5242, col: 52, offset: 159643},
+								pos: position{line: 5244, col: 52, offset: 159780},
 								expr: &seqExpr{
-									pos: position{line: 5242, col: 53, offset: 159644},
+									pos: position{line: 5244, col: 53, offset: 159781},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5242, col: 53, offset: 159644},
+											pos:  position{line: 5244, col: 53, offset: 159781},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5242, col: 59, offset: 159650},
+											pos:  position{line: 5244, col: 59, offset: 159787},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13457,37 +13457,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5269, col: 1, offset: 160460},
+			pos:  position{line: 5271, col: 1, offset: 160597},
 			expr: &actionExpr{
-				pos: position{line: 5269, col: 16, offset: 160475},
+				pos: position{line: 5271, col: 16, offset: 160612},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5269, col: 16, offset: 160475},
+					pos: position{line: 5271, col: 16, offset: 160612},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5269, col: 16, offset: 160475},
+							pos:  position{line: 5271, col: 16, offset: 160612},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5269, col: 21, offset: 160480},
+							pos:  position{line: 5271, col: 21, offset: 160617},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5269, col: 32, offset: 160491},
+							pos:   position{line: 5271, col: 32, offset: 160628},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5269, col: 40, offset: 160499},
+								pos: position{line: 5271, col: 40, offset: 160636},
 								expr: &seqExpr{
-									pos: position{line: 5269, col: 41, offset: 160500},
+									pos: position{line: 5271, col: 41, offset: 160637},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5269, col: 41, offset: 160500},
+											pos:  position{line: 5271, col: 41, offset: 160637},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5269, col: 57, offset: 160516},
+											pos: position{line: 5271, col: 57, offset: 160653},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5269, col: 57, offset: 160516},
+												pos:  position{line: 5271, col: 57, offset: 160653},
 												name: "SPACE",
 											},
 										},
@@ -13496,10 +13496,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5269, col: 66, offset: 160525},
+							pos:   position{line: 5271, col: 66, offset: 160662},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5269, col: 76, offset: 160535},
+								pos:  position{line: 5271, col: 76, offset: 160672},
 								name: "Subsearch",
 							},
 						},
@@ -13509,128 +13509,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5313, col: 1, offset: 162107},
+			pos:  position{line: 5315, col: 1, offset: 162244},
 			expr: &choiceExpr{
-				pos: position{line: 5313, col: 12, offset: 162118},
+				pos: position{line: 5315, col: 12, offset: 162255},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 12, offset: 162118},
+						pos:  position{line: 5315, col: 12, offset: 162255},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 24, offset: 162130},
+						pos:  position{line: 5315, col: 24, offset: 162267},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 36, offset: 162142},
+						pos:  position{line: 5315, col: 36, offset: 162279},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 49, offset: 162155},
+						pos:  position{line: 5315, col: 49, offset: 162292},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 61, offset: 162167},
+						pos:  position{line: 5315, col: 61, offset: 162304},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 81, offset: 162187},
+						pos:  position{line: 5315, col: 81, offset: 162324},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 92, offset: 162198},
+						pos:  position{line: 5315, col: 92, offset: 162335},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 112, offset: 162218},
+						pos:  position{line: 5315, col: 112, offset: 162355},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 123, offset: 162229},
+						pos:  position{line: 5315, col: 123, offset: 162366},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 134, offset: 162240},
+						pos:  position{line: 5315, col: 134, offset: 162377},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 144, offset: 162250},
+						pos:  position{line: 5315, col: 144, offset: 162387},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 154, offset: 162260},
+						pos:  position{line: 5315, col: 154, offset: 162397},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 165, offset: 162271},
+						pos:  position{line: 5315, col: 165, offset: 162408},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 178, offset: 162284},
+						pos:  position{line: 5315, col: 178, offset: 162421},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 194, offset: 162300},
+						pos:  position{line: 5315, col: 194, offset: 162437},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 212, offset: 162318},
+						pos:  position{line: 5315, col: 212, offset: 162455},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 224, offset: 162330},
+						pos:  position{line: 5315, col: 224, offset: 162467},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 235, offset: 162341},
+						pos:  position{line: 5315, col: 235, offset: 162478},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 248, offset: 162354},
+						pos:  position{line: 5315, col: 248, offset: 162491},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 260, offset: 162366},
+						pos:  position{line: 5315, col: 260, offset: 162503},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 273, offset: 162379},
+						pos:  position{line: 5315, col: 273, offset: 162516},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 288, offset: 162394},
+						pos:  position{line: 5315, col: 288, offset: 162531},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 301, offset: 162407},
+						pos:  position{line: 5315, col: 301, offset: 162544},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 318, offset: 162424},
+						pos:  position{line: 5315, col: 318, offset: 162561},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 328, offset: 162434},
+						pos:  position{line: 5315, col: 328, offset: 162571},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 346, offset: 162452},
+						pos:  position{line: 5315, col: 346, offset: 162589},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 361, offset: 162467},
+						pos:  position{line: 5315, col: 361, offset: 162604},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 376, offset: 162482},
+						pos:  position{line: 5315, col: 376, offset: 162619},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 391, offset: 162497},
+						pos:  position{line: 5315, col: 391, offset: 162634},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5313, col: 409, offset: 162515},
+						pos:  position{line: 5315, col: 409, offset: 162652},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13638,18 +13638,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5314, col: 1, offset: 162527},
+			pos:  position{line: 5316, col: 1, offset: 162664},
 			expr: &seqExpr{
-				pos: position{line: 5314, col: 15, offset: 162541},
+				pos: position{line: 5316, col: 15, offset: 162678},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5314, col: 15, offset: 162541},
+						pos:        position{line: 5316, col: 15, offset: 162678},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5314, col: 24, offset: 162550},
+						pos:  position{line: 5316, col: 24, offset: 162687},
 						name: "SPACE",
 					},
 				},
@@ -13657,18 +13657,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5315, col: 1, offset: 162556},
+			pos:  position{line: 5317, col: 1, offset: 162693},
 			expr: &seqExpr{
-				pos: position{line: 5315, col: 14, offset: 162569},
+				pos: position{line: 5317, col: 14, offset: 162706},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5315, col: 14, offset: 162569},
+						pos:        position{line: 5317, col: 14, offset: 162706},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 22, offset: 162577},
+						pos:  position{line: 5317, col: 22, offset: 162714},
 						name: "SPACE",
 					},
 				},
@@ -13676,18 +13676,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5316, col: 1, offset: 162583},
+			pos:  position{line: 5318, col: 1, offset: 162720},
 			expr: &seqExpr{
-				pos: position{line: 5316, col: 14, offset: 162596},
+				pos: position{line: 5318, col: 14, offset: 162733},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5316, col: 14, offset: 162596},
+						pos:        position{line: 5318, col: 14, offset: 162733},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5316, col: 22, offset: 162604},
+						pos:  position{line: 5318, col: 22, offset: 162741},
 						name: "SPACE",
 					},
 				},
@@ -13695,18 +13695,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5317, col: 1, offset: 162610},
+			pos:  position{line: 5319, col: 1, offset: 162747},
 			expr: &seqExpr{
-				pos: position{line: 5317, col: 20, offset: 162629},
+				pos: position{line: 5319, col: 20, offset: 162766},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5317, col: 20, offset: 162629},
+						pos:        position{line: 5319, col: 20, offset: 162766},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5317, col: 34, offset: 162643},
+						pos:  position{line: 5319, col: 34, offset: 162780},
 						name: "SPACE",
 					},
 				},
@@ -13714,18 +13714,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5318, col: 1, offset: 162649},
+			pos:  position{line: 5320, col: 1, offset: 162786},
 			expr: &seqExpr{
-				pos: position{line: 5318, col: 15, offset: 162663},
+				pos: position{line: 5320, col: 15, offset: 162800},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5318, col: 15, offset: 162663},
+						pos:        position{line: 5320, col: 15, offset: 162800},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5318, col: 24, offset: 162672},
+						pos:  position{line: 5320, col: 24, offset: 162809},
 						name: "SPACE",
 					},
 				},
@@ -13733,18 +13733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5319, col: 1, offset: 162678},
+			pos:  position{line: 5321, col: 1, offset: 162815},
 			expr: &seqExpr{
-				pos: position{line: 5319, col: 14, offset: 162691},
+				pos: position{line: 5321, col: 14, offset: 162828},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5319, col: 14, offset: 162691},
+						pos:        position{line: 5321, col: 14, offset: 162828},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5319, col: 22, offset: 162699},
+						pos:  position{line: 5321, col: 22, offset: 162836},
 						name: "SPACE",
 					},
 				},
@@ -13752,9 +13752,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5320, col: 1, offset: 162705},
+			pos:  position{line: 5322, col: 1, offset: 162842},
 			expr: &litMatcher{
-				pos:        position{line: 5320, col: 22, offset: 162726},
+				pos:        position{line: 5322, col: 22, offset: 162863},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13762,16 +13762,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5321, col: 1, offset: 162733},
+			pos:  position{line: 5323, col: 1, offset: 162870},
 			expr: &seqExpr{
-				pos: position{line: 5321, col: 13, offset: 162745},
+				pos: position{line: 5323, col: 13, offset: 162882},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5321, col: 13, offset: 162745},
+						pos:  position{line: 5323, col: 13, offset: 162882},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5321, col: 31, offset: 162763},
+						pos:  position{line: 5323, col: 31, offset: 162900},
 						name: "SPACE",
 					},
 				},
@@ -13779,9 +13779,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5322, col: 1, offset: 162769},
+			pos:  position{line: 5324, col: 1, offset: 162906},
 			expr: &litMatcher{
-				pos:        position{line: 5322, col: 22, offset: 162790},
+				pos:        position{line: 5324, col: 22, offset: 162927},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13789,16 +13789,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5323, col: 1, offset: 162797},
+			pos:  position{line: 5325, col: 1, offset: 162934},
 			expr: &seqExpr{
-				pos: position{line: 5323, col: 13, offset: 162809},
+				pos: position{line: 5325, col: 13, offset: 162946},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5323, col: 13, offset: 162809},
+						pos:  position{line: 5325, col: 13, offset: 162946},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5323, col: 31, offset: 162827},
+						pos:  position{line: 5325, col: 31, offset: 162964},
 						name: "SPACE",
 					},
 				},
@@ -13806,18 +13806,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5324, col: 1, offset: 162833},
+			pos:  position{line: 5326, col: 1, offset: 162970},
 			expr: &seqExpr{
-				pos: position{line: 5324, col: 13, offset: 162845},
+				pos: position{line: 5326, col: 13, offset: 162982},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5324, col: 13, offset: 162845},
+						pos:        position{line: 5326, col: 13, offset: 162982},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5324, col: 20, offset: 162852},
+						pos:  position{line: 5326, col: 20, offset: 162989},
 						name: "SPACE",
 					},
 				},
@@ -13825,18 +13825,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5325, col: 1, offset: 162858},
+			pos:  position{line: 5327, col: 1, offset: 162995},
 			expr: &seqExpr{
-				pos: position{line: 5325, col: 12, offset: 162869},
+				pos: position{line: 5327, col: 12, offset: 163006},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5325, col: 12, offset: 162869},
+						pos:        position{line: 5327, col: 12, offset: 163006},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5325, col: 18, offset: 162875},
+						pos:  position{line: 5327, col: 18, offset: 163012},
 						name: "SPACE",
 					},
 				},
@@ -13844,18 +13844,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5326, col: 1, offset: 162881},
+			pos:  position{line: 5328, col: 1, offset: 163018},
 			expr: &seqExpr{
-				pos: position{line: 5326, col: 13, offset: 162893},
+				pos: position{line: 5328, col: 13, offset: 163030},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5326, col: 13, offset: 162893},
+						pos:        position{line: 5328, col: 13, offset: 163030},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5326, col: 20, offset: 162900},
+						pos:  position{line: 5328, col: 20, offset: 163037},
 						name: "SPACE",
 					},
 				},
@@ -13863,9 +13863,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5327, col: 1, offset: 162906},
+			pos:  position{line: 5329, col: 1, offset: 163043},
 			expr: &litMatcher{
-				pos:        position{line: 5327, col: 12, offset: 162917},
+				pos:        position{line: 5329, col: 12, offset: 163054},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13873,9 +13873,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5328, col: 1, offset: 162923},
+			pos:  position{line: 5330, col: 1, offset: 163060},
 			expr: &litMatcher{
-				pos:        position{line: 5328, col: 13, offset: 162935},
+				pos:        position{line: 5330, col: 13, offset: 163072},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13883,18 +13883,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5329, col: 1, offset: 162942},
+			pos:  position{line: 5331, col: 1, offset: 163079},
 			expr: &seqExpr{
-				pos: position{line: 5329, col: 15, offset: 162956},
+				pos: position{line: 5331, col: 15, offset: 163093},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5329, col: 15, offset: 162956},
+						pos:        position{line: 5331, col: 15, offset: 163093},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 24, offset: 162965},
+						pos:  position{line: 5331, col: 24, offset: 163102},
 						name: "SPACE",
 					},
 				},
@@ -13902,18 +13902,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5330, col: 1, offset: 162971},
+			pos:  position{line: 5332, col: 1, offset: 163108},
 			expr: &seqExpr{
-				pos: position{line: 5330, col: 18, offset: 162988},
+				pos: position{line: 5332, col: 18, offset: 163125},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5330, col: 18, offset: 162988},
+						pos:        position{line: 5332, col: 18, offset: 163125},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5330, col: 30, offset: 163000},
+						pos:  position{line: 5332, col: 30, offset: 163137},
 						name: "SPACE",
 					},
 				},
@@ -13921,18 +13921,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5331, col: 1, offset: 163006},
+			pos:  position{line: 5333, col: 1, offset: 163143},
 			expr: &seqExpr{
-				pos: position{line: 5331, col: 12, offset: 163017},
+				pos: position{line: 5333, col: 12, offset: 163154},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5331, col: 12, offset: 163017},
+						pos:        position{line: 5333, col: 12, offset: 163154},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5331, col: 18, offset: 163023},
+						pos:  position{line: 5333, col: 18, offset: 163160},
 						name: "SPACE",
 					},
 				},
@@ -13940,9 +13940,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5332, col: 1, offset: 163029},
+			pos:  position{line: 5334, col: 1, offset: 163166},
 			expr: &litMatcher{
-				pos:        position{line: 5332, col: 13, offset: 163041},
+				pos:        position{line: 5334, col: 13, offset: 163178},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13950,18 +13950,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5333, col: 1, offset: 163048},
+			pos:  position{line: 5335, col: 1, offset: 163185},
 			expr: &seqExpr{
-				pos: position{line: 5333, col: 20, offset: 163067},
+				pos: position{line: 5335, col: 20, offset: 163204},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5333, col: 20, offset: 163067},
+						pos:        position{line: 5335, col: 20, offset: 163204},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5333, col: 34, offset: 163081},
+						pos:  position{line: 5335, col: 34, offset: 163218},
 						name: "SPACE",
 					},
 				},
@@ -13969,9 +13969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5334, col: 1, offset: 163087},
+			pos:  position{line: 5336, col: 1, offset: 163224},
 			expr: &litMatcher{
-				pos:        position{line: 5334, col: 14, offset: 163100},
+				pos:        position{line: 5336, col: 14, offset: 163237},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13979,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5335, col: 1, offset: 163108},
+			pos:  position{line: 5337, col: 1, offset: 163245},
 			expr: &seqExpr{
-				pos: position{line: 5335, col: 21, offset: 163128},
+				pos: position{line: 5337, col: 21, offset: 163265},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 21, offset: 163128},
+						pos:  position{line: 5337, col: 21, offset: 163265},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5335, col: 27, offset: 163134},
+						pos:        position{line: 5337, col: 27, offset: 163271},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 36, offset: 163143},
+						pos:  position{line: 5337, col: 36, offset: 163280},
 						name: "SPACE",
 					},
 				},
@@ -14002,9 +14002,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5336, col: 1, offset: 163149},
+			pos:  position{line: 5338, col: 1, offset: 163286},
 			expr: &litMatcher{
-				pos:        position{line: 5336, col: 15, offset: 163163},
+				pos:        position{line: 5338, col: 15, offset: 163300},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14012,9 +14012,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5337, col: 1, offset: 163172},
+			pos:  position{line: 5339, col: 1, offset: 163309},
 			expr: &litMatcher{
-				pos:        position{line: 5337, col: 14, offset: 163185},
+				pos:        position{line: 5339, col: 14, offset: 163322},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14022,9 +14022,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5338, col: 1, offset: 163193},
+			pos:  position{line: 5340, col: 1, offset: 163330},
 			expr: &litMatcher{
-				pos:        position{line: 5338, col: 15, offset: 163207},
+				pos:        position{line: 5340, col: 15, offset: 163344},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14032,9 +14032,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5339, col: 1, offset: 163216},
+			pos:  position{line: 5341, col: 1, offset: 163353},
 			expr: &litMatcher{
-				pos:        position{line: 5339, col: 17, offset: 163232},
+				pos:        position{line: 5341, col: 17, offset: 163369},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14042,9 +14042,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5340, col: 1, offset: 163243},
+			pos:  position{line: 5342, col: 1, offset: 163380},
 			expr: &litMatcher{
-				pos:        position{line: 5340, col: 15, offset: 163257},
+				pos:        position{line: 5342, col: 15, offset: 163394},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14052,9 +14052,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5341, col: 1, offset: 163266},
+			pos:  position{line: 5343, col: 1, offset: 163403},
 			expr: &litMatcher{
-				pos:        position{line: 5341, col: 19, offset: 163284},
+				pos:        position{line: 5343, col: 19, offset: 163421},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14062,9 +14062,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5342, col: 1, offset: 163297},
+			pos:  position{line: 5344, col: 1, offset: 163434},
 			expr: &litMatcher{
-				pos:        position{line: 5342, col: 17, offset: 163313},
+				pos:        position{line: 5344, col: 17, offset: 163450},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14072,9 +14072,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5343, col: 1, offset: 163324},
+			pos:  position{line: 5345, col: 1, offset: 163461},
 			expr: &litMatcher{
-				pos:        position{line: 5343, col: 17, offset: 163340},
+				pos:        position{line: 5345, col: 17, offset: 163477},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14082,18 +14082,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5344, col: 1, offset: 163351},
+			pos:  position{line: 5346, col: 1, offset: 163488},
 			expr: &seqExpr{
-				pos: position{line: 5344, col: 20, offset: 163370},
+				pos: position{line: 5346, col: 20, offset: 163507},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5344, col: 20, offset: 163370},
+						pos:        position{line: 5346, col: 20, offset: 163507},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5344, col: 34, offset: 163384},
+						pos:  position{line: 5346, col: 34, offset: 163521},
 						name: "SPACE",
 					},
 				},
@@ -14101,28 +14101,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5345, col: 1, offset: 163390},
+			pos:  position{line: 5347, col: 1, offset: 163527},
 			expr: &seqExpr{
-				pos: position{line: 5345, col: 16, offset: 163405},
+				pos: position{line: 5347, col: 16, offset: 163542},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5345, col: 16, offset: 163405},
+						pos: position{line: 5347, col: 16, offset: 163542},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5345, col: 16, offset: 163405},
+							pos:  position{line: 5347, col: 16, offset: 163542},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5345, col: 24, offset: 163413},
+						pos: position{line: 5347, col: 24, offset: 163550},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5345, col: 24, offset: 163413},
+								pos:        position{line: 5347, col: 24, offset: 163550},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5345, col: 30, offset: 163419},
+								pos:        position{line: 5347, col: 30, offset: 163556},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14130,9 +14130,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5345, col: 35, offset: 163424},
+						pos: position{line: 5347, col: 35, offset: 163561},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5345, col: 35, offset: 163424},
+							pos:  position{line: 5347, col: 35, offset: 163561},
 							name: "SPACE",
 						},
 					},
@@ -14141,9 +14141,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5346, col: 1, offset: 163431},
+			pos:  position{line: 5348, col: 1, offset: 163568},
 			expr: &litMatcher{
-				pos:        position{line: 5346, col: 17, offset: 163447},
+				pos:        position{line: 5348, col: 17, offset: 163584},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14151,18 +14151,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5347, col: 1, offset: 163458},
+			pos:  position{line: 5349, col: 1, offset: 163595},
 			expr: &seqExpr{
-				pos: position{line: 5347, col: 15, offset: 163472},
+				pos: position{line: 5349, col: 15, offset: 163609},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5347, col: 15, offset: 163472},
+						pos:        position{line: 5349, col: 15, offset: 163609},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5347, col: 24, offset: 163481},
+						pos:  position{line: 5349, col: 24, offset: 163618},
 						name: "SPACE",
 					},
 				},
@@ -14170,115 +14170,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5350, col: 1, offset: 163591},
+			pos:  position{line: 5352, col: 1, offset: 163728},
 			expr: &choiceExpr{
-				pos: position{line: 5350, col: 16, offset: 163606},
+				pos: position{line: 5352, col: 16, offset: 163743},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5350, col: 16, offset: 163606},
+						pos:        position{line: 5352, col: 16, offset: 163743},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5350, col: 47, offset: 163637},
+						pos:        position{line: 5352, col: 47, offset: 163774},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5350, col: 55, offset: 163645},
+						pos:        position{line: 5352, col: 55, offset: 163782},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 16, offset: 163668},
+						pos:        position{line: 5353, col: 16, offset: 163805},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 26, offset: 163678},
+						pos:        position{line: 5353, col: 26, offset: 163815},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 34, offset: 163686},
+						pos:        position{line: 5353, col: 34, offset: 163823},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 42, offset: 163694},
+						pos:        position{line: 5353, col: 42, offset: 163831},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 50, offset: 163702},
+						pos:        position{line: 5353, col: 50, offset: 163839},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 58, offset: 163710},
+						pos:        position{line: 5353, col: 58, offset: 163847},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5351, col: 66, offset: 163718},
+						pos:        position{line: 5353, col: 66, offset: 163855},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 16, offset: 163740},
+						pos:        position{line: 5354, col: 16, offset: 163877},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 26, offset: 163750},
+						pos:        position{line: 5354, col: 26, offset: 163887},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 34, offset: 163758},
+						pos:        position{line: 5354, col: 34, offset: 163895},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 42, offset: 163766},
+						pos:        position{line: 5354, col: 42, offset: 163903},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 50, offset: 163774},
+						pos:        position{line: 5354, col: 50, offset: 163911},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 58, offset: 163782},
+						pos:        position{line: 5354, col: 58, offset: 163919},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 66, offset: 163790},
+						pos:        position{line: 5354, col: 66, offset: 163927},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 74, offset: 163798},
+						pos:        position{line: 5354, col: 74, offset: 163935},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14288,25 +14288,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5353, col: 1, offset: 163804},
+			pos:  position{line: 5355, col: 1, offset: 163941},
 			expr: &choiceExpr{
-				pos: position{line: 5353, col: 16, offset: 163819},
+				pos: position{line: 5355, col: 16, offset: 163956},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5353, col: 16, offset: 163819},
+						pos:        position{line: 5355, col: 16, offset: 163956},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 30, offset: 163833},
+						pos:        position{line: 5355, col: 30, offset: 163970},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 36, offset: 163839},
+						pos:        position{line: 5355, col: 36, offset: 163976},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14316,18 +14316,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5357, col: 1, offset: 163995},
+			pos:  position{line: 5359, col: 1, offset: 164132},
 			expr: &seqExpr{
-				pos: position{line: 5357, col: 8, offset: 164002},
+				pos: position{line: 5359, col: 8, offset: 164139},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5357, col: 8, offset: 164002},
+						pos:        position{line: 5359, col: 8, offset: 164139},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5357, col: 14, offset: 164008},
+						pos:  position{line: 5359, col: 14, offset: 164145},
 						name: "SPACE",
 					},
 				},
@@ -14335,22 +14335,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5358, col: 1, offset: 164014},
+			pos:  position{line: 5360, col: 1, offset: 164151},
 			expr: &seqExpr{
-				pos: position{line: 5358, col: 7, offset: 164020},
+				pos: position{line: 5360, col: 7, offset: 164157},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5358, col: 7, offset: 164020},
+						pos:  position{line: 5360, col: 7, offset: 164157},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5358, col: 13, offset: 164026},
+						pos:        position{line: 5360, col: 13, offset: 164163},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5358, col: 18, offset: 164031},
+						pos:  position{line: 5360, col: 18, offset: 164168},
 						name: "SPACE",
 					},
 				},
@@ -14358,22 +14358,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5359, col: 1, offset: 164037},
+			pos:  position{line: 5361, col: 1, offset: 164174},
 			expr: &seqExpr{
-				pos: position{line: 5359, col: 8, offset: 164044},
+				pos: position{line: 5361, col: 8, offset: 164181},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5359, col: 8, offset: 164044},
+						pos:  position{line: 5361, col: 8, offset: 164181},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5359, col: 14, offset: 164050},
+						pos:        position{line: 5361, col: 14, offset: 164187},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5359, col: 20, offset: 164056},
+						pos:  position{line: 5361, col: 20, offset: 164193},
 						name: "SPACE",
 					},
 				},
@@ -14381,22 +14381,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5360, col: 1, offset: 164062},
+			pos:  position{line: 5362, col: 1, offset: 164199},
 			expr: &seqExpr{
-				pos: position{line: 5360, col: 9, offset: 164070},
+				pos: position{line: 5362, col: 9, offset: 164207},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5360, col: 9, offset: 164070},
+						pos:  position{line: 5362, col: 9, offset: 164207},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5360, col: 24, offset: 164085},
+						pos:        position{line: 5362, col: 24, offset: 164222},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5360, col: 28, offset: 164089},
+						pos:  position{line: 5362, col: 28, offset: 164226},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14404,22 +14404,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5361, col: 1, offset: 164104},
+			pos:  position{line: 5363, col: 1, offset: 164241},
 			expr: &seqExpr{
-				pos: position{line: 5361, col: 7, offset: 164110},
+				pos: position{line: 5363, col: 7, offset: 164247},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5361, col: 7, offset: 164110},
+						pos:  position{line: 5363, col: 7, offset: 164247},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5361, col: 13, offset: 164116},
+						pos:        position{line: 5363, col: 13, offset: 164253},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5361, col: 19, offset: 164122},
+						pos:  position{line: 5363, col: 19, offset: 164259},
 						name: "SPACE",
 					},
 				},
@@ -14427,22 +14427,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5362, col: 1, offset: 164148},
+			pos:  position{line: 5364, col: 1, offset: 164285},
 			expr: &seqExpr{
-				pos: position{line: 5362, col: 7, offset: 164154},
+				pos: position{line: 5364, col: 7, offset: 164291},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5362, col: 7, offset: 164154},
+						pos:  position{line: 5364, col: 7, offset: 164291},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5362, col: 13, offset: 164160},
+						pos:        position{line: 5364, col: 13, offset: 164297},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5362, col: 19, offset: 164166},
+						pos:  position{line: 5364, col: 19, offset: 164303},
 						name: "SPACE",
 					},
 				},
@@ -14450,22 +14450,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5364, col: 1, offset: 164193},
+			pos:  position{line: 5366, col: 1, offset: 164330},
 			expr: &seqExpr{
-				pos: position{line: 5364, col: 10, offset: 164202},
+				pos: position{line: 5366, col: 10, offset: 164339},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5364, col: 10, offset: 164202},
+						pos:  position{line: 5366, col: 10, offset: 164339},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5364, col: 25, offset: 164217},
+						pos:        position{line: 5366, col: 25, offset: 164354},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5364, col: 29, offset: 164221},
+						pos:  position{line: 5366, col: 29, offset: 164358},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14473,22 +14473,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5365, col: 1, offset: 164236},
+			pos:  position{line: 5367, col: 1, offset: 164373},
 			expr: &seqExpr{
-				pos: position{line: 5365, col: 10, offset: 164245},
+				pos: position{line: 5367, col: 10, offset: 164382},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5365, col: 10, offset: 164245},
+						pos:  position{line: 5367, col: 10, offset: 164382},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 25, offset: 164260},
+						pos:        position{line: 5367, col: 25, offset: 164397},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5365, col: 29, offset: 164264},
+						pos:  position{line: 5367, col: 29, offset: 164401},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14496,9 +14496,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5366, col: 1, offset: 164279},
+			pos:  position{line: 5368, col: 1, offset: 164416},
 			expr: &litMatcher{
-				pos:        position{line: 5366, col: 10, offset: 164288},
+				pos:        position{line: 5368, col: 10, offset: 164425},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14506,18 +14506,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5367, col: 1, offset: 164292},
+			pos:  position{line: 5369, col: 1, offset: 164429},
 			expr: &seqExpr{
-				pos: position{line: 5367, col: 12, offset: 164303},
+				pos: position{line: 5369, col: 12, offset: 164440},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5367, col: 12, offset: 164303},
+						pos:        position{line: 5369, col: 12, offset: 164440},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5367, col: 16, offset: 164307},
+						pos:  position{line: 5369, col: 16, offset: 164444},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14525,16 +14525,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5368, col: 1, offset: 164322},
+			pos:  position{line: 5370, col: 1, offset: 164459},
 			expr: &seqExpr{
-				pos: position{line: 5368, col: 12, offset: 164333},
+				pos: position{line: 5370, col: 12, offset: 164470},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5368, col: 12, offset: 164333},
+						pos:  position{line: 5370, col: 12, offset: 164470},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5368, col: 27, offset: 164348},
+						pos:        position{line: 5370, col: 27, offset: 164485},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14544,40 +14544,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5370, col: 1, offset: 164353},
+			pos:  position{line: 5372, col: 1, offset: 164490},
 			expr: &notExpr{
-				pos: position{line: 5370, col: 8, offset: 164360},
+				pos: position{line: 5372, col: 8, offset: 164497},
 				expr: &anyMatcher{
-					line: 5370, col: 9, offset: 164361,
+					line: 5372, col: 9, offset: 164498,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5371, col: 1, offset: 164363},
+			pos:  position{line: 5373, col: 1, offset: 164500},
 			expr: &choiceExpr{
-				pos: position{line: 5371, col: 15, offset: 164377},
+				pos: position{line: 5373, col: 15, offset: 164514},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5371, col: 15, offset: 164377},
+						pos:        position{line: 5373, col: 15, offset: 164514},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5371, col: 21, offset: 164383},
+						pos:        position{line: 5373, col: 21, offset: 164520},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5371, col: 28, offset: 164390},
+						pos:        position{line: 5373, col: 28, offset: 164527},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5371, col: 35, offset: 164397},
+						pos:        position{line: 5373, col: 35, offset: 164534},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14587,37 +14587,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5372, col: 1, offset: 164402},
+			pos:  position{line: 5374, col: 1, offset: 164539},
 			expr: &choiceExpr{
-				pos: position{line: 5372, col: 10, offset: 164411},
+				pos: position{line: 5374, col: 10, offset: 164548},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5372, col: 11, offset: 164412},
+						pos: position{line: 5374, col: 11, offset: 164549},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5372, col: 11, offset: 164412},
+								pos: position{line: 5374, col: 11, offset: 164549},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5372, col: 11, offset: 164412},
+									pos:  position{line: 5374, col: 11, offset: 164549},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5372, col: 23, offset: 164424},
+								pos:  position{line: 5374, col: 23, offset: 164561},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5372, col: 31, offset: 164432},
+								pos: position{line: 5374, col: 31, offset: 164569},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5372, col: 31, offset: 164432},
+									pos:  position{line: 5374, col: 31, offset: 164569},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5372, col: 46, offset: 164447},
+						pos: position{line: 5374, col: 46, offset: 164584},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5372, col: 46, offset: 164447},
+							pos:  position{line: 5374, col: 46, offset: 164584},
 							name: "WHITESPACE",
 						},
 					},
@@ -14626,38 +14626,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5373, col: 1, offset: 164459},
+			pos:  position{line: 5375, col: 1, offset: 164596},
 			expr: &seqExpr{
-				pos: position{line: 5373, col: 12, offset: 164470},
+				pos: position{line: 5375, col: 12, offset: 164607},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5373, col: 12, offset: 164470},
+						pos:        position{line: 5375, col: 12, offset: 164607},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5373, col: 18, offset: 164476},
+						pos: position{line: 5375, col: 18, offset: 164613},
 						expr: &seqExpr{
-							pos: position{line: 5373, col: 19, offset: 164477},
+							pos: position{line: 5375, col: 19, offset: 164614},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5373, col: 19, offset: 164477},
+									pos: position{line: 5375, col: 19, offset: 164614},
 									expr: &litMatcher{
-										pos:        position{line: 5373, col: 21, offset: 164479},
+										pos:        position{line: 5375, col: 21, offset: 164616},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5373, col: 28, offset: 164486,
+									line: 5375, col: 28, offset: 164623,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5373, col: 32, offset: 164490},
+						pos:        position{line: 5375, col: 32, offset: 164627},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14667,16 +14667,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5374, col: 1, offset: 164496},
+			pos:  position{line: 5376, col: 1, offset: 164633},
 			expr: &choiceExpr{
-				pos: position{line: 5374, col: 20, offset: 164515},
+				pos: position{line: 5376, col: 20, offset: 164652},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5374, col: 20, offset: 164515},
+						pos:  position{line: 5376, col: 20, offset: 164652},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5374, col: 28, offset: 164523},
+						pos:        position{line: 5376, col: 28, offset: 164660},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14686,16 +14686,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5375, col: 1, offset: 164526},
+			pos:  position{line: 5377, col: 1, offset: 164663},
 			expr: &choiceExpr{
-				pos: position{line: 5375, col: 19, offset: 164544},
+				pos: position{line: 5377, col: 19, offset: 164681},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 19, offset: 164544},
+						pos:  position{line: 5377, col: 19, offset: 164681},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 27, offset: 164552},
+						pos:  position{line: 5377, col: 27, offset: 164689},
 						name: "SPACE",
 					},
 				},
@@ -16507,6 +16507,7 @@ func (c *current) onStatisticBlock1(statisticExpr any) (any, error) {
 
 	if config.IsNewQueryPipelineEnabled() {
 		root.GroupByRequest = aggNode.GroupByRequest
+		root.StatisticExpr = statisticExpr.(*structs.StatisticExpr)
 		return root, nil
 	}
 
@@ -20308,6 +20309,7 @@ func (c *current) onTransactionBlock1(txnOptions any) (any, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType:      structs.TransactionType,
 		TransactionArguments: txnOptions.(*structs.TransactionArguments),
+		TransactionExpr:      txnOptions.(*structs.TransactionArguments),
 	}
 	return queryAgg, nil
 }
@@ -21535,7 +21537,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expressions parsed")
+	errMaxExprCnt = errors.New("max number of expresssions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -2366,35 +2366,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1356, col: 1, offset: 41945},
+			pos:  position{line: 1358, col: 1, offset: 42038},
 			expr: &actionExpr{
-				pos: position{line: 1356, col: 27, offset: 41971},
+				pos: position{line: 1358, col: 27, offset: 42064},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1356, col: 27, offset: 41971},
+					pos: position{line: 1358, col: 27, offset: 42064},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1356, col: 27, offset: 41971},
+							pos:   position{line: 1358, col: 27, offset: 42064},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1356, col: 33, offset: 41977},
+								pos:  position{line: 1358, col: 33, offset: 42070},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1356, col: 51, offset: 41995},
+							pos:   position{line: 1358, col: 51, offset: 42088},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1356, col: 56, offset: 42000},
+								pos: position{line: 1358, col: 56, offset: 42093},
 								expr: &seqExpr{
-									pos: position{line: 1356, col: 57, offset: 42001},
+									pos: position{line: 1358, col: 57, offset: 42094},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1356, col: 57, offset: 42001},
+											pos:  position{line: 1358, col: 57, offset: 42094},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1356, col: 63, offset: 42007},
+											pos:  position{line: 1358, col: 63, offset: 42100},
 											name: "TimechartArgument",
 										},
 									},
@@ -2407,22 +2407,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1385, col: 1, offset: 42741},
+			pos:  position{line: 1387, col: 1, offset: 42834},
 			expr: &actionExpr{
-				pos: position{line: 1385, col: 22, offset: 42762},
+				pos: position{line: 1387, col: 22, offset: 42855},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1385, col: 22, offset: 42762},
+					pos:   position{line: 1387, col: 22, offset: 42855},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1385, col: 29, offset: 42769},
+						pos: position{line: 1387, col: 29, offset: 42862},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1385, col: 29, offset: 42769},
+								pos:  position{line: 1387, col: 29, offset: 42862},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1385, col: 45, offset: 42785},
+								pos:  position{line: 1387, col: 45, offset: 42878},
 								name: "TcOptions",
 							},
 						},
@@ -2432,28 +2432,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1389, col: 1, offset: 42823},
+			pos:  position{line: 1391, col: 1, offset: 42916},
 			expr: &actionExpr{
-				pos: position{line: 1389, col: 18, offset: 42840},
+				pos: position{line: 1391, col: 18, offset: 42933},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1389, col: 18, offset: 42840},
+					pos: position{line: 1391, col: 18, offset: 42933},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1389, col: 18, offset: 42840},
+							pos:   position{line: 1391, col: 18, offset: 42933},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1389, col: 23, offset: 42845},
+								pos:  position{line: 1391, col: 23, offset: 42938},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1389, col: 39, offset: 42861},
+							pos:   position{line: 1391, col: 39, offset: 42954},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1389, col: 53, offset: 42875},
+								pos: position{line: 1391, col: 53, offset: 42968},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1389, col: 53, offset: 42875},
+									pos:  position{line: 1391, col: 53, offset: 42968},
 									name: "SplitByClause",
 								},
 							},
@@ -2464,22 +2464,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1403, col: 1, offset: 43214},
+			pos:  position{line: 1405, col: 1, offset: 43307},
 			expr: &actionExpr{
-				pos: position{line: 1403, col: 18, offset: 43231},
+				pos: position{line: 1405, col: 18, offset: 43324},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1403, col: 18, offset: 43231},
+					pos: position{line: 1405, col: 18, offset: 43324},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1403, col: 18, offset: 43231},
+							pos:  position{line: 1405, col: 18, offset: 43324},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1403, col: 21, offset: 43234},
+							pos:   position{line: 1405, col: 21, offset: 43327},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1403, col: 27, offset: 43240},
+								pos:  position{line: 1405, col: 27, offset: 43333},
 								name: "FieldName",
 							},
 						},
@@ -2489,24 +2489,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1411, col: 1, offset: 43369},
+			pos:  position{line: 1413, col: 1, offset: 43462},
 			expr: &actionExpr{
-				pos: position{line: 1411, col: 14, offset: 43382},
+				pos: position{line: 1413, col: 14, offset: 43475},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1411, col: 14, offset: 43382},
+					pos:   position{line: 1413, col: 14, offset: 43475},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1411, col: 22, offset: 43390},
+						pos: position{line: 1413, col: 22, offset: 43483},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1411, col: 22, offset: 43390},
+								pos:  position{line: 1413, col: 22, offset: 43483},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1411, col: 35, offset: 43403},
+								pos: position{line: 1413, col: 35, offset: 43496},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1411, col: 36, offset: 43404},
+									pos:  position{line: 1413, col: 36, offset: 43497},
 									name: "TcOption",
 								},
 							},
@@ -2517,34 +2517,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1453, col: 1, offset: 44924},
+			pos:  position{line: 1455, col: 1, offset: 45017},
 			expr: &actionExpr{
-				pos: position{line: 1453, col: 13, offset: 44936},
+				pos: position{line: 1455, col: 13, offset: 45029},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1453, col: 13, offset: 44936},
+					pos: position{line: 1455, col: 13, offset: 45029},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1453, col: 13, offset: 44936},
+							pos:  position{line: 1455, col: 13, offset: 45029},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1453, col: 19, offset: 44942},
+							pos:   position{line: 1455, col: 19, offset: 45035},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1453, col: 31, offset: 44954},
+								pos:  position{line: 1455, col: 31, offset: 45047},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1453, col: 43, offset: 44966},
+							pos:  position{line: 1455, col: 43, offset: 45059},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1453, col: 49, offset: 44972},
+							pos:   position{line: 1455, col: 49, offset: 45065},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1453, col: 53, offset: 44976},
+								pos:  position{line: 1455, col: 53, offset: 45069},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2554,36 +2554,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1458, col: 1, offset: 45089},
+			pos:  position{line: 1460, col: 1, offset: 45182},
 			expr: &actionExpr{
-				pos: position{line: 1458, col: 16, offset: 45104},
+				pos: position{line: 1460, col: 16, offset: 45197},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1458, col: 16, offset: 45104},
+					pos:   position{line: 1460, col: 16, offset: 45197},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1458, col: 24, offset: 45112},
+						pos: position{line: 1460, col: 24, offset: 45205},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1458, col: 24, offset: 45112},
+								pos:        position{line: 1460, col: 24, offset: 45205},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1458, col: 36, offset: 45124},
+								pos:        position{line: 1460, col: 36, offset: 45217},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1458, col: 49, offset: 45137},
+								pos:        position{line: 1460, col: 49, offset: 45230},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1458, col: 61, offset: 45149},
+								pos:        position{line: 1460, col: 61, offset: 45242},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2595,50 +2595,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1466, col: 1, offset: 45345},
+			pos:  position{line: 1468, col: 1, offset: 45438},
 			expr: &actionExpr{
-				pos: position{line: 1466, col: 17, offset: 45361},
+				pos: position{line: 1468, col: 17, offset: 45454},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1466, col: 17, offset: 45361},
+					pos:   position{line: 1468, col: 17, offset: 45454},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1466, col: 27, offset: 45371},
+						pos: position{line: 1468, col: 27, offset: 45464},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 27, offset: 45371},
+								pos:  position{line: 1468, col: 27, offset: 45464},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 36, offset: 45380},
+								pos:  position{line: 1468, col: 36, offset: 45473},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 44, offset: 45388},
+								pos:  position{line: 1468, col: 44, offset: 45481},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 57, offset: 45401},
+								pos:  position{line: 1468, col: 57, offset: 45494},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 66, offset: 45410},
+								pos:  position{line: 1468, col: 66, offset: 45503},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 73, offset: 45417},
+								pos:  position{line: 1468, col: 73, offset: 45510},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 79, offset: 45423},
+								pos:  position{line: 1468, col: 79, offset: 45516},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 86, offset: 45430},
+								pos:  position{line: 1468, col: 86, offset: 45523},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1466, col: 96, offset: 45440},
+								pos:  position{line: 1468, col: 96, offset: 45533},
 								name: "Year",
 							},
 						},
@@ -2648,37 +2648,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1470, col: 1, offset: 45476},
+			pos:  position{line: 1472, col: 1, offset: 45569},
 			expr: &actionExpr{
-				pos: position{line: 1470, col: 21, offset: 45496},
+				pos: position{line: 1472, col: 21, offset: 45589},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1470, col: 21, offset: 45496},
+					pos: position{line: 1472, col: 21, offset: 45589},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1470, col: 21, offset: 45496},
+							pos:   position{line: 1472, col: 21, offset: 45589},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1470, col: 29, offset: 45504},
+								pos: position{line: 1472, col: 29, offset: 45597},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1470, col: 29, offset: 45504},
+										pos:  position{line: 1472, col: 29, offset: 45597},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1470, col: 45, offset: 45520},
+										pos:  position{line: 1472, col: 45, offset: 45613},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1470, col: 62, offset: 45537},
+							pos:   position{line: 1472, col: 62, offset: 45630},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1470, col: 72, offset: 45547},
+								pos: position{line: 1472, col: 72, offset: 45640},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1470, col: 73, offset: 45548},
+									pos:  position{line: 1472, col: 73, offset: 45641},
 									name: "AllTimeScale",
 								},
 							},
@@ -2689,28 +2689,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1529, col: 1, offset: 48230},
+			pos:  position{line: 1531, col: 1, offset: 48323},
 			expr: &actionExpr{
-				pos: position{line: 1529, col: 21, offset: 48250},
+				pos: position{line: 1531, col: 21, offset: 48343},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1529, col: 21, offset: 48250},
+					pos: position{line: 1531, col: 21, offset: 48343},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1529, col: 21, offset: 48250},
+							pos:        position{line: 1531, col: 21, offset: 48343},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1529, col: 31, offset: 48260},
+							pos:  position{line: 1531, col: 31, offset: 48353},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1529, col: 37, offset: 48266},
+							pos:   position{line: 1531, col: 37, offset: 48359},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1529, col: 48, offset: 48277},
+								pos:  position{line: 1531, col: 48, offset: 48370},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2720,28 +2720,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1540, col: 1, offset: 48518},
+			pos:  position{line: 1542, col: 1, offset: 48611},
 			expr: &actionExpr{
-				pos: position{line: 1540, col: 21, offset: 48538},
+				pos: position{line: 1542, col: 21, offset: 48631},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1540, col: 21, offset: 48538},
+					pos: position{line: 1542, col: 21, offset: 48631},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1540, col: 21, offset: 48538},
+							pos:        position{line: 1542, col: 21, offset: 48631},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1540, col: 28, offset: 48545},
+							pos:  position{line: 1542, col: 28, offset: 48638},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1540, col: 34, offset: 48551},
+							pos:   position{line: 1542, col: 34, offset: 48644},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1540, col: 43, offset: 48560},
+								pos:  position{line: 1542, col: 43, offset: 48653},
 								name: "IntegerAsString",
 							},
 						},
@@ -2751,31 +2751,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1561, col: 1, offset: 49139},
+			pos:  position{line: 1563, col: 1, offset: 49232},
 			expr: &choiceExpr{
-				pos: position{line: 1561, col: 23, offset: 49161},
+				pos: position{line: 1563, col: 23, offset: 49254},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1561, col: 23, offset: 49161},
+						pos: position{line: 1563, col: 23, offset: 49254},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1561, col: 23, offset: 49161},
+							pos: position{line: 1563, col: 23, offset: 49254},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1561, col: 23, offset: 49161},
+									pos:        position{line: 1563, col: 23, offset: 49254},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1561, col: 35, offset: 49173},
+									pos:  position{line: 1563, col: 35, offset: 49266},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1561, col: 41, offset: 49179},
+									pos:   position{line: 1563, col: 41, offset: 49272},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1561, col: 51, offset: 49189},
+										pos:  position{line: 1563, col: 51, offset: 49282},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2783,33 +2783,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1575, col: 3, offset: 49608},
+						pos: position{line: 1577, col: 3, offset: 49701},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1575, col: 3, offset: 49608},
+							pos: position{line: 1577, col: 3, offset: 49701},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1575, col: 3, offset: 49608},
+									pos:        position{line: 1577, col: 3, offset: 49701},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1575, col: 15, offset: 49620},
+									pos:  position{line: 1577, col: 15, offset: 49713},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1575, col: 21, offset: 49626},
+									pos:   position{line: 1577, col: 21, offset: 49719},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1575, col: 32, offset: 49637},
+										pos: position{line: 1577, col: 32, offset: 49730},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1575, col: 32, offset: 49637},
+												pos:  position{line: 1577, col: 32, offset: 49730},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1575, col: 52, offset: 49657},
+												pos:  position{line: 1577, col: 52, offset: 49750},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2823,35 +2823,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1595, col: 1, offset: 50126},
+			pos:  position{line: 1597, col: 1, offset: 50219},
 			expr: &actionExpr{
-				pos: position{line: 1595, col: 19, offset: 50144},
+				pos: position{line: 1597, col: 19, offset: 50237},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1595, col: 19, offset: 50144},
+					pos: position{line: 1597, col: 19, offset: 50237},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1595, col: 19, offset: 50144},
+							pos:        position{line: 1597, col: 19, offset: 50237},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1595, col: 27, offset: 50152},
+							pos:  position{line: 1597, col: 27, offset: 50245},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1595, col: 33, offset: 50158},
+							pos:   position{line: 1597, col: 33, offset: 50251},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1595, col: 41, offset: 50166},
+								pos: position{line: 1597, col: 41, offset: 50259},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1595, col: 41, offset: 50166},
+										pos:  position{line: 1597, col: 41, offset: 50259},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1595, col: 57, offset: 50182},
+										pos:  position{line: 1597, col: 57, offset: 50275},
 										name: "IntegerAsString",
 									},
 								},
@@ -2863,35 +2863,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1610, col: 1, offset: 50561},
+			pos:  position{line: 1612, col: 1, offset: 50654},
 			expr: &actionExpr{
-				pos: position{line: 1610, col: 17, offset: 50577},
+				pos: position{line: 1612, col: 17, offset: 50670},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1610, col: 17, offset: 50577},
+					pos: position{line: 1612, col: 17, offset: 50670},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1610, col: 17, offset: 50577},
+							pos:        position{line: 1612, col: 17, offset: 50670},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1610, col: 23, offset: 50583},
+							pos:  position{line: 1612, col: 23, offset: 50676},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1610, col: 29, offset: 50589},
+							pos:   position{line: 1612, col: 29, offset: 50682},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1610, col: 37, offset: 50597},
+								pos: position{line: 1612, col: 37, offset: 50690},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1610, col: 37, offset: 50597},
+										pos:  position{line: 1612, col: 37, offset: 50690},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1610, col: 53, offset: 50613},
+										pos:  position{line: 1612, col: 53, offset: 50706},
 										name: "IntegerAsString",
 									},
 								},
@@ -2903,40 +2903,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1625, col: 1, offset: 50984},
+			pos:  position{line: 1627, col: 1, offset: 51077},
 			expr: &choiceExpr{
-				pos: position{line: 1625, col: 18, offset: 51001},
+				pos: position{line: 1627, col: 18, offset: 51094},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1625, col: 18, offset: 51001},
+						pos: position{line: 1627, col: 18, offset: 51094},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1625, col: 18, offset: 51001},
+							pos: position{line: 1627, col: 18, offset: 51094},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1625, col: 18, offset: 51001},
+									pos:        position{line: 1627, col: 18, offset: 51094},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1625, col: 25, offset: 51008},
+									pos:  position{line: 1627, col: 25, offset: 51101},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1625, col: 31, offset: 51014},
+									pos:   position{line: 1627, col: 31, offset: 51107},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1625, col: 36, offset: 51019},
+										pos: position{line: 1627, col: 36, offset: 51112},
 										expr: &choiceExpr{
-											pos: position{line: 1625, col: 37, offset: 51020},
+											pos: position{line: 1627, col: 37, offset: 51113},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1625, col: 37, offset: 51020},
+													pos:  position{line: 1627, col: 37, offset: 51113},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1625, col: 53, offset: 51036},
+													pos:  position{line: 1627, col: 53, offset: 51129},
 													name: "IntegerAsString",
 												},
 											},
@@ -2944,25 +2944,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1625, col: 71, offset: 51054},
+									pos:        position{line: 1627, col: 71, offset: 51147},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1625, col: 77, offset: 51060},
+									pos:   position{line: 1627, col: 77, offset: 51153},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1625, col: 82, offset: 51065},
+										pos: position{line: 1627, col: 82, offset: 51158},
 										expr: &choiceExpr{
-											pos: position{line: 1625, col: 83, offset: 51066},
+											pos: position{line: 1627, col: 83, offset: 51159},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1625, col: 83, offset: 51066},
+													pos:  position{line: 1627, col: 83, offset: 51159},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1625, col: 99, offset: 51082},
+													pos:  position{line: 1627, col: 99, offset: 51175},
 													name: "IntegerAsString",
 												},
 											},
@@ -2973,26 +2973,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1668, col: 3, offset: 52518},
+						pos: position{line: 1670, col: 3, offset: 52611},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1668, col: 3, offset: 52518},
+							pos: position{line: 1670, col: 3, offset: 52611},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1668, col: 3, offset: 52518},
+									pos:        position{line: 1670, col: 3, offset: 52611},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1668, col: 10, offset: 52525},
+									pos:  position{line: 1670, col: 10, offset: 52618},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1668, col: 16, offset: 52531},
+									pos:   position{line: 1670, col: 16, offset: 52624},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1668, col: 24, offset: 52539},
+										pos:  position{line: 1670, col: 24, offset: 52632},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3004,38 +3004,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1683, col: 1, offset: 52870},
+			pos:  position{line: 1685, col: 1, offset: 52963},
 			expr: &actionExpr{
-				pos: position{line: 1683, col: 17, offset: 52886},
+				pos: position{line: 1685, col: 17, offset: 52979},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1683, col: 17, offset: 52886},
+					pos:   position{line: 1685, col: 17, offset: 52979},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1683, col: 25, offset: 52894},
+						pos: position{line: 1685, col: 25, offset: 52987},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 25, offset: 52894},
+								pos:  position{line: 1685, col: 25, offset: 52987},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 46, offset: 52915},
+								pos:  position{line: 1685, col: 46, offset: 53008},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 65, offset: 52934},
+								pos:  position{line: 1685, col: 65, offset: 53027},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 84, offset: 52953},
+								pos:  position{line: 1685, col: 84, offset: 53046},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 101, offset: 52970},
+								pos:  position{line: 1685, col: 101, offset: 53063},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1683, col: 116, offset: 52985},
+								pos:  position{line: 1685, col: 116, offset: 53078},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3045,35 +3045,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1687, col: 1, offset: 53028},
+			pos:  position{line: 1689, col: 1, offset: 53121},
 			expr: &actionExpr{
-				pos: position{line: 1687, col: 22, offset: 53049},
+				pos: position{line: 1689, col: 22, offset: 53142},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1687, col: 22, offset: 53049},
+					pos: position{line: 1689, col: 22, offset: 53142},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1687, col: 22, offset: 53049},
+							pos:   position{line: 1689, col: 22, offset: 53142},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1687, col: 29, offset: 53056},
+								pos:  position{line: 1689, col: 29, offset: 53149},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1687, col: 42, offset: 53069},
+							pos:   position{line: 1689, col: 42, offset: 53162},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1687, col: 48, offset: 53075},
+								pos: position{line: 1689, col: 48, offset: 53168},
 								expr: &seqExpr{
-									pos: position{line: 1687, col: 49, offset: 53076},
+									pos: position{line: 1689, col: 49, offset: 53169},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1687, col: 49, offset: 53076},
+											pos:  position{line: 1689, col: 49, offset: 53169},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1687, col: 55, offset: 53082},
+											pos:  position{line: 1689, col: 55, offset: 53175},
 											name: "BinCmdOption",
 										},
 									},
@@ -3086,51 +3086,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1733, col: 1, offset: 54566},
+			pos:  position{line: 1735, col: 1, offset: 54659},
 			expr: &choiceExpr{
-				pos: position{line: 1733, col: 13, offset: 54578},
+				pos: position{line: 1735, col: 13, offset: 54671},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1733, col: 13, offset: 54578},
+						pos: position{line: 1735, col: 13, offset: 54671},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1733, col: 13, offset: 54578},
+							pos: position{line: 1735, col: 13, offset: 54671},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1733, col: 13, offset: 54578},
+									pos:  position{line: 1735, col: 13, offset: 54671},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1733, col: 18, offset: 54583},
+									pos:  position{line: 1735, col: 18, offset: 54676},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1733, col: 26, offset: 54591},
+									pos:   position{line: 1735, col: 26, offset: 54684},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1733, col: 40, offset: 54605},
+										pos:  position{line: 1735, col: 40, offset: 54698},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1733, col: 59, offset: 54624},
+									pos:  position{line: 1735, col: 59, offset: 54717},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1733, col: 65, offset: 54630},
+									pos:   position{line: 1735, col: 65, offset: 54723},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1733, col: 71, offset: 54636},
+										pos:  position{line: 1735, col: 71, offset: 54729},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1733, col: 81, offset: 54646},
+									pos:   position{line: 1735, col: 81, offset: 54739},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1733, col: 94, offset: 54659},
+										pos: position{line: 1735, col: 94, offset: 54752},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1733, col: 95, offset: 54660},
+											pos:  position{line: 1735, col: 95, offset: 54753},
 											name: "AsField",
 										},
 									},
@@ -3139,34 +3139,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1760, col: 3, offset: 55503},
+						pos: position{line: 1762, col: 3, offset: 55596},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1760, col: 3, offset: 55503},
+							pos: position{line: 1762, col: 3, offset: 55596},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1760, col: 3, offset: 55503},
+									pos:  position{line: 1762, col: 3, offset: 55596},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1760, col: 8, offset: 55508},
+									pos:  position{line: 1762, col: 8, offset: 55601},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1760, col: 16, offset: 55516},
+									pos:   position{line: 1762, col: 16, offset: 55609},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1760, col: 22, offset: 55522},
+										pos:  position{line: 1762, col: 22, offset: 55615},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1760, col: 32, offset: 55532},
+									pos:   position{line: 1762, col: 32, offset: 55625},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1760, col: 45, offset: 55545},
+										pos: position{line: 1762, col: 45, offset: 55638},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1760, col: 46, offset: 55546},
+											pos:  position{line: 1762, col: 46, offset: 55639},
 											name: "AsField",
 										},
 									},
@@ -3179,15 +3179,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1791, col: 1, offset: 56420},
+			pos:  position{line: 1793, col: 1, offset: 56513},
 			expr: &actionExpr{
-				pos: position{line: 1791, col: 15, offset: 56434},
+				pos: position{line: 1793, col: 15, offset: 56527},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1791, col: 15, offset: 56434},
+					pos:   position{line: 1793, col: 15, offset: 56527},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1791, col: 27, offset: 56446},
+						pos:  position{line: 1793, col: 27, offset: 56539},
 						name: "SpanOptions",
 					},
 				},
@@ -3195,26 +3195,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1799, col: 1, offset: 56671},
+			pos:  position{line: 1801, col: 1, offset: 56764},
 			expr: &actionExpr{
-				pos: position{line: 1799, col: 16, offset: 56686},
+				pos: position{line: 1801, col: 16, offset: 56779},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1799, col: 16, offset: 56686},
+					pos: position{line: 1801, col: 16, offset: 56779},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1799, col: 16, offset: 56686},
+							pos:  position{line: 1801, col: 16, offset: 56779},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1799, col: 25, offset: 56695},
+							pos:  position{line: 1801, col: 25, offset: 56788},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1799, col: 31, offset: 56701},
+							pos:   position{line: 1801, col: 31, offset: 56794},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1799, col: 42, offset: 56712},
+								pos:  position{line: 1801, col: 42, offset: 56805},
 								name: "SpanLength",
 							},
 						},
@@ -3224,26 +3224,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1806, col: 1, offset: 56858},
+			pos:  position{line: 1808, col: 1, offset: 56951},
 			expr: &actionExpr{
-				pos: position{line: 1806, col: 15, offset: 56872},
+				pos: position{line: 1808, col: 15, offset: 56965},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1806, col: 15, offset: 56872},
+					pos: position{line: 1808, col: 15, offset: 56965},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1806, col: 15, offset: 56872},
+							pos:   position{line: 1808, col: 15, offset: 56965},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1806, col: 24, offset: 56881},
+								pos:  position{line: 1808, col: 24, offset: 56974},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1806, col: 40, offset: 56897},
+							pos:   position{line: 1808, col: 40, offset: 56990},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1806, col: 50, offset: 56907},
+								pos:  position{line: 1808, col: 50, offset: 57000},
 								name: "AllTimeScale",
 							},
 						},
@@ -3253,43 +3253,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1823, col: 1, offset: 57453},
+			pos:  position{line: 1825, col: 1, offset: 57546},
 			expr: &actionExpr{
-				pos: position{line: 1823, col: 14, offset: 57466},
+				pos: position{line: 1825, col: 14, offset: 57559},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1823, col: 14, offset: 57466},
+					pos: position{line: 1825, col: 14, offset: 57559},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1823, col: 14, offset: 57466},
+							pos:  position{line: 1825, col: 14, offset: 57559},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1823, col: 20, offset: 57472},
+							pos:        position{line: 1825, col: 20, offset: 57565},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1823, col: 28, offset: 57480},
+							pos:  position{line: 1825, col: 28, offset: 57573},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1823, col: 34, offset: 57486},
+							pos:   position{line: 1825, col: 34, offset: 57579},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1823, col: 41, offset: 57493},
+								pos: position{line: 1825, col: 41, offset: 57586},
 								expr: &choiceExpr{
-									pos: position{line: 1823, col: 42, offset: 57494},
+									pos: position{line: 1825, col: 42, offset: 57587},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1823, col: 42, offset: 57494},
+											pos:        position{line: 1825, col: 42, offset: 57587},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1823, col: 50, offset: 57502},
+											pos:        position{line: 1825, col: 50, offset: 57595},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3299,14 +3299,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1823, col: 61, offset: 57513},
+							pos:  position{line: 1825, col: 61, offset: 57606},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1823, col: 76, offset: 57528},
+							pos:   position{line: 1825, col: 76, offset: 57621},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1823, col: 86, offset: 57538},
+								pos:  position{line: 1825, col: 86, offset: 57631},
 								name: "IntegerAsString",
 							},
 						},
@@ -3316,22 +3316,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1847, col: 1, offset: 58119},
+			pos:  position{line: 1849, col: 1, offset: 58212},
 			expr: &actionExpr{
-				pos: position{line: 1847, col: 19, offset: 58137},
+				pos: position{line: 1849, col: 19, offset: 58230},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1847, col: 19, offset: 58137},
+					pos: position{line: 1849, col: 19, offset: 58230},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1847, col: 19, offset: 58137},
+							pos:  position{line: 1849, col: 19, offset: 58230},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1847, col: 24, offset: 58142},
+							pos:   position{line: 1849, col: 24, offset: 58235},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1847, col: 38, offset: 58156},
+								pos:  position{line: 1849, col: 38, offset: 58249},
 								name: "StatisticExpr",
 							},
 						},
@@ -3341,76 +3341,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1887, col: 1, offset: 59367},
+			pos:  position{line: 1889, col: 1, offset: 59460},
 			expr: &actionExpr{
-				pos: position{line: 1887, col: 18, offset: 59384},
+				pos: position{line: 1889, col: 18, offset: 59477},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1887, col: 18, offset: 59384},
+					pos: position{line: 1889, col: 18, offset: 59477},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1887, col: 18, offset: 59384},
+							pos:   position{line: 1889, col: 18, offset: 59477},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1887, col: 23, offset: 59389},
+								pos: position{line: 1889, col: 23, offset: 59482},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1887, col: 23, offset: 59389},
+										pos:  position{line: 1889, col: 23, offset: 59482},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1887, col: 33, offset: 59399},
+										pos:  position{line: 1889, col: 33, offset: 59492},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 43, offset: 59409},
+							pos:   position{line: 1889, col: 43, offset: 59502},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1887, col: 49, offset: 59415},
+								pos: position{line: 1889, col: 49, offset: 59508},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1887, col: 50, offset: 59416},
+									pos:  position{line: 1889, col: 50, offset: 59509},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 67, offset: 59433},
+							pos:   position{line: 1889, col: 67, offset: 59526},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1887, col: 78, offset: 59444},
+								pos: position{line: 1889, col: 78, offset: 59537},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1887, col: 78, offset: 59444},
+										pos:  position{line: 1889, col: 78, offset: 59537},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1887, col: 84, offset: 59450},
+										pos:  position{line: 1889, col: 84, offset: 59543},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 99, offset: 59465},
+							pos:   position{line: 1889, col: 99, offset: 59558},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1887, col: 108, offset: 59474},
+								pos: position{line: 1889, col: 108, offset: 59567},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1887, col: 109, offset: 59475},
+									pos:  position{line: 1889, col: 109, offset: 59568},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1887, col: 120, offset: 59486},
+							pos:   position{line: 1889, col: 120, offset: 59579},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1887, col: 128, offset: 59494},
+								pos: position{line: 1889, col: 128, offset: 59587},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1887, col: 129, offset: 59495},
+									pos:  position{line: 1889, col: 129, offset: 59588},
 									name: "StatisticOptions",
 								},
 							},
@@ -3421,25 +3421,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1929, col: 1, offset: 60580},
+			pos:  position{line: 1931, col: 1, offset: 60673},
 			expr: &choiceExpr{
-				pos: position{line: 1929, col: 19, offset: 60598},
+				pos: position{line: 1931, col: 19, offset: 60691},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1929, col: 19, offset: 60598},
+						pos: position{line: 1931, col: 19, offset: 60691},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1929, col: 19, offset: 60598},
+							pos: position{line: 1931, col: 19, offset: 60691},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1929, col: 19, offset: 60598},
+									pos:  position{line: 1931, col: 19, offset: 60691},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1929, col: 25, offset: 60604},
+									pos:   position{line: 1931, col: 25, offset: 60697},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1929, col: 32, offset: 60611},
+										pos:  position{line: 1931, col: 32, offset: 60704},
 										name: "IntegerAsString",
 									},
 								},
@@ -3447,30 +3447,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1932, col: 3, offset: 60665},
+						pos: position{line: 1934, col: 3, offset: 60758},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1932, col: 3, offset: 60665},
+							pos: position{line: 1934, col: 3, offset: 60758},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1932, col: 3, offset: 60665},
+									pos:  position{line: 1934, col: 3, offset: 60758},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1932, col: 9, offset: 60671},
+									pos:        position{line: 1934, col: 9, offset: 60764},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1932, col: 17, offset: 60679},
+									pos:  position{line: 1934, col: 17, offset: 60772},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1932, col: 23, offset: 60685},
+									pos:   position{line: 1934, col: 23, offset: 60778},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1932, col: 30, offset: 60692},
+										pos:  position{line: 1934, col: 30, offset: 60785},
 										name: "IntegerAsString",
 									},
 								},
@@ -3482,17 +3482,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1937, col: 1, offset: 60790},
+			pos:  position{line: 1939, col: 1, offset: 60883},
 			expr: &actionExpr{
-				pos: position{line: 1937, col: 21, offset: 60810},
+				pos: position{line: 1939, col: 21, offset: 60903},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1937, col: 21, offset: 60810},
+					pos:   position{line: 1939, col: 21, offset: 60903},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1937, col: 28, offset: 60817},
+						pos: position{line: 1939, col: 28, offset: 60910},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1937, col: 29, offset: 60818},
+							pos:  position{line: 1939, col: 29, offset: 60911},
 							name: "StatisticOption",
 						},
 					},
@@ -3501,34 +3501,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1986, col: 1, offset: 62380},
+			pos:  position{line: 1988, col: 1, offset: 62473},
 			expr: &actionExpr{
-				pos: position{line: 1986, col: 20, offset: 62399},
+				pos: position{line: 1988, col: 20, offset: 62492},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1986, col: 20, offset: 62399},
+					pos: position{line: 1988, col: 20, offset: 62492},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1986, col: 20, offset: 62399},
+							pos:  position{line: 1988, col: 20, offset: 62492},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 26, offset: 62405},
+							pos:   position{line: 1988, col: 26, offset: 62498},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 36, offset: 62415},
+								pos:  position{line: 1988, col: 36, offset: 62508},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1986, col: 55, offset: 62434},
+							pos:  position{line: 1988, col: 55, offset: 62527},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1986, col: 61, offset: 62440},
+							pos:   position{line: 1988, col: 61, offset: 62533},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1986, col: 67, offset: 62446},
+								pos:  position{line: 1988, col: 67, offset: 62539},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3538,48 +3538,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1991, col: 1, offset: 62555},
+			pos:  position{line: 1993, col: 1, offset: 62648},
 			expr: &actionExpr{
-				pos: position{line: 1991, col: 23, offset: 62577},
+				pos: position{line: 1993, col: 23, offset: 62670},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1991, col: 23, offset: 62577},
+					pos:   position{line: 1993, col: 23, offset: 62670},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1991, col: 31, offset: 62585},
+						pos: position{line: 1993, col: 31, offset: 62678},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1991, col: 31, offset: 62585},
+								pos:        position{line: 1993, col: 31, offset: 62678},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1991, col: 46, offset: 62600},
+								pos:        position{line: 1993, col: 46, offset: 62693},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1991, col: 60, offset: 62614},
+								pos:        position{line: 1993, col: 60, offset: 62707},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1991, col: 73, offset: 62627},
+								pos:        position{line: 1993, col: 73, offset: 62720},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1991, col: 85, offset: 62639},
+								pos:        position{line: 1993, col: 85, offset: 62732},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1991, col: 102, offset: 62656},
+								pos:        position{line: 1993, col: 102, offset: 62749},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3591,25 +3591,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1999, col: 1, offset: 62843},
+			pos:  position{line: 2001, col: 1, offset: 62936},
 			expr: &choiceExpr{
-				pos: position{line: 1999, col: 13, offset: 62855},
+				pos: position{line: 2001, col: 13, offset: 62948},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1999, col: 13, offset: 62855},
+						pos: position{line: 2001, col: 13, offset: 62948},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1999, col: 13, offset: 62855},
+							pos: position{line: 2001, col: 13, offset: 62948},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1999, col: 13, offset: 62855},
+									pos:  position{line: 2001, col: 13, offset: 62948},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1999, col: 16, offset: 62858},
+									pos:   position{line: 2001, col: 16, offset: 62951},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1999, col: 26, offset: 62868},
+										pos:  position{line: 2001, col: 26, offset: 62961},
 										name: "FieldNameList",
 									},
 								},
@@ -3617,13 +3617,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2002, col: 3, offset: 62925},
+						pos: position{line: 2004, col: 3, offset: 63018},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2002, col: 3, offset: 62925},
+							pos:   position{line: 2004, col: 3, offset: 63018},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2002, col: 16, offset: 62938},
+								pos:  position{line: 2004, col: 16, offset: 63031},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3633,26 +3633,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2006, col: 1, offset: 62996},
+			pos:  position{line: 2008, col: 1, offset: 63089},
 			expr: &actionExpr{
-				pos: position{line: 2006, col: 15, offset: 63010},
+				pos: position{line: 2008, col: 15, offset: 63103},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2006, col: 15, offset: 63010},
+					pos: position{line: 2008, col: 15, offset: 63103},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 15, offset: 63010},
+							pos:  position{line: 2008, col: 15, offset: 63103},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2006, col: 20, offset: 63015},
+							pos:  position{line: 2008, col: 20, offset: 63108},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2006, col: 30, offset: 63025},
+							pos:   position{line: 2008, col: 30, offset: 63118},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2006, col: 40, offset: 63035},
+								pos:  position{line: 2008, col: 40, offset: 63128},
 								name: "DedupExpr",
 							},
 						},
@@ -3662,27 +3662,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2052, col: 1, offset: 64364},
+			pos:  position{line: 2054, col: 1, offset: 64457},
 			expr: &actionExpr{
-				pos: position{line: 2052, col: 14, offset: 64377},
+				pos: position{line: 2054, col: 14, offset: 64470},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2052, col: 14, offset: 64377},
+					pos: position{line: 2054, col: 14, offset: 64470},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2052, col: 14, offset: 64377},
+							pos:   position{line: 2054, col: 14, offset: 64470},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2052, col: 23, offset: 64386},
+								pos: position{line: 2054, col: 23, offset: 64479},
 								expr: &seqExpr{
-									pos: position{line: 2052, col: 24, offset: 64387},
+									pos: position{line: 2054, col: 24, offset: 64480},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2052, col: 24, offset: 64387},
+											pos:  position{line: 2054, col: 24, offset: 64480},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2052, col: 30, offset: 64393},
+											pos:  position{line: 2054, col: 30, offset: 64486},
 											name: "IntegerAsString",
 										},
 									},
@@ -3690,45 +3690,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 48, offset: 64411},
+							pos:   position{line: 2054, col: 48, offset: 64504},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2052, col: 57, offset: 64420},
+								pos: position{line: 2054, col: 57, offset: 64513},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2052, col: 58, offset: 64421},
+									pos:  position{line: 2054, col: 58, offset: 64514},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 73, offset: 64436},
+							pos:   position{line: 2054, col: 73, offset: 64529},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2052, col: 83, offset: 64446},
+								pos: position{line: 2054, col: 83, offset: 64539},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2052, col: 84, offset: 64447},
+									pos:  position{line: 2054, col: 84, offset: 64540},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 101, offset: 64464},
+							pos:   position{line: 2054, col: 101, offset: 64557},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2052, col: 110, offset: 64473},
+								pos: position{line: 2054, col: 110, offset: 64566},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2052, col: 111, offset: 64474},
+									pos:  position{line: 2054, col: 111, offset: 64567},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 126, offset: 64489},
+							pos:   position{line: 2054, col: 126, offset: 64582},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2052, col: 139, offset: 64502},
+								pos: position{line: 2054, col: 139, offset: 64595},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2052, col: 140, offset: 64503},
+									pos:  position{line: 2054, col: 140, offset: 64596},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3739,27 +3739,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2109, col: 1, offset: 66241},
+			pos:  position{line: 2111, col: 1, offset: 66334},
 			expr: &actionExpr{
-				pos: position{line: 2109, col: 19, offset: 66259},
+				pos: position{line: 2111, col: 19, offset: 66352},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2109, col: 19, offset: 66259},
+					pos: position{line: 2111, col: 19, offset: 66352},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2109, col: 19, offset: 66259},
+							pos: position{line: 2111, col: 19, offset: 66352},
 							expr: &litMatcher{
-								pos:        position{line: 2109, col: 21, offset: 66261},
+								pos:        position{line: 2111, col: 21, offset: 66354},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2109, col: 31, offset: 66271},
+							pos:   position{line: 2111, col: 31, offset: 66364},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2109, col: 37, offset: 66277},
+								pos:  position{line: 2111, col: 37, offset: 66370},
 								name: "FieldName",
 							},
 						},
@@ -3769,48 +3769,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2115, col: 1, offset: 66416},
+			pos:  position{line: 2117, col: 1, offset: 66509},
 			expr: &actionExpr{
-				pos: position{line: 2115, col: 32, offset: 66447},
+				pos: position{line: 2117, col: 32, offset: 66540},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2115, col: 32, offset: 66447},
+					pos: position{line: 2117, col: 32, offset: 66540},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2115, col: 32, offset: 66447},
+							pos:   position{line: 2117, col: 32, offset: 66540},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 38, offset: 66453},
+								pos:  position{line: 2117, col: 38, offset: 66546},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2115, col: 48, offset: 66463},
+							pos: position{line: 2117, col: 48, offset: 66556},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2115, col: 50, offset: 66465},
+								pos:  position{line: 2117, col: 50, offset: 66558},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2115, col: 57, offset: 66472},
+							pos:   position{line: 2117, col: 57, offset: 66565},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2115, col: 62, offset: 66477},
+								pos: position{line: 2117, col: 62, offset: 66570},
 								expr: &seqExpr{
-									pos: position{line: 2115, col: 63, offset: 66478},
+									pos: position{line: 2117, col: 63, offset: 66571},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2115, col: 63, offset: 66478},
+											pos:  position{line: 2117, col: 63, offset: 66571},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2115, col: 69, offset: 66484},
+											pos:  position{line: 2117, col: 69, offset: 66577},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2115, col: 79, offset: 66494},
+											pos: position{line: 2117, col: 79, offset: 66587},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2115, col: 81, offset: 66496},
+												pos:  position{line: 2117, col: 81, offset: 66589},
 												name: "EQUAL",
 											},
 										},
@@ -3824,45 +3824,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2126, col: 1, offset: 66771},
+			pos:  position{line: 2128, col: 1, offset: 66864},
 			expr: &actionExpr{
-				pos: position{line: 2126, col: 19, offset: 66789},
+				pos: position{line: 2128, col: 19, offset: 66882},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2126, col: 19, offset: 66789},
+					pos: position{line: 2128, col: 19, offset: 66882},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2126, col: 19, offset: 66789},
+							pos:  position{line: 2128, col: 19, offset: 66882},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2126, col: 25, offset: 66795},
+							pos:   position{line: 2128, col: 25, offset: 66888},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2126, col: 31, offset: 66801},
+								pos:  position{line: 2128, col: 31, offset: 66894},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2126, col: 46, offset: 66816},
+							pos:   position{line: 2128, col: 46, offset: 66909},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2126, col: 51, offset: 66821},
+								pos: position{line: 2128, col: 51, offset: 66914},
 								expr: &seqExpr{
-									pos: position{line: 2126, col: 52, offset: 66822},
+									pos: position{line: 2128, col: 52, offset: 66915},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2126, col: 52, offset: 66822},
+											pos:  position{line: 2128, col: 52, offset: 66915},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2126, col: 58, offset: 66828},
+											pos:  position{line: 2128, col: 58, offset: 66921},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2126, col: 73, offset: 66843},
+											pos: position{line: 2128, col: 73, offset: 66936},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2126, col: 74, offset: 66844},
+												pos:  position{line: 2128, col: 74, offset: 66937},
 												name: "EQUAL",
 											},
 										},
@@ -3876,17 +3876,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2144, col: 1, offset: 67372},
+			pos:  position{line: 2146, col: 1, offset: 67465},
 			expr: &actionExpr{
-				pos: position{line: 2144, col: 17, offset: 67388},
+				pos: position{line: 2146, col: 17, offset: 67481},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2144, col: 17, offset: 67388},
+					pos:   position{line: 2146, col: 17, offset: 67481},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2144, col: 24, offset: 67395},
+						pos: position{line: 2146, col: 24, offset: 67488},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2144, col: 25, offset: 67396},
+							pos:  position{line: 2146, col: 25, offset: 67489},
 							name: "DedupOption",
 						},
 					},
@@ -3895,36 +3895,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2184, col: 1, offset: 68662},
+			pos:  position{line: 2186, col: 1, offset: 68755},
 			expr: &actionExpr{
-				pos: position{line: 2184, col: 16, offset: 68677},
+				pos: position{line: 2186, col: 16, offset: 68770},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2184, col: 16, offset: 68677},
+					pos: position{line: 2186, col: 16, offset: 68770},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 16, offset: 68677},
+							pos:  position{line: 2186, col: 16, offset: 68770},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 22, offset: 68683},
+							pos:   position{line: 2186, col: 22, offset: 68776},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 32, offset: 68693},
+								pos:  position{line: 2186, col: 32, offset: 68786},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2184, col: 47, offset: 68708},
+							pos:        position{line: 2186, col: 47, offset: 68801},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 51, offset: 68712},
+							pos:   position{line: 2186, col: 51, offset: 68805},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 57, offset: 68718},
+								pos:  position{line: 2186, col: 57, offset: 68811},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3934,30 +3934,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2189, col: 1, offset: 68827},
+			pos:  position{line: 2191, col: 1, offset: 68920},
 			expr: &actionExpr{
-				pos: position{line: 2189, col: 19, offset: 68845},
+				pos: position{line: 2191, col: 19, offset: 68938},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2189, col: 19, offset: 68845},
+					pos:   position{line: 2191, col: 19, offset: 68938},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2189, col: 27, offset: 68853},
+						pos: position{line: 2191, col: 27, offset: 68946},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2189, col: 27, offset: 68853},
+								pos:        position{line: 2191, col: 27, offset: 68946},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2189, col: 43, offset: 68869},
+								pos:        position{line: 2191, col: 43, offset: 68962},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2189, col: 57, offset: 68883},
+								pos:        position{line: 2191, col: 57, offset: 68976},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3969,22 +3969,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2197, col: 1, offset: 69068},
+			pos:  position{line: 2199, col: 1, offset: 69161},
 			expr: &actionExpr{
-				pos: position{line: 2197, col: 22, offset: 69089},
+				pos: position{line: 2199, col: 22, offset: 69182},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2197, col: 22, offset: 69089},
+					pos: position{line: 2199, col: 22, offset: 69182},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2197, col: 22, offset: 69089},
+							pos:  position{line: 2199, col: 22, offset: 69182},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2197, col: 39, offset: 69106},
+							pos:   position{line: 2199, col: 39, offset: 69199},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2197, col: 53, offset: 69120},
+								pos:  position{line: 2199, col: 53, offset: 69213},
 								name: "SortElements",
 							},
 						},
@@ -3994,35 +3994,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2202, col: 1, offset: 69228},
+			pos:  position{line: 2204, col: 1, offset: 69321},
 			expr: &actionExpr{
-				pos: position{line: 2202, col: 17, offset: 69244},
+				pos: position{line: 2204, col: 17, offset: 69337},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2202, col: 17, offset: 69244},
+					pos: position{line: 2204, col: 17, offset: 69337},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2202, col: 17, offset: 69244},
+							pos:   position{line: 2204, col: 17, offset: 69337},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2202, col: 23, offset: 69250},
+								pos:  position{line: 2204, col: 23, offset: 69343},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2202, col: 41, offset: 69268},
+							pos:   position{line: 2204, col: 41, offset: 69361},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2202, col: 46, offset: 69273},
+								pos: position{line: 2204, col: 46, offset: 69366},
 								expr: &seqExpr{
-									pos: position{line: 2202, col: 47, offset: 69274},
+									pos: position{line: 2204, col: 47, offset: 69367},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2202, col: 47, offset: 69274},
+											pos:  position{line: 2204, col: 47, offset: 69367},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2202, col: 62, offset: 69289},
+											pos:  position{line: 2204, col: 62, offset: 69382},
 											name: "SingleSortElement",
 										},
 									},
@@ -4035,22 +4035,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2217, col: 1, offset: 69647},
+			pos:  position{line: 2219, col: 1, offset: 69740},
 			expr: &actionExpr{
-				pos: position{line: 2217, col: 22, offset: 69668},
+				pos: position{line: 2219, col: 22, offset: 69761},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2217, col: 22, offset: 69668},
+					pos:   position{line: 2219, col: 22, offset: 69761},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2217, col: 31, offset: 69677},
+						pos: position{line: 2219, col: 31, offset: 69770},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2217, col: 31, offset: 69677},
+								pos:  position{line: 2219, col: 31, offset: 69770},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2217, col: 59, offset: 69705},
+								pos:  position{line: 2219, col: 59, offset: 69798},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4060,33 +4060,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2221, col: 1, offset: 69764},
+			pos:  position{line: 2223, col: 1, offset: 69857},
 			expr: &actionExpr{
-				pos: position{line: 2221, col: 33, offset: 69796},
+				pos: position{line: 2223, col: 33, offset: 69889},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2221, col: 33, offset: 69796},
+					pos: position{line: 2223, col: 33, offset: 69889},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2221, col: 33, offset: 69796},
+							pos:   position{line: 2223, col: 33, offset: 69889},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2221, col: 47, offset: 69810},
+								pos: position{line: 2223, col: 47, offset: 69903},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2221, col: 47, offset: 69810},
+										pos:        position{line: 2223, col: 47, offset: 69903},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2221, col: 53, offset: 69816},
+										pos:        position{line: 2223, col: 53, offset: 69909},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2221, col: 59, offset: 69822},
+										pos:        position{line: 2223, col: 59, offset: 69915},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4095,10 +4095,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2221, col: 63, offset: 69826},
+							pos:   position{line: 2223, col: 63, offset: 69919},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2221, col: 69, offset: 69832},
+								pos:  position{line: 2223, col: 69, offset: 69925},
 								name: "FieldName",
 							},
 						},
@@ -4108,33 +4108,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2236, col: 1, offset: 70107},
+			pos:  position{line: 2238, col: 1, offset: 70200},
 			expr: &actionExpr{
-				pos: position{line: 2236, col: 30, offset: 70136},
+				pos: position{line: 2238, col: 30, offset: 70229},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2236, col: 30, offset: 70136},
+					pos: position{line: 2238, col: 30, offset: 70229},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2236, col: 30, offset: 70136},
+							pos:   position{line: 2238, col: 30, offset: 70229},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2236, col: 44, offset: 70150},
+								pos: position{line: 2238, col: 44, offset: 70243},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2236, col: 44, offset: 70150},
+										pos:        position{line: 2238, col: 44, offset: 70243},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2236, col: 50, offset: 70156},
+										pos:        position{line: 2238, col: 50, offset: 70249},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2236, col: 56, offset: 70162},
+										pos:        position{line: 2238, col: 56, offset: 70255},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4143,31 +4143,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2236, col: 60, offset: 70166},
+							pos:   position{line: 2238, col: 60, offset: 70259},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2236, col: 64, offset: 70170},
+								pos: position{line: 2238, col: 64, offset: 70263},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2236, col: 64, offset: 70170},
+										pos:        position{line: 2238, col: 64, offset: 70263},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2236, col: 73, offset: 70179},
+										pos:        position{line: 2238, col: 73, offset: 70272},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2236, col: 81, offset: 70187},
+										pos:        position{line: 2238, col: 81, offset: 70280},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2236, col: 88, offset: 70194},
+										pos:        position{line: 2238, col: 88, offset: 70287},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4176,19 +4176,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2236, col: 95, offset: 70201},
+							pos:  position{line: 2238, col: 95, offset: 70294},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2236, col: 103, offset: 70209},
+							pos:   position{line: 2238, col: 103, offset: 70302},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2236, col: 109, offset: 70215},
+								pos:  position{line: 2238, col: 109, offset: 70308},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2236, col: 119, offset: 70225},
+							pos:  position{line: 2238, col: 119, offset: 70318},
 							name: "R_PAREN",
 						},
 					},
@@ -4197,26 +4197,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2256, col: 1, offset: 70650},
+			pos:  position{line: 2258, col: 1, offset: 70743},
 			expr: &actionExpr{
-				pos: position{line: 2256, col: 16, offset: 70665},
+				pos: position{line: 2258, col: 16, offset: 70758},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2256, col: 16, offset: 70665},
+					pos: position{line: 2258, col: 16, offset: 70758},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2256, col: 16, offset: 70665},
+							pos:  position{line: 2258, col: 16, offset: 70758},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2256, col: 21, offset: 70670},
+							pos:  position{line: 2258, col: 21, offset: 70763},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2256, col: 32, offset: 70681},
+							pos:   position{line: 2258, col: 32, offset: 70774},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2256, col: 43, offset: 70692},
+								pos:  position{line: 2258, col: 43, offset: 70785},
 								name: "RenameExpr",
 							},
 						},
@@ -4226,33 +4226,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2279, col: 1, offset: 71356},
+			pos:  position{line: 2281, col: 1, offset: 71449},
 			expr: &choiceExpr{
-				pos: position{line: 2279, col: 15, offset: 71370},
+				pos: position{line: 2281, col: 15, offset: 71463},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2279, col: 15, offset: 71370},
+						pos: position{line: 2281, col: 15, offset: 71463},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2279, col: 15, offset: 71370},
+							pos: position{line: 2281, col: 15, offset: 71463},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2279, col: 15, offset: 71370},
+									pos:   position{line: 2281, col: 15, offset: 71463},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2279, col: 31, offset: 71386},
+										pos:  position{line: 2281, col: 31, offset: 71479},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2279, col: 45, offset: 71400},
+									pos:  position{line: 2281, col: 45, offset: 71493},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2279, col: 48, offset: 71403},
+									pos:   position{line: 2281, col: 48, offset: 71496},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2279, col: 59, offset: 71414},
+										pos:  position{line: 2281, col: 59, offset: 71507},
 										name: "QuotedString",
 									},
 								},
@@ -4260,28 +4260,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2290, col: 3, offset: 71733},
+						pos: position{line: 2292, col: 3, offset: 71826},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2290, col: 3, offset: 71733},
+							pos: position{line: 2292, col: 3, offset: 71826},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2290, col: 3, offset: 71733},
+									pos:   position{line: 2292, col: 3, offset: 71826},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 19, offset: 71749},
+										pos:  position{line: 2292, col: 19, offset: 71842},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2290, col: 33, offset: 71763},
+									pos:  position{line: 2292, col: 33, offset: 71856},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2290, col: 36, offset: 71766},
+									pos:   position{line: 2292, col: 36, offset: 71859},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2290, col: 47, offset: 71777},
+										pos:  position{line: 2292, col: 47, offset: 71870},
 										name: "RenamePattern",
 									},
 								},
@@ -4293,48 +4293,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2312, col: 1, offset: 72343},
+			pos:  position{line: 2314, col: 1, offset: 72436},
 			expr: &actionExpr{
-				pos: position{line: 2312, col: 13, offset: 72355},
+				pos: position{line: 2314, col: 13, offset: 72448},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2312, col: 13, offset: 72355},
+					pos: position{line: 2314, col: 13, offset: 72448},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2312, col: 13, offset: 72355},
+							pos:  position{line: 2314, col: 13, offset: 72448},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2312, col: 18, offset: 72360},
+							pos:  position{line: 2314, col: 18, offset: 72453},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2312, col: 26, offset: 72368},
+							pos:        position{line: 2314, col: 26, offset: 72461},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2312, col: 34, offset: 72376},
+							pos:  position{line: 2314, col: 34, offset: 72469},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2312, col: 40, offset: 72382},
+							pos:   position{line: 2314, col: 40, offset: 72475},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2312, col: 46, offset: 72388},
+								pos:  position{line: 2314, col: 46, offset: 72481},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2312, col: 62, offset: 72404},
+							pos:  position{line: 2314, col: 62, offset: 72497},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2312, col: 68, offset: 72410},
+							pos:   position{line: 2314, col: 68, offset: 72503},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2312, col: 72, offset: 72414},
+								pos:  position{line: 2314, col: 72, offset: 72507},
 								name: "QuotedString",
 							},
 						},
@@ -4344,37 +4344,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2341, col: 1, offset: 73143},
+			pos:  position{line: 2343, col: 1, offset: 73236},
 			expr: &actionExpr{
-				pos: position{line: 2341, col: 14, offset: 73156},
+				pos: position{line: 2343, col: 14, offset: 73249},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2341, col: 14, offset: 73156},
+					pos: position{line: 2343, col: 14, offset: 73249},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2341, col: 14, offset: 73156},
+							pos:  position{line: 2343, col: 14, offset: 73249},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2341, col: 19, offset: 73161},
+							pos:  position{line: 2343, col: 19, offset: 73254},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2341, col: 28, offset: 73170},
+							pos:   position{line: 2343, col: 28, offset: 73263},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2341, col: 34, offset: 73176},
+								pos: position{line: 2343, col: 34, offset: 73269},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2341, col: 35, offset: 73177},
+									pos:  position{line: 2343, col: 35, offset: 73270},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2341, col: 47, offset: 73189},
+							pos:   position{line: 2343, col: 47, offset: 73282},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2341, col: 58, offset: 73200},
+								pos:  position{line: 2343, col: 58, offset: 73293},
 								name: "SortElements",
 							},
 						},
@@ -4384,41 +4384,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2379, col: 1, offset: 74079},
+			pos:  position{line: 2381, col: 1, offset: 74172},
 			expr: &actionExpr{
-				pos: position{line: 2379, col: 14, offset: 74092},
+				pos: position{line: 2381, col: 14, offset: 74185},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2379, col: 14, offset: 74092},
+					pos: position{line: 2381, col: 14, offset: 74185},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2379, col: 14, offset: 74092},
+							pos: position{line: 2381, col: 14, offset: 74185},
 							expr: &seqExpr{
-								pos: position{line: 2379, col: 15, offset: 74093},
+								pos: position{line: 2381, col: 15, offset: 74186},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2379, col: 15, offset: 74093},
+										pos:        position{line: 2381, col: 15, offset: 74186},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2379, col: 23, offset: 74101},
+										pos:  position{line: 2381, col: 23, offset: 74194},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2379, col: 31, offset: 74109},
+							pos:   position{line: 2381, col: 31, offset: 74202},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2379, col: 40, offset: 74118},
+								pos:  position{line: 2381, col: 40, offset: 74211},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2379, col: 56, offset: 74134},
+							pos:  position{line: 2381, col: 56, offset: 74227},
 							name: "SPACE",
 						},
 					},
@@ -4427,43 +4427,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2393, col: 1, offset: 74433},
+			pos:  position{line: 2395, col: 1, offset: 74526},
 			expr: &actionExpr{
-				pos: position{line: 2393, col: 14, offset: 74446},
+				pos: position{line: 2395, col: 14, offset: 74539},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2393, col: 14, offset: 74446},
+					pos: position{line: 2395, col: 14, offset: 74539},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2393, col: 14, offset: 74446},
+							pos:  position{line: 2395, col: 14, offset: 74539},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2393, col: 19, offset: 74451},
+							pos:  position{line: 2395, col: 19, offset: 74544},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2393, col: 28, offset: 74460},
+							pos:   position{line: 2395, col: 28, offset: 74553},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2393, col: 34, offset: 74466},
+								pos:  position{line: 2395, col: 34, offset: 74559},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2393, col: 45, offset: 74477},
+							pos:   position{line: 2395, col: 45, offset: 74570},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2393, col: 50, offset: 74482},
+								pos: position{line: 2395, col: 50, offset: 74575},
 								expr: &seqExpr{
-									pos: position{line: 2393, col: 51, offset: 74483},
+									pos: position{line: 2395, col: 51, offset: 74576},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2393, col: 51, offset: 74483},
+											pos:  position{line: 2395, col: 51, offset: 74576},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2393, col: 57, offset: 74489},
+											pos:  position{line: 2395, col: 57, offset: 74582},
 											name: "SingleEval",
 										},
 									},
@@ -4476,30 +4476,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2428, col: 1, offset: 75722},
+			pos:  position{line: 2430, col: 1, offset: 75815},
 			expr: &actionExpr{
-				pos: position{line: 2428, col: 15, offset: 75736},
+				pos: position{line: 2430, col: 15, offset: 75829},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2428, col: 15, offset: 75736},
+					pos: position{line: 2430, col: 15, offset: 75829},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2428, col: 15, offset: 75736},
+							pos:   position{line: 2430, col: 15, offset: 75829},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2428, col: 21, offset: 75742},
+								pos:  position{line: 2430, col: 21, offset: 75835},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2428, col: 31, offset: 75752},
+							pos:  position{line: 2430, col: 31, offset: 75845},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2428, col: 37, offset: 75758},
+							pos:   position{line: 2430, col: 37, offset: 75851},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2428, col: 42, offset: 75763},
+								pos:  position{line: 2430, col: 42, offset: 75856},
 								name: "EvalExpression",
 							},
 						},
@@ -4509,15 +4509,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2441, col: 1, offset: 76164},
+			pos:  position{line: 2443, col: 1, offset: 76257},
 			expr: &actionExpr{
-				pos: position{line: 2441, col: 19, offset: 76182},
+				pos: position{line: 2443, col: 19, offset: 76275},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2441, col: 19, offset: 76182},
+					pos:   position{line: 2443, col: 19, offset: 76275},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2441, col: 25, offset: 76188},
+						pos:  position{line: 2443, col: 25, offset: 76281},
 						name: "ValueExpr",
 					},
 				},
@@ -4525,85 +4525,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2450, col: 1, offset: 76412},
+			pos:  position{line: 2452, col: 1, offset: 76505},
 			expr: &choiceExpr{
-				pos: position{line: 2450, col: 18, offset: 76429},
+				pos: position{line: 2452, col: 18, offset: 76522},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2450, col: 18, offset: 76429},
+						pos: position{line: 2452, col: 18, offset: 76522},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2450, col: 18, offset: 76429},
+							pos: position{line: 2452, col: 18, offset: 76522},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2450, col: 18, offset: 76429},
+									pos:        position{line: 2452, col: 18, offset: 76522},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 23, offset: 76434},
+									pos:  position{line: 2452, col: 23, offset: 76527},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 31, offset: 76442},
+									pos:   position{line: 2452, col: 31, offset: 76535},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2450, col: 41, offset: 76452},
+										pos:  position{line: 2452, col: 41, offset: 76545},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 50, offset: 76461},
+									pos:  position{line: 2452, col: 50, offset: 76554},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 56, offset: 76467},
+									pos:   position{line: 2452, col: 56, offset: 76560},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2450, col: 66, offset: 76477},
+										pos:  position{line: 2452, col: 66, offset: 76570},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 76, offset: 76487},
+									pos:  position{line: 2452, col: 76, offset: 76580},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2450, col: 82, offset: 76493},
+									pos:   position{line: 2452, col: 82, offset: 76586},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2450, col: 93, offset: 76504},
+										pos:  position{line: 2452, col: 93, offset: 76597},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2450, col: 103, offset: 76514},
+									pos:  position{line: 2452, col: 103, offset: 76607},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2461, col: 3, offset: 76765},
+						pos: position{line: 2463, col: 3, offset: 76858},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2461, col: 3, offset: 76765},
+							pos: position{line: 2463, col: 3, offset: 76858},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2461, col: 3, offset: 76765},
+									pos:   position{line: 2463, col: 3, offset: 76858},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2461, col: 11, offset: 76773},
+										pos: position{line: 2463, col: 11, offset: 76866},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2461, col: 11, offset: 76773},
+												pos:        position{line: 2463, col: 11, offset: 76866},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2461, col: 20, offset: 76782},
+												pos:        position{line: 2463, col: 20, offset: 76875},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4612,31 +4612,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2461, col: 32, offset: 76794},
+									pos:  position{line: 2463, col: 32, offset: 76887},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2461, col: 40, offset: 76802},
+									pos:   position{line: 2463, col: 40, offset: 76895},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2461, col: 45, offset: 76807},
+										pos:  position{line: 2463, col: 45, offset: 76900},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2461, col: 64, offset: 76826},
+									pos:   position{line: 2463, col: 64, offset: 76919},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2461, col: 69, offset: 76831},
+										pos: position{line: 2463, col: 69, offset: 76924},
 										expr: &seqExpr{
-											pos: position{line: 2461, col: 70, offset: 76832},
+											pos: position{line: 2463, col: 70, offset: 76925},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2461, col: 70, offset: 76832},
+													pos:  position{line: 2463, col: 70, offset: 76925},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2461, col: 76, offset: 76838},
+													pos:  position{line: 2463, col: 76, offset: 76931},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4644,50 +4644,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2461, col: 97, offset: 76859},
+									pos:  position{line: 2463, col: 97, offset: 76952},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2484, col: 3, offset: 77463},
+						pos: position{line: 2486, col: 3, offset: 77556},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2484, col: 3, offset: 77463},
+							pos: position{line: 2486, col: 3, offset: 77556},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2484, col: 3, offset: 77463},
+									pos:        position{line: 2486, col: 3, offset: 77556},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2484, col: 14, offset: 77474},
+									pos:  position{line: 2486, col: 14, offset: 77567},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2484, col: 22, offset: 77482},
+									pos:   position{line: 2486, col: 22, offset: 77575},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2484, col: 32, offset: 77492},
+										pos:  position{line: 2486, col: 32, offset: 77585},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2484, col: 42, offset: 77502},
+									pos:   position{line: 2486, col: 42, offset: 77595},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2484, col: 47, offset: 77507},
+										pos: position{line: 2486, col: 47, offset: 77600},
 										expr: &seqExpr{
-											pos: position{line: 2484, col: 48, offset: 77508},
+											pos: position{line: 2486, col: 48, offset: 77601},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2484, col: 48, offset: 77508},
+													pos:  position{line: 2486, col: 48, offset: 77601},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2484, col: 54, offset: 77514},
+													pos:  position{line: 2486, col: 54, offset: 77607},
 													name: "ValueExpr",
 												},
 											},
@@ -4695,73 +4695,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2484, col: 66, offset: 77526},
+									pos:  position{line: 2486, col: 66, offset: 77619},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2501, col: 3, offset: 77945},
+						pos: position{line: 2503, col: 3, offset: 78038},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2501, col: 3, offset: 77945},
+							pos: position{line: 2503, col: 3, offset: 78038},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2501, col: 3, offset: 77945},
+									pos:        position{line: 2503, col: 3, offset: 78038},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2501, col: 12, offset: 77954},
+									pos:  position{line: 2503, col: 12, offset: 78047},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2501, col: 20, offset: 77962},
+									pos:   position{line: 2503, col: 20, offset: 78055},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2501, col: 30, offset: 77972},
+										pos:  position{line: 2503, col: 30, offset: 78065},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2501, col: 40, offset: 77982},
+									pos:  position{line: 2503, col: 40, offset: 78075},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2501, col: 46, offset: 77988},
+									pos:   position{line: 2503, col: 46, offset: 78081},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2501, col: 57, offset: 77999},
+										pos:  position{line: 2503, col: 57, offset: 78092},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2501, col: 67, offset: 78009},
+									pos:  position{line: 2503, col: 67, offset: 78102},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2513, col: 3, offset: 78289},
+						pos: position{line: 2515, col: 3, offset: 78382},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2513, col: 3, offset: 78289},
+							pos: position{line: 2515, col: 3, offset: 78382},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2513, col: 3, offset: 78289},
+									pos:        position{line: 2515, col: 3, offset: 78382},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2513, col: 10, offset: 78296},
+									pos:  position{line: 2515, col: 10, offset: 78389},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2513, col: 18, offset: 78304},
+									pos:  position{line: 2515, col: 18, offset: 78397},
 									name: "R_PAREN",
 								},
 							},
@@ -4772,30 +4772,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2520, col: 1, offset: 78401},
+			pos:  position{line: 2522, col: 1, offset: 78494},
 			expr: &actionExpr{
-				pos: position{line: 2520, col: 23, offset: 78423},
+				pos: position{line: 2522, col: 23, offset: 78516},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2520, col: 23, offset: 78423},
+					pos: position{line: 2522, col: 23, offset: 78516},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2520, col: 23, offset: 78423},
+							pos:   position{line: 2522, col: 23, offset: 78516},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2520, col: 33, offset: 78433},
+								pos:  position{line: 2522, col: 33, offset: 78526},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2520, col: 42, offset: 78442},
+							pos:  position{line: 2522, col: 42, offset: 78535},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2520, col: 48, offset: 78448},
+							pos:   position{line: 2522, col: 48, offset: 78541},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2520, col: 54, offset: 78454},
+								pos:  position{line: 2522, col: 54, offset: 78547},
 								name: "ValueExpr",
 							},
 						},
@@ -4805,15 +4805,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2528, col: 1, offset: 78659},
+			pos:  position{line: 2530, col: 1, offset: 78752},
 			expr: &actionExpr{
-				pos: position{line: 2528, col: 26, offset: 78684},
+				pos: position{line: 2530, col: 26, offset: 78777},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2528, col: 26, offset: 78684},
+					pos:   position{line: 2530, col: 26, offset: 78777},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2528, col: 37, offset: 78695},
+						pos:  position{line: 2530, col: 37, offset: 78788},
 						name: "StringExpr",
 					},
 				},
@@ -4821,15 +4821,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2538, col: 1, offset: 78904},
+			pos:  position{line: 2540, col: 1, offset: 78997},
 			expr: &actionExpr{
-				pos: position{line: 2538, col: 30, offset: 78933},
+				pos: position{line: 2540, col: 30, offset: 79026},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2538, col: 30, offset: 78933},
+					pos:   position{line: 2540, col: 30, offset: 79026},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2538, col: 45, offset: 78948},
+						pos:  position{line: 2540, col: 45, offset: 79041},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4837,22 +4837,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2547, col: 1, offset: 79154},
+			pos:  position{line: 2549, col: 1, offset: 79247},
 			expr: &actionExpr{
-				pos: position{line: 2547, col: 27, offset: 79180},
+				pos: position{line: 2549, col: 27, offset: 79273},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2547, col: 27, offset: 79180},
+					pos:   position{line: 2549, col: 27, offset: 79273},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2547, col: 40, offset: 79193},
+						pos: position{line: 2549, col: 40, offset: 79286},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2547, col: 40, offset: 79193},
+								pos:  position{line: 2549, col: 40, offset: 79286},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2547, col: 68, offset: 79221},
+								pos:  position{line: 2549, col: 68, offset: 79314},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4862,135 +4862,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2551, col: 1, offset: 79298},
+			pos:  position{line: 2553, col: 1, offset: 79391},
 			expr: &choiceExpr{
-				pos: position{line: 2551, col: 19, offset: 79316},
+				pos: position{line: 2553, col: 19, offset: 79409},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2551, col: 19, offset: 79316},
+						pos: position{line: 2553, col: 19, offset: 79409},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2551, col: 20, offset: 79317},
+							pos: position{line: 2553, col: 20, offset: 79410},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2551, col: 20, offset: 79317},
+									pos:   position{line: 2553, col: 20, offset: 79410},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2551, col: 28, offset: 79325},
+										pos:        position{line: 2553, col: 28, offset: 79418},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 37, offset: 79334},
+									pos:  position{line: 2553, col: 37, offset: 79427},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 45, offset: 79342},
+									pos:   position{line: 2553, col: 45, offset: 79435},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 56, offset: 79353},
+										pos:  position{line: 2553, col: 56, offset: 79446},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 67, offset: 79364},
+									pos:  position{line: 2553, col: 67, offset: 79457},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 73, offset: 79370},
+									pos:   position{line: 2553, col: 73, offset: 79463},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 79, offset: 79376},
+										pos:  position{line: 2553, col: 79, offset: 79469},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 90, offset: 79387},
+									pos:  position{line: 2553, col: 90, offset: 79480},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2563, col: 3, offset: 79748},
+						pos: position{line: 2565, col: 3, offset: 79841},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2563, col: 4, offset: 79749},
+							pos: position{line: 2565, col: 4, offset: 79842},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2563, col: 4, offset: 79749},
+									pos:   position{line: 2565, col: 4, offset: 79842},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2563, col: 12, offset: 79757},
+										pos:        position{line: 2565, col: 12, offset: 79850},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2563, col: 23, offset: 79768},
+									pos:  position{line: 2565, col: 23, offset: 79861},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2563, col: 31, offset: 79776},
+									pos:   position{line: 2565, col: 31, offset: 79869},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2563, col: 46, offset: 79791},
+										pos:  position{line: 2565, col: 46, offset: 79884},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2563, col: 61, offset: 79806},
+									pos:  position{line: 2565, col: 61, offset: 79899},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2563, col: 67, offset: 79812},
+									pos:   position{line: 2565, col: 67, offset: 79905},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2563, col: 78, offset: 79823},
+										pos:  position{line: 2565, col: 78, offset: 79916},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2563, col: 90, offset: 79835},
+									pos:   position{line: 2565, col: 90, offset: 79928},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2563, col: 99, offset: 79844},
+										pos: position{line: 2565, col: 99, offset: 79937},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2563, col: 100, offset: 79845},
+											pos:  position{line: 2565, col: 100, offset: 79938},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2563, col: 119, offset: 79864},
+									pos:  position{line: 2565, col: 119, offset: 79957},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2579, col: 3, offset: 80426},
+						pos: position{line: 2581, col: 3, offset: 80519},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2579, col: 4, offset: 80427},
+							pos: position{line: 2581, col: 4, offset: 80520},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2579, col: 4, offset: 80427},
+									pos:   position{line: 2581, col: 4, offset: 80520},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2579, col: 12, offset: 80435},
+										pos: position{line: 2581, col: 12, offset: 80528},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2579, col: 12, offset: 80435},
+												pos:        position{line: 2581, col: 12, offset: 80528},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2579, col: 24, offset: 80447},
+												pos:        position{line: 2581, col: 24, offset: 80540},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4999,222 +4999,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2579, col: 34, offset: 80457},
+									pos:  position{line: 2581, col: 34, offset: 80550},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2579, col: 42, offset: 80465},
+									pos:   position{line: 2581, col: 42, offset: 80558},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2579, col: 57, offset: 80480},
+										pos:  position{line: 2581, col: 57, offset: 80573},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2579, col: 72, offset: 80495},
+									pos:  position{line: 2581, col: 72, offset: 80588},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2591, col: 3, offset: 80843},
+						pos: position{line: 2593, col: 3, offset: 80936},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2591, col: 4, offset: 80844},
+							pos: position{line: 2593, col: 4, offset: 80937},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2591, col: 4, offset: 80844},
+									pos:   position{line: 2593, col: 4, offset: 80937},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2591, col: 12, offset: 80852},
+										pos:        position{line: 2593, col: 12, offset: 80945},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 24, offset: 80864},
+									pos:  position{line: 2593, col: 24, offset: 80957},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2591, col: 32, offset: 80872},
+									pos:   position{line: 2593, col: 32, offset: 80965},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2591, col: 42, offset: 80882},
+										pos:  position{line: 2593, col: 42, offset: 80975},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2591, col: 51, offset: 80891},
+									pos:  position{line: 2593, col: 51, offset: 80984},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2604, col: 3, offset: 81238},
+						pos: position{line: 2606, col: 3, offset: 81331},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2604, col: 4, offset: 81239},
+							pos: position{line: 2606, col: 4, offset: 81332},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2604, col: 4, offset: 81239},
+									pos:   position{line: 2606, col: 4, offset: 81332},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2604, col: 12, offset: 81247},
+										pos:        position{line: 2606, col: 12, offset: 81340},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 21, offset: 81256},
+									pos:  position{line: 2606, col: 21, offset: 81349},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2604, col: 29, offset: 81264},
+									pos:   position{line: 2606, col: 29, offset: 81357},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2604, col: 44, offset: 81279},
+										pos:  position{line: 2606, col: 44, offset: 81372},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 59, offset: 81294},
+									pos:  position{line: 2606, col: 59, offset: 81387},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2604, col: 65, offset: 81300},
+									pos:   position{line: 2606, col: 65, offset: 81393},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2604, col: 70, offset: 81305},
+										pos:  position{line: 2606, col: 70, offset: 81398},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2604, col: 80, offset: 81315},
+									pos:  position{line: 2606, col: 80, offset: 81408},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2617, col: 3, offset: 81737},
+						pos: position{line: 2619, col: 3, offset: 81830},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2617, col: 4, offset: 81738},
+							pos: position{line: 2619, col: 4, offset: 81831},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2617, col: 4, offset: 81738},
+									pos:   position{line: 2619, col: 4, offset: 81831},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2617, col: 12, offset: 81746},
+										pos:        position{line: 2619, col: 12, offset: 81839},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 23, offset: 81757},
+									pos:  position{line: 2619, col: 23, offset: 81850},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 31, offset: 81765},
+									pos:   position{line: 2619, col: 31, offset: 81858},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2617, col: 42, offset: 81776},
+										pos:  position{line: 2619, col: 42, offset: 81869},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 54, offset: 81788},
+									pos:  position{line: 2619, col: 54, offset: 81881},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 60, offset: 81794},
+									pos:   position{line: 2619, col: 60, offset: 81887},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2617, col: 69, offset: 81803},
+										pos:  position{line: 2619, col: 69, offset: 81896},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 81, offset: 81815},
+									pos:  position{line: 2619, col: 81, offset: 81908},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2617, col: 87, offset: 81821},
+									pos:   position{line: 2619, col: 87, offset: 81914},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2617, col: 98, offset: 81832},
+										pos: position{line: 2619, col: 98, offset: 81925},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2617, col: 99, offset: 81833},
+											pos:  position{line: 2619, col: 99, offset: 81926},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2617, col: 112, offset: 81846},
+									pos:  position{line: 2619, col: 112, offset: 81939},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2630, col: 3, offset: 82297},
+						pos: position{line: 2632, col: 3, offset: 82390},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2630, col: 4, offset: 82298},
+							pos: position{line: 2632, col: 4, offset: 82391},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2630, col: 4, offset: 82298},
+									pos:   position{line: 2632, col: 4, offset: 82391},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2630, col: 12, offset: 82306},
+										pos:        position{line: 2632, col: 12, offset: 82399},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2630, col: 21, offset: 82315},
+									pos:  position{line: 2632, col: 21, offset: 82408},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2630, col: 29, offset: 82323},
+									pos:   position{line: 2632, col: 29, offset: 82416},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2630, col: 36, offset: 82330},
+										pos:  position{line: 2632, col: 36, offset: 82423},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2630, col: 51, offset: 82345},
+									pos:  position{line: 2632, col: 51, offset: 82438},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2630, col: 57, offset: 82351},
+									pos:   position{line: 2632, col: 57, offset: 82444},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2630, col: 65, offset: 82359},
+										pos:  position{line: 2632, col: 65, offset: 82452},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2630, col: 80, offset: 82374},
+									pos:   position{line: 2632, col: 80, offset: 82467},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2630, col: 85, offset: 82379},
+										pos: position{line: 2632, col: 85, offset: 82472},
 										expr: &seqExpr{
-											pos: position{line: 2630, col: 86, offset: 82380},
+											pos: position{line: 2632, col: 86, offset: 82473},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2630, col: 86, offset: 82380},
+													pos:  position{line: 2632, col: 86, offset: 82473},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2630, col: 92, offset: 82386},
+													pos:  position{line: 2632, col: 92, offset: 82479},
 													name: "StringExpr",
 												},
 											},
@@ -5222,63 +5222,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2630, col: 105, offset: 82399},
+									pos:  position{line: 2632, col: 105, offset: 82492},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2647, col: 3, offset: 82927},
+						pos: position{line: 2649, col: 3, offset: 83020},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2647, col: 4, offset: 82928},
+							pos: position{line: 2649, col: 4, offset: 83021},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2647, col: 4, offset: 82928},
+									pos:   position{line: 2649, col: 4, offset: 83021},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2647, col: 12, offset: 82936},
+										pos:        position{line: 2649, col: 12, offset: 83029},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2647, col: 32, offset: 82956},
+									pos:  position{line: 2649, col: 32, offset: 83049},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2647, col: 40, offset: 82964},
+									pos:   position{line: 2649, col: 40, offset: 83057},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2647, col: 55, offset: 82979},
+										pos:  position{line: 2649, col: 55, offset: 83072},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2647, col: 70, offset: 82994},
+									pos:   position{line: 2649, col: 70, offset: 83087},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2647, col: 75, offset: 82999},
+										pos: position{line: 2649, col: 75, offset: 83092},
 										expr: &seqExpr{
-											pos: position{line: 2647, col: 76, offset: 83000},
+											pos: position{line: 2649, col: 76, offset: 83093},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2647, col: 76, offset: 83000},
+													pos:  position{line: 2649, col: 76, offset: 83093},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2647, col: 83, offset: 83007},
+													pos: position{line: 2649, col: 83, offset: 83100},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2647, col: 83, offset: 83007},
+															pos:        position{line: 2649, col: 83, offset: 83100},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2647, col: 92, offset: 83016},
+															pos:        position{line: 2649, col: 92, offset: 83109},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5286,7 +5286,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2647, col: 101, offset: 83025},
+													pos:        position{line: 2649, col: 101, offset: 83118},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5296,54 +5296,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2647, col: 108, offset: 83032},
+									pos:  position{line: 2649, col: 108, offset: 83125},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2672, col: 3, offset: 83735},
+						pos: position{line: 2674, col: 3, offset: 83828},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2672, col: 4, offset: 83736},
+							pos: position{line: 2674, col: 4, offset: 83829},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2672, col: 4, offset: 83736},
+									pos:   position{line: 2674, col: 4, offset: 83829},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2672, col: 12, offset: 83744},
+										pos:        position{line: 2674, col: 12, offset: 83837},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 24, offset: 83756},
+									pos:  position{line: 2674, col: 24, offset: 83849},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 32, offset: 83764},
+									pos:   position{line: 2674, col: 32, offset: 83857},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2672, col: 41, offset: 83773},
+										pos:  position{line: 2674, col: 41, offset: 83866},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 64, offset: 83796},
+									pos:   position{line: 2674, col: 64, offset: 83889},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2672, col: 69, offset: 83801},
+										pos: position{line: 2674, col: 69, offset: 83894},
 										expr: &seqExpr{
-											pos: position{line: 2672, col: 70, offset: 83802},
+											pos: position{line: 2674, col: 70, offset: 83895},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2672, col: 70, offset: 83802},
+													pos:  position{line: 2674, col: 70, offset: 83895},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2672, col: 76, offset: 83808},
+													pos:  position{line: 2674, col: 76, offset: 83901},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5351,57 +5351,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 101, offset: 83833},
+									pos:  position{line: 2674, col: 101, offset: 83926},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2692, col: 3, offset: 84421},
+						pos: position{line: 2694, col: 3, offset: 84514},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2692, col: 3, offset: 84421},
+							pos: position{line: 2694, col: 3, offset: 84514},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2692, col: 3, offset: 84421},
+									pos:   position{line: 2694, col: 3, offset: 84514},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 9, offset: 84427},
+										pos:  position{line: 2694, col: 9, offset: 84520},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2692, col: 25, offset: 84443},
+									pos: position{line: 2694, col: 25, offset: 84536},
 									expr: &choiceExpr{
-										pos: position{line: 2692, col: 27, offset: 84445},
+										pos: position{line: 2694, col: 27, offset: 84538},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 27, offset: 84445},
+												pos:  position{line: 2694, col: 27, offset: 84538},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 36, offset: 84454},
+												pos:  position{line: 2694, col: 36, offset: 84547},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 46, offset: 84464},
+												pos:  position{line: 2694, col: 46, offset: 84557},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 54, offset: 84472},
+												pos:  position{line: 2694, col: 54, offset: 84565},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 62, offset: 84480},
+												pos:  position{line: 2694, col: 62, offset: 84573},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2692, col: 70, offset: 84488},
+												pos:  position{line: 2694, col: 70, offset: 84581},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2692, col: 84, offset: 84502},
+												pos:        position{line: 2694, col: 84, offset: 84595},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5417,36 +5417,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2704, col: 1, offset: 84897},
+			pos:  position{line: 2706, col: 1, offset: 84990},
 			expr: &choiceExpr{
-				pos: position{line: 2704, col: 13, offset: 84909},
+				pos: position{line: 2706, col: 13, offset: 85002},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2704, col: 13, offset: 84909},
+						pos: position{line: 2706, col: 13, offset: 85002},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2704, col: 14, offset: 84910},
+							pos: position{line: 2706, col: 14, offset: 85003},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2704, col: 14, offset: 84910},
+									pos:   position{line: 2706, col: 14, offset: 85003},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2704, col: 22, offset: 84918},
+										pos: position{line: 2706, col: 22, offset: 85011},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2704, col: 22, offset: 84918},
+												pos:        position{line: 2706, col: 22, offset: 85011},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2704, col: 32, offset: 84928},
+												pos:        position{line: 2706, col: 32, offset: 85021},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2704, col: 42, offset: 84938},
+												pos:        position{line: 2706, col: 42, offset: 85031},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5455,44 +5455,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2704, col: 55, offset: 84951},
+									pos:  position{line: 2706, col: 55, offset: 85044},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2704, col: 63, offset: 84959},
+									pos:   position{line: 2706, col: 63, offset: 85052},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2704, col: 74, offset: 84970},
+										pos:  position{line: 2706, col: 74, offset: 85063},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2704, col: 85, offset: 84981},
+									pos:  position{line: 2706, col: 85, offset: 85074},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2716, col: 3, offset: 85295},
+						pos: position{line: 2718, col: 3, offset: 85388},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2716, col: 4, offset: 85296},
+							pos: position{line: 2718, col: 4, offset: 85389},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2716, col: 4, offset: 85296},
+									pos:   position{line: 2718, col: 4, offset: 85389},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2716, col: 12, offset: 85304},
+										pos: position{line: 2718, col: 12, offset: 85397},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2716, col: 12, offset: 85304},
+												pos:        position{line: 2718, col: 12, offset: 85397},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2716, col: 20, offset: 85312},
+												pos:        position{line: 2718, col: 20, offset: 85405},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5501,31 +5501,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2716, col: 27, offset: 85319},
+									pos:  position{line: 2718, col: 27, offset: 85412},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2716, col: 35, offset: 85327},
+									pos:   position{line: 2718, col: 35, offset: 85420},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2716, col: 44, offset: 85336},
+										pos:  position{line: 2718, col: 44, offset: 85429},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2716, col: 55, offset: 85347},
+									pos:   position{line: 2718, col: 55, offset: 85440},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2716, col: 60, offset: 85352},
+										pos: position{line: 2718, col: 60, offset: 85445},
 										expr: &seqExpr{
-											pos: position{line: 2716, col: 61, offset: 85353},
+											pos: position{line: 2718, col: 61, offset: 85446},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2716, col: 61, offset: 85353},
+													pos:  position{line: 2718, col: 61, offset: 85446},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2716, col: 67, offset: 85359},
+													pos:  position{line: 2718, col: 67, offset: 85452},
 													name: "StringExpr",
 												},
 											},
@@ -5533,195 +5533,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2716, col: 80, offset: 85372},
+									pos:  position{line: 2718, col: 80, offset: 85465},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2738, col: 3, offset: 85972},
+						pos: position{line: 2740, col: 3, offset: 86065},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2738, col: 4, offset: 85973},
+							pos: position{line: 2740, col: 4, offset: 86066},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2738, col: 4, offset: 85973},
+									pos:   position{line: 2740, col: 4, offset: 86066},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2738, col: 12, offset: 85981},
+										pos:        position{line: 2740, col: 12, offset: 86074},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2738, col: 23, offset: 85992},
+									pos:  position{line: 2740, col: 23, offset: 86085},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2738, col: 31, offset: 86000},
+									pos:   position{line: 2740, col: 31, offset: 86093},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2738, col: 46, offset: 86015},
+										pos:  position{line: 2740, col: 46, offset: 86108},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2738, col: 61, offset: 86030},
+									pos:  position{line: 2740, col: 61, offset: 86123},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2749, col: 3, offset: 86332},
+						pos: position{line: 2751, col: 3, offset: 86425},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2749, col: 4, offset: 86333},
+							pos: position{line: 2751, col: 4, offset: 86426},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2749, col: 4, offset: 86333},
+									pos:   position{line: 2751, col: 4, offset: 86426},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2749, col: 12, offset: 86341},
+										pos:        position{line: 2751, col: 12, offset: 86434},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 22, offset: 86351},
+									pos:  position{line: 2751, col: 22, offset: 86444},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2749, col: 30, offset: 86359},
+									pos:   position{line: 2751, col: 30, offset: 86452},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2749, col: 45, offset: 86374},
+										pos:  position{line: 2751, col: 45, offset: 86467},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 60, offset: 86389},
+									pos:  position{line: 2751, col: 60, offset: 86482},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2749, col: 66, offset: 86395},
+									pos:   position{line: 2751, col: 66, offset: 86488},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2749, col: 72, offset: 86401},
+										pos:  position{line: 2751, col: 72, offset: 86494},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 83, offset: 86412},
+									pos:  position{line: 2751, col: 83, offset: 86505},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2761, col: 3, offset: 86762},
+						pos: position{line: 2763, col: 3, offset: 86855},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2761, col: 4, offset: 86763},
+							pos: position{line: 2763, col: 4, offset: 86856},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2761, col: 4, offset: 86763},
+									pos:   position{line: 2763, col: 4, offset: 86856},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2761, col: 12, offset: 86771},
+										pos:        position{line: 2763, col: 12, offset: 86864},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2761, col: 22, offset: 86781},
+									pos:  position{line: 2763, col: 22, offset: 86874},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2761, col: 30, offset: 86789},
+									pos:   position{line: 2763, col: 30, offset: 86882},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2761, col: 45, offset: 86804},
+										pos:  position{line: 2763, col: 45, offset: 86897},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2761, col: 60, offset: 86819},
+									pos:  position{line: 2763, col: 60, offset: 86912},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2761, col: 66, offset: 86825},
+									pos:   position{line: 2763, col: 66, offset: 86918},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2761, col: 79, offset: 86838},
+										pos:  position{line: 2763, col: 79, offset: 86931},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2761, col: 90, offset: 86849},
+									pos:  position{line: 2763, col: 90, offset: 86942},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2785, col: 3, offset: 87518},
+						pos: position{line: 2787, col: 3, offset: 87611},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2785, col: 4, offset: 87519},
+							pos: position{line: 2787, col: 4, offset: 87612},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2785, col: 4, offset: 87519},
+									pos:   position{line: 2787, col: 4, offset: 87612},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2785, col: 12, offset: 87527},
+										pos:        position{line: 2787, col: 12, offset: 87620},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 22, offset: 87537},
+									pos:  position{line: 2787, col: 22, offset: 87630},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2785, col: 30, offset: 87545},
+									pos:   position{line: 2787, col: 30, offset: 87638},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2785, col: 41, offset: 87556},
+										pos:  position{line: 2787, col: 41, offset: 87649},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 52, offset: 87567},
+									pos:  position{line: 2787, col: 52, offset: 87660},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2785, col: 58, offset: 87573},
+									pos:   position{line: 2787, col: 58, offset: 87666},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2785, col: 69, offset: 87584},
+										pos:  position{line: 2787, col: 69, offset: 87677},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2785, col: 81, offset: 87596},
+									pos:   position{line: 2787, col: 81, offset: 87689},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2785, col: 93, offset: 87608},
+										pos: position{line: 2787, col: 93, offset: 87701},
 										expr: &seqExpr{
-											pos: position{line: 2785, col: 94, offset: 87609},
+											pos: position{line: 2787, col: 94, offset: 87702},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2785, col: 94, offset: 87609},
+													pos:  position{line: 2787, col: 94, offset: 87702},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2785, col: 100, offset: 87615},
+													pos:  position{line: 2787, col: 100, offset: 87708},
 													name: "NumericExpr",
 												},
 											},
@@ -5729,50 +5729,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 114, offset: 87629},
+									pos:  position{line: 2787, col: 114, offset: 87722},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2810, col: 3, offset: 88459},
+						pos: position{line: 2812, col: 3, offset: 88552},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2810, col: 3, offset: 88459},
+							pos: position{line: 2812, col: 3, offset: 88552},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2810, col: 3, offset: 88459},
+									pos:        position{line: 2812, col: 3, offset: 88552},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 14, offset: 88470},
+									pos:  position{line: 2812, col: 14, offset: 88563},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 22, offset: 88478},
+									pos:   position{line: 2812, col: 22, offset: 88571},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 28, offset: 88484},
+										pos:  position{line: 2812, col: 28, offset: 88577},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 38, offset: 88494},
+									pos:   position{line: 2812, col: 38, offset: 88587},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2810, col: 45, offset: 88501},
+										pos: position{line: 2812, col: 45, offset: 88594},
 										expr: &seqExpr{
-											pos: position{line: 2810, col: 46, offset: 88502},
+											pos: position{line: 2812, col: 46, offset: 88595},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2810, col: 46, offset: 88502},
+													pos:  position{line: 2812, col: 46, offset: 88595},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2810, col: 52, offset: 88508},
+													pos:  position{line: 2812, col: 52, offset: 88601},
 													name: "StringExpr",
 												},
 											},
@@ -5780,38 +5780,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 65, offset: 88521},
+									pos:  position{line: 2812, col: 65, offset: 88614},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2823, col: 3, offset: 88889},
+						pos: position{line: 2825, col: 3, offset: 88982},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2823, col: 4, offset: 88890},
+							pos: position{line: 2825, col: 4, offset: 88983},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2823, col: 4, offset: 88890},
+									pos:   position{line: 2825, col: 4, offset: 88983},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2823, col: 12, offset: 88898},
+										pos: position{line: 2825, col: 12, offset: 88991},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2823, col: 12, offset: 88898},
+												pos:        position{line: 2825, col: 12, offset: 88991},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2823, col: 22, offset: 88908},
+												pos:        position{line: 2825, col: 22, offset: 89001},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2823, col: 32, offset: 88918},
+												pos:        position{line: 2825, col: 32, offset: 89011},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5820,223 +5820,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 40, offset: 88926},
+									pos:  position{line: 2825, col: 40, offset: 89019},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 48, offset: 88934},
+									pos:   position{line: 2825, col: 48, offset: 89027},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2823, col: 54, offset: 88940},
+										pos:  position{line: 2825, col: 54, offset: 89033},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 66, offset: 88952},
+									pos:   position{line: 2825, col: 66, offset: 89045},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2823, col: 82, offset: 88968},
+										pos: position{line: 2825, col: 82, offset: 89061},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2823, col: 83, offset: 88969},
+											pos:  position{line: 2825, col: 83, offset: 89062},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 101, offset: 88987},
+									pos:  position{line: 2825, col: 101, offset: 89080},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2842, col: 3, offset: 89427},
+						pos: position{line: 2844, col: 3, offset: 89520},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2842, col: 3, offset: 89427},
+							pos: position{line: 2844, col: 3, offset: 89520},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2842, col: 3, offset: 89427},
+									pos:        position{line: 2844, col: 3, offset: 89520},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 11, offset: 89435},
+									pos:  position{line: 2844, col: 11, offset: 89528},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2842, col: 19, offset: 89443},
+									pos:   position{line: 2844, col: 19, offset: 89536},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2842, col: 30, offset: 89454},
+										pos:  position{line: 2844, col: 30, offset: 89547},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 50, offset: 89474},
+									pos:  position{line: 2844, col: 50, offset: 89567},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2842, col: 56, offset: 89480},
+									pos:   position{line: 2844, col: 56, offset: 89573},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2842, col: 62, offset: 89486},
+										pos: position{line: 2844, col: 62, offset: 89579},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2842, col: 62, offset: 89486},
+												pos:  position{line: 2844, col: 62, offset: 89579},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2842, col: 81, offset: 89505},
+												pos:  position{line: 2844, col: 81, offset: 89598},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 100, offset: 89524},
+									pos:  position{line: 2844, col: 100, offset: 89617},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2853, col: 3, offset: 89829},
+						pos: position{line: 2855, col: 3, offset: 89922},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2853, col: 3, offset: 89829},
+							pos: position{line: 2855, col: 3, offset: 89922},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2853, col: 3, offset: 89829},
+									pos:        position{line: 2855, col: 3, offset: 89922},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2853, col: 12, offset: 89838},
+									pos:  position{line: 2855, col: 12, offset: 89931},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2853, col: 20, offset: 89846},
+									pos:   position{line: 2855, col: 20, offset: 89939},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2853, col: 25, offset: 89851},
+										pos:  position{line: 2855, col: 25, offset: 89944},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2853, col: 36, offset: 89862},
+									pos:  position{line: 2855, col: 36, offset: 89955},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2853, col: 42, offset: 89868},
+									pos:   position{line: 2855, col: 42, offset: 89961},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2853, col: 45, offset: 89871},
+										pos:  position{line: 2855, col: 45, offset: 89964},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2853, col: 55, offset: 89881},
+									pos:  position{line: 2855, col: 55, offset: 89974},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2860, col: 3, offset: 90039},
+						pos: position{line: 2862, col: 3, offset: 90132},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2860, col: 3, offset: 90039},
+							pos: position{line: 2862, col: 3, offset: 90132},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2860, col: 3, offset: 90039},
+									pos:        position{line: 2862, col: 3, offset: 90132},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2860, col: 21, offset: 90057},
+									pos:  position{line: 2862, col: 21, offset: 90150},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2860, col: 29, offset: 90065},
+									pos:   position{line: 2862, col: 29, offset: 90158},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2860, col: 33, offset: 90069},
+										pos:  position{line: 2862, col: 33, offset: 90162},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2860, col: 43, offset: 90079},
+									pos:  position{line: 2862, col: 43, offset: 90172},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2860, col: 49, offset: 90085},
+									pos:   position{line: 2862, col: 49, offset: 90178},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2860, col: 53, offset: 90089},
+										pos:  position{line: 2862, col: 53, offset: 90182},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2860, col: 66, offset: 90102},
+									pos:  position{line: 2862, col: 66, offset: 90195},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2860, col: 72, offset: 90108},
+									pos:   position{line: 2862, col: 72, offset: 90201},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2860, col: 78, offset: 90114},
+										pos:  position{line: 2862, col: 78, offset: 90207},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2860, col: 91, offset: 90127},
+									pos:  position{line: 2862, col: 91, offset: 90220},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2871, col: 3, offset: 90435},
+						pos: position{line: 2873, col: 3, offset: 90528},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2871, col: 3, offset: 90435},
+							pos: position{line: 2873, col: 3, offset: 90528},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2871, col: 3, offset: 90435},
+									pos:        position{line: 2873, col: 3, offset: 90528},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2871, col: 12, offset: 90444},
+									pos:  position{line: 2873, col: 12, offset: 90537},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2871, col: 20, offset: 90452},
+									pos:   position{line: 2873, col: 20, offset: 90545},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2871, col: 27, offset: 90459},
+										pos:  position{line: 2873, col: 27, offset: 90552},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2871, col: 38, offset: 90470},
+									pos:   position{line: 2873, col: 38, offset: 90563},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2871, col: 43, offset: 90475},
+										pos: position{line: 2873, col: 43, offset: 90568},
 										expr: &seqExpr{
-											pos: position{line: 2871, col: 44, offset: 90476},
+											pos: position{line: 2873, col: 44, offset: 90569},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2871, col: 44, offset: 90476},
+													pos:  position{line: 2873, col: 44, offset: 90569},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2871, col: 50, offset: 90482},
+													pos:  position{line: 2873, col: 50, offset: 90575},
 													name: "StringExpr",
 												},
 											},
@@ -6044,47 +6044,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2871, col: 63, offset: 90495},
+									pos:  position{line: 2873, col: 63, offset: 90588},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2889, col: 3, offset: 90962},
+						pos: position{line: 2891, col: 3, offset: 91055},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2889, col: 3, offset: 90962},
+							pos: position{line: 2891, col: 3, offset: 91055},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2889, col: 3, offset: 90962},
+									pos:        position{line: 2891, col: 3, offset: 91055},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2889, col: 12, offset: 90971},
+									pos:  position{line: 2891, col: 12, offset: 91064},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2889, col: 20, offset: 90979},
+									pos:   position{line: 2891, col: 20, offset: 91072},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2889, col: 42, offset: 91001},
+										pos: position{line: 2891, col: 42, offset: 91094},
 										expr: &seqExpr{
-											pos: position{line: 2889, col: 43, offset: 91002},
+											pos: position{line: 2891, col: 43, offset: 91095},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2889, col: 44, offset: 91003},
+													pos: position{line: 2891, col: 44, offset: 91096},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2889, col: 44, offset: 91003},
+															pos:        position{line: 2891, col: 44, offset: 91096},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2889, col: 53, offset: 91012},
+															pos:        position{line: 2891, col: 53, offset: 91105},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6092,7 +6092,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2889, col: 62, offset: 91021},
+													pos:        position{line: 2891, col: 62, offset: 91114},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6102,56 +6102,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2889, col: 69, offset: 91028},
+									pos:  position{line: 2891, col: 69, offset: 91121},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2911, col: 3, offset: 91625},
+						pos: position{line: 2913, col: 3, offset: 91718},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2911, col: 3, offset: 91625},
+							pos: position{line: 2913, col: 3, offset: 91718},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2911, col: 3, offset: 91625},
+									pos:        position{line: 2913, col: 3, offset: 91718},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2911, col: 13, offset: 91635},
+									pos:  position{line: 2913, col: 13, offset: 91728},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2911, col: 21, offset: 91643},
+									pos:   position{line: 2913, col: 21, offset: 91736},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2911, col: 27, offset: 91649},
+										pos:  position{line: 2913, col: 27, offset: 91742},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2911, col: 43, offset: 91665},
+									pos:   position{line: 2913, col: 43, offset: 91758},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2911, col: 53, offset: 91675},
+										pos: position{line: 2913, col: 53, offset: 91768},
 										expr: &seqExpr{
-											pos: position{line: 2911, col: 54, offset: 91676},
+											pos: position{line: 2913, col: 54, offset: 91769},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2911, col: 54, offset: 91676},
+													pos:  position{line: 2913, col: 54, offset: 91769},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2911, col: 60, offset: 91682},
+													pos:        position{line: 2913, col: 60, offset: 91775},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2911, col: 73, offset: 91695},
+													pos:  position{line: 2913, col: 73, offset: 91788},
 													name: "FloatAsString",
 												},
 											},
@@ -6159,40 +6159,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2911, col: 89, offset: 91711},
+									pos:   position{line: 2913, col: 89, offset: 91804},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2911, col: 95, offset: 91717},
+										pos: position{line: 2913, col: 95, offset: 91810},
 										expr: &seqExpr{
-											pos: position{line: 2911, col: 96, offset: 91718},
+											pos: position{line: 2913, col: 96, offset: 91811},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2911, col: 96, offset: 91718},
+													pos:  position{line: 2913, col: 96, offset: 91811},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2911, col: 102, offset: 91724},
+													pos:        position{line: 2913, col: 102, offset: 91817},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2911, col: 112, offset: 91734},
+													pos: position{line: 2913, col: 112, offset: 91827},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2911, col: 112, offset: 91734},
+															pos:        position{line: 2913, col: 112, offset: 91827},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2911, col: 125, offset: 91747},
+															pos:        position{line: 2913, col: 125, offset: 91840},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2911, col: 137, offset: 91759},
+															pos:        position{line: 2913, col: 137, offset: 91852},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6204,25 +6204,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2911, col: 151, offset: 91773},
+									pos:   position{line: 2913, col: 151, offset: 91866},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2911, col: 158, offset: 91780},
+										pos: position{line: 2913, col: 158, offset: 91873},
 										expr: &seqExpr{
-											pos: position{line: 2911, col: 159, offset: 91781},
+											pos: position{line: 2913, col: 159, offset: 91874},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2911, col: 159, offset: 91781},
+													pos:  position{line: 2913, col: 159, offset: 91874},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2911, col: 165, offset: 91787},
+													pos:        position{line: 2913, col: 165, offset: 91880},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2911, col: 175, offset: 91797},
+													pos:  position{line: 2913, col: 175, offset: 91890},
 													name: "QuotedString",
 												},
 											},
@@ -6230,213 +6230,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2911, col: 190, offset: 91812},
+									pos:  position{line: 2913, col: 190, offset: 91905},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2951, col: 3, offset: 92807},
+						pos: position{line: 2953, col: 3, offset: 92900},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2951, col: 3, offset: 92807},
+							pos: position{line: 2953, col: 3, offset: 92900},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2951, col: 3, offset: 92807},
+									pos:        position{line: 2953, col: 3, offset: 92900},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 15, offset: 92819},
+									pos:  position{line: 2953, col: 15, offset: 92912},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2951, col: 23, offset: 92827},
+									pos:   position{line: 2953, col: 23, offset: 92920},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2951, col: 30, offset: 92834},
+										pos: position{line: 2953, col: 30, offset: 92927},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2951, col: 31, offset: 92835},
+											pos:  position{line: 2953, col: 31, offset: 92928},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 44, offset: 92848},
+									pos:  position{line: 2953, col: 44, offset: 92941},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2962, col: 3, offset: 93039},
+						pos: position{line: 2964, col: 3, offset: 93132},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2962, col: 3, offset: 93039},
+							pos: position{line: 2964, col: 3, offset: 93132},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2962, col: 3, offset: 93039},
+									pos:        position{line: 2964, col: 3, offset: 93132},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2962, col: 12, offset: 93048},
+									pos:  position{line: 2964, col: 12, offset: 93141},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2962, col: 20, offset: 93056},
+									pos:   position{line: 2964, col: 20, offset: 93149},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2962, col: 30, offset: 93066},
+										pos:  position{line: 2964, col: 30, offset: 93159},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2962, col: 40, offset: 93076},
+									pos:  position{line: 2964, col: 40, offset: 93169},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2968, col: 3, offset: 93199},
+						pos: position{line: 2970, col: 3, offset: 93292},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2968, col: 3, offset: 93199},
+							pos: position{line: 2970, col: 3, offset: 93292},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2968, col: 3, offset: 93199},
+									pos:        position{line: 2970, col: 3, offset: 93292},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 13, offset: 93209},
+									pos:  position{line: 2970, col: 13, offset: 93302},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 21, offset: 93217},
+									pos:   position{line: 2970, col: 21, offset: 93310},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 25, offset: 93221},
+										pos:  position{line: 2970, col: 25, offset: 93314},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 35, offset: 93231},
+									pos:  position{line: 2970, col: 35, offset: 93324},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 41, offset: 93237},
+									pos:   position{line: 2970, col: 41, offset: 93330},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 47, offset: 93243},
+										pos:  position{line: 2970, col: 47, offset: 93336},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 58, offset: 93254},
+									pos:  position{line: 2970, col: 58, offset: 93347},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2968, col: 64, offset: 93260},
+									pos:   position{line: 2970, col: 64, offset: 93353},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2968, col: 76, offset: 93272},
+										pos:  position{line: 2970, col: 76, offset: 93365},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2968, col: 87, offset: 93283},
+									pos:  position{line: 2970, col: 87, offset: 93376},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2975, col: 3, offset: 93507},
+						pos: position{line: 2977, col: 3, offset: 93600},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2975, col: 3, offset: 93507},
+							pos: position{line: 2977, col: 3, offset: 93600},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2975, col: 3, offset: 93507},
+									pos:        position{line: 2977, col: 3, offset: 93600},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2975, col: 14, offset: 93518},
+									pos:  position{line: 2977, col: 14, offset: 93611},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2975, col: 22, offset: 93526},
+									pos:   position{line: 2977, col: 22, offset: 93619},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2975, col: 26, offset: 93530},
+										pos:  position{line: 2977, col: 26, offset: 93623},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2975, col: 36, offset: 93540},
+									pos:  position{line: 2977, col: 36, offset: 93633},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2975, col: 42, offset: 93546},
+									pos:   position{line: 2977, col: 42, offset: 93639},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2975, col: 49, offset: 93553},
+										pos:  position{line: 2977, col: 49, offset: 93646},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2975, col: 60, offset: 93564},
+									pos:  position{line: 2977, col: 60, offset: 93657},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2983, col: 3, offset: 93728},
+						pos: position{line: 2985, col: 3, offset: 93821},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2983, col: 3, offset: 93728},
+							pos: position{line: 2985, col: 3, offset: 93821},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2983, col: 3, offset: 93728},
+									pos:        position{line: 2985, col: 3, offset: 93821},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2983, col: 14, offset: 93739},
+									pos:  position{line: 2985, col: 14, offset: 93832},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2983, col: 22, offset: 93747},
+									pos:   position{line: 2985, col: 22, offset: 93840},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2983, col: 26, offset: 93751},
+										pos:  position{line: 2985, col: 26, offset: 93844},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2983, col: 36, offset: 93761},
+									pos:  position{line: 2985, col: 36, offset: 93854},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2983, col: 42, offset: 93767},
+									pos:   position{line: 2985, col: 42, offset: 93860},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2983, col: 49, offset: 93774},
+										pos:  position{line: 2985, col: 49, offset: 93867},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2983, col: 60, offset: 93785},
+									pos:  position{line: 2985, col: 60, offset: 93878},
 									name: "R_PAREN",
 								},
 							},
@@ -6447,15 +6447,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2991, col: 1, offset: 93947},
+			pos:  position{line: 2993, col: 1, offset: 94040},
 			expr: &actionExpr{
-				pos: position{line: 2991, col: 21, offset: 93967},
+				pos: position{line: 2993, col: 21, offset: 94060},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2991, col: 21, offset: 93967},
+					pos:   position{line: 2993, col: 21, offset: 94060},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2991, col: 25, offset: 93971},
+						pos:  position{line: 2993, col: 25, offset: 94064},
 						name: "QuotedString",
 					},
 				},
@@ -6463,15 +6463,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2998, col: 1, offset: 94098},
+			pos:  position{line: 3000, col: 1, offset: 94191},
 			expr: &actionExpr{
-				pos: position{line: 2998, col: 22, offset: 94119},
+				pos: position{line: 3000, col: 22, offset: 94212},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2998, col: 22, offset: 94119},
+					pos:   position{line: 3000, col: 22, offset: 94212},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2998, col: 26, offset: 94123},
+						pos:  position{line: 3000, col: 26, offset: 94216},
 						name: "UnquotedString",
 					},
 				},
@@ -6479,22 +6479,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3005, col: 1, offset: 94251},
+			pos:  position{line: 3007, col: 1, offset: 94344},
 			expr: &actionExpr{
-				pos: position{line: 3005, col: 20, offset: 94270},
+				pos: position{line: 3007, col: 20, offset: 94363},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3005, col: 20, offset: 94270},
+					pos: position{line: 3007, col: 20, offset: 94363},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3005, col: 20, offset: 94270},
+							pos:  position{line: 3007, col: 20, offset: 94363},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3005, col: 26, offset: 94276},
+							pos:   position{line: 3007, col: 26, offset: 94369},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3005, col: 38, offset: 94288},
+								pos:  position{line: 3007, col: 38, offset: 94381},
 								name: "String",
 							},
 						},
@@ -6504,27 +6504,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3011, col: 1, offset: 94473},
+			pos:  position{line: 3013, col: 1, offset: 94566},
 			expr: &choiceExpr{
-				pos: position{line: 3011, col: 20, offset: 94492},
+				pos: position{line: 3013, col: 20, offset: 94585},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3011, col: 20, offset: 94492},
+						pos: position{line: 3013, col: 20, offset: 94585},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3011, col: 20, offset: 94492},
+							pos: position{line: 3013, col: 20, offset: 94585},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3011, col: 20, offset: 94492},
+									pos:        position{line: 3013, col: 20, offset: 94585},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3011, col: 28, offset: 94500},
+									pos: position{line: 3013, col: 28, offset: 94593},
 									expr: &charClassMatcher{
-										pos:        position{line: 3011, col: 28, offset: 94500},
+										pos:        position{line: 3013, col: 28, offset: 94593},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6533,9 +6533,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3011, col: 42, offset: 94514},
+									pos: position{line: 3013, col: 42, offset: 94607},
 									expr: &litMatcher{
-										pos:        position{line: 3011, col: 44, offset: 94516},
+										pos:        position{line: 3013, col: 44, offset: 94609},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6545,27 +6545,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3014, col: 3, offset: 94558},
+						pos: position{line: 3016, col: 3, offset: 94651},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3014, col: 3, offset: 94558},
+							pos: position{line: 3016, col: 3, offset: 94651},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3014, col: 3, offset: 94558},
+									pos:        position{line: 3016, col: 3, offset: 94651},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3014, col: 7, offset: 94562},
+									pos:   position{line: 3016, col: 7, offset: 94655},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3014, col: 13, offset: 94568},
+										pos:  position{line: 3016, col: 13, offset: 94661},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3014, col: 23, offset: 94578},
+									pos:        position{line: 3016, col: 23, offset: 94671},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6578,26 +6578,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3019, col: 1, offset: 94646},
+			pos:  position{line: 3021, col: 1, offset: 94739},
 			expr: &actionExpr{
-				pos: position{line: 3019, col: 15, offset: 94660},
+				pos: position{line: 3021, col: 15, offset: 94753},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3019, col: 15, offset: 94660},
+					pos: position{line: 3021, col: 15, offset: 94753},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3019, col: 15, offset: 94660},
+							pos:  position{line: 3021, col: 15, offset: 94753},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3019, col: 20, offset: 94665},
+							pos:  position{line: 3021, col: 20, offset: 94758},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3019, col: 30, offset: 94675},
+							pos:   position{line: 3021, col: 30, offset: 94768},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3019, col: 40, offset: 94685},
+								pos:  position{line: 3021, col: 40, offset: 94778},
 								name: "BoolExpr",
 							},
 						},
@@ -6607,15 +6607,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3032, col: 1, offset: 95028},
+			pos:  position{line: 3034, col: 1, offset: 95121},
 			expr: &actionExpr{
-				pos: position{line: 3032, col: 13, offset: 95040},
+				pos: position{line: 3034, col: 13, offset: 95133},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3032, col: 13, offset: 95040},
+					pos:   position{line: 3034, col: 13, offset: 95133},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3032, col: 18, offset: 95045},
+						pos:  position{line: 3034, col: 18, offset: 95138},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6623,35 +6623,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3037, col: 1, offset: 95115},
+			pos:  position{line: 3039, col: 1, offset: 95208},
 			expr: &actionExpr{
-				pos: position{line: 3037, col: 19, offset: 95133},
+				pos: position{line: 3039, col: 19, offset: 95226},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3037, col: 19, offset: 95133},
+					pos: position{line: 3039, col: 19, offset: 95226},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3037, col: 19, offset: 95133},
+							pos:   position{line: 3039, col: 19, offset: 95226},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3037, col: 25, offset: 95139},
+								pos:  position{line: 3039, col: 25, offset: 95232},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3037, col: 40, offset: 95154},
+							pos:   position{line: 3039, col: 40, offset: 95247},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3037, col: 45, offset: 95159},
+								pos: position{line: 3039, col: 45, offset: 95252},
 								expr: &seqExpr{
-									pos: position{line: 3037, col: 46, offset: 95160},
+									pos: position{line: 3039, col: 46, offset: 95253},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3037, col: 46, offset: 95160},
+											pos:  position{line: 3039, col: 46, offset: 95253},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3037, col: 49, offset: 95163},
+											pos:  position{line: 3039, col: 49, offset: 95256},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6664,35 +6664,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3057, col: 1, offset: 95601},
+			pos:  position{line: 3059, col: 1, offset: 95694},
 			expr: &actionExpr{
-				pos: position{line: 3057, col: 19, offset: 95619},
+				pos: position{line: 3059, col: 19, offset: 95712},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3057, col: 19, offset: 95619},
+					pos: position{line: 3059, col: 19, offset: 95712},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3057, col: 19, offset: 95619},
+							pos:   position{line: 3059, col: 19, offset: 95712},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3057, col: 25, offset: 95625},
+								pos:  position{line: 3059, col: 25, offset: 95718},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3057, col: 40, offset: 95640},
+							pos:   position{line: 3059, col: 40, offset: 95733},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3057, col: 45, offset: 95645},
+								pos: position{line: 3059, col: 45, offset: 95738},
 								expr: &seqExpr{
-									pos: position{line: 3057, col: 46, offset: 95646},
+									pos: position{line: 3059, col: 46, offset: 95739},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3057, col: 46, offset: 95646},
+											pos:  position{line: 3059, col: 46, offset: 95739},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3057, col: 50, offset: 95650},
+											pos:  position{line: 3059, col: 50, offset: 95743},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6705,47 +6705,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3077, col: 1, offset: 96089},
+			pos:  position{line: 3079, col: 1, offset: 96182},
 			expr: &choiceExpr{
-				pos: position{line: 3077, col: 19, offset: 96107},
+				pos: position{line: 3079, col: 19, offset: 96200},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3077, col: 19, offset: 96107},
+						pos: position{line: 3079, col: 19, offset: 96200},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3077, col: 19, offset: 96107},
+							pos: position{line: 3079, col: 19, offset: 96200},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 19, offset: 96107},
+									pos:  position{line: 3079, col: 19, offset: 96200},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 23, offset: 96111},
+									pos:  position{line: 3079, col: 23, offset: 96204},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3077, col: 31, offset: 96119},
+									pos:   position{line: 3079, col: 31, offset: 96212},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3077, col: 37, offset: 96125},
+										pos:  position{line: 3079, col: 37, offset: 96218},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3077, col: 52, offset: 96140},
+									pos:  position{line: 3079, col: 52, offset: 96233},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3087, col: 3, offset: 96343},
+						pos: position{line: 3089, col: 3, offset: 96436},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3087, col: 3, offset: 96343},
+							pos:   position{line: 3089, col: 3, offset: 96436},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3087, col: 9, offset: 96349},
+								pos:  position{line: 3089, col: 9, offset: 96442},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6755,50 +6755,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3092, col: 1, offset: 96420},
+			pos:  position{line: 3094, col: 1, offset: 96513},
 			expr: &choiceExpr{
-				pos: position{line: 3092, col: 19, offset: 96438},
+				pos: position{line: 3094, col: 19, offset: 96531},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3092, col: 19, offset: 96438},
+						pos: position{line: 3094, col: 19, offset: 96531},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3092, col: 19, offset: 96438},
+							pos: position{line: 3094, col: 19, offset: 96531},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3092, col: 19, offset: 96438},
+									pos:  position{line: 3094, col: 19, offset: 96531},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3092, col: 27, offset: 96446},
+									pos:   position{line: 3094, col: 27, offset: 96539},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3092, col: 33, offset: 96452},
+										pos:  position{line: 3094, col: 33, offset: 96545},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3092, col: 48, offset: 96467},
+									pos:  position{line: 3094, col: 48, offset: 96560},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3095, col: 3, offset: 96503},
+						pos: position{line: 3097, col: 3, offset: 96596},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3095, col: 3, offset: 96503},
+							pos:   position{line: 3097, col: 3, offset: 96596},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3095, col: 10, offset: 96510},
+								pos: position{line: 3097, col: 10, offset: 96603},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3095, col: 10, offset: 96510},
+										pos:  position{line: 3097, col: 10, offset: 96603},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3095, col: 31, offset: 96531},
+										pos:  position{line: 3097, col: 31, offset: 96624},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6810,60 +6810,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3100, col: 1, offset: 96651},
+			pos:  position{line: 3102, col: 1, offset: 96744},
 			expr: &choiceExpr{
-				pos: position{line: 3100, col: 23, offset: 96673},
+				pos: position{line: 3102, col: 23, offset: 96766},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3100, col: 23, offset: 96673},
+						pos: position{line: 3102, col: 23, offset: 96766},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3100, col: 24, offset: 96674},
+							pos: position{line: 3102, col: 24, offset: 96767},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3100, col: 24, offset: 96674},
+									pos:   position{line: 3102, col: 24, offset: 96767},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3100, col: 28, offset: 96678},
+										pos: position{line: 3102, col: 28, offset: 96771},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3100, col: 28, offset: 96678},
+												pos:        position{line: 3102, col: 28, offset: 96771},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 39, offset: 96689},
+												pos:        position{line: 3102, col: 39, offset: 96782},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 49, offset: 96699},
+												pos:        position{line: 3102, col: 49, offset: 96792},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 59, offset: 96709},
+												pos:        position{line: 3102, col: 59, offset: 96802},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 70, offset: 96720},
+												pos:        position{line: 3102, col: 70, offset: 96813},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 84, offset: 96734},
+												pos:        position{line: 3102, col: 84, offset: 96827},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3100, col: 94, offset: 96744},
+												pos:        position{line: 3102, col: 94, offset: 96837},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6872,56 +6872,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3100, col: 109, offset: 96759},
+									pos:  position{line: 3102, col: 109, offset: 96852},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3100, col: 117, offset: 96767},
+									pos:   position{line: 3102, col: 117, offset: 96860},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3100, col: 123, offset: 96773},
+										pos:  position{line: 3102, col: 123, offset: 96866},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3100, col: 133, offset: 96783},
+									pos:  position{line: 3102, col: 133, offset: 96876},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3130, col: 3, offset: 97654},
+						pos: position{line: 3132, col: 3, offset: 97747},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3130, col: 3, offset: 97654},
+							pos: position{line: 3132, col: 3, offset: 97747},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3130, col: 3, offset: 97654},
+									pos:   position{line: 3132, col: 3, offset: 97747},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3130, col: 11, offset: 97662},
+										pos: position{line: 3132, col: 11, offset: 97755},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3130, col: 11, offset: 97662},
+												pos:        position{line: 3132, col: 11, offset: 97755},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3130, col: 20, offset: 97671},
+												pos:        position{line: 3132, col: 20, offset: 97764},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3130, col: 29, offset: 97680},
+												pos:        position{line: 3132, col: 29, offset: 97773},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3130, col: 39, offset: 97690},
+												pos:        position{line: 3132, col: 39, offset: 97783},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6930,86 +6930,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 52, offset: 97703},
+									pos:  position{line: 3132, col: 52, offset: 97796},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3130, col: 60, offset: 97711},
+									pos:   position{line: 3132, col: 60, offset: 97804},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3130, col: 70, offset: 97721},
+										pos:  position{line: 3132, col: 70, offset: 97814},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 80, offset: 97731},
+									pos:  position{line: 3132, col: 80, offset: 97824},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3130, col: 86, offset: 97737},
+									pos:   position{line: 3132, col: 86, offset: 97830},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3130, col: 97, offset: 97748},
+										pos:  position{line: 3132, col: 97, offset: 97841},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3130, col: 107, offset: 97758},
+									pos:  position{line: 3132, col: 107, offset: 97851},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3143, col: 3, offset: 98128},
+						pos: position{line: 3145, col: 3, offset: 98221},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3143, col: 3, offset: 98128},
+							pos: position{line: 3145, col: 3, offset: 98221},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3143, col: 3, offset: 98128},
+									pos:   position{line: 3145, col: 3, offset: 98221},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3143, col: 8, offset: 98133},
+										pos:  position{line: 3145, col: 8, offset: 98226},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3143, col: 18, offset: 98143},
+									pos:  position{line: 3145, col: 18, offset: 98236},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3143, col: 24, offset: 98149},
+									pos:        position{line: 3145, col: 24, offset: 98242},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3143, col: 29, offset: 98154},
+									pos:  position{line: 3145, col: 29, offset: 98247},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3143, col: 37, offset: 98162},
+									pos:   position{line: 3145, col: 37, offset: 98255},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3143, col: 50, offset: 98175},
+										pos:  position{line: 3145, col: 50, offset: 98268},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3143, col: 60, offset: 98185},
+									pos:   position{line: 3145, col: 60, offset: 98278},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3143, col: 65, offset: 98190},
+										pos: position{line: 3145, col: 65, offset: 98283},
 										expr: &seqExpr{
-											pos: position{line: 3143, col: 66, offset: 98191},
+											pos: position{line: 3145, col: 66, offset: 98284},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3143, col: 66, offset: 98191},
+													pos:  position{line: 3145, col: 66, offset: 98284},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3143, col: 72, offset: 98197},
+													pos:  position{line: 3145, col: 72, offset: 98290},
 													name: "ValueExpr",
 												},
 											},
@@ -7017,50 +7017,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3143, col: 84, offset: 98209},
+									pos:  position{line: 3145, col: 84, offset: 98302},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3162, col: 3, offset: 98760},
+						pos: position{line: 3164, col: 3, offset: 98853},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3162, col: 3, offset: 98760},
+							pos: position{line: 3164, col: 3, offset: 98853},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3162, col: 3, offset: 98760},
+									pos:        position{line: 3164, col: 3, offset: 98853},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 8, offset: 98765},
+									pos:  position{line: 3164, col: 8, offset: 98858},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3162, col: 16, offset: 98773},
+									pos:   position{line: 3164, col: 16, offset: 98866},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3162, col: 29, offset: 98786},
+										pos:  position{line: 3164, col: 29, offset: 98879},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3162, col: 39, offset: 98796},
+									pos:   position{line: 3164, col: 39, offset: 98889},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3162, col: 44, offset: 98801},
+										pos: position{line: 3164, col: 44, offset: 98894},
 										expr: &seqExpr{
-											pos: position{line: 3162, col: 45, offset: 98802},
+											pos: position{line: 3164, col: 45, offset: 98895},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3162, col: 45, offset: 98802},
+													pos:  position{line: 3164, col: 45, offset: 98895},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3162, col: 51, offset: 98808},
+													pos:  position{line: 3164, col: 51, offset: 98901},
 													name: "ValueExpr",
 												},
 											},
@@ -7068,7 +7068,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 63, offset: 98820},
+									pos:  position{line: 3164, col: 63, offset: 98913},
 									name: "R_PAREN",
 								},
 							},
@@ -7079,34 +7079,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3180, col: 1, offset: 99241},
+			pos:  position{line: 3182, col: 1, offset: 99334},
 			expr: &actionExpr{
-				pos: position{line: 3180, col: 23, offset: 99263},
+				pos: position{line: 3182, col: 23, offset: 99356},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3180, col: 23, offset: 99263},
+					pos: position{line: 3182, col: 23, offset: 99356},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3180, col: 23, offset: 99263},
+							pos:   position{line: 3182, col: 23, offset: 99356},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3180, col: 28, offset: 99268},
+								pos:  position{line: 3182, col: 28, offset: 99361},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3180, col: 38, offset: 99278},
+							pos:   position{line: 3182, col: 38, offset: 99371},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3180, col: 41, offset: 99281},
+								pos:  position{line: 3182, col: 41, offset: 99374},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3180, col: 62, offset: 99302},
+							pos:   position{line: 3182, col: 62, offset: 99395},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3180, col: 68, offset: 99308},
+								pos:  position{line: 3182, col: 68, offset: 99401},
 								name: "ValueExpr",
 							},
 						},
@@ -7116,129 +7116,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3198, col: 1, offset: 99902},
+			pos:  position{line: 3200, col: 1, offset: 99995},
 			expr: &choiceExpr{
-				pos: position{line: 3198, col: 14, offset: 99915},
+				pos: position{line: 3200, col: 14, offset: 100008},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3198, col: 14, offset: 99915},
+						pos: position{line: 3200, col: 14, offset: 100008},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3198, col: 14, offset: 99915},
+							pos:   position{line: 3200, col: 14, offset: 100008},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3198, col: 24, offset: 99925},
+								pos:  position{line: 3200, col: 24, offset: 100018},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3207, col: 3, offset: 100115},
+						pos: position{line: 3209, col: 3, offset: 100208},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3207, col: 3, offset: 100115},
+							pos: position{line: 3209, col: 3, offset: 100208},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3207, col: 3, offset: 100115},
+									pos:  position{line: 3209, col: 3, offset: 100208},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3207, col: 12, offset: 100124},
+									pos:   position{line: 3209, col: 12, offset: 100217},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3207, col: 22, offset: 100134},
+										pos:  position{line: 3209, col: 22, offset: 100227},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3207, col: 37, offset: 100149},
+									pos:  position{line: 3209, col: 37, offset: 100242},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3216, col: 3, offset: 100333},
+						pos: position{line: 3218, col: 3, offset: 100426},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3216, col: 3, offset: 100333},
+							pos:   position{line: 3218, col: 3, offset: 100426},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3216, col: 11, offset: 100341},
+								pos:  position{line: 3218, col: 11, offset: 100434},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3225, col: 3, offset: 100521},
+						pos: position{line: 3227, col: 3, offset: 100614},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3225, col: 3, offset: 100521},
+							pos:   position{line: 3227, col: 3, offset: 100614},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3225, col: 7, offset: 100525},
+								pos:  position{line: 3227, col: 7, offset: 100618},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3234, col: 3, offset: 100697},
+						pos: position{line: 3236, col: 3, offset: 100790},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3234, col: 3, offset: 100697},
+							pos: position{line: 3236, col: 3, offset: 100790},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3234, col: 3, offset: 100697},
+									pos:  position{line: 3236, col: 3, offset: 100790},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3234, col: 12, offset: 100706},
+									pos:   position{line: 3236, col: 12, offset: 100799},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3234, col: 16, offset: 100710},
+										pos:  position{line: 3236, col: 16, offset: 100803},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3234, col: 28, offset: 100722},
+									pos:  position{line: 3236, col: 28, offset: 100815},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3243, col: 3, offset: 100891},
+						pos: position{line: 3245, col: 3, offset: 100984},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3243, col: 3, offset: 100891},
+							pos: position{line: 3245, col: 3, offset: 100984},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 3, offset: 100891},
+									pos:  position{line: 3245, col: 3, offset: 100984},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3243, col: 11, offset: 100899},
+									pos:   position{line: 3245, col: 11, offset: 100992},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3243, col: 19, offset: 100907},
+										pos:  position{line: 3245, col: 19, offset: 101000},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3243, col: 28, offset: 100916},
+									pos:  position{line: 3245, col: 28, offset: 101009},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3252, col: 3, offset: 101088},
+						pos: position{line: 3254, col: 3, offset: 101181},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3252, col: 3, offset: 101088},
+							pos:   position{line: 3254, col: 3, offset: 101181},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3252, col: 18, offset: 101103},
+								pos:  position{line: 3254, col: 18, offset: 101196},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7248,28 +7248,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3262, col: 1, offset: 101300},
+			pos:  position{line: 3264, col: 1, offset: 101393},
 			expr: &choiceExpr{
-				pos: position{line: 3262, col: 15, offset: 101314},
+				pos: position{line: 3264, col: 15, offset: 101407},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3262, col: 15, offset: 101314},
+						pos: position{line: 3264, col: 15, offset: 101407},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3262, col: 15, offset: 101314},
+							pos: position{line: 3264, col: 15, offset: 101407},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3262, col: 15, offset: 101314},
+									pos:   position{line: 3264, col: 15, offset: 101407},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3262, col: 20, offset: 101319},
+										pos:  position{line: 3264, col: 20, offset: 101412},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3262, col: 29, offset: 101328},
+									pos: position{line: 3264, col: 29, offset: 101421},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3262, col: 31, offset: 101330},
+										pos:  position{line: 3264, col: 31, offset: 101423},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7277,23 +7277,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3270, col: 3, offset: 101500},
+						pos: position{line: 3272, col: 3, offset: 101593},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3270, col: 3, offset: 101500},
+							pos: position{line: 3272, col: 3, offset: 101593},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3270, col: 3, offset: 101500},
+									pos:   position{line: 3272, col: 3, offset: 101593},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3270, col: 7, offset: 101504},
+										pos:  position{line: 3272, col: 7, offset: 101597},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3270, col: 20, offset: 101517},
+									pos: position{line: 3272, col: 20, offset: 101610},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3270, col: 22, offset: 101519},
+										pos:  position{line: 3272, col: 22, offset: 101612},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7301,50 +7301,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3278, col: 3, offset: 101684},
+						pos: position{line: 3280, col: 3, offset: 101777},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3278, col: 3, offset: 101684},
+							pos: position{line: 3280, col: 3, offset: 101777},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3278, col: 3, offset: 101684},
+									pos:   position{line: 3280, col: 3, offset: 101777},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3278, col: 9, offset: 101690},
+										pos:  position{line: 3280, col: 9, offset: 101783},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3278, col: 25, offset: 101706},
+									pos: position{line: 3280, col: 25, offset: 101799},
 									expr: &choiceExpr{
-										pos: position{line: 3278, col: 27, offset: 101708},
+										pos: position{line: 3280, col: 27, offset: 101801},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 27, offset: 101708},
+												pos:  position{line: 3280, col: 27, offset: 101801},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 36, offset: 101717},
+												pos:  position{line: 3280, col: 36, offset: 101810},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 46, offset: 101727},
+												pos:  position{line: 3280, col: 46, offset: 101820},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 54, offset: 101735},
+												pos:  position{line: 3280, col: 54, offset: 101828},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 62, offset: 101743},
+												pos:  position{line: 3280, col: 62, offset: 101836},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3278, col: 70, offset: 101751},
+												pos:  position{line: 3280, col: 70, offset: 101844},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3278, col: 84, offset: 101765},
+												pos:        position{line: 3280, col: 84, offset: 101858},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7356,13 +7356,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3286, col: 3, offset: 101915},
+						pos: position{line: 3288, col: 3, offset: 102008},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3286, col: 3, offset: 101915},
+							pos:   position{line: 3288, col: 3, offset: 102008},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3286, col: 10, offset: 101922},
+								pos:  position{line: 3288, col: 10, offset: 102015},
 								name: "ConcatExpr",
 							},
 						},
@@ -7372,35 +7372,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3296, col: 1, offset: 102128},
+			pos:  position{line: 3298, col: 1, offset: 102221},
 			expr: &actionExpr{
-				pos: position{line: 3296, col: 15, offset: 102142},
+				pos: position{line: 3298, col: 15, offset: 102235},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3296, col: 15, offset: 102142},
+					pos: position{line: 3298, col: 15, offset: 102235},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3296, col: 15, offset: 102142},
+							pos:   position{line: 3298, col: 15, offset: 102235},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3296, col: 21, offset: 102148},
+								pos:  position{line: 3298, col: 21, offset: 102241},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3296, col: 32, offset: 102159},
+							pos:   position{line: 3298, col: 32, offset: 102252},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3296, col: 37, offset: 102164},
+								pos: position{line: 3298, col: 37, offset: 102257},
 								expr: &seqExpr{
-									pos: position{line: 3296, col: 38, offset: 102165},
+									pos: position{line: 3298, col: 38, offset: 102258},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3296, col: 38, offset: 102165},
+											pos:  position{line: 3298, col: 38, offset: 102258},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3296, col: 50, offset: 102177},
+											pos:  position{line: 3298, col: 50, offset: 102270},
 											name: "ConcatAtom",
 										},
 									},
@@ -7408,28 +7408,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3296, col: 63, offset: 102190},
+							pos: position{line: 3298, col: 63, offset: 102283},
 							expr: &choiceExpr{
-								pos: position{line: 3296, col: 65, offset: 102192},
+								pos: position{line: 3298, col: 65, offset: 102285},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3296, col: 65, offset: 102192},
+										pos:  position{line: 3298, col: 65, offset: 102285},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3296, col: 74, offset: 102201},
+										pos:  position{line: 3298, col: 74, offset: 102294},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3296, col: 84, offset: 102211},
+										pos:  position{line: 3298, col: 84, offset: 102304},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3296, col: 92, offset: 102219},
+										pos:  position{line: 3298, col: 92, offset: 102312},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3296, col: 100, offset: 102227},
+										pos:        position{line: 3298, col: 100, offset: 102320},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7443,54 +7443,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3314, col: 1, offset: 102633},
+			pos:  position{line: 3316, col: 1, offset: 102726},
 			expr: &choiceExpr{
-				pos: position{line: 3314, col: 15, offset: 102647},
+				pos: position{line: 3316, col: 15, offset: 102740},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3314, col: 15, offset: 102647},
+						pos: position{line: 3316, col: 15, offset: 102740},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3314, col: 15, offset: 102647},
+							pos:   position{line: 3316, col: 15, offset: 102740},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3314, col: 20, offset: 102652},
+								pos:  position{line: 3316, col: 20, offset: 102745},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3323, col: 3, offset: 102816},
+						pos: position{line: 3325, col: 3, offset: 102909},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3323, col: 3, offset: 102816},
+							pos:   position{line: 3325, col: 3, offset: 102909},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3323, col: 7, offset: 102820},
+								pos:  position{line: 3325, col: 7, offset: 102913},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3331, col: 3, offset: 102959},
+						pos: position{line: 3333, col: 3, offset: 103052},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3331, col: 3, offset: 102959},
+							pos:   position{line: 3333, col: 3, offset: 103052},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3331, col: 10, offset: 102966},
+								pos:  position{line: 3333, col: 10, offset: 103059},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3339, col: 3, offset: 103105},
+						pos: position{line: 3341, col: 3, offset: 103198},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3339, col: 3, offset: 103105},
+							pos:   position{line: 3341, col: 3, offset: 103198},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3339, col: 9, offset: 103111},
+								pos:  position{line: 3341, col: 9, offset: 103204},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7500,32 +7500,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3349, col: 1, offset: 103280},
+			pos:  position{line: 3351, col: 1, offset: 103373},
 			expr: &actionExpr{
-				pos: position{line: 3349, col: 16, offset: 103295},
+				pos: position{line: 3351, col: 16, offset: 103388},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3349, col: 16, offset: 103295},
+					pos: position{line: 3351, col: 16, offset: 103388},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3349, col: 16, offset: 103295},
+							pos:   position{line: 3351, col: 16, offset: 103388},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3349, col: 21, offset: 103300},
+								pos:  position{line: 3351, col: 21, offset: 103393},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3349, col: 39, offset: 103318},
+							pos: position{line: 3351, col: 39, offset: 103411},
 							expr: &choiceExpr{
-								pos: position{line: 3349, col: 41, offset: 103320},
+								pos: position{line: 3351, col: 41, offset: 103413},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3349, col: 41, offset: 103320},
+										pos:  position{line: 3351, col: 41, offset: 103413},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3349, col: 55, offset: 103334},
+										pos:        position{line: 3351, col: 55, offset: 103427},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7539,44 +7539,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3354, col: 1, offset: 103399},
+			pos:  position{line: 3356, col: 1, offset: 103492},
 			expr: &actionExpr{
-				pos: position{line: 3354, col: 22, offset: 103420},
+				pos: position{line: 3356, col: 22, offset: 103513},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3354, col: 22, offset: 103420},
+					pos: position{line: 3356, col: 22, offset: 103513},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3354, col: 22, offset: 103420},
+							pos:   position{line: 3356, col: 22, offset: 103513},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3354, col: 28, offset: 103426},
+								pos:  position{line: 3356, col: 28, offset: 103519},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3354, col: 46, offset: 103444},
+							pos:   position{line: 3356, col: 46, offset: 103537},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3354, col: 51, offset: 103449},
+								pos: position{line: 3356, col: 51, offset: 103542},
 								expr: &seqExpr{
-									pos: position{line: 3354, col: 52, offset: 103450},
+									pos: position{line: 3356, col: 52, offset: 103543},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3354, col: 53, offset: 103451},
+											pos: position{line: 3356, col: 53, offset: 103544},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3354, col: 53, offset: 103451},
+													pos:  position{line: 3356, col: 53, offset: 103544},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3354, col: 62, offset: 103460},
+													pos:  position{line: 3356, col: 62, offset: 103553},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3354, col: 71, offset: 103469},
+											pos:  position{line: 3356, col: 71, offset: 103562},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7589,48 +7589,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3375, col: 1, offset: 103970},
+			pos:  position{line: 3377, col: 1, offset: 104063},
 			expr: &actionExpr{
-				pos: position{line: 3375, col: 22, offset: 103991},
+				pos: position{line: 3377, col: 22, offset: 104084},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3375, col: 22, offset: 103991},
+					pos: position{line: 3377, col: 22, offset: 104084},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3375, col: 22, offset: 103991},
+							pos:   position{line: 3377, col: 22, offset: 104084},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3375, col: 28, offset: 103997},
+								pos:  position{line: 3377, col: 28, offset: 104090},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3375, col: 46, offset: 104015},
+							pos:   position{line: 3377, col: 46, offset: 104108},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3375, col: 51, offset: 104020},
+								pos: position{line: 3377, col: 51, offset: 104113},
 								expr: &seqExpr{
-									pos: position{line: 3375, col: 52, offset: 104021},
+									pos: position{line: 3377, col: 52, offset: 104114},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3375, col: 53, offset: 104022},
+											pos: position{line: 3377, col: 53, offset: 104115},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3375, col: 53, offset: 104022},
+													pos:  position{line: 3377, col: 53, offset: 104115},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3375, col: 61, offset: 104030},
+													pos:  position{line: 3377, col: 61, offset: 104123},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3375, col: 69, offset: 104038},
+													pos:  position{line: 3377, col: 69, offset: 104131},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3375, col: 76, offset: 104045},
+											pos:  position{line: 3377, col: 76, offset: 104138},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7643,22 +7643,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3395, col: 1, offset: 104514},
+			pos:  position{line: 3397, col: 1, offset: 104607},
 			expr: &actionExpr{
-				pos: position{line: 3395, col: 21, offset: 104534},
+				pos: position{line: 3397, col: 21, offset: 104627},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3395, col: 21, offset: 104534},
+					pos: position{line: 3397, col: 21, offset: 104627},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3395, col: 21, offset: 104534},
+							pos:  position{line: 3397, col: 21, offset: 104627},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3395, col: 27, offset: 104540},
+							pos:   position{line: 3397, col: 27, offset: 104633},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3395, col: 32, offset: 104545},
+								pos:  position{line: 3397, col: 32, offset: 104638},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7668,67 +7668,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3405, col: 1, offset: 104789},
+			pos:  position{line: 3407, col: 1, offset: 104882},
 			expr: &choiceExpr{
-				pos: position{line: 3405, col: 22, offset: 104810},
+				pos: position{line: 3407, col: 22, offset: 104903},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3405, col: 22, offset: 104810},
+						pos: position{line: 3407, col: 22, offset: 104903},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3405, col: 22, offset: 104810},
+							pos: position{line: 3407, col: 22, offset: 104903},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3405, col: 22, offset: 104810},
+									pos:  position{line: 3407, col: 22, offset: 104903},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3405, col: 30, offset: 104818},
+									pos:   position{line: 3407, col: 30, offset: 104911},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3405, col: 35, offset: 104823},
+										pos:  position{line: 3407, col: 35, offset: 104916},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3405, col: 53, offset: 104841},
+									pos:  position{line: 3407, col: 53, offset: 104934},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3408, col: 3, offset: 104876},
+						pos: position{line: 3410, col: 3, offset: 104969},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3408, col: 3, offset: 104876},
+							pos:   position{line: 3410, col: 3, offset: 104969},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3408, col: 20, offset: 104893},
+								pos:  position{line: 3410, col: 20, offset: 104986},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3411, col: 3, offset: 104947},
+						pos: position{line: 3413, col: 3, offset: 105040},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3411, col: 3, offset: 104947},
+							pos:   position{line: 3413, col: 3, offset: 105040},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3411, col: 9, offset: 104953},
+								pos:  position{line: 3413, col: 9, offset: 105046},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3421, col: 3, offset: 105172},
+						pos: position{line: 3423, col: 3, offset: 105265},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3421, col: 3, offset: 105172},
+							pos:   position{line: 3423, col: 3, offset: 105265},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3421, col: 10, offset: 105179},
+								pos:  position{line: 3423, col: 10, offset: 105272},
 								name: "NumberAsString",
 							},
 						},
@@ -7738,144 +7738,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3434, col: 1, offset: 105557},
+			pos:  position{line: 3436, col: 1, offset: 105650},
 			expr: &choiceExpr{
-				pos: position{line: 3434, col: 20, offset: 105576},
+				pos: position{line: 3436, col: 20, offset: 105669},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3434, col: 20, offset: 105576},
+						pos: position{line: 3436, col: 20, offset: 105669},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3434, col: 21, offset: 105577},
+							pos: position{line: 3436, col: 21, offset: 105670},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3434, col: 21, offset: 105577},
+									pos:   position{line: 3436, col: 21, offset: 105670},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3434, col: 29, offset: 105585},
+										pos: position{line: 3436, col: 29, offset: 105678},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3434, col: 29, offset: 105585},
+												pos:        position{line: 3436, col: 29, offset: 105678},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 37, offset: 105593},
+												pos:        position{line: 3436, col: 37, offset: 105686},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 46, offset: 105602},
+												pos:        position{line: 3436, col: 46, offset: 105695},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 58, offset: 105614},
+												pos:        position{line: 3436, col: 58, offset: 105707},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 67, offset: 105623},
+												pos:        position{line: 3436, col: 67, offset: 105716},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 77, offset: 105633},
+												pos:        position{line: 3436, col: 77, offset: 105726},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 85, offset: 105641},
+												pos:        position{line: 3436, col: 85, offset: 105734},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 95, offset: 105651},
+												pos:        position{line: 3436, col: 95, offset: 105744},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 102, offset: 105658},
+												pos:        position{line: 3436, col: 102, offset: 105751},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 113, offset: 105669},
+												pos:        position{line: 3436, col: 113, offset: 105762},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 123, offset: 105679},
+												pos:        position{line: 3436, col: 123, offset: 105772},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 132, offset: 105688},
+												pos:        position{line: 3436, col: 132, offset: 105781},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 142, offset: 105698},
+												pos:        position{line: 3436, col: 142, offset: 105791},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 151, offset: 105707},
+												pos:        position{line: 3436, col: 151, offset: 105800},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 161, offset: 105717},
+												pos:        position{line: 3436, col: 161, offset: 105810},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 170, offset: 105726},
+												pos:        position{line: 3436, col: 170, offset: 105819},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 179, offset: 105735},
+												pos:        position{line: 3436, col: 179, offset: 105828},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 187, offset: 105743},
+												pos:        position{line: 3436, col: 187, offset: 105836},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 196, offset: 105752},
+												pos:        position{line: 3436, col: 196, offset: 105845},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 204, offset: 105760},
+												pos:        position{line: 3436, col: 204, offset: 105853},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3434, col: 213, offset: 105769},
+												pos:        position{line: 3436, col: 213, offset: 105862},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7884,102 +7884,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3434, col: 220, offset: 105776},
+									pos:  position{line: 3436, col: 220, offset: 105869},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3434, col: 228, offset: 105784},
+									pos:   position{line: 3436, col: 228, offset: 105877},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3434, col: 234, offset: 105790},
+										pos:  position{line: 3436, col: 234, offset: 105883},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3434, col: 253, offset: 105809},
+									pos:  position{line: 3436, col: 253, offset: 105902},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3454, col: 3, offset: 106321},
+						pos: position{line: 3456, col: 3, offset: 106414},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3454, col: 3, offset: 106321},
+							pos: position{line: 3456, col: 3, offset: 106414},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3454, col: 3, offset: 106321},
+									pos:   position{line: 3456, col: 3, offset: 106414},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3454, col: 13, offset: 106331},
+										pos:        position{line: 3456, col: 13, offset: 106424},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3454, col: 21, offset: 106339},
+									pos:  position{line: 3456, col: 21, offset: 106432},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3454, col: 29, offset: 106347},
+									pos:   position{line: 3456, col: 29, offset: 106440},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3454, col: 35, offset: 106353},
+										pos:  position{line: 3456, col: 35, offset: 106446},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3454, col: 54, offset: 106372},
+									pos:   position{line: 3456, col: 54, offset: 106465},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3454, col: 69, offset: 106387},
+										pos: position{line: 3456, col: 69, offset: 106480},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3454, col: 70, offset: 106388},
+											pos:  position{line: 3456, col: 70, offset: 106481},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3454, col: 89, offset: 106407},
+									pos:  position{line: 3456, col: 89, offset: 106500},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3475, col: 3, offset: 107025},
+						pos: position{line: 3477, col: 3, offset: 107118},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3475, col: 4, offset: 107026},
+							pos: position{line: 3477, col: 4, offset: 107119},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3475, col: 4, offset: 107026},
+									pos:   position{line: 3477, col: 4, offset: 107119},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3475, col: 12, offset: 107034},
+										pos: position{line: 3477, col: 12, offset: 107127},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3475, col: 12, offset: 107034},
+												pos:        position{line: 3477, col: 12, offset: 107127},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3475, col: 20, offset: 107042},
+												pos:        position{line: 3477, col: 20, offset: 107135},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3475, col: 27, offset: 107049},
+												pos:        position{line: 3477, col: 27, offset: 107142},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3475, col: 38, offset: 107060},
+												pos:        position{line: 3477, col: 38, offset: 107153},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7988,54 +7988,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 46, offset: 107068},
+									pos:  position{line: 3477, col: 46, offset: 107161},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 54, offset: 107076},
+									pos:  position{line: 3477, col: 54, offset: 107169},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3488, col: 3, offset: 107362},
+						pos: position{line: 3490, col: 3, offset: 107455},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3488, col: 3, offset: 107362},
+							pos: position{line: 3490, col: 3, offset: 107455},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3488, col: 3, offset: 107362},
+									pos:        position{line: 3490, col: 3, offset: 107455},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3488, col: 14, offset: 107373},
+									pos:  position{line: 3490, col: 14, offset: 107466},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3488, col: 22, offset: 107381},
+									pos:   position{line: 3490, col: 22, offset: 107474},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3488, col: 33, offset: 107392},
+										pos:  position{line: 3490, col: 33, offset: 107485},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3488, col: 44, offset: 107403},
+									pos:   position{line: 3490, col: 44, offset: 107496},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3488, col: 53, offset: 107412},
+										pos: position{line: 3490, col: 53, offset: 107505},
 										expr: &seqExpr{
-											pos: position{line: 3488, col: 54, offset: 107413},
+											pos: position{line: 3490, col: 54, offset: 107506},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3488, col: 54, offset: 107413},
+													pos:  position{line: 3490, col: 54, offset: 107506},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3488, col: 60, offset: 107419},
+													pos:  position{line: 3490, col: 60, offset: 107512},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8043,73 +8043,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3488, col: 80, offset: 107439},
+									pos:  position{line: 3490, col: 80, offset: 107532},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3516, col: 3, offset: 108281},
+						pos: position{line: 3518, col: 3, offset: 108374},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3516, col: 3, offset: 108281},
+							pos: position{line: 3518, col: 3, offset: 108374},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3516, col: 3, offset: 108281},
+									pos:   position{line: 3518, col: 3, offset: 108374},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3516, col: 12, offset: 108290},
+										pos:        position{line: 3518, col: 12, offset: 108383},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3516, col: 18, offset: 108296},
+									pos:  position{line: 3518, col: 18, offset: 108389},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3516, col: 26, offset: 108304},
+									pos:   position{line: 3518, col: 26, offset: 108397},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3516, col: 31, offset: 108309},
+										pos:  position{line: 3518, col: 31, offset: 108402},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3516, col: 39, offset: 108317},
+									pos:  position{line: 3518, col: 39, offset: 108410},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3519, col: 3, offset: 108352},
+						pos: position{line: 3521, col: 3, offset: 108445},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3519, col: 4, offset: 108353},
+							pos: position{line: 3521, col: 4, offset: 108446},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3519, col: 4, offset: 108353},
+									pos:   position{line: 3521, col: 4, offset: 108446},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3519, col: 12, offset: 108361},
+										pos: position{line: 3521, col: 12, offset: 108454},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3519, col: 12, offset: 108361},
+												pos:        position{line: 3521, col: 12, offset: 108454},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3519, col: 20, offset: 108369},
+												pos:        position{line: 3521, col: 20, offset: 108462},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3519, col: 30, offset: 108379},
+												pos:        position{line: 3521, col: 30, offset: 108472},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8118,128 +8118,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3519, col: 39, offset: 108388},
+									pos:  position{line: 3521, col: 39, offset: 108481},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3519, col: 47, offset: 108396},
+									pos:   position{line: 3521, col: 47, offset: 108489},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3519, col: 53, offset: 108402},
+										pos:  position{line: 3521, col: 53, offset: 108495},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3519, col: 72, offset: 108421},
+									pos:   position{line: 3521, col: 72, offset: 108514},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3519, col: 79, offset: 108428},
+										pos:  position{line: 3521, col: 79, offset: 108521},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3519, col: 97, offset: 108446},
+									pos:  position{line: 3521, col: 97, offset: 108539},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3549, col: 3, offset: 109285},
+						pos: position{line: 3551, col: 3, offset: 109378},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3549, col: 4, offset: 109286},
+							pos: position{line: 3551, col: 4, offset: 109379},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3549, col: 4, offset: 109286},
+									pos:   position{line: 3551, col: 4, offset: 109379},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3549, col: 11, offset: 109293},
+										pos:        position{line: 3551, col: 11, offset: 109386},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3549, col: 17, offset: 109299},
+									pos:  position{line: 3551, col: 17, offset: 109392},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3549, col: 25, offset: 109307},
+									pos:   position{line: 3551, col: 25, offset: 109400},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3549, col: 31, offset: 109313},
+										pos:  position{line: 3551, col: 31, offset: 109406},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3549, col: 50, offset: 109332},
+									pos:   position{line: 3551, col: 50, offset: 109425},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3549, col: 56, offset: 109338},
+										pos: position{line: 3551, col: 56, offset: 109431},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3549, col: 57, offset: 109339},
+											pos:  position{line: 3551, col: 57, offset: 109432},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3549, col: 76, offset: 109358},
+									pos:  position{line: 3551, col: 76, offset: 109451},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3578, col: 3, offset: 110131},
+						pos: position{line: 3580, col: 3, offset: 110224},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3578, col: 3, offset: 110131},
+							pos: position{line: 3580, col: 3, offset: 110224},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3578, col: 3, offset: 110131},
+									pos:   position{line: 3580, col: 3, offset: 110224},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3578, col: 11, offset: 110139},
+										pos:        position{line: 3580, col: 11, offset: 110232},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3578, col: 28, offset: 110156},
+									pos:  position{line: 3580, col: 28, offset: 110249},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3578, col: 36, offset: 110164},
+									pos:   position{line: 3580, col: 36, offset: 110257},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3578, col: 42, offset: 110170},
+										pos:  position{line: 3580, col: 42, offset: 110263},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3578, col: 61, offset: 110189},
+									pos:  position{line: 3580, col: 61, offset: 110282},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3578, col: 67, offset: 110195},
+									pos:  position{line: 3580, col: 67, offset: 110288},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3578, col: 73, offset: 110201},
+									pos:   position{line: 3580, col: 73, offset: 110294},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3578, col: 84, offset: 110212},
+										pos:  position{line: 3580, col: 84, offset: 110305},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3578, col: 120, offset: 110248},
+									pos:  position{line: 3580, col: 120, offset: 110341},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3578, col: 126, offset: 110254},
+									pos:  position{line: 3580, col: 126, offset: 110347},
 									name: "R_PAREN",
 								},
 							},
@@ -8250,28 +8250,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3595, col: 1, offset: 110783},
+			pos:  position{line: 3597, col: 1, offset: 110876},
 			expr: &choiceExpr{
-				pos: position{line: 3595, col: 12, offset: 110794},
+				pos: position{line: 3597, col: 12, offset: 110887},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3595, col: 12, offset: 110794},
+						pos: position{line: 3597, col: 12, offset: 110887},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3595, col: 12, offset: 110794},
+							pos: position{line: 3597, col: 12, offset: 110887},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3595, col: 12, offset: 110794},
+									pos:   position{line: 3597, col: 12, offset: 110887},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3595, col: 16, offset: 110798},
+										pos:  position{line: 3597, col: 16, offset: 110891},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3595, col: 29, offset: 110811},
+									pos: position{line: 3597, col: 29, offset: 110904},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3595, col: 31, offset: 110813},
+										pos:  position{line: 3597, col: 31, offset: 110906},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8279,50 +8279,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3611, col: 3, offset: 111174},
+						pos: position{line: 3613, col: 3, offset: 111267},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3611, col: 3, offset: 111174},
+							pos: position{line: 3613, col: 3, offset: 111267},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3611, col: 3, offset: 111174},
+									pos:   position{line: 3613, col: 3, offset: 111267},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3611, col: 9, offset: 111180},
+										pos:  position{line: 3613, col: 9, offset: 111273},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3611, col: 25, offset: 111196},
+									pos: position{line: 3613, col: 25, offset: 111289},
 									expr: &choiceExpr{
-										pos: position{line: 3611, col: 27, offset: 111198},
+										pos: position{line: 3613, col: 27, offset: 111291},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 27, offset: 111198},
+												pos:  position{line: 3613, col: 27, offset: 111291},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 36, offset: 111207},
+												pos:  position{line: 3613, col: 36, offset: 111300},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 46, offset: 111217},
+												pos:  position{line: 3613, col: 46, offset: 111310},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 54, offset: 111225},
+												pos:  position{line: 3613, col: 54, offset: 111318},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 62, offset: 111233},
+												pos:  position{line: 3613, col: 62, offset: 111326},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3611, col: 70, offset: 111241},
+												pos:  position{line: 3613, col: 70, offset: 111334},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3611, col: 84, offset: 111255},
+												pos:        position{line: 3613, col: 84, offset: 111348},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8338,28 +8338,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3628, col: 1, offset: 111606},
+			pos:  position{line: 3630, col: 1, offset: 111699},
 			expr: &actionExpr{
-				pos: position{line: 3628, col: 19, offset: 111624},
+				pos: position{line: 3630, col: 19, offset: 111717},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3628, col: 19, offset: 111624},
+					pos: position{line: 3630, col: 19, offset: 111717},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3628, col: 19, offset: 111624},
+							pos:        position{line: 3630, col: 19, offset: 111717},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3628, col: 26, offset: 111631},
+							pos:  position{line: 3630, col: 26, offset: 111724},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3628, col: 32, offset: 111637},
+							pos:   position{line: 3630, col: 32, offset: 111730},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3628, col: 40, offset: 111645},
+								pos:  position{line: 3630, col: 40, offset: 111738},
 								name: "Boolean",
 							},
 						},
@@ -8369,28 +8369,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3639, col: 1, offset: 111834},
+			pos:  position{line: 3641, col: 1, offset: 111927},
 			expr: &actionExpr{
-				pos: position{line: 3639, col: 23, offset: 111856},
+				pos: position{line: 3641, col: 23, offset: 111949},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3639, col: 23, offset: 111856},
+					pos: position{line: 3641, col: 23, offset: 111949},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3639, col: 23, offset: 111856},
+							pos:        position{line: 3641, col: 23, offset: 111949},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3639, col: 34, offset: 111867},
+							pos:  position{line: 3641, col: 34, offset: 111960},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3639, col: 40, offset: 111873},
+							pos:   position{line: 3641, col: 40, offset: 111966},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3639, col: 48, offset: 111881},
+								pos:  position{line: 3641, col: 48, offset: 111974},
 								name: "Boolean",
 							},
 						},
@@ -8400,28 +8400,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3650, col: 1, offset: 112078},
+			pos:  position{line: 3652, col: 1, offset: 112171},
 			expr: &actionExpr{
-				pos: position{line: 3650, col: 20, offset: 112097},
+				pos: position{line: 3652, col: 20, offset: 112190},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3650, col: 20, offset: 112097},
+					pos: position{line: 3652, col: 20, offset: 112190},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3650, col: 20, offset: 112097},
+							pos:        position{line: 3652, col: 20, offset: 112190},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3650, col: 28, offset: 112105},
+							pos:  position{line: 3652, col: 28, offset: 112198},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3650, col: 34, offset: 112111},
+							pos:   position{line: 3652, col: 34, offset: 112204},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3650, col: 43, offset: 112120},
+								pos:  position{line: 3652, col: 43, offset: 112213},
 								name: "IntegerAsString",
 							},
 						},
@@ -8431,15 +8431,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3665, col: 1, offset: 112482},
+			pos:  position{line: 3667, col: 1, offset: 112575},
 			expr: &actionExpr{
-				pos: position{line: 3665, col: 19, offset: 112500},
+				pos: position{line: 3667, col: 19, offset: 112593},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3665, col: 19, offset: 112500},
+					pos:   position{line: 3667, col: 19, offset: 112593},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3665, col: 28, offset: 112509},
+						pos:  position{line: 3667, col: 28, offset: 112602},
 						name: "BoolExpr",
 					},
 				},
@@ -8447,30 +8447,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3676, col: 1, offset: 112721},
+			pos:  position{line: 3678, col: 1, offset: 112814},
 			expr: &actionExpr{
-				pos: position{line: 3676, col: 15, offset: 112735},
+				pos: position{line: 3678, col: 15, offset: 112828},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3676, col: 15, offset: 112735},
+					pos:   position{line: 3678, col: 15, offset: 112828},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3676, col: 23, offset: 112743},
+						pos: position{line: 3678, col: 23, offset: 112836},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3676, col: 23, offset: 112743},
+								pos:  position{line: 3678, col: 23, offset: 112836},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3676, col: 44, offset: 112764},
+								pos:  position{line: 3678, col: 44, offset: 112857},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3676, col: 61, offset: 112781},
+								pos:  position{line: 3678, col: 61, offset: 112874},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3676, col: 79, offset: 112799},
+								pos:  position{line: 3678, col: 79, offset: 112892},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8480,35 +8480,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3680, col: 1, offset: 112843},
+			pos:  position{line: 3682, col: 1, offset: 112936},
 			expr: &actionExpr{
-				pos: position{line: 3680, col: 19, offset: 112861},
+				pos: position{line: 3682, col: 19, offset: 112954},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3680, col: 19, offset: 112861},
+					pos: position{line: 3682, col: 19, offset: 112954},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3680, col: 19, offset: 112861},
+							pos:   position{line: 3682, col: 19, offset: 112954},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3680, col: 26, offset: 112868},
+								pos:  position{line: 3682, col: 26, offset: 112961},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3680, col: 37, offset: 112879},
+							pos:   position{line: 3682, col: 37, offset: 112972},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3680, col: 43, offset: 112885},
+								pos: position{line: 3682, col: 43, offset: 112978},
 								expr: &seqExpr{
-									pos: position{line: 3680, col: 44, offset: 112886},
+									pos: position{line: 3682, col: 44, offset: 112979},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3680, col: 44, offset: 112886},
+											pos:  position{line: 3682, col: 44, offset: 112979},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3680, col: 50, offset: 112892},
+											pos:  position{line: 3682, col: 50, offset: 112985},
 											name: "HeadOption",
 										},
 									},
@@ -8521,29 +8521,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3737, col: 1, offset: 114692},
+			pos:  position{line: 3739, col: 1, offset: 114785},
 			expr: &choiceExpr{
-				pos: position{line: 3737, col: 14, offset: 114705},
+				pos: position{line: 3739, col: 14, offset: 114798},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3737, col: 14, offset: 114705},
+						pos: position{line: 3739, col: 14, offset: 114798},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3737, col: 14, offset: 114705},
+							pos: position{line: 3739, col: 14, offset: 114798},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3737, col: 14, offset: 114705},
+									pos:  position{line: 3739, col: 14, offset: 114798},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3737, col: 19, offset: 114710},
+									pos:  position{line: 3739, col: 19, offset: 114803},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3737, col: 28, offset: 114719},
+									pos:   position{line: 3739, col: 28, offset: 114812},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3737, col: 37, offset: 114728},
+										pos:  position{line: 3739, col: 37, offset: 114821},
 										name: "HeadOptionList",
 									},
 								},
@@ -8551,24 +8551,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3748, col: 3, offset: 115047},
+						pos: position{line: 3750, col: 3, offset: 115140},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3748, col: 3, offset: 115047},
+							pos: position{line: 3750, col: 3, offset: 115140},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 3, offset: 115047},
+									pos:  position{line: 3750, col: 3, offset: 115140},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3748, col: 8, offset: 115052},
+									pos:  position{line: 3750, col: 8, offset: 115145},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3748, col: 17, offset: 115061},
+									pos:   position{line: 3750, col: 17, offset: 115154},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3748, col: 26, offset: 115070},
+										pos:  position{line: 3750, col: 26, offset: 115163},
 										name: "IntegerAsString",
 									},
 								},
@@ -8576,17 +8576,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3768, col: 3, offset: 115587},
+						pos: position{line: 3770, col: 3, offset: 115680},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3768, col: 3, offset: 115587},
+							pos: position{line: 3770, col: 3, offset: 115680},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3768, col: 3, offset: 115587},
+									pos:  position{line: 3770, col: 3, offset: 115680},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3768, col: 8, offset: 115592},
+									pos:  position{line: 3770, col: 8, offset: 115685},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8597,29 +8597,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3786, col: 1, offset: 116062},
+			pos:  position{line: 3788, col: 1, offset: 116155},
 			expr: &choiceExpr{
-				pos: position{line: 3786, col: 14, offset: 116075},
+				pos: position{line: 3788, col: 14, offset: 116168},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3786, col: 14, offset: 116075},
+						pos: position{line: 3788, col: 14, offset: 116168},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3786, col: 14, offset: 116075},
+							pos: position{line: 3788, col: 14, offset: 116168},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3786, col: 14, offset: 116075},
+									pos:  position{line: 3788, col: 14, offset: 116168},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3786, col: 19, offset: 116080},
+									pos:  position{line: 3788, col: 19, offset: 116173},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3786, col: 28, offset: 116089},
+									pos:   position{line: 3788, col: 28, offset: 116182},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3786, col: 37, offset: 116098},
+										pos:  position{line: 3788, col: 37, offset: 116191},
 										name: "IntegerAsString",
 									},
 								},
@@ -8627,17 +8627,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3807, col: 3, offset: 116672},
+						pos: position{line: 3809, col: 3, offset: 116765},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3807, col: 3, offset: 116672},
+							pos: position{line: 3809, col: 3, offset: 116765},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3807, col: 3, offset: 116672},
+									pos:  position{line: 3809, col: 3, offset: 116765},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3807, col: 8, offset: 116677},
+									pos:  position{line: 3809, col: 8, offset: 116770},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8648,44 +8648,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3828, col: 1, offset: 117295},
+			pos:  position{line: 3830, col: 1, offset: 117388},
 			expr: &actionExpr{
-				pos: position{line: 3828, col: 20, offset: 117314},
+				pos: position{line: 3830, col: 20, offset: 117407},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3828, col: 20, offset: 117314},
+					pos: position{line: 3830, col: 20, offset: 117407},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3828, col: 20, offset: 117314},
+							pos:   position{line: 3830, col: 20, offset: 117407},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3828, col: 26, offset: 117320},
+								pos:  position{line: 3830, col: 26, offset: 117413},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3828, col: 37, offset: 117331},
+							pos:   position{line: 3830, col: 37, offset: 117424},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3828, col: 42, offset: 117336},
+								pos: position{line: 3830, col: 42, offset: 117429},
 								expr: &seqExpr{
-									pos: position{line: 3828, col: 43, offset: 117337},
+									pos: position{line: 3830, col: 43, offset: 117430},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3828, col: 44, offset: 117338},
+											pos: position{line: 3830, col: 44, offset: 117431},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3828, col: 44, offset: 117338},
+													pos:  position{line: 3830, col: 44, offset: 117431},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3828, col: 52, offset: 117346},
+													pos:  position{line: 3830, col: 52, offset: 117439},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3828, col: 59, offset: 117353},
+											pos:  position{line: 3830, col: 59, offset: 117446},
 											name: "Aggregator",
 										},
 									},
@@ -8698,28 +8698,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3845, col: 1, offset: 117856},
+			pos:  position{line: 3847, col: 1, offset: 117949},
 			expr: &actionExpr{
-				pos: position{line: 3845, col: 15, offset: 117870},
+				pos: position{line: 3847, col: 15, offset: 117963},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3845, col: 15, offset: 117870},
+					pos: position{line: 3847, col: 15, offset: 117963},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3845, col: 15, offset: 117870},
+							pos:   position{line: 3847, col: 15, offset: 117963},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3845, col: 23, offset: 117878},
+								pos:  position{line: 3847, col: 23, offset: 117971},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3845, col: 35, offset: 117890},
+							pos:   position{line: 3847, col: 35, offset: 117983},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3845, col: 43, offset: 117898},
+								pos: position{line: 3847, col: 43, offset: 117991},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3845, col: 43, offset: 117898},
+									pos:  position{line: 3847, col: 43, offset: 117991},
 									name: "AsField",
 								},
 							},
@@ -8730,26 +8730,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3861, col: 1, offset: 118739},
+			pos:  position{line: 3863, col: 1, offset: 118832},
 			expr: &actionExpr{
-				pos: position{line: 3861, col: 16, offset: 118754},
+				pos: position{line: 3863, col: 16, offset: 118847},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3861, col: 16, offset: 118754},
+					pos:   position{line: 3863, col: 16, offset: 118847},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3861, col: 21, offset: 118759},
+						pos: position{line: 3863, col: 21, offset: 118852},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3861, col: 21, offset: 118759},
+								pos:  position{line: 3863, col: 21, offset: 118852},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3861, col: 32, offset: 118770},
+								pos:  position{line: 3863, col: 32, offset: 118863},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3861, col: 48, offset: 118786},
+								pos:  position{line: 3863, col: 48, offset: 118879},
 								name: "AggCommon",
 							},
 						},
@@ -8759,165 +8759,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3866, col: 1, offset: 118992},
+			pos:  position{line: 3868, col: 1, offset: 119085},
 			expr: &actionExpr{
-				pos: position{line: 3866, col: 18, offset: 119009},
+				pos: position{line: 3868, col: 18, offset: 119102},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3866, col: 19, offset: 119010},
+					pos: position{line: 3868, col: 19, offset: 119103},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3866, col: 19, offset: 119010},
+							pos:        position{line: 3868, col: 19, offset: 119103},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 30, offset: 119021},
+							pos:        position{line: 3868, col: 30, offset: 119114},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 39, offset: 119030},
+							pos:        position{line: 3868, col: 39, offset: 119123},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 47, offset: 119038},
+							pos:        position{line: 3868, col: 47, offset: 119131},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 57, offset: 119048},
+							pos:        position{line: 3868, col: 57, offset: 119141},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 65, offset: 119056},
+							pos:        position{line: 3868, col: 65, offset: 119149},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 76, offset: 119067},
+							pos:        position{line: 3868, col: 76, offset: 119160},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 86, offset: 119077},
+							pos:        position{line: 3868, col: 86, offset: 119170},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 95, offset: 119086},
+							pos:        position{line: 3868, col: 95, offset: 119179},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 105, offset: 119096},
+							pos:        position{line: 3868, col: 105, offset: 119189},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 114, offset: 119105},
+							pos:        position{line: 3868, col: 114, offset: 119198},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 122, offset: 119113},
+							pos:        position{line: 3868, col: 122, offset: 119206},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 133, offset: 119124},
+							pos:        position{line: 3868, col: 133, offset: 119217},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3866, col: 142, offset: 119133},
+							pos:        position{line: 3868, col: 142, offset: 119226},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 1, offset: 119142},
+							pos:        position{line: 3869, col: 1, offset: 119235},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 10, offset: 119151},
+							pos:        position{line: 3869, col: 10, offset: 119244},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 26, offset: 119167},
+							pos:        position{line: 3869, col: 26, offset: 119260},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 37, offset: 119178},
+							pos:        position{line: 3869, col: 37, offset: 119271},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 46, offset: 119187},
+							pos:        position{line: 3869, col: 46, offset: 119280},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 56, offset: 119197},
+							pos:        position{line: 3869, col: 56, offset: 119290},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 72, offset: 119213},
+							pos:        position{line: 3869, col: 72, offset: 119306},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 82, offset: 119223},
+							pos:        position{line: 3869, col: 82, offset: 119316},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 100, offset: 119241},
+							pos:        position{line: 3869, col: 100, offset: 119334},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 113, offset: 119254},
+							pos:        position{line: 3869, col: 113, offset: 119347},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 132, offset: 119273},
+							pos:        position{line: 3869, col: 132, offset: 119366},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3867, col: 139, offset: 119280},
+							pos:        position{line: 3869, col: 139, offset: 119373},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8928,27 +8928,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3871, col: 1, offset: 119323},
+			pos:  position{line: 3873, col: 1, offset: 119416},
 			expr: &actionExpr{
-				pos: position{line: 3871, col: 22, offset: 119344},
+				pos: position{line: 3873, col: 22, offset: 119437},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3871, col: 23, offset: 119345},
+					pos: position{line: 3873, col: 23, offset: 119438},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3871, col: 23, offset: 119345},
+							pos:        position{line: 3873, col: 23, offset: 119438},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3871, col: 37, offset: 119359},
+							pos:        position{line: 3873, col: 37, offset: 119452},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3871, col: 51, offset: 119373},
+							pos:        position{line: 3873, col: 51, offset: 119466},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8959,29 +8959,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3875, col: 1, offset: 119417},
+			pos:  position{line: 3877, col: 1, offset: 119510},
 			expr: &actionExpr{
-				pos: position{line: 3875, col: 12, offset: 119428},
+				pos: position{line: 3877, col: 12, offset: 119521},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3875, col: 12, offset: 119428},
+					pos: position{line: 3877, col: 12, offset: 119521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3875, col: 12, offset: 119428},
+							pos:  position{line: 3877, col: 12, offset: 119521},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3875, col: 15, offset: 119431},
+							pos:   position{line: 3877, col: 15, offset: 119524},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3875, col: 23, offset: 119439},
+								pos: position{line: 3877, col: 23, offset: 119532},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3875, col: 23, offset: 119439},
+										pos:  position{line: 3877, col: 23, offset: 119532},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3875, col: 35, offset: 119451},
+										pos:  position{line: 3877, col: 35, offset: 119544},
 										name: "String",
 									},
 								},
@@ -8993,27 +8993,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3889, col: 1, offset: 119780},
+			pos:  position{line: 3891, col: 1, offset: 119873},
 			expr: &choiceExpr{
-				pos: position{line: 3889, col: 13, offset: 119792},
+				pos: position{line: 3891, col: 13, offset: 119885},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3889, col: 13, offset: 119792},
+						pos: position{line: 3891, col: 13, offset: 119885},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3889, col: 13, offset: 119792},
+							pos: position{line: 3891, col: 13, offset: 119885},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3889, col: 14, offset: 119793},
+									pos: position{line: 3891, col: 14, offset: 119886},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3889, col: 14, offset: 119793},
+											pos:        position{line: 3891, col: 14, offset: 119886},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3889, col: 24, offset: 119803},
+											pos:        position{line: 3891, col: 24, offset: 119896},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9021,47 +9021,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3889, col: 29, offset: 119808},
+									pos:  position{line: 3891, col: 29, offset: 119901},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3889, col: 37, offset: 119816},
+									pos:        position{line: 3891, col: 37, offset: 119909},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3889, col: 44, offset: 119823},
+									pos:   position{line: 3891, col: 44, offset: 119916},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3889, col: 54, offset: 119833},
+										pos:  position{line: 3891, col: 54, offset: 119926},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3889, col: 64, offset: 119843},
+									pos:  position{line: 3891, col: 64, offset: 119936},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3899, col: 3, offset: 120071},
+						pos: position{line: 3901, col: 3, offset: 120164},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3899, col: 3, offset: 120071},
+							pos: position{line: 3901, col: 3, offset: 120164},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3899, col: 4, offset: 120072},
+									pos: position{line: 3901, col: 4, offset: 120165},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3899, col: 4, offset: 120072},
+											pos:        position{line: 3901, col: 4, offset: 120165},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3899, col: 14, offset: 120082},
+											pos:        position{line: 3901, col: 14, offset: 120175},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9069,38 +9069,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3899, col: 19, offset: 120087},
+									pos:  position{line: 3901, col: 19, offset: 120180},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3899, col: 27, offset: 120095},
+									pos:   position{line: 3901, col: 27, offset: 120188},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3899, col: 33, offset: 120101},
+										pos:  position{line: 3901, col: 33, offset: 120194},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3899, col: 43, offset: 120111},
+									pos:  position{line: 3901, col: 43, offset: 120204},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3906, col: 5, offset: 120262},
+						pos: position{line: 3908, col: 5, offset: 120355},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3906, col: 6, offset: 120263},
+							pos: position{line: 3908, col: 6, offset: 120356},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3906, col: 6, offset: 120263},
+									pos:        position{line: 3908, col: 6, offset: 120356},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3906, col: 16, offset: 120273},
+									pos:        position{line: 3908, col: 16, offset: 120366},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9113,77 +9113,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3915, col: 1, offset: 120409},
+			pos:  position{line: 3917, col: 1, offset: 120502},
 			expr: &choiceExpr{
-				pos: position{line: 3915, col: 14, offset: 120422},
+				pos: position{line: 3917, col: 14, offset: 120515},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3915, col: 14, offset: 120422},
+						pos: position{line: 3917, col: 14, offset: 120515},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3915, col: 14, offset: 120422},
+							pos: position{line: 3917, col: 14, offset: 120515},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3915, col: 14, offset: 120422},
+									pos:   position{line: 3917, col: 14, offset: 120515},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3915, col: 22, offset: 120430},
+										pos:  position{line: 3917, col: 22, offset: 120523},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3915, col: 36, offset: 120444},
+									pos:  position{line: 3917, col: 36, offset: 120537},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3915, col: 44, offset: 120452},
+									pos:        position{line: 3917, col: 44, offset: 120545},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3915, col: 51, offset: 120459},
+									pos:   position{line: 3917, col: 51, offset: 120552},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3915, col: 61, offset: 120469},
+										pos:  position{line: 3917, col: 61, offset: 120562},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3915, col: 71, offset: 120479},
+									pos:  position{line: 3917, col: 71, offset: 120572},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3930, col: 3, offset: 120889},
+						pos: position{line: 3932, col: 3, offset: 120982},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3930, col: 3, offset: 120889},
+							pos: position{line: 3932, col: 3, offset: 120982},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3930, col: 3, offset: 120889},
+									pos:   position{line: 3932, col: 3, offset: 120982},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3930, col: 11, offset: 120897},
+										pos:  position{line: 3932, col: 11, offset: 120990},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3930, col: 25, offset: 120911},
+									pos:  position{line: 3932, col: 25, offset: 121004},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3930, col: 33, offset: 120919},
+									pos:   position{line: 3932, col: 33, offset: 121012},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3930, col: 39, offset: 120925},
+										pos:  position{line: 3932, col: 39, offset: 121018},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3930, col: 49, offset: 120935},
+									pos:  position{line: 3932, col: 49, offset: 121028},
 									name: "R_PAREN",
 								},
 							},
@@ -9194,22 +9194,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3944, col: 1, offset: 121267},
+			pos:  position{line: 3946, col: 1, offset: 121360},
 			expr: &actionExpr{
-				pos: position{line: 3944, col: 18, offset: 121284},
+				pos: position{line: 3946, col: 18, offset: 121377},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3944, col: 18, offset: 121284},
+					pos:   position{line: 3946, col: 18, offset: 121377},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3944, col: 26, offset: 121292},
+						pos: position{line: 3946, col: 26, offset: 121385},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3944, col: 26, offset: 121292},
+								pos:  position{line: 3946, col: 26, offset: 121385},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3944, col: 42, offset: 121308},
+								pos:  position{line: 3946, col: 42, offset: 121401},
 								name: "IntegerAsString",
 							},
 						},
@@ -9219,93 +9219,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3956, col: 1, offset: 121682},
+			pos:  position{line: 3958, col: 1, offset: 121775},
 			expr: &choiceExpr{
-				pos: position{line: 3956, col: 18, offset: 121699},
+				pos: position{line: 3958, col: 18, offset: 121792},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3956, col: 18, offset: 121699},
+						pos: position{line: 3958, col: 18, offset: 121792},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3956, col: 18, offset: 121699},
+							pos: position{line: 3958, col: 18, offset: 121792},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3956, col: 18, offset: 121699},
+									pos:   position{line: 3958, col: 18, offset: 121792},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3956, col: 26, offset: 121707},
+										pos:  position{line: 3958, col: 26, offset: 121800},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3956, col: 44, offset: 121725},
+									pos:   position{line: 3958, col: 44, offset: 121818},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3956, col: 58, offset: 121739},
+										pos:  position{line: 3958, col: 58, offset: 121832},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3956, col: 72, offset: 121753},
+									pos:  position{line: 3958, col: 72, offset: 121846},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3956, col: 80, offset: 121761},
+									pos:        position{line: 3958, col: 80, offset: 121854},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3956, col: 87, offset: 121768},
+									pos:   position{line: 3958, col: 87, offset: 121861},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3956, col: 97, offset: 121778},
+										pos:  position{line: 3958, col: 97, offset: 121871},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3956, col: 107, offset: 121788},
+									pos:  position{line: 3958, col: 107, offset: 121881},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3972, col: 3, offset: 122237},
+						pos: position{line: 3974, col: 3, offset: 122330},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3972, col: 3, offset: 122237},
+							pos: position{line: 3974, col: 3, offset: 122330},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3972, col: 3, offset: 122237},
+									pos:   position{line: 3974, col: 3, offset: 122330},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 11, offset: 122245},
+										pos:  position{line: 3974, col: 11, offset: 122338},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 29, offset: 122263},
+									pos:   position{line: 3974, col: 29, offset: 122356},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 43, offset: 122277},
+										pos:  position{line: 3974, col: 43, offset: 122370},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 57, offset: 122291},
+									pos:  position{line: 3974, col: 57, offset: 122384},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 65, offset: 122299},
+									pos:   position{line: 3974, col: 65, offset: 122392},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 71, offset: 122305},
+										pos:  position{line: 3974, col: 71, offset: 122398},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 81, offset: 122315},
+									pos:  position{line: 3974, col: 81, offset: 122408},
 									name: "R_PAREN",
 								},
 							},
@@ -9316,22 +9316,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3988, col: 1, offset: 122687},
+			pos:  position{line: 3990, col: 1, offset: 122780},
 			expr: &actionExpr{
-				pos: position{line: 3988, col: 25, offset: 122711},
+				pos: position{line: 3990, col: 25, offset: 122804},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3988, col: 25, offset: 122711},
+					pos:   position{line: 3990, col: 25, offset: 122804},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3988, col: 39, offset: 122725},
+						pos: position{line: 3990, col: 39, offset: 122818},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3988, col: 39, offset: 122725},
+								pos:  position{line: 3990, col: 39, offset: 122818},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3988, col: 67, offset: 122753},
+								pos:  position{line: 3990, col: 67, offset: 122846},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9341,43 +9341,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3992, col: 1, offset: 122816},
+			pos:  position{line: 3994, col: 1, offset: 122909},
 			expr: &actionExpr{
-				pos: position{line: 3992, col: 30, offset: 122845},
+				pos: position{line: 3994, col: 30, offset: 122938},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3992, col: 30, offset: 122845},
+					pos: position{line: 3994, col: 30, offset: 122938},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3992, col: 30, offset: 122845},
+							pos:   position{line: 3994, col: 30, offset: 122938},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3992, col: 34, offset: 122849},
+								pos:  position{line: 3994, col: 34, offset: 122942},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3992, col: 44, offset: 122859},
+							pos:   position{line: 3994, col: 44, offset: 122952},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3992, col: 48, offset: 122863},
+								pos: position{line: 3994, col: 48, offset: 122956},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3992, col: 48, offset: 122863},
+										pos:  position{line: 3994, col: 48, offset: 122956},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3992, col: 67, offset: 122882},
+										pos:  position{line: 3994, col: 67, offset: 122975},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3992, col: 87, offset: 122902},
+							pos:   position{line: 3994, col: 87, offset: 122995},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3992, col: 93, offset: 122908},
+								pos:  position{line: 3994, col: 93, offset: 123001},
 								name: "Number",
 							},
 						},
@@ -9387,15 +9387,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4005, col: 1, offset: 123142},
+			pos:  position{line: 4007, col: 1, offset: 123235},
 			expr: &actionExpr{
-				pos: position{line: 4005, col: 32, offset: 123173},
+				pos: position{line: 4007, col: 32, offset: 123266},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4005, col: 32, offset: 123173},
+					pos:   position{line: 4007, col: 32, offset: 123266},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4005, col: 38, offset: 123179},
+						pos:  position{line: 4007, col: 38, offset: 123272},
 						name: "Number",
 					},
 				},
@@ -9403,34 +9403,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4018, col: 1, offset: 123396},
+			pos:  position{line: 4020, col: 1, offset: 123489},
 			expr: &actionExpr{
-				pos: position{line: 4018, col: 26, offset: 123421},
+				pos: position{line: 4020, col: 26, offset: 123514},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4018, col: 26, offset: 123421},
+					pos: position{line: 4020, col: 26, offset: 123514},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4018, col: 26, offset: 123421},
+							pos:   position{line: 4020, col: 26, offset: 123514},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4018, col: 30, offset: 123425},
+								pos:  position{line: 4020, col: 30, offset: 123518},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4018, col: 40, offset: 123435},
+							pos:   position{line: 4020, col: 40, offset: 123528},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4018, col: 43, offset: 123438},
+								pos:  position{line: 4020, col: 43, offset: 123531},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4018, col: 60, offset: 123455},
+							pos:   position{line: 4020, col: 60, offset: 123548},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4018, col: 66, offset: 123461},
+								pos:  position{line: 4020, col: 66, offset: 123554},
 								name: "Boolean",
 							},
 						},
@@ -9440,22 +9440,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4031, col: 1, offset: 123696},
+			pos:  position{line: 4033, col: 1, offset: 123789},
 			expr: &actionExpr{
-				pos: position{line: 4031, col: 25, offset: 123720},
+				pos: position{line: 4033, col: 25, offset: 123813},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4031, col: 25, offset: 123720},
+					pos:   position{line: 4033, col: 25, offset: 123813},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4031, col: 39, offset: 123734},
+						pos: position{line: 4033, col: 39, offset: 123827},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4031, col: 39, offset: 123734},
+								pos:  position{line: 4033, col: 39, offset: 123827},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4031, col: 67, offset: 123762},
+								pos:  position{line: 4033, col: 67, offset: 123855},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9465,41 +9465,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4035, col: 1, offset: 123825},
+			pos:  position{line: 4037, col: 1, offset: 123918},
 			expr: &actionExpr{
-				pos: position{line: 4035, col: 30, offset: 123854},
+				pos: position{line: 4037, col: 30, offset: 123947},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4035, col: 30, offset: 123854},
+					pos: position{line: 4037, col: 30, offset: 123947},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4035, col: 30, offset: 123854},
+							pos:   position{line: 4037, col: 30, offset: 123947},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4035, col: 34, offset: 123858},
+								pos:  position{line: 4037, col: 34, offset: 123951},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4035, col: 44, offset: 123868},
+							pos:   position{line: 4037, col: 44, offset: 123961},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4035, col: 47, offset: 123871},
+								pos:  position{line: 4037, col: 47, offset: 123964},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4035, col: 64, offset: 123888},
+							pos:   position{line: 4037, col: 64, offset: 123981},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4035, col: 81, offset: 123905},
+								pos: position{line: 4037, col: 81, offset: 123998},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4035, col: 81, offset: 123905},
+										pos:  position{line: 4037, col: 81, offset: 123998},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4035, col: 103, offset: 123927},
+										pos:  position{line: 4037, col: 103, offset: 124020},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9511,22 +9511,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4050, col: 1, offset: 124327},
+			pos:  position{line: 4052, col: 1, offset: 124420},
 			expr: &actionExpr{
-				pos: position{line: 4050, col: 32, offset: 124358},
+				pos: position{line: 4052, col: 32, offset: 124451},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4050, col: 32, offset: 124358},
+					pos:   position{line: 4052, col: 32, offset: 124451},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4050, col: 49, offset: 124375},
+						pos: position{line: 4052, col: 49, offset: 124468},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4050, col: 49, offset: 124375},
+								pos:  position{line: 4052, col: 49, offset: 124468},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4050, col: 71, offset: 124397},
+								pos:  position{line: 4052, col: 71, offset: 124490},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9536,33 +9536,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4065, col: 1, offset: 124780},
+			pos:  position{line: 4067, col: 1, offset: 124873},
 			expr: &actionExpr{
-				pos: position{line: 4065, col: 24, offset: 124803},
+				pos: position{line: 4067, col: 24, offset: 124896},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4065, col: 24, offset: 124803},
+					pos: position{line: 4067, col: 24, offset: 124896},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4065, col: 24, offset: 124803},
+							pos:        position{line: 4067, col: 24, offset: 124896},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4065, col: 31, offset: 124810},
+							pos:  position{line: 4067, col: 31, offset: 124903},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4065, col: 39, offset: 124818},
+							pos:   position{line: 4067, col: 39, offset: 124911},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4065, col: 45, offset: 124824},
+								pos:  position{line: 4067, col: 45, offset: 124917},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4065, col: 52, offset: 124831},
+							pos:  position{line: 4067, col: 52, offset: 124924},
 							name: "R_PAREN",
 						},
 					},
@@ -9571,15 +9571,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4073, col: 1, offset: 124972},
+			pos:  position{line: 4075, col: 1, offset: 125065},
 			expr: &actionExpr{
-				pos: position{line: 4073, col: 26, offset: 124997},
+				pos: position{line: 4075, col: 26, offset: 125090},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4073, col: 26, offset: 124997},
+					pos:   position{line: 4075, col: 26, offset: 125090},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4073, col: 32, offset: 125003},
+						pos:  position{line: 4075, col: 32, offset: 125096},
 						name: "String",
 					},
 				},
@@ -9587,35 +9587,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4083, col: 1, offset: 125283},
+			pos:  position{line: 4085, col: 1, offset: 125376},
 			expr: &actionExpr{
-				pos: position{line: 4083, col: 18, offset: 125300},
+				pos: position{line: 4085, col: 18, offset: 125393},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4083, col: 18, offset: 125300},
+					pos: position{line: 4085, col: 18, offset: 125393},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4083, col: 18, offset: 125300},
+							pos:   position{line: 4085, col: 18, offset: 125393},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4083, col: 24, offset: 125306},
+								pos:  position{line: 4085, col: 24, offset: 125399},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4083, col: 34, offset: 125316},
+							pos:   position{line: 4085, col: 34, offset: 125409},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4083, col: 39, offset: 125321},
+								pos: position{line: 4085, col: 39, offset: 125414},
 								expr: &seqExpr{
-									pos: position{line: 4083, col: 40, offset: 125322},
+									pos: position{line: 4085, col: 40, offset: 125415},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4083, col: 40, offset: 125322},
+											pos:  position{line: 4085, col: 40, offset: 125415},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4083, col: 46, offset: 125328},
+											pos:  position{line: 4085, col: 46, offset: 125421},
 											name: "FieldName",
 										},
 									},
@@ -9628,16 +9628,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4100, col: 1, offset: 125823},
+			pos:  position{line: 4102, col: 1, offset: 125916},
 			expr: &choiceExpr{
-				pos: position{line: 4100, col: 18, offset: 125840},
+				pos: position{line: 4102, col: 18, offset: 125933},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4100, col: 18, offset: 125840},
+						pos:  position{line: 4102, col: 18, offset: 125933},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4100, col: 38, offset: 125860},
+						pos:  position{line: 4102, col: 38, offset: 125953},
 						name: "EarliestOnly",
 					},
 				},
@@ -9645,62 +9645,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4102, col: 1, offset: 125874},
+			pos:  position{line: 4104, col: 1, offset: 125967},
 			expr: &actionExpr{
-				pos: position{line: 4102, col: 22, offset: 125895},
+				pos: position{line: 4104, col: 22, offset: 125988},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4102, col: 22, offset: 125895},
+					pos: position{line: 4104, col: 22, offset: 125988},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4102, col: 22, offset: 125895},
+							pos:  position{line: 4104, col: 22, offset: 125988},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4102, col: 35, offset: 125908},
+							pos:  position{line: 4104, col: 35, offset: 126001},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4102, col: 41, offset: 125914},
+							pos:   position{line: 4104, col: 41, offset: 126007},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4102, col: 55, offset: 125928},
+								pos: position{line: 4104, col: 55, offset: 126021},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4102, col: 55, offset: 125928},
+										pos:  position{line: 4104, col: 55, offset: 126021},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4102, col: 75, offset: 125948},
+										pos:  position{line: 4104, col: 75, offset: 126041},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4102, col: 94, offset: 125967},
+							pos:  position{line: 4104, col: 94, offset: 126060},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4102, col: 100, offset: 125973},
+							pos:  position{line: 4104, col: 100, offset: 126066},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4102, col: 111, offset: 125984},
+							pos:  position{line: 4104, col: 111, offset: 126077},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4102, col: 117, offset: 125990},
+							pos:   position{line: 4104, col: 117, offset: 126083},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4102, col: 129, offset: 126002},
+								pos: position{line: 4104, col: 129, offset: 126095},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4102, col: 129, offset: 126002},
+										pos:  position{line: 4104, col: 129, offset: 126095},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4102, col: 149, offset: 126022},
+										pos:  position{line: 4104, col: 149, offset: 126115},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9712,33 +9712,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4143, col: 1, offset: 127161},
+			pos:  position{line: 4145, col: 1, offset: 127254},
 			expr: &actionExpr{
-				pos: position{line: 4143, col: 17, offset: 127177},
+				pos: position{line: 4145, col: 17, offset: 127270},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4143, col: 17, offset: 127177},
+					pos: position{line: 4145, col: 17, offset: 127270},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4143, col: 17, offset: 127177},
+							pos:  position{line: 4145, col: 17, offset: 127270},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4143, col: 30, offset: 127190},
+							pos:  position{line: 4145, col: 30, offset: 127283},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4143, col: 36, offset: 127196},
+							pos:   position{line: 4145, col: 36, offset: 127289},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4143, col: 50, offset: 127210},
+								pos: position{line: 4145, col: 50, offset: 127303},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4143, col: 50, offset: 127210},
+										pos:  position{line: 4145, col: 50, offset: 127303},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4143, col: 70, offset: 127230},
+										pos:  position{line: 4145, col: 70, offset: 127323},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9750,24 +9750,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4171, col: 1, offset: 127938},
+			pos:  position{line: 4173, col: 1, offset: 128031},
 			expr: &actionExpr{
-				pos: position{line: 4171, col: 23, offset: 127960},
+				pos: position{line: 4173, col: 23, offset: 128053},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4171, col: 23, offset: 127960},
+					pos: position{line: 4173, col: 23, offset: 128053},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4171, col: 23, offset: 127960},
+							pos:        position{line: 4173, col: 23, offset: 128053},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4171, col: 27, offset: 127964},
+							pos: position{line: 4173, col: 27, offset: 128057},
 							expr: &charClassMatcher{
-								pos:        position{line: 4171, col: 27, offset: 127964},
+								pos:        position{line: 4173, col: 27, offset: 128057},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9780,21 +9780,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4175, col: 1, offset: 128007},
+			pos:  position{line: 4177, col: 1, offset: 128100},
 			expr: &actionExpr{
-				pos: position{line: 4175, col: 13, offset: 128019},
+				pos: position{line: 4177, col: 13, offset: 128112},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4175, col: 14, offset: 128020},
+					pos: position{line: 4177, col: 14, offset: 128113},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4175, col: 14, offset: 128020},
+							pos:        position{line: 4177, col: 14, offset: 128113},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4175, col: 17, offset: 128023},
+							pos:        position{line: 4177, col: 17, offset: 128116},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9806,15 +9806,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4179, col: 1, offset: 128066},
+			pos:  position{line: 4181, col: 1, offset: 128159},
 			expr: &actionExpr{
-				pos: position{line: 4179, col: 16, offset: 128081},
+				pos: position{line: 4181, col: 16, offset: 128174},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4179, col: 16, offset: 128081},
+					pos:   position{line: 4181, col: 16, offset: 128174},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4179, col: 26, offset: 128091},
+						pos:  position{line: 4181, col: 26, offset: 128184},
 						name: "AllTimeScale",
 					},
 				},
@@ -9822,31 +9822,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4186, col: 1, offset: 128315},
+			pos:  position{line: 4188, col: 1, offset: 128408},
 			expr: &actionExpr{
-				pos: position{line: 4186, col: 9, offset: 128323},
+				pos: position{line: 4188, col: 9, offset: 128416},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4186, col: 9, offset: 128323},
+					pos: position{line: 4188, col: 9, offset: 128416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4186, col: 9, offset: 128323},
+							pos:        position{line: 4188, col: 9, offset: 128416},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4186, col: 13, offset: 128327},
+							pos:   position{line: 4188, col: 13, offset: 128420},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4186, col: 19, offset: 128333},
+								pos: position{line: 4188, col: 19, offset: 128426},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4186, col: 19, offset: 128333},
+										pos:  position{line: 4188, col: 19, offset: 128426},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4186, col: 30, offset: 128344},
+										pos:  position{line: 4188, col: 30, offset: 128437},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9858,26 +9858,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4190, col: 1, offset: 128392},
+			pos:  position{line: 4192, col: 1, offset: 128485},
 			expr: &actionExpr{
-				pos: position{line: 4190, col: 11, offset: 128402},
+				pos: position{line: 4192, col: 11, offset: 128495},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4190, col: 11, offset: 128402},
+					pos: position{line: 4192, col: 11, offset: 128495},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4190, col: 11, offset: 128402},
+							pos:   position{line: 4192, col: 11, offset: 128495},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4190, col: 16, offset: 128407},
+								pos:  position{line: 4192, col: 16, offset: 128500},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4190, col: 36, offset: 128427},
+							pos:   position{line: 4192, col: 36, offset: 128520},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4190, col: 43, offset: 128434},
+								pos:  position{line: 4192, col: 43, offset: 128527},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9887,44 +9887,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4218, col: 1, offset: 129172},
+			pos:  position{line: 4220, col: 1, offset: 129265},
 			expr: &actionExpr{
-				pos: position{line: 4218, col: 29, offset: 129200},
+				pos: position{line: 4220, col: 29, offset: 129293},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4218, col: 29, offset: 129200},
+					pos: position{line: 4220, col: 29, offset: 129293},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4218, col: 29, offset: 129200},
+							pos:   position{line: 4220, col: 29, offset: 129293},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4218, col: 36, offset: 129207},
+								pos: position{line: 4220, col: 36, offset: 129300},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4218, col: 36, offset: 129207},
+										pos:  position{line: 4220, col: 36, offset: 129300},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4218, col: 45, offset: 129216},
+										pos:  position{line: 4220, col: 45, offset: 129309},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4218, col: 51, offset: 129222},
+							pos:   position{line: 4220, col: 51, offset: 129315},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4218, col: 57, offset: 129228},
+								pos: position{line: 4220, col: 57, offset: 129321},
 								expr: &choiceExpr{
-									pos: position{line: 4218, col: 58, offset: 129229},
+									pos: position{line: 4220, col: 58, offset: 129322},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4218, col: 58, offset: 129229},
+											pos:  position{line: 4220, col: 58, offset: 129322},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4218, col: 67, offset: 129238},
+											pos:  position{line: 4220, col: 67, offset: 129331},
 											name: "Snap",
 										},
 									},
@@ -9937,29 +9937,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4265, col: 1, offset: 130670},
+			pos:  position{line: 4267, col: 1, offset: 130763},
 			expr: &actionExpr{
-				pos: position{line: 4265, col: 22, offset: 130691},
+				pos: position{line: 4267, col: 22, offset: 130784},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4265, col: 22, offset: 130691},
+					pos: position{line: 4267, col: 22, offset: 130784},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4265, col: 22, offset: 130691},
+							pos:   position{line: 4267, col: 22, offset: 130784},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4265, col: 34, offset: 130703},
+								pos: position{line: 4267, col: 34, offset: 130796},
 								expr: &choiceExpr{
-									pos: position{line: 4265, col: 35, offset: 130704},
+									pos: position{line: 4267, col: 35, offset: 130797},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4265, col: 35, offset: 130704},
+											pos:        position{line: 4267, col: 35, offset: 130797},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4265, col: 43, offset: 130712},
+											pos:        position{line: 4267, col: 43, offset: 130805},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9969,12 +9969,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4265, col: 49, offset: 130718},
+							pos:   position{line: 4267, col: 49, offset: 130811},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4265, col: 57, offset: 130726},
+								pos: position{line: 4267, col: 57, offset: 130819},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4265, col: 58, offset: 130727},
+									pos:  position{line: 4267, col: 58, offset: 130820},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9985,31 +9985,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4290, col: 1, offset: 131410},
+			pos:  position{line: 4292, col: 1, offset: 131503},
 			expr: &actionExpr{
-				pos: position{line: 4290, col: 39, offset: 131448},
+				pos: position{line: 4292, col: 39, offset: 131541},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4290, col: 39, offset: 131448},
+					pos: position{line: 4292, col: 39, offset: 131541},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4290, col: 39, offset: 131448},
+							pos:   position{line: 4292, col: 39, offset: 131541},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4290, col: 46, offset: 131455},
+								pos: position{line: 4292, col: 46, offset: 131548},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4290, col: 47, offset: 131456},
+									pos:  position{line: 4292, col: 47, offset: 131549},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4290, col: 56, offset: 131465},
+							pos:   position{line: 4292, col: 56, offset: 131558},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4290, col: 66, offset: 131475},
+								pos: position{line: 4292, col: 66, offset: 131568},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4290, col: 67, offset: 131476},
+									pos:  position{line: 4292, col: 67, offset: 131569},
 									name: "Snap",
 								},
 							},
@@ -10020,136 +10020,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4317, col: 1, offset: 132104},
+			pos:  position{line: 4319, col: 1, offset: 132197},
 			expr: &actionExpr{
-				pos: position{line: 4317, col: 18, offset: 132121},
+				pos: position{line: 4319, col: 18, offset: 132214},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4317, col: 18, offset: 132121},
+					pos: position{line: 4319, col: 18, offset: 132214},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 18, offset: 132121},
+							pos:        position{line: 4319, col: 18, offset: 132214},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 23, offset: 132126},
+							pos:        position{line: 4319, col: 23, offset: 132219},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4317, col: 29, offset: 132132},
+							pos:        position{line: 4319, col: 29, offset: 132225},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 33, offset: 132136},
+							pos:        position{line: 4319, col: 33, offset: 132229},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 38, offset: 132141},
+							pos:        position{line: 4319, col: 38, offset: 132234},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4317, col: 44, offset: 132147},
+							pos:        position{line: 4319, col: 44, offset: 132240},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 48, offset: 132151},
+							pos:        position{line: 4319, col: 48, offset: 132244},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 53, offset: 132156},
+							pos:        position{line: 4319, col: 53, offset: 132249},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 58, offset: 132161},
+							pos:        position{line: 4319, col: 58, offset: 132254},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 63, offset: 132166},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4317, col: 69, offset: 132172},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4317, col: 73, offset: 132176},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4317, col: 78, offset: 132181},
+							pos:        position{line: 4319, col: 63, offset: 132259},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4317, col: 84, offset: 132187},
+							pos:        position{line: 4319, col: 69, offset: 132265},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 88, offset: 132191},
+							pos:        position{line: 4319, col: 73, offset: 132269},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 93, offset: 132196},
+							pos:        position{line: 4319, col: 78, offset: 132274},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4317, col: 99, offset: 132202},
+							pos:        position{line: 4319, col: 84, offset: 132280},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 103, offset: 132206},
+							pos:        position{line: 4319, col: 88, offset: 132284},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4317, col: 108, offset: 132211},
+							pos:        position{line: 4319, col: 93, offset: 132289},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4319, col: 99, offset: 132295},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4319, col: 103, offset: 132299},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4319, col: 108, offset: 132304},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10161,15 +10161,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4321, col: 1, offset: 132253},
+			pos:  position{line: 4323, col: 1, offset: 132346},
 			expr: &actionExpr{
-				pos: position{line: 4321, col: 22, offset: 132274},
+				pos: position{line: 4323, col: 22, offset: 132367},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4321, col: 22, offset: 132274},
+					pos:   position{line: 4323, col: 22, offset: 132367},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4321, col: 32, offset: 132284},
+						pos:  position{line: 4323, col: 32, offset: 132377},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10177,15 +10177,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4331, col: 1, offset: 132692},
+			pos:  position{line: 4333, col: 1, offset: 132785},
 			expr: &actionExpr{
-				pos: position{line: 4331, col: 14, offset: 132705},
+				pos: position{line: 4333, col: 14, offset: 132798},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4331, col: 14, offset: 132705},
+					pos: position{line: 4333, col: 14, offset: 132798},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4331, col: 14, offset: 132705},
+							pos:        position{line: 4333, col: 14, offset: 132798},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10193,9 +10193,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4331, col: 27, offset: 132718},
+							pos: position{line: 4333, col: 27, offset: 132811},
 							expr: &charClassMatcher{
-								pos:        position{line: 4331, col: 27, offset: 132718},
+								pos:        position{line: 4333, col: 27, offset: 132811},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10209,15 +10209,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4335, col: 1, offset: 132771},
+			pos:  position{line: 4337, col: 1, offset: 132864},
 			expr: &actionExpr{
-				pos: position{line: 4335, col: 24, offset: 132794},
+				pos: position{line: 4337, col: 24, offset: 132887},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4335, col: 24, offset: 132794},
+					pos: position{line: 4337, col: 24, offset: 132887},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4335, col: 24, offset: 132794},
+							pos:        position{line: 4337, col: 24, offset: 132887},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10225,9 +10225,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4335, col: 39, offset: 132809},
+							pos: position{line: 4337, col: 39, offset: 132902},
 							expr: &charClassMatcher{
-								pos:        position{line: 4335, col: 39, offset: 132809},
+								pos:        position{line: 4337, col: 39, offset: 132902},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10241,22 +10241,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4339, col: 1, offset: 132862},
+			pos:  position{line: 4341, col: 1, offset: 132955},
 			expr: &actionExpr{
-				pos: position{line: 4339, col: 11, offset: 132872},
+				pos: position{line: 4341, col: 11, offset: 132965},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4339, col: 11, offset: 132872},
+					pos:   position{line: 4341, col: 11, offset: 132965},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4339, col: 16, offset: 132877},
+						pos: position{line: 4341, col: 16, offset: 132970},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4339, col: 16, offset: 132877},
+								pos:  position{line: 4341, col: 16, offset: 132970},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4339, col: 31, offset: 132892},
+								pos:  position{line: 4341, col: 31, offset: 132985},
 								name: "UnquotedString",
 							},
 						},
@@ -10266,23 +10266,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4343, col: 1, offset: 132933},
+			pos:  position{line: 4345, col: 1, offset: 133026},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 17, offset: 132949},
+				pos: position{line: 4345, col: 17, offset: 133042},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4343, col: 17, offset: 132949},
+					pos: position{line: 4345, col: 17, offset: 133042},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4343, col: 17, offset: 132949},
+							pos:        position{line: 4345, col: 17, offset: 133042},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4343, col: 21, offset: 132953},
+							pos: position{line: 4345, col: 21, offset: 133046},
 							expr: &charClassMatcher{
-								pos:        position{line: 4343, col: 21, offset: 132953},
+								pos:        position{line: 4345, col: 21, offset: 133046},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10290,7 +10290,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4343, col: 27, offset: 132959},
+							pos:        position{line: 4345, col: 27, offset: 133052},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10301,48 +10301,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4348, col: 1, offset: 133070},
+			pos:  position{line: 4350, col: 1, offset: 133163},
 			expr: &actionExpr{
-				pos: position{line: 4348, col: 19, offset: 133088},
+				pos: position{line: 4350, col: 19, offset: 133181},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4348, col: 19, offset: 133088},
+					pos: position{line: 4350, col: 19, offset: 133181},
 					expr: &choiceExpr{
-						pos: position{line: 4348, col: 20, offset: 133089},
+						pos: position{line: 4350, col: 20, offset: 133182},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4348, col: 20, offset: 133089},
+								pos:        position{line: 4350, col: 20, offset: 133182},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4348, col: 27, offset: 133096},
+								pos: position{line: 4350, col: 27, offset: 133189},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4348, col: 27, offset: 133096},
+										pos: position{line: 4350, col: 27, offset: 133189},
 										expr: &choiceExpr{
-											pos: position{line: 4348, col: 29, offset: 133098},
+											pos: position{line: 4350, col: 29, offset: 133191},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4348, col: 29, offset: 133098},
+													pos:  position{line: 4350, col: 29, offset: 133191},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4348, col: 43, offset: 133112},
+													pos:        position{line: 4350, col: 43, offset: 133205},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4348, col: 49, offset: 133118},
+													pos:  position{line: 4350, col: 49, offset: 133211},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4348, col: 54, offset: 133123,
+										line: 4350, col: 54, offset: 133216,
 									},
 								},
 							},
@@ -10353,12 +10353,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4355, col: 1, offset: 133238},
+			pos:  position{line: 4357, col: 1, offset: 133331},
 			expr: &choiceExpr{
-				pos: position{line: 4355, col: 16, offset: 133253},
+				pos: position{line: 4357, col: 16, offset: 133346},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4355, col: 16, offset: 133253},
+						pos:        position{line: 4357, col: 16, offset: 133346},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10366,18 +10366,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4355, col: 37, offset: 133274},
+						pos: position{line: 4357, col: 37, offset: 133367},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4355, col: 37, offset: 133274},
+								pos:        position{line: 4357, col: 37, offset: 133367},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4355, col: 41, offset: 133278},
+								pos: position{line: 4357, col: 41, offset: 133371},
 								expr: &charClassMatcher{
-									pos:        position{line: 4355, col: 41, offset: 133278},
+									pos:        position{line: 4357, col: 41, offset: 133371},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10385,7 +10385,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4355, col: 48, offset: 133285},
+								pos:        position{line: 4357, col: 48, offset: 133378},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10397,46 +10397,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4357, col: 1, offset: 133291},
+			pos:  position{line: 4359, col: 1, offset: 133384},
 			expr: &actionExpr{
-				pos: position{line: 4357, col: 39, offset: 133329},
+				pos: position{line: 4359, col: 39, offset: 133422},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4357, col: 39, offset: 133329},
+					pos: position{line: 4359, col: 39, offset: 133422},
 					expr: &choiceExpr{
-						pos: position{line: 4357, col: 40, offset: 133330},
+						pos: position{line: 4359, col: 40, offset: 133423},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4357, col: 40, offset: 133330},
+								pos:  position{line: 4359, col: 40, offset: 133423},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4357, col: 54, offset: 133344},
+								pos: position{line: 4359, col: 54, offset: 133437},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4357, col: 54, offset: 133344},
+										pos: position{line: 4359, col: 54, offset: 133437},
 										expr: &choiceExpr{
-											pos: position{line: 4357, col: 56, offset: 133346},
+											pos: position{line: 4359, col: 56, offset: 133439},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4357, col: 56, offset: 133346},
+													pos:  position{line: 4359, col: 56, offset: 133439},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4357, col: 70, offset: 133360},
+													pos:        position{line: 4359, col: 70, offset: 133453},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4357, col: 76, offset: 133366},
+													pos:  position{line: 4359, col: 76, offset: 133459},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4357, col: 81, offset: 133371,
+										line: 4359, col: 81, offset: 133464,
 									},
 								},
 							},
@@ -10447,21 +10447,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4361, col: 1, offset: 133411},
+			pos:  position{line: 4363, col: 1, offset: 133504},
 			expr: &actionExpr{
-				pos: position{line: 4361, col: 12, offset: 133422},
+				pos: position{line: 4363, col: 12, offset: 133515},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4361, col: 13, offset: 133423},
+					pos: position{line: 4363, col: 13, offset: 133516},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4361, col: 13, offset: 133423},
+							pos:        position{line: 4363, col: 13, offset: 133516},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4361, col: 22, offset: 133432},
+							pos:        position{line: 4363, col: 22, offset: 133525},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10472,14 +10472,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4367, col: 1, offset: 133586},
+			pos:  position{line: 4369, col: 1, offset: 133679},
 			expr: &actionExpr{
-				pos: position{line: 4367, col: 18, offset: 133603},
+				pos: position{line: 4369, col: 18, offset: 133696},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4367, col: 18, offset: 133603},
+					pos: position{line: 4369, col: 18, offset: 133696},
 					expr: &charClassMatcher{
-						pos:        position{line: 4367, col: 18, offset: 133603},
+						pos:        position{line: 4369, col: 18, offset: 133696},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10491,15 +10491,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4371, col: 1, offset: 133654},
+			pos:  position{line: 4373, col: 1, offset: 133747},
 			expr: &actionExpr{
-				pos: position{line: 4371, col: 11, offset: 133664},
+				pos: position{line: 4373, col: 11, offset: 133757},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4371, col: 11, offset: 133664},
+					pos:   position{line: 4373, col: 11, offset: 133757},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4371, col: 18, offset: 133671},
+						pos:  position{line: 4373, col: 18, offset: 133764},
 						name: "NumberAsString",
 					},
 				},
@@ -10507,59 +10507,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4377, col: 1, offset: 133860},
+			pos:  position{line: 4379, col: 1, offset: 133953},
 			expr: &actionExpr{
-				pos: position{line: 4377, col: 19, offset: 133878},
+				pos: position{line: 4379, col: 19, offset: 133971},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4377, col: 19, offset: 133878},
+					pos: position{line: 4379, col: 19, offset: 133971},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4377, col: 19, offset: 133878},
+							pos:   position{line: 4379, col: 19, offset: 133971},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4377, col: 27, offset: 133886},
+								pos: position{line: 4379, col: 27, offset: 133979},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4377, col: 27, offset: 133886},
+										pos:  position{line: 4379, col: 27, offset: 133979},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4377, col: 43, offset: 133902},
+										pos:  position{line: 4379, col: 43, offset: 133995},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4377, col: 60, offset: 133919},
+							pos: position{line: 4379, col: 60, offset: 134012},
 							expr: &choiceExpr{
-								pos: position{line: 4377, col: 62, offset: 133921},
+								pos: position{line: 4379, col: 62, offset: 134014},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4377, col: 62, offset: 133921},
+										pos:  position{line: 4379, col: 62, offset: 134014},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4377, col: 70, offset: 133929},
+										pos:        position{line: 4379, col: 70, offset: 134022},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4377, col: 76, offset: 133935},
+										pos:        position{line: 4379, col: 76, offset: 134028},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4377, col: 82, offset: 133941},
+										pos:        position{line: 4379, col: 82, offset: 134034},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4377, col: 88, offset: 133947},
+										pos:  position{line: 4379, col: 88, offset: 134040},
 										name: "EOF",
 									},
 								},
@@ -10571,17 +10571,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4383, col: 1, offset: 134076},
+			pos:  position{line: 4385, col: 1, offset: 134169},
 			expr: &actionExpr{
-				pos: position{line: 4383, col: 18, offset: 134093},
+				pos: position{line: 4385, col: 18, offset: 134186},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4383, col: 18, offset: 134093},
+					pos: position{line: 4385, col: 18, offset: 134186},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4383, col: 18, offset: 134093},
+							pos: position{line: 4385, col: 18, offset: 134186},
 							expr: &charClassMatcher{
-								pos:        position{line: 4383, col: 18, offset: 134093},
+								pos:        position{line: 4385, col: 18, offset: 134186},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10589,9 +10589,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4383, col: 24, offset: 134099},
+							pos: position{line: 4385, col: 24, offset: 134192},
 							expr: &charClassMatcher{
-								pos:        position{line: 4383, col: 24, offset: 134099},
+								pos:        position{line: 4385, col: 24, offset: 134192},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10599,15 +10599,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4383, col: 31, offset: 134106},
+							pos:        position{line: 4385, col: 31, offset: 134199},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4383, col: 35, offset: 134110},
+							pos: position{line: 4385, col: 35, offset: 134203},
 							expr: &charClassMatcher{
-								pos:        position{line: 4383, col: 35, offset: 134110},
+								pos:        position{line: 4385, col: 35, offset: 134203},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10620,17 +10620,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4388, col: 1, offset: 134205},
+			pos:  position{line: 4390, col: 1, offset: 134298},
 			expr: &actionExpr{
-				pos: position{line: 4388, col: 20, offset: 134224},
+				pos: position{line: 4390, col: 20, offset: 134317},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4388, col: 20, offset: 134224},
+					pos: position{line: 4390, col: 20, offset: 134317},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4388, col: 20, offset: 134224},
+							pos: position{line: 4390, col: 20, offset: 134317},
 							expr: &charClassMatcher{
-								pos:        position{line: 4388, col: 20, offset: 134224},
+								pos:        position{line: 4390, col: 20, offset: 134317},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10638,9 +10638,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4388, col: 26, offset: 134230},
+							pos: position{line: 4390, col: 26, offset: 134323},
 							expr: &charClassMatcher{
-								pos:        position{line: 4388, col: 26, offset: 134230},
+								pos:        position{line: 4390, col: 26, offset: 134323},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10653,14 +10653,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4392, col: 1, offset: 134273},
+			pos:  position{line: 4394, col: 1, offset: 134366},
 			expr: &actionExpr{
-				pos: position{line: 4392, col: 28, offset: 134300},
+				pos: position{line: 4394, col: 28, offset: 134393},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4392, col: 28, offset: 134300},
+					pos: position{line: 4394, col: 28, offset: 134393},
 					expr: &charClassMatcher{
-						pos:        position{line: 4392, col: 28, offset: 134300},
+						pos:        position{line: 4394, col: 28, offset: 134393},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10671,15 +10671,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4396, col: 1, offset: 134343},
+			pos:  position{line: 4398, col: 1, offset: 134436},
 			expr: &actionExpr{
-				pos: position{line: 4396, col: 20, offset: 134362},
+				pos: position{line: 4398, col: 20, offset: 134455},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4396, col: 20, offset: 134362},
+					pos:   position{line: 4398, col: 20, offset: 134455},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4396, col: 27, offset: 134369},
+						pos:  position{line: 4398, col: 27, offset: 134462},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10687,31 +10687,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4404, col: 1, offset: 134616},
+			pos:  position{line: 4406, col: 1, offset: 134709},
 			expr: &actionExpr{
-				pos: position{line: 4404, col: 21, offset: 134636},
+				pos: position{line: 4406, col: 21, offset: 134729},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4404, col: 21, offset: 134636},
+					pos: position{line: 4406, col: 21, offset: 134729},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4404, col: 21, offset: 134636},
+							pos:  position{line: 4406, col: 21, offset: 134729},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4404, col: 36, offset: 134651},
+							pos:   position{line: 4406, col: 36, offset: 134744},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4404, col: 40, offset: 134655},
+								pos: position{line: 4406, col: 40, offset: 134748},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4404, col: 40, offset: 134655},
+										pos:        position{line: 4406, col: 40, offset: 134748},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4404, col: 46, offset: 134661},
+										pos:        position{line: 4406, col: 46, offset: 134754},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10720,7 +10720,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4404, col: 52, offset: 134667},
+							pos:  position{line: 4406, col: 52, offset: 134760},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10729,43 +10729,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4412, col: 1, offset: 134848},
+			pos:  position{line: 4414, col: 1, offset: 134941},
 			expr: &actionExpr{
-				pos: position{line: 4412, col: 23, offset: 134870},
+				pos: position{line: 4414, col: 23, offset: 134963},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4412, col: 23, offset: 134870},
+					pos: position{line: 4414, col: 23, offset: 134963},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4412, col: 23, offset: 134870},
+							pos:  position{line: 4414, col: 23, offset: 134963},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4412, col: 38, offset: 134885},
+							pos:   position{line: 4414, col: 38, offset: 134978},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4412, col: 42, offset: 134889},
+								pos: position{line: 4414, col: 42, offset: 134982},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4412, col: 42, offset: 134889},
+										pos:        position{line: 4414, col: 42, offset: 134982},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4412, col: 49, offset: 134896},
+										pos:        position{line: 4414, col: 49, offset: 134989},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4412, col: 55, offset: 134902},
+										pos:        position{line: 4414, col: 55, offset: 134995},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4412, col: 62, offset: 134909},
+										pos:        position{line: 4414, col: 62, offset: 135002},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10774,7 +10774,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4412, col: 67, offset: 134914},
+							pos:  position{line: 4414, col: 67, offset: 135007},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10783,30 +10783,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4420, col: 1, offset: 135097},
+			pos:  position{line: 4422, col: 1, offset: 135190},
 			expr: &choiceExpr{
-				pos: position{line: 4420, col: 25, offset: 135121},
+				pos: position{line: 4422, col: 25, offset: 135214},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4420, col: 25, offset: 135121},
+						pos: position{line: 4422, col: 25, offset: 135214},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4420, col: 25, offset: 135121},
+							pos:   position{line: 4422, col: 25, offset: 135214},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4420, col: 28, offset: 135124},
+								pos:  position{line: 4422, col: 28, offset: 135217},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4423, col: 3, offset: 135166},
+						pos: position{line: 4425, col: 3, offset: 135259},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4423, col: 3, offset: 135166},
+							pos:   position{line: 4425, col: 3, offset: 135259},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4423, col: 6, offset: 135169},
+								pos:  position{line: 4425, col: 6, offset: 135262},
 								name: "InequalityOperator",
 							},
 						},
@@ -10816,25 +10816,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4427, col: 1, offset: 135212},
+			pos:  position{line: 4429, col: 1, offset: 135305},
 			expr: &actionExpr{
-				pos: position{line: 4427, col: 11, offset: 135222},
+				pos: position{line: 4429, col: 11, offset: 135315},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4427, col: 11, offset: 135222},
+					pos: position{line: 4429, col: 11, offset: 135315},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4427, col: 11, offset: 135222},
+							pos:  position{line: 4429, col: 11, offset: 135315},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 26, offset: 135237},
+							pos:        position{line: 4429, col: 26, offset: 135330},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4427, col: 30, offset: 135241},
+							pos:  position{line: 4429, col: 30, offset: 135334},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10843,25 +10843,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4431, col: 1, offset: 135281},
+			pos:  position{line: 4433, col: 1, offset: 135374},
 			expr: &actionExpr{
-				pos: position{line: 4431, col: 12, offset: 135292},
+				pos: position{line: 4433, col: 12, offset: 135385},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4431, col: 12, offset: 135292},
+					pos: position{line: 4433, col: 12, offset: 135385},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4431, col: 12, offset: 135292},
+							pos:  position{line: 4433, col: 12, offset: 135385},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4431, col: 27, offset: 135307},
+							pos:        position{line: 4433, col: 27, offset: 135400},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4431, col: 31, offset: 135311},
+							pos:  position{line: 4433, col: 31, offset: 135404},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10870,25 +10870,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4435, col: 1, offset: 135351},
+			pos:  position{line: 4437, col: 1, offset: 135444},
 			expr: &actionExpr{
-				pos: position{line: 4435, col: 10, offset: 135360},
+				pos: position{line: 4437, col: 10, offset: 135453},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4435, col: 10, offset: 135360},
+					pos: position{line: 4437, col: 10, offset: 135453},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4435, col: 10, offset: 135360},
+							pos:  position{line: 4437, col: 10, offset: 135453},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 25, offset: 135375},
+							pos:        position{line: 4437, col: 25, offset: 135468},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4435, col: 29, offset: 135379},
+							pos:  position{line: 4437, col: 29, offset: 135472},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10897,25 +10897,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4439, col: 1, offset: 135419},
+			pos:  position{line: 4441, col: 1, offset: 135512},
 			expr: &actionExpr{
-				pos: position{line: 4439, col: 10, offset: 135428},
+				pos: position{line: 4441, col: 10, offset: 135521},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4439, col: 10, offset: 135428},
+					pos: position{line: 4441, col: 10, offset: 135521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4439, col: 10, offset: 135428},
+							pos:  position{line: 4441, col: 10, offset: 135521},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 25, offset: 135443},
+							pos:        position{line: 4441, col: 25, offset: 135536},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4439, col: 29, offset: 135447},
+							pos:  position{line: 4441, col: 29, offset: 135540},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10924,25 +10924,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4443, col: 1, offset: 135487},
+			pos:  position{line: 4445, col: 1, offset: 135580},
 			expr: &actionExpr{
-				pos: position{line: 4443, col: 10, offset: 135496},
+				pos: position{line: 4445, col: 10, offset: 135589},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4443, col: 10, offset: 135496},
+					pos: position{line: 4445, col: 10, offset: 135589},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4443, col: 10, offset: 135496},
+							pos:  position{line: 4445, col: 10, offset: 135589},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4443, col: 25, offset: 135511},
+							pos:        position{line: 4445, col: 25, offset: 135604},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4443, col: 29, offset: 135515},
+							pos:  position{line: 4445, col: 29, offset: 135608},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10951,39 +10951,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4448, col: 1, offset: 135579},
+			pos:  position{line: 4450, col: 1, offset: 135672},
 			expr: &actionExpr{
-				pos: position{line: 4448, col: 11, offset: 135589},
+				pos: position{line: 4450, col: 11, offset: 135682},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4448, col: 12, offset: 135590},
+					pos: position{line: 4450, col: 12, offset: 135683},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4448, col: 12, offset: 135590},
+							pos:        position{line: 4450, col: 12, offset: 135683},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 24, offset: 135602},
+							pos:        position{line: 4450, col: 24, offset: 135695},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 35, offset: 135613},
+							pos:        position{line: 4450, col: 35, offset: 135706},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 44, offset: 135622},
+							pos:        position{line: 4450, col: 44, offset: 135715},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 52, offset: 135630},
+							pos:        position{line: 4450, col: 52, offset: 135723},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10994,39 +10994,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4452, col: 1, offset: 135671},
+			pos:  position{line: 4454, col: 1, offset: 135764},
 			expr: &actionExpr{
-				pos: position{line: 4452, col: 11, offset: 135681},
+				pos: position{line: 4454, col: 11, offset: 135774},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4452, col: 12, offset: 135682},
+					pos: position{line: 4454, col: 12, offset: 135775},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4452, col: 12, offset: 135682},
+							pos:        position{line: 4454, col: 12, offset: 135775},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 24, offset: 135694},
+							pos:        position{line: 4454, col: 24, offset: 135787},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 35, offset: 135705},
+							pos:        position{line: 4454, col: 35, offset: 135798},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 44, offset: 135714},
+							pos:        position{line: 4454, col: 44, offset: 135807},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 52, offset: 135722},
+							pos:        position{line: 4454, col: 52, offset: 135815},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11037,39 +11037,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4456, col: 1, offset: 135763},
+			pos:  position{line: 4458, col: 1, offset: 135856},
 			expr: &actionExpr{
-				pos: position{line: 4456, col: 9, offset: 135771},
+				pos: position{line: 4458, col: 9, offset: 135864},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4456, col: 10, offset: 135772},
+					pos: position{line: 4458, col: 10, offset: 135865},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4456, col: 10, offset: 135772},
+							pos:        position{line: 4458, col: 10, offset: 135865},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 20, offset: 135782},
+							pos:        position{line: 4458, col: 20, offset: 135875},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 29, offset: 135791},
+							pos:        position{line: 4458, col: 29, offset: 135884},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 37, offset: 135799},
+							pos:        position{line: 4458, col: 37, offset: 135892},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 44, offset: 135806},
+							pos:        position{line: 4458, col: 44, offset: 135899},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11080,27 +11080,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4460, col: 1, offset: 135845},
+			pos:  position{line: 4462, col: 1, offset: 135938},
 			expr: &actionExpr{
-				pos: position{line: 4460, col: 8, offset: 135852},
+				pos: position{line: 4462, col: 8, offset: 135945},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4460, col: 9, offset: 135853},
+					pos: position{line: 4462, col: 9, offset: 135946},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4460, col: 9, offset: 135853},
+							pos:        position{line: 4462, col: 9, offset: 135946},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 18, offset: 135862},
+							pos:        position{line: 4462, col: 18, offset: 135955},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 26, offset: 135870},
+							pos:        position{line: 4462, col: 26, offset: 135963},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11111,27 +11111,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4464, col: 1, offset: 135908},
+			pos:  position{line: 4466, col: 1, offset: 136001},
 			expr: &actionExpr{
-				pos: position{line: 4464, col: 9, offset: 135916},
+				pos: position{line: 4466, col: 9, offset: 136009},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4464, col: 10, offset: 135917},
+					pos: position{line: 4466, col: 10, offset: 136010},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4464, col: 10, offset: 135917},
+							pos:        position{line: 4466, col: 10, offset: 136010},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 20, offset: 135927},
+							pos:        position{line: 4466, col: 20, offset: 136020},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 29, offset: 135936},
+							pos:        position{line: 4466, col: 29, offset: 136029},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11142,27 +11142,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4468, col: 1, offset: 135975},
+			pos:  position{line: 4470, col: 1, offset: 136068},
 			expr: &actionExpr{
-				pos: position{line: 4468, col: 10, offset: 135984},
+				pos: position{line: 4470, col: 10, offset: 136077},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4468, col: 11, offset: 135985},
+					pos: position{line: 4470, col: 11, offset: 136078},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4468, col: 11, offset: 135985},
+							pos:        position{line: 4470, col: 11, offset: 136078},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4468, col: 22, offset: 135996},
+							pos:        position{line: 4470, col: 22, offset: 136089},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4468, col: 32, offset: 136006},
+							pos:        position{line: 4470, col: 32, offset: 136099},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11173,39 +11173,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4472, col: 1, offset: 136048},
+			pos:  position{line: 4474, col: 1, offset: 136141},
 			expr: &actionExpr{
-				pos: position{line: 4472, col: 12, offset: 136059},
+				pos: position{line: 4474, col: 12, offset: 136152},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4472, col: 13, offset: 136060},
+					pos: position{line: 4474, col: 13, offset: 136153},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4472, col: 13, offset: 136060},
+							pos:        position{line: 4474, col: 13, offset: 136153},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4472, col: 26, offset: 136073},
+							pos:        position{line: 4474, col: 26, offset: 136166},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4472, col: 38, offset: 136085},
+							pos:        position{line: 4474, col: 38, offset: 136178},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4472, col: 47, offset: 136094},
+							pos:        position{line: 4474, col: 47, offset: 136187},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4472, col: 55, offset: 136102},
+							pos:        position{line: 4474, col: 55, offset: 136195},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11216,39 +11216,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4476, col: 1, offset: 136144},
+			pos:  position{line: 4478, col: 1, offset: 136237},
 			expr: &actionExpr{
-				pos: position{line: 4476, col: 9, offset: 136152},
+				pos: position{line: 4478, col: 9, offset: 136245},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4476, col: 10, offset: 136153},
+					pos: position{line: 4478, col: 10, offset: 136246},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4476, col: 10, offset: 136153},
+							pos:        position{line: 4478, col: 10, offset: 136246},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4476, col: 20, offset: 136163},
+							pos:        position{line: 4478, col: 20, offset: 136256},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4476, col: 29, offset: 136172},
+							pos:        position{line: 4478, col: 29, offset: 136265},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4476, col: 37, offset: 136180},
+							pos:        position{line: 4478, col: 37, offset: 136273},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4476, col: 44, offset: 136187},
+							pos:        position{line: 4478, col: 44, offset: 136280},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11259,33 +11259,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4481, col: 1, offset: 136318},
+			pos:  position{line: 4483, col: 1, offset: 136411},
 			expr: &actionExpr{
-				pos: position{line: 4481, col: 15, offset: 136332},
+				pos: position{line: 4483, col: 15, offset: 136425},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4481, col: 16, offset: 136333},
+					pos: position{line: 4483, col: 16, offset: 136426},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4481, col: 16, offset: 136333},
+							pos:        position{line: 4483, col: 16, offset: 136426},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4481, col: 23, offset: 136340},
+							pos:        position{line: 4483, col: 23, offset: 136433},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4481, col: 30, offset: 136347},
+							pos:        position{line: 4483, col: 30, offset: 136440},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4481, col: 37, offset: 136354},
+							pos:        position{line: 4483, col: 37, offset: 136447},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11296,26 +11296,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4490, col: 1, offset: 136577},
+			pos:  position{line: 4492, col: 1, offset: 136670},
 			expr: &actionExpr{
-				pos: position{line: 4490, col: 21, offset: 136597},
+				pos: position{line: 4492, col: 21, offset: 136690},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4490, col: 21, offset: 136597},
+					pos: position{line: 4492, col: 21, offset: 136690},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4490, col: 21, offset: 136597},
+							pos:  position{line: 4492, col: 21, offset: 136690},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4490, col: 26, offset: 136602},
+							pos:  position{line: 4492, col: 26, offset: 136695},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4490, col: 42, offset: 136618},
+							pos:   position{line: 4492, col: 42, offset: 136711},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4490, col: 53, offset: 136629},
+								pos:  position{line: 4492, col: 53, offset: 136722},
 								name: "TransactionOptions",
 							},
 						},
@@ -11325,17 +11325,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4500, col: 1, offset: 137004},
+			pos:  position{line: 4502, col: 1, offset: 137097},
 			expr: &actionExpr{
-				pos: position{line: 4500, col: 23, offset: 137026},
+				pos: position{line: 4502, col: 23, offset: 137119},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4500, col: 23, offset: 137026},
+					pos:   position{line: 4502, col: 23, offset: 137119},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4500, col: 34, offset: 137037},
+						pos: position{line: 4502, col: 34, offset: 137130},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4500, col: 34, offset: 137037},
+							pos:  position{line: 4502, col: 34, offset: 137130},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11344,35 +11344,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4515, col: 1, offset: 137428},
+			pos:  position{line: 4517, col: 1, offset: 137521},
 			expr: &actionExpr{
-				pos: position{line: 4515, col: 37, offset: 137464},
+				pos: position{line: 4517, col: 37, offset: 137557},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4515, col: 37, offset: 137464},
+					pos: position{line: 4517, col: 37, offset: 137557},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4515, col: 37, offset: 137464},
+							pos:   position{line: 4517, col: 37, offset: 137557},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4515, col: 43, offset: 137470},
+								pos:  position{line: 4517, col: 43, offset: 137563},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4515, col: 71, offset: 137498},
+							pos:   position{line: 4517, col: 71, offset: 137591},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4515, col: 76, offset: 137503},
+								pos: position{line: 4517, col: 76, offset: 137596},
 								expr: &seqExpr{
-									pos: position{line: 4515, col: 77, offset: 137504},
+									pos: position{line: 4517, col: 77, offset: 137597},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4515, col: 77, offset: 137504},
+											pos:  position{line: 4517, col: 77, offset: 137597},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4515, col: 83, offset: 137510},
+											pos:  position{line: 4517, col: 83, offset: 137603},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11385,26 +11385,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4550, col: 1, offset: 138499},
+			pos:  position{line: 4552, col: 1, offset: 138592},
 			expr: &actionExpr{
-				pos: position{line: 4550, col: 32, offset: 138530},
+				pos: position{line: 4552, col: 32, offset: 138623},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4550, col: 32, offset: 138530},
+					pos:   position{line: 4552, col: 32, offset: 138623},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4550, col: 40, offset: 138538},
+						pos: position{line: 4552, col: 40, offset: 138631},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4550, col: 40, offset: 138538},
+								pos:  position{line: 4552, col: 40, offset: 138631},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4550, col: 77, offset: 138575},
+								pos:  position{line: 4552, col: 77, offset: 138668},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4550, col: 96, offset: 138594},
+								pos:  position{line: 4552, col: 96, offset: 138687},
 								name: "EndsWithOption",
 							},
 						},
@@ -11414,15 +11414,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4554, col: 1, offset: 138638},
+			pos:  position{line: 4556, col: 1, offset: 138731},
 			expr: &actionExpr{
-				pos: position{line: 4554, col: 39, offset: 138676},
+				pos: position{line: 4556, col: 39, offset: 138769},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4554, col: 39, offset: 138676},
+					pos:   position{line: 4556, col: 39, offset: 138769},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4554, col: 46, offset: 138683},
+						pos:  position{line: 4556, col: 46, offset: 138776},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11430,28 +11430,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4565, col: 1, offset: 138899},
+			pos:  position{line: 4567, col: 1, offset: 138992},
 			expr: &actionExpr{
-				pos: position{line: 4565, col: 21, offset: 138919},
+				pos: position{line: 4567, col: 21, offset: 139012},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4565, col: 21, offset: 138919},
+					pos: position{line: 4567, col: 21, offset: 139012},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4565, col: 21, offset: 138919},
+							pos:        position{line: 4567, col: 21, offset: 139012},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4565, col: 34, offset: 138932},
+							pos:  position{line: 4567, col: 34, offset: 139025},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4565, col: 40, offset: 138938},
+							pos:   position{line: 4567, col: 40, offset: 139031},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4565, col: 48, offset: 138946},
+								pos:  position{line: 4567, col: 48, offset: 139039},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11461,28 +11461,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4575, col: 1, offset: 139184},
+			pos:  position{line: 4577, col: 1, offset: 139277},
 			expr: &actionExpr{
-				pos: position{line: 4575, col: 19, offset: 139202},
+				pos: position{line: 4577, col: 19, offset: 139295},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4575, col: 19, offset: 139202},
+					pos: position{line: 4577, col: 19, offset: 139295},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4575, col: 19, offset: 139202},
+							pos:        position{line: 4577, col: 19, offset: 139295},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4575, col: 30, offset: 139213},
+							pos:  position{line: 4577, col: 30, offset: 139306},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4575, col: 36, offset: 139219},
+							pos:   position{line: 4577, col: 36, offset: 139312},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4575, col: 44, offset: 139227},
+								pos:  position{line: 4577, col: 44, offset: 139320},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11492,26 +11492,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4586, col: 1, offset: 139496},
+			pos:  position{line: 4588, col: 1, offset: 139589},
 			expr: &actionExpr{
-				pos: position{line: 4586, col: 28, offset: 139523},
+				pos: position{line: 4588, col: 28, offset: 139616},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4586, col: 28, offset: 139523},
+					pos:   position{line: 4588, col: 28, offset: 139616},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4586, col: 37, offset: 139532},
+						pos: position{line: 4588, col: 37, offset: 139625},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4586, col: 37, offset: 139532},
+								pos:  position{line: 4588, col: 37, offset: 139625},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4586, col: 63, offset: 139558},
+								pos:  position{line: 4588, col: 63, offset: 139651},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4586, col: 81, offset: 139576},
+								pos:  position{line: 4588, col: 81, offset: 139669},
 								name: "TransactionSearch",
 							},
 						},
@@ -11521,22 +11521,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4590, col: 1, offset: 139624},
+			pos:  position{line: 4592, col: 1, offset: 139717},
 			expr: &actionExpr{
-				pos: position{line: 4590, col: 28, offset: 139651},
+				pos: position{line: 4592, col: 28, offset: 139744},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4590, col: 28, offset: 139651},
+					pos:   position{line: 4592, col: 28, offset: 139744},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4590, col: 33, offset: 139656},
+						pos: position{line: 4592, col: 33, offset: 139749},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4590, col: 33, offset: 139656},
+								pos:  position{line: 4592, col: 33, offset: 139749},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4590, col: 64, offset: 139687},
+								pos:  position{line: 4592, col: 64, offset: 139780},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11546,29 +11546,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4594, col: 1, offset: 139747},
+			pos:  position{line: 4596, col: 1, offset: 139840},
 			expr: &actionExpr{
-				pos: position{line: 4594, col: 38, offset: 139784},
+				pos: position{line: 4596, col: 38, offset: 139877},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4594, col: 38, offset: 139784},
+					pos: position{line: 4596, col: 38, offset: 139877},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4594, col: 38, offset: 139784},
+							pos:        position{line: 4596, col: 38, offset: 139877},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4594, col: 42, offset: 139788},
+							pos:   position{line: 4596, col: 42, offset: 139881},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4594, col: 55, offset: 139801},
+								pos:  position{line: 4596, col: 55, offset: 139894},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4594, col: 68, offset: 139814},
+							pos:        position{line: 4596, col: 68, offset: 139907},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11579,23 +11579,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4602, col: 1, offset: 139953},
+			pos:  position{line: 4604, col: 1, offset: 140046},
 			expr: &actionExpr{
-				pos: position{line: 4602, col: 21, offset: 139973},
+				pos: position{line: 4604, col: 21, offset: 140066},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4602, col: 21, offset: 139973},
+					pos: position{line: 4604, col: 21, offset: 140066},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4602, col: 21, offset: 139973},
+							pos:        position{line: 4604, col: 21, offset: 140066},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4602, col: 25, offset: 139977},
+							pos: position{line: 4604, col: 25, offset: 140070},
 							expr: &charClassMatcher{
-								pos:        position{line: 4602, col: 25, offset: 139977},
+								pos:        position{line: 4604, col: 25, offset: 140070},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11603,7 +11603,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4602, col: 44, offset: 139996},
+							pos:        position{line: 4604, col: 44, offset: 140089},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11614,15 +11614,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4607, col: 1, offset: 140107},
+			pos:  position{line: 4609, col: 1, offset: 140200},
 			expr: &actionExpr{
-				pos: position{line: 4607, col: 33, offset: 140139},
+				pos: position{line: 4609, col: 33, offset: 140232},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4607, col: 33, offset: 140139},
+					pos:   position{line: 4609, col: 33, offset: 140232},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4607, col: 37, offset: 140143},
+						pos:  position{line: 4609, col: 37, offset: 140236},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11630,15 +11630,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4615, col: 1, offset: 140298},
+			pos:  position{line: 4617, col: 1, offset: 140391},
 			expr: &actionExpr{
-				pos: position{line: 4615, col: 22, offset: 140319},
+				pos: position{line: 4617, col: 22, offset: 140412},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4615, col: 22, offset: 140319},
+					pos:   position{line: 4617, col: 22, offset: 140412},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4615, col: 27, offset: 140324},
+						pos:  position{line: 4617, col: 27, offset: 140417},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11646,37 +11646,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4625, col: 1, offset: 140496},
+			pos:  position{line: 4627, col: 1, offset: 140589},
 			expr: &actionExpr{
-				pos: position{line: 4625, col: 20, offset: 140515},
+				pos: position{line: 4627, col: 20, offset: 140608},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4625, col: 20, offset: 140515},
+					pos: position{line: 4627, col: 20, offset: 140608},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4625, col: 20, offset: 140515},
+							pos:        position{line: 4627, col: 20, offset: 140608},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 27, offset: 140522},
+							pos:  position{line: 4627, col: 27, offset: 140615},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 42, offset: 140537},
+							pos:  position{line: 4627, col: 42, offset: 140630},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4625, col: 50, offset: 140545},
+							pos:   position{line: 4627, col: 50, offset: 140638},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4625, col: 60, offset: 140555},
+								pos:  position{line: 4627, col: 60, offset: 140648},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 69, offset: 140564},
+							pos:  position{line: 4627, col: 69, offset: 140657},
 							name: "R_PAREN",
 						},
 					},
@@ -11685,22 +11685,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4635, col: 1, offset: 140867},
+			pos:  position{line: 4637, col: 1, offset: 140960},
 			expr: &actionExpr{
-				pos: position{line: 4635, col: 20, offset: 140886},
+				pos: position{line: 4637, col: 20, offset: 140979},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4635, col: 20, offset: 140886},
+					pos: position{line: 4637, col: 20, offset: 140979},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4635, col: 20, offset: 140886},
+							pos:  position{line: 4637, col: 20, offset: 140979},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4635, col: 25, offset: 140891},
+							pos:   position{line: 4637, col: 25, offset: 140984},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4635, col: 42, offset: 140908},
+								pos:  position{line: 4637, col: 42, offset: 141001},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11710,41 +11710,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4639, col: 1, offset: 140957},
+			pos:  position{line: 4641, col: 1, offset: 141050},
 			expr: &actionExpr{
-				pos: position{line: 4639, col: 16, offset: 140972},
+				pos: position{line: 4641, col: 16, offset: 141065},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4639, col: 16, offset: 140972},
+					pos: position{line: 4641, col: 16, offset: 141065},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4639, col: 16, offset: 140972},
+							pos:  position{line: 4641, col: 16, offset: 141065},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4639, col: 27, offset: 140983},
+							pos:  position{line: 4641, col: 27, offset: 141076},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4639, col: 33, offset: 140989},
+							pos:   position{line: 4641, col: 33, offset: 141082},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4639, col: 50, offset: 141006},
+								pos: position{line: 4641, col: 50, offset: 141099},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4639, col: 50, offset: 141006},
+									pos:  position{line: 4641, col: 50, offset: 141099},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4639, col: 70, offset: 141026},
+							pos:  position{line: 4641, col: 70, offset: 141119},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4639, col: 85, offset: 141041},
+							pos:   position{line: 4641, col: 85, offset: 141134},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4639, col: 91, offset: 141047},
+								pos:  position{line: 4641, col: 91, offset: 141140},
 								name: "FieldName",
 							},
 						},
@@ -11754,35 +11754,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4668, col: 1, offset: 141818},
+			pos:  position{line: 4670, col: 1, offset: 141911},
 			expr: &actionExpr{
-				pos: position{line: 4668, col: 23, offset: 141840},
+				pos: position{line: 4670, col: 23, offset: 141933},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4668, col: 23, offset: 141840},
+					pos: position{line: 4670, col: 23, offset: 141933},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4668, col: 23, offset: 141840},
+							pos:   position{line: 4670, col: 23, offset: 141933},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4668, col: 31, offset: 141848},
+								pos:  position{line: 4670, col: 31, offset: 141941},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4668, col: 46, offset: 141863},
+							pos:   position{line: 4670, col: 46, offset: 141956},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4668, col: 52, offset: 141869},
+								pos: position{line: 4670, col: 52, offset: 141962},
 								expr: &seqExpr{
-									pos: position{line: 4668, col: 53, offset: 141870},
+									pos: position{line: 4670, col: 53, offset: 141963},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4668, col: 53, offset: 141870},
+											pos:  position{line: 4670, col: 53, offset: 141963},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4668, col: 59, offset: 141876},
+											pos:  position{line: 4670, col: 59, offset: 141969},
 											name: "MVBlockOption",
 										},
 									},
@@ -11795,26 +11795,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4702, col: 1, offset: 142932},
+			pos:  position{line: 4704, col: 1, offset: 143025},
 			expr: &actionExpr{
-				pos: position{line: 4702, col: 18, offset: 142949},
+				pos: position{line: 4704, col: 18, offset: 143042},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4702, col: 18, offset: 142949},
+					pos:   position{line: 4704, col: 18, offset: 143042},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4702, col: 27, offset: 142958},
+						pos: position{line: 4704, col: 27, offset: 143051},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4702, col: 27, offset: 142958},
+								pos:  position{line: 4704, col: 27, offset: 143051},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4702, col: 41, offset: 142972},
+								pos:  position{line: 4704, col: 41, offset: 143065},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4702, col: 60, offset: 142991},
+								pos:  position{line: 4704, col: 60, offset: 143084},
 								name: "SetSvOption",
 							},
 						},
@@ -11824,22 +11824,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4706, col: 1, offset: 143032},
+			pos:  position{line: 4708, col: 1, offset: 143125},
 			expr: &actionExpr{
-				pos: position{line: 4706, col: 16, offset: 143047},
+				pos: position{line: 4708, col: 16, offset: 143140},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4706, col: 16, offset: 143047},
+					pos:   position{line: 4708, col: 16, offset: 143140},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4706, col: 28, offset: 143059},
+						pos: position{line: 4708, col: 28, offset: 143152},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4706, col: 28, offset: 143059},
+								pos:  position{line: 4708, col: 28, offset: 143152},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4706, col: 46, offset: 143077},
+								pos:  position{line: 4708, col: 46, offset: 143170},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11849,28 +11849,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4710, col: 1, offset: 143124},
+			pos:  position{line: 4712, col: 1, offset: 143217},
 			expr: &actionExpr{
-				pos: position{line: 4710, col: 20, offset: 143143},
+				pos: position{line: 4712, col: 20, offset: 143236},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4710, col: 20, offset: 143143},
+					pos: position{line: 4712, col: 20, offset: 143236},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4710, col: 20, offset: 143143},
+							pos:        position{line: 4712, col: 20, offset: 143236},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4710, col: 28, offset: 143151},
+							pos:  position{line: 4712, col: 28, offset: 143244},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4710, col: 34, offset: 143157},
+							pos:   position{line: 4712, col: 34, offset: 143250},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4710, col: 38, offset: 143161},
+								pos:  position{line: 4712, col: 38, offset: 143254},
 								name: "QuotedString",
 							},
 						},
@@ -11880,28 +11880,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4721, col: 1, offset: 143412},
+			pos:  position{line: 4723, col: 1, offset: 143505},
 			expr: &actionExpr{
-				pos: position{line: 4721, col: 19, offset: 143430},
+				pos: position{line: 4723, col: 19, offset: 143523},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4721, col: 19, offset: 143430},
+					pos: position{line: 4723, col: 19, offset: 143523},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4721, col: 19, offset: 143430},
+							pos:        position{line: 4723, col: 19, offset: 143523},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4721, col: 31, offset: 143442},
+							pos:  position{line: 4723, col: 31, offset: 143535},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4721, col: 37, offset: 143448},
+							pos:   position{line: 4723, col: 37, offset: 143541},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4721, col: 41, offset: 143452},
+								pos:  position{line: 4723, col: 41, offset: 143545},
 								name: "QuotedString",
 							},
 						},
@@ -11911,28 +11911,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4739, col: 1, offset: 143923},
+			pos:  position{line: 4741, col: 1, offset: 144016},
 			expr: &actionExpr{
-				pos: position{line: 4739, col: 21, offset: 143943},
+				pos: position{line: 4741, col: 21, offset: 144036},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4739, col: 21, offset: 143943},
+					pos: position{line: 4741, col: 21, offset: 144036},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4739, col: 21, offset: 143943},
+							pos:        position{line: 4741, col: 21, offset: 144036},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4739, col: 34, offset: 143956},
+							pos:  position{line: 4741, col: 34, offset: 144049},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4739, col: 40, offset: 143962},
+							pos:   position{line: 4741, col: 40, offset: 144055},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4739, col: 48, offset: 143970},
+								pos:  position{line: 4741, col: 48, offset: 144063},
 								name: "Boolean",
 							},
 						},
@@ -11942,28 +11942,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4751, col: 1, offset: 144210},
+			pos:  position{line: 4753, col: 1, offset: 144303},
 			expr: &actionExpr{
-				pos: position{line: 4751, col: 16, offset: 144225},
+				pos: position{line: 4753, col: 16, offset: 144318},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4751, col: 16, offset: 144225},
+					pos: position{line: 4753, col: 16, offset: 144318},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4751, col: 16, offset: 144225},
+							pos:        position{line: 4753, col: 16, offset: 144318},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4751, col: 24, offset: 144233},
+							pos:  position{line: 4753, col: 24, offset: 144326},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4751, col: 30, offset: 144239},
+							pos:   position{line: 4753, col: 30, offset: 144332},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4751, col: 38, offset: 144247},
+								pos:  position{line: 4753, col: 38, offset: 144340},
 								name: "Boolean",
 							},
 						},
@@ -11973,28 +11973,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4763, col: 1, offset: 144512},
+			pos:  position{line: 4765, col: 1, offset: 144605},
 			expr: &actionExpr{
-				pos: position{line: 4763, col: 15, offset: 144526},
+				pos: position{line: 4765, col: 15, offset: 144619},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4763, col: 15, offset: 144526},
+					pos: position{line: 4765, col: 15, offset: 144619},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 15, offset: 144526},
+							pos:  position{line: 4765, col: 15, offset: 144619},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4763, col: 20, offset: 144531},
+							pos:  position{line: 4765, col: 20, offset: 144624},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4763, col: 30, offset: 144541},
+							pos:   position{line: 4765, col: 30, offset: 144634},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4763, col: 40, offset: 144551},
+								pos: position{line: 4765, col: 40, offset: 144644},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4763, col: 40, offset: 144551},
+									pos:  position{line: 4765, col: 40, offset: 144644},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12005,39 +12005,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4770, col: 1, offset: 144677},
+			pos:  position{line: 4772, col: 1, offset: 144770},
 			expr: &actionExpr{
-				pos: position{line: 4770, col: 23, offset: 144699},
+				pos: position{line: 4772, col: 23, offset: 144792},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4770, col: 23, offset: 144699},
+					pos: position{line: 4772, col: 23, offset: 144792},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4770, col: 23, offset: 144699},
+							pos:  position{line: 4772, col: 23, offset: 144792},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 29, offset: 144705},
+							pos:   position{line: 4772, col: 29, offset: 144798},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4770, col: 35, offset: 144711},
+								pos:  position{line: 4772, col: 35, offset: 144804},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4770, col: 49, offset: 144725},
+							pos:   position{line: 4772, col: 49, offset: 144818},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4770, col: 54, offset: 144730},
+								pos: position{line: 4772, col: 54, offset: 144823},
 								expr: &seqExpr{
-									pos: position{line: 4770, col: 55, offset: 144731},
+									pos: position{line: 4772, col: 55, offset: 144824},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 55, offset: 144731},
+											pos:  position{line: 4772, col: 55, offset: 144824},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4770, col: 61, offset: 144737},
+											pos:  position{line: 4772, col: 61, offset: 144830},
 											name: "SPathArgument",
 										},
 									},
@@ -12050,26 +12050,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4802, col: 1, offset: 145630},
+			pos:  position{line: 4804, col: 1, offset: 145723},
 			expr: &actionExpr{
-				pos: position{line: 4802, col: 18, offset: 145647},
+				pos: position{line: 4804, col: 18, offset: 145740},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4802, col: 18, offset: 145647},
+					pos:   position{line: 4804, col: 18, offset: 145740},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4802, col: 23, offset: 145652},
+						pos: position{line: 4804, col: 23, offset: 145745},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4802, col: 23, offset: 145652},
+								pos:  position{line: 4804, col: 23, offset: 145745},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4802, col: 36, offset: 145665},
+								pos:  position{line: 4804, col: 36, offset: 145758},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4802, col: 50, offset: 145679},
+								pos:  position{line: 4804, col: 50, offset: 145772},
 								name: "PathField",
 							},
 						},
@@ -12079,28 +12079,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4806, col: 1, offset: 145715},
+			pos:  position{line: 4808, col: 1, offset: 145808},
 			expr: &actionExpr{
-				pos: position{line: 4806, col: 15, offset: 145729},
+				pos: position{line: 4808, col: 15, offset: 145822},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4806, col: 15, offset: 145729},
+					pos: position{line: 4808, col: 15, offset: 145822},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4806, col: 15, offset: 145729},
+							pos:        position{line: 4808, col: 15, offset: 145822},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4806, col: 23, offset: 145737},
+							pos:  position{line: 4808, col: 23, offset: 145830},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4806, col: 29, offset: 145743},
+							pos:   position{line: 4808, col: 29, offset: 145836},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4806, col: 35, offset: 145749},
+								pos:  position{line: 4808, col: 35, offset: 145842},
 								name: "FieldName",
 							},
 						},
@@ -12110,28 +12110,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4809, col: 1, offset: 145805},
+			pos:  position{line: 4811, col: 1, offset: 145898},
 			expr: &actionExpr{
-				pos: position{line: 4809, col: 16, offset: 145820},
+				pos: position{line: 4811, col: 16, offset: 145913},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4809, col: 16, offset: 145820},
+					pos: position{line: 4811, col: 16, offset: 145913},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4809, col: 16, offset: 145820},
+							pos:        position{line: 4811, col: 16, offset: 145913},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4809, col: 25, offset: 145829},
+							pos:  position{line: 4811, col: 25, offset: 145922},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4809, col: 31, offset: 145835},
+							pos:   position{line: 4811, col: 31, offset: 145928},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4809, col: 37, offset: 145841},
+								pos:  position{line: 4811, col: 37, offset: 145934},
 								name: "FieldName",
 							},
 						},
@@ -12141,34 +12141,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4812, col: 1, offset: 145898},
+			pos:  position{line: 4814, col: 1, offset: 145991},
 			expr: &actionExpr{
-				pos: position{line: 4812, col: 14, offset: 145911},
+				pos: position{line: 4814, col: 14, offset: 146004},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4812, col: 15, offset: 145912},
+					pos: position{line: 4814, col: 15, offset: 146005},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4812, col: 15, offset: 145912},
+							pos: position{line: 4814, col: 15, offset: 146005},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4812, col: 15, offset: 145912},
+									pos:        position{line: 4814, col: 15, offset: 146005},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4812, col: 22, offset: 145919},
+									pos:  position{line: 4814, col: 22, offset: 146012},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4812, col: 28, offset: 145925},
+									pos:  position{line: 4814, col: 28, offset: 146018},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4812, col: 47, offset: 145944},
+							pos:  position{line: 4814, col: 47, offset: 146037},
 							name: "SPathFieldString",
 						},
 					},
@@ -12177,16 +12177,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4824, col: 1, offset: 146356},
+			pos:  position{line: 4826, col: 1, offset: 146449},
 			expr: &choiceExpr{
-				pos: position{line: 4824, col: 21, offset: 146376},
+				pos: position{line: 4826, col: 21, offset: 146469},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4824, col: 21, offset: 146376},
+						pos:  position{line: 4826, col: 21, offset: 146469},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4824, col: 36, offset: 146391},
+						pos:  position{line: 4826, col: 36, offset: 146484},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12194,28 +12194,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4827, col: 1, offset: 146464},
+			pos:  position{line: 4829, col: 1, offset: 146557},
 			expr: &actionExpr{
-				pos: position{line: 4827, col: 16, offset: 146479},
+				pos: position{line: 4829, col: 16, offset: 146572},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4827, col: 16, offset: 146479},
+					pos: position{line: 4829, col: 16, offset: 146572},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4827, col: 16, offset: 146479},
+							pos:  position{line: 4829, col: 16, offset: 146572},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4827, col: 21, offset: 146484},
+							pos:  position{line: 4829, col: 21, offset: 146577},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4827, col: 32, offset: 146495},
+							pos:   position{line: 4829, col: 32, offset: 146588},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4827, col: 46, offset: 146509},
+								pos: position{line: 4829, col: 46, offset: 146602},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4827, col: 46, offset: 146509},
+									pos:  position{line: 4829, col: 46, offset: 146602},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12226,39 +12226,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4849, col: 1, offset: 147118},
+			pos:  position{line: 4851, col: 1, offset: 147211},
 			expr: &actionExpr{
-				pos: position{line: 4849, col: 24, offset: 147141},
+				pos: position{line: 4851, col: 24, offset: 147234},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4849, col: 24, offset: 147141},
+					pos: position{line: 4851, col: 24, offset: 147234},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4849, col: 24, offset: 147141},
+							pos:  position{line: 4851, col: 24, offset: 147234},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4849, col: 30, offset: 147147},
+							pos:   position{line: 4851, col: 30, offset: 147240},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4849, col: 37, offset: 147154},
+								pos:  position{line: 4851, col: 37, offset: 147247},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4849, col: 52, offset: 147169},
+							pos:   position{line: 4851, col: 52, offset: 147262},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4849, col: 57, offset: 147174},
+								pos: position{line: 4851, col: 57, offset: 147267},
 								expr: &seqExpr{
-									pos: position{line: 4849, col: 58, offset: 147175},
+									pos: position{line: 4851, col: 58, offset: 147268},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4849, col: 58, offset: 147175},
+											pos:  position{line: 4851, col: 58, offset: 147268},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4849, col: 64, offset: 147181},
+											pos:  position{line: 4851, col: 64, offset: 147274},
 											name: "FormatArgument",
 										},
 									},
@@ -12271,30 +12271,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4883, col: 1, offset: 148370},
+			pos:  position{line: 4885, col: 1, offset: 148463},
 			expr: &actionExpr{
-				pos: position{line: 4883, col: 19, offset: 148388},
+				pos: position{line: 4885, col: 19, offset: 148481},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4883, col: 19, offset: 148388},
+					pos:   position{line: 4885, col: 19, offset: 148481},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4883, col: 28, offset: 148397},
+						pos: position{line: 4885, col: 28, offset: 148490},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4883, col: 28, offset: 148397},
+								pos:  position{line: 4885, col: 28, offset: 148490},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4883, col: 46, offset: 148415},
+								pos:  position{line: 4885, col: 46, offset: 148508},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4883, col: 65, offset: 148434},
+								pos:  position{line: 4885, col: 65, offset: 148527},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4883, col: 82, offset: 148451},
+								pos:  position{line: 4885, col: 82, offset: 148544},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12304,28 +12304,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4887, col: 1, offset: 148501},
+			pos:  position{line: 4889, col: 1, offset: 148594},
 			expr: &actionExpr{
-				pos: position{line: 4887, col: 20, offset: 148520},
+				pos: position{line: 4889, col: 20, offset: 148613},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4887, col: 20, offset: 148520},
+					pos: position{line: 4889, col: 20, offset: 148613},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4887, col: 20, offset: 148520},
+							pos:        position{line: 4889, col: 20, offset: 148613},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4887, col: 28, offset: 148528},
+							pos:  position{line: 4889, col: 28, offset: 148621},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4887, col: 34, offset: 148534},
+							pos:   position{line: 4889, col: 34, offset: 148627},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4887, col: 38, offset: 148538},
+								pos:  position{line: 4889, col: 38, offset: 148631},
 								name: "QuotedString",
 							},
 						},
@@ -12335,28 +12335,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4896, col: 1, offset: 148750},
+			pos:  position{line: 4898, col: 1, offset: 148843},
 			expr: &actionExpr{
-				pos: position{line: 4896, col: 21, offset: 148770},
+				pos: position{line: 4898, col: 21, offset: 148863},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4896, col: 21, offset: 148770},
+					pos: position{line: 4898, col: 21, offset: 148863},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4896, col: 21, offset: 148770},
+							pos:        position{line: 4898, col: 21, offset: 148863},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4896, col: 34, offset: 148783},
+							pos:  position{line: 4898, col: 34, offset: 148876},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4896, col: 40, offset: 148789},
+							pos:   position{line: 4898, col: 40, offset: 148882},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4896, col: 47, offset: 148796},
+								pos:  position{line: 4898, col: 47, offset: 148889},
 								name: "IntegerAsString",
 							},
 						},
@@ -12366,28 +12366,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4909, col: 1, offset: 149202},
+			pos:  position{line: 4911, col: 1, offset: 149295},
 			expr: &actionExpr{
-				pos: position{line: 4909, col: 19, offset: 149220},
+				pos: position{line: 4911, col: 19, offset: 149313},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4909, col: 19, offset: 149220},
+					pos: position{line: 4911, col: 19, offset: 149313},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4909, col: 19, offset: 149220},
+							pos:        position{line: 4911, col: 19, offset: 149313},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4909, col: 30, offset: 149231},
+							pos:  position{line: 4911, col: 30, offset: 149324},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4909, col: 36, offset: 149237},
+							pos:   position{line: 4911, col: 36, offset: 149330},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4909, col: 40, offset: 149241},
+								pos:  position{line: 4911, col: 40, offset: 149334},
 								name: "QuotedString",
 							},
 						},
@@ -12397,78 +12397,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4918, col: 1, offset: 149456},
+			pos:  position{line: 4920, col: 1, offset: 149549},
 			expr: &actionExpr{
-				pos: position{line: 4918, col: 24, offset: 149479},
+				pos: position{line: 4920, col: 24, offset: 149572},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4918, col: 24, offset: 149479},
+					pos: position{line: 4920, col: 24, offset: 149572},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4918, col: 24, offset: 149479},
+							pos:   position{line: 4920, col: 24, offset: 149572},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 34, offset: 149489},
+								pos:  position{line: 4920, col: 34, offset: 149582},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4918, col: 47, offset: 149502},
+							pos:  position{line: 4920, col: 47, offset: 149595},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4918, col: 53, offset: 149508},
+							pos:   position{line: 4920, col: 53, offset: 149601},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 63, offset: 149518},
+								pos:  position{line: 4920, col: 63, offset: 149611},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4918, col: 76, offset: 149531},
+							pos:  position{line: 4920, col: 76, offset: 149624},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4918, col: 82, offset: 149537},
+							pos:   position{line: 4920, col: 82, offset: 149630},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 95, offset: 149550},
+								pos:  position{line: 4920, col: 95, offset: 149643},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4918, col: 108, offset: 149563},
+							pos:  position{line: 4920, col: 108, offset: 149656},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4918, col: 114, offset: 149569},
+							pos:   position{line: 4920, col: 114, offset: 149662},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 121, offset: 149576},
+								pos:  position{line: 4920, col: 121, offset: 149669},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4918, col: 134, offset: 149589},
+							pos:  position{line: 4920, col: 134, offset: 149682},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4918, col: 140, offset: 149595},
+							pos:   position{line: 4920, col: 140, offset: 149688},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 153, offset: 149608},
+								pos:  position{line: 4920, col: 153, offset: 149701},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4918, col: 166, offset: 149621},
+							pos:  position{line: 4920, col: 166, offset: 149714},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4918, col: 172, offset: 149627},
+							pos:   position{line: 4920, col: 172, offset: 149720},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4918, col: 179, offset: 149634},
+								pos:  position{line: 4920, col: 179, offset: 149727},
 								name: "QuotedString",
 							},
 						},
@@ -12478,28 +12478,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4936, col: 1, offset: 150210},
+			pos:  position{line: 4938, col: 1, offset: 150303},
 			expr: &actionExpr{
-				pos: position{line: 4936, col: 20, offset: 150229},
+				pos: position{line: 4938, col: 20, offset: 150322},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4936, col: 20, offset: 150229},
+					pos: position{line: 4938, col: 20, offset: 150322},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4936, col: 20, offset: 150229},
+							pos:  position{line: 4938, col: 20, offset: 150322},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4936, col: 25, offset: 150234},
+							pos:  position{line: 4938, col: 25, offset: 150327},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4936, col: 40, offset: 150249},
+							pos:   position{line: 4938, col: 40, offset: 150342},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4936, col: 55, offset: 150264},
+								pos: position{line: 4938, col: 55, offset: 150357},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4936, col: 55, offset: 150264},
+									pos:  position{line: 4938, col: 55, offset: 150357},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12510,42 +12510,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4943, col: 1, offset: 150417},
+			pos:  position{line: 4945, col: 1, offset: 150510},
 			expr: &actionExpr{
-				pos: position{line: 4943, col: 28, offset: 150444},
+				pos: position{line: 4945, col: 28, offset: 150537},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4943, col: 28, offset: 150444},
+					pos: position{line: 4945, col: 28, offset: 150537},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4943, col: 28, offset: 150444},
+							pos:  position{line: 4945, col: 28, offset: 150537},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4943, col: 34, offset: 150450},
+							pos:   position{line: 4945, col: 34, offset: 150543},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4943, col: 40, offset: 150456},
+								pos: position{line: 4945, col: 40, offset: 150549},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4943, col: 40, offset: 150456},
+									pos:  position{line: 4945, col: 40, offset: 150549},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4943, col: 60, offset: 150476},
+							pos:   position{line: 4945, col: 60, offset: 150569},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4943, col: 65, offset: 150481},
+								pos: position{line: 4945, col: 65, offset: 150574},
 								expr: &seqExpr{
-									pos: position{line: 4943, col: 66, offset: 150482},
+									pos: position{line: 4945, col: 66, offset: 150575},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4943, col: 66, offset: 150482},
+											pos:  position{line: 4945, col: 66, offset: 150575},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4943, col: 72, offset: 150488},
+											pos:  position{line: 4945, col: 72, offset: 150581},
 											name: "EventCountArgument",
 										},
 									},
@@ -12558,30 +12558,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4999, col: 1, offset: 152365},
+			pos:  position{line: 5001, col: 1, offset: 152458},
 			expr: &actionExpr{
-				pos: position{line: 4999, col: 23, offset: 152387},
+				pos: position{line: 5001, col: 23, offset: 152480},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4999, col: 23, offset: 152387},
+					pos:   position{line: 5001, col: 23, offset: 152480},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4999, col: 28, offset: 152392},
+						pos: position{line: 5001, col: 28, offset: 152485},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4999, col: 28, offset: 152392},
+								pos:  position{line: 5001, col: 28, offset: 152485},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4999, col: 41, offset: 152405},
+								pos:  position{line: 5001, col: 41, offset: 152498},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4999, col: 58, offset: 152422},
+								pos:  position{line: 5001, col: 58, offset: 152515},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4999, col: 76, offset: 152440},
+								pos:  position{line: 5001, col: 76, offset: 152533},
 								name: "ListVixField",
 							},
 						},
@@ -12591,28 +12591,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5003, col: 1, offset: 152479},
+			pos:  position{line: 5005, col: 1, offset: 152572},
 			expr: &actionExpr{
-				pos: position{line: 5003, col: 15, offset: 152493},
+				pos: position{line: 5005, col: 15, offset: 152586},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5003, col: 15, offset: 152493},
+					pos: position{line: 5005, col: 15, offset: 152586},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5003, col: 15, offset: 152493},
+							pos:        position{line: 5005, col: 15, offset: 152586},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5003, col: 23, offset: 152501},
+							pos:  position{line: 5005, col: 23, offset: 152594},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5003, col: 29, offset: 152507},
+							pos:   position{line: 5005, col: 29, offset: 152600},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5003, col: 35, offset: 152513},
+								pos:  position{line: 5005, col: 35, offset: 152606},
 								name: "IndexName",
 							},
 						},
@@ -12622,28 +12622,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5006, col: 1, offset: 152569},
+			pos:  position{line: 5008, col: 1, offset: 152662},
 			expr: &actionExpr{
-				pos: position{line: 5006, col: 19, offset: 152587},
+				pos: position{line: 5008, col: 19, offset: 152680},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5006, col: 19, offset: 152587},
+					pos: position{line: 5008, col: 19, offset: 152680},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5006, col: 19, offset: 152587},
+							pos:        position{line: 5008, col: 19, offset: 152680},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5006, col: 31, offset: 152599},
+							pos:  position{line: 5008, col: 31, offset: 152692},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5006, col: 37, offset: 152605},
+							pos:   position{line: 5008, col: 37, offset: 152698},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5006, col: 43, offset: 152611},
+								pos:  position{line: 5008, col: 43, offset: 152704},
 								name: "Boolean",
 							},
 						},
@@ -12653,28 +12653,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5009, col: 1, offset: 152687},
+			pos:  position{line: 5011, col: 1, offset: 152780},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 20, offset: 152706},
+				pos: position{line: 5011, col: 20, offset: 152799},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 20, offset: 152706},
+					pos: position{line: 5011, col: 20, offset: 152799},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5009, col: 20, offset: 152706},
+							pos:        position{line: 5011, col: 20, offset: 152799},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 34, offset: 152720},
+							pos:  position{line: 5011, col: 34, offset: 152813},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 40, offset: 152726},
+							pos:   position{line: 5011, col: 40, offset: 152819},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5009, col: 46, offset: 152732},
+								pos:  position{line: 5011, col: 46, offset: 152825},
 								name: "Boolean",
 							},
 						},
@@ -12684,28 +12684,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5012, col: 1, offset: 152810},
+			pos:  position{line: 5014, col: 1, offset: 152903},
 			expr: &actionExpr{
-				pos: position{line: 5012, col: 17, offset: 152826},
+				pos: position{line: 5014, col: 17, offset: 152919},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5012, col: 17, offset: 152826},
+					pos: position{line: 5014, col: 17, offset: 152919},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5012, col: 17, offset: 152826},
+							pos:        position{line: 5014, col: 17, offset: 152919},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5012, col: 28, offset: 152837},
+							pos:  position{line: 5014, col: 28, offset: 152930},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5012, col: 34, offset: 152843},
+							pos:   position{line: 5014, col: 34, offset: 152936},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5012, col: 40, offset: 152849},
+								pos:  position{line: 5014, col: 40, offset: 152942},
 								name: "Boolean",
 							},
 						},
@@ -12715,24 +12715,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5016, col: 1, offset: 152925},
+			pos:  position{line: 5018, col: 1, offset: 153018},
 			expr: &actionExpr{
-				pos: position{line: 5016, col: 14, offset: 152938},
+				pos: position{line: 5018, col: 14, offset: 153031},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5016, col: 14, offset: 152938},
+					pos: position{line: 5018, col: 14, offset: 153031},
 					expr: &seqExpr{
-						pos: position{line: 5016, col: 15, offset: 152939},
+						pos: position{line: 5018, col: 15, offset: 153032},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5016, col: 15, offset: 152939},
+								pos: position{line: 5018, col: 15, offset: 153032},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5016, col: 16, offset: 152940},
+									pos:  position{line: 5018, col: 16, offset: 153033},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5016, col: 22, offset: 152946,
+								line: 5018, col: 22, offset: 153039,
 							},
 						},
 					},
@@ -12741,39 +12741,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5021, col: 1, offset: 153019},
+			pos:  position{line: 5023, col: 1, offset: 153112},
 			expr: &actionExpr{
-				pos: position{line: 5021, col: 18, offset: 153036},
+				pos: position{line: 5023, col: 18, offset: 153129},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5021, col: 18, offset: 153036},
+					pos: position{line: 5023, col: 18, offset: 153129},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5021, col: 18, offset: 153036},
+							pos:  position{line: 5023, col: 18, offset: 153129},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5021, col: 23, offset: 153041},
+							pos:  position{line: 5023, col: 23, offset: 153134},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5021, col: 36, offset: 153054},
+							pos:   position{line: 5023, col: 36, offset: 153147},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5021, col: 49, offset: 153067},
+								pos: position{line: 5023, col: 49, offset: 153160},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5021, col: 49, offset: 153067},
+									pos:  position{line: 5023, col: 49, offset: 153160},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5021, col: 70, offset: 153088},
+							pos:   position{line: 5023, col: 70, offset: 153181},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5021, col: 77, offset: 153095},
+								pos: position{line: 5023, col: 77, offset: 153188},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5021, col: 77, offset: 153095},
+									pos:  position{line: 5023, col: 77, offset: 153188},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12784,32 +12784,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5051, col: 1, offset: 153858},
+			pos:  position{line: 5053, col: 1, offset: 153951},
 			expr: &actionExpr{
-				pos: position{line: 5051, col: 24, offset: 153881},
+				pos: position{line: 5053, col: 24, offset: 153974},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5051, col: 24, offset: 153881},
+					pos: position{line: 5053, col: 24, offset: 153974},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5051, col: 24, offset: 153881},
+							pos:  position{line: 5053, col: 24, offset: 153974},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5051, col: 30, offset: 153887},
+							pos:        position{line: 5053, col: 30, offset: 153980},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5051, col: 38, offset: 153895},
+							pos:  position{line: 5053, col: 38, offset: 153988},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5051, col: 44, offset: 153901},
+							pos:   position{line: 5053, col: 44, offset: 153994},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5051, col: 48, offset: 153905},
+								pos:  position{line: 5053, col: 48, offset: 153998},
 								name: "String",
 							},
 						},
@@ -12819,22 +12819,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5055, col: 1, offset: 153951},
+			pos:  position{line: 5057, col: 1, offset: 154044},
 			expr: &actionExpr{
-				pos: position{line: 5055, col: 22, offset: 153972},
+				pos: position{line: 5057, col: 22, offset: 154065},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5055, col: 22, offset: 153972},
+					pos: position{line: 5057, col: 22, offset: 154065},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5055, col: 22, offset: 153972},
+							pos:  position{line: 5057, col: 22, offset: 154065},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5055, col: 28, offset: 153978},
+							pos:   position{line: 5057, col: 28, offset: 154071},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5055, col: 38, offset: 153988},
+								pos:  position{line: 5057, col: 38, offset: 154081},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12844,36 +12844,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5059, col: 1, offset: 154047},
+			pos:  position{line: 5061, col: 1, offset: 154140},
 			expr: &actionExpr{
-				pos: position{line: 5059, col: 18, offset: 154064},
+				pos: position{line: 5061, col: 18, offset: 154157},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5059, col: 18, offset: 154064},
+					pos: position{line: 5061, col: 18, offset: 154157},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5059, col: 18, offset: 154064},
+							pos:  position{line: 5061, col: 18, offset: 154157},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5059, col: 23, offset: 154069},
+							pos:  position{line: 5061, col: 23, offset: 154162},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5059, col: 36, offset: 154082},
+							pos:   position{line: 5061, col: 36, offset: 154175},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5059, col: 42, offset: 154088},
+								pos:  position{line: 5061, col: 42, offset: 154181},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5059, col: 56, offset: 154102},
+							pos:   position{line: 5061, col: 56, offset: 154195},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5059, col: 65, offset: 154111},
+								pos: position{line: 5061, col: 65, offset: 154204},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5059, col: 65, offset: 154111},
+									pos:  position{line: 5061, col: 65, offset: 154204},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12884,22 +12884,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5088, col: 1, offset: 154900},
+			pos:  position{line: 5090, col: 1, offset: 154993},
 			expr: &actionExpr{
-				pos: position{line: 5088, col: 18, offset: 154917},
+				pos: position{line: 5090, col: 18, offset: 155010},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5088, col: 18, offset: 154917},
+					pos: position{line: 5090, col: 18, offset: 155010},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5088, col: 18, offset: 154917},
+							pos:  position{line: 5090, col: 18, offset: 155010},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5088, col: 24, offset: 154923},
+							pos:   position{line: 5090, col: 24, offset: 155016},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5088, col: 34, offset: 154933},
+								pos:  position{line: 5090, col: 34, offset: 155026},
 								name: "FieldName",
 							},
 						},
@@ -12909,32 +12909,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5092, col: 1, offset: 154974},
+			pos:  position{line: 5094, col: 1, offset: 155067},
 			expr: &actionExpr{
-				pos: position{line: 5092, col: 18, offset: 154991},
+				pos: position{line: 5094, col: 18, offset: 155084},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5092, col: 18, offset: 154991},
+					pos: position{line: 5094, col: 18, offset: 155084},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5092, col: 18, offset: 154991},
+							pos:  position{line: 5094, col: 18, offset: 155084},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5092, col: 24, offset: 154997},
+							pos:        position{line: 5094, col: 24, offset: 155090},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5092, col: 32, offset: 155005},
+							pos:  position{line: 5094, col: 32, offset: 155098},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5092, col: 38, offset: 155011},
+							pos:   position{line: 5094, col: 38, offset: 155104},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5092, col: 47, offset: 155020},
+								pos:  position{line: 5094, col: 47, offset: 155113},
 								name: "IntegerAsString",
 							},
 						},
@@ -12944,26 +12944,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5096, col: 1, offset: 155066},
+			pos:  position{line: 5098, col: 1, offset: 155159},
 			expr: &actionExpr{
-				pos: position{line: 5096, col: 16, offset: 155081},
+				pos: position{line: 5098, col: 16, offset: 155174},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5096, col: 16, offset: 155081},
+					pos: position{line: 5098, col: 16, offset: 155174},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5096, col: 16, offset: 155081},
+							pos:  position{line: 5098, col: 16, offset: 155174},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5096, col: 22, offset: 155087},
+							pos:  position{line: 5098, col: 22, offset: 155180},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5096, col: 32, offset: 155097},
+							pos:   position{line: 5098, col: 32, offset: 155190},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5096, col: 42, offset: 155107},
+								pos:  position{line: 5098, col: 42, offset: 155200},
 								name: "BoolExpr",
 							},
 						},
@@ -12973,28 +12973,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5100, col: 1, offset: 155167},
+			pos:  position{line: 5102, col: 1, offset: 155260},
 			expr: &actionExpr{
-				pos: position{line: 5100, col: 28, offset: 155194},
+				pos: position{line: 5102, col: 28, offset: 155287},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5100, col: 28, offset: 155194},
+					pos: position{line: 5102, col: 28, offset: 155287},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5100, col: 28, offset: 155194},
+							pos:        position{line: 5102, col: 28, offset: 155287},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 37, offset: 155203},
+							pos:  position{line: 5102, col: 37, offset: 155296},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 43, offset: 155209},
+							pos:   position{line: 5102, col: 43, offset: 155302},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 51, offset: 155217},
+								pos:  position{line: 5102, col: 51, offset: 155310},
 								name: "Boolean",
 							},
 						},
@@ -13004,28 +13004,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5109, col: 1, offset: 155401},
+			pos:  position{line: 5111, col: 1, offset: 155494},
 			expr: &actionExpr{
-				pos: position{line: 5109, col: 28, offset: 155428},
+				pos: position{line: 5111, col: 28, offset: 155521},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5109, col: 28, offset: 155428},
+					pos: position{line: 5111, col: 28, offset: 155521},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5109, col: 28, offset: 155428},
+							pos:        position{line: 5111, col: 28, offset: 155521},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5109, col: 37, offset: 155437},
+							pos:  position{line: 5111, col: 37, offset: 155530},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5109, col: 43, offset: 155443},
+							pos:   position{line: 5111, col: 43, offset: 155536},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5109, col: 51, offset: 155451},
+								pos:  position{line: 5111, col: 51, offset: 155544},
 								name: "Boolean",
 							},
 						},
@@ -13035,28 +13035,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5118, col: 1, offset: 155635},
+			pos:  position{line: 5120, col: 1, offset: 155728},
 			expr: &actionExpr{
-				pos: position{line: 5118, col: 27, offset: 155661},
+				pos: position{line: 5120, col: 27, offset: 155754},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5118, col: 27, offset: 155661},
+					pos: position{line: 5120, col: 27, offset: 155754},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5118, col: 27, offset: 155661},
+							pos:        position{line: 5120, col: 27, offset: 155754},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5118, col: 35, offset: 155669},
+							pos:  position{line: 5120, col: 35, offset: 155762},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5118, col: 41, offset: 155675},
+							pos:   position{line: 5120, col: 41, offset: 155768},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5118, col: 48, offset: 155682},
+								pos:  position{line: 5120, col: 48, offset: 155775},
 								name: "PositiveInteger",
 							},
 						},
@@ -13066,28 +13066,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5127, col: 1, offset: 155873},
+			pos:  position{line: 5129, col: 1, offset: 155966},
 			expr: &actionExpr{
-				pos: position{line: 5127, col: 25, offset: 155897},
+				pos: position{line: 5129, col: 25, offset: 155990},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5127, col: 25, offset: 155897},
+					pos: position{line: 5129, col: 25, offset: 155990},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5127, col: 25, offset: 155897},
+							pos:        position{line: 5129, col: 25, offset: 155990},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5127, col: 31, offset: 155903},
+							pos:  position{line: 5129, col: 31, offset: 155996},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5127, col: 37, offset: 155909},
+							pos:   position{line: 5129, col: 37, offset: 156002},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5127, col: 44, offset: 155916},
+								pos:  position{line: 5129, col: 44, offset: 156009},
 								name: "PositiveInteger",
 							},
 						},
@@ -13097,30 +13097,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5136, col: 1, offset: 156103},
+			pos:  position{line: 5138, col: 1, offset: 156196},
 			expr: &actionExpr{
-				pos: position{line: 5136, col: 22, offset: 156124},
+				pos: position{line: 5138, col: 22, offset: 156217},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5136, col: 22, offset: 156124},
+					pos:   position{line: 5138, col: 22, offset: 156217},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5136, col: 41, offset: 156143},
+						pos: position{line: 5138, col: 41, offset: 156236},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5136, col: 41, offset: 156143},
+								pos:  position{line: 5138, col: 41, offset: 156236},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5136, col: 67, offset: 156169},
+								pos:  position{line: 5138, col: 67, offset: 156262},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5136, col: 93, offset: 156195},
+								pos:  position{line: 5138, col: 93, offset: 156288},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5136, col: 118, offset: 156220},
+								pos:  position{line: 5138, col: 118, offset: 156313},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13130,35 +13130,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5140, col: 1, offset: 156281},
+			pos:  position{line: 5142, col: 1, offset: 156374},
 			expr: &actionExpr{
-				pos: position{line: 5140, col: 26, offset: 156306},
+				pos: position{line: 5142, col: 26, offset: 156399},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5140, col: 26, offset: 156306},
+					pos: position{line: 5142, col: 26, offset: 156399},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5140, col: 26, offset: 156306},
+							pos:   position{line: 5142, col: 26, offset: 156399},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5140, col: 34, offset: 156314},
+								pos:  position{line: 5142, col: 34, offset: 156407},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5140, col: 53, offset: 156333},
+							pos:   position{line: 5142, col: 53, offset: 156426},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5140, col: 58, offset: 156338},
+								pos: position{line: 5142, col: 58, offset: 156431},
 								expr: &seqExpr{
-									pos: position{line: 5140, col: 59, offset: 156339},
+									pos: position{line: 5142, col: 59, offset: 156432},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5140, col: 59, offset: 156339},
+											pos:  position{line: 5142, col: 59, offset: 156432},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5140, col: 65, offset: 156345},
+											pos:  position{line: 5142, col: 65, offset: 156438},
 											name: "InputLookupOption",
 										},
 									},
@@ -13171,35 +13171,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5182, col: 1, offset: 157791},
+			pos:  position{line: 5184, col: 1, offset: 157884},
 			expr: &actionExpr{
-				pos: position{line: 5182, col: 21, offset: 157811},
+				pos: position{line: 5184, col: 21, offset: 157904},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5182, col: 21, offset: 157811},
+					pos: position{line: 5184, col: 21, offset: 157904},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5182, col: 21, offset: 157811},
+							pos:  position{line: 5184, col: 21, offset: 157904},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5182, col: 26, offset: 157816},
+							pos:  position{line: 5184, col: 26, offset: 157909},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5182, col: 42, offset: 157832},
+							pos:   position{line: 5184, col: 42, offset: 157925},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5182, col: 60, offset: 157850},
+								pos: position{line: 5184, col: 60, offset: 157943},
 								expr: &seqExpr{
-									pos: position{line: 5182, col: 61, offset: 157851},
+									pos: position{line: 5184, col: 61, offset: 157944},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5182, col: 61, offset: 157851},
+											pos:  position{line: 5184, col: 61, offset: 157944},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5182, col: 83, offset: 157873},
+											pos:  position{line: 5184, col: 83, offset: 157966},
 											name: "SPACE",
 										},
 									},
@@ -13207,20 +13207,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5182, col: 91, offset: 157881},
+							pos:   position{line: 5184, col: 91, offset: 157974},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5182, col: 101, offset: 157891},
+								pos:  position{line: 5184, col: 101, offset: 157984},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5182, col: 109, offset: 157899},
+							pos:   position{line: 5184, col: 109, offset: 157992},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5182, col: 121, offset: 157911},
+								pos: position{line: 5184, col: 121, offset: 158004},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5182, col: 122, offset: 157912},
+									pos:  position{line: 5184, col: 122, offset: 158005},
 									name: "WhereClause",
 								},
 							},
@@ -13231,15 +13231,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5205, col: 1, offset: 158600},
+			pos:  position{line: 5207, col: 1, offset: 158693},
 			expr: &actionExpr{
-				pos: position{line: 5205, col: 24, offset: 158623},
+				pos: position{line: 5207, col: 24, offset: 158716},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5205, col: 24, offset: 158623},
+					pos:   position{line: 5207, col: 24, offset: 158716},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5205, col: 41, offset: 158640},
+						pos:  position{line: 5207, col: 41, offset: 158733},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13247,26 +13247,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5216, col: 1, offset: 159039},
+			pos:  position{line: 5218, col: 1, offset: 159132},
 			expr: &actionExpr{
-				pos: position{line: 5216, col: 20, offset: 159058},
+				pos: position{line: 5218, col: 20, offset: 159151},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5216, col: 20, offset: 159058},
+					pos:   position{line: 5218, col: 20, offset: 159151},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5216, col: 28, offset: 159066},
+						pos: position{line: 5218, col: 28, offset: 159159},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5216, col: 28, offset: 159066},
+								pos:  position{line: 5218, col: 28, offset: 159159},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5216, col: 52, offset: 159090},
+								pos:  position{line: 5218, col: 52, offset: 159183},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5216, col: 68, offset: 159106},
+								pos:  position{line: 5218, col: 68, offset: 159199},
 								name: "MaxOutOption",
 							},
 						},
@@ -13276,28 +13276,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5221, col: 1, offset: 159204},
+			pos:  position{line: 5223, col: 1, offset: 159297},
 			expr: &actionExpr{
-				pos: position{line: 5221, col: 26, offset: 159229},
+				pos: position{line: 5223, col: 26, offset: 159322},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5221, col: 26, offset: 159229},
+					pos: position{line: 5223, col: 26, offset: 159322},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5221, col: 26, offset: 159229},
+							pos:        position{line: 5223, col: 26, offset: 159322},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5221, col: 44, offset: 159247},
+							pos:  position{line: 5223, col: 44, offset: 159340},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5221, col: 50, offset: 159253},
+							pos:   position{line: 5223, col: 50, offset: 159346},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5221, col: 58, offset: 159261},
+								pos:  position{line: 5223, col: 58, offset: 159354},
 								name: "Boolean",
 							},
 						},
@@ -13307,28 +13307,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5228, col: 1, offset: 159400},
+			pos:  position{line: 5230, col: 1, offset: 159493},
 			expr: &actionExpr{
-				pos: position{line: 5228, col: 18, offset: 159417},
+				pos: position{line: 5230, col: 18, offset: 159510},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5228, col: 18, offset: 159417},
+					pos: position{line: 5230, col: 18, offset: 159510},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5228, col: 18, offset: 159417},
+							pos:        position{line: 5230, col: 18, offset: 159510},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5228, col: 28, offset: 159427},
+							pos:  position{line: 5230, col: 28, offset: 159520},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5228, col: 34, offset: 159433},
+							pos:   position{line: 5230, col: 34, offset: 159526},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5228, col: 39, offset: 159438},
+								pos:  position{line: 5230, col: 39, offset: 159531},
 								name: "IntegerAsString",
 							},
 						},
@@ -13338,28 +13338,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5239, col: 1, offset: 159739},
+			pos:  position{line: 5241, col: 1, offset: 159832},
 			expr: &actionExpr{
-				pos: position{line: 5239, col: 17, offset: 159755},
+				pos: position{line: 5241, col: 17, offset: 159848},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5239, col: 17, offset: 159755},
+					pos: position{line: 5241, col: 17, offset: 159848},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5239, col: 17, offset: 159755},
+							pos:        position{line: 5241, col: 17, offset: 159848},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5239, col: 26, offset: 159764},
+							pos:  position{line: 5241, col: 26, offset: 159857},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5239, col: 32, offset: 159770},
+							pos:   position{line: 5241, col: 32, offset: 159863},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5239, col: 36, offset: 159774},
+								pos:  position{line: 5241, col: 36, offset: 159867},
 								name: "IntegerAsString",
 							},
 						},
@@ -13369,43 +13369,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5251, col: 1, offset: 160129},
+			pos:  position{line: 5253, col: 1, offset: 160222},
 			expr: &actionExpr{
-				pos: position{line: 5251, col: 14, offset: 160142},
+				pos: position{line: 5253, col: 14, offset: 160235},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5251, col: 14, offset: 160142},
+					pos: position{line: 5253, col: 14, offset: 160235},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5251, col: 14, offset: 160142},
+							pos:        position{line: 5253, col: 14, offset: 160235},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5251, col: 18, offset: 160146},
+							pos: position{line: 5253, col: 18, offset: 160239},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5251, col: 18, offset: 160146},
+								pos:  position{line: 5253, col: 18, offset: 160239},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5251, col: 25, offset: 160153},
+							pos:   position{line: 5253, col: 25, offset: 160246},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5251, col: 32, offset: 160160},
+								pos:  position{line: 5253, col: 32, offset: 160253},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5251, col: 44, offset: 160172},
+							pos: position{line: 5253, col: 44, offset: 160265},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5251, col: 44, offset: 160172},
+								pos:  position{line: 5253, col: 44, offset: 160265},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5251, col: 51, offset: 160179},
+							pos:        position{line: 5253, col: 51, offset: 160272},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13416,35 +13416,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5256, col: 1, offset: 160268},
+			pos:  position{line: 5258, col: 1, offset: 160361},
 			expr: &actionExpr{
-				pos: position{line: 5256, col: 25, offset: 160292},
+				pos: position{line: 5258, col: 25, offset: 160385},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5256, col: 25, offset: 160292},
+					pos: position{line: 5258, col: 25, offset: 160385},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5256, col: 25, offset: 160292},
+							pos:   position{line: 5258, col: 25, offset: 160385},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5256, col: 31, offset: 160298},
+								pos:  position{line: 5258, col: 31, offset: 160391},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5256, col: 47, offset: 160314},
+							pos:   position{line: 5258, col: 47, offset: 160407},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5256, col: 52, offset: 160319},
+								pos: position{line: 5258, col: 52, offset: 160412},
 								expr: &seqExpr{
-									pos: position{line: 5256, col: 53, offset: 160320},
+									pos: position{line: 5258, col: 53, offset: 160413},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5256, col: 53, offset: 160320},
+											pos:  position{line: 5258, col: 53, offset: 160413},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5256, col: 59, offset: 160326},
+											pos:  position{line: 5258, col: 59, offset: 160419},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13457,37 +13457,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5283, col: 1, offset: 161136},
+			pos:  position{line: 5285, col: 1, offset: 161229},
 			expr: &actionExpr{
-				pos: position{line: 5283, col: 16, offset: 161151},
+				pos: position{line: 5285, col: 16, offset: 161244},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5283, col: 16, offset: 161151},
+					pos: position{line: 5285, col: 16, offset: 161244},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5283, col: 16, offset: 161151},
+							pos:  position{line: 5285, col: 16, offset: 161244},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5283, col: 21, offset: 161156},
+							pos:  position{line: 5285, col: 21, offset: 161249},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5283, col: 32, offset: 161167},
+							pos:   position{line: 5285, col: 32, offset: 161260},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5283, col: 40, offset: 161175},
+								pos: position{line: 5285, col: 40, offset: 161268},
 								expr: &seqExpr{
-									pos: position{line: 5283, col: 41, offset: 161176},
+									pos: position{line: 5285, col: 41, offset: 161269},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5283, col: 41, offset: 161176},
+											pos:  position{line: 5285, col: 41, offset: 161269},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5283, col: 57, offset: 161192},
+											pos: position{line: 5285, col: 57, offset: 161285},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5283, col: 57, offset: 161192},
+												pos:  position{line: 5285, col: 57, offset: 161285},
 												name: "SPACE",
 											},
 										},
@@ -13496,10 +13496,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5283, col: 66, offset: 161201},
+							pos:   position{line: 5285, col: 66, offset: 161294},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5283, col: 76, offset: 161211},
+								pos:  position{line: 5285, col: 76, offset: 161304},
 								name: "Subsearch",
 							},
 						},
@@ -13509,128 +13509,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5327, col: 1, offset: 162783},
+			pos:  position{line: 5329, col: 1, offset: 162876},
 			expr: &choiceExpr{
-				pos: position{line: 5327, col: 12, offset: 162794},
+				pos: position{line: 5329, col: 12, offset: 162887},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 12, offset: 162794},
+						pos:  position{line: 5329, col: 12, offset: 162887},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 24, offset: 162806},
+						pos:  position{line: 5329, col: 24, offset: 162899},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 36, offset: 162818},
+						pos:  position{line: 5329, col: 36, offset: 162911},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 49, offset: 162831},
+						pos:  position{line: 5329, col: 49, offset: 162924},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 61, offset: 162843},
+						pos:  position{line: 5329, col: 61, offset: 162936},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 81, offset: 162863},
+						pos:  position{line: 5329, col: 81, offset: 162956},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 92, offset: 162874},
+						pos:  position{line: 5329, col: 92, offset: 162967},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 112, offset: 162894},
+						pos:  position{line: 5329, col: 112, offset: 162987},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 123, offset: 162905},
+						pos:  position{line: 5329, col: 123, offset: 162998},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 134, offset: 162916},
+						pos:  position{line: 5329, col: 134, offset: 163009},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 144, offset: 162926},
+						pos:  position{line: 5329, col: 144, offset: 163019},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 154, offset: 162936},
+						pos:  position{line: 5329, col: 154, offset: 163029},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 165, offset: 162947},
+						pos:  position{line: 5329, col: 165, offset: 163040},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 178, offset: 162960},
+						pos:  position{line: 5329, col: 178, offset: 163053},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 194, offset: 162976},
+						pos:  position{line: 5329, col: 194, offset: 163069},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 212, offset: 162994},
+						pos:  position{line: 5329, col: 212, offset: 163087},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 224, offset: 163006},
+						pos:  position{line: 5329, col: 224, offset: 163099},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 235, offset: 163017},
+						pos:  position{line: 5329, col: 235, offset: 163110},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 248, offset: 163030},
+						pos:  position{line: 5329, col: 248, offset: 163123},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 260, offset: 163042},
+						pos:  position{line: 5329, col: 260, offset: 163135},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 273, offset: 163055},
+						pos:  position{line: 5329, col: 273, offset: 163148},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 288, offset: 163070},
+						pos:  position{line: 5329, col: 288, offset: 163163},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 301, offset: 163083},
+						pos:  position{line: 5329, col: 301, offset: 163176},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 318, offset: 163100},
+						pos:  position{line: 5329, col: 318, offset: 163193},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 328, offset: 163110},
+						pos:  position{line: 5329, col: 328, offset: 163203},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 346, offset: 163128},
+						pos:  position{line: 5329, col: 346, offset: 163221},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 361, offset: 163143},
+						pos:  position{line: 5329, col: 361, offset: 163236},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 376, offset: 163158},
+						pos:  position{line: 5329, col: 376, offset: 163251},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 391, offset: 163173},
+						pos:  position{line: 5329, col: 391, offset: 163266},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 409, offset: 163191},
+						pos:  position{line: 5329, col: 409, offset: 163284},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13638,18 +13638,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5328, col: 1, offset: 163203},
+			pos:  position{line: 5330, col: 1, offset: 163296},
 			expr: &seqExpr{
-				pos: position{line: 5328, col: 15, offset: 163217},
+				pos: position{line: 5330, col: 15, offset: 163310},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5328, col: 15, offset: 163217},
+						pos:        position{line: 5330, col: 15, offset: 163310},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5328, col: 24, offset: 163226},
+						pos:  position{line: 5330, col: 24, offset: 163319},
 						name: "SPACE",
 					},
 				},
@@ -13657,18 +13657,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5329, col: 1, offset: 163232},
+			pos:  position{line: 5331, col: 1, offset: 163325},
 			expr: &seqExpr{
-				pos: position{line: 5329, col: 14, offset: 163245},
+				pos: position{line: 5331, col: 14, offset: 163338},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5329, col: 14, offset: 163245},
+						pos:        position{line: 5331, col: 14, offset: 163338},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5329, col: 22, offset: 163253},
+						pos:  position{line: 5331, col: 22, offset: 163346},
 						name: "SPACE",
 					},
 				},
@@ -13676,18 +13676,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5330, col: 1, offset: 163259},
+			pos:  position{line: 5332, col: 1, offset: 163352},
 			expr: &seqExpr{
-				pos: position{line: 5330, col: 14, offset: 163272},
+				pos: position{line: 5332, col: 14, offset: 163365},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5330, col: 14, offset: 163272},
+						pos:        position{line: 5332, col: 14, offset: 163365},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5330, col: 22, offset: 163280},
+						pos:  position{line: 5332, col: 22, offset: 163373},
 						name: "SPACE",
 					},
 				},
@@ -13695,18 +13695,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5331, col: 1, offset: 163286},
+			pos:  position{line: 5333, col: 1, offset: 163379},
 			expr: &seqExpr{
-				pos: position{line: 5331, col: 20, offset: 163305},
+				pos: position{line: 5333, col: 20, offset: 163398},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5331, col: 20, offset: 163305},
+						pos:        position{line: 5333, col: 20, offset: 163398},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5331, col: 34, offset: 163319},
+						pos:  position{line: 5333, col: 34, offset: 163412},
 						name: "SPACE",
 					},
 				},
@@ -13714,18 +13714,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5332, col: 1, offset: 163325},
+			pos:  position{line: 5334, col: 1, offset: 163418},
 			expr: &seqExpr{
-				pos: position{line: 5332, col: 15, offset: 163339},
+				pos: position{line: 5334, col: 15, offset: 163432},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5332, col: 15, offset: 163339},
+						pos:        position{line: 5334, col: 15, offset: 163432},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5332, col: 24, offset: 163348},
+						pos:  position{line: 5334, col: 24, offset: 163441},
 						name: "SPACE",
 					},
 				},
@@ -13733,18 +13733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5333, col: 1, offset: 163354},
+			pos:  position{line: 5335, col: 1, offset: 163447},
 			expr: &seqExpr{
-				pos: position{line: 5333, col: 14, offset: 163367},
+				pos: position{line: 5335, col: 14, offset: 163460},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5333, col: 14, offset: 163367},
+						pos:        position{line: 5335, col: 14, offset: 163460},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5333, col: 22, offset: 163375},
+						pos:  position{line: 5335, col: 22, offset: 163468},
 						name: "SPACE",
 					},
 				},
@@ -13752,9 +13752,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5334, col: 1, offset: 163381},
+			pos:  position{line: 5336, col: 1, offset: 163474},
 			expr: &litMatcher{
-				pos:        position{line: 5334, col: 22, offset: 163402},
+				pos:        position{line: 5336, col: 22, offset: 163495},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13762,16 +13762,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5335, col: 1, offset: 163409},
+			pos:  position{line: 5337, col: 1, offset: 163502},
 			expr: &seqExpr{
-				pos: position{line: 5335, col: 13, offset: 163421},
+				pos: position{line: 5337, col: 13, offset: 163514},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 13, offset: 163421},
+						pos:  position{line: 5337, col: 13, offset: 163514},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 31, offset: 163439},
+						pos:  position{line: 5337, col: 31, offset: 163532},
 						name: "SPACE",
 					},
 				},
@@ -13779,9 +13779,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5336, col: 1, offset: 163445},
+			pos:  position{line: 5338, col: 1, offset: 163538},
 			expr: &litMatcher{
-				pos:        position{line: 5336, col: 22, offset: 163466},
+				pos:        position{line: 5338, col: 22, offset: 163559},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13789,16 +13789,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5337, col: 1, offset: 163473},
+			pos:  position{line: 5339, col: 1, offset: 163566},
 			expr: &seqExpr{
-				pos: position{line: 5337, col: 13, offset: 163485},
+				pos: position{line: 5339, col: 13, offset: 163578},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 13, offset: 163485},
+						pos:  position{line: 5339, col: 13, offset: 163578},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 31, offset: 163503},
+						pos:  position{line: 5339, col: 31, offset: 163596},
 						name: "SPACE",
 					},
 				},
@@ -13806,18 +13806,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5338, col: 1, offset: 163509},
+			pos:  position{line: 5340, col: 1, offset: 163602},
 			expr: &seqExpr{
-				pos: position{line: 5338, col: 13, offset: 163521},
+				pos: position{line: 5340, col: 13, offset: 163614},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5338, col: 13, offset: 163521},
+						pos:        position{line: 5340, col: 13, offset: 163614},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5338, col: 20, offset: 163528},
+						pos:  position{line: 5340, col: 20, offset: 163621},
 						name: "SPACE",
 					},
 				},
@@ -13825,18 +13825,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5339, col: 1, offset: 163534},
+			pos:  position{line: 5341, col: 1, offset: 163627},
 			expr: &seqExpr{
-				pos: position{line: 5339, col: 12, offset: 163545},
+				pos: position{line: 5341, col: 12, offset: 163638},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5339, col: 12, offset: 163545},
+						pos:        position{line: 5341, col: 12, offset: 163638},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5339, col: 18, offset: 163551},
+						pos:  position{line: 5341, col: 18, offset: 163644},
 						name: "SPACE",
 					},
 				},
@@ -13844,18 +13844,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5340, col: 1, offset: 163557},
+			pos:  position{line: 5342, col: 1, offset: 163650},
 			expr: &seqExpr{
-				pos: position{line: 5340, col: 13, offset: 163569},
+				pos: position{line: 5342, col: 13, offset: 163662},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5340, col: 13, offset: 163569},
+						pos:        position{line: 5342, col: 13, offset: 163662},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5340, col: 20, offset: 163576},
+						pos:  position{line: 5342, col: 20, offset: 163669},
 						name: "SPACE",
 					},
 				},
@@ -13863,9 +13863,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5341, col: 1, offset: 163582},
+			pos:  position{line: 5343, col: 1, offset: 163675},
 			expr: &litMatcher{
-				pos:        position{line: 5341, col: 12, offset: 163593},
+				pos:        position{line: 5343, col: 12, offset: 163686},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13873,9 +13873,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5342, col: 1, offset: 163599},
+			pos:  position{line: 5344, col: 1, offset: 163692},
 			expr: &litMatcher{
-				pos:        position{line: 5342, col: 13, offset: 163611},
+				pos:        position{line: 5344, col: 13, offset: 163704},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13883,18 +13883,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5343, col: 1, offset: 163618},
+			pos:  position{line: 5345, col: 1, offset: 163711},
 			expr: &seqExpr{
-				pos: position{line: 5343, col: 15, offset: 163632},
+				pos: position{line: 5345, col: 15, offset: 163725},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5343, col: 15, offset: 163632},
+						pos:        position{line: 5345, col: 15, offset: 163725},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5343, col: 24, offset: 163641},
+						pos:  position{line: 5345, col: 24, offset: 163734},
 						name: "SPACE",
 					},
 				},
@@ -13902,18 +13902,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5344, col: 1, offset: 163647},
+			pos:  position{line: 5346, col: 1, offset: 163740},
 			expr: &seqExpr{
-				pos: position{line: 5344, col: 18, offset: 163664},
+				pos: position{line: 5346, col: 18, offset: 163757},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5344, col: 18, offset: 163664},
+						pos:        position{line: 5346, col: 18, offset: 163757},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5344, col: 30, offset: 163676},
+						pos:  position{line: 5346, col: 30, offset: 163769},
 						name: "SPACE",
 					},
 				},
@@ -13921,18 +13921,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5345, col: 1, offset: 163682},
+			pos:  position{line: 5347, col: 1, offset: 163775},
 			expr: &seqExpr{
-				pos: position{line: 5345, col: 12, offset: 163693},
+				pos: position{line: 5347, col: 12, offset: 163786},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5345, col: 12, offset: 163693},
+						pos:        position{line: 5347, col: 12, offset: 163786},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5345, col: 18, offset: 163699},
+						pos:  position{line: 5347, col: 18, offset: 163792},
 						name: "SPACE",
 					},
 				},
@@ -13940,9 +13940,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5346, col: 1, offset: 163705},
+			pos:  position{line: 5348, col: 1, offset: 163798},
 			expr: &litMatcher{
-				pos:        position{line: 5346, col: 13, offset: 163717},
+				pos:        position{line: 5348, col: 13, offset: 163810},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13950,18 +13950,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5347, col: 1, offset: 163724},
+			pos:  position{line: 5349, col: 1, offset: 163817},
 			expr: &seqExpr{
-				pos: position{line: 5347, col: 20, offset: 163743},
+				pos: position{line: 5349, col: 20, offset: 163836},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5347, col: 20, offset: 163743},
+						pos:        position{line: 5349, col: 20, offset: 163836},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5347, col: 34, offset: 163757},
+						pos:  position{line: 5349, col: 34, offset: 163850},
 						name: "SPACE",
 					},
 				},
@@ -13969,9 +13969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5348, col: 1, offset: 163763},
+			pos:  position{line: 5350, col: 1, offset: 163856},
 			expr: &litMatcher{
-				pos:        position{line: 5348, col: 14, offset: 163776},
+				pos:        position{line: 5350, col: 14, offset: 163869},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13979,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5349, col: 1, offset: 163784},
+			pos:  position{line: 5351, col: 1, offset: 163877},
 			expr: &seqExpr{
-				pos: position{line: 5349, col: 21, offset: 163804},
+				pos: position{line: 5351, col: 21, offset: 163897},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5349, col: 21, offset: 163804},
+						pos:  position{line: 5351, col: 21, offset: 163897},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5349, col: 27, offset: 163810},
+						pos:        position{line: 5351, col: 27, offset: 163903},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5349, col: 36, offset: 163819},
+						pos:  position{line: 5351, col: 36, offset: 163912},
 						name: "SPACE",
 					},
 				},
@@ -14002,9 +14002,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5350, col: 1, offset: 163825},
+			pos:  position{line: 5352, col: 1, offset: 163918},
 			expr: &litMatcher{
-				pos:        position{line: 5350, col: 15, offset: 163839},
+				pos:        position{line: 5352, col: 15, offset: 163932},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14012,9 +14012,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5351, col: 1, offset: 163848},
+			pos:  position{line: 5353, col: 1, offset: 163941},
 			expr: &litMatcher{
-				pos:        position{line: 5351, col: 14, offset: 163861},
+				pos:        position{line: 5353, col: 14, offset: 163954},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14022,9 +14022,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5352, col: 1, offset: 163869},
+			pos:  position{line: 5354, col: 1, offset: 163962},
 			expr: &litMatcher{
-				pos:        position{line: 5352, col: 15, offset: 163883},
+				pos:        position{line: 5354, col: 15, offset: 163976},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14032,9 +14032,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5353, col: 1, offset: 163892},
+			pos:  position{line: 5355, col: 1, offset: 163985},
 			expr: &litMatcher{
-				pos:        position{line: 5353, col: 17, offset: 163908},
+				pos:        position{line: 5355, col: 17, offset: 164001},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14042,9 +14042,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5354, col: 1, offset: 163919},
+			pos:  position{line: 5356, col: 1, offset: 164012},
 			expr: &litMatcher{
-				pos:        position{line: 5354, col: 15, offset: 163933},
+				pos:        position{line: 5356, col: 15, offset: 164026},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14052,9 +14052,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5355, col: 1, offset: 163942},
+			pos:  position{line: 5357, col: 1, offset: 164035},
 			expr: &litMatcher{
-				pos:        position{line: 5355, col: 19, offset: 163960},
+				pos:        position{line: 5357, col: 19, offset: 164053},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14062,9 +14062,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5356, col: 1, offset: 163973},
+			pos:  position{line: 5358, col: 1, offset: 164066},
 			expr: &litMatcher{
-				pos:        position{line: 5356, col: 17, offset: 163989},
+				pos:        position{line: 5358, col: 17, offset: 164082},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14072,9 +14072,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5357, col: 1, offset: 164000},
+			pos:  position{line: 5359, col: 1, offset: 164093},
 			expr: &litMatcher{
-				pos:        position{line: 5357, col: 17, offset: 164016},
+				pos:        position{line: 5359, col: 17, offset: 164109},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14082,18 +14082,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5358, col: 1, offset: 164027},
+			pos:  position{line: 5360, col: 1, offset: 164120},
 			expr: &seqExpr{
-				pos: position{line: 5358, col: 20, offset: 164046},
+				pos: position{line: 5360, col: 20, offset: 164139},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5358, col: 20, offset: 164046},
+						pos:        position{line: 5360, col: 20, offset: 164139},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5358, col: 34, offset: 164060},
+						pos:  position{line: 5360, col: 34, offset: 164153},
 						name: "SPACE",
 					},
 				},
@@ -14101,28 +14101,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5359, col: 1, offset: 164066},
+			pos:  position{line: 5361, col: 1, offset: 164159},
 			expr: &seqExpr{
-				pos: position{line: 5359, col: 16, offset: 164081},
+				pos: position{line: 5361, col: 16, offset: 164174},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5359, col: 16, offset: 164081},
+						pos: position{line: 5361, col: 16, offset: 164174},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5359, col: 16, offset: 164081},
+							pos:  position{line: 5361, col: 16, offset: 164174},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5359, col: 24, offset: 164089},
+						pos: position{line: 5361, col: 24, offset: 164182},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5359, col: 24, offset: 164089},
+								pos:        position{line: 5361, col: 24, offset: 164182},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5359, col: 30, offset: 164095},
+								pos:        position{line: 5361, col: 30, offset: 164188},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14130,9 +14130,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5359, col: 35, offset: 164100},
+						pos: position{line: 5361, col: 35, offset: 164193},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5359, col: 35, offset: 164100},
+							pos:  position{line: 5361, col: 35, offset: 164193},
 							name: "SPACE",
 						},
 					},
@@ -14141,9 +14141,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5360, col: 1, offset: 164107},
+			pos:  position{line: 5362, col: 1, offset: 164200},
 			expr: &litMatcher{
-				pos:        position{line: 5360, col: 17, offset: 164123},
+				pos:        position{line: 5362, col: 17, offset: 164216},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14151,18 +14151,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5361, col: 1, offset: 164134},
+			pos:  position{line: 5363, col: 1, offset: 164227},
 			expr: &seqExpr{
-				pos: position{line: 5361, col: 15, offset: 164148},
+				pos: position{line: 5363, col: 15, offset: 164241},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5361, col: 15, offset: 164148},
+						pos:        position{line: 5363, col: 15, offset: 164241},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5361, col: 24, offset: 164157},
+						pos:  position{line: 5363, col: 24, offset: 164250},
 						name: "SPACE",
 					},
 				},
@@ -14170,115 +14170,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5364, col: 1, offset: 164267},
+			pos:  position{line: 5366, col: 1, offset: 164360},
 			expr: &choiceExpr{
-				pos: position{line: 5364, col: 16, offset: 164282},
+				pos: position{line: 5366, col: 16, offset: 164375},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5364, col: 16, offset: 164282},
+						pos:        position{line: 5366, col: 16, offset: 164375},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5364, col: 47, offset: 164313},
+						pos:        position{line: 5366, col: 47, offset: 164406},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5364, col: 55, offset: 164321},
+						pos:        position{line: 5366, col: 55, offset: 164414},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 16, offset: 164344},
+						pos:        position{line: 5367, col: 16, offset: 164437},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 26, offset: 164354},
+						pos:        position{line: 5367, col: 26, offset: 164447},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 34, offset: 164362},
+						pos:        position{line: 5367, col: 34, offset: 164455},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 42, offset: 164370},
+						pos:        position{line: 5367, col: 42, offset: 164463},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 50, offset: 164378},
+						pos:        position{line: 5367, col: 50, offset: 164471},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 58, offset: 164386},
+						pos:        position{line: 5367, col: 58, offset: 164479},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5365, col: 66, offset: 164394},
+						pos:        position{line: 5367, col: 66, offset: 164487},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 16, offset: 164416},
+						pos:        position{line: 5368, col: 16, offset: 164509},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 26, offset: 164426},
+						pos:        position{line: 5368, col: 26, offset: 164519},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 34, offset: 164434},
+						pos:        position{line: 5368, col: 34, offset: 164527},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 42, offset: 164442},
+						pos:        position{line: 5368, col: 42, offset: 164535},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 50, offset: 164450},
+						pos:        position{line: 5368, col: 50, offset: 164543},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 58, offset: 164458},
+						pos:        position{line: 5368, col: 58, offset: 164551},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 66, offset: 164466},
+						pos:        position{line: 5368, col: 66, offset: 164559},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 74, offset: 164474},
+						pos:        position{line: 5368, col: 74, offset: 164567},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14288,25 +14288,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5367, col: 1, offset: 164480},
+			pos:  position{line: 5369, col: 1, offset: 164573},
 			expr: &choiceExpr{
-				pos: position{line: 5367, col: 16, offset: 164495},
+				pos: position{line: 5369, col: 16, offset: 164588},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5367, col: 16, offset: 164495},
+						pos:        position{line: 5369, col: 16, offset: 164588},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 30, offset: 164509},
+						pos:        position{line: 5369, col: 30, offset: 164602},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 36, offset: 164515},
+						pos:        position{line: 5369, col: 36, offset: 164608},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14316,18 +14316,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5371, col: 1, offset: 164671},
+			pos:  position{line: 5373, col: 1, offset: 164764},
 			expr: &seqExpr{
-				pos: position{line: 5371, col: 8, offset: 164678},
+				pos: position{line: 5373, col: 8, offset: 164771},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5371, col: 8, offset: 164678},
+						pos:        position{line: 5373, col: 8, offset: 164771},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5371, col: 14, offset: 164684},
+						pos:  position{line: 5373, col: 14, offset: 164777},
 						name: "SPACE",
 					},
 				},
@@ -14335,22 +14335,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5372, col: 1, offset: 164690},
+			pos:  position{line: 5374, col: 1, offset: 164783},
 			expr: &seqExpr{
-				pos: position{line: 5372, col: 7, offset: 164696},
+				pos: position{line: 5374, col: 7, offset: 164789},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5372, col: 7, offset: 164696},
+						pos:  position{line: 5374, col: 7, offset: 164789},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5372, col: 13, offset: 164702},
+						pos:        position{line: 5374, col: 13, offset: 164795},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5372, col: 18, offset: 164707},
+						pos:  position{line: 5374, col: 18, offset: 164800},
 						name: "SPACE",
 					},
 				},
@@ -14358,22 +14358,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5373, col: 1, offset: 164713},
+			pos:  position{line: 5375, col: 1, offset: 164806},
 			expr: &seqExpr{
-				pos: position{line: 5373, col: 8, offset: 164720},
+				pos: position{line: 5375, col: 8, offset: 164813},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5373, col: 8, offset: 164720},
+						pos:  position{line: 5375, col: 8, offset: 164813},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5373, col: 14, offset: 164726},
+						pos:        position{line: 5375, col: 14, offset: 164819},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5373, col: 20, offset: 164732},
+						pos:  position{line: 5375, col: 20, offset: 164825},
 						name: "SPACE",
 					},
 				},
@@ -14381,22 +14381,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5374, col: 1, offset: 164738},
+			pos:  position{line: 5376, col: 1, offset: 164831},
 			expr: &seqExpr{
-				pos: position{line: 5374, col: 9, offset: 164746},
+				pos: position{line: 5376, col: 9, offset: 164839},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5374, col: 9, offset: 164746},
+						pos:  position{line: 5376, col: 9, offset: 164839},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5374, col: 24, offset: 164761},
+						pos:        position{line: 5376, col: 24, offset: 164854},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5374, col: 28, offset: 164765},
+						pos:  position{line: 5376, col: 28, offset: 164858},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14404,22 +14404,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5375, col: 1, offset: 164780},
+			pos:  position{line: 5377, col: 1, offset: 164873},
 			expr: &seqExpr{
-				pos: position{line: 5375, col: 7, offset: 164786},
+				pos: position{line: 5377, col: 7, offset: 164879},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 7, offset: 164786},
+						pos:  position{line: 5377, col: 7, offset: 164879},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5375, col: 13, offset: 164792},
+						pos:        position{line: 5377, col: 13, offset: 164885},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5375, col: 19, offset: 164798},
+						pos:  position{line: 5377, col: 19, offset: 164891},
 						name: "SPACE",
 					},
 				},
@@ -14427,22 +14427,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5376, col: 1, offset: 164824},
+			pos:  position{line: 5378, col: 1, offset: 164917},
 			expr: &seqExpr{
-				pos: position{line: 5376, col: 7, offset: 164830},
+				pos: position{line: 5378, col: 7, offset: 164923},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5376, col: 7, offset: 164830},
+						pos:  position{line: 5378, col: 7, offset: 164923},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5376, col: 13, offset: 164836},
+						pos:        position{line: 5378, col: 13, offset: 164929},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5376, col: 19, offset: 164842},
+						pos:  position{line: 5378, col: 19, offset: 164935},
 						name: "SPACE",
 					},
 				},
@@ -14450,22 +14450,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5378, col: 1, offset: 164869},
+			pos:  position{line: 5380, col: 1, offset: 164962},
 			expr: &seqExpr{
-				pos: position{line: 5378, col: 10, offset: 164878},
+				pos: position{line: 5380, col: 10, offset: 164971},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5378, col: 10, offset: 164878},
+						pos:  position{line: 5380, col: 10, offset: 164971},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5378, col: 25, offset: 164893},
+						pos:        position{line: 5380, col: 25, offset: 164986},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5378, col: 29, offset: 164897},
+						pos:  position{line: 5380, col: 29, offset: 164990},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14473,22 +14473,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5379, col: 1, offset: 164912},
+			pos:  position{line: 5381, col: 1, offset: 165005},
 			expr: &seqExpr{
-				pos: position{line: 5379, col: 10, offset: 164921},
+				pos: position{line: 5381, col: 10, offset: 165014},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5379, col: 10, offset: 164921},
+						pos:  position{line: 5381, col: 10, offset: 165014},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5379, col: 25, offset: 164936},
+						pos:        position{line: 5381, col: 25, offset: 165029},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5379, col: 29, offset: 164940},
+						pos:  position{line: 5381, col: 29, offset: 165033},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14496,9 +14496,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5380, col: 1, offset: 164955},
+			pos:  position{line: 5382, col: 1, offset: 165048},
 			expr: &litMatcher{
-				pos:        position{line: 5380, col: 10, offset: 164964},
+				pos:        position{line: 5382, col: 10, offset: 165057},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14506,18 +14506,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5381, col: 1, offset: 164968},
+			pos:  position{line: 5383, col: 1, offset: 165061},
 			expr: &seqExpr{
-				pos: position{line: 5381, col: 12, offset: 164979},
+				pos: position{line: 5383, col: 12, offset: 165072},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5381, col: 12, offset: 164979},
+						pos:        position{line: 5383, col: 12, offset: 165072},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5381, col: 16, offset: 164983},
+						pos:  position{line: 5383, col: 16, offset: 165076},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14525,16 +14525,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5382, col: 1, offset: 164998},
+			pos:  position{line: 5384, col: 1, offset: 165091},
 			expr: &seqExpr{
-				pos: position{line: 5382, col: 12, offset: 165009},
+				pos: position{line: 5384, col: 12, offset: 165102},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5382, col: 12, offset: 165009},
+						pos:  position{line: 5384, col: 12, offset: 165102},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5382, col: 27, offset: 165024},
+						pos:        position{line: 5384, col: 27, offset: 165117},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14544,40 +14544,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5384, col: 1, offset: 165029},
+			pos:  position{line: 5386, col: 1, offset: 165122},
 			expr: &notExpr{
-				pos: position{line: 5384, col: 8, offset: 165036},
+				pos: position{line: 5386, col: 8, offset: 165129},
 				expr: &anyMatcher{
-					line: 5384, col: 9, offset: 165037,
+					line: 5386, col: 9, offset: 165130,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5385, col: 1, offset: 165039},
+			pos:  position{line: 5387, col: 1, offset: 165132},
 			expr: &choiceExpr{
-				pos: position{line: 5385, col: 15, offset: 165053},
+				pos: position{line: 5387, col: 15, offset: 165146},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5385, col: 15, offset: 165053},
+						pos:        position{line: 5387, col: 15, offset: 165146},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5385, col: 21, offset: 165059},
+						pos:        position{line: 5387, col: 21, offset: 165152},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5385, col: 28, offset: 165066},
+						pos:        position{line: 5387, col: 28, offset: 165159},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5385, col: 35, offset: 165073},
+						pos:        position{line: 5387, col: 35, offset: 165166},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14587,37 +14587,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5386, col: 1, offset: 165078},
+			pos:  position{line: 5388, col: 1, offset: 165171},
 			expr: &choiceExpr{
-				pos: position{line: 5386, col: 10, offset: 165087},
+				pos: position{line: 5388, col: 10, offset: 165180},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5386, col: 11, offset: 165088},
+						pos: position{line: 5388, col: 11, offset: 165181},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5386, col: 11, offset: 165088},
+								pos: position{line: 5388, col: 11, offset: 165181},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5386, col: 11, offset: 165088},
+									pos:  position{line: 5388, col: 11, offset: 165181},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5386, col: 23, offset: 165100},
+								pos:  position{line: 5388, col: 23, offset: 165193},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5386, col: 31, offset: 165108},
+								pos: position{line: 5388, col: 31, offset: 165201},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5386, col: 31, offset: 165108},
+									pos:  position{line: 5388, col: 31, offset: 165201},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5386, col: 46, offset: 165123},
+						pos: position{line: 5388, col: 46, offset: 165216},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5386, col: 46, offset: 165123},
+							pos:  position{line: 5388, col: 46, offset: 165216},
 							name: "WHITESPACE",
 						},
 					},
@@ -14626,38 +14626,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5387, col: 1, offset: 165135},
+			pos:  position{line: 5389, col: 1, offset: 165228},
 			expr: &seqExpr{
-				pos: position{line: 5387, col: 12, offset: 165146},
+				pos: position{line: 5389, col: 12, offset: 165239},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5387, col: 12, offset: 165146},
+						pos:        position{line: 5389, col: 12, offset: 165239},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5387, col: 18, offset: 165152},
+						pos: position{line: 5389, col: 18, offset: 165245},
 						expr: &seqExpr{
-							pos: position{line: 5387, col: 19, offset: 165153},
+							pos: position{line: 5389, col: 19, offset: 165246},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5387, col: 19, offset: 165153},
+									pos: position{line: 5389, col: 19, offset: 165246},
 									expr: &litMatcher{
-										pos:        position{line: 5387, col: 21, offset: 165155},
+										pos:        position{line: 5389, col: 21, offset: 165248},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5387, col: 28, offset: 165162,
+									line: 5389, col: 28, offset: 165255,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5387, col: 32, offset: 165166},
+						pos:        position{line: 5389, col: 32, offset: 165259},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14667,16 +14667,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5388, col: 1, offset: 165172},
+			pos:  position{line: 5390, col: 1, offset: 165265},
 			expr: &choiceExpr{
-				pos: position{line: 5388, col: 20, offset: 165191},
+				pos: position{line: 5390, col: 20, offset: 165284},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5388, col: 20, offset: 165191},
+						pos:  position{line: 5390, col: 20, offset: 165284},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5388, col: 28, offset: 165199},
+						pos:        position{line: 5390, col: 28, offset: 165292},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14686,16 +14686,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5389, col: 1, offset: 165202},
+			pos:  position{line: 5391, col: 1, offset: 165295},
 			expr: &choiceExpr{
-				pos: position{line: 5389, col: 19, offset: 165220},
+				pos: position{line: 5391, col: 19, offset: 165313},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5389, col: 19, offset: 165220},
+						pos:  position{line: 5391, col: 19, offset: 165313},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5389, col: 27, offset: 165228},
+						pos:  position{line: 5391, col: 27, offset: 165321},
 						name: "SPACE",
 					},
 				},
@@ -15771,6 +15771,7 @@ func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
 	measureAggs := make([]*structs.MeasureAggregator, 0)
 
 	timechartExpr := &structs.TimechartExpr{}
+	aggNode.TimechartExpr = timechartExpr
 	byField := ""
 
 	if tcArgs == nil {
@@ -15819,6 +15820,7 @@ func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
 		MeasureOperations: measureAggs,
 		GroupByColumns:    []string{"timestamp"},
 	}
+	timechartExpr.GroupBy = aggNode.GroupByRequest
 	aggNode.BucketLimit = query.MAX_GRP_BUCKS
 
 	if bOptions == nil {

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -1441,36 +1441,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 863, col: 1, offset: 26072},
+			pos:  position{line: 875, col: 1, offset: 26611},
 			expr: &actionExpr{
-				pos: position{line: 863, col: 20, offset: 26091},
+				pos: position{line: 875, col: 20, offset: 26630},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 863, col: 20, offset: 26091},
+					pos: position{line: 875, col: 20, offset: 26630},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 863, col: 20, offset: 26091},
+							pos:  position{line: 875, col: 20, offset: 26630},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 863, col: 25, offset: 26096},
+							pos:  position{line: 875, col: 25, offset: 26635},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 863, col: 35, offset: 26106},
+							pos:   position{line: 875, col: 35, offset: 26645},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 863, col: 41, offset: 26112},
+								pos:  position{line: 875, col: 41, offset: 26651},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 863, col: 64, offset: 26135},
+							pos:   position{line: 875, col: 64, offset: 26674},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 863, col: 72, offset: 26143},
+								pos: position{line: 875, col: 72, offset: 26682},
 								expr: &ruleRefExpr{
-									pos:  position{line: 863, col: 73, offset: 26144},
+									pos:  position{line: 875, col: 73, offset: 26683},
 									name: "StatsOptions",
 								},
 							},
@@ -1481,17 +1481,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 877, col: 1, offset: 26477},
+			pos:  position{line: 889, col: 1, offset: 27016},
 			expr: &actionExpr{
-				pos: position{line: 877, col: 17, offset: 26493},
+				pos: position{line: 889, col: 17, offset: 27032},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 877, col: 17, offset: 26493},
+					pos:   position{line: 889, col: 17, offset: 27032},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 877, col: 24, offset: 26500},
+						pos: position{line: 889, col: 24, offset: 27039},
 						expr: &ruleRefExpr{
-							pos:  position{line: 877, col: 25, offset: 26501},
+							pos:  position{line: 889, col: 25, offset: 27040},
 							name: "StatsOption",
 						},
 					},
@@ -1500,45 +1500,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 915, col: 1, offset: 27942},
+			pos:  position{line: 927, col: 1, offset: 28481},
 			expr: &actionExpr{
-				pos: position{line: 915, col: 16, offset: 27957},
+				pos: position{line: 927, col: 16, offset: 28496},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 915, col: 16, offset: 27957},
+					pos: position{line: 927, col: 16, offset: 28496},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 16, offset: 27957},
+							pos:  position{line: 927, col: 16, offset: 28496},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 915, col: 22, offset: 27963},
+							pos:   position{line: 927, col: 22, offset: 28502},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 915, col: 32, offset: 27973},
+								pos:  position{line: 927, col: 32, offset: 28512},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 915, col: 47, offset: 27988},
+							pos:  position{line: 927, col: 47, offset: 28527},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 915, col: 53, offset: 27994},
+							pos:   position{line: 927, col: 53, offset: 28533},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 915, col: 58, offset: 27999},
+								pos: position{line: 927, col: 58, offset: 28538},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 915, col: 58, offset: 27999},
+										pos:  position{line: 927, col: 58, offset: 28538},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 915, col: 76, offset: 28017},
+										pos:  position{line: 927, col: 76, offset: 28556},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 915, col: 94, offset: 28035},
+										pos:  position{line: 927, col: 94, offset: 28574},
 										name: "QuotedString",
 									},
 								},
@@ -1550,36 +1550,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 920, col: 1, offset: 28140},
+			pos:  position{line: 932, col: 1, offset: 28679},
 			expr: &actionExpr{
-				pos: position{line: 920, col: 19, offset: 28158},
+				pos: position{line: 932, col: 19, offset: 28697},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 920, col: 19, offset: 28158},
+					pos:   position{line: 932, col: 19, offset: 28697},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 920, col: 27, offset: 28166},
+						pos: position{line: 932, col: 27, offset: 28705},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 920, col: 27, offset: 28166},
+								pos:        position{line: 932, col: 27, offset: 28705},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 920, col: 38, offset: 28177},
+								pos:        position{line: 932, col: 38, offset: 28716},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 920, col: 58, offset: 28197},
+								pos:        position{line: 932, col: 58, offset: 28736},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 920, col: 68, offset: 28207},
+								pos:        position{line: 932, col: 68, offset: 28746},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1591,22 +1591,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 928, col: 1, offset: 28397},
+			pos:  position{line: 940, col: 1, offset: 28936},
 			expr: &actionExpr{
-				pos: position{line: 928, col: 17, offset: 28413},
+				pos: position{line: 940, col: 17, offset: 28952},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 928, col: 17, offset: 28413},
+					pos: position{line: 940, col: 17, offset: 28952},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 928, col: 17, offset: 28413},
+							pos:  position{line: 940, col: 17, offset: 28952},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 928, col: 20, offset: 28416},
+							pos:   position{line: 940, col: 20, offset: 28955},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 928, col: 27, offset: 28423},
+								pos:  position{line: 940, col: 27, offset: 28962},
 								name: "FieldNameList",
 							},
 						},
@@ -1616,28 +1616,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 940, col: 1, offset: 28773},
+			pos:  position{line: 952, col: 1, offset: 29312},
 			expr: &actionExpr{
-				pos: position{line: 940, col: 35, offset: 28807},
+				pos: position{line: 952, col: 35, offset: 29346},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 940, col: 35, offset: 28807},
+					pos: position{line: 952, col: 35, offset: 29346},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 940, col: 35, offset: 28807},
+							pos:        position{line: 952, col: 35, offset: 29346},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 940, col: 53, offset: 28825},
+							pos:  position{line: 952, col: 53, offset: 29364},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 940, col: 59, offset: 28831},
+							pos:   position{line: 952, col: 59, offset: 29370},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 940, col: 67, offset: 28839},
+								pos:  position{line: 952, col: 67, offset: 29378},
 								name: "Boolean",
 							},
 						},
@@ -1647,28 +1647,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 952, col: 1, offset: 29100},
+			pos:  position{line: 964, col: 1, offset: 29639},
 			expr: &actionExpr{
-				pos: position{line: 952, col: 29, offset: 29128},
+				pos: position{line: 964, col: 29, offset: 29667},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 952, col: 29, offset: 29128},
+					pos: position{line: 964, col: 29, offset: 29667},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 952, col: 29, offset: 29128},
+							pos:        position{line: 964, col: 29, offset: 29667},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 952, col: 39, offset: 29138},
+							pos:  position{line: 964, col: 39, offset: 29677},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 952, col: 45, offset: 29144},
+							pos:   position{line: 964, col: 45, offset: 29683},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 952, col: 53, offset: 29152},
+								pos:  position{line: 964, col: 53, offset: 29691},
 								name: "Boolean",
 							},
 						},
@@ -1678,28 +1678,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 964, col: 1, offset: 29399},
+			pos:  position{line: 976, col: 1, offset: 29938},
 			expr: &actionExpr{
-				pos: position{line: 964, col: 28, offset: 29426},
+				pos: position{line: 976, col: 28, offset: 29965},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 964, col: 28, offset: 29426},
+					pos: position{line: 976, col: 28, offset: 29965},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 964, col: 28, offset: 29426},
+							pos:        position{line: 976, col: 28, offset: 29965},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 964, col: 37, offset: 29435},
+							pos:  position{line: 976, col: 37, offset: 29974},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 964, col: 43, offset: 29441},
+							pos:   position{line: 976, col: 43, offset: 29980},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 964, col: 51, offset: 29449},
+								pos:  position{line: 976, col: 51, offset: 29988},
 								name: "Boolean",
 							},
 						},
@@ -1709,28 +1709,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 977, col: 1, offset: 29783},
+			pos:  position{line: 989, col: 1, offset: 30322},
 			expr: &actionExpr{
-				pos: position{line: 977, col: 28, offset: 29810},
+				pos: position{line: 989, col: 28, offset: 30349},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 977, col: 28, offset: 29810},
+					pos: position{line: 989, col: 28, offset: 30349},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 977, col: 28, offset: 29810},
+							pos:        position{line: 989, col: 28, offset: 30349},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 977, col: 37, offset: 29819},
+							pos:  position{line: 989, col: 37, offset: 30358},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 977, col: 43, offset: 29825},
+							pos:   position{line: 989, col: 43, offset: 30364},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 977, col: 51, offset: 29833},
+								pos:  position{line: 989, col: 51, offset: 30372},
 								name: "Boolean",
 							},
 						},
@@ -1740,28 +1740,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 990, col: 1, offset: 30167},
+			pos:  position{line: 1002, col: 1, offset: 30706},
 			expr: &actionExpr{
-				pos: position{line: 990, col: 28, offset: 30194},
+				pos: position{line: 1002, col: 28, offset: 30733},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 990, col: 28, offset: 30194},
+					pos: position{line: 1002, col: 28, offset: 30733},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 990, col: 28, offset: 30194},
+							pos:        position{line: 1002, col: 28, offset: 30733},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 990, col: 37, offset: 30203},
+							pos:  position{line: 1002, col: 37, offset: 30742},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 990, col: 43, offset: 30209},
+							pos:   position{line: 1002, col: 43, offset: 30748},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 990, col: 54, offset: 30220},
+								pos:  position{line: 1002, col: 54, offset: 30759},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1771,37 +1771,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1010, col: 1, offset: 30824},
+			pos:  position{line: 1022, col: 1, offset: 31363},
 			expr: &actionExpr{
-				pos: position{line: 1010, col: 33, offset: 30856},
+				pos: position{line: 1022, col: 33, offset: 31395},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1010, col: 33, offset: 30856},
+					pos: position{line: 1022, col: 33, offset: 31395},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1010, col: 33, offset: 30856},
+							pos:        position{line: 1022, col: 33, offset: 31395},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1010, col: 48, offset: 30871},
+							pos:  position{line: 1022, col: 48, offset: 31410},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1010, col: 54, offset: 30877},
+							pos:  position{line: 1022, col: 54, offset: 31416},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1010, col: 62, offset: 30885},
+							pos:   position{line: 1022, col: 62, offset: 31424},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1010, col: 71, offset: 30894},
+								pos:  position{line: 1022, col: 71, offset: 31433},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1010, col: 80, offset: 30903},
+							pos:  position{line: 1022, col: 80, offset: 31442},
 							name: "R_PAREN",
 						},
 					},
@@ -1810,37 +1810,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1022, col: 1, offset: 31173},
+			pos:  position{line: 1034, col: 1, offset: 31712},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 32, offset: 31204},
+				pos: position{line: 1034, col: 32, offset: 31743},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1022, col: 32, offset: 31204},
+					pos: position{line: 1034, col: 32, offset: 31743},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1022, col: 32, offset: 31204},
+							pos:        position{line: 1034, col: 32, offset: 31743},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 46, offset: 31218},
+							pos:  position{line: 1034, col: 46, offset: 31757},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 52, offset: 31224},
+							pos:  position{line: 1034, col: 52, offset: 31763},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1022, col: 60, offset: 31232},
+							pos:   position{line: 1034, col: 60, offset: 31771},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1022, col: 69, offset: 31241},
+								pos:  position{line: 1034, col: 69, offset: 31780},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 78, offset: 31250},
+							pos:  position{line: 1034, col: 78, offset: 31789},
 							name: "R_PAREN",
 						},
 					},
@@ -1849,28 +1849,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1034, col: 1, offset: 31518},
+			pos:  position{line: 1046, col: 1, offset: 32057},
 			expr: &actionExpr{
-				pos: position{line: 1034, col: 32, offset: 31549},
+				pos: position{line: 1046, col: 32, offset: 32088},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1034, col: 32, offset: 31549},
+					pos: position{line: 1046, col: 32, offset: 32088},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1034, col: 32, offset: 31549},
+							pos:        position{line: 1046, col: 32, offset: 32088},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1034, col: 46, offset: 31563},
+							pos:  position{line: 1046, col: 46, offset: 32102},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1034, col: 52, offset: 31569},
+							pos:   position{line: 1046, col: 52, offset: 32108},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1034, col: 63, offset: 31580},
+								pos:  position{line: 1046, col: 63, offset: 32119},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1880,46 +1880,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1050, col: 1, offset: 32042},
+			pos:  position{line: 1062, col: 1, offset: 32581},
 			expr: &actionExpr{
-				pos: position{line: 1050, col: 22, offset: 32063},
+				pos: position{line: 1062, col: 22, offset: 32602},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1050, col: 22, offset: 32063},
+					pos:   position{line: 1062, col: 22, offset: 32602},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1050, col: 32, offset: 32073},
+						pos: position{line: 1062, col: 32, offset: 32612},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 32, offset: 32073},
+								pos:  position{line: 1062, col: 32, offset: 32612},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 65, offset: 32106},
+								pos:  position{line: 1062, col: 65, offset: 32645},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 92, offset: 32133},
+								pos:  position{line: 1062, col: 92, offset: 32672},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 118, offset: 32159},
+								pos:  position{line: 1062, col: 118, offset: 32698},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 144, offset: 32185},
+								pos:  position{line: 1062, col: 144, offset: 32724},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 170, offset: 32211},
+								pos:  position{line: 1062, col: 170, offset: 32750},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 201, offset: 32242},
+								pos:  position{line: 1062, col: 201, offset: 32781},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1050, col: 231, offset: 32272},
+								pos:  position{line: 1062, col: 231, offset: 32811},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1929,35 +1929,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1054, col: 1, offset: 32331},
+			pos:  position{line: 1066, col: 1, offset: 32870},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 26, offset: 32356},
+				pos: position{line: 1066, col: 26, offset: 32895},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1054, col: 26, offset: 32356},
+					pos: position{line: 1066, col: 26, offset: 32895},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1054, col: 26, offset: 32356},
+							pos:   position{line: 1066, col: 26, offset: 32895},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1054, col: 32, offset: 32362},
+								pos:  position{line: 1066, col: 32, offset: 32901},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1054, col: 50, offset: 32380},
+							pos:   position{line: 1066, col: 50, offset: 32919},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1054, col: 55, offset: 32385},
+								pos: position{line: 1066, col: 55, offset: 32924},
 								expr: &seqExpr{
-									pos: position{line: 1054, col: 56, offset: 32386},
+									pos: position{line: 1066, col: 56, offset: 32925},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1054, col: 56, offset: 32386},
+											pos:  position{line: 1066, col: 56, offset: 32925},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1054, col: 62, offset: 32392},
+											pos:  position{line: 1066, col: 62, offset: 32931},
 											name: "StreamStatsOption",
 										},
 									},
@@ -1970,41 +1970,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1113, col: 1, offset: 34581},
+			pos:  position{line: 1125, col: 1, offset: 35120},
 			expr: &choiceExpr{
-				pos: position{line: 1113, col: 21, offset: 34601},
+				pos: position{line: 1125, col: 21, offset: 35140},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1113, col: 21, offset: 34601},
+						pos: position{line: 1125, col: 21, offset: 35140},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1113, col: 21, offset: 34601},
+							pos: position{line: 1125, col: 21, offset: 35140},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 21, offset: 34601},
+									pos:  position{line: 1125, col: 21, offset: 35140},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 26, offset: 34606},
+									pos:  position{line: 1125, col: 26, offset: 35145},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1113, col: 42, offset: 34622},
+									pos:   position{line: 1125, col: 42, offset: 35161},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1113, col: 56, offset: 34636},
+										pos:  position{line: 1125, col: 56, offset: 35175},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1113, col: 79, offset: 34659},
+									pos:  position{line: 1125, col: 79, offset: 35198},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1113, col: 85, offset: 34665},
+									pos:   position{line: 1125, col: 85, offset: 35204},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1113, col: 91, offset: 34671},
+										pos:  position{line: 1125, col: 91, offset: 35210},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2012,24 +2012,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1124, col: 3, offset: 35056},
+						pos: position{line: 1136, col: 3, offset: 35595},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1124, col: 3, offset: 35056},
+							pos: position{line: 1136, col: 3, offset: 35595},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1124, col: 3, offset: 35056},
+									pos:  position{line: 1136, col: 3, offset: 35595},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1124, col: 8, offset: 35061},
+									pos:  position{line: 1136, col: 8, offset: 35600},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1124, col: 24, offset: 35077},
+									pos:   position{line: 1136, col: 24, offset: 35616},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1124, col: 30, offset: 35083},
+										pos:  position{line: 1136, col: 30, offset: 35622},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2041,31 +2041,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1136, col: 1, offset: 35455},
+			pos:  position{line: 1148, col: 1, offset: 35994},
 			expr: &actionExpr{
-				pos: position{line: 1136, col: 15, offset: 35469},
+				pos: position{line: 1148, col: 15, offset: 36008},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1136, col: 15, offset: 35469},
+					pos: position{line: 1148, col: 15, offset: 36008},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1136, col: 15, offset: 35469},
+							pos:  position{line: 1148, col: 15, offset: 36008},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1136, col: 25, offset: 35479},
+							pos:   position{line: 1148, col: 25, offset: 36018},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1136, col: 34, offset: 35488},
+								pos: position{line: 1148, col: 34, offset: 36027},
 								expr: &seqExpr{
-									pos: position{line: 1136, col: 35, offset: 35489},
+									pos: position{line: 1148, col: 35, offset: 36028},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1136, col: 35, offset: 35489},
+											pos:  position{line: 1148, col: 35, offset: 36028},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1136, col: 45, offset: 35499},
+											pos:  position{line: 1148, col: 45, offset: 36038},
 											name: "EqualityOperator",
 										},
 									},
@@ -2073,10 +2073,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1136, col: 64, offset: 35518},
+							pos:   position{line: 1148, col: 64, offset: 36057},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1136, col: 68, offset: 35522},
+								pos:  position{line: 1148, col: 68, offset: 36061},
 								name: "QuotedString",
 							},
 						},
@@ -2086,22 +2086,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1164, col: 1, offset: 36101},
+			pos:  position{line: 1176, col: 1, offset: 36640},
 			expr: &actionExpr{
-				pos: position{line: 1164, col: 18, offset: 36118},
+				pos: position{line: 1176, col: 18, offset: 36657},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1164, col: 18, offset: 36118},
+					pos: position{line: 1176, col: 18, offset: 36657},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1164, col: 18, offset: 36118},
+							pos:  position{line: 1176, col: 18, offset: 36657},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1164, col: 23, offset: 36123},
+							pos:   position{line: 1176, col: 23, offset: 36662},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1164, col: 28, offset: 36128},
+								pos:  position{line: 1176, col: 28, offset: 36667},
 								name: "RegexBlock",
 							},
 						},
@@ -2111,44 +2111,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1192, col: 1, offset: 36913},
+			pos:  position{line: 1204, col: 1, offset: 37452},
 			expr: &actionExpr{
-				pos: position{line: 1192, col: 17, offset: 36929},
+				pos: position{line: 1204, col: 17, offset: 37468},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1192, col: 17, offset: 36929},
+					pos: position{line: 1204, col: 17, offset: 37468},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1192, col: 17, offset: 36929},
+							pos:   position{line: 1204, col: 17, offset: 37468},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1192, col: 23, offset: 36935},
+								pos:  position{line: 1204, col: 23, offset: 37474},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1192, col: 36, offset: 36948},
+							pos:   position{line: 1204, col: 36, offset: 37487},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1192, col: 41, offset: 36953},
+								pos: position{line: 1204, col: 41, offset: 37492},
 								expr: &seqExpr{
-									pos: position{line: 1192, col: 42, offset: 36954},
+									pos: position{line: 1204, col: 42, offset: 37493},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1192, col: 43, offset: 36955},
+											pos: position{line: 1204, col: 43, offset: 37494},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1192, col: 43, offset: 36955},
+													pos:  position{line: 1204, col: 43, offset: 37494},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1192, col: 49, offset: 36961},
+													pos:  position{line: 1204, col: 49, offset: 37500},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1192, col: 56, offset: 36968},
+											pos:  position{line: 1204, col: 56, offset: 37507},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2161,35 +2161,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1210, col: 1, offset: 37345},
+			pos:  position{line: 1222, col: 1, offset: 37884},
 			expr: &actionExpr{
-				pos: position{line: 1210, col: 17, offset: 37361},
+				pos: position{line: 1222, col: 17, offset: 37900},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1210, col: 17, offset: 37361},
+					pos: position{line: 1222, col: 17, offset: 37900},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1210, col: 17, offset: 37361},
+							pos:   position{line: 1222, col: 17, offset: 37900},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1210, col: 23, offset: 37367},
+								pos:  position{line: 1222, col: 23, offset: 37906},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1210, col: 36, offset: 37380},
+							pos:   position{line: 1222, col: 36, offset: 37919},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1210, col: 41, offset: 37385},
+								pos: position{line: 1222, col: 41, offset: 37924},
 								expr: &seqExpr{
-									pos: position{line: 1210, col: 42, offset: 37386},
+									pos: position{line: 1222, col: 42, offset: 37925},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1210, col: 42, offset: 37386},
+											pos:  position{line: 1222, col: 42, offset: 37925},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1210, col: 45, offset: 37389},
+											pos:  position{line: 1222, col: 45, offset: 37928},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2202,32 +2202,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1228, col: 1, offset: 37754},
+			pos:  position{line: 1240, col: 1, offset: 38293},
 			expr: &choiceExpr{
-				pos: position{line: 1228, col: 17, offset: 37770},
+				pos: position{line: 1240, col: 17, offset: 38309},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1228, col: 17, offset: 37770},
+						pos: position{line: 1240, col: 17, offset: 38309},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1228, col: 17, offset: 37770},
+							pos: position{line: 1240, col: 17, offset: 38309},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1228, col: 17, offset: 37770},
+									pos:   position{line: 1240, col: 17, offset: 38309},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1228, col: 25, offset: 37778},
+										pos: position{line: 1240, col: 25, offset: 38317},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1228, col: 25, offset: 37778},
+											pos:  position{line: 1240, col: 25, offset: 38317},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1228, col: 30, offset: 37783},
+									pos:   position{line: 1240, col: 30, offset: 38322},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1228, col: 36, offset: 37789},
+										pos:  position{line: 1240, col: 36, offset: 38328},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2235,13 +2235,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1239, col: 5, offset: 38085},
+						pos: position{line: 1251, col: 5, offset: 38624},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1239, col: 5, offset: 38085},
+							pos:   position{line: 1251, col: 5, offset: 38624},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1239, col: 12, offset: 38092},
+								pos:  position{line: 1251, col: 12, offset: 38631},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2251,43 +2251,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1243, col: 1, offset: 38133},
+			pos:  position{line: 1255, col: 1, offset: 38672},
 			expr: &choiceExpr{
-				pos: position{line: 1243, col: 17, offset: 38149},
+				pos: position{line: 1255, col: 17, offset: 38688},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1243, col: 17, offset: 38149},
+						pos: position{line: 1255, col: 17, offset: 38688},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1243, col: 17, offset: 38149},
+							pos: position{line: 1255, col: 17, offset: 38688},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1243, col: 17, offset: 38149},
+									pos:  position{line: 1255, col: 17, offset: 38688},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1243, col: 25, offset: 38157},
+									pos:   position{line: 1255, col: 25, offset: 38696},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1243, col: 32, offset: 38164},
+										pos:  position{line: 1255, col: 32, offset: 38703},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1243, col: 45, offset: 38177},
+									pos:  position{line: 1255, col: 45, offset: 38716},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1245, col: 5, offset: 38214},
+						pos: position{line: 1257, col: 5, offset: 38753},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1245, col: 5, offset: 38214},
+							pos:   position{line: 1257, col: 5, offset: 38753},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1245, col: 10, offset: 38219},
+								pos:  position{line: 1257, col: 10, offset: 38758},
 								name: "SearchTerm",
 							},
 						},
@@ -2297,26 +2297,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1251, col: 1, offset: 38377},
+			pos:  position{line: 1263, col: 1, offset: 38916},
 			expr: &actionExpr{
-				pos: position{line: 1251, col: 15, offset: 38391},
+				pos: position{line: 1263, col: 15, offset: 38930},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1251, col: 15, offset: 38391},
+					pos:   position{line: 1263, col: 15, offset: 38930},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1251, col: 21, offset: 38397},
+						pos: position{line: 1263, col: 21, offset: 38936},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1251, col: 21, offset: 38397},
+								pos:  position{line: 1263, col: 21, offset: 38936},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1251, col: 44, offset: 38420},
+								pos:  position{line: 1263, col: 44, offset: 38959},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1251, col: 68, offset: 38444},
+								pos:  position{line: 1263, col: 68, offset: 38983},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2326,36 +2326,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1256, col: 1, offset: 38585},
+			pos:  position{line: 1268, col: 1, offset: 39124},
 			expr: &actionExpr{
-				pos: position{line: 1256, col: 19, offset: 38603},
+				pos: position{line: 1268, col: 19, offset: 39142},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1256, col: 19, offset: 38603},
+					pos: position{line: 1268, col: 19, offset: 39142},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 19, offset: 38603},
+							pos:  position{line: 1268, col: 19, offset: 39142},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1256, col: 24, offset: 38608},
+							pos:  position{line: 1268, col: 24, offset: 39147},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 38, offset: 38622},
+							pos:   position{line: 1268, col: 38, offset: 39161},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1256, col: 45, offset: 38629},
+								pos:  position{line: 1268, col: 45, offset: 39168},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1256, col: 68, offset: 38652},
+							pos:   position{line: 1268, col: 68, offset: 39191},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1256, col: 78, offset: 38662},
+								pos: position{line: 1268, col: 78, offset: 39201},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1256, col: 79, offset: 38663},
+									pos:  position{line: 1268, col: 79, offset: 39202},
 									name: "LimitExpr",
 								},
 							},
@@ -2366,35 +2366,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1344, col: 1, offset: 41406},
+			pos:  position{line: 1356, col: 1, offset: 41945},
 			expr: &actionExpr{
-				pos: position{line: 1344, col: 27, offset: 41432},
+				pos: position{line: 1356, col: 27, offset: 41971},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1344, col: 27, offset: 41432},
+					pos: position{line: 1356, col: 27, offset: 41971},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1344, col: 27, offset: 41432},
+							pos:   position{line: 1356, col: 27, offset: 41971},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1344, col: 33, offset: 41438},
+								pos:  position{line: 1356, col: 33, offset: 41977},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1344, col: 51, offset: 41456},
+							pos:   position{line: 1356, col: 51, offset: 41995},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1344, col: 56, offset: 41461},
+								pos: position{line: 1356, col: 56, offset: 42000},
 								expr: &seqExpr{
-									pos: position{line: 1344, col: 57, offset: 41462},
+									pos: position{line: 1356, col: 57, offset: 42001},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1344, col: 57, offset: 41462},
+											pos:  position{line: 1356, col: 57, offset: 42001},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1344, col: 63, offset: 41468},
+											pos:  position{line: 1356, col: 63, offset: 42007},
 											name: "TimechartArgument",
 										},
 									},
@@ -2407,22 +2407,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1373, col: 1, offset: 42202},
+			pos:  position{line: 1385, col: 1, offset: 42741},
 			expr: &actionExpr{
-				pos: position{line: 1373, col: 22, offset: 42223},
+				pos: position{line: 1385, col: 22, offset: 42762},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1373, col: 22, offset: 42223},
+					pos:   position{line: 1385, col: 22, offset: 42762},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1373, col: 29, offset: 42230},
+						pos: position{line: 1385, col: 29, offset: 42769},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1373, col: 29, offset: 42230},
+								pos:  position{line: 1385, col: 29, offset: 42769},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1373, col: 45, offset: 42246},
+								pos:  position{line: 1385, col: 45, offset: 42785},
 								name: "TcOptions",
 							},
 						},
@@ -2432,28 +2432,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1377, col: 1, offset: 42284},
+			pos:  position{line: 1389, col: 1, offset: 42823},
 			expr: &actionExpr{
-				pos: position{line: 1377, col: 18, offset: 42301},
+				pos: position{line: 1389, col: 18, offset: 42840},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1377, col: 18, offset: 42301},
+					pos: position{line: 1389, col: 18, offset: 42840},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1377, col: 18, offset: 42301},
+							pos:   position{line: 1389, col: 18, offset: 42840},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1377, col: 23, offset: 42306},
+								pos:  position{line: 1389, col: 23, offset: 42845},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1377, col: 39, offset: 42322},
+							pos:   position{line: 1389, col: 39, offset: 42861},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1377, col: 53, offset: 42336},
+								pos: position{line: 1389, col: 53, offset: 42875},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1377, col: 53, offset: 42336},
+									pos:  position{line: 1389, col: 53, offset: 42875},
 									name: "SplitByClause",
 								},
 							},
@@ -2464,22 +2464,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1391, col: 1, offset: 42675},
+			pos:  position{line: 1403, col: 1, offset: 43214},
 			expr: &actionExpr{
-				pos: position{line: 1391, col: 18, offset: 42692},
+				pos: position{line: 1403, col: 18, offset: 43231},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1391, col: 18, offset: 42692},
+					pos: position{line: 1403, col: 18, offset: 43231},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1391, col: 18, offset: 42692},
+							pos:  position{line: 1403, col: 18, offset: 43231},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1391, col: 21, offset: 42695},
+							pos:   position{line: 1403, col: 21, offset: 43234},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1391, col: 27, offset: 42701},
+								pos:  position{line: 1403, col: 27, offset: 43240},
 								name: "FieldName",
 							},
 						},
@@ -2489,24 +2489,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1399, col: 1, offset: 42830},
+			pos:  position{line: 1411, col: 1, offset: 43369},
 			expr: &actionExpr{
-				pos: position{line: 1399, col: 14, offset: 42843},
+				pos: position{line: 1411, col: 14, offset: 43382},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1399, col: 14, offset: 42843},
+					pos:   position{line: 1411, col: 14, offset: 43382},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1399, col: 22, offset: 42851},
+						pos: position{line: 1411, col: 22, offset: 43390},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1399, col: 22, offset: 42851},
+								pos:  position{line: 1411, col: 22, offset: 43390},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1399, col: 35, offset: 42864},
+								pos: position{line: 1411, col: 35, offset: 43403},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1399, col: 36, offset: 42865},
+									pos:  position{line: 1411, col: 36, offset: 43404},
 									name: "TcOption",
 								},
 							},
@@ -2517,34 +2517,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1441, col: 1, offset: 44385},
+			pos:  position{line: 1453, col: 1, offset: 44924},
 			expr: &actionExpr{
-				pos: position{line: 1441, col: 13, offset: 44397},
+				pos: position{line: 1453, col: 13, offset: 44936},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1441, col: 13, offset: 44397},
+					pos: position{line: 1453, col: 13, offset: 44936},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1441, col: 13, offset: 44397},
+							pos:  position{line: 1453, col: 13, offset: 44936},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1441, col: 19, offset: 44403},
+							pos:   position{line: 1453, col: 19, offset: 44942},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1441, col: 31, offset: 44415},
+								pos:  position{line: 1453, col: 31, offset: 44954},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1441, col: 43, offset: 44427},
+							pos:  position{line: 1453, col: 43, offset: 44966},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1441, col: 49, offset: 44433},
+							pos:   position{line: 1453, col: 49, offset: 44972},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1441, col: 53, offset: 44437},
+								pos:  position{line: 1453, col: 53, offset: 44976},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2554,36 +2554,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1446, col: 1, offset: 44550},
+			pos:  position{line: 1458, col: 1, offset: 45089},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 16, offset: 44565},
+				pos: position{line: 1458, col: 16, offset: 45104},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1446, col: 16, offset: 44565},
+					pos:   position{line: 1458, col: 16, offset: 45104},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1446, col: 24, offset: 44573},
+						pos: position{line: 1458, col: 24, offset: 45112},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1446, col: 24, offset: 44573},
+								pos:        position{line: 1458, col: 24, offset: 45112},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1446, col: 36, offset: 44585},
+								pos:        position{line: 1458, col: 36, offset: 45124},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1446, col: 49, offset: 44598},
+								pos:        position{line: 1458, col: 49, offset: 45137},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1446, col: 61, offset: 44610},
+								pos:        position{line: 1458, col: 61, offset: 45149},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2595,50 +2595,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1454, col: 1, offset: 44806},
+			pos:  position{line: 1466, col: 1, offset: 45345},
 			expr: &actionExpr{
-				pos: position{line: 1454, col: 17, offset: 44822},
+				pos: position{line: 1466, col: 17, offset: 45361},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1454, col: 17, offset: 44822},
+					pos:   position{line: 1466, col: 17, offset: 45361},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1454, col: 27, offset: 44832},
+						pos: position{line: 1466, col: 27, offset: 45371},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 27, offset: 44832},
+								pos:  position{line: 1466, col: 27, offset: 45371},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 36, offset: 44841},
+								pos:  position{line: 1466, col: 36, offset: 45380},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 44, offset: 44849},
+								pos:  position{line: 1466, col: 44, offset: 45388},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 57, offset: 44862},
+								pos:  position{line: 1466, col: 57, offset: 45401},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 66, offset: 44871},
+								pos:  position{line: 1466, col: 66, offset: 45410},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 73, offset: 44878},
+								pos:  position{line: 1466, col: 73, offset: 45417},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 79, offset: 44884},
+								pos:  position{line: 1466, col: 79, offset: 45423},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 86, offset: 44891},
+								pos:  position{line: 1466, col: 86, offset: 45430},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 96, offset: 44901},
+								pos:  position{line: 1466, col: 96, offset: 45440},
 								name: "Year",
 							},
 						},
@@ -2648,37 +2648,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1458, col: 1, offset: 44937},
+			pos:  position{line: 1470, col: 1, offset: 45476},
 			expr: &actionExpr{
-				pos: position{line: 1458, col: 21, offset: 44957},
+				pos: position{line: 1470, col: 21, offset: 45496},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1458, col: 21, offset: 44957},
+					pos: position{line: 1470, col: 21, offset: 45496},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1458, col: 21, offset: 44957},
+							pos:   position{line: 1470, col: 21, offset: 45496},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1458, col: 29, offset: 44965},
+								pos: position{line: 1470, col: 29, offset: 45504},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1458, col: 29, offset: 44965},
+										pos:  position{line: 1470, col: 29, offset: 45504},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1458, col: 45, offset: 44981},
+										pos:  position{line: 1470, col: 45, offset: 45520},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1458, col: 62, offset: 44998},
+							pos:   position{line: 1470, col: 62, offset: 45537},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1458, col: 72, offset: 45008},
+								pos: position{line: 1470, col: 72, offset: 45547},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1458, col: 73, offset: 45009},
+									pos:  position{line: 1470, col: 73, offset: 45548},
 									name: "AllTimeScale",
 								},
 							},
@@ -2689,28 +2689,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1517, col: 1, offset: 47691},
+			pos:  position{line: 1529, col: 1, offset: 48230},
 			expr: &actionExpr{
-				pos: position{line: 1517, col: 21, offset: 47711},
+				pos: position{line: 1529, col: 21, offset: 48250},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1517, col: 21, offset: 47711},
+					pos: position{line: 1529, col: 21, offset: 48250},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1517, col: 21, offset: 47711},
+							pos:        position{line: 1529, col: 21, offset: 48250},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1517, col: 31, offset: 47721},
+							pos:  position{line: 1529, col: 31, offset: 48260},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1517, col: 37, offset: 47727},
+							pos:   position{line: 1529, col: 37, offset: 48266},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1517, col: 48, offset: 47738},
+								pos:  position{line: 1529, col: 48, offset: 48277},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2720,28 +2720,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1528, col: 1, offset: 47979},
+			pos:  position{line: 1540, col: 1, offset: 48518},
 			expr: &actionExpr{
-				pos: position{line: 1528, col: 21, offset: 47999},
+				pos: position{line: 1540, col: 21, offset: 48538},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1528, col: 21, offset: 47999},
+					pos: position{line: 1540, col: 21, offset: 48538},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1528, col: 21, offset: 47999},
+							pos:        position{line: 1540, col: 21, offset: 48538},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1528, col: 28, offset: 48006},
+							pos:  position{line: 1540, col: 28, offset: 48545},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1528, col: 34, offset: 48012},
+							pos:   position{line: 1540, col: 34, offset: 48551},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1528, col: 43, offset: 48021},
+								pos:  position{line: 1540, col: 43, offset: 48560},
 								name: "IntegerAsString",
 							},
 						},
@@ -2751,31 +2751,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1549, col: 1, offset: 48600},
+			pos:  position{line: 1561, col: 1, offset: 49139},
 			expr: &choiceExpr{
-				pos: position{line: 1549, col: 23, offset: 48622},
+				pos: position{line: 1561, col: 23, offset: 49161},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1549, col: 23, offset: 48622},
+						pos: position{line: 1561, col: 23, offset: 49161},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1549, col: 23, offset: 48622},
+							pos: position{line: 1561, col: 23, offset: 49161},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1549, col: 23, offset: 48622},
+									pos:        position{line: 1561, col: 23, offset: 49161},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1549, col: 35, offset: 48634},
+									pos:  position{line: 1561, col: 35, offset: 49173},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1549, col: 41, offset: 48640},
+									pos:   position{line: 1561, col: 41, offset: 49179},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1549, col: 51, offset: 48650},
+										pos:  position{line: 1561, col: 51, offset: 49189},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2783,33 +2783,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1563, col: 3, offset: 49069},
+						pos: position{line: 1575, col: 3, offset: 49608},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1563, col: 3, offset: 49069},
+							pos: position{line: 1575, col: 3, offset: 49608},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1563, col: 3, offset: 49069},
+									pos:        position{line: 1575, col: 3, offset: 49608},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1563, col: 15, offset: 49081},
+									pos:  position{line: 1575, col: 15, offset: 49620},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1563, col: 21, offset: 49087},
+									pos:   position{line: 1575, col: 21, offset: 49626},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1563, col: 32, offset: 49098},
+										pos: position{line: 1575, col: 32, offset: 49637},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 32, offset: 49098},
+												pos:  position{line: 1575, col: 32, offset: 49637},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1563, col: 52, offset: 49118},
+												pos:  position{line: 1575, col: 52, offset: 49657},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2823,35 +2823,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1583, col: 1, offset: 49587},
+			pos:  position{line: 1595, col: 1, offset: 50126},
 			expr: &actionExpr{
-				pos: position{line: 1583, col: 19, offset: 49605},
+				pos: position{line: 1595, col: 19, offset: 50144},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1583, col: 19, offset: 49605},
+					pos: position{line: 1595, col: 19, offset: 50144},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1583, col: 19, offset: 49605},
+							pos:        position{line: 1595, col: 19, offset: 50144},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1583, col: 27, offset: 49613},
+							pos:  position{line: 1595, col: 27, offset: 50152},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1583, col: 33, offset: 49619},
+							pos:   position{line: 1595, col: 33, offset: 50158},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1583, col: 41, offset: 49627},
+								pos: position{line: 1595, col: 41, offset: 50166},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1583, col: 41, offset: 49627},
+										pos:  position{line: 1595, col: 41, offset: 50166},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1583, col: 57, offset: 49643},
+										pos:  position{line: 1595, col: 57, offset: 50182},
 										name: "IntegerAsString",
 									},
 								},
@@ -2863,35 +2863,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1598, col: 1, offset: 50022},
+			pos:  position{line: 1610, col: 1, offset: 50561},
 			expr: &actionExpr{
-				pos: position{line: 1598, col: 17, offset: 50038},
+				pos: position{line: 1610, col: 17, offset: 50577},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1598, col: 17, offset: 50038},
+					pos: position{line: 1610, col: 17, offset: 50577},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1598, col: 17, offset: 50038},
+							pos:        position{line: 1610, col: 17, offset: 50577},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1598, col: 23, offset: 50044},
+							pos:  position{line: 1610, col: 23, offset: 50583},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1598, col: 29, offset: 50050},
+							pos:   position{line: 1610, col: 29, offset: 50589},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1598, col: 37, offset: 50058},
+								pos: position{line: 1610, col: 37, offset: 50597},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1598, col: 37, offset: 50058},
+										pos:  position{line: 1610, col: 37, offset: 50597},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1598, col: 53, offset: 50074},
+										pos:  position{line: 1610, col: 53, offset: 50613},
 										name: "IntegerAsString",
 									},
 								},
@@ -2903,40 +2903,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1613, col: 1, offset: 50445},
+			pos:  position{line: 1625, col: 1, offset: 50984},
 			expr: &choiceExpr{
-				pos: position{line: 1613, col: 18, offset: 50462},
+				pos: position{line: 1625, col: 18, offset: 51001},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1613, col: 18, offset: 50462},
+						pos: position{line: 1625, col: 18, offset: 51001},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1613, col: 18, offset: 50462},
+							pos: position{line: 1625, col: 18, offset: 51001},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1613, col: 18, offset: 50462},
+									pos:        position{line: 1625, col: 18, offset: 51001},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1613, col: 25, offset: 50469},
+									pos:  position{line: 1625, col: 25, offset: 51008},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1613, col: 31, offset: 50475},
+									pos:   position{line: 1625, col: 31, offset: 51014},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1613, col: 36, offset: 50480},
+										pos: position{line: 1625, col: 36, offset: 51019},
 										expr: &choiceExpr{
-											pos: position{line: 1613, col: 37, offset: 50481},
+											pos: position{line: 1625, col: 37, offset: 51020},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1613, col: 37, offset: 50481},
+													pos:  position{line: 1625, col: 37, offset: 51020},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1613, col: 53, offset: 50497},
+													pos:  position{line: 1625, col: 53, offset: 51036},
 													name: "IntegerAsString",
 												},
 											},
@@ -2944,25 +2944,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1613, col: 71, offset: 50515},
+									pos:        position{line: 1625, col: 71, offset: 51054},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1613, col: 77, offset: 50521},
+									pos:   position{line: 1625, col: 77, offset: 51060},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1613, col: 82, offset: 50526},
+										pos: position{line: 1625, col: 82, offset: 51065},
 										expr: &choiceExpr{
-											pos: position{line: 1613, col: 83, offset: 50527},
+											pos: position{line: 1625, col: 83, offset: 51066},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1613, col: 83, offset: 50527},
+													pos:  position{line: 1625, col: 83, offset: 51066},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1613, col: 99, offset: 50543},
+													pos:  position{line: 1625, col: 99, offset: 51082},
 													name: "IntegerAsString",
 												},
 											},
@@ -2973,26 +2973,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1656, col: 3, offset: 51979},
+						pos: position{line: 1668, col: 3, offset: 52518},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1656, col: 3, offset: 51979},
+							pos: position{line: 1668, col: 3, offset: 52518},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1656, col: 3, offset: 51979},
+									pos:        position{line: 1668, col: 3, offset: 52518},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1656, col: 10, offset: 51986},
+									pos:  position{line: 1668, col: 10, offset: 52525},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1656, col: 16, offset: 51992},
+									pos:   position{line: 1668, col: 16, offset: 52531},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1656, col: 24, offset: 52000},
+										pos:  position{line: 1668, col: 24, offset: 52539},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3004,38 +3004,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1671, col: 1, offset: 52331},
+			pos:  position{line: 1683, col: 1, offset: 52870},
 			expr: &actionExpr{
-				pos: position{line: 1671, col: 17, offset: 52347},
+				pos: position{line: 1683, col: 17, offset: 52886},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1671, col: 17, offset: 52347},
+					pos:   position{line: 1683, col: 17, offset: 52886},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1671, col: 25, offset: 52355},
+						pos: position{line: 1683, col: 25, offset: 52894},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 25, offset: 52355},
+								pos:  position{line: 1683, col: 25, offset: 52894},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 46, offset: 52376},
+								pos:  position{line: 1683, col: 46, offset: 52915},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 65, offset: 52395},
+								pos:  position{line: 1683, col: 65, offset: 52934},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 84, offset: 52414},
+								pos:  position{line: 1683, col: 84, offset: 52953},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 101, offset: 52431},
+								pos:  position{line: 1683, col: 101, offset: 52970},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1671, col: 116, offset: 52446},
+								pos:  position{line: 1683, col: 116, offset: 52985},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3045,35 +3045,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1675, col: 1, offset: 52489},
+			pos:  position{line: 1687, col: 1, offset: 53028},
 			expr: &actionExpr{
-				pos: position{line: 1675, col: 22, offset: 52510},
+				pos: position{line: 1687, col: 22, offset: 53049},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1675, col: 22, offset: 52510},
+					pos: position{line: 1687, col: 22, offset: 53049},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1675, col: 22, offset: 52510},
+							pos:   position{line: 1687, col: 22, offset: 53049},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1675, col: 29, offset: 52517},
+								pos:  position{line: 1687, col: 29, offset: 53056},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1675, col: 42, offset: 52530},
+							pos:   position{line: 1687, col: 42, offset: 53069},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1675, col: 48, offset: 52536},
+								pos: position{line: 1687, col: 48, offset: 53075},
 								expr: &seqExpr{
-									pos: position{line: 1675, col: 49, offset: 52537},
+									pos: position{line: 1687, col: 49, offset: 53076},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1675, col: 49, offset: 52537},
+											pos:  position{line: 1687, col: 49, offset: 53076},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1675, col: 55, offset: 52543},
+											pos:  position{line: 1687, col: 55, offset: 53082},
 											name: "BinCmdOption",
 										},
 									},
@@ -3086,51 +3086,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1721, col: 1, offset: 54027},
+			pos:  position{line: 1733, col: 1, offset: 54566},
 			expr: &choiceExpr{
-				pos: position{line: 1721, col: 13, offset: 54039},
+				pos: position{line: 1733, col: 13, offset: 54578},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1721, col: 13, offset: 54039},
+						pos: position{line: 1733, col: 13, offset: 54578},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1721, col: 13, offset: 54039},
+							pos: position{line: 1733, col: 13, offset: 54578},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1721, col: 13, offset: 54039},
+									pos:  position{line: 1733, col: 13, offset: 54578},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1721, col: 18, offset: 54044},
+									pos:  position{line: 1733, col: 18, offset: 54583},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1721, col: 26, offset: 54052},
+									pos:   position{line: 1733, col: 26, offset: 54591},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1721, col: 40, offset: 54066},
+										pos:  position{line: 1733, col: 40, offset: 54605},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1721, col: 59, offset: 54085},
+									pos:  position{line: 1733, col: 59, offset: 54624},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1721, col: 65, offset: 54091},
+									pos:   position{line: 1733, col: 65, offset: 54630},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1721, col: 71, offset: 54097},
+										pos:  position{line: 1733, col: 71, offset: 54636},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1721, col: 81, offset: 54107},
+									pos:   position{line: 1733, col: 81, offset: 54646},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1721, col: 94, offset: 54120},
+										pos: position{line: 1733, col: 94, offset: 54659},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1721, col: 95, offset: 54121},
+											pos:  position{line: 1733, col: 95, offset: 54660},
 											name: "AsField",
 										},
 									},
@@ -3139,34 +3139,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1748, col: 3, offset: 54964},
+						pos: position{line: 1760, col: 3, offset: 55503},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1748, col: 3, offset: 54964},
+							pos: position{line: 1760, col: 3, offset: 55503},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1748, col: 3, offset: 54964},
+									pos:  position{line: 1760, col: 3, offset: 55503},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1748, col: 8, offset: 54969},
+									pos:  position{line: 1760, col: 8, offset: 55508},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1748, col: 16, offset: 54977},
+									pos:   position{line: 1760, col: 16, offset: 55516},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1748, col: 22, offset: 54983},
+										pos:  position{line: 1760, col: 22, offset: 55522},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1748, col: 32, offset: 54993},
+									pos:   position{line: 1760, col: 32, offset: 55532},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1748, col: 45, offset: 55006},
+										pos: position{line: 1760, col: 45, offset: 55545},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1748, col: 46, offset: 55007},
+											pos:  position{line: 1760, col: 46, offset: 55546},
 											name: "AsField",
 										},
 									},
@@ -3179,15 +3179,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1779, col: 1, offset: 55881},
+			pos:  position{line: 1791, col: 1, offset: 56420},
 			expr: &actionExpr{
-				pos: position{line: 1779, col: 15, offset: 55895},
+				pos: position{line: 1791, col: 15, offset: 56434},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1779, col: 15, offset: 55895},
+					pos:   position{line: 1791, col: 15, offset: 56434},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1779, col: 27, offset: 55907},
+						pos:  position{line: 1791, col: 27, offset: 56446},
 						name: "SpanOptions",
 					},
 				},
@@ -3195,26 +3195,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1787, col: 1, offset: 56132},
+			pos:  position{line: 1799, col: 1, offset: 56671},
 			expr: &actionExpr{
-				pos: position{line: 1787, col: 16, offset: 56147},
+				pos: position{line: 1799, col: 16, offset: 56686},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1787, col: 16, offset: 56147},
+					pos: position{line: 1799, col: 16, offset: 56686},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1787, col: 16, offset: 56147},
+							pos:  position{line: 1799, col: 16, offset: 56686},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1787, col: 25, offset: 56156},
+							pos:  position{line: 1799, col: 25, offset: 56695},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1787, col: 31, offset: 56162},
+							pos:   position{line: 1799, col: 31, offset: 56701},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1787, col: 42, offset: 56173},
+								pos:  position{line: 1799, col: 42, offset: 56712},
 								name: "SpanLength",
 							},
 						},
@@ -3224,26 +3224,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1794, col: 1, offset: 56319},
+			pos:  position{line: 1806, col: 1, offset: 56858},
 			expr: &actionExpr{
-				pos: position{line: 1794, col: 15, offset: 56333},
+				pos: position{line: 1806, col: 15, offset: 56872},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1794, col: 15, offset: 56333},
+					pos: position{line: 1806, col: 15, offset: 56872},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1794, col: 15, offset: 56333},
+							pos:   position{line: 1806, col: 15, offset: 56872},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1794, col: 24, offset: 56342},
+								pos:  position{line: 1806, col: 24, offset: 56881},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1794, col: 40, offset: 56358},
+							pos:   position{line: 1806, col: 40, offset: 56897},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1794, col: 50, offset: 56368},
+								pos:  position{line: 1806, col: 50, offset: 56907},
 								name: "AllTimeScale",
 							},
 						},
@@ -3253,43 +3253,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1811, col: 1, offset: 56914},
+			pos:  position{line: 1823, col: 1, offset: 57453},
 			expr: &actionExpr{
-				pos: position{line: 1811, col: 14, offset: 56927},
+				pos: position{line: 1823, col: 14, offset: 57466},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1811, col: 14, offset: 56927},
+					pos: position{line: 1823, col: 14, offset: 57466},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1811, col: 14, offset: 56927},
+							pos:  position{line: 1823, col: 14, offset: 57466},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1811, col: 20, offset: 56933},
+							pos:        position{line: 1823, col: 20, offset: 57472},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1811, col: 28, offset: 56941},
+							pos:  position{line: 1823, col: 28, offset: 57480},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1811, col: 34, offset: 56947},
+							pos:   position{line: 1823, col: 34, offset: 57486},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1811, col: 41, offset: 56954},
+								pos: position{line: 1823, col: 41, offset: 57493},
 								expr: &choiceExpr{
-									pos: position{line: 1811, col: 42, offset: 56955},
+									pos: position{line: 1823, col: 42, offset: 57494},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1811, col: 42, offset: 56955},
+											pos:        position{line: 1823, col: 42, offset: 57494},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1811, col: 50, offset: 56963},
+											pos:        position{line: 1823, col: 50, offset: 57502},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3299,14 +3299,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1811, col: 61, offset: 56974},
+							pos:  position{line: 1823, col: 61, offset: 57513},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1811, col: 76, offset: 56989},
+							pos:   position{line: 1823, col: 76, offset: 57528},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1811, col: 86, offset: 56999},
+								pos:  position{line: 1823, col: 86, offset: 57538},
 								name: "IntegerAsString",
 							},
 						},
@@ -3316,22 +3316,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1835, col: 1, offset: 57580},
+			pos:  position{line: 1847, col: 1, offset: 58119},
 			expr: &actionExpr{
-				pos: position{line: 1835, col: 19, offset: 57598},
+				pos: position{line: 1847, col: 19, offset: 58137},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1835, col: 19, offset: 57598},
+					pos: position{line: 1847, col: 19, offset: 58137},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1835, col: 19, offset: 57598},
+							pos:  position{line: 1847, col: 19, offset: 58137},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1835, col: 24, offset: 57603},
+							pos:   position{line: 1847, col: 24, offset: 58142},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1835, col: 38, offset: 57617},
+								pos:  position{line: 1847, col: 38, offset: 58156},
 								name: "StatisticExpr",
 							},
 						},
@@ -3341,76 +3341,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1875, col: 1, offset: 58828},
+			pos:  position{line: 1887, col: 1, offset: 59367},
 			expr: &actionExpr{
-				pos: position{line: 1875, col: 18, offset: 58845},
+				pos: position{line: 1887, col: 18, offset: 59384},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1875, col: 18, offset: 58845},
+					pos: position{line: 1887, col: 18, offset: 59384},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1875, col: 18, offset: 58845},
+							pos:   position{line: 1887, col: 18, offset: 59384},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1875, col: 23, offset: 58850},
+								pos: position{line: 1887, col: 23, offset: 59389},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1875, col: 23, offset: 58850},
+										pos:  position{line: 1887, col: 23, offset: 59389},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1875, col: 33, offset: 58860},
+										pos:  position{line: 1887, col: 33, offset: 59399},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1875, col: 43, offset: 58870},
+							pos:   position{line: 1887, col: 43, offset: 59409},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1875, col: 49, offset: 58876},
+								pos: position{line: 1887, col: 49, offset: 59415},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1875, col: 50, offset: 58877},
+									pos:  position{line: 1887, col: 50, offset: 59416},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1875, col: 67, offset: 58894},
+							pos:   position{line: 1887, col: 67, offset: 59433},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1875, col: 78, offset: 58905},
+								pos: position{line: 1887, col: 78, offset: 59444},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1875, col: 78, offset: 58905},
+										pos:  position{line: 1887, col: 78, offset: 59444},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1875, col: 84, offset: 58911},
+										pos:  position{line: 1887, col: 84, offset: 59450},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1875, col: 99, offset: 58926},
+							pos:   position{line: 1887, col: 99, offset: 59465},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1875, col: 108, offset: 58935},
+								pos: position{line: 1887, col: 108, offset: 59474},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1875, col: 109, offset: 58936},
+									pos:  position{line: 1887, col: 109, offset: 59475},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1875, col: 120, offset: 58947},
+							pos:   position{line: 1887, col: 120, offset: 59486},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1875, col: 128, offset: 58955},
+								pos: position{line: 1887, col: 128, offset: 59494},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1875, col: 129, offset: 58956},
+									pos:  position{line: 1887, col: 129, offset: 59495},
 									name: "StatisticOptions",
 								},
 							},
@@ -3421,25 +3421,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1917, col: 1, offset: 60041},
+			pos:  position{line: 1929, col: 1, offset: 60580},
 			expr: &choiceExpr{
-				pos: position{line: 1917, col: 19, offset: 60059},
+				pos: position{line: 1929, col: 19, offset: 60598},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1917, col: 19, offset: 60059},
+						pos: position{line: 1929, col: 19, offset: 60598},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1917, col: 19, offset: 60059},
+							pos: position{line: 1929, col: 19, offset: 60598},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1917, col: 19, offset: 60059},
+									pos:  position{line: 1929, col: 19, offset: 60598},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1917, col: 25, offset: 60065},
+									pos:   position{line: 1929, col: 25, offset: 60604},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1917, col: 32, offset: 60072},
+										pos:  position{line: 1929, col: 32, offset: 60611},
 										name: "IntegerAsString",
 									},
 								},
@@ -3447,30 +3447,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1920, col: 3, offset: 60126},
+						pos: position{line: 1932, col: 3, offset: 60665},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1920, col: 3, offset: 60126},
+							pos: position{line: 1932, col: 3, offset: 60665},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 3, offset: 60126},
+									pos:  position{line: 1932, col: 3, offset: 60665},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1920, col: 9, offset: 60132},
+									pos:        position{line: 1932, col: 9, offset: 60671},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1920, col: 17, offset: 60140},
+									pos:  position{line: 1932, col: 17, offset: 60679},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1920, col: 23, offset: 60146},
+									pos:   position{line: 1932, col: 23, offset: 60685},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1920, col: 30, offset: 60153},
+										pos:  position{line: 1932, col: 30, offset: 60692},
 										name: "IntegerAsString",
 									},
 								},
@@ -3482,17 +3482,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1925, col: 1, offset: 60251},
+			pos:  position{line: 1937, col: 1, offset: 60790},
 			expr: &actionExpr{
-				pos: position{line: 1925, col: 21, offset: 60271},
+				pos: position{line: 1937, col: 21, offset: 60810},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1925, col: 21, offset: 60271},
+					pos:   position{line: 1937, col: 21, offset: 60810},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1925, col: 28, offset: 60278},
+						pos: position{line: 1937, col: 28, offset: 60817},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1925, col: 29, offset: 60279},
+							pos:  position{line: 1937, col: 29, offset: 60818},
 							name: "StatisticOption",
 						},
 					},
@@ -3501,34 +3501,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 1974, col: 1, offset: 61841},
+			pos:  position{line: 1986, col: 1, offset: 62380},
 			expr: &actionExpr{
-				pos: position{line: 1974, col: 20, offset: 61860},
+				pos: position{line: 1986, col: 20, offset: 62399},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 1974, col: 20, offset: 61860},
+					pos: position{line: 1986, col: 20, offset: 62399},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1974, col: 20, offset: 61860},
+							pos:  position{line: 1986, col: 20, offset: 62399},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1974, col: 26, offset: 61866},
+							pos:   position{line: 1986, col: 26, offset: 62405},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1974, col: 36, offset: 61876},
+								pos:  position{line: 1986, col: 36, offset: 62415},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1974, col: 55, offset: 61895},
+							pos:  position{line: 1986, col: 55, offset: 62434},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1974, col: 61, offset: 61901},
+							pos:   position{line: 1986, col: 61, offset: 62440},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1974, col: 67, offset: 61907},
+								pos:  position{line: 1986, col: 67, offset: 62446},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3538,48 +3538,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 1979, col: 1, offset: 62016},
+			pos:  position{line: 1991, col: 1, offset: 62555},
 			expr: &actionExpr{
-				pos: position{line: 1979, col: 23, offset: 62038},
+				pos: position{line: 1991, col: 23, offset: 62577},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1979, col: 23, offset: 62038},
+					pos:   position{line: 1991, col: 23, offset: 62577},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1979, col: 31, offset: 62046},
+						pos: position{line: 1991, col: 31, offset: 62585},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1979, col: 31, offset: 62046},
+								pos:        position{line: 1991, col: 31, offset: 62585},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1979, col: 46, offset: 62061},
+								pos:        position{line: 1991, col: 46, offset: 62600},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1979, col: 60, offset: 62075},
+								pos:        position{line: 1991, col: 60, offset: 62614},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1979, col: 73, offset: 62088},
+								pos:        position{line: 1991, col: 73, offset: 62627},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1979, col: 85, offset: 62100},
+								pos:        position{line: 1991, col: 85, offset: 62639},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1979, col: 102, offset: 62117},
+								pos:        position{line: 1991, col: 102, offset: 62656},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3591,25 +3591,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 1987, col: 1, offset: 62304},
+			pos:  position{line: 1999, col: 1, offset: 62843},
 			expr: &choiceExpr{
-				pos: position{line: 1987, col: 13, offset: 62316},
+				pos: position{line: 1999, col: 13, offset: 62855},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1987, col: 13, offset: 62316},
+						pos: position{line: 1999, col: 13, offset: 62855},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 1987, col: 13, offset: 62316},
+							pos: position{line: 1999, col: 13, offset: 62855},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1987, col: 13, offset: 62316},
+									pos:  position{line: 1999, col: 13, offset: 62855},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 1987, col: 16, offset: 62319},
+									pos:   position{line: 1999, col: 16, offset: 62858},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1987, col: 26, offset: 62329},
+										pos:  position{line: 1999, col: 26, offset: 62868},
 										name: "FieldNameList",
 									},
 								},
@@ -3617,13 +3617,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1990, col: 3, offset: 62386},
+						pos: position{line: 2002, col: 3, offset: 62925},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 1990, col: 3, offset: 62386},
+							pos:   position{line: 2002, col: 3, offset: 62925},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1990, col: 16, offset: 62399},
+								pos:  position{line: 2002, col: 16, offset: 62938},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3633,26 +3633,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 1994, col: 1, offset: 62457},
+			pos:  position{line: 2006, col: 1, offset: 62996},
 			expr: &actionExpr{
-				pos: position{line: 1994, col: 15, offset: 62471},
+				pos: position{line: 2006, col: 15, offset: 63010},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1994, col: 15, offset: 62471},
+					pos: position{line: 2006, col: 15, offset: 63010},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 15, offset: 62471},
+							pos:  position{line: 2006, col: 15, offset: 63010},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1994, col: 20, offset: 62476},
+							pos:  position{line: 2006, col: 20, offset: 63015},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 1994, col: 30, offset: 62486},
+							pos:   position{line: 2006, col: 30, offset: 63025},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1994, col: 40, offset: 62496},
+								pos:  position{line: 2006, col: 40, offset: 63035},
 								name: "DedupExpr",
 							},
 						},
@@ -3662,27 +3662,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2040, col: 1, offset: 63825},
+			pos:  position{line: 2052, col: 1, offset: 64364},
 			expr: &actionExpr{
-				pos: position{line: 2040, col: 14, offset: 63838},
+				pos: position{line: 2052, col: 14, offset: 64377},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2040, col: 14, offset: 63838},
+					pos: position{line: 2052, col: 14, offset: 64377},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2040, col: 14, offset: 63838},
+							pos:   position{line: 2052, col: 14, offset: 64377},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2040, col: 23, offset: 63847},
+								pos: position{line: 2052, col: 23, offset: 64386},
 								expr: &seqExpr{
-									pos: position{line: 2040, col: 24, offset: 63848},
+									pos: position{line: 2052, col: 24, offset: 64387},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2040, col: 24, offset: 63848},
+											pos:  position{line: 2052, col: 24, offset: 64387},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2040, col: 30, offset: 63854},
+											pos:  position{line: 2052, col: 30, offset: 64393},
 											name: "IntegerAsString",
 										},
 									},
@@ -3690,45 +3690,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 48, offset: 63872},
+							pos:   position{line: 2052, col: 48, offset: 64411},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2040, col: 57, offset: 63881},
+								pos: position{line: 2052, col: 57, offset: 64420},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2040, col: 58, offset: 63882},
+									pos:  position{line: 2052, col: 58, offset: 64421},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 73, offset: 63897},
+							pos:   position{line: 2052, col: 73, offset: 64436},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2040, col: 83, offset: 63907},
+								pos: position{line: 2052, col: 83, offset: 64446},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2040, col: 84, offset: 63908},
+									pos:  position{line: 2052, col: 84, offset: 64447},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 101, offset: 63925},
+							pos:   position{line: 2052, col: 101, offset: 64464},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2040, col: 110, offset: 63934},
+								pos: position{line: 2052, col: 110, offset: 64473},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2040, col: 111, offset: 63935},
+									pos:  position{line: 2052, col: 111, offset: 64474},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2040, col: 126, offset: 63950},
+							pos:   position{line: 2052, col: 126, offset: 64489},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2040, col: 139, offset: 63963},
+								pos: position{line: 2052, col: 139, offset: 64502},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2040, col: 140, offset: 63964},
+									pos:  position{line: 2052, col: 140, offset: 64503},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3739,27 +3739,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2097, col: 1, offset: 65702},
+			pos:  position{line: 2109, col: 1, offset: 66241},
 			expr: &actionExpr{
-				pos: position{line: 2097, col: 19, offset: 65720},
+				pos: position{line: 2109, col: 19, offset: 66259},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2097, col: 19, offset: 65720},
+					pos: position{line: 2109, col: 19, offset: 66259},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2097, col: 19, offset: 65720},
+							pos: position{line: 2109, col: 19, offset: 66259},
 							expr: &litMatcher{
-								pos:        position{line: 2097, col: 21, offset: 65722},
+								pos:        position{line: 2109, col: 21, offset: 66261},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2097, col: 31, offset: 65732},
+							pos:   position{line: 2109, col: 31, offset: 66271},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2097, col: 37, offset: 65738},
+								pos:  position{line: 2109, col: 37, offset: 66277},
 								name: "FieldName",
 							},
 						},
@@ -3769,48 +3769,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2103, col: 1, offset: 65877},
+			pos:  position{line: 2115, col: 1, offset: 66416},
 			expr: &actionExpr{
-				pos: position{line: 2103, col: 32, offset: 65908},
+				pos: position{line: 2115, col: 32, offset: 66447},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2103, col: 32, offset: 65908},
+					pos: position{line: 2115, col: 32, offset: 66447},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2103, col: 32, offset: 65908},
+							pos:   position{line: 2115, col: 32, offset: 66447},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2103, col: 38, offset: 65914},
+								pos:  position{line: 2115, col: 38, offset: 66453},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2103, col: 48, offset: 65924},
+							pos: position{line: 2115, col: 48, offset: 66463},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2103, col: 50, offset: 65926},
+								pos:  position{line: 2115, col: 50, offset: 66465},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2103, col: 57, offset: 65933},
+							pos:   position{line: 2115, col: 57, offset: 66472},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2103, col: 62, offset: 65938},
+								pos: position{line: 2115, col: 62, offset: 66477},
 								expr: &seqExpr{
-									pos: position{line: 2103, col: 63, offset: 65939},
+									pos: position{line: 2115, col: 63, offset: 66478},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2103, col: 63, offset: 65939},
+											pos:  position{line: 2115, col: 63, offset: 66478},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2103, col: 69, offset: 65945},
+											pos:  position{line: 2115, col: 69, offset: 66484},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2103, col: 79, offset: 65955},
+											pos: position{line: 2115, col: 79, offset: 66494},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2103, col: 81, offset: 65957},
+												pos:  position{line: 2115, col: 81, offset: 66496},
 												name: "EQUAL",
 											},
 										},
@@ -3824,45 +3824,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2114, col: 1, offset: 66232},
+			pos:  position{line: 2126, col: 1, offset: 66771},
 			expr: &actionExpr{
-				pos: position{line: 2114, col: 19, offset: 66250},
+				pos: position{line: 2126, col: 19, offset: 66789},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2114, col: 19, offset: 66250},
+					pos: position{line: 2126, col: 19, offset: 66789},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2114, col: 19, offset: 66250},
+							pos:  position{line: 2126, col: 19, offset: 66789},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 25, offset: 66256},
+							pos:   position{line: 2126, col: 25, offset: 66795},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2114, col: 31, offset: 66262},
+								pos:  position{line: 2126, col: 31, offset: 66801},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2114, col: 46, offset: 66277},
+							pos:   position{line: 2126, col: 46, offset: 66816},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2114, col: 51, offset: 66282},
+								pos: position{line: 2126, col: 51, offset: 66821},
 								expr: &seqExpr{
-									pos: position{line: 2114, col: 52, offset: 66283},
+									pos: position{line: 2126, col: 52, offset: 66822},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2114, col: 52, offset: 66283},
+											pos:  position{line: 2126, col: 52, offset: 66822},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2114, col: 58, offset: 66289},
+											pos:  position{line: 2126, col: 58, offset: 66828},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2114, col: 73, offset: 66304},
+											pos: position{line: 2126, col: 73, offset: 66843},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2114, col: 74, offset: 66305},
+												pos:  position{line: 2126, col: 74, offset: 66844},
 												name: "EQUAL",
 											},
 										},
@@ -3876,17 +3876,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2132, col: 1, offset: 66833},
+			pos:  position{line: 2144, col: 1, offset: 67372},
 			expr: &actionExpr{
-				pos: position{line: 2132, col: 17, offset: 66849},
+				pos: position{line: 2144, col: 17, offset: 67388},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2132, col: 17, offset: 66849},
+					pos:   position{line: 2144, col: 17, offset: 67388},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2132, col: 24, offset: 66856},
+						pos: position{line: 2144, col: 24, offset: 67395},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2132, col: 25, offset: 66857},
+							pos:  position{line: 2144, col: 25, offset: 67396},
 							name: "DedupOption",
 						},
 					},
@@ -3895,36 +3895,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2172, col: 1, offset: 68123},
+			pos:  position{line: 2184, col: 1, offset: 68662},
 			expr: &actionExpr{
-				pos: position{line: 2172, col: 16, offset: 68138},
+				pos: position{line: 2184, col: 16, offset: 68677},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2172, col: 16, offset: 68138},
+					pos: position{line: 2184, col: 16, offset: 68677},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2172, col: 16, offset: 68138},
+							pos:  position{line: 2184, col: 16, offset: 68677},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2172, col: 22, offset: 68144},
+							pos:   position{line: 2184, col: 22, offset: 68683},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2172, col: 32, offset: 68154},
+								pos:  position{line: 2184, col: 32, offset: 68693},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2172, col: 47, offset: 68169},
+							pos:        position{line: 2184, col: 47, offset: 68708},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2172, col: 51, offset: 68173},
+							pos:   position{line: 2184, col: 51, offset: 68712},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2172, col: 57, offset: 68179},
+								pos:  position{line: 2184, col: 57, offset: 68718},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3934,30 +3934,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2177, col: 1, offset: 68288},
+			pos:  position{line: 2189, col: 1, offset: 68827},
 			expr: &actionExpr{
-				pos: position{line: 2177, col: 19, offset: 68306},
+				pos: position{line: 2189, col: 19, offset: 68845},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2177, col: 19, offset: 68306},
+					pos:   position{line: 2189, col: 19, offset: 68845},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2177, col: 27, offset: 68314},
+						pos: position{line: 2189, col: 27, offset: 68853},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2177, col: 27, offset: 68314},
+								pos:        position{line: 2189, col: 27, offset: 68853},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2177, col: 43, offset: 68330},
+								pos:        position{line: 2189, col: 43, offset: 68869},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2177, col: 57, offset: 68344},
+								pos:        position{line: 2189, col: 57, offset: 68883},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -3969,22 +3969,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2185, col: 1, offset: 68529},
+			pos:  position{line: 2197, col: 1, offset: 69068},
 			expr: &actionExpr{
-				pos: position{line: 2185, col: 22, offset: 68550},
+				pos: position{line: 2197, col: 22, offset: 69089},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2185, col: 22, offset: 68550},
+					pos: position{line: 2197, col: 22, offset: 69089},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2185, col: 22, offset: 68550},
+							pos:  position{line: 2197, col: 22, offset: 69089},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2185, col: 39, offset: 68567},
+							pos:   position{line: 2197, col: 39, offset: 69106},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2185, col: 53, offset: 68581},
+								pos:  position{line: 2197, col: 53, offset: 69120},
 								name: "SortElements",
 							},
 						},
@@ -3994,35 +3994,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2190, col: 1, offset: 68689},
+			pos:  position{line: 2202, col: 1, offset: 69228},
 			expr: &actionExpr{
-				pos: position{line: 2190, col: 17, offset: 68705},
+				pos: position{line: 2202, col: 17, offset: 69244},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2190, col: 17, offset: 68705},
+					pos: position{line: 2202, col: 17, offset: 69244},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2190, col: 17, offset: 68705},
+							pos:   position{line: 2202, col: 17, offset: 69244},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2190, col: 23, offset: 68711},
+								pos:  position{line: 2202, col: 23, offset: 69250},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2190, col: 41, offset: 68729},
+							pos:   position{line: 2202, col: 41, offset: 69268},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2190, col: 46, offset: 68734},
+								pos: position{line: 2202, col: 46, offset: 69273},
 								expr: &seqExpr{
-									pos: position{line: 2190, col: 47, offset: 68735},
+									pos: position{line: 2202, col: 47, offset: 69274},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2190, col: 47, offset: 68735},
+											pos:  position{line: 2202, col: 47, offset: 69274},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2190, col: 62, offset: 68750},
+											pos:  position{line: 2202, col: 62, offset: 69289},
 											name: "SingleSortElement",
 										},
 									},
@@ -4035,22 +4035,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2205, col: 1, offset: 69108},
+			pos:  position{line: 2217, col: 1, offset: 69647},
 			expr: &actionExpr{
-				pos: position{line: 2205, col: 22, offset: 69129},
+				pos: position{line: 2217, col: 22, offset: 69668},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2205, col: 22, offset: 69129},
+					pos:   position{line: 2217, col: 22, offset: 69668},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2205, col: 31, offset: 69138},
+						pos: position{line: 2217, col: 31, offset: 69677},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2205, col: 31, offset: 69138},
+								pos:  position{line: 2217, col: 31, offset: 69677},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2205, col: 59, offset: 69166},
+								pos:  position{line: 2217, col: 59, offset: 69705},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4060,33 +4060,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2209, col: 1, offset: 69225},
+			pos:  position{line: 2221, col: 1, offset: 69764},
 			expr: &actionExpr{
-				pos: position{line: 2209, col: 33, offset: 69257},
+				pos: position{line: 2221, col: 33, offset: 69796},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2209, col: 33, offset: 69257},
+					pos: position{line: 2221, col: 33, offset: 69796},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2209, col: 33, offset: 69257},
+							pos:   position{line: 2221, col: 33, offset: 69796},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2209, col: 47, offset: 69271},
+								pos: position{line: 2221, col: 47, offset: 69810},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2209, col: 47, offset: 69271},
+										pos:        position{line: 2221, col: 47, offset: 69810},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2209, col: 53, offset: 69277},
+										pos:        position{line: 2221, col: 53, offset: 69816},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2209, col: 59, offset: 69283},
+										pos:        position{line: 2221, col: 59, offset: 69822},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4095,10 +4095,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2209, col: 63, offset: 69287},
+							pos:   position{line: 2221, col: 63, offset: 69826},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2209, col: 69, offset: 69293},
+								pos:  position{line: 2221, col: 69, offset: 69832},
 								name: "FieldName",
 							},
 						},
@@ -4108,33 +4108,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2224, col: 1, offset: 69568},
+			pos:  position{line: 2236, col: 1, offset: 70107},
 			expr: &actionExpr{
-				pos: position{line: 2224, col: 30, offset: 69597},
+				pos: position{line: 2236, col: 30, offset: 70136},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2224, col: 30, offset: 69597},
+					pos: position{line: 2236, col: 30, offset: 70136},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2224, col: 30, offset: 69597},
+							pos:   position{line: 2236, col: 30, offset: 70136},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2224, col: 44, offset: 69611},
+								pos: position{line: 2236, col: 44, offset: 70150},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2224, col: 44, offset: 69611},
+										pos:        position{line: 2236, col: 44, offset: 70150},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2224, col: 50, offset: 69617},
+										pos:        position{line: 2236, col: 50, offset: 70156},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2224, col: 56, offset: 69623},
+										pos:        position{line: 2236, col: 56, offset: 70162},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4143,31 +4143,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2224, col: 60, offset: 69627},
+							pos:   position{line: 2236, col: 60, offset: 70166},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2224, col: 64, offset: 69631},
+								pos: position{line: 2236, col: 64, offset: 70170},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2224, col: 64, offset: 69631},
+										pos:        position{line: 2236, col: 64, offset: 70170},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2224, col: 73, offset: 69640},
+										pos:        position{line: 2236, col: 73, offset: 70179},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2224, col: 81, offset: 69648},
+										pos:        position{line: 2236, col: 81, offset: 70187},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2224, col: 88, offset: 69655},
+										pos:        position{line: 2236, col: 88, offset: 70194},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4176,19 +4176,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2224, col: 95, offset: 69662},
+							pos:  position{line: 2236, col: 95, offset: 70201},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2224, col: 103, offset: 69670},
+							pos:   position{line: 2236, col: 103, offset: 70209},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2224, col: 109, offset: 69676},
+								pos:  position{line: 2236, col: 109, offset: 70215},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2224, col: 119, offset: 69686},
+							pos:  position{line: 2236, col: 119, offset: 70225},
 							name: "R_PAREN",
 						},
 					},
@@ -4197,26 +4197,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2244, col: 1, offset: 70111},
+			pos:  position{line: 2256, col: 1, offset: 70650},
 			expr: &actionExpr{
-				pos: position{line: 2244, col: 16, offset: 70126},
+				pos: position{line: 2256, col: 16, offset: 70665},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2244, col: 16, offset: 70126},
+					pos: position{line: 2256, col: 16, offset: 70665},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2244, col: 16, offset: 70126},
+							pos:  position{line: 2256, col: 16, offset: 70665},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2244, col: 21, offset: 70131},
+							pos:  position{line: 2256, col: 21, offset: 70670},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2244, col: 32, offset: 70142},
+							pos:   position{line: 2256, col: 32, offset: 70681},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2244, col: 43, offset: 70153},
+								pos:  position{line: 2256, col: 43, offset: 70692},
 								name: "RenameExpr",
 							},
 						},
@@ -4226,33 +4226,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2267, col: 1, offset: 70817},
+			pos:  position{line: 2279, col: 1, offset: 71356},
 			expr: &choiceExpr{
-				pos: position{line: 2267, col: 15, offset: 70831},
+				pos: position{line: 2279, col: 15, offset: 71370},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2267, col: 15, offset: 70831},
+						pos: position{line: 2279, col: 15, offset: 71370},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2267, col: 15, offset: 70831},
+							pos: position{line: 2279, col: 15, offset: 71370},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2267, col: 15, offset: 70831},
+									pos:   position{line: 2279, col: 15, offset: 71370},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2267, col: 31, offset: 70847},
+										pos:  position{line: 2279, col: 31, offset: 71386},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2267, col: 45, offset: 70861},
+									pos:  position{line: 2279, col: 45, offset: 71400},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2267, col: 48, offset: 70864},
+									pos:   position{line: 2279, col: 48, offset: 71403},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2267, col: 59, offset: 70875},
+										pos:  position{line: 2279, col: 59, offset: 71414},
 										name: "QuotedString",
 									},
 								},
@@ -4260,28 +4260,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2278, col: 3, offset: 71194},
+						pos: position{line: 2290, col: 3, offset: 71733},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2278, col: 3, offset: 71194},
+							pos: position{line: 2290, col: 3, offset: 71733},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2278, col: 3, offset: 71194},
+									pos:   position{line: 2290, col: 3, offset: 71733},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2278, col: 19, offset: 71210},
+										pos:  position{line: 2290, col: 19, offset: 71749},
 										name: "RenamePattern",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2278, col: 33, offset: 71224},
+									pos:  position{line: 2290, col: 33, offset: 71763},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2278, col: 36, offset: 71227},
+									pos:   position{line: 2290, col: 36, offset: 71766},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2278, col: 47, offset: 71238},
+										pos:  position{line: 2290, col: 47, offset: 71777},
 										name: "RenamePattern",
 									},
 								},
@@ -4293,48 +4293,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2300, col: 1, offset: 71804},
+			pos:  position{line: 2312, col: 1, offset: 72343},
 			expr: &actionExpr{
-				pos: position{line: 2300, col: 13, offset: 71816},
+				pos: position{line: 2312, col: 13, offset: 72355},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2300, col: 13, offset: 71816},
+					pos: position{line: 2312, col: 13, offset: 72355},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2300, col: 13, offset: 71816},
+							pos:  position{line: 2312, col: 13, offset: 72355},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2300, col: 18, offset: 71821},
+							pos:  position{line: 2312, col: 18, offset: 72360},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2300, col: 26, offset: 71829},
+							pos:        position{line: 2312, col: 26, offset: 72368},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2300, col: 34, offset: 71837},
+							pos:  position{line: 2312, col: 34, offset: 72376},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2300, col: 40, offset: 71843},
+							pos:   position{line: 2312, col: 40, offset: 72382},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 46, offset: 71849},
+								pos:  position{line: 2312, col: 46, offset: 72388},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2300, col: 62, offset: 71865},
+							pos:  position{line: 2312, col: 62, offset: 72404},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2300, col: 68, offset: 71871},
+							pos:   position{line: 2312, col: 68, offset: 72410},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2300, col: 72, offset: 71875},
+								pos:  position{line: 2312, col: 72, offset: 72414},
 								name: "QuotedString",
 							},
 						},
@@ -4344,37 +4344,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2329, col: 1, offset: 72604},
+			pos:  position{line: 2341, col: 1, offset: 73143},
 			expr: &actionExpr{
-				pos: position{line: 2329, col: 14, offset: 72617},
+				pos: position{line: 2341, col: 14, offset: 73156},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2329, col: 14, offset: 72617},
+					pos: position{line: 2341, col: 14, offset: 73156},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2329, col: 14, offset: 72617},
+							pos:  position{line: 2341, col: 14, offset: 73156},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2329, col: 19, offset: 72622},
+							pos:  position{line: 2341, col: 19, offset: 73161},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2329, col: 28, offset: 72631},
+							pos:   position{line: 2341, col: 28, offset: 73170},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2329, col: 34, offset: 72637},
+								pos: position{line: 2341, col: 34, offset: 73176},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2329, col: 35, offset: 72638},
+									pos:  position{line: 2341, col: 35, offset: 73177},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2329, col: 47, offset: 72650},
+							pos:   position{line: 2341, col: 47, offset: 73189},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2329, col: 58, offset: 72661},
+								pos:  position{line: 2341, col: 58, offset: 73200},
 								name: "SortElements",
 							},
 						},
@@ -4384,41 +4384,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2367, col: 1, offset: 73540},
+			pos:  position{line: 2379, col: 1, offset: 74079},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 14, offset: 73553},
+				pos: position{line: 2379, col: 14, offset: 74092},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2367, col: 14, offset: 73553},
+					pos: position{line: 2379, col: 14, offset: 74092},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2367, col: 14, offset: 73553},
+							pos: position{line: 2379, col: 14, offset: 74092},
 							expr: &seqExpr{
-								pos: position{line: 2367, col: 15, offset: 73554},
+								pos: position{line: 2379, col: 15, offset: 74093},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2367, col: 15, offset: 73554},
+										pos:        position{line: 2379, col: 15, offset: 74093},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2367, col: 23, offset: 73562},
+										pos:  position{line: 2379, col: 23, offset: 74101},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2367, col: 31, offset: 73570},
+							pos:   position{line: 2379, col: 31, offset: 74109},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2367, col: 40, offset: 73579},
+								pos:  position{line: 2379, col: 40, offset: 74118},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2367, col: 56, offset: 73595},
+							pos:  position{line: 2379, col: 56, offset: 74134},
 							name: "SPACE",
 						},
 					},
@@ -4427,43 +4427,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2381, col: 1, offset: 73894},
+			pos:  position{line: 2393, col: 1, offset: 74433},
 			expr: &actionExpr{
-				pos: position{line: 2381, col: 14, offset: 73907},
+				pos: position{line: 2393, col: 14, offset: 74446},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2381, col: 14, offset: 73907},
+					pos: position{line: 2393, col: 14, offset: 74446},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2381, col: 14, offset: 73907},
+							pos:  position{line: 2393, col: 14, offset: 74446},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2381, col: 19, offset: 73912},
+							pos:  position{line: 2393, col: 19, offset: 74451},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2381, col: 28, offset: 73921},
+							pos:   position{line: 2393, col: 28, offset: 74460},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2381, col: 34, offset: 73927},
+								pos:  position{line: 2393, col: 34, offset: 74466},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2381, col: 45, offset: 73938},
+							pos:   position{line: 2393, col: 45, offset: 74477},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2381, col: 50, offset: 73943},
+								pos: position{line: 2393, col: 50, offset: 74482},
 								expr: &seqExpr{
-									pos: position{line: 2381, col: 51, offset: 73944},
+									pos: position{line: 2393, col: 51, offset: 74483},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2381, col: 51, offset: 73944},
+											pos:  position{line: 2393, col: 51, offset: 74483},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2381, col: 57, offset: 73950},
+											pos:  position{line: 2393, col: 57, offset: 74489},
 											name: "SingleEval",
 										},
 									},
@@ -4476,30 +4476,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2416, col: 1, offset: 75183},
+			pos:  position{line: 2428, col: 1, offset: 75722},
 			expr: &actionExpr{
-				pos: position{line: 2416, col: 15, offset: 75197},
+				pos: position{line: 2428, col: 15, offset: 75736},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2416, col: 15, offset: 75197},
+					pos: position{line: 2428, col: 15, offset: 75736},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2416, col: 15, offset: 75197},
+							pos:   position{line: 2428, col: 15, offset: 75736},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2416, col: 21, offset: 75203},
+								pos:  position{line: 2428, col: 21, offset: 75742},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2416, col: 31, offset: 75213},
+							pos:  position{line: 2428, col: 31, offset: 75752},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2416, col: 37, offset: 75219},
+							pos:   position{line: 2428, col: 37, offset: 75758},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2416, col: 42, offset: 75224},
+								pos:  position{line: 2428, col: 42, offset: 75763},
 								name: "EvalExpression",
 							},
 						},
@@ -4509,15 +4509,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2429, col: 1, offset: 75625},
+			pos:  position{line: 2441, col: 1, offset: 76164},
 			expr: &actionExpr{
-				pos: position{line: 2429, col: 19, offset: 75643},
+				pos: position{line: 2441, col: 19, offset: 76182},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2429, col: 19, offset: 75643},
+					pos:   position{line: 2441, col: 19, offset: 76182},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2429, col: 25, offset: 75649},
+						pos:  position{line: 2441, col: 25, offset: 76188},
 						name: "ValueExpr",
 					},
 				},
@@ -4525,85 +4525,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2438, col: 1, offset: 75873},
+			pos:  position{line: 2450, col: 1, offset: 76412},
 			expr: &choiceExpr{
-				pos: position{line: 2438, col: 18, offset: 75890},
+				pos: position{line: 2450, col: 18, offset: 76429},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2438, col: 18, offset: 75890},
+						pos: position{line: 2450, col: 18, offset: 76429},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2438, col: 18, offset: 75890},
+							pos: position{line: 2450, col: 18, offset: 76429},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2438, col: 18, offset: 75890},
+									pos:        position{line: 2450, col: 18, offset: 76429},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 23, offset: 75895},
+									pos:  position{line: 2450, col: 23, offset: 76434},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 31, offset: 75903},
+									pos:   position{line: 2450, col: 31, offset: 76442},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 41, offset: 75913},
+										pos:  position{line: 2450, col: 41, offset: 76452},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 50, offset: 75922},
+									pos:  position{line: 2450, col: 50, offset: 76461},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 56, offset: 75928},
+									pos:   position{line: 2450, col: 56, offset: 76467},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 66, offset: 75938},
+										pos:  position{line: 2450, col: 66, offset: 76477},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 76, offset: 75948},
+									pos:  position{line: 2450, col: 76, offset: 76487},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2438, col: 82, offset: 75954},
+									pos:   position{line: 2450, col: 82, offset: 76493},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2438, col: 93, offset: 75965},
+										pos:  position{line: 2450, col: 93, offset: 76504},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2438, col: 103, offset: 75975},
+									pos:  position{line: 2450, col: 103, offset: 76514},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2449, col: 3, offset: 76226},
+						pos: position{line: 2461, col: 3, offset: 76765},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2449, col: 3, offset: 76226},
+							pos: position{line: 2461, col: 3, offset: 76765},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2449, col: 3, offset: 76226},
+									pos:   position{line: 2461, col: 3, offset: 76765},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2449, col: 11, offset: 76234},
+										pos: position{line: 2461, col: 11, offset: 76773},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2449, col: 11, offset: 76234},
+												pos:        position{line: 2461, col: 11, offset: 76773},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2449, col: 20, offset: 76243},
+												pos:        position{line: 2461, col: 20, offset: 76782},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4612,31 +4612,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2449, col: 32, offset: 76255},
+									pos:  position{line: 2461, col: 32, offset: 76794},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2449, col: 40, offset: 76263},
+									pos:   position{line: 2461, col: 40, offset: 76802},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2449, col: 45, offset: 76268},
+										pos:  position{line: 2461, col: 45, offset: 76807},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2449, col: 64, offset: 76287},
+									pos:   position{line: 2461, col: 64, offset: 76826},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2449, col: 69, offset: 76292},
+										pos: position{line: 2461, col: 69, offset: 76831},
 										expr: &seqExpr{
-											pos: position{line: 2449, col: 70, offset: 76293},
+											pos: position{line: 2461, col: 70, offset: 76832},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2449, col: 70, offset: 76293},
+													pos:  position{line: 2461, col: 70, offset: 76832},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2449, col: 76, offset: 76299},
+													pos:  position{line: 2461, col: 76, offset: 76838},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4644,50 +4644,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2449, col: 97, offset: 76320},
+									pos:  position{line: 2461, col: 97, offset: 76859},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2472, col: 3, offset: 76924},
+						pos: position{line: 2484, col: 3, offset: 77463},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2472, col: 3, offset: 76924},
+							pos: position{line: 2484, col: 3, offset: 77463},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2472, col: 3, offset: 76924},
+									pos:        position{line: 2484, col: 3, offset: 77463},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2472, col: 14, offset: 76935},
+									pos:  position{line: 2484, col: 14, offset: 77474},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2472, col: 22, offset: 76943},
+									pos:   position{line: 2484, col: 22, offset: 77482},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2472, col: 32, offset: 76953},
+										pos:  position{line: 2484, col: 32, offset: 77492},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2472, col: 42, offset: 76963},
+									pos:   position{line: 2484, col: 42, offset: 77502},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2472, col: 47, offset: 76968},
+										pos: position{line: 2484, col: 47, offset: 77507},
 										expr: &seqExpr{
-											pos: position{line: 2472, col: 48, offset: 76969},
+											pos: position{line: 2484, col: 48, offset: 77508},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2472, col: 48, offset: 76969},
+													pos:  position{line: 2484, col: 48, offset: 77508},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2472, col: 54, offset: 76975},
+													pos:  position{line: 2484, col: 54, offset: 77514},
 													name: "ValueExpr",
 												},
 											},
@@ -4695,73 +4695,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2472, col: 66, offset: 76987},
+									pos:  position{line: 2484, col: 66, offset: 77526},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2489, col: 3, offset: 77406},
+						pos: position{line: 2501, col: 3, offset: 77945},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2489, col: 3, offset: 77406},
+							pos: position{line: 2501, col: 3, offset: 77945},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2489, col: 3, offset: 77406},
+									pos:        position{line: 2501, col: 3, offset: 77945},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2489, col: 12, offset: 77415},
+									pos:  position{line: 2501, col: 12, offset: 77954},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2489, col: 20, offset: 77423},
+									pos:   position{line: 2501, col: 20, offset: 77962},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2489, col: 30, offset: 77433},
+										pos:  position{line: 2501, col: 30, offset: 77972},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2489, col: 40, offset: 77443},
+									pos:  position{line: 2501, col: 40, offset: 77982},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2489, col: 46, offset: 77449},
+									pos:   position{line: 2501, col: 46, offset: 77988},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2489, col: 57, offset: 77460},
+										pos:  position{line: 2501, col: 57, offset: 77999},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2489, col: 67, offset: 77470},
+									pos:  position{line: 2501, col: 67, offset: 78009},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2501, col: 3, offset: 77750},
+						pos: position{line: 2513, col: 3, offset: 78289},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2501, col: 3, offset: 77750},
+							pos: position{line: 2513, col: 3, offset: 78289},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2501, col: 3, offset: 77750},
+									pos:        position{line: 2513, col: 3, offset: 78289},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2501, col: 10, offset: 77757},
+									pos:  position{line: 2513, col: 10, offset: 78296},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2501, col: 18, offset: 77765},
+									pos:  position{line: 2513, col: 18, offset: 78304},
 									name: "R_PAREN",
 								},
 							},
@@ -4772,30 +4772,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2508, col: 1, offset: 77862},
+			pos:  position{line: 2520, col: 1, offset: 78401},
 			expr: &actionExpr{
-				pos: position{line: 2508, col: 23, offset: 77884},
+				pos: position{line: 2520, col: 23, offset: 78423},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2508, col: 23, offset: 77884},
+					pos: position{line: 2520, col: 23, offset: 78423},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2508, col: 23, offset: 77884},
+							pos:   position{line: 2520, col: 23, offset: 78423},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2508, col: 33, offset: 77894},
+								pos:  position{line: 2520, col: 33, offset: 78433},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2508, col: 42, offset: 77903},
+							pos:  position{line: 2520, col: 42, offset: 78442},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2508, col: 48, offset: 77909},
+							pos:   position{line: 2520, col: 48, offset: 78448},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2508, col: 54, offset: 77915},
+								pos:  position{line: 2520, col: 54, offset: 78454},
 								name: "ValueExpr",
 							},
 						},
@@ -4805,15 +4805,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2516, col: 1, offset: 78120},
+			pos:  position{line: 2528, col: 1, offset: 78659},
 			expr: &actionExpr{
-				pos: position{line: 2516, col: 26, offset: 78145},
+				pos: position{line: 2528, col: 26, offset: 78684},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2516, col: 26, offset: 78145},
+					pos:   position{line: 2528, col: 26, offset: 78684},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2516, col: 37, offset: 78156},
+						pos:  position{line: 2528, col: 37, offset: 78695},
 						name: "StringExpr",
 					},
 				},
@@ -4821,15 +4821,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2526, col: 1, offset: 78365},
+			pos:  position{line: 2538, col: 1, offset: 78904},
 			expr: &actionExpr{
-				pos: position{line: 2526, col: 30, offset: 78394},
+				pos: position{line: 2538, col: 30, offset: 78933},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2526, col: 30, offset: 78394},
+					pos:   position{line: 2538, col: 30, offset: 78933},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2526, col: 45, offset: 78409},
+						pos:  position{line: 2538, col: 45, offset: 78948},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4837,22 +4837,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2535, col: 1, offset: 78615},
+			pos:  position{line: 2547, col: 1, offset: 79154},
 			expr: &actionExpr{
-				pos: position{line: 2535, col: 27, offset: 78641},
+				pos: position{line: 2547, col: 27, offset: 79180},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2535, col: 27, offset: 78641},
+					pos:   position{line: 2547, col: 27, offset: 79180},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2535, col: 40, offset: 78654},
+						pos: position{line: 2547, col: 40, offset: 79193},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2535, col: 40, offset: 78654},
+								pos:  position{line: 2547, col: 40, offset: 79193},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2535, col: 68, offset: 78682},
+								pos:  position{line: 2547, col: 68, offset: 79221},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4862,135 +4862,135 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2539, col: 1, offset: 78759},
+			pos:  position{line: 2551, col: 1, offset: 79298},
 			expr: &choiceExpr{
-				pos: position{line: 2539, col: 19, offset: 78777},
+				pos: position{line: 2551, col: 19, offset: 79316},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2539, col: 19, offset: 78777},
+						pos: position{line: 2551, col: 19, offset: 79316},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2539, col: 20, offset: 78778},
+							pos: position{line: 2551, col: 20, offset: 79317},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2539, col: 20, offset: 78778},
+									pos:   position{line: 2551, col: 20, offset: 79317},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2539, col: 28, offset: 78786},
+										pos:        position{line: 2551, col: 28, offset: 79325},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2539, col: 37, offset: 78795},
+									pos:  position{line: 2551, col: 37, offset: 79334},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2539, col: 45, offset: 78803},
+									pos:   position{line: 2551, col: 45, offset: 79342},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2539, col: 56, offset: 78814},
+										pos:  position{line: 2551, col: 56, offset: 79353},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2539, col: 67, offset: 78825},
+									pos:  position{line: 2551, col: 67, offset: 79364},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2539, col: 73, offset: 78831},
+									pos:   position{line: 2551, col: 73, offset: 79370},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2539, col: 79, offset: 78837},
+										pos:  position{line: 2551, col: 79, offset: 79376},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2539, col: 90, offset: 78848},
+									pos:  position{line: 2551, col: 90, offset: 79387},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2551, col: 3, offset: 79209},
+						pos: position{line: 2563, col: 3, offset: 79748},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2551, col: 4, offset: 79210},
+							pos: position{line: 2563, col: 4, offset: 79749},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2551, col: 4, offset: 79210},
+									pos:   position{line: 2563, col: 4, offset: 79749},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2551, col: 12, offset: 79218},
+										pos:        position{line: 2563, col: 12, offset: 79757},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 23, offset: 79229},
+									pos:  position{line: 2563, col: 23, offset: 79768},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 31, offset: 79237},
+									pos:   position{line: 2563, col: 31, offset: 79776},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 46, offset: 79252},
+										pos:  position{line: 2563, col: 46, offset: 79791},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 61, offset: 79267},
+									pos:  position{line: 2563, col: 61, offset: 79806},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 67, offset: 79273},
+									pos:   position{line: 2563, col: 67, offset: 79812},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2551, col: 78, offset: 79284},
+										pos:  position{line: 2563, col: 78, offset: 79823},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2551, col: 90, offset: 79296},
+									pos:   position{line: 2563, col: 90, offset: 79835},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2551, col: 99, offset: 79305},
+										pos: position{line: 2563, col: 99, offset: 79844},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2551, col: 100, offset: 79306},
+											pos:  position{line: 2563, col: 100, offset: 79845},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2551, col: 119, offset: 79325},
+									pos:  position{line: 2563, col: 119, offset: 79864},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2567, col: 3, offset: 79887},
+						pos: position{line: 2579, col: 3, offset: 80426},
 						run: (*parser).callonMultiValueExpr27,
 						expr: &seqExpr{
-							pos: position{line: 2567, col: 4, offset: 79888},
+							pos: position{line: 2579, col: 4, offset: 80427},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2567, col: 4, offset: 79888},
+									pos:   position{line: 2579, col: 4, offset: 80427},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2567, col: 12, offset: 79896},
+										pos: position{line: 2579, col: 12, offset: 80435},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2567, col: 12, offset: 79896},
+												pos:        position{line: 2579, col: 12, offset: 80435},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2567, col: 24, offset: 79908},
+												pos:        position{line: 2579, col: 24, offset: 80447},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -4999,222 +4999,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2567, col: 34, offset: 79918},
+									pos:  position{line: 2579, col: 34, offset: 80457},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2567, col: 42, offset: 79926},
+									pos:   position{line: 2579, col: 42, offset: 80465},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2567, col: 57, offset: 79941},
+										pos:  position{line: 2579, col: 57, offset: 80480},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2567, col: 72, offset: 79956},
+									pos:  position{line: 2579, col: 72, offset: 80495},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2579, col: 3, offset: 80304},
+						pos: position{line: 2591, col: 3, offset: 80843},
 						run: (*parser).callonMultiValueExpr37,
 						expr: &seqExpr{
-							pos: position{line: 2579, col: 4, offset: 80305},
+							pos: position{line: 2591, col: 4, offset: 80844},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2579, col: 4, offset: 80305},
+									pos:   position{line: 2591, col: 4, offset: 80844},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2579, col: 12, offset: 80313},
+										pos:        position{line: 2591, col: 12, offset: 80852},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2579, col: 24, offset: 80325},
+									pos:  position{line: 2591, col: 24, offset: 80864},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2579, col: 32, offset: 80333},
+									pos:   position{line: 2591, col: 32, offset: 80872},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2579, col: 42, offset: 80343},
+										pos:  position{line: 2591, col: 42, offset: 80882},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2579, col: 51, offset: 80352},
+									pos:  position{line: 2591, col: 51, offset: 80891},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2592, col: 3, offset: 80699},
+						pos: position{line: 2604, col: 3, offset: 81238},
 						run: (*parser).callonMultiValueExpr45,
 						expr: &seqExpr{
-							pos: position{line: 2592, col: 4, offset: 80700},
+							pos: position{line: 2604, col: 4, offset: 81239},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2592, col: 4, offset: 80700},
+									pos:   position{line: 2604, col: 4, offset: 81239},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2592, col: 12, offset: 80708},
+										pos:        position{line: 2604, col: 12, offset: 81247},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2592, col: 21, offset: 80717},
+									pos:  position{line: 2604, col: 21, offset: 81256},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2592, col: 29, offset: 80725},
+									pos:   position{line: 2604, col: 29, offset: 81264},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2592, col: 44, offset: 80740},
+										pos:  position{line: 2604, col: 44, offset: 81279},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2592, col: 59, offset: 80755},
+									pos:  position{line: 2604, col: 59, offset: 81294},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2592, col: 65, offset: 80761},
+									pos:   position{line: 2604, col: 65, offset: 81300},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2592, col: 70, offset: 80766},
+										pos:  position{line: 2604, col: 70, offset: 81305},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2592, col: 80, offset: 80776},
+									pos:  position{line: 2604, col: 80, offset: 81315},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2605, col: 3, offset: 81198},
+						pos: position{line: 2617, col: 3, offset: 81737},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2605, col: 4, offset: 81199},
+							pos: position{line: 2617, col: 4, offset: 81738},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2605, col: 4, offset: 81199},
+									pos:   position{line: 2617, col: 4, offset: 81738},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2605, col: 12, offset: 81207},
+										pos:        position{line: 2617, col: 12, offset: 81746},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2605, col: 23, offset: 81218},
+									pos:  position{line: 2617, col: 23, offset: 81757},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2605, col: 31, offset: 81226},
+									pos:   position{line: 2617, col: 31, offset: 81765},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2605, col: 42, offset: 81237},
+										pos:  position{line: 2617, col: 42, offset: 81776},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2605, col: 54, offset: 81249},
+									pos:  position{line: 2617, col: 54, offset: 81788},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2605, col: 60, offset: 81255},
+									pos:   position{line: 2617, col: 60, offset: 81794},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2605, col: 69, offset: 81264},
+										pos:  position{line: 2617, col: 69, offset: 81803},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2605, col: 81, offset: 81276},
+									pos:  position{line: 2617, col: 81, offset: 81815},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2605, col: 87, offset: 81282},
+									pos:   position{line: 2617, col: 87, offset: 81821},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2605, col: 98, offset: 81293},
+										pos: position{line: 2617, col: 98, offset: 81832},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2605, col: 99, offset: 81294},
+											pos:  position{line: 2617, col: 99, offset: 81833},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2605, col: 112, offset: 81307},
+									pos:  position{line: 2617, col: 112, offset: 81846},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2618, col: 3, offset: 81758},
+						pos: position{line: 2630, col: 3, offset: 82297},
 						run: (*parser).callonMultiValueExpr71,
 						expr: &seqExpr{
-							pos: position{line: 2618, col: 4, offset: 81759},
+							pos: position{line: 2630, col: 4, offset: 82298},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2618, col: 4, offset: 81759},
+									pos:   position{line: 2630, col: 4, offset: 82298},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2618, col: 12, offset: 81767},
+										pos:        position{line: 2630, col: 12, offset: 82306},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2618, col: 21, offset: 81776},
+									pos:  position{line: 2630, col: 21, offset: 82315},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2618, col: 29, offset: 81784},
+									pos:   position{line: 2630, col: 29, offset: 82323},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2618, col: 36, offset: 81791},
+										pos:  position{line: 2630, col: 36, offset: 82330},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2618, col: 51, offset: 81806},
+									pos:  position{line: 2630, col: 51, offset: 82345},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2618, col: 57, offset: 81812},
+									pos:   position{line: 2630, col: 57, offset: 82351},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2618, col: 65, offset: 81820},
+										pos:  position{line: 2630, col: 65, offset: 82359},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2618, col: 80, offset: 81835},
+									pos:   position{line: 2630, col: 80, offset: 82374},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2618, col: 85, offset: 81840},
+										pos: position{line: 2630, col: 85, offset: 82379},
 										expr: &seqExpr{
-											pos: position{line: 2618, col: 86, offset: 81841},
+											pos: position{line: 2630, col: 86, offset: 82380},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2618, col: 86, offset: 81841},
+													pos:  position{line: 2630, col: 86, offset: 82380},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2618, col: 92, offset: 81847},
+													pos:  position{line: 2630, col: 92, offset: 82386},
 													name: "StringExpr",
 												},
 											},
@@ -5222,63 +5222,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2618, col: 105, offset: 81860},
+									pos:  position{line: 2630, col: 105, offset: 82399},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2635, col: 3, offset: 82388},
+						pos: position{line: 2647, col: 3, offset: 82927},
 						run: (*parser).callonMultiValueExpr87,
 						expr: &seqExpr{
-							pos: position{line: 2635, col: 4, offset: 82389},
+							pos: position{line: 2647, col: 4, offset: 82928},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2635, col: 4, offset: 82389},
+									pos:   position{line: 2647, col: 4, offset: 82928},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2635, col: 12, offset: 82397},
+										pos:        position{line: 2647, col: 12, offset: 82936},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2635, col: 32, offset: 82417},
+									pos:  position{line: 2647, col: 32, offset: 82956},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2635, col: 40, offset: 82425},
+									pos:   position{line: 2647, col: 40, offset: 82964},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2635, col: 55, offset: 82440},
+										pos:  position{line: 2647, col: 55, offset: 82979},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2635, col: 70, offset: 82455},
+									pos:   position{line: 2647, col: 70, offset: 82994},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2635, col: 75, offset: 82460},
+										pos: position{line: 2647, col: 75, offset: 82999},
 										expr: &seqExpr{
-											pos: position{line: 2635, col: 76, offset: 82461},
+											pos: position{line: 2647, col: 76, offset: 83000},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2635, col: 76, offset: 82461},
+													pos:  position{line: 2647, col: 76, offset: 83000},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2635, col: 83, offset: 82468},
+													pos: position{line: 2647, col: 83, offset: 83007},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2635, col: 83, offset: 82468},
+															pos:        position{line: 2647, col: 83, offset: 83007},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2635, col: 92, offset: 82477},
+															pos:        position{line: 2647, col: 92, offset: 83016},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5286,7 +5286,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2635, col: 101, offset: 82486},
+													pos:        position{line: 2647, col: 101, offset: 83025},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5296,54 +5296,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2635, col: 108, offset: 82493},
+									pos:  position{line: 2647, col: 108, offset: 83032},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2660, col: 3, offset: 83196},
+						pos: position{line: 2672, col: 3, offset: 83735},
 						run: (*parser).callonMultiValueExpr103,
 						expr: &seqExpr{
-							pos: position{line: 2660, col: 4, offset: 83197},
+							pos: position{line: 2672, col: 4, offset: 83736},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2660, col: 4, offset: 83197},
+									pos:   position{line: 2672, col: 4, offset: 83736},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2660, col: 12, offset: 83205},
+										pos:        position{line: 2672, col: 12, offset: 83744},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2660, col: 24, offset: 83217},
+									pos:  position{line: 2672, col: 24, offset: 83756},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2660, col: 32, offset: 83225},
+									pos:   position{line: 2672, col: 32, offset: 83764},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2660, col: 41, offset: 83234},
+										pos:  position{line: 2672, col: 41, offset: 83773},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2660, col: 64, offset: 83257},
+									pos:   position{line: 2672, col: 64, offset: 83796},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2660, col: 69, offset: 83262},
+										pos: position{line: 2672, col: 69, offset: 83801},
 										expr: &seqExpr{
-											pos: position{line: 2660, col: 70, offset: 83263},
+											pos: position{line: 2672, col: 70, offset: 83802},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2660, col: 70, offset: 83263},
+													pos:  position{line: 2672, col: 70, offset: 83802},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2660, col: 76, offset: 83269},
+													pos:  position{line: 2672, col: 76, offset: 83808},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5351,57 +5351,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2660, col: 101, offset: 83294},
+									pos:  position{line: 2672, col: 101, offset: 83833},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2680, col: 3, offset: 83882},
+						pos: position{line: 2692, col: 3, offset: 84421},
 						run: (*parser).callonMultiValueExpr116,
 						expr: &seqExpr{
-							pos: position{line: 2680, col: 3, offset: 83882},
+							pos: position{line: 2692, col: 3, offset: 84421},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2680, col: 3, offset: 83882},
+									pos:   position{line: 2692, col: 3, offset: 84421},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2680, col: 9, offset: 83888},
+										pos:  position{line: 2692, col: 9, offset: 84427},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2680, col: 25, offset: 83904},
+									pos: position{line: 2692, col: 25, offset: 84443},
 									expr: &choiceExpr{
-										pos: position{line: 2680, col: 27, offset: 83906},
+										pos: position{line: 2692, col: 27, offset: 84445},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 27, offset: 83906},
+												pos:  position{line: 2692, col: 27, offset: 84445},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 36, offset: 83915},
+												pos:  position{line: 2692, col: 36, offset: 84454},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 46, offset: 83925},
+												pos:  position{line: 2692, col: 46, offset: 84464},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 54, offset: 83933},
+												pos:  position{line: 2692, col: 54, offset: 84472},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 62, offset: 83941},
+												pos:  position{line: 2692, col: 62, offset: 84480},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2680, col: 70, offset: 83949},
+												pos:  position{line: 2692, col: 70, offset: 84488},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2680, col: 84, offset: 83963},
+												pos:        position{line: 2692, col: 84, offset: 84502},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5417,36 +5417,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2692, col: 1, offset: 84358},
+			pos:  position{line: 2704, col: 1, offset: 84897},
 			expr: &choiceExpr{
-				pos: position{line: 2692, col: 13, offset: 84370},
+				pos: position{line: 2704, col: 13, offset: 84909},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2692, col: 13, offset: 84370},
+						pos: position{line: 2704, col: 13, offset: 84909},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2692, col: 14, offset: 84371},
+							pos: position{line: 2704, col: 14, offset: 84910},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2692, col: 14, offset: 84371},
+									pos:   position{line: 2704, col: 14, offset: 84910},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2692, col: 22, offset: 84379},
+										pos: position{line: 2704, col: 22, offset: 84918},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2692, col: 22, offset: 84379},
+												pos:        position{line: 2704, col: 22, offset: 84918},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2692, col: 32, offset: 84389},
+												pos:        position{line: 2704, col: 32, offset: 84928},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2692, col: 42, offset: 84399},
+												pos:        position{line: 2704, col: 42, offset: 84938},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5455,44 +5455,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 55, offset: 84412},
+									pos:  position{line: 2704, col: 55, offset: 84951},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2692, col: 63, offset: 84420},
+									pos:   position{line: 2704, col: 63, offset: 84959},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2692, col: 74, offset: 84431},
+										pos:  position{line: 2704, col: 74, offset: 84970},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2692, col: 85, offset: 84442},
+									pos:  position{line: 2704, col: 85, offset: 84981},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2704, col: 3, offset: 84756},
+						pos: position{line: 2716, col: 3, offset: 85295},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2704, col: 4, offset: 84757},
+							pos: position{line: 2716, col: 4, offset: 85296},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2704, col: 4, offset: 84757},
+									pos:   position{line: 2716, col: 4, offset: 85296},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2704, col: 12, offset: 84765},
+										pos: position{line: 2716, col: 12, offset: 85304},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2704, col: 12, offset: 84765},
+												pos:        position{line: 2716, col: 12, offset: 85304},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2704, col: 20, offset: 84773},
+												pos:        position{line: 2716, col: 20, offset: 85312},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5501,31 +5501,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2704, col: 27, offset: 84780},
+									pos:  position{line: 2716, col: 27, offset: 85319},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2704, col: 35, offset: 84788},
+									pos:   position{line: 2716, col: 35, offset: 85327},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2704, col: 44, offset: 84797},
+										pos:  position{line: 2716, col: 44, offset: 85336},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2704, col: 55, offset: 84808},
+									pos:   position{line: 2716, col: 55, offset: 85347},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2704, col: 60, offset: 84813},
+										pos: position{line: 2716, col: 60, offset: 85352},
 										expr: &seqExpr{
-											pos: position{line: 2704, col: 61, offset: 84814},
+											pos: position{line: 2716, col: 61, offset: 85353},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2704, col: 61, offset: 84814},
+													pos:  position{line: 2716, col: 61, offset: 85353},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2704, col: 67, offset: 84820},
+													pos:  position{line: 2716, col: 67, offset: 85359},
 													name: "StringExpr",
 												},
 											},
@@ -5533,195 +5533,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2704, col: 80, offset: 84833},
+									pos:  position{line: 2716, col: 80, offset: 85372},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2726, col: 3, offset: 85433},
+						pos: position{line: 2738, col: 3, offset: 85972},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2726, col: 4, offset: 85434},
+							pos: position{line: 2738, col: 4, offset: 85973},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2726, col: 4, offset: 85434},
+									pos:   position{line: 2738, col: 4, offset: 85973},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2726, col: 12, offset: 85442},
+										pos:        position{line: 2738, col: 12, offset: 85981},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2726, col: 23, offset: 85453},
+									pos:  position{line: 2738, col: 23, offset: 85992},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2726, col: 31, offset: 85461},
+									pos:   position{line: 2738, col: 31, offset: 86000},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2726, col: 46, offset: 85476},
+										pos:  position{line: 2738, col: 46, offset: 86015},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2726, col: 61, offset: 85491},
+									pos:  position{line: 2738, col: 61, offset: 86030},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2737, col: 3, offset: 85793},
+						pos: position{line: 2749, col: 3, offset: 86332},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2737, col: 4, offset: 85794},
+							pos: position{line: 2749, col: 4, offset: 86333},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2737, col: 4, offset: 85794},
+									pos:   position{line: 2749, col: 4, offset: 86333},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2737, col: 12, offset: 85802},
+										pos:        position{line: 2749, col: 12, offset: 86341},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2737, col: 22, offset: 85812},
+									pos:  position{line: 2749, col: 22, offset: 86351},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2737, col: 30, offset: 85820},
+									pos:   position{line: 2749, col: 30, offset: 86359},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2737, col: 45, offset: 85835},
+										pos:  position{line: 2749, col: 45, offset: 86374},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2737, col: 60, offset: 85850},
+									pos:  position{line: 2749, col: 60, offset: 86389},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2737, col: 66, offset: 85856},
+									pos:   position{line: 2749, col: 66, offset: 86395},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2737, col: 72, offset: 85862},
+										pos:  position{line: 2749, col: 72, offset: 86401},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2737, col: 83, offset: 85873},
+									pos:  position{line: 2749, col: 83, offset: 86412},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2749, col: 3, offset: 86223},
+						pos: position{line: 2761, col: 3, offset: 86762},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2749, col: 4, offset: 86224},
+							pos: position{line: 2761, col: 4, offset: 86763},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2749, col: 4, offset: 86224},
+									pos:   position{line: 2761, col: 4, offset: 86763},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2749, col: 12, offset: 86232},
+										pos:        position{line: 2761, col: 12, offset: 86771},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 22, offset: 86242},
+									pos:  position{line: 2761, col: 22, offset: 86781},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2749, col: 30, offset: 86250},
+									pos:   position{line: 2761, col: 30, offset: 86789},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2749, col: 45, offset: 86265},
+										pos:  position{line: 2761, col: 45, offset: 86804},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 60, offset: 86280},
+									pos:  position{line: 2761, col: 60, offset: 86819},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2749, col: 66, offset: 86286},
+									pos:   position{line: 2761, col: 66, offset: 86825},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2749, col: 79, offset: 86299},
+										pos:  position{line: 2761, col: 79, offset: 86838},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2749, col: 90, offset: 86310},
+									pos:  position{line: 2761, col: 90, offset: 86849},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2773, col: 3, offset: 86979},
+						pos: position{line: 2785, col: 3, offset: 87518},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2773, col: 4, offset: 86980},
+							pos: position{line: 2785, col: 4, offset: 87519},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2773, col: 4, offset: 86980},
+									pos:   position{line: 2785, col: 4, offset: 87519},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2773, col: 12, offset: 86988},
+										pos:        position{line: 2785, col: 12, offset: 87527},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2773, col: 22, offset: 86998},
+									pos:  position{line: 2785, col: 22, offset: 87537},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2773, col: 30, offset: 87006},
+									pos:   position{line: 2785, col: 30, offset: 87545},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2773, col: 41, offset: 87017},
+										pos:  position{line: 2785, col: 41, offset: 87556},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2773, col: 52, offset: 87028},
+									pos:  position{line: 2785, col: 52, offset: 87567},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2773, col: 58, offset: 87034},
+									pos:   position{line: 2785, col: 58, offset: 87573},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2773, col: 69, offset: 87045},
+										pos:  position{line: 2785, col: 69, offset: 87584},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2773, col: 81, offset: 87057},
+									pos:   position{line: 2785, col: 81, offset: 87596},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2773, col: 93, offset: 87069},
+										pos: position{line: 2785, col: 93, offset: 87608},
 										expr: &seqExpr{
-											pos: position{line: 2773, col: 94, offset: 87070},
+											pos: position{line: 2785, col: 94, offset: 87609},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2773, col: 94, offset: 87070},
+													pos:  position{line: 2785, col: 94, offset: 87609},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2773, col: 100, offset: 87076},
+													pos:  position{line: 2785, col: 100, offset: 87615},
 													name: "NumericExpr",
 												},
 											},
@@ -5729,50 +5729,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2773, col: 114, offset: 87090},
+									pos:  position{line: 2785, col: 114, offset: 87629},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2798, col: 3, offset: 87920},
+						pos: position{line: 2810, col: 3, offset: 88459},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2798, col: 3, offset: 87920},
+							pos: position{line: 2810, col: 3, offset: 88459},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2798, col: 3, offset: 87920},
+									pos:        position{line: 2810, col: 3, offset: 88459},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 14, offset: 87931},
+									pos:  position{line: 2810, col: 14, offset: 88470},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 22, offset: 87939},
+									pos:   position{line: 2810, col: 22, offset: 88478},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2798, col: 28, offset: 87945},
+										pos:  position{line: 2810, col: 28, offset: 88484},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 38, offset: 87955},
+									pos:   position{line: 2810, col: 38, offset: 88494},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2798, col: 45, offset: 87962},
+										pos: position{line: 2810, col: 45, offset: 88501},
 										expr: &seqExpr{
-											pos: position{line: 2798, col: 46, offset: 87963},
+											pos: position{line: 2810, col: 46, offset: 88502},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 46, offset: 87963},
+													pos:  position{line: 2810, col: 46, offset: 88502},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2798, col: 52, offset: 87969},
+													pos:  position{line: 2810, col: 52, offset: 88508},
 													name: "StringExpr",
 												},
 											},
@@ -5780,38 +5780,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 65, offset: 87982},
+									pos:  position{line: 2810, col: 65, offset: 88521},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2811, col: 3, offset: 88350},
+						pos: position{line: 2823, col: 3, offset: 88889},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2811, col: 4, offset: 88351},
+							pos: position{line: 2823, col: 4, offset: 88890},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2811, col: 4, offset: 88351},
+									pos:   position{line: 2823, col: 4, offset: 88890},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2811, col: 12, offset: 88359},
+										pos: position{line: 2823, col: 12, offset: 88898},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2811, col: 12, offset: 88359},
+												pos:        position{line: 2823, col: 12, offset: 88898},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2811, col: 22, offset: 88369},
+												pos:        position{line: 2823, col: 22, offset: 88908},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2811, col: 32, offset: 88379},
+												pos:        position{line: 2823, col: 32, offset: 88918},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5820,223 +5820,223 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2811, col: 40, offset: 88387},
+									pos:  position{line: 2823, col: 40, offset: 88926},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2811, col: 48, offset: 88395},
+									pos:   position{line: 2823, col: 48, offset: 88934},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2811, col: 54, offset: 88401},
+										pos:  position{line: 2823, col: 54, offset: 88940},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2811, col: 66, offset: 88413},
+									pos:   position{line: 2823, col: 66, offset: 88952},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2811, col: 82, offset: 88429},
+										pos: position{line: 2823, col: 82, offset: 88968},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2811, col: 83, offset: 88430},
+											pos:  position{line: 2823, col: 83, offset: 88969},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2811, col: 101, offset: 88448},
+									pos:  position{line: 2823, col: 101, offset: 88987},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2830, col: 3, offset: 88888},
+						pos: position{line: 2842, col: 3, offset: 89427},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2830, col: 3, offset: 88888},
+							pos: position{line: 2842, col: 3, offset: 89427},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2830, col: 3, offset: 88888},
+									pos:        position{line: 2842, col: 3, offset: 89427},
 									val:        "spath",
 									ignoreCase: false,
 									want:       "\"spath\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 11, offset: 88896},
+									pos:  position{line: 2842, col: 11, offset: 89435},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2830, col: 19, offset: 88904},
+									pos:   position{line: 2842, col: 19, offset: 89443},
 									label: "inputField",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2830, col: 30, offset: 88915},
+										pos:  position{line: 2842, col: 30, offset: 89454},
 										name: "FieldNameStartWith_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 50, offset: 88935},
+									pos:  position{line: 2842, col: 50, offset: 89474},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2830, col: 56, offset: 88941},
+									pos:   position{line: 2842, col: 56, offset: 89480},
 									label: "path",
 									expr: &choiceExpr{
-										pos: position{line: 2830, col: 62, offset: 88947},
+										pos: position{line: 2842, col: 62, offset: 89486},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2830, col: 62, offset: 88947},
+												pos:  position{line: 2842, col: 62, offset: 89486},
 												name: "QuotedPathString",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2830, col: 81, offset: 88966},
+												pos:  position{line: 2842, col: 81, offset: 89505},
 												name: "UnquotedPathValue",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 100, offset: 88985},
+									pos:  position{line: 2842, col: 100, offset: 89524},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2841, col: 3, offset: 89290},
+						pos: position{line: 2853, col: 3, offset: 89829},
 						run: (*parser).callonTextExpr112,
 						expr: &seqExpr{
-							pos: position{line: 2841, col: 3, offset: 89290},
+							pos: position{line: 2853, col: 3, offset: 89829},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2841, col: 3, offset: 89290},
+									pos:        position{line: 2853, col: 3, offset: 89829},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2841, col: 12, offset: 89299},
+									pos:  position{line: 2853, col: 12, offset: 89838},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2841, col: 20, offset: 89307},
+									pos:   position{line: 2853, col: 20, offset: 89846},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2841, col: 25, offset: 89312},
+										pos:  position{line: 2853, col: 25, offset: 89851},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2841, col: 36, offset: 89323},
+									pos:  position{line: 2853, col: 36, offset: 89862},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2841, col: 42, offset: 89329},
+									pos:   position{line: 2853, col: 42, offset: 89868},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2841, col: 45, offset: 89332},
+										pos:  position{line: 2853, col: 45, offset: 89871},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2841, col: 55, offset: 89342},
+									pos:  position{line: 2853, col: 55, offset: 89881},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2848, col: 3, offset: 89500},
+						pos: position{line: 2860, col: 3, offset: 90039},
 						run: (*parser).callonTextExpr122,
 						expr: &seqExpr{
-							pos: position{line: 2848, col: 3, offset: 89500},
+							pos: position{line: 2860, col: 3, offset: 90039},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2848, col: 3, offset: 89500},
+									pos:        position{line: 2860, col: 3, offset: 90039},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2848, col: 21, offset: 89518},
+									pos:  position{line: 2860, col: 21, offset: 90057},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2848, col: 29, offset: 89526},
+									pos:   position{line: 2860, col: 29, offset: 90065},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2848, col: 33, offset: 89530},
+										pos:  position{line: 2860, col: 33, offset: 90069},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2848, col: 43, offset: 89540},
+									pos:  position{line: 2860, col: 43, offset: 90079},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2848, col: 49, offset: 89546},
+									pos:   position{line: 2860, col: 49, offset: 90085},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2848, col: 53, offset: 89550},
+										pos:  position{line: 2860, col: 53, offset: 90089},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2848, col: 66, offset: 89563},
+									pos:  position{line: 2860, col: 66, offset: 90102},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2848, col: 72, offset: 89569},
+									pos:   position{line: 2860, col: 72, offset: 90108},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2848, col: 78, offset: 89575},
+										pos:  position{line: 2860, col: 78, offset: 90114},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2848, col: 91, offset: 89588},
+									pos:  position{line: 2860, col: 91, offset: 90127},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2859, col: 3, offset: 89896},
+						pos: position{line: 2871, col: 3, offset: 90435},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2859, col: 3, offset: 89896},
+							pos: position{line: 2871, col: 3, offset: 90435},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2859, col: 3, offset: 89896},
+									pos:        position{line: 2871, col: 3, offset: 90435},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2859, col: 12, offset: 89905},
+									pos:  position{line: 2871, col: 12, offset: 90444},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2859, col: 20, offset: 89913},
+									pos:   position{line: 2871, col: 20, offset: 90452},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2859, col: 27, offset: 89920},
+										pos:  position{line: 2871, col: 27, offset: 90459},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2859, col: 38, offset: 89931},
+									pos:   position{line: 2871, col: 38, offset: 90470},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2859, col: 43, offset: 89936},
+										pos: position{line: 2871, col: 43, offset: 90475},
 										expr: &seqExpr{
-											pos: position{line: 2859, col: 44, offset: 89937},
+											pos: position{line: 2871, col: 44, offset: 90476},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2859, col: 44, offset: 89937},
+													pos:  position{line: 2871, col: 44, offset: 90476},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2859, col: 50, offset: 89943},
+													pos:  position{line: 2871, col: 50, offset: 90482},
 													name: "StringExpr",
 												},
 											},
@@ -6044,47 +6044,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2859, col: 63, offset: 89956},
+									pos:  position{line: 2871, col: 63, offset: 90495},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2877, col: 3, offset: 90423},
+						pos: position{line: 2889, col: 3, offset: 90962},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2877, col: 3, offset: 90423},
+							pos: position{line: 2889, col: 3, offset: 90962},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2877, col: 3, offset: 90423},
+									pos:        position{line: 2889, col: 3, offset: 90962},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2877, col: 12, offset: 90432},
+									pos:  position{line: 2889, col: 12, offset: 90971},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2877, col: 20, offset: 90440},
+									pos:   position{line: 2889, col: 20, offset: 90979},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2877, col: 42, offset: 90462},
+										pos: position{line: 2889, col: 42, offset: 91001},
 										expr: &seqExpr{
-											pos: position{line: 2877, col: 43, offset: 90463},
+											pos: position{line: 2889, col: 43, offset: 91002},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2877, col: 44, offset: 90464},
+													pos: position{line: 2889, col: 44, offset: 91003},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2877, col: 44, offset: 90464},
+															pos:        position{line: 2889, col: 44, offset: 91003},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2877, col: 53, offset: 90473},
+															pos:        position{line: 2889, col: 53, offset: 91012},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6092,7 +6092,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2877, col: 62, offset: 90482},
+													pos:        position{line: 2889, col: 62, offset: 91021},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6102,56 +6102,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2877, col: 69, offset: 90489},
+									pos:  position{line: 2889, col: 69, offset: 91028},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2899, col: 3, offset: 91086},
+						pos: position{line: 2911, col: 3, offset: 91625},
 						run: (*parser).callonTextExpr159,
 						expr: &seqExpr{
-							pos: position{line: 2899, col: 3, offset: 91086},
+							pos: position{line: 2911, col: 3, offset: 91625},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2899, col: 3, offset: 91086},
+									pos:        position{line: 2911, col: 3, offset: 91625},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2899, col: 13, offset: 91096},
+									pos:  position{line: 2911, col: 13, offset: 91635},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2899, col: 21, offset: 91104},
+									pos:   position{line: 2911, col: 21, offset: 91643},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2899, col: 27, offset: 91110},
+										pos:  position{line: 2911, col: 27, offset: 91649},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2899, col: 43, offset: 91126},
+									pos:   position{line: 2911, col: 43, offset: 91665},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2899, col: 53, offset: 91136},
+										pos: position{line: 2911, col: 53, offset: 91675},
 										expr: &seqExpr{
-											pos: position{line: 2899, col: 54, offset: 91137},
+											pos: position{line: 2911, col: 54, offset: 91676},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2899, col: 54, offset: 91137},
+													pos:  position{line: 2911, col: 54, offset: 91676},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2899, col: 60, offset: 91143},
+													pos:        position{line: 2911, col: 60, offset: 91682},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2899, col: 73, offset: 91156},
+													pos:  position{line: 2911, col: 73, offset: 91695},
 													name: "FloatAsString",
 												},
 											},
@@ -6159,40 +6159,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2899, col: 89, offset: 91172},
+									pos:   position{line: 2911, col: 89, offset: 91711},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2899, col: 95, offset: 91178},
+										pos: position{line: 2911, col: 95, offset: 91717},
 										expr: &seqExpr{
-											pos: position{line: 2899, col: 96, offset: 91179},
+											pos: position{line: 2911, col: 96, offset: 91718},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2899, col: 96, offset: 91179},
+													pos:  position{line: 2911, col: 96, offset: 91718},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2899, col: 102, offset: 91185},
+													pos:        position{line: 2911, col: 102, offset: 91724},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2899, col: 112, offset: 91195},
+													pos: position{line: 2911, col: 112, offset: 91734},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2899, col: 112, offset: 91195},
+															pos:        position{line: 2911, col: 112, offset: 91734},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2899, col: 125, offset: 91208},
+															pos:        position{line: 2911, col: 125, offset: 91747},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2899, col: 137, offset: 91220},
+															pos:        position{line: 2911, col: 137, offset: 91759},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6204,25 +6204,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2899, col: 151, offset: 91234},
+									pos:   position{line: 2911, col: 151, offset: 91773},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2899, col: 158, offset: 91241},
+										pos: position{line: 2911, col: 158, offset: 91780},
 										expr: &seqExpr{
-											pos: position{line: 2899, col: 159, offset: 91242},
+											pos: position{line: 2911, col: 159, offset: 91781},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2899, col: 159, offset: 91242},
+													pos:  position{line: 2911, col: 159, offset: 91781},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2899, col: 165, offset: 91248},
+													pos:        position{line: 2911, col: 165, offset: 91787},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2899, col: 175, offset: 91258},
+													pos:  position{line: 2911, col: 175, offset: 91797},
 													name: "QuotedString",
 												},
 											},
@@ -6230,213 +6230,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2899, col: 190, offset: 91273},
+									pos:  position{line: 2911, col: 190, offset: 91812},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2939, col: 3, offset: 92268},
+						pos: position{line: 2951, col: 3, offset: 92807},
 						run: (*parser).callonTextExpr187,
 						expr: &seqExpr{
-							pos: position{line: 2939, col: 3, offset: 92268},
+							pos: position{line: 2951, col: 3, offset: 92807},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2939, col: 3, offset: 92268},
+									pos:        position{line: 2951, col: 3, offset: 92807},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2939, col: 15, offset: 92280},
+									pos:  position{line: 2951, col: 15, offset: 92819},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2939, col: 23, offset: 92288},
+									pos:   position{line: 2951, col: 23, offset: 92827},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2939, col: 30, offset: 92295},
+										pos: position{line: 2951, col: 30, offset: 92834},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2939, col: 31, offset: 92296},
+											pos:  position{line: 2951, col: 31, offset: 92835},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2939, col: 44, offset: 92309},
+									pos:  position{line: 2951, col: 44, offset: 92848},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2950, col: 3, offset: 92500},
+						pos: position{line: 2962, col: 3, offset: 93039},
 						run: (*parser).callonTextExpr195,
 						expr: &seqExpr{
-							pos: position{line: 2950, col: 3, offset: 92500},
+							pos: position{line: 2962, col: 3, offset: 93039},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2950, col: 3, offset: 92500},
+									pos:        position{line: 2962, col: 3, offset: 93039},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2950, col: 12, offset: 92509},
+									pos:  position{line: 2962, col: 12, offset: 93048},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2950, col: 20, offset: 92517},
+									pos:   position{line: 2962, col: 20, offset: 93056},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2950, col: 30, offset: 92527},
+										pos:  position{line: 2962, col: 30, offset: 93066},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2950, col: 40, offset: 92537},
+									pos:  position{line: 2962, col: 40, offset: 93076},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2956, col: 3, offset: 92660},
+						pos: position{line: 2968, col: 3, offset: 93199},
 						run: (*parser).callonTextExpr202,
 						expr: &seqExpr{
-							pos: position{line: 2956, col: 3, offset: 92660},
+							pos: position{line: 2968, col: 3, offset: 93199},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2956, col: 3, offset: 92660},
+									pos:        position{line: 2968, col: 3, offset: 93199},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2956, col: 13, offset: 92670},
+									pos:  position{line: 2968, col: 13, offset: 93209},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2956, col: 21, offset: 92678},
+									pos:   position{line: 2968, col: 21, offset: 93217},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2956, col: 25, offset: 92682},
+										pos:  position{line: 2968, col: 25, offset: 93221},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2956, col: 35, offset: 92692},
+									pos:  position{line: 2968, col: 35, offset: 93231},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2956, col: 41, offset: 92698},
+									pos:   position{line: 2968, col: 41, offset: 93237},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2956, col: 47, offset: 92704},
+										pos:  position{line: 2968, col: 47, offset: 93243},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2956, col: 58, offset: 92715},
+									pos:  position{line: 2968, col: 58, offset: 93254},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2956, col: 64, offset: 92721},
+									pos:   position{line: 2968, col: 64, offset: 93260},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2956, col: 76, offset: 92733},
+										pos:  position{line: 2968, col: 76, offset: 93272},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2956, col: 87, offset: 92744},
+									pos:  position{line: 2968, col: 87, offset: 93283},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2963, col: 3, offset: 92968},
+						pos: position{line: 2975, col: 3, offset: 93507},
 						run: (*parser).callonTextExpr215,
 						expr: &seqExpr{
-							pos: position{line: 2963, col: 3, offset: 92968},
+							pos: position{line: 2975, col: 3, offset: 93507},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2963, col: 3, offset: 92968},
+									pos:        position{line: 2975, col: 3, offset: 93507},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 14, offset: 92979},
+									pos:  position{line: 2975, col: 14, offset: 93518},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 22, offset: 92987},
+									pos:   position{line: 2975, col: 22, offset: 93526},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2963, col: 26, offset: 92991},
+										pos:  position{line: 2975, col: 26, offset: 93530},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 36, offset: 93001},
+									pos:  position{line: 2975, col: 36, offset: 93540},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 42, offset: 93007},
+									pos:   position{line: 2975, col: 42, offset: 93546},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2963, col: 49, offset: 93014},
+										pos:  position{line: 2975, col: 49, offset: 93553},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 60, offset: 93025},
+									pos:  position{line: 2975, col: 60, offset: 93564},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2971, col: 3, offset: 93189},
+						pos: position{line: 2983, col: 3, offset: 93728},
 						run: (*parser).callonTextExpr225,
 						expr: &seqExpr{
-							pos: position{line: 2971, col: 3, offset: 93189},
+							pos: position{line: 2983, col: 3, offset: 93728},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2971, col: 3, offset: 93189},
+									pos:        position{line: 2983, col: 3, offset: 93728},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2971, col: 14, offset: 93200},
+									pos:  position{line: 2983, col: 14, offset: 93739},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2971, col: 22, offset: 93208},
+									pos:   position{line: 2983, col: 22, offset: 93747},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2971, col: 26, offset: 93212},
+										pos:  position{line: 2983, col: 26, offset: 93751},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2971, col: 36, offset: 93222},
+									pos:  position{line: 2983, col: 36, offset: 93761},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2971, col: 42, offset: 93228},
+									pos:   position{line: 2983, col: 42, offset: 93767},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2971, col: 49, offset: 93235},
+										pos:  position{line: 2983, col: 49, offset: 93774},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2971, col: 60, offset: 93246},
+									pos:  position{line: 2983, col: 60, offset: 93785},
 									name: "R_PAREN",
 								},
 							},
@@ -6447,15 +6447,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 2979, col: 1, offset: 93408},
+			pos:  position{line: 2991, col: 1, offset: 93947},
 			expr: &actionExpr{
-				pos: position{line: 2979, col: 21, offset: 93428},
+				pos: position{line: 2991, col: 21, offset: 93967},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 2979, col: 21, offset: 93428},
+					pos:   position{line: 2991, col: 21, offset: 93967},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2979, col: 25, offset: 93432},
+						pos:  position{line: 2991, col: 25, offset: 93971},
 						name: "QuotedString",
 					},
 				},
@@ -6463,15 +6463,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 2986, col: 1, offset: 93559},
+			pos:  position{line: 2998, col: 1, offset: 94098},
 			expr: &actionExpr{
-				pos: position{line: 2986, col: 22, offset: 93580},
+				pos: position{line: 2998, col: 22, offset: 94119},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 2986, col: 22, offset: 93580},
+					pos:   position{line: 2998, col: 22, offset: 94119},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2986, col: 26, offset: 93584},
+						pos:  position{line: 2998, col: 26, offset: 94123},
 						name: "UnquotedString",
 					},
 				},
@@ -6479,22 +6479,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 2993, col: 1, offset: 93712},
+			pos:  position{line: 3005, col: 1, offset: 94251},
 			expr: &actionExpr{
-				pos: position{line: 2993, col: 20, offset: 93731},
+				pos: position{line: 3005, col: 20, offset: 94270},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2993, col: 20, offset: 93731},
+					pos: position{line: 3005, col: 20, offset: 94270},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2993, col: 20, offset: 93731},
+							pos:  position{line: 3005, col: 20, offset: 94270},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2993, col: 26, offset: 93737},
+							pos:   position{line: 3005, col: 26, offset: 94276},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2993, col: 38, offset: 93749},
+								pos:  position{line: 3005, col: 38, offset: 94288},
 								name: "String",
 							},
 						},
@@ -6504,27 +6504,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 2999, col: 1, offset: 93934},
+			pos:  position{line: 3011, col: 1, offset: 94473},
 			expr: &choiceExpr{
-				pos: position{line: 2999, col: 20, offset: 93953},
+				pos: position{line: 3011, col: 20, offset: 94492},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2999, col: 20, offset: 93953},
+						pos: position{line: 3011, col: 20, offset: 94492},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 2999, col: 20, offset: 93953},
+							pos: position{line: 3011, col: 20, offset: 94492},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 2999, col: 20, offset: 93953},
+									pos:        position{line: 3011, col: 20, offset: 94492},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 2999, col: 28, offset: 93961},
+									pos: position{line: 3011, col: 28, offset: 94500},
 									expr: &charClassMatcher{
-										pos:        position{line: 2999, col: 28, offset: 93961},
+										pos:        position{line: 3011, col: 28, offset: 94500},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6533,9 +6533,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 2999, col: 42, offset: 93975},
+									pos: position{line: 3011, col: 42, offset: 94514},
 									expr: &litMatcher{
-										pos:        position{line: 2999, col: 44, offset: 93977},
+										pos:        position{line: 3011, col: 44, offset: 94516},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6545,27 +6545,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3002, col: 3, offset: 94019},
+						pos: position{line: 3014, col: 3, offset: 94558},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3002, col: 3, offset: 94019},
+							pos: position{line: 3014, col: 3, offset: 94558},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3002, col: 3, offset: 94019},
+									pos:        position{line: 3014, col: 3, offset: 94558},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3002, col: 7, offset: 94023},
+									pos:   position{line: 3014, col: 7, offset: 94562},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3002, col: 13, offset: 94029},
+										pos:  position{line: 3014, col: 13, offset: 94568},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3002, col: 23, offset: 94039},
+									pos:        position{line: 3014, col: 23, offset: 94578},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6578,26 +6578,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3007, col: 1, offset: 94107},
+			pos:  position{line: 3019, col: 1, offset: 94646},
 			expr: &actionExpr{
-				pos: position{line: 3007, col: 15, offset: 94121},
+				pos: position{line: 3019, col: 15, offset: 94660},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3007, col: 15, offset: 94121},
+					pos: position{line: 3019, col: 15, offset: 94660},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3007, col: 15, offset: 94121},
+							pos:  position{line: 3019, col: 15, offset: 94660},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3007, col: 20, offset: 94126},
+							pos:  position{line: 3019, col: 20, offset: 94665},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3007, col: 30, offset: 94136},
+							pos:   position{line: 3019, col: 30, offset: 94675},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3007, col: 40, offset: 94146},
+								pos:  position{line: 3019, col: 40, offset: 94685},
 								name: "BoolExpr",
 							},
 						},
@@ -6607,15 +6607,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3020, col: 1, offset: 94489},
+			pos:  position{line: 3032, col: 1, offset: 95028},
 			expr: &actionExpr{
-				pos: position{line: 3020, col: 13, offset: 94501},
+				pos: position{line: 3032, col: 13, offset: 95040},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3020, col: 13, offset: 94501},
+					pos:   position{line: 3032, col: 13, offset: 95040},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3020, col: 18, offset: 94506},
+						pos:  position{line: 3032, col: 18, offset: 95045},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6623,35 +6623,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3025, col: 1, offset: 94576},
+			pos:  position{line: 3037, col: 1, offset: 95115},
 			expr: &actionExpr{
-				pos: position{line: 3025, col: 19, offset: 94594},
+				pos: position{line: 3037, col: 19, offset: 95133},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3025, col: 19, offset: 94594},
+					pos: position{line: 3037, col: 19, offset: 95133},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3025, col: 19, offset: 94594},
+							pos:   position{line: 3037, col: 19, offset: 95133},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3025, col: 25, offset: 94600},
+								pos:  position{line: 3037, col: 25, offset: 95139},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3025, col: 40, offset: 94615},
+							pos:   position{line: 3037, col: 40, offset: 95154},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3025, col: 45, offset: 94620},
+								pos: position{line: 3037, col: 45, offset: 95159},
 								expr: &seqExpr{
-									pos: position{line: 3025, col: 46, offset: 94621},
+									pos: position{line: 3037, col: 46, offset: 95160},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3025, col: 46, offset: 94621},
+											pos:  position{line: 3037, col: 46, offset: 95160},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3025, col: 49, offset: 94624},
+											pos:  position{line: 3037, col: 49, offset: 95163},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6664,35 +6664,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3045, col: 1, offset: 95062},
+			pos:  position{line: 3057, col: 1, offset: 95601},
 			expr: &actionExpr{
-				pos: position{line: 3045, col: 19, offset: 95080},
+				pos: position{line: 3057, col: 19, offset: 95619},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3045, col: 19, offset: 95080},
+					pos: position{line: 3057, col: 19, offset: 95619},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3045, col: 19, offset: 95080},
+							pos:   position{line: 3057, col: 19, offset: 95619},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3045, col: 25, offset: 95086},
+								pos:  position{line: 3057, col: 25, offset: 95625},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3045, col: 40, offset: 95101},
+							pos:   position{line: 3057, col: 40, offset: 95640},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3045, col: 45, offset: 95106},
+								pos: position{line: 3057, col: 45, offset: 95645},
 								expr: &seqExpr{
-									pos: position{line: 3045, col: 46, offset: 95107},
+									pos: position{line: 3057, col: 46, offset: 95646},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3045, col: 46, offset: 95107},
+											pos:  position{line: 3057, col: 46, offset: 95646},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3045, col: 50, offset: 95111},
+											pos:  position{line: 3057, col: 50, offset: 95650},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6705,47 +6705,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3065, col: 1, offset: 95550},
+			pos:  position{line: 3077, col: 1, offset: 96089},
 			expr: &choiceExpr{
-				pos: position{line: 3065, col: 19, offset: 95568},
+				pos: position{line: 3077, col: 19, offset: 96107},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3065, col: 19, offset: 95568},
+						pos: position{line: 3077, col: 19, offset: 96107},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3065, col: 19, offset: 95568},
+							pos: position{line: 3077, col: 19, offset: 96107},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3065, col: 19, offset: 95568},
+									pos:  position{line: 3077, col: 19, offset: 96107},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3065, col: 23, offset: 95572},
+									pos:  position{line: 3077, col: 23, offset: 96111},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3065, col: 31, offset: 95580},
+									pos:   position{line: 3077, col: 31, offset: 96119},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3065, col: 37, offset: 95586},
+										pos:  position{line: 3077, col: 37, offset: 96125},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3065, col: 52, offset: 95601},
+									pos:  position{line: 3077, col: 52, offset: 96140},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3075, col: 3, offset: 95804},
+						pos: position{line: 3087, col: 3, offset: 96343},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3075, col: 3, offset: 95804},
+							pos:   position{line: 3087, col: 3, offset: 96343},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3075, col: 9, offset: 95810},
+								pos:  position{line: 3087, col: 9, offset: 96349},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6755,50 +6755,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3080, col: 1, offset: 95881},
+			pos:  position{line: 3092, col: 1, offset: 96420},
 			expr: &choiceExpr{
-				pos: position{line: 3080, col: 19, offset: 95899},
+				pos: position{line: 3092, col: 19, offset: 96438},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3080, col: 19, offset: 95899},
+						pos: position{line: 3092, col: 19, offset: 96438},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3080, col: 19, offset: 95899},
+							pos: position{line: 3092, col: 19, offset: 96438},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3080, col: 19, offset: 95899},
+									pos:  position{line: 3092, col: 19, offset: 96438},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3080, col: 27, offset: 95907},
+									pos:   position{line: 3092, col: 27, offset: 96446},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3080, col: 33, offset: 95913},
+										pos:  position{line: 3092, col: 33, offset: 96452},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3080, col: 48, offset: 95928},
+									pos:  position{line: 3092, col: 48, offset: 96467},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3083, col: 3, offset: 95964},
+						pos: position{line: 3095, col: 3, offset: 96503},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3083, col: 3, offset: 95964},
+							pos:   position{line: 3095, col: 3, offset: 96503},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3083, col: 10, offset: 95971},
+								pos: position{line: 3095, col: 10, offset: 96510},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3083, col: 10, offset: 95971},
+										pos:  position{line: 3095, col: 10, offset: 96510},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3083, col: 31, offset: 95992},
+										pos:  position{line: 3095, col: 31, offset: 96531},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6810,60 +6810,60 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3088, col: 1, offset: 96112},
+			pos:  position{line: 3100, col: 1, offset: 96651},
 			expr: &choiceExpr{
-				pos: position{line: 3088, col: 23, offset: 96134},
+				pos: position{line: 3100, col: 23, offset: 96673},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3088, col: 23, offset: 96134},
+						pos: position{line: 3100, col: 23, offset: 96673},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3088, col: 24, offset: 96135},
+							pos: position{line: 3100, col: 24, offset: 96674},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3088, col: 24, offset: 96135},
+									pos:   position{line: 3100, col: 24, offset: 96674},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3088, col: 28, offset: 96139},
+										pos: position{line: 3100, col: 28, offset: 96678},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3088, col: 28, offset: 96139},
+												pos:        position{line: 3100, col: 28, offset: 96678},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 39, offset: 96150},
+												pos:        position{line: 3100, col: 39, offset: 96689},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 49, offset: 96160},
+												pos:        position{line: 3100, col: 49, offset: 96699},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 59, offset: 96170},
+												pos:        position{line: 3100, col: 59, offset: 96709},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 70, offset: 96181},
+												pos:        position{line: 3100, col: 70, offset: 96720},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 84, offset: 96195},
+												pos:        position{line: 3100, col: 84, offset: 96734},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3088, col: 94, offset: 96205},
+												pos:        position{line: 3100, col: 94, offset: 96744},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
@@ -6872,56 +6872,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3088, col: 109, offset: 96220},
+									pos:  position{line: 3100, col: 109, offset: 96759},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3088, col: 117, offset: 96228},
+									pos:   position{line: 3100, col: 117, offset: 96767},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3088, col: 123, offset: 96234},
+										pos:  position{line: 3100, col: 123, offset: 96773},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3088, col: 133, offset: 96244},
+									pos:  position{line: 3100, col: 133, offset: 96783},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3118, col: 3, offset: 97115},
+						pos: position{line: 3130, col: 3, offset: 97654},
 						run: (*parser).callonEvalComparisonExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3118, col: 3, offset: 97115},
+							pos: position{line: 3130, col: 3, offset: 97654},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3118, col: 3, offset: 97115},
+									pos:   position{line: 3130, col: 3, offset: 97654},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3118, col: 11, offset: 97123},
+										pos: position{line: 3130, col: 11, offset: 97662},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3118, col: 11, offset: 97123},
+												pos:        position{line: 3130, col: 11, offset: 97662},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3118, col: 20, offset: 97132},
+												pos:        position{line: 3130, col: 20, offset: 97671},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3118, col: 29, offset: 97141},
+												pos:        position{line: 3130, col: 29, offset: 97680},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3118, col: 39, offset: 97151},
+												pos:        position{line: 3130, col: 39, offset: 97690},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6930,86 +6930,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3118, col: 52, offset: 97164},
+									pos:  position{line: 3130, col: 52, offset: 97703},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3118, col: 60, offset: 97172},
+									pos:   position{line: 3130, col: 60, offset: 97711},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3118, col: 70, offset: 97182},
+										pos:  position{line: 3130, col: 70, offset: 97721},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3118, col: 80, offset: 97192},
+									pos:  position{line: 3130, col: 80, offset: 97731},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3118, col: 86, offset: 97198},
+									pos:   position{line: 3130, col: 86, offset: 97737},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3118, col: 97, offset: 97209},
+										pos:  position{line: 3130, col: 97, offset: 97748},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3118, col: 107, offset: 97219},
+									pos:  position{line: 3130, col: 107, offset: 97758},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3131, col: 3, offset: 97589},
+						pos: position{line: 3143, col: 3, offset: 98128},
 						run: (*parser).callonEvalComparisonExpr32,
 						expr: &seqExpr{
-							pos: position{line: 3131, col: 3, offset: 97589},
+							pos: position{line: 3143, col: 3, offset: 98128},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3131, col: 3, offset: 97589},
+									pos:   position{line: 3143, col: 3, offset: 98128},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3131, col: 8, offset: 97594},
+										pos:  position{line: 3143, col: 8, offset: 98133},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3131, col: 18, offset: 97604},
+									pos:  position{line: 3143, col: 18, offset: 98143},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3131, col: 24, offset: 97610},
+									pos:        position{line: 3143, col: 24, offset: 98149},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3131, col: 29, offset: 97615},
+									pos:  position{line: 3143, col: 29, offset: 98154},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3131, col: 37, offset: 97623},
+									pos:   position{line: 3143, col: 37, offset: 98162},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3131, col: 50, offset: 97636},
+										pos:  position{line: 3143, col: 50, offset: 98175},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3131, col: 60, offset: 97646},
+									pos:   position{line: 3143, col: 60, offset: 98185},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3131, col: 65, offset: 97651},
+										pos: position{line: 3143, col: 65, offset: 98190},
 										expr: &seqExpr{
-											pos: position{line: 3131, col: 66, offset: 97652},
+											pos: position{line: 3143, col: 66, offset: 98191},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3131, col: 66, offset: 97652},
+													pos:  position{line: 3143, col: 66, offset: 98191},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3131, col: 72, offset: 97658},
+													pos:  position{line: 3143, col: 72, offset: 98197},
 													name: "ValueExpr",
 												},
 											},
@@ -7017,50 +7017,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3131, col: 84, offset: 97670},
+									pos:  position{line: 3143, col: 84, offset: 98209},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3150, col: 3, offset: 98221},
+						pos: position{line: 3162, col: 3, offset: 98760},
 						run: (*parser).callonEvalComparisonExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3150, col: 3, offset: 98221},
+							pos: position{line: 3162, col: 3, offset: 98760},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3150, col: 3, offset: 98221},
+									pos:        position{line: 3162, col: 3, offset: 98760},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 8, offset: 98226},
+									pos:  position{line: 3162, col: 8, offset: 98765},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3150, col: 16, offset: 98234},
+									pos:   position{line: 3162, col: 16, offset: 98773},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3150, col: 29, offset: 98247},
+										pos:  position{line: 3162, col: 29, offset: 98786},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3150, col: 39, offset: 98257},
+									pos:   position{line: 3162, col: 39, offset: 98796},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3150, col: 44, offset: 98262},
+										pos: position{line: 3162, col: 44, offset: 98801},
 										expr: &seqExpr{
-											pos: position{line: 3150, col: 45, offset: 98263},
+											pos: position{line: 3162, col: 45, offset: 98802},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3150, col: 45, offset: 98263},
+													pos:  position{line: 3162, col: 45, offset: 98802},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3150, col: 51, offset: 98269},
+													pos:  position{line: 3162, col: 51, offset: 98808},
 													name: "ValueExpr",
 												},
 											},
@@ -7068,7 +7068,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 63, offset: 98281},
+									pos:  position{line: 3162, col: 63, offset: 98820},
 									name: "R_PAREN",
 								},
 							},
@@ -7079,34 +7079,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3168, col: 1, offset: 98702},
+			pos:  position{line: 3180, col: 1, offset: 99241},
 			expr: &actionExpr{
-				pos: position{line: 3168, col: 23, offset: 98724},
+				pos: position{line: 3180, col: 23, offset: 99263},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3168, col: 23, offset: 98724},
+					pos: position{line: 3180, col: 23, offset: 99263},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3168, col: 23, offset: 98724},
+							pos:   position{line: 3180, col: 23, offset: 99263},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3168, col: 28, offset: 98729},
+								pos:  position{line: 3180, col: 28, offset: 99268},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3168, col: 38, offset: 98739},
+							pos:   position{line: 3180, col: 38, offset: 99278},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3168, col: 41, offset: 98742},
+								pos:  position{line: 3180, col: 41, offset: 99281},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3168, col: 62, offset: 98763},
+							pos:   position{line: 3180, col: 62, offset: 99302},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3168, col: 68, offset: 98769},
+								pos:  position{line: 3180, col: 68, offset: 99308},
 								name: "ValueExpr",
 							},
 						},
@@ -7116,129 +7116,129 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3186, col: 1, offset: 99363},
+			pos:  position{line: 3198, col: 1, offset: 99902},
 			expr: &choiceExpr{
-				pos: position{line: 3186, col: 14, offset: 99376},
+				pos: position{line: 3198, col: 14, offset: 99915},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3186, col: 14, offset: 99376},
+						pos: position{line: 3198, col: 14, offset: 99915},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3186, col: 14, offset: 99376},
+							pos:   position{line: 3198, col: 14, offset: 99915},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3186, col: 24, offset: 99386},
+								pos:  position{line: 3198, col: 24, offset: 99925},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3195, col: 3, offset: 99576},
+						pos: position{line: 3207, col: 3, offset: 100115},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3195, col: 3, offset: 99576},
+							pos: position{line: 3207, col: 3, offset: 100115},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3195, col: 3, offset: 99576},
+									pos:  position{line: 3207, col: 3, offset: 100115},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3195, col: 12, offset: 99585},
+									pos:   position{line: 3207, col: 12, offset: 100124},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3195, col: 22, offset: 99595},
+										pos:  position{line: 3207, col: 22, offset: 100134},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3195, col: 37, offset: 99610},
+									pos:  position{line: 3207, col: 37, offset: 100149},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3204, col: 3, offset: 99794},
+						pos: position{line: 3216, col: 3, offset: 100333},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3204, col: 3, offset: 99794},
+							pos:   position{line: 3216, col: 3, offset: 100333},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3204, col: 11, offset: 99802},
+								pos:  position{line: 3216, col: 11, offset: 100341},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3213, col: 3, offset: 99982},
+						pos: position{line: 3225, col: 3, offset: 100521},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3213, col: 3, offset: 99982},
+							pos:   position{line: 3225, col: 3, offset: 100521},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3213, col: 7, offset: 99986},
+								pos:  position{line: 3225, col: 7, offset: 100525},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3222, col: 3, offset: 100158},
+						pos: position{line: 3234, col: 3, offset: 100697},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3222, col: 3, offset: 100158},
+							pos: position{line: 3234, col: 3, offset: 100697},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3222, col: 3, offset: 100158},
+									pos:  position{line: 3234, col: 3, offset: 100697},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3222, col: 12, offset: 100167},
+									pos:   position{line: 3234, col: 12, offset: 100706},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3222, col: 16, offset: 100171},
+										pos:  position{line: 3234, col: 16, offset: 100710},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3222, col: 28, offset: 100183},
+									pos:  position{line: 3234, col: 28, offset: 100722},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3231, col: 3, offset: 100352},
+						pos: position{line: 3243, col: 3, offset: 100891},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3231, col: 3, offset: 100352},
+							pos: position{line: 3243, col: 3, offset: 100891},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3231, col: 3, offset: 100352},
+									pos:  position{line: 3243, col: 3, offset: 100891},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3231, col: 11, offset: 100360},
+									pos:   position{line: 3243, col: 11, offset: 100899},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3231, col: 19, offset: 100368},
+										pos:  position{line: 3243, col: 19, offset: 100907},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3231, col: 28, offset: 100377},
+									pos:  position{line: 3243, col: 28, offset: 100916},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3240, col: 3, offset: 100549},
+						pos: position{line: 3252, col: 3, offset: 101088},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3240, col: 3, offset: 100549},
+							pos:   position{line: 3252, col: 3, offset: 101088},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3240, col: 18, offset: 100564},
+								pos:  position{line: 3252, col: 18, offset: 101103},
 								name: "MultiValueExpr",
 							},
 						},
@@ -7248,28 +7248,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3250, col: 1, offset: 100761},
+			pos:  position{line: 3262, col: 1, offset: 101300},
 			expr: &choiceExpr{
-				pos: position{line: 3250, col: 15, offset: 100775},
+				pos: position{line: 3262, col: 15, offset: 101314},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3250, col: 15, offset: 100775},
+						pos: position{line: 3262, col: 15, offset: 101314},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3250, col: 15, offset: 100775},
+							pos: position{line: 3262, col: 15, offset: 101314},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3250, col: 15, offset: 100775},
+									pos:   position{line: 3262, col: 15, offset: 101314},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3250, col: 20, offset: 100780},
+										pos:  position{line: 3262, col: 20, offset: 101319},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3250, col: 29, offset: 100789},
+									pos: position{line: 3262, col: 29, offset: 101328},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3250, col: 31, offset: 100791},
+										pos:  position{line: 3262, col: 31, offset: 101330},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7277,23 +7277,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3258, col: 3, offset: 100961},
+						pos: position{line: 3270, col: 3, offset: 101500},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3258, col: 3, offset: 100961},
+							pos: position{line: 3270, col: 3, offset: 101500},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3258, col: 3, offset: 100961},
+									pos:   position{line: 3270, col: 3, offset: 101500},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3258, col: 7, offset: 100965},
+										pos:  position{line: 3270, col: 7, offset: 101504},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3258, col: 20, offset: 100978},
+									pos: position{line: 3270, col: 20, offset: 101517},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3258, col: 22, offset: 100980},
+										pos:  position{line: 3270, col: 22, offset: 101519},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7301,50 +7301,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3266, col: 3, offset: 101145},
+						pos: position{line: 3278, col: 3, offset: 101684},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3266, col: 3, offset: 101145},
+							pos: position{line: 3278, col: 3, offset: 101684},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3266, col: 3, offset: 101145},
+									pos:   position{line: 3278, col: 3, offset: 101684},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3266, col: 9, offset: 101151},
+										pos:  position{line: 3278, col: 9, offset: 101690},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3266, col: 25, offset: 101167},
+									pos: position{line: 3278, col: 25, offset: 101706},
 									expr: &choiceExpr{
-										pos: position{line: 3266, col: 27, offset: 101169},
+										pos: position{line: 3278, col: 27, offset: 101708},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 27, offset: 101169},
+												pos:  position{line: 3278, col: 27, offset: 101708},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 36, offset: 101178},
+												pos:  position{line: 3278, col: 36, offset: 101717},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 46, offset: 101188},
+												pos:  position{line: 3278, col: 46, offset: 101727},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 54, offset: 101196},
+												pos:  position{line: 3278, col: 54, offset: 101735},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 62, offset: 101204},
+												pos:  position{line: 3278, col: 62, offset: 101743},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3266, col: 70, offset: 101212},
+												pos:  position{line: 3278, col: 70, offset: 101751},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3266, col: 84, offset: 101226},
+												pos:        position{line: 3278, col: 84, offset: 101765},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7356,13 +7356,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3274, col: 3, offset: 101376},
+						pos: position{line: 3286, col: 3, offset: 101915},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3274, col: 3, offset: 101376},
+							pos:   position{line: 3286, col: 3, offset: 101915},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3274, col: 10, offset: 101383},
+								pos:  position{line: 3286, col: 10, offset: 101922},
 								name: "ConcatExpr",
 							},
 						},
@@ -7372,35 +7372,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3284, col: 1, offset: 101589},
+			pos:  position{line: 3296, col: 1, offset: 102128},
 			expr: &actionExpr{
-				pos: position{line: 3284, col: 15, offset: 101603},
+				pos: position{line: 3296, col: 15, offset: 102142},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3284, col: 15, offset: 101603},
+					pos: position{line: 3296, col: 15, offset: 102142},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3284, col: 15, offset: 101603},
+							pos:   position{line: 3296, col: 15, offset: 102142},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3284, col: 21, offset: 101609},
+								pos:  position{line: 3296, col: 21, offset: 102148},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3284, col: 32, offset: 101620},
+							pos:   position{line: 3296, col: 32, offset: 102159},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3284, col: 37, offset: 101625},
+								pos: position{line: 3296, col: 37, offset: 102164},
 								expr: &seqExpr{
-									pos: position{line: 3284, col: 38, offset: 101626},
+									pos: position{line: 3296, col: 38, offset: 102165},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3284, col: 38, offset: 101626},
+											pos:  position{line: 3296, col: 38, offset: 102165},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3284, col: 50, offset: 101638},
+											pos:  position{line: 3296, col: 50, offset: 102177},
 											name: "ConcatAtom",
 										},
 									},
@@ -7408,28 +7408,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3284, col: 63, offset: 101651},
+							pos: position{line: 3296, col: 63, offset: 102190},
 							expr: &choiceExpr{
-								pos: position{line: 3284, col: 65, offset: 101653},
+								pos: position{line: 3296, col: 65, offset: 102192},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3284, col: 65, offset: 101653},
+										pos:  position{line: 3296, col: 65, offset: 102192},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3284, col: 74, offset: 101662},
+										pos:  position{line: 3296, col: 74, offset: 102201},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3284, col: 84, offset: 101672},
+										pos:  position{line: 3296, col: 84, offset: 102211},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3284, col: 92, offset: 101680},
+										pos:  position{line: 3296, col: 92, offset: 102219},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3284, col: 100, offset: 101688},
+										pos:        position{line: 3296, col: 100, offset: 102227},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7443,54 +7443,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3302, col: 1, offset: 102094},
+			pos:  position{line: 3314, col: 1, offset: 102633},
 			expr: &choiceExpr{
-				pos: position{line: 3302, col: 15, offset: 102108},
+				pos: position{line: 3314, col: 15, offset: 102647},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3302, col: 15, offset: 102108},
+						pos: position{line: 3314, col: 15, offset: 102647},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3302, col: 15, offset: 102108},
+							pos:   position{line: 3314, col: 15, offset: 102647},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3302, col: 20, offset: 102113},
+								pos:  position{line: 3314, col: 20, offset: 102652},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3311, col: 3, offset: 102277},
+						pos: position{line: 3323, col: 3, offset: 102816},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3311, col: 3, offset: 102277},
+							pos:   position{line: 3323, col: 3, offset: 102816},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3311, col: 7, offset: 102281},
+								pos:  position{line: 3323, col: 7, offset: 102820},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3319, col: 3, offset: 102420},
+						pos: position{line: 3331, col: 3, offset: 102959},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3319, col: 3, offset: 102420},
+							pos:   position{line: 3331, col: 3, offset: 102959},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3319, col: 10, offset: 102427},
+								pos:  position{line: 3331, col: 10, offset: 102966},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3327, col: 3, offset: 102566},
+						pos: position{line: 3339, col: 3, offset: 103105},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3327, col: 3, offset: 102566},
+							pos:   position{line: 3339, col: 3, offset: 103105},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3327, col: 9, offset: 102572},
+								pos:  position{line: 3339, col: 9, offset: 103111},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7500,32 +7500,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3337, col: 1, offset: 102741},
+			pos:  position{line: 3349, col: 1, offset: 103280},
 			expr: &actionExpr{
-				pos: position{line: 3337, col: 16, offset: 102756},
+				pos: position{line: 3349, col: 16, offset: 103295},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3337, col: 16, offset: 102756},
+					pos: position{line: 3349, col: 16, offset: 103295},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3337, col: 16, offset: 102756},
+							pos:   position{line: 3349, col: 16, offset: 103295},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3337, col: 21, offset: 102761},
+								pos:  position{line: 3349, col: 21, offset: 103300},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3337, col: 39, offset: 102779},
+							pos: position{line: 3349, col: 39, offset: 103318},
 							expr: &choiceExpr{
-								pos: position{line: 3337, col: 41, offset: 102781},
+								pos: position{line: 3349, col: 41, offset: 103320},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3337, col: 41, offset: 102781},
+										pos:  position{line: 3349, col: 41, offset: 103320},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3337, col: 55, offset: 102795},
+										pos:        position{line: 3349, col: 55, offset: 103334},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7539,44 +7539,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3342, col: 1, offset: 102860},
+			pos:  position{line: 3354, col: 1, offset: 103399},
 			expr: &actionExpr{
-				pos: position{line: 3342, col: 22, offset: 102881},
+				pos: position{line: 3354, col: 22, offset: 103420},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3342, col: 22, offset: 102881},
+					pos: position{line: 3354, col: 22, offset: 103420},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3342, col: 22, offset: 102881},
+							pos:   position{line: 3354, col: 22, offset: 103420},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3342, col: 28, offset: 102887},
+								pos:  position{line: 3354, col: 28, offset: 103426},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3342, col: 46, offset: 102905},
+							pos:   position{line: 3354, col: 46, offset: 103444},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3342, col: 51, offset: 102910},
+								pos: position{line: 3354, col: 51, offset: 103449},
 								expr: &seqExpr{
-									pos: position{line: 3342, col: 52, offset: 102911},
+									pos: position{line: 3354, col: 52, offset: 103450},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3342, col: 53, offset: 102912},
+											pos: position{line: 3354, col: 53, offset: 103451},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3342, col: 53, offset: 102912},
+													pos:  position{line: 3354, col: 53, offset: 103451},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3342, col: 62, offset: 102921},
+													pos:  position{line: 3354, col: 62, offset: 103460},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3342, col: 71, offset: 102930},
+											pos:  position{line: 3354, col: 71, offset: 103469},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7589,48 +7589,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3363, col: 1, offset: 103431},
+			pos:  position{line: 3375, col: 1, offset: 103970},
 			expr: &actionExpr{
-				pos: position{line: 3363, col: 22, offset: 103452},
+				pos: position{line: 3375, col: 22, offset: 103991},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3363, col: 22, offset: 103452},
+					pos: position{line: 3375, col: 22, offset: 103991},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3363, col: 22, offset: 103452},
+							pos:   position{line: 3375, col: 22, offset: 103991},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3363, col: 28, offset: 103458},
+								pos:  position{line: 3375, col: 28, offset: 103997},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3363, col: 46, offset: 103476},
+							pos:   position{line: 3375, col: 46, offset: 104015},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3363, col: 51, offset: 103481},
+								pos: position{line: 3375, col: 51, offset: 104020},
 								expr: &seqExpr{
-									pos: position{line: 3363, col: 52, offset: 103482},
+									pos: position{line: 3375, col: 52, offset: 104021},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3363, col: 53, offset: 103483},
+											pos: position{line: 3375, col: 53, offset: 104022},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3363, col: 53, offset: 103483},
+													pos:  position{line: 3375, col: 53, offset: 104022},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3363, col: 61, offset: 103491},
+													pos:  position{line: 3375, col: 61, offset: 104030},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3363, col: 69, offset: 103499},
+													pos:  position{line: 3375, col: 69, offset: 104038},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3363, col: 76, offset: 103506},
+											pos:  position{line: 3375, col: 76, offset: 104045},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7643,22 +7643,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3383, col: 1, offset: 103975},
+			pos:  position{line: 3395, col: 1, offset: 104514},
 			expr: &actionExpr{
-				pos: position{line: 3383, col: 21, offset: 103995},
+				pos: position{line: 3395, col: 21, offset: 104534},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3383, col: 21, offset: 103995},
+					pos: position{line: 3395, col: 21, offset: 104534},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3383, col: 21, offset: 103995},
+							pos:  position{line: 3395, col: 21, offset: 104534},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3383, col: 27, offset: 104001},
+							pos:   position{line: 3395, col: 27, offset: 104540},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3383, col: 32, offset: 104006},
+								pos:  position{line: 3395, col: 32, offset: 104545},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7668,67 +7668,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3393, col: 1, offset: 104250},
+			pos:  position{line: 3405, col: 1, offset: 104789},
 			expr: &choiceExpr{
-				pos: position{line: 3393, col: 22, offset: 104271},
+				pos: position{line: 3405, col: 22, offset: 104810},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3393, col: 22, offset: 104271},
+						pos: position{line: 3405, col: 22, offset: 104810},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3393, col: 22, offset: 104271},
+							pos: position{line: 3405, col: 22, offset: 104810},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3393, col: 22, offset: 104271},
+									pos:  position{line: 3405, col: 22, offset: 104810},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3393, col: 30, offset: 104279},
+									pos:   position{line: 3405, col: 30, offset: 104818},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3393, col: 35, offset: 104284},
+										pos:  position{line: 3405, col: 35, offset: 104823},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3393, col: 53, offset: 104302},
+									pos:  position{line: 3405, col: 53, offset: 104841},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3396, col: 3, offset: 104337},
+						pos: position{line: 3408, col: 3, offset: 104876},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3396, col: 3, offset: 104337},
+							pos:   position{line: 3408, col: 3, offset: 104876},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3396, col: 20, offset: 104354},
+								pos:  position{line: 3408, col: 20, offset: 104893},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3399, col: 3, offset: 104408},
+						pos: position{line: 3411, col: 3, offset: 104947},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3399, col: 3, offset: 104408},
+							pos:   position{line: 3411, col: 3, offset: 104947},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3399, col: 9, offset: 104414},
+								pos:  position{line: 3411, col: 9, offset: 104953},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3409, col: 3, offset: 104633},
+						pos: position{line: 3421, col: 3, offset: 105172},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3409, col: 3, offset: 104633},
+							pos:   position{line: 3421, col: 3, offset: 105172},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3409, col: 10, offset: 104640},
+								pos:  position{line: 3421, col: 10, offset: 105179},
 								name: "NumberAsString",
 							},
 						},
@@ -7738,144 +7738,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3422, col: 1, offset: 105018},
+			pos:  position{line: 3434, col: 1, offset: 105557},
 			expr: &choiceExpr{
-				pos: position{line: 3422, col: 20, offset: 105037},
+				pos: position{line: 3434, col: 20, offset: 105576},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3422, col: 20, offset: 105037},
+						pos: position{line: 3434, col: 20, offset: 105576},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3422, col: 21, offset: 105038},
+							pos: position{line: 3434, col: 21, offset: 105577},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3422, col: 21, offset: 105038},
+									pos:   position{line: 3434, col: 21, offset: 105577},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3422, col: 29, offset: 105046},
+										pos: position{line: 3434, col: 29, offset: 105585},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3422, col: 29, offset: 105046},
+												pos:        position{line: 3434, col: 29, offset: 105585},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 37, offset: 105054},
+												pos:        position{line: 3434, col: 37, offset: 105593},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 46, offset: 105063},
+												pos:        position{line: 3434, col: 46, offset: 105602},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 58, offset: 105075},
+												pos:        position{line: 3434, col: 58, offset: 105614},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 67, offset: 105084},
+												pos:        position{line: 3434, col: 67, offset: 105623},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 77, offset: 105094},
+												pos:        position{line: 3434, col: 77, offset: 105633},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 85, offset: 105102},
+												pos:        position{line: 3434, col: 85, offset: 105641},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 95, offset: 105112},
+												pos:        position{line: 3434, col: 95, offset: 105651},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 102, offset: 105119},
+												pos:        position{line: 3434, col: 102, offset: 105658},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 113, offset: 105130},
+												pos:        position{line: 3434, col: 113, offset: 105669},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 123, offset: 105140},
+												pos:        position{line: 3434, col: 123, offset: 105679},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 132, offset: 105149},
+												pos:        position{line: 3434, col: 132, offset: 105688},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 142, offset: 105159},
+												pos:        position{line: 3434, col: 142, offset: 105698},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 151, offset: 105168},
+												pos:        position{line: 3434, col: 151, offset: 105707},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 161, offset: 105178},
+												pos:        position{line: 3434, col: 161, offset: 105717},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 170, offset: 105187},
+												pos:        position{line: 3434, col: 170, offset: 105726},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 179, offset: 105196},
+												pos:        position{line: 3434, col: 179, offset: 105735},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 187, offset: 105204},
+												pos:        position{line: 3434, col: 187, offset: 105743},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 196, offset: 105213},
+												pos:        position{line: 3434, col: 196, offset: 105752},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 204, offset: 105221},
+												pos:        position{line: 3434, col: 204, offset: 105760},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3422, col: 213, offset: 105230},
+												pos:        position{line: 3434, col: 213, offset: 105769},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7884,102 +7884,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3422, col: 220, offset: 105237},
+									pos:  position{line: 3434, col: 220, offset: 105776},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3422, col: 228, offset: 105245},
+									pos:   position{line: 3434, col: 228, offset: 105784},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3422, col: 234, offset: 105251},
+										pos:  position{line: 3434, col: 234, offset: 105790},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3422, col: 253, offset: 105270},
+									pos:  position{line: 3434, col: 253, offset: 105809},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3442, col: 3, offset: 105782},
+						pos: position{line: 3454, col: 3, offset: 106321},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3442, col: 3, offset: 105782},
+							pos: position{line: 3454, col: 3, offset: 106321},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3442, col: 3, offset: 105782},
+									pos:   position{line: 3454, col: 3, offset: 106321},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3442, col: 13, offset: 105792},
+										pos:        position{line: 3454, col: 13, offset: 106331},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3442, col: 21, offset: 105800},
+									pos:  position{line: 3454, col: 21, offset: 106339},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3442, col: 29, offset: 105808},
+									pos:   position{line: 3454, col: 29, offset: 106347},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3442, col: 35, offset: 105814},
+										pos:  position{line: 3454, col: 35, offset: 106353},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3442, col: 54, offset: 105833},
+									pos:   position{line: 3454, col: 54, offset: 106372},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3442, col: 69, offset: 105848},
+										pos: position{line: 3454, col: 69, offset: 106387},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3442, col: 70, offset: 105849},
+											pos:  position{line: 3454, col: 70, offset: 106388},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3442, col: 89, offset: 105868},
+									pos:  position{line: 3454, col: 89, offset: 106407},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3463, col: 3, offset: 106486},
+						pos: position{line: 3475, col: 3, offset: 107025},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3463, col: 4, offset: 106487},
+							pos: position{line: 3475, col: 4, offset: 107026},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3463, col: 4, offset: 106487},
+									pos:   position{line: 3475, col: 4, offset: 107026},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3463, col: 12, offset: 106495},
+										pos: position{line: 3475, col: 12, offset: 107034},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3463, col: 12, offset: 106495},
+												pos:        position{line: 3475, col: 12, offset: 107034},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3463, col: 20, offset: 106503},
+												pos:        position{line: 3475, col: 20, offset: 107042},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3463, col: 27, offset: 106510},
+												pos:        position{line: 3475, col: 27, offset: 107049},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3463, col: 38, offset: 106521},
+												pos:        position{line: 3475, col: 38, offset: 107060},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -7988,54 +7988,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3463, col: 46, offset: 106529},
+									pos:  position{line: 3475, col: 46, offset: 107068},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3463, col: 54, offset: 106537},
+									pos:  position{line: 3475, col: 54, offset: 107076},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3476, col: 3, offset: 106823},
+						pos: position{line: 3488, col: 3, offset: 107362},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3476, col: 3, offset: 106823},
+							pos: position{line: 3488, col: 3, offset: 107362},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3476, col: 3, offset: 106823},
+									pos:        position{line: 3488, col: 3, offset: 107362},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3476, col: 14, offset: 106834},
+									pos:  position{line: 3488, col: 14, offset: 107373},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3476, col: 22, offset: 106842},
+									pos:   position{line: 3488, col: 22, offset: 107381},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3476, col: 33, offset: 106853},
+										pos:  position{line: 3488, col: 33, offset: 107392},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3476, col: 44, offset: 106864},
+									pos:   position{line: 3488, col: 44, offset: 107403},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3476, col: 53, offset: 106873},
+										pos: position{line: 3488, col: 53, offset: 107412},
 										expr: &seqExpr{
-											pos: position{line: 3476, col: 54, offset: 106874},
+											pos: position{line: 3488, col: 54, offset: 107413},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3476, col: 54, offset: 106874},
+													pos:  position{line: 3488, col: 54, offset: 107413},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3476, col: 60, offset: 106880},
+													pos:  position{line: 3488, col: 60, offset: 107419},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8043,73 +8043,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3476, col: 80, offset: 106900},
+									pos:  position{line: 3488, col: 80, offset: 107439},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3504, col: 3, offset: 107742},
+						pos: position{line: 3516, col: 3, offset: 108281},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3504, col: 3, offset: 107742},
+							pos: position{line: 3516, col: 3, offset: 108281},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3504, col: 3, offset: 107742},
+									pos:   position{line: 3516, col: 3, offset: 108281},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3504, col: 12, offset: 107751},
+										pos:        position{line: 3516, col: 12, offset: 108290},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3504, col: 18, offset: 107757},
+									pos:  position{line: 3516, col: 18, offset: 108296},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3504, col: 26, offset: 107765},
+									pos:   position{line: 3516, col: 26, offset: 108304},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3504, col: 31, offset: 107770},
+										pos:  position{line: 3516, col: 31, offset: 108309},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3504, col: 39, offset: 107778},
+									pos:  position{line: 3516, col: 39, offset: 108317},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3507, col: 3, offset: 107813},
+						pos: position{line: 3519, col: 3, offset: 108352},
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
-							pos: position{line: 3507, col: 4, offset: 107814},
+							pos: position{line: 3519, col: 4, offset: 108353},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3507, col: 4, offset: 107814},
+									pos:   position{line: 3519, col: 4, offset: 108353},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3507, col: 12, offset: 107822},
+										pos: position{line: 3519, col: 12, offset: 108361},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3507, col: 12, offset: 107822},
+												pos:        position{line: 3519, col: 12, offset: 108361},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3507, col: 20, offset: 107830},
+												pos:        position{line: 3519, col: 20, offset: 108369},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3507, col: 30, offset: 107840},
+												pos:        position{line: 3519, col: 30, offset: 108379},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8118,128 +8118,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3507, col: 39, offset: 107849},
+									pos:  position{line: 3519, col: 39, offset: 108388},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3507, col: 47, offset: 107857},
+									pos:   position{line: 3519, col: 47, offset: 108396},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3507, col: 53, offset: 107863},
+										pos:  position{line: 3519, col: 53, offset: 108402},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3507, col: 72, offset: 107882},
+									pos:   position{line: 3519, col: 72, offset: 108421},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3507, col: 79, offset: 107889},
+										pos:  position{line: 3519, col: 79, offset: 108428},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3507, col: 97, offset: 107907},
+									pos:  position{line: 3519, col: 97, offset: 108446},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3537, col: 3, offset: 108746},
+						pos: position{line: 3549, col: 3, offset: 109285},
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
-							pos: position{line: 3537, col: 4, offset: 108747},
+							pos: position{line: 3549, col: 4, offset: 109286},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3537, col: 4, offset: 108747},
+									pos:   position{line: 3549, col: 4, offset: 109286},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3537, col: 11, offset: 108754},
+										pos:        position{line: 3549, col: 11, offset: 109293},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3537, col: 17, offset: 108760},
+									pos:  position{line: 3549, col: 17, offset: 109299},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3537, col: 25, offset: 108768},
+									pos:   position{line: 3549, col: 25, offset: 109307},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3537, col: 31, offset: 108774},
+										pos:  position{line: 3549, col: 31, offset: 109313},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3537, col: 50, offset: 108793},
+									pos:   position{line: 3549, col: 50, offset: 109332},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3537, col: 56, offset: 108799},
+										pos: position{line: 3549, col: 56, offset: 109338},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3537, col: 57, offset: 108800},
+											pos:  position{line: 3549, col: 57, offset: 109339},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3537, col: 76, offset: 108819},
+									pos:  position{line: 3549, col: 76, offset: 109358},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3566, col: 3, offset: 109592},
+						pos: position{line: 3578, col: 3, offset: 110131},
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
-							pos: position{line: 3566, col: 3, offset: 109592},
+							pos: position{line: 3578, col: 3, offset: 110131},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3566, col: 3, offset: 109592},
+									pos:   position{line: 3578, col: 3, offset: 110131},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3566, col: 11, offset: 109600},
+										pos:        position{line: 3578, col: 11, offset: 110139},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 28, offset: 109617},
+									pos:  position{line: 3578, col: 28, offset: 110156},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3566, col: 36, offset: 109625},
+									pos:   position{line: 3578, col: 36, offset: 110164},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3566, col: 42, offset: 109631},
+										pos:  position{line: 3578, col: 42, offset: 110170},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 61, offset: 109650},
+									pos:  position{line: 3578, col: 61, offset: 110189},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 67, offset: 109656},
+									pos:  position{line: 3578, col: 67, offset: 110195},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3566, col: 73, offset: 109662},
+									pos:   position{line: 3578, col: 73, offset: 110201},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3566, col: 84, offset: 109673},
+										pos:  position{line: 3578, col: 84, offset: 110212},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 120, offset: 109709},
+									pos:  position{line: 3578, col: 120, offset: 110248},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 126, offset: 109715},
+									pos:  position{line: 3578, col: 126, offset: 110254},
 									name: "R_PAREN",
 								},
 							},
@@ -8250,28 +8250,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3583, col: 1, offset: 110244},
+			pos:  position{line: 3595, col: 1, offset: 110783},
 			expr: &choiceExpr{
-				pos: position{line: 3583, col: 12, offset: 110255},
+				pos: position{line: 3595, col: 12, offset: 110794},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3583, col: 12, offset: 110255},
+						pos: position{line: 3595, col: 12, offset: 110794},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3583, col: 12, offset: 110255},
+							pos: position{line: 3595, col: 12, offset: 110794},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3583, col: 12, offset: 110255},
+									pos:   position{line: 3595, col: 12, offset: 110794},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3583, col: 16, offset: 110259},
+										pos:  position{line: 3595, col: 16, offset: 110798},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3583, col: 29, offset: 110272},
+									pos: position{line: 3595, col: 29, offset: 110811},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3583, col: 31, offset: 110274},
+										pos:  position{line: 3595, col: 31, offset: 110813},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8279,50 +8279,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3599, col: 3, offset: 110635},
+						pos: position{line: 3611, col: 3, offset: 111174},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3599, col: 3, offset: 110635},
+							pos: position{line: 3611, col: 3, offset: 111174},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3599, col: 3, offset: 110635},
+									pos:   position{line: 3611, col: 3, offset: 111174},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3599, col: 9, offset: 110641},
+										pos:  position{line: 3611, col: 9, offset: 111180},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3599, col: 25, offset: 110657},
+									pos: position{line: 3611, col: 25, offset: 111196},
 									expr: &choiceExpr{
-										pos: position{line: 3599, col: 27, offset: 110659},
+										pos: position{line: 3611, col: 27, offset: 111198},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 27, offset: 110659},
+												pos:  position{line: 3611, col: 27, offset: 111198},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 36, offset: 110668},
+												pos:  position{line: 3611, col: 36, offset: 111207},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 46, offset: 110678},
+												pos:  position{line: 3611, col: 46, offset: 111217},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 54, offset: 110686},
+												pos:  position{line: 3611, col: 54, offset: 111225},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 62, offset: 110694},
+												pos:  position{line: 3611, col: 62, offset: 111233},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3599, col: 70, offset: 110702},
+												pos:  position{line: 3611, col: 70, offset: 111241},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3599, col: 84, offset: 110716},
+												pos:        position{line: 3611, col: 84, offset: 111255},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8338,28 +8338,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3616, col: 1, offset: 111067},
+			pos:  position{line: 3628, col: 1, offset: 111606},
 			expr: &actionExpr{
-				pos: position{line: 3616, col: 19, offset: 111085},
+				pos: position{line: 3628, col: 19, offset: 111624},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3616, col: 19, offset: 111085},
+					pos: position{line: 3628, col: 19, offset: 111624},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3616, col: 19, offset: 111085},
+							pos:        position{line: 3628, col: 19, offset: 111624},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3616, col: 26, offset: 111092},
+							pos:  position{line: 3628, col: 26, offset: 111631},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3616, col: 32, offset: 111098},
+							pos:   position{line: 3628, col: 32, offset: 111637},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3616, col: 40, offset: 111106},
+								pos:  position{line: 3628, col: 40, offset: 111645},
 								name: "Boolean",
 							},
 						},
@@ -8369,28 +8369,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3627, col: 1, offset: 111295},
+			pos:  position{line: 3639, col: 1, offset: 111834},
 			expr: &actionExpr{
-				pos: position{line: 3627, col: 23, offset: 111317},
+				pos: position{line: 3639, col: 23, offset: 111856},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3627, col: 23, offset: 111317},
+					pos: position{line: 3639, col: 23, offset: 111856},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3627, col: 23, offset: 111317},
+							pos:        position{line: 3639, col: 23, offset: 111856},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3627, col: 34, offset: 111328},
+							pos:  position{line: 3639, col: 34, offset: 111867},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3627, col: 40, offset: 111334},
+							pos:   position{line: 3639, col: 40, offset: 111873},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3627, col: 48, offset: 111342},
+								pos:  position{line: 3639, col: 48, offset: 111881},
 								name: "Boolean",
 							},
 						},
@@ -8400,28 +8400,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3638, col: 1, offset: 111539},
+			pos:  position{line: 3650, col: 1, offset: 112078},
 			expr: &actionExpr{
-				pos: position{line: 3638, col: 20, offset: 111558},
+				pos: position{line: 3650, col: 20, offset: 112097},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3638, col: 20, offset: 111558},
+					pos: position{line: 3650, col: 20, offset: 112097},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3638, col: 20, offset: 111558},
+							pos:        position{line: 3650, col: 20, offset: 112097},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3638, col: 28, offset: 111566},
+							pos:  position{line: 3650, col: 28, offset: 112105},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3638, col: 34, offset: 111572},
+							pos:   position{line: 3650, col: 34, offset: 112111},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3638, col: 43, offset: 111581},
+								pos:  position{line: 3650, col: 43, offset: 112120},
 								name: "IntegerAsString",
 							},
 						},
@@ -8431,15 +8431,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3653, col: 1, offset: 111943},
+			pos:  position{line: 3665, col: 1, offset: 112482},
 			expr: &actionExpr{
-				pos: position{line: 3653, col: 19, offset: 111961},
+				pos: position{line: 3665, col: 19, offset: 112500},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3653, col: 19, offset: 111961},
+					pos:   position{line: 3665, col: 19, offset: 112500},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3653, col: 28, offset: 111970},
+						pos:  position{line: 3665, col: 28, offset: 112509},
 						name: "BoolExpr",
 					},
 				},
@@ -8447,30 +8447,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3664, col: 1, offset: 112182},
+			pos:  position{line: 3676, col: 1, offset: 112721},
 			expr: &actionExpr{
-				pos: position{line: 3664, col: 15, offset: 112196},
+				pos: position{line: 3676, col: 15, offset: 112735},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3664, col: 15, offset: 112196},
+					pos:   position{line: 3676, col: 15, offset: 112735},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3664, col: 23, offset: 112204},
+						pos: position{line: 3676, col: 23, offset: 112743},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3664, col: 23, offset: 112204},
+								pos:  position{line: 3676, col: 23, offset: 112743},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3664, col: 44, offset: 112225},
+								pos:  position{line: 3676, col: 44, offset: 112764},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3664, col: 61, offset: 112242},
+								pos:  position{line: 3676, col: 61, offset: 112781},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3664, col: 79, offset: 112260},
+								pos:  position{line: 3676, col: 79, offset: 112799},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8480,35 +8480,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3668, col: 1, offset: 112304},
+			pos:  position{line: 3680, col: 1, offset: 112843},
 			expr: &actionExpr{
-				pos: position{line: 3668, col: 19, offset: 112322},
+				pos: position{line: 3680, col: 19, offset: 112861},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3668, col: 19, offset: 112322},
+					pos: position{line: 3680, col: 19, offset: 112861},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3668, col: 19, offset: 112322},
+							pos:   position{line: 3680, col: 19, offset: 112861},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3668, col: 26, offset: 112329},
+								pos:  position{line: 3680, col: 26, offset: 112868},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3668, col: 37, offset: 112340},
+							pos:   position{line: 3680, col: 37, offset: 112879},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3668, col: 43, offset: 112346},
+								pos: position{line: 3680, col: 43, offset: 112885},
 								expr: &seqExpr{
-									pos: position{line: 3668, col: 44, offset: 112347},
+									pos: position{line: 3680, col: 44, offset: 112886},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3668, col: 44, offset: 112347},
+											pos:  position{line: 3680, col: 44, offset: 112886},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3668, col: 50, offset: 112353},
+											pos:  position{line: 3680, col: 50, offset: 112892},
 											name: "HeadOption",
 										},
 									},
@@ -8521,29 +8521,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3725, col: 1, offset: 114153},
+			pos:  position{line: 3737, col: 1, offset: 114692},
 			expr: &choiceExpr{
-				pos: position{line: 3725, col: 14, offset: 114166},
+				pos: position{line: 3737, col: 14, offset: 114705},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3725, col: 14, offset: 114166},
+						pos: position{line: 3737, col: 14, offset: 114705},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3725, col: 14, offset: 114166},
+							pos: position{line: 3737, col: 14, offset: 114705},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3725, col: 14, offset: 114166},
+									pos:  position{line: 3737, col: 14, offset: 114705},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3725, col: 19, offset: 114171},
+									pos:  position{line: 3737, col: 19, offset: 114710},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3725, col: 28, offset: 114180},
+									pos:   position{line: 3737, col: 28, offset: 114719},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3725, col: 37, offset: 114189},
+										pos:  position{line: 3737, col: 37, offset: 114728},
 										name: "HeadOptionList",
 									},
 								},
@@ -8551,24 +8551,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3736, col: 3, offset: 114508},
+						pos: position{line: 3748, col: 3, offset: 115047},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3736, col: 3, offset: 114508},
+							pos: position{line: 3748, col: 3, offset: 115047},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3736, col: 3, offset: 114508},
+									pos:  position{line: 3748, col: 3, offset: 115047},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3736, col: 8, offset: 114513},
+									pos:  position{line: 3748, col: 8, offset: 115052},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3736, col: 17, offset: 114522},
+									pos:   position{line: 3748, col: 17, offset: 115061},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3736, col: 26, offset: 114531},
+										pos:  position{line: 3748, col: 26, offset: 115070},
 										name: "IntegerAsString",
 									},
 								},
@@ -8576,17 +8576,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3756, col: 3, offset: 115048},
+						pos: position{line: 3768, col: 3, offset: 115587},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3756, col: 3, offset: 115048},
+							pos: position{line: 3768, col: 3, offset: 115587},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3756, col: 3, offset: 115048},
+									pos:  position{line: 3768, col: 3, offset: 115587},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3756, col: 8, offset: 115053},
+									pos:  position{line: 3768, col: 8, offset: 115592},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8597,29 +8597,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3774, col: 1, offset: 115523},
+			pos:  position{line: 3786, col: 1, offset: 116062},
 			expr: &choiceExpr{
-				pos: position{line: 3774, col: 14, offset: 115536},
+				pos: position{line: 3786, col: 14, offset: 116075},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3774, col: 14, offset: 115536},
+						pos: position{line: 3786, col: 14, offset: 116075},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3774, col: 14, offset: 115536},
+							pos: position{line: 3786, col: 14, offset: 116075},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3774, col: 14, offset: 115536},
+									pos:  position{line: 3786, col: 14, offset: 116075},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3774, col: 19, offset: 115541},
+									pos:  position{line: 3786, col: 19, offset: 116080},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3774, col: 28, offset: 115550},
+									pos:   position{line: 3786, col: 28, offset: 116089},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3774, col: 37, offset: 115559},
+										pos:  position{line: 3786, col: 37, offset: 116098},
 										name: "IntegerAsString",
 									},
 								},
@@ -8627,17 +8627,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3795, col: 3, offset: 116133},
+						pos: position{line: 3807, col: 3, offset: 116672},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3795, col: 3, offset: 116133},
+							pos: position{line: 3807, col: 3, offset: 116672},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3795, col: 3, offset: 116133},
+									pos:  position{line: 3807, col: 3, offset: 116672},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3795, col: 8, offset: 116138},
+									pos:  position{line: 3807, col: 8, offset: 116677},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8648,44 +8648,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3816, col: 1, offset: 116756},
+			pos:  position{line: 3828, col: 1, offset: 117295},
 			expr: &actionExpr{
-				pos: position{line: 3816, col: 20, offset: 116775},
+				pos: position{line: 3828, col: 20, offset: 117314},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3816, col: 20, offset: 116775},
+					pos: position{line: 3828, col: 20, offset: 117314},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3816, col: 20, offset: 116775},
+							pos:   position{line: 3828, col: 20, offset: 117314},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3816, col: 26, offset: 116781},
+								pos:  position{line: 3828, col: 26, offset: 117320},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3816, col: 37, offset: 116792},
+							pos:   position{line: 3828, col: 37, offset: 117331},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3816, col: 42, offset: 116797},
+								pos: position{line: 3828, col: 42, offset: 117336},
 								expr: &seqExpr{
-									pos: position{line: 3816, col: 43, offset: 116798},
+									pos: position{line: 3828, col: 43, offset: 117337},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3816, col: 44, offset: 116799},
+											pos: position{line: 3828, col: 44, offset: 117338},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3816, col: 44, offset: 116799},
+													pos:  position{line: 3828, col: 44, offset: 117338},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3816, col: 52, offset: 116807},
+													pos:  position{line: 3828, col: 52, offset: 117346},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3816, col: 59, offset: 116814},
+											pos:  position{line: 3828, col: 59, offset: 117353},
 											name: "Aggregator",
 										},
 									},
@@ -8698,28 +8698,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3833, col: 1, offset: 117317},
+			pos:  position{line: 3845, col: 1, offset: 117856},
 			expr: &actionExpr{
-				pos: position{line: 3833, col: 15, offset: 117331},
+				pos: position{line: 3845, col: 15, offset: 117870},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3833, col: 15, offset: 117331},
+					pos: position{line: 3845, col: 15, offset: 117870},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3833, col: 15, offset: 117331},
+							pos:   position{line: 3845, col: 15, offset: 117870},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3833, col: 23, offset: 117339},
+								pos:  position{line: 3845, col: 23, offset: 117878},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3833, col: 35, offset: 117351},
+							pos:   position{line: 3845, col: 35, offset: 117890},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3833, col: 43, offset: 117359},
+								pos: position{line: 3845, col: 43, offset: 117898},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3833, col: 43, offset: 117359},
+									pos:  position{line: 3845, col: 43, offset: 117898},
 									name: "AsField",
 								},
 							},
@@ -8730,26 +8730,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3849, col: 1, offset: 118200},
+			pos:  position{line: 3861, col: 1, offset: 118739},
 			expr: &actionExpr{
-				pos: position{line: 3849, col: 16, offset: 118215},
+				pos: position{line: 3861, col: 16, offset: 118754},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3849, col: 16, offset: 118215},
+					pos:   position{line: 3861, col: 16, offset: 118754},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3849, col: 21, offset: 118220},
+						pos: position{line: 3861, col: 21, offset: 118759},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3849, col: 21, offset: 118220},
+								pos:  position{line: 3861, col: 21, offset: 118759},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3849, col: 32, offset: 118231},
+								pos:  position{line: 3861, col: 32, offset: 118770},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3849, col: 48, offset: 118247},
+								pos:  position{line: 3861, col: 48, offset: 118786},
 								name: "AggCommon",
 							},
 						},
@@ -8759,165 +8759,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3854, col: 1, offset: 118453},
+			pos:  position{line: 3866, col: 1, offset: 118992},
 			expr: &actionExpr{
-				pos: position{line: 3854, col: 18, offset: 118470},
+				pos: position{line: 3866, col: 18, offset: 119009},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3854, col: 19, offset: 118471},
+					pos: position{line: 3866, col: 19, offset: 119010},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3854, col: 19, offset: 118471},
+							pos:        position{line: 3866, col: 19, offset: 119010},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 30, offset: 118482},
+							pos:        position{line: 3866, col: 30, offset: 119021},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 39, offset: 118491},
+							pos:        position{line: 3866, col: 39, offset: 119030},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 47, offset: 118499},
+							pos:        position{line: 3866, col: 47, offset: 119038},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 57, offset: 118509},
+							pos:        position{line: 3866, col: 57, offset: 119048},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 65, offset: 118517},
+							pos:        position{line: 3866, col: 65, offset: 119056},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 76, offset: 118528},
+							pos:        position{line: 3866, col: 76, offset: 119067},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 86, offset: 118538},
+							pos:        position{line: 3866, col: 86, offset: 119077},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 95, offset: 118547},
+							pos:        position{line: 3866, col: 95, offset: 119086},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 105, offset: 118557},
+							pos:        position{line: 3866, col: 105, offset: 119096},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 114, offset: 118566},
+							pos:        position{line: 3866, col: 114, offset: 119105},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 122, offset: 118574},
+							pos:        position{line: 3866, col: 122, offset: 119113},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 133, offset: 118585},
+							pos:        position{line: 3866, col: 133, offset: 119124},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3854, col: 142, offset: 118594},
+							pos:        position{line: 3866, col: 142, offset: 119133},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 1, offset: 118603},
+							pos:        position{line: 3867, col: 1, offset: 119142},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 10, offset: 118612},
+							pos:        position{line: 3867, col: 10, offset: 119151},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 26, offset: 118628},
+							pos:        position{line: 3867, col: 26, offset: 119167},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 37, offset: 118639},
+							pos:        position{line: 3867, col: 37, offset: 119178},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 46, offset: 118648},
+							pos:        position{line: 3867, col: 46, offset: 119187},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 56, offset: 118658},
+							pos:        position{line: 3867, col: 56, offset: 119197},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 72, offset: 118674},
+							pos:        position{line: 3867, col: 72, offset: 119213},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 82, offset: 118684},
+							pos:        position{line: 3867, col: 82, offset: 119223},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 100, offset: 118702},
+							pos:        position{line: 3867, col: 100, offset: 119241},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 113, offset: 118715},
+							pos:        position{line: 3867, col: 113, offset: 119254},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 132, offset: 118734},
+							pos:        position{line: 3867, col: 132, offset: 119273},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3855, col: 139, offset: 118741},
+							pos:        position{line: 3867, col: 139, offset: 119280},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -8928,27 +8928,27 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3859, col: 1, offset: 118784},
+			pos:  position{line: 3871, col: 1, offset: 119323},
 			expr: &actionExpr{
-				pos: position{line: 3859, col: 22, offset: 118805},
+				pos: position{line: 3871, col: 22, offset: 119344},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3859, col: 23, offset: 118806},
+					pos: position{line: 3871, col: 23, offset: 119345},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3859, col: 23, offset: 118806},
+							pos:        position{line: 3871, col: 23, offset: 119345},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3859, col: 37, offset: 118820},
+							pos:        position{line: 3871, col: 37, offset: 119359},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3859, col: 51, offset: 118834},
+							pos:        position{line: 3871, col: 51, offset: 119373},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
@@ -8959,29 +8959,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3863, col: 1, offset: 118878},
+			pos:  position{line: 3875, col: 1, offset: 119417},
 			expr: &actionExpr{
-				pos: position{line: 3863, col: 12, offset: 118889},
+				pos: position{line: 3875, col: 12, offset: 119428},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3863, col: 12, offset: 118889},
+					pos: position{line: 3875, col: 12, offset: 119428},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3863, col: 12, offset: 118889},
+							pos:  position{line: 3875, col: 12, offset: 119428},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3863, col: 15, offset: 118892},
+							pos:   position{line: 3875, col: 15, offset: 119431},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3863, col: 23, offset: 118900},
+								pos: position{line: 3875, col: 23, offset: 119439},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3863, col: 23, offset: 118900},
+										pos:  position{line: 3875, col: 23, offset: 119439},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3863, col: 35, offset: 118912},
+										pos:  position{line: 3875, col: 35, offset: 119451},
 										name: "String",
 									},
 								},
@@ -8993,27 +8993,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 3877, col: 1, offset: 119241},
+			pos:  position{line: 3889, col: 1, offset: 119780},
 			expr: &choiceExpr{
-				pos: position{line: 3877, col: 13, offset: 119253},
+				pos: position{line: 3889, col: 13, offset: 119792},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3877, col: 13, offset: 119253},
+						pos: position{line: 3889, col: 13, offset: 119792},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 3877, col: 13, offset: 119253},
+							pos: position{line: 3889, col: 13, offset: 119792},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3877, col: 14, offset: 119254},
+									pos: position{line: 3889, col: 14, offset: 119793},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3877, col: 14, offset: 119254},
+											pos:        position{line: 3889, col: 14, offset: 119793},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3877, col: 24, offset: 119264},
+											pos:        position{line: 3889, col: 24, offset: 119803},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9021,47 +9021,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3877, col: 29, offset: 119269},
+									pos:  position{line: 3889, col: 29, offset: 119808},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3877, col: 37, offset: 119277},
+									pos:        position{line: 3889, col: 37, offset: 119816},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3877, col: 44, offset: 119284},
+									pos:   position{line: 3889, col: 44, offset: 119823},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3877, col: 54, offset: 119294},
+										pos:  position{line: 3889, col: 54, offset: 119833},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3877, col: 64, offset: 119304},
+									pos:  position{line: 3889, col: 64, offset: 119843},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3887, col: 3, offset: 119532},
+						pos: position{line: 3899, col: 3, offset: 120071},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 3887, col: 3, offset: 119532},
+							pos: position{line: 3899, col: 3, offset: 120071},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 3887, col: 4, offset: 119533},
+									pos: position{line: 3899, col: 4, offset: 120072},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 3887, col: 4, offset: 119533},
+											pos:        position{line: 3899, col: 4, offset: 120072},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 3887, col: 14, offset: 119543},
+											pos:        position{line: 3899, col: 14, offset: 120082},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9069,38 +9069,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3887, col: 19, offset: 119548},
+									pos:  position{line: 3899, col: 19, offset: 120087},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3887, col: 27, offset: 119556},
+									pos:   position{line: 3899, col: 27, offset: 120095},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3887, col: 33, offset: 119562},
+										pos:  position{line: 3899, col: 33, offset: 120101},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3887, col: 43, offset: 119572},
+									pos:  position{line: 3899, col: 43, offset: 120111},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3894, col: 5, offset: 119723},
+						pos: position{line: 3906, col: 5, offset: 120262},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 3894, col: 6, offset: 119724},
+							pos: position{line: 3906, col: 6, offset: 120263},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 3894, col: 6, offset: 119724},
+									pos:        position{line: 3906, col: 6, offset: 120263},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 3894, col: 16, offset: 119734},
+									pos:        position{line: 3906, col: 16, offset: 120273},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9113,77 +9113,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 3903, col: 1, offset: 119870},
+			pos:  position{line: 3915, col: 1, offset: 120409},
 			expr: &choiceExpr{
-				pos: position{line: 3903, col: 14, offset: 119883},
+				pos: position{line: 3915, col: 14, offset: 120422},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3903, col: 14, offset: 119883},
+						pos: position{line: 3915, col: 14, offset: 120422},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3903, col: 14, offset: 119883},
+							pos: position{line: 3915, col: 14, offset: 120422},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3903, col: 14, offset: 119883},
+									pos:   position{line: 3915, col: 14, offset: 120422},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3903, col: 22, offset: 119891},
+										pos:  position{line: 3915, col: 22, offset: 120430},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3903, col: 36, offset: 119905},
+									pos:  position{line: 3915, col: 36, offset: 120444},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3903, col: 44, offset: 119913},
+									pos:        position{line: 3915, col: 44, offset: 120452},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3903, col: 51, offset: 119920},
+									pos:   position{line: 3915, col: 51, offset: 120459},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3903, col: 61, offset: 119930},
+										pos:  position{line: 3915, col: 61, offset: 120469},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3903, col: 71, offset: 119940},
+									pos:  position{line: 3915, col: 71, offset: 120479},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3918, col: 3, offset: 120350},
+						pos: position{line: 3930, col: 3, offset: 120889},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 3918, col: 3, offset: 120350},
+							pos: position{line: 3930, col: 3, offset: 120889},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3918, col: 3, offset: 120350},
+									pos:   position{line: 3930, col: 3, offset: 120889},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3918, col: 11, offset: 120358},
+										pos:  position{line: 3930, col: 11, offset: 120897},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3918, col: 25, offset: 120372},
+									pos:  position{line: 3930, col: 25, offset: 120911},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3918, col: 33, offset: 120380},
+									pos:   position{line: 3930, col: 33, offset: 120919},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3918, col: 39, offset: 120386},
+										pos:  position{line: 3930, col: 39, offset: 120925},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3918, col: 49, offset: 120396},
+									pos:  position{line: 3930, col: 49, offset: 120935},
 									name: "R_PAREN",
 								},
 							},
@@ -9194,22 +9194,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileStr",
-			pos:  position{line: 3932, col: 1, offset: 120728},
+			pos:  position{line: 3944, col: 1, offset: 121267},
 			expr: &actionExpr{
-				pos: position{line: 3932, col: 18, offset: 120745},
+				pos: position{line: 3944, col: 18, offset: 121284},
 				run: (*parser).callonPercentileStr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3932, col: 18, offset: 120745},
+					pos:   position{line: 3944, col: 18, offset: 121284},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 3932, col: 26, offset: 120753},
+						pos: position{line: 3944, col: 26, offset: 121292},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3932, col: 26, offset: 120753},
+								pos:  position{line: 3944, col: 26, offset: 121292},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3932, col: 42, offset: 120769},
+								pos:  position{line: 3944, col: 42, offset: 121308},
 								name: "IntegerAsString",
 							},
 						},
@@ -9219,93 +9219,93 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 3944, col: 1, offset: 121143},
+			pos:  position{line: 3956, col: 1, offset: 121682},
 			expr: &choiceExpr{
-				pos: position{line: 3944, col: 18, offset: 121160},
+				pos: position{line: 3956, col: 18, offset: 121699},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3944, col: 18, offset: 121160},
+						pos: position{line: 3956, col: 18, offset: 121699},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 3944, col: 18, offset: 121160},
+							pos: position{line: 3956, col: 18, offset: 121699},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3944, col: 18, offset: 121160},
+									pos:   position{line: 3956, col: 18, offset: 121699},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3944, col: 26, offset: 121168},
+										pos:  position{line: 3956, col: 26, offset: 121707},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3944, col: 44, offset: 121186},
+									pos:   position{line: 3956, col: 44, offset: 121725},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3944, col: 58, offset: 121200},
+										pos:  position{line: 3956, col: 58, offset: 121739},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3944, col: 72, offset: 121214},
+									pos:  position{line: 3956, col: 72, offset: 121753},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 3944, col: 80, offset: 121222},
+									pos:        position{line: 3956, col: 80, offset: 121761},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3944, col: 87, offset: 121229},
+									pos:   position{line: 3956, col: 87, offset: 121768},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3944, col: 97, offset: 121239},
+										pos:  position{line: 3956, col: 97, offset: 121778},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3944, col: 107, offset: 121249},
+									pos:  position{line: 3956, col: 107, offset: 121788},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3960, col: 3, offset: 121698},
+						pos: position{line: 3972, col: 3, offset: 122237},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 3960, col: 3, offset: 121698},
+							pos: position{line: 3972, col: 3, offset: 122237},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3960, col: 3, offset: 121698},
+									pos:   position{line: 3972, col: 3, offset: 122237},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3960, col: 11, offset: 121706},
+										pos:  position{line: 3972, col: 11, offset: 122245},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3960, col: 29, offset: 121724},
+									pos:   position{line: 3972, col: 29, offset: 122263},
 									label: "percentileStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3960, col: 43, offset: 121738},
+										pos:  position{line: 3972, col: 43, offset: 122277},
 										name: "PercentileStr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3960, col: 57, offset: 121752},
+									pos:  position{line: 3972, col: 57, offset: 122291},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3960, col: 65, offset: 121760},
+									pos:   position{line: 3972, col: 65, offset: 122299},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3960, col: 71, offset: 121766},
+										pos:  position{line: 3972, col: 71, offset: 122305},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3960, col: 81, offset: 121776},
+									pos:  position{line: 3972, col: 81, offset: 122315},
 									name: "R_PAREN",
 								},
 							},
@@ -9316,22 +9316,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 3976, col: 1, offset: 122148},
+			pos:  position{line: 3988, col: 1, offset: 122687},
 			expr: &actionExpr{
-				pos: position{line: 3976, col: 25, offset: 122172},
+				pos: position{line: 3988, col: 25, offset: 122711},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3976, col: 25, offset: 122172},
+					pos:   position{line: 3988, col: 25, offset: 122711},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 3976, col: 39, offset: 122186},
+						pos: position{line: 3988, col: 39, offset: 122725},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3976, col: 39, offset: 122186},
+								pos:  position{line: 3988, col: 39, offset: 122725},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3976, col: 67, offset: 122214},
+								pos:  position{line: 3988, col: 67, offset: 122753},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9341,43 +9341,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 3980, col: 1, offset: 122277},
+			pos:  position{line: 3992, col: 1, offset: 122816},
 			expr: &actionExpr{
-				pos: position{line: 3980, col: 30, offset: 122306},
+				pos: position{line: 3992, col: 30, offset: 122845},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 3980, col: 30, offset: 122306},
+					pos: position{line: 3992, col: 30, offset: 122845},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3980, col: 30, offset: 122306},
+							pos:   position{line: 3992, col: 30, offset: 122845},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3980, col: 34, offset: 122310},
+								pos:  position{line: 3992, col: 34, offset: 122849},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3980, col: 44, offset: 122320},
+							pos:   position{line: 3992, col: 44, offset: 122859},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 3980, col: 48, offset: 122324},
+								pos: position{line: 3992, col: 48, offset: 122863},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3980, col: 48, offset: 122324},
+										pos:  position{line: 3992, col: 48, offset: 122863},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3980, col: 67, offset: 122343},
+										pos:  position{line: 3992, col: 67, offset: 122882},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3980, col: 87, offset: 122363},
+							pos:   position{line: 3992, col: 87, offset: 122902},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3980, col: 93, offset: 122369},
+								pos:  position{line: 3992, col: 93, offset: 122908},
 								name: "Number",
 							},
 						},
@@ -9387,15 +9387,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 3993, col: 1, offset: 122603},
+			pos:  position{line: 4005, col: 1, offset: 123142},
 			expr: &actionExpr{
-				pos: position{line: 3993, col: 32, offset: 122634},
+				pos: position{line: 4005, col: 32, offset: 123173},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3993, col: 32, offset: 122634},
+					pos:   position{line: 4005, col: 32, offset: 123173},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3993, col: 38, offset: 122640},
+						pos:  position{line: 4005, col: 38, offset: 123179},
 						name: "Number",
 					},
 				},
@@ -9403,34 +9403,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4006, col: 1, offset: 122857},
+			pos:  position{line: 4018, col: 1, offset: 123396},
 			expr: &actionExpr{
-				pos: position{line: 4006, col: 26, offset: 122882},
+				pos: position{line: 4018, col: 26, offset: 123421},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4006, col: 26, offset: 122882},
+					pos: position{line: 4018, col: 26, offset: 123421},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4006, col: 26, offset: 122882},
+							pos:   position{line: 4018, col: 26, offset: 123421},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4006, col: 30, offset: 122886},
+								pos:  position{line: 4018, col: 30, offset: 123425},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4006, col: 40, offset: 122896},
+							pos:   position{line: 4018, col: 40, offset: 123435},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4006, col: 43, offset: 122899},
+								pos:  position{line: 4018, col: 43, offset: 123438},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4006, col: 60, offset: 122916},
+							pos:   position{line: 4018, col: 60, offset: 123455},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4006, col: 66, offset: 122922},
+								pos:  position{line: 4018, col: 66, offset: 123461},
 								name: "Boolean",
 							},
 						},
@@ -9440,22 +9440,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4019, col: 1, offset: 123157},
+			pos:  position{line: 4031, col: 1, offset: 123696},
 			expr: &actionExpr{
-				pos: position{line: 4019, col: 25, offset: 123181},
+				pos: position{line: 4031, col: 25, offset: 123720},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4019, col: 25, offset: 123181},
+					pos:   position{line: 4031, col: 25, offset: 123720},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4019, col: 39, offset: 123195},
+						pos: position{line: 4031, col: 39, offset: 123734},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4019, col: 39, offset: 123195},
+								pos:  position{line: 4031, col: 39, offset: 123734},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4019, col: 67, offset: 123223},
+								pos:  position{line: 4031, col: 67, offset: 123762},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9465,41 +9465,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4023, col: 1, offset: 123286},
+			pos:  position{line: 4035, col: 1, offset: 123825},
 			expr: &actionExpr{
-				pos: position{line: 4023, col: 30, offset: 123315},
+				pos: position{line: 4035, col: 30, offset: 123854},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4023, col: 30, offset: 123315},
+					pos: position{line: 4035, col: 30, offset: 123854},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4023, col: 30, offset: 123315},
+							pos:   position{line: 4035, col: 30, offset: 123854},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4023, col: 34, offset: 123319},
+								pos:  position{line: 4035, col: 34, offset: 123858},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4023, col: 44, offset: 123329},
+							pos:   position{line: 4035, col: 44, offset: 123868},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4023, col: 47, offset: 123332},
+								pos:  position{line: 4035, col: 47, offset: 123871},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4023, col: 64, offset: 123349},
+							pos:   position{line: 4035, col: 64, offset: 123888},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4023, col: 81, offset: 123366},
+								pos: position{line: 4035, col: 81, offset: 123905},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4023, col: 81, offset: 123366},
+										pos:  position{line: 4035, col: 81, offset: 123905},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4023, col: 103, offset: 123388},
+										pos:  position{line: 4035, col: 103, offset: 123927},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9511,22 +9511,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4038, col: 1, offset: 123788},
+			pos:  position{line: 4050, col: 1, offset: 124327},
 			expr: &actionExpr{
-				pos: position{line: 4038, col: 32, offset: 123819},
+				pos: position{line: 4050, col: 32, offset: 124358},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4038, col: 32, offset: 123819},
+					pos:   position{line: 4050, col: 32, offset: 124358},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4038, col: 49, offset: 123836},
+						pos: position{line: 4050, col: 49, offset: 124375},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4038, col: 49, offset: 123836},
+								pos:  position{line: 4050, col: 49, offset: 124375},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4038, col: 71, offset: 123858},
+								pos:  position{line: 4050, col: 71, offset: 124397},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9536,33 +9536,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4053, col: 1, offset: 124241},
+			pos:  position{line: 4065, col: 1, offset: 124780},
 			expr: &actionExpr{
-				pos: position{line: 4053, col: 24, offset: 124264},
+				pos: position{line: 4065, col: 24, offset: 124803},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4053, col: 24, offset: 124264},
+					pos: position{line: 4065, col: 24, offset: 124803},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4053, col: 24, offset: 124264},
+							pos:        position{line: 4065, col: 24, offset: 124803},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4053, col: 31, offset: 124271},
+							pos:  position{line: 4065, col: 31, offset: 124810},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4053, col: 39, offset: 124279},
+							pos:   position{line: 4065, col: 39, offset: 124818},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4053, col: 45, offset: 124285},
+								pos:  position{line: 4065, col: 45, offset: 124824},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4053, col: 52, offset: 124292},
+							pos:  position{line: 4065, col: 52, offset: 124831},
 							name: "R_PAREN",
 						},
 					},
@@ -9571,15 +9571,15 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4061, col: 1, offset: 124433},
+			pos:  position{line: 4073, col: 1, offset: 124972},
 			expr: &actionExpr{
-				pos: position{line: 4061, col: 26, offset: 124458},
+				pos: position{line: 4073, col: 26, offset: 124997},
 				run: (*parser).callonCaseInsensitiveString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4061, col: 26, offset: 124458},
+					pos:   position{line: 4073, col: 26, offset: 124997},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4061, col: 32, offset: 124464},
+						pos:  position{line: 4073, col: 32, offset: 125003},
 						name: "String",
 					},
 				},
@@ -9587,35 +9587,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4071, col: 1, offset: 124744},
+			pos:  position{line: 4083, col: 1, offset: 125283},
 			expr: &actionExpr{
-				pos: position{line: 4071, col: 18, offset: 124761},
+				pos: position{line: 4083, col: 18, offset: 125300},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4071, col: 18, offset: 124761},
+					pos: position{line: 4083, col: 18, offset: 125300},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4071, col: 18, offset: 124761},
+							pos:   position{line: 4083, col: 18, offset: 125300},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4071, col: 24, offset: 124767},
+								pos:  position{line: 4083, col: 24, offset: 125306},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4071, col: 34, offset: 124777},
+							pos:   position{line: 4083, col: 34, offset: 125316},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4071, col: 39, offset: 124782},
+								pos: position{line: 4083, col: 39, offset: 125321},
 								expr: &seqExpr{
-									pos: position{line: 4071, col: 40, offset: 124783},
+									pos: position{line: 4083, col: 40, offset: 125322},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4071, col: 40, offset: 124783},
+											pos:  position{line: 4083, col: 40, offset: 125322},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4071, col: 46, offset: 124789},
+											pos:  position{line: 4083, col: 46, offset: 125328},
 											name: "FieldName",
 										},
 									},
@@ -9628,16 +9628,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4088, col: 1, offset: 125284},
+			pos:  position{line: 4100, col: 1, offset: 125823},
 			expr: &choiceExpr{
-				pos: position{line: 4088, col: 18, offset: 125301},
+				pos: position{line: 4100, col: 18, offset: 125840},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4088, col: 18, offset: 125301},
+						pos:  position{line: 4100, col: 18, offset: 125840},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4088, col: 38, offset: 125321},
+						pos:  position{line: 4100, col: 38, offset: 125860},
 						name: "EarliestOnly",
 					},
 				},
@@ -9645,62 +9645,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4090, col: 1, offset: 125335},
+			pos:  position{line: 4102, col: 1, offset: 125874},
 			expr: &actionExpr{
-				pos: position{line: 4090, col: 22, offset: 125356},
+				pos: position{line: 4102, col: 22, offset: 125895},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4090, col: 22, offset: 125356},
+					pos: position{line: 4102, col: 22, offset: 125895},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 22, offset: 125356},
+							pos:  position{line: 4102, col: 22, offset: 125895},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 35, offset: 125369},
+							pos:  position{line: 4102, col: 35, offset: 125908},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4090, col: 41, offset: 125375},
+							pos:   position{line: 4102, col: 41, offset: 125914},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4090, col: 55, offset: 125389},
+								pos: position{line: 4102, col: 55, offset: 125928},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 55, offset: 125389},
+										pos:  position{line: 4102, col: 55, offset: 125928},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 75, offset: 125409},
+										pos:  position{line: 4102, col: 75, offset: 125948},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 94, offset: 125428},
+							pos:  position{line: 4102, col: 94, offset: 125967},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 100, offset: 125434},
+							pos:  position{line: 4102, col: 100, offset: 125973},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4090, col: 111, offset: 125445},
+							pos:  position{line: 4102, col: 111, offset: 125984},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4090, col: 117, offset: 125451},
+							pos:   position{line: 4102, col: 117, offset: 125990},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4090, col: 129, offset: 125463},
+								pos: position{line: 4102, col: 129, offset: 126002},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 129, offset: 125463},
+										pos:  position{line: 4102, col: 129, offset: 126002},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4090, col: 149, offset: 125483},
+										pos:  position{line: 4102, col: 149, offset: 126022},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9712,33 +9712,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4131, col: 1, offset: 126622},
+			pos:  position{line: 4143, col: 1, offset: 127161},
 			expr: &actionExpr{
-				pos: position{line: 4131, col: 17, offset: 126638},
+				pos: position{line: 4143, col: 17, offset: 127177},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4131, col: 17, offset: 126638},
+					pos: position{line: 4143, col: 17, offset: 127177},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4131, col: 17, offset: 126638},
+							pos:  position{line: 4143, col: 17, offset: 127177},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4131, col: 30, offset: 126651},
+							pos:  position{line: 4143, col: 30, offset: 127190},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4131, col: 36, offset: 126657},
+							pos:   position{line: 4143, col: 36, offset: 127196},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4131, col: 50, offset: 126671},
+								pos: position{line: 4143, col: 50, offset: 127210},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4131, col: 50, offset: 126671},
+										pos:  position{line: 4143, col: 50, offset: 127210},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4131, col: 70, offset: 126691},
+										pos:  position{line: 4143, col: 70, offset: 127230},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9750,24 +9750,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4159, col: 1, offset: 127399},
+			pos:  position{line: 4171, col: 1, offset: 127938},
 			expr: &actionExpr{
-				pos: position{line: 4159, col: 23, offset: 127421},
+				pos: position{line: 4171, col: 23, offset: 127960},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4159, col: 23, offset: 127421},
+					pos: position{line: 4171, col: 23, offset: 127960},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4159, col: 23, offset: 127421},
+							pos:        position{line: 4171, col: 23, offset: 127960},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4159, col: 27, offset: 127425},
+							pos: position{line: 4171, col: 27, offset: 127964},
 							expr: &charClassMatcher{
-								pos:        position{line: 4159, col: 27, offset: 127425},
+								pos:        position{line: 4171, col: 27, offset: 127964},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9780,21 +9780,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4163, col: 1, offset: 127468},
+			pos:  position{line: 4175, col: 1, offset: 128007},
 			expr: &actionExpr{
-				pos: position{line: 4163, col: 13, offset: 127480},
+				pos: position{line: 4175, col: 13, offset: 128019},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4163, col: 14, offset: 127481},
+					pos: position{line: 4175, col: 14, offset: 128020},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4163, col: 14, offset: 127481},
+							pos:        position{line: 4175, col: 14, offset: 128020},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4163, col: 17, offset: 127484},
+							pos:        position{line: 4175, col: 17, offset: 128023},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9806,15 +9806,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4167, col: 1, offset: 127527},
+			pos:  position{line: 4179, col: 1, offset: 128066},
 			expr: &actionExpr{
-				pos: position{line: 4167, col: 16, offset: 127542},
+				pos: position{line: 4179, col: 16, offset: 128081},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4167, col: 16, offset: 127542},
+					pos:   position{line: 4179, col: 16, offset: 128081},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4167, col: 26, offset: 127552},
+						pos:  position{line: 4179, col: 26, offset: 128091},
 						name: "AllTimeScale",
 					},
 				},
@@ -9822,31 +9822,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4174, col: 1, offset: 127776},
+			pos:  position{line: 4186, col: 1, offset: 128315},
 			expr: &actionExpr{
-				pos: position{line: 4174, col: 9, offset: 127784},
+				pos: position{line: 4186, col: 9, offset: 128323},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4174, col: 9, offset: 127784},
+					pos: position{line: 4186, col: 9, offset: 128323},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4174, col: 9, offset: 127784},
+							pos:        position{line: 4186, col: 9, offset: 128323},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4174, col: 13, offset: 127788},
+							pos:   position{line: 4186, col: 13, offset: 128327},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4174, col: 19, offset: 127794},
+								pos: position{line: 4186, col: 19, offset: 128333},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4174, col: 19, offset: 127794},
+										pos:  position{line: 4186, col: 19, offset: 128333},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4174, col: 30, offset: 127805},
+										pos:  position{line: 4186, col: 30, offset: 128344},
 										name: "RelTimeUnit",
 									},
 								},
@@ -9858,26 +9858,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4178, col: 1, offset: 127853},
+			pos:  position{line: 4190, col: 1, offset: 128392},
 			expr: &actionExpr{
-				pos: position{line: 4178, col: 11, offset: 127863},
+				pos: position{line: 4190, col: 11, offset: 128402},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4178, col: 11, offset: 127863},
+					pos: position{line: 4190, col: 11, offset: 128402},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4178, col: 11, offset: 127863},
+							pos:   position{line: 4190, col: 11, offset: 128402},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4178, col: 16, offset: 127868},
+								pos:  position{line: 4190, col: 16, offset: 128407},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4178, col: 36, offset: 127888},
+							pos:   position{line: 4190, col: 36, offset: 128427},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4178, col: 43, offset: 127895},
+								pos:  position{line: 4190, col: 43, offset: 128434},
 								name: "RelTimeUnit",
 							},
 						},
@@ -9887,44 +9887,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4206, col: 1, offset: 128633},
+			pos:  position{line: 4218, col: 1, offset: 129172},
 			expr: &actionExpr{
-				pos: position{line: 4206, col: 29, offset: 128661},
+				pos: position{line: 4218, col: 29, offset: 129200},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4206, col: 29, offset: 128661},
+					pos: position{line: 4218, col: 29, offset: 129200},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4206, col: 29, offset: 128661},
+							pos:   position{line: 4218, col: 29, offset: 129200},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4206, col: 36, offset: 128668},
+								pos: position{line: 4218, col: 36, offset: 129207},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 36, offset: 128668},
+										pos:  position{line: 4218, col: 36, offset: 129207},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4206, col: 45, offset: 128677},
+										pos:  position{line: 4218, col: 45, offset: 129216},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4206, col: 51, offset: 128683},
+							pos:   position{line: 4218, col: 51, offset: 129222},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4206, col: 57, offset: 128689},
+								pos: position{line: 4218, col: 57, offset: 129228},
 								expr: &choiceExpr{
-									pos: position{line: 4206, col: 58, offset: 128690},
+									pos: position{line: 4218, col: 58, offset: 129229},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4206, col: 58, offset: 128690},
+											pos:  position{line: 4218, col: 58, offset: 129229},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4206, col: 67, offset: 128699},
+											pos:  position{line: 4218, col: 67, offset: 129238},
 											name: "Snap",
 										},
 									},
@@ -9937,29 +9937,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4253, col: 1, offset: 130131},
+			pos:  position{line: 4265, col: 1, offset: 130670},
 			expr: &actionExpr{
-				pos: position{line: 4253, col: 22, offset: 130152},
+				pos: position{line: 4265, col: 22, offset: 130691},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4253, col: 22, offset: 130152},
+					pos: position{line: 4265, col: 22, offset: 130691},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4253, col: 22, offset: 130152},
+							pos:   position{line: 4265, col: 22, offset: 130691},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4253, col: 34, offset: 130164},
+								pos: position{line: 4265, col: 34, offset: 130703},
 								expr: &choiceExpr{
-									pos: position{line: 4253, col: 35, offset: 130165},
+									pos: position{line: 4265, col: 35, offset: 130704},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4253, col: 35, offset: 130165},
+											pos:        position{line: 4265, col: 35, offset: 130704},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4253, col: 43, offset: 130173},
+											pos:        position{line: 4265, col: 43, offset: 130712},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -9969,12 +9969,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4253, col: 49, offset: 130179},
+							pos:   position{line: 4265, col: 49, offset: 130718},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4253, col: 57, offset: 130187},
+								pos: position{line: 4265, col: 57, offset: 130726},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4253, col: 58, offset: 130188},
+									pos:  position{line: 4265, col: 58, offset: 130727},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -9985,31 +9985,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4278, col: 1, offset: 130871},
+			pos:  position{line: 4290, col: 1, offset: 131410},
 			expr: &actionExpr{
-				pos: position{line: 4278, col: 39, offset: 130909},
+				pos: position{line: 4290, col: 39, offset: 131448},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4278, col: 39, offset: 130909},
+					pos: position{line: 4290, col: 39, offset: 131448},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4278, col: 39, offset: 130909},
+							pos:   position{line: 4290, col: 39, offset: 131448},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4278, col: 46, offset: 130916},
+								pos: position{line: 4290, col: 46, offset: 131455},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4278, col: 47, offset: 130917},
+									pos:  position{line: 4290, col: 47, offset: 131456},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4278, col: 56, offset: 130926},
+							pos:   position{line: 4290, col: 56, offset: 131465},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4278, col: 66, offset: 130936},
+								pos: position{line: 4290, col: 66, offset: 131475},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4278, col: 67, offset: 130937},
+									pos:  position{line: 4290, col: 67, offset: 131476},
 									name: "Snap",
 								},
 							},
@@ -10020,136 +10020,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4305, col: 1, offset: 131565},
+			pos:  position{line: 4317, col: 1, offset: 132104},
 			expr: &actionExpr{
-				pos: position{line: 4305, col: 18, offset: 131582},
+				pos: position{line: 4317, col: 18, offset: 132121},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4305, col: 18, offset: 131582},
+					pos: position{line: 4317, col: 18, offset: 132121},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 18, offset: 131582},
+							pos:        position{line: 4317, col: 18, offset: 132121},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 23, offset: 131587},
+							pos:        position{line: 4317, col: 23, offset: 132126},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 29, offset: 131593},
+							pos:        position{line: 4317, col: 29, offset: 132132},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 33, offset: 131597},
+							pos:        position{line: 4317, col: 33, offset: 132136},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 38, offset: 131602},
+							pos:        position{line: 4317, col: 38, offset: 132141},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 44, offset: 131608},
+							pos:        position{line: 4317, col: 44, offset: 132147},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 48, offset: 131612},
+							pos:        position{line: 4317, col: 48, offset: 132151},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 53, offset: 131617},
+							pos:        position{line: 4317, col: 53, offset: 132156},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 58, offset: 131622},
+							pos:        position{line: 4317, col: 58, offset: 132161},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 63, offset: 131627},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4305, col: 69, offset: 131633},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4305, col: 73, offset: 131637},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4305, col: 78, offset: 131642},
+							pos:        position{line: 4317, col: 63, offset: 132166},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 84, offset: 131648},
+							pos:        position{line: 4317, col: 69, offset: 132172},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 88, offset: 131652},
+							pos:        position{line: 4317, col: 73, offset: 132176},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 93, offset: 131657},
+							pos:        position{line: 4317, col: 78, offset: 132181},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4305, col: 99, offset: 131663},
+							pos:        position{line: 4317, col: 84, offset: 132187},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 103, offset: 131667},
+							pos:        position{line: 4317, col: 88, offset: 132191},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4305, col: 108, offset: 131672},
+							pos:        position{line: 4317, col: 93, offset: 132196},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4317, col: 99, offset: 132202},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4317, col: 103, offset: 132206},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4317, col: 108, offset: 132211},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10161,15 +10161,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4309, col: 1, offset: 131714},
+			pos:  position{line: 4321, col: 1, offset: 132253},
 			expr: &actionExpr{
-				pos: position{line: 4309, col: 22, offset: 131735},
+				pos: position{line: 4321, col: 22, offset: 132274},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4309, col: 22, offset: 131735},
+					pos:   position{line: 4321, col: 22, offset: 132274},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4309, col: 32, offset: 131745},
+						pos:  position{line: 4321, col: 32, offset: 132284},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10177,15 +10177,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4319, col: 1, offset: 132153},
+			pos:  position{line: 4331, col: 1, offset: 132692},
 			expr: &actionExpr{
-				pos: position{line: 4319, col: 14, offset: 132166},
+				pos: position{line: 4331, col: 14, offset: 132705},
 				run: (*parser).callonFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 4319, col: 14, offset: 132166},
+					pos: position{line: 4331, col: 14, offset: 132705},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4319, col: 14, offset: 132166},
+							pos:        position{line: 4331, col: 14, offset: 132705},
 							val:        "[a-zA-Z0-9:*]",
 							chars:      []rune{':', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10193,9 +10193,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4319, col: 27, offset: 132179},
+							pos: position{line: 4331, col: 27, offset: 132718},
 							expr: &charClassMatcher{
-								pos:        position{line: 4319, col: 27, offset: 132179},
+								pos:        position{line: 4331, col: 27, offset: 132718},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10209,15 +10209,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4323, col: 1, offset: 132232},
+			pos:  position{line: 4335, col: 1, offset: 132771},
 			expr: &actionExpr{
-				pos: position{line: 4323, col: 24, offset: 132255},
+				pos: position{line: 4335, col: 24, offset: 132794},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4323, col: 24, offset: 132255},
+					pos: position{line: 4335, col: 24, offset: 132794},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4323, col: 24, offset: 132255},
+							pos:        position{line: 4335, col: 24, offset: 132794},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10225,9 +10225,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4323, col: 39, offset: 132270},
+							pos: position{line: 4335, col: 39, offset: 132809},
 							expr: &charClassMatcher{
-								pos:        position{line: 4323, col: 39, offset: 132270},
+								pos:        position{line: 4335, col: 39, offset: 132809},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10241,22 +10241,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4327, col: 1, offset: 132323},
+			pos:  position{line: 4339, col: 1, offset: 132862},
 			expr: &actionExpr{
-				pos: position{line: 4327, col: 11, offset: 132333},
+				pos: position{line: 4339, col: 11, offset: 132872},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4327, col: 11, offset: 132333},
+					pos:   position{line: 4339, col: 11, offset: 132872},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4327, col: 16, offset: 132338},
+						pos: position{line: 4339, col: 16, offset: 132877},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4327, col: 16, offset: 132338},
+								pos:  position{line: 4339, col: 16, offset: 132877},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4327, col: 31, offset: 132353},
+								pos:  position{line: 4339, col: 31, offset: 132892},
 								name: "UnquotedString",
 							},
 						},
@@ -10266,23 +10266,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4331, col: 1, offset: 132394},
+			pos:  position{line: 4343, col: 1, offset: 132933},
 			expr: &actionExpr{
-				pos: position{line: 4331, col: 17, offset: 132410},
+				pos: position{line: 4343, col: 17, offset: 132949},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4331, col: 17, offset: 132410},
+					pos: position{line: 4343, col: 17, offset: 132949},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4331, col: 17, offset: 132410},
+							pos:        position{line: 4343, col: 17, offset: 132949},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4331, col: 21, offset: 132414},
+							pos: position{line: 4343, col: 21, offset: 132953},
 							expr: &charClassMatcher{
-								pos:        position{line: 4331, col: 21, offset: 132414},
+								pos:        position{line: 4343, col: 21, offset: 132953},
 								val:        "[^\"]",
 								chars:      []rune{'"'},
 								ignoreCase: false,
@@ -10290,7 +10290,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4331, col: 27, offset: 132420},
+							pos:        position{line: 4343, col: 27, offset: 132959},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10301,48 +10301,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4336, col: 1, offset: 132531},
+			pos:  position{line: 4348, col: 1, offset: 133070},
 			expr: &actionExpr{
-				pos: position{line: 4336, col: 19, offset: 132549},
+				pos: position{line: 4348, col: 19, offset: 133088},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4336, col: 19, offset: 132549},
+					pos: position{line: 4348, col: 19, offset: 133088},
 					expr: &choiceExpr{
-						pos: position{line: 4336, col: 20, offset: 132550},
+						pos: position{line: 4348, col: 20, offset: 133089},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4336, col: 20, offset: 132550},
+								pos:        position{line: 4348, col: 20, offset: 133089},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4336, col: 27, offset: 132557},
+								pos: position{line: 4348, col: 27, offset: 133096},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4336, col: 27, offset: 132557},
+										pos: position{line: 4348, col: 27, offset: 133096},
 										expr: &choiceExpr{
-											pos: position{line: 4336, col: 29, offset: 132559},
+											pos: position{line: 4348, col: 29, offset: 133098},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4336, col: 29, offset: 132559},
+													pos:  position{line: 4348, col: 29, offset: 133098},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4336, col: 43, offset: 132573},
+													pos:        position{line: 4348, col: 43, offset: 133112},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4336, col: 49, offset: 132579},
+													pos:  position{line: 4348, col: 49, offset: 133118},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4336, col: 54, offset: 132584,
+										line: 4348, col: 54, offset: 133123,
 									},
 								},
 							},
@@ -10353,12 +10353,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4343, col: 1, offset: 132699},
+			pos:  position{line: 4355, col: 1, offset: 133238},
 			expr: &choiceExpr{
-				pos: position{line: 4343, col: 16, offset: 132714},
+				pos: position{line: 4355, col: 16, offset: 133253},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4343, col: 16, offset: 132714},
+						pos:        position{line: 4355, col: 16, offset: 133253},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10366,18 +10366,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4343, col: 37, offset: 132735},
+						pos: position{line: 4355, col: 37, offset: 133274},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4343, col: 37, offset: 132735},
+								pos:        position{line: 4355, col: 37, offset: 133274},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4343, col: 41, offset: 132739},
+								pos: position{line: 4355, col: 41, offset: 133278},
 								expr: &charClassMatcher{
-									pos:        position{line: 4343, col: 41, offset: 132739},
+									pos:        position{line: 4355, col: 41, offset: 133278},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10385,7 +10385,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4343, col: 48, offset: 132746},
+								pos:        position{line: 4355, col: 48, offset: 133285},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10397,46 +10397,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4345, col: 1, offset: 132752},
+			pos:  position{line: 4357, col: 1, offset: 133291},
 			expr: &actionExpr{
-				pos: position{line: 4345, col: 39, offset: 132790},
+				pos: position{line: 4357, col: 39, offset: 133329},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4345, col: 39, offset: 132790},
+					pos: position{line: 4357, col: 39, offset: 133329},
 					expr: &choiceExpr{
-						pos: position{line: 4345, col: 40, offset: 132791},
+						pos: position{line: 4357, col: 40, offset: 133330},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4345, col: 40, offset: 132791},
+								pos:  position{line: 4357, col: 40, offset: 133330},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4345, col: 54, offset: 132805},
+								pos: position{line: 4357, col: 54, offset: 133344},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4345, col: 54, offset: 132805},
+										pos: position{line: 4357, col: 54, offset: 133344},
 										expr: &choiceExpr{
-											pos: position{line: 4345, col: 56, offset: 132807},
+											pos: position{line: 4357, col: 56, offset: 133346},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4345, col: 56, offset: 132807},
+													pos:  position{line: 4357, col: 56, offset: 133346},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4345, col: 70, offset: 132821},
+													pos:        position{line: 4357, col: 70, offset: 133360},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4345, col: 76, offset: 132827},
+													pos:  position{line: 4357, col: 76, offset: 133366},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4345, col: 81, offset: 132832,
+										line: 4357, col: 81, offset: 133371,
 									},
 								},
 							},
@@ -10447,21 +10447,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4349, col: 1, offset: 132872},
+			pos:  position{line: 4361, col: 1, offset: 133411},
 			expr: &actionExpr{
-				pos: position{line: 4349, col: 12, offset: 132883},
+				pos: position{line: 4361, col: 12, offset: 133422},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4349, col: 13, offset: 132884},
+					pos: position{line: 4361, col: 13, offset: 133423},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4349, col: 13, offset: 132884},
+							pos:        position{line: 4361, col: 13, offset: 133423},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4349, col: 22, offset: 132893},
+							pos:        position{line: 4361, col: 22, offset: 133432},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10472,14 +10472,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4355, col: 1, offset: 133047},
+			pos:  position{line: 4367, col: 1, offset: 133586},
 			expr: &actionExpr{
-				pos: position{line: 4355, col: 18, offset: 133064},
+				pos: position{line: 4367, col: 18, offset: 133603},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4355, col: 18, offset: 133064},
+					pos: position{line: 4367, col: 18, offset: 133603},
 					expr: &charClassMatcher{
-						pos:        position{line: 4355, col: 18, offset: 133064},
+						pos:        position{line: 4367, col: 18, offset: 133603},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10491,15 +10491,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4359, col: 1, offset: 133115},
+			pos:  position{line: 4371, col: 1, offset: 133654},
 			expr: &actionExpr{
-				pos: position{line: 4359, col: 11, offset: 133125},
+				pos: position{line: 4371, col: 11, offset: 133664},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4359, col: 11, offset: 133125},
+					pos:   position{line: 4371, col: 11, offset: 133664},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4359, col: 18, offset: 133132},
+						pos:  position{line: 4371, col: 18, offset: 133671},
 						name: "NumberAsString",
 					},
 				},
@@ -10507,59 +10507,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4365, col: 1, offset: 133321},
+			pos:  position{line: 4377, col: 1, offset: 133860},
 			expr: &actionExpr{
-				pos: position{line: 4365, col: 19, offset: 133339},
+				pos: position{line: 4377, col: 19, offset: 133878},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4365, col: 19, offset: 133339},
+					pos: position{line: 4377, col: 19, offset: 133878},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4365, col: 19, offset: 133339},
+							pos:   position{line: 4377, col: 19, offset: 133878},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4365, col: 27, offset: 133347},
+								pos: position{line: 4377, col: 27, offset: 133886},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4365, col: 27, offset: 133347},
+										pos:  position{line: 4377, col: 27, offset: 133886},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4365, col: 43, offset: 133363},
+										pos:  position{line: 4377, col: 43, offset: 133902},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4365, col: 60, offset: 133380},
+							pos: position{line: 4377, col: 60, offset: 133919},
 							expr: &choiceExpr{
-								pos: position{line: 4365, col: 62, offset: 133382},
+								pos: position{line: 4377, col: 62, offset: 133921},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4365, col: 62, offset: 133382},
+										pos:  position{line: 4377, col: 62, offset: 133921},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4365, col: 70, offset: 133390},
+										pos:        position{line: 4377, col: 70, offset: 133929},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4365, col: 76, offset: 133396},
+										pos:        position{line: 4377, col: 76, offset: 133935},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4365, col: 82, offset: 133402},
+										pos:        position{line: 4377, col: 82, offset: 133941},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4365, col: 88, offset: 133408},
+										pos:  position{line: 4377, col: 88, offset: 133947},
 										name: "EOF",
 									},
 								},
@@ -10571,17 +10571,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4371, col: 1, offset: 133537},
+			pos:  position{line: 4383, col: 1, offset: 134076},
 			expr: &actionExpr{
-				pos: position{line: 4371, col: 18, offset: 133554},
+				pos: position{line: 4383, col: 18, offset: 134093},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4371, col: 18, offset: 133554},
+					pos: position{line: 4383, col: 18, offset: 134093},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4371, col: 18, offset: 133554},
+							pos: position{line: 4383, col: 18, offset: 134093},
 							expr: &charClassMatcher{
-								pos:        position{line: 4371, col: 18, offset: 133554},
+								pos:        position{line: 4383, col: 18, offset: 134093},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10589,9 +10589,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4371, col: 24, offset: 133560},
+							pos: position{line: 4383, col: 24, offset: 134099},
 							expr: &charClassMatcher{
-								pos:        position{line: 4371, col: 24, offset: 133560},
+								pos:        position{line: 4383, col: 24, offset: 134099},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10599,15 +10599,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4371, col: 31, offset: 133567},
+							pos:        position{line: 4383, col: 31, offset: 134106},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4371, col: 35, offset: 133571},
+							pos: position{line: 4383, col: 35, offset: 134110},
 							expr: &charClassMatcher{
-								pos:        position{line: 4371, col: 35, offset: 133571},
+								pos:        position{line: 4383, col: 35, offset: 134110},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10620,17 +10620,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4376, col: 1, offset: 133666},
+			pos:  position{line: 4388, col: 1, offset: 134205},
 			expr: &actionExpr{
-				pos: position{line: 4376, col: 20, offset: 133685},
+				pos: position{line: 4388, col: 20, offset: 134224},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4376, col: 20, offset: 133685},
+					pos: position{line: 4388, col: 20, offset: 134224},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4376, col: 20, offset: 133685},
+							pos: position{line: 4388, col: 20, offset: 134224},
 							expr: &charClassMatcher{
-								pos:        position{line: 4376, col: 20, offset: 133685},
+								pos:        position{line: 4388, col: 20, offset: 134224},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10638,9 +10638,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4376, col: 26, offset: 133691},
+							pos: position{line: 4388, col: 26, offset: 134230},
 							expr: &charClassMatcher{
-								pos:        position{line: 4376, col: 26, offset: 133691},
+								pos:        position{line: 4388, col: 26, offset: 134230},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10653,14 +10653,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4380, col: 1, offset: 133734},
+			pos:  position{line: 4392, col: 1, offset: 134273},
 			expr: &actionExpr{
-				pos: position{line: 4380, col: 28, offset: 133761},
+				pos: position{line: 4392, col: 28, offset: 134300},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4380, col: 28, offset: 133761},
+					pos: position{line: 4392, col: 28, offset: 134300},
 					expr: &charClassMatcher{
-						pos:        position{line: 4380, col: 28, offset: 133761},
+						pos:        position{line: 4392, col: 28, offset: 134300},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10671,15 +10671,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4384, col: 1, offset: 133804},
+			pos:  position{line: 4396, col: 1, offset: 134343},
 			expr: &actionExpr{
-				pos: position{line: 4384, col: 20, offset: 133823},
+				pos: position{line: 4396, col: 20, offset: 134362},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4384, col: 20, offset: 133823},
+					pos:   position{line: 4396, col: 20, offset: 134362},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4384, col: 27, offset: 133830},
+						pos:  position{line: 4396, col: 27, offset: 134369},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10687,31 +10687,31 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4392, col: 1, offset: 134077},
+			pos:  position{line: 4404, col: 1, offset: 134616},
 			expr: &actionExpr{
-				pos: position{line: 4392, col: 21, offset: 134097},
+				pos: position{line: 4404, col: 21, offset: 134636},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4392, col: 21, offset: 134097},
+					pos: position{line: 4404, col: 21, offset: 134636},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4392, col: 21, offset: 134097},
+							pos:  position{line: 4404, col: 21, offset: 134636},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4392, col: 36, offset: 134112},
+							pos:   position{line: 4404, col: 36, offset: 134651},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4392, col: 40, offset: 134116},
+								pos: position{line: 4404, col: 40, offset: 134655},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4392, col: 40, offset: 134116},
+										pos:        position{line: 4404, col: 40, offset: 134655},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4392, col: 46, offset: 134122},
+										pos:        position{line: 4404, col: 46, offset: 134661},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10720,7 +10720,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4392, col: 52, offset: 134128},
+							pos:  position{line: 4404, col: 52, offset: 134667},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10729,43 +10729,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4400, col: 1, offset: 134309},
+			pos:  position{line: 4412, col: 1, offset: 134848},
 			expr: &actionExpr{
-				pos: position{line: 4400, col: 23, offset: 134331},
+				pos: position{line: 4412, col: 23, offset: 134870},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4400, col: 23, offset: 134331},
+					pos: position{line: 4412, col: 23, offset: 134870},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4400, col: 23, offset: 134331},
+							pos:  position{line: 4412, col: 23, offset: 134870},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4400, col: 38, offset: 134346},
+							pos:   position{line: 4412, col: 38, offset: 134885},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4400, col: 42, offset: 134350},
+								pos: position{line: 4412, col: 42, offset: 134889},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4400, col: 42, offset: 134350},
+										pos:        position{line: 4412, col: 42, offset: 134889},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4400, col: 49, offset: 134357},
+										pos:        position{line: 4412, col: 49, offset: 134896},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4400, col: 55, offset: 134363},
+										pos:        position{line: 4412, col: 55, offset: 134902},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4400, col: 62, offset: 134370},
+										pos:        position{line: 4412, col: 62, offset: 134909},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10774,7 +10774,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4400, col: 67, offset: 134375},
+							pos:  position{line: 4412, col: 67, offset: 134914},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10783,30 +10783,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4408, col: 1, offset: 134558},
+			pos:  position{line: 4420, col: 1, offset: 135097},
 			expr: &choiceExpr{
-				pos: position{line: 4408, col: 25, offset: 134582},
+				pos: position{line: 4420, col: 25, offset: 135121},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4408, col: 25, offset: 134582},
+						pos: position{line: 4420, col: 25, offset: 135121},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4408, col: 25, offset: 134582},
+							pos:   position{line: 4420, col: 25, offset: 135121},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4408, col: 28, offset: 134585},
+								pos:  position{line: 4420, col: 28, offset: 135124},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4411, col: 3, offset: 134627},
+						pos: position{line: 4423, col: 3, offset: 135166},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4411, col: 3, offset: 134627},
+							pos:   position{line: 4423, col: 3, offset: 135166},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4411, col: 6, offset: 134630},
+								pos:  position{line: 4423, col: 6, offset: 135169},
 								name: "InequalityOperator",
 							},
 						},
@@ -10816,25 +10816,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4415, col: 1, offset: 134673},
+			pos:  position{line: 4427, col: 1, offset: 135212},
 			expr: &actionExpr{
-				pos: position{line: 4415, col: 11, offset: 134683},
+				pos: position{line: 4427, col: 11, offset: 135222},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4415, col: 11, offset: 134683},
+					pos: position{line: 4427, col: 11, offset: 135222},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4415, col: 11, offset: 134683},
+							pos:  position{line: 4427, col: 11, offset: 135222},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4415, col: 26, offset: 134698},
+							pos:        position{line: 4427, col: 26, offset: 135237},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4415, col: 30, offset: 134702},
+							pos:  position{line: 4427, col: 30, offset: 135241},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10843,25 +10843,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4419, col: 1, offset: 134742},
+			pos:  position{line: 4431, col: 1, offset: 135281},
 			expr: &actionExpr{
-				pos: position{line: 4419, col: 12, offset: 134753},
+				pos: position{line: 4431, col: 12, offset: 135292},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4419, col: 12, offset: 134753},
+					pos: position{line: 4431, col: 12, offset: 135292},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4419, col: 12, offset: 134753},
+							pos:  position{line: 4431, col: 12, offset: 135292},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4419, col: 27, offset: 134768},
+							pos:        position{line: 4431, col: 27, offset: 135307},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4419, col: 31, offset: 134772},
+							pos:  position{line: 4431, col: 31, offset: 135311},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10870,25 +10870,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4423, col: 1, offset: 134812},
+			pos:  position{line: 4435, col: 1, offset: 135351},
 			expr: &actionExpr{
-				pos: position{line: 4423, col: 10, offset: 134821},
+				pos: position{line: 4435, col: 10, offset: 135360},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4423, col: 10, offset: 134821},
+					pos: position{line: 4435, col: 10, offset: 135360},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4423, col: 10, offset: 134821},
+							pos:  position{line: 4435, col: 10, offset: 135360},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4423, col: 25, offset: 134836},
+							pos:        position{line: 4435, col: 25, offset: 135375},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4423, col: 29, offset: 134840},
+							pos:  position{line: 4435, col: 29, offset: 135379},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10897,25 +10897,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4427, col: 1, offset: 134880},
+			pos:  position{line: 4439, col: 1, offset: 135419},
 			expr: &actionExpr{
-				pos: position{line: 4427, col: 10, offset: 134889},
+				pos: position{line: 4439, col: 10, offset: 135428},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4427, col: 10, offset: 134889},
+					pos: position{line: 4439, col: 10, offset: 135428},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4427, col: 10, offset: 134889},
+							pos:  position{line: 4439, col: 10, offset: 135428},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 25, offset: 134904},
+							pos:        position{line: 4439, col: 25, offset: 135443},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4427, col: 29, offset: 134908},
+							pos:  position{line: 4439, col: 29, offset: 135447},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10924,25 +10924,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4431, col: 1, offset: 134948},
+			pos:  position{line: 4443, col: 1, offset: 135487},
 			expr: &actionExpr{
-				pos: position{line: 4431, col: 10, offset: 134957},
+				pos: position{line: 4443, col: 10, offset: 135496},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4431, col: 10, offset: 134957},
+					pos: position{line: 4443, col: 10, offset: 135496},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4431, col: 10, offset: 134957},
+							pos:  position{line: 4443, col: 10, offset: 135496},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4431, col: 25, offset: 134972},
+							pos:        position{line: 4443, col: 25, offset: 135511},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4431, col: 29, offset: 134976},
+							pos:  position{line: 4443, col: 29, offset: 135515},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10951,39 +10951,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4436, col: 1, offset: 135040},
+			pos:  position{line: 4448, col: 1, offset: 135579},
 			expr: &actionExpr{
-				pos: position{line: 4436, col: 11, offset: 135050},
+				pos: position{line: 4448, col: 11, offset: 135589},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4436, col: 12, offset: 135051},
+					pos: position{line: 4448, col: 12, offset: 135590},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4436, col: 12, offset: 135051},
+							pos:        position{line: 4448, col: 12, offset: 135590},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4436, col: 24, offset: 135063},
+							pos:        position{line: 4448, col: 24, offset: 135602},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4436, col: 35, offset: 135074},
+							pos:        position{line: 4448, col: 35, offset: 135613},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4436, col: 44, offset: 135083},
+							pos:        position{line: 4448, col: 44, offset: 135622},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4436, col: 52, offset: 135091},
+							pos:        position{line: 4448, col: 52, offset: 135630},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -10994,39 +10994,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4440, col: 1, offset: 135132},
+			pos:  position{line: 4452, col: 1, offset: 135671},
 			expr: &actionExpr{
-				pos: position{line: 4440, col: 11, offset: 135142},
+				pos: position{line: 4452, col: 11, offset: 135681},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4440, col: 12, offset: 135143},
+					pos: position{line: 4452, col: 12, offset: 135682},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4440, col: 12, offset: 135143},
+							pos:        position{line: 4452, col: 12, offset: 135682},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4440, col: 24, offset: 135155},
+							pos:        position{line: 4452, col: 24, offset: 135694},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4440, col: 35, offset: 135166},
+							pos:        position{line: 4452, col: 35, offset: 135705},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4440, col: 44, offset: 135175},
+							pos:        position{line: 4452, col: 44, offset: 135714},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4440, col: 52, offset: 135183},
+							pos:        position{line: 4452, col: 52, offset: 135722},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11037,39 +11037,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4444, col: 1, offset: 135224},
+			pos:  position{line: 4456, col: 1, offset: 135763},
 			expr: &actionExpr{
-				pos: position{line: 4444, col: 9, offset: 135232},
+				pos: position{line: 4456, col: 9, offset: 135771},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4444, col: 10, offset: 135233},
+					pos: position{line: 4456, col: 10, offset: 135772},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4444, col: 10, offset: 135233},
+							pos:        position{line: 4456, col: 10, offset: 135772},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4444, col: 20, offset: 135243},
+							pos:        position{line: 4456, col: 20, offset: 135782},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4444, col: 29, offset: 135252},
+							pos:        position{line: 4456, col: 29, offset: 135791},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4444, col: 37, offset: 135260},
+							pos:        position{line: 4456, col: 37, offset: 135799},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4444, col: 44, offset: 135267},
+							pos:        position{line: 4456, col: 44, offset: 135806},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11080,27 +11080,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4448, col: 1, offset: 135306},
+			pos:  position{line: 4460, col: 1, offset: 135845},
 			expr: &actionExpr{
-				pos: position{line: 4448, col: 8, offset: 135313},
+				pos: position{line: 4460, col: 8, offset: 135852},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4448, col: 9, offset: 135314},
+					pos: position{line: 4460, col: 9, offset: 135853},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4448, col: 9, offset: 135314},
+							pos:        position{line: 4460, col: 9, offset: 135853},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 18, offset: 135323},
+							pos:        position{line: 4460, col: 18, offset: 135862},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4448, col: 26, offset: 135331},
+							pos:        position{line: 4460, col: 26, offset: 135870},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11111,27 +11111,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4452, col: 1, offset: 135369},
+			pos:  position{line: 4464, col: 1, offset: 135908},
 			expr: &actionExpr{
-				pos: position{line: 4452, col: 9, offset: 135377},
+				pos: position{line: 4464, col: 9, offset: 135916},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4452, col: 10, offset: 135378},
+					pos: position{line: 4464, col: 10, offset: 135917},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4452, col: 10, offset: 135378},
+							pos:        position{line: 4464, col: 10, offset: 135917},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 20, offset: 135388},
+							pos:        position{line: 4464, col: 20, offset: 135927},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4452, col: 29, offset: 135397},
+							pos:        position{line: 4464, col: 29, offset: 135936},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11142,27 +11142,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4456, col: 1, offset: 135436},
+			pos:  position{line: 4468, col: 1, offset: 135975},
 			expr: &actionExpr{
-				pos: position{line: 4456, col: 10, offset: 135445},
+				pos: position{line: 4468, col: 10, offset: 135984},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4456, col: 11, offset: 135446},
+					pos: position{line: 4468, col: 11, offset: 135985},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4456, col: 11, offset: 135446},
+							pos:        position{line: 4468, col: 11, offset: 135985},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 22, offset: 135457},
+							pos:        position{line: 4468, col: 22, offset: 135996},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4456, col: 32, offset: 135467},
+							pos:        position{line: 4468, col: 32, offset: 136006},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11173,39 +11173,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4460, col: 1, offset: 135509},
+			pos:  position{line: 4472, col: 1, offset: 136048},
 			expr: &actionExpr{
-				pos: position{line: 4460, col: 12, offset: 135520},
+				pos: position{line: 4472, col: 12, offset: 136059},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4460, col: 13, offset: 135521},
+					pos: position{line: 4472, col: 13, offset: 136060},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4460, col: 13, offset: 135521},
+							pos:        position{line: 4472, col: 13, offset: 136060},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 26, offset: 135534},
+							pos:        position{line: 4472, col: 26, offset: 136073},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 38, offset: 135546},
+							pos:        position{line: 4472, col: 38, offset: 136085},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 47, offset: 135555},
+							pos:        position{line: 4472, col: 47, offset: 136094},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4460, col: 55, offset: 135563},
+							pos:        position{line: 4472, col: 55, offset: 136102},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11216,39 +11216,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4464, col: 1, offset: 135605},
+			pos:  position{line: 4476, col: 1, offset: 136144},
 			expr: &actionExpr{
-				pos: position{line: 4464, col: 9, offset: 135613},
+				pos: position{line: 4476, col: 9, offset: 136152},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4464, col: 10, offset: 135614},
+					pos: position{line: 4476, col: 10, offset: 136153},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4464, col: 10, offset: 135614},
+							pos:        position{line: 4476, col: 10, offset: 136153},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 20, offset: 135624},
+							pos:        position{line: 4476, col: 20, offset: 136163},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 29, offset: 135633},
+							pos:        position{line: 4476, col: 29, offset: 136172},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 37, offset: 135641},
+							pos:        position{line: 4476, col: 37, offset: 136180},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4464, col: 44, offset: 135648},
+							pos:        position{line: 4476, col: 44, offset: 136187},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11259,33 +11259,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4469, col: 1, offset: 135779},
+			pos:  position{line: 4481, col: 1, offset: 136318},
 			expr: &actionExpr{
-				pos: position{line: 4469, col: 15, offset: 135793},
+				pos: position{line: 4481, col: 15, offset: 136332},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4469, col: 16, offset: 135794},
+					pos: position{line: 4481, col: 16, offset: 136333},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4469, col: 16, offset: 135794},
+							pos:        position{line: 4481, col: 16, offset: 136333},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4469, col: 23, offset: 135801},
+							pos:        position{line: 4481, col: 23, offset: 136340},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4469, col: 30, offset: 135808},
+							pos:        position{line: 4481, col: 30, offset: 136347},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4469, col: 37, offset: 135815},
+							pos:        position{line: 4481, col: 37, offset: 136354},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11296,26 +11296,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4478, col: 1, offset: 136038},
+			pos:  position{line: 4490, col: 1, offset: 136577},
 			expr: &actionExpr{
-				pos: position{line: 4478, col: 21, offset: 136058},
+				pos: position{line: 4490, col: 21, offset: 136597},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4478, col: 21, offset: 136058},
+					pos: position{line: 4490, col: 21, offset: 136597},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4478, col: 21, offset: 136058},
+							pos:  position{line: 4490, col: 21, offset: 136597},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4478, col: 26, offset: 136063},
+							pos:  position{line: 4490, col: 26, offset: 136602},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4478, col: 42, offset: 136079},
+							pos:   position{line: 4490, col: 42, offset: 136618},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4478, col: 53, offset: 136090},
+								pos:  position{line: 4490, col: 53, offset: 136629},
 								name: "TransactionOptions",
 							},
 						},
@@ -11325,17 +11325,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4488, col: 1, offset: 136465},
+			pos:  position{line: 4500, col: 1, offset: 137004},
 			expr: &actionExpr{
-				pos: position{line: 4488, col: 23, offset: 136487},
+				pos: position{line: 4500, col: 23, offset: 137026},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4488, col: 23, offset: 136487},
+					pos:   position{line: 4500, col: 23, offset: 137026},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4488, col: 34, offset: 136498},
+						pos: position{line: 4500, col: 34, offset: 137037},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4488, col: 34, offset: 136498},
+							pos:  position{line: 4500, col: 34, offset: 137037},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11344,35 +11344,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4503, col: 1, offset: 136889},
+			pos:  position{line: 4515, col: 1, offset: 137428},
 			expr: &actionExpr{
-				pos: position{line: 4503, col: 37, offset: 136925},
+				pos: position{line: 4515, col: 37, offset: 137464},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4503, col: 37, offset: 136925},
+					pos: position{line: 4515, col: 37, offset: 137464},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4503, col: 37, offset: 136925},
+							pos:   position{line: 4515, col: 37, offset: 137464},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4503, col: 43, offset: 136931},
+								pos:  position{line: 4515, col: 43, offset: 137470},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4503, col: 71, offset: 136959},
+							pos:   position{line: 4515, col: 71, offset: 137498},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4503, col: 76, offset: 136964},
+								pos: position{line: 4515, col: 76, offset: 137503},
 								expr: &seqExpr{
-									pos: position{line: 4503, col: 77, offset: 136965},
+									pos: position{line: 4515, col: 77, offset: 137504},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4503, col: 77, offset: 136965},
+											pos:  position{line: 4515, col: 77, offset: 137504},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4503, col: 83, offset: 136971},
+											pos:  position{line: 4515, col: 83, offset: 137510},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11385,26 +11385,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4538, col: 1, offset: 137960},
+			pos:  position{line: 4550, col: 1, offset: 138499},
 			expr: &actionExpr{
-				pos: position{line: 4538, col: 32, offset: 137991},
+				pos: position{line: 4550, col: 32, offset: 138530},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4538, col: 32, offset: 137991},
+					pos:   position{line: 4550, col: 32, offset: 138530},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4538, col: 40, offset: 137999},
+						pos: position{line: 4550, col: 40, offset: 138538},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4538, col: 40, offset: 137999},
+								pos:  position{line: 4550, col: 40, offset: 138538},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4538, col: 77, offset: 138036},
+								pos:  position{line: 4550, col: 77, offset: 138575},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4538, col: 96, offset: 138055},
+								pos:  position{line: 4550, col: 96, offset: 138594},
 								name: "EndsWithOption",
 							},
 						},
@@ -11414,15 +11414,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4542, col: 1, offset: 138099},
+			pos:  position{line: 4554, col: 1, offset: 138638},
 			expr: &actionExpr{
-				pos: position{line: 4542, col: 39, offset: 138137},
+				pos: position{line: 4554, col: 39, offset: 138676},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4542, col: 39, offset: 138137},
+					pos:   position{line: 4554, col: 39, offset: 138676},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4542, col: 46, offset: 138144},
+						pos:  position{line: 4554, col: 46, offset: 138683},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11430,28 +11430,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4553, col: 1, offset: 138360},
+			pos:  position{line: 4565, col: 1, offset: 138899},
 			expr: &actionExpr{
-				pos: position{line: 4553, col: 21, offset: 138380},
+				pos: position{line: 4565, col: 21, offset: 138919},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4553, col: 21, offset: 138380},
+					pos: position{line: 4565, col: 21, offset: 138919},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4553, col: 21, offset: 138380},
+							pos:        position{line: 4565, col: 21, offset: 138919},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4553, col: 34, offset: 138393},
+							pos:  position{line: 4565, col: 34, offset: 138932},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4553, col: 40, offset: 138399},
+							pos:   position{line: 4565, col: 40, offset: 138938},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4553, col: 48, offset: 138407},
+								pos:  position{line: 4565, col: 48, offset: 138946},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11461,28 +11461,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4563, col: 1, offset: 138645},
+			pos:  position{line: 4575, col: 1, offset: 139184},
 			expr: &actionExpr{
-				pos: position{line: 4563, col: 19, offset: 138663},
+				pos: position{line: 4575, col: 19, offset: 139202},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4563, col: 19, offset: 138663},
+					pos: position{line: 4575, col: 19, offset: 139202},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4563, col: 19, offset: 138663},
+							pos:        position{line: 4575, col: 19, offset: 139202},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4563, col: 30, offset: 138674},
+							pos:  position{line: 4575, col: 30, offset: 139213},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4563, col: 36, offset: 138680},
+							pos:   position{line: 4575, col: 36, offset: 139219},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4563, col: 44, offset: 138688},
+								pos:  position{line: 4575, col: 44, offset: 139227},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11492,26 +11492,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4574, col: 1, offset: 138957},
+			pos:  position{line: 4586, col: 1, offset: 139496},
 			expr: &actionExpr{
-				pos: position{line: 4574, col: 28, offset: 138984},
+				pos: position{line: 4586, col: 28, offset: 139523},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4574, col: 28, offset: 138984},
+					pos:   position{line: 4586, col: 28, offset: 139523},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4574, col: 37, offset: 138993},
+						pos: position{line: 4586, col: 37, offset: 139532},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4574, col: 37, offset: 138993},
+								pos:  position{line: 4586, col: 37, offset: 139532},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4574, col: 63, offset: 139019},
+								pos:  position{line: 4586, col: 63, offset: 139558},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4574, col: 81, offset: 139037},
+								pos:  position{line: 4586, col: 81, offset: 139576},
 								name: "TransactionSearch",
 							},
 						},
@@ -11521,22 +11521,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4578, col: 1, offset: 139085},
+			pos:  position{line: 4590, col: 1, offset: 139624},
 			expr: &actionExpr{
-				pos: position{line: 4578, col: 28, offset: 139112},
+				pos: position{line: 4590, col: 28, offset: 139651},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4578, col: 28, offset: 139112},
+					pos:   position{line: 4590, col: 28, offset: 139651},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4578, col: 33, offset: 139117},
+						pos: position{line: 4590, col: 33, offset: 139656},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4578, col: 33, offset: 139117},
+								pos:  position{line: 4590, col: 33, offset: 139656},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4578, col: 64, offset: 139148},
+								pos:  position{line: 4590, col: 64, offset: 139687},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11546,29 +11546,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4582, col: 1, offset: 139208},
+			pos:  position{line: 4594, col: 1, offset: 139747},
 			expr: &actionExpr{
-				pos: position{line: 4582, col: 38, offset: 139245},
+				pos: position{line: 4594, col: 38, offset: 139784},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4582, col: 38, offset: 139245},
+					pos: position{line: 4594, col: 38, offset: 139784},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4582, col: 38, offset: 139245},
+							pos:        position{line: 4594, col: 38, offset: 139784},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4582, col: 42, offset: 139249},
+							pos:   position{line: 4594, col: 42, offset: 139788},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4582, col: 55, offset: 139262},
+								pos:  position{line: 4594, col: 55, offset: 139801},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4582, col: 68, offset: 139275},
+							pos:        position{line: 4594, col: 68, offset: 139814},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11579,23 +11579,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4590, col: 1, offset: 139414},
+			pos:  position{line: 4602, col: 1, offset: 139953},
 			expr: &actionExpr{
-				pos: position{line: 4590, col: 21, offset: 139434},
+				pos: position{line: 4602, col: 21, offset: 139973},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4590, col: 21, offset: 139434},
+					pos: position{line: 4602, col: 21, offset: 139973},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4590, col: 21, offset: 139434},
+							pos:        position{line: 4602, col: 21, offset: 139973},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4590, col: 25, offset: 139438},
+							pos: position{line: 4602, col: 25, offset: 139977},
 							expr: &charClassMatcher{
-								pos:        position{line: 4590, col: 25, offset: 139438},
+								pos:        position{line: 4602, col: 25, offset: 139977},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11603,7 +11603,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4590, col: 44, offset: 139457},
+							pos:        position{line: 4602, col: 44, offset: 139996},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11614,15 +11614,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4595, col: 1, offset: 139568},
+			pos:  position{line: 4607, col: 1, offset: 140107},
 			expr: &actionExpr{
-				pos: position{line: 4595, col: 33, offset: 139600},
+				pos: position{line: 4607, col: 33, offset: 140139},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4595, col: 33, offset: 139600},
+					pos:   position{line: 4607, col: 33, offset: 140139},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4595, col: 37, offset: 139604},
+						pos:  position{line: 4607, col: 37, offset: 140143},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11630,15 +11630,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4603, col: 1, offset: 139759},
+			pos:  position{line: 4615, col: 1, offset: 140298},
 			expr: &actionExpr{
-				pos: position{line: 4603, col: 22, offset: 139780},
+				pos: position{line: 4615, col: 22, offset: 140319},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4603, col: 22, offset: 139780},
+					pos:   position{line: 4615, col: 22, offset: 140319},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4603, col: 27, offset: 139785},
+						pos:  position{line: 4615, col: 27, offset: 140324},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11646,37 +11646,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4613, col: 1, offset: 139957},
+			pos:  position{line: 4625, col: 1, offset: 140496},
 			expr: &actionExpr{
-				pos: position{line: 4613, col: 20, offset: 139976},
+				pos: position{line: 4625, col: 20, offset: 140515},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4613, col: 20, offset: 139976},
+					pos: position{line: 4625, col: 20, offset: 140515},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4613, col: 20, offset: 139976},
+							pos:        position{line: 4625, col: 20, offset: 140515},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 27, offset: 139983},
+							pos:  position{line: 4625, col: 27, offset: 140522},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 42, offset: 139998},
+							pos:  position{line: 4625, col: 42, offset: 140537},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4613, col: 50, offset: 140006},
+							pos:   position{line: 4625, col: 50, offset: 140545},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4613, col: 60, offset: 140016},
+								pos:  position{line: 4625, col: 60, offset: 140555},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 69, offset: 140025},
+							pos:  position{line: 4625, col: 69, offset: 140564},
 							name: "R_PAREN",
 						},
 					},
@@ -11685,22 +11685,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4623, col: 1, offset: 140328},
+			pos:  position{line: 4635, col: 1, offset: 140867},
 			expr: &actionExpr{
-				pos: position{line: 4623, col: 20, offset: 140347},
+				pos: position{line: 4635, col: 20, offset: 140886},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4623, col: 20, offset: 140347},
+					pos: position{line: 4635, col: 20, offset: 140886},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4623, col: 20, offset: 140347},
+							pos:  position{line: 4635, col: 20, offset: 140886},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4623, col: 25, offset: 140352},
+							pos:   position{line: 4635, col: 25, offset: 140891},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4623, col: 42, offset: 140369},
+								pos:  position{line: 4635, col: 42, offset: 140908},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11710,41 +11710,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4627, col: 1, offset: 140418},
+			pos:  position{line: 4639, col: 1, offset: 140957},
 			expr: &actionExpr{
-				pos: position{line: 4627, col: 16, offset: 140433},
+				pos: position{line: 4639, col: 16, offset: 140972},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4627, col: 16, offset: 140433},
+					pos: position{line: 4639, col: 16, offset: 140972},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 16, offset: 140433},
+							pos:  position{line: 4639, col: 16, offset: 140972},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 27, offset: 140444},
+							pos:  position{line: 4639, col: 27, offset: 140983},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4627, col: 33, offset: 140450},
+							pos:   position{line: 4639, col: 33, offset: 140989},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4627, col: 50, offset: 140467},
+								pos: position{line: 4639, col: 50, offset: 141006},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4627, col: 50, offset: 140467},
+									pos:  position{line: 4639, col: 50, offset: 141006},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4627, col: 70, offset: 140487},
+							pos:  position{line: 4639, col: 70, offset: 141026},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4627, col: 85, offset: 140502},
+							pos:   position{line: 4639, col: 85, offset: 141041},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4627, col: 91, offset: 140508},
+								pos:  position{line: 4639, col: 91, offset: 141047},
 								name: "FieldName",
 							},
 						},
@@ -11754,35 +11754,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4656, col: 1, offset: 141279},
+			pos:  position{line: 4668, col: 1, offset: 141818},
 			expr: &actionExpr{
-				pos: position{line: 4656, col: 23, offset: 141301},
+				pos: position{line: 4668, col: 23, offset: 141840},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4656, col: 23, offset: 141301},
+					pos: position{line: 4668, col: 23, offset: 141840},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4656, col: 23, offset: 141301},
+							pos:   position{line: 4668, col: 23, offset: 141840},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4656, col: 31, offset: 141309},
+								pos:  position{line: 4668, col: 31, offset: 141848},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4656, col: 46, offset: 141324},
+							pos:   position{line: 4668, col: 46, offset: 141863},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4656, col: 52, offset: 141330},
+								pos: position{line: 4668, col: 52, offset: 141869},
 								expr: &seqExpr{
-									pos: position{line: 4656, col: 53, offset: 141331},
+									pos: position{line: 4668, col: 53, offset: 141870},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4656, col: 53, offset: 141331},
+											pos:  position{line: 4668, col: 53, offset: 141870},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4656, col: 59, offset: 141337},
+											pos:  position{line: 4668, col: 59, offset: 141876},
 											name: "MVBlockOption",
 										},
 									},
@@ -11795,26 +11795,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4690, col: 1, offset: 142393},
+			pos:  position{line: 4702, col: 1, offset: 142932},
 			expr: &actionExpr{
-				pos: position{line: 4690, col: 18, offset: 142410},
+				pos: position{line: 4702, col: 18, offset: 142949},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4690, col: 18, offset: 142410},
+					pos:   position{line: 4702, col: 18, offset: 142949},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4690, col: 27, offset: 142419},
+						pos: position{line: 4702, col: 27, offset: 142958},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4690, col: 27, offset: 142419},
+								pos:  position{line: 4702, col: 27, offset: 142958},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4690, col: 41, offset: 142433},
+								pos:  position{line: 4702, col: 41, offset: 142972},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4690, col: 60, offset: 142452},
+								pos:  position{line: 4702, col: 60, offset: 142991},
 								name: "SetSvOption",
 							},
 						},
@@ -11824,22 +11824,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4694, col: 1, offset: 142493},
+			pos:  position{line: 4706, col: 1, offset: 143032},
 			expr: &actionExpr{
-				pos: position{line: 4694, col: 16, offset: 142508},
+				pos: position{line: 4706, col: 16, offset: 143047},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4694, col: 16, offset: 142508},
+					pos:   position{line: 4706, col: 16, offset: 143047},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4694, col: 28, offset: 142520},
+						pos: position{line: 4706, col: 28, offset: 143059},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4694, col: 28, offset: 142520},
+								pos:  position{line: 4706, col: 28, offset: 143059},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4694, col: 46, offset: 142538},
+								pos:  position{line: 4706, col: 46, offset: 143077},
 								name: "RegexDelimiter",
 							},
 						},
@@ -11849,28 +11849,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4698, col: 1, offset: 142585},
+			pos:  position{line: 4710, col: 1, offset: 143124},
 			expr: &actionExpr{
-				pos: position{line: 4698, col: 20, offset: 142604},
+				pos: position{line: 4710, col: 20, offset: 143143},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4698, col: 20, offset: 142604},
+					pos: position{line: 4710, col: 20, offset: 143143},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4698, col: 20, offset: 142604},
+							pos:        position{line: 4710, col: 20, offset: 143143},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4698, col: 28, offset: 142612},
+							pos:  position{line: 4710, col: 28, offset: 143151},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4698, col: 34, offset: 142618},
+							pos:   position{line: 4710, col: 34, offset: 143157},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4698, col: 38, offset: 142622},
+								pos:  position{line: 4710, col: 38, offset: 143161},
 								name: "QuotedString",
 							},
 						},
@@ -11880,28 +11880,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4709, col: 1, offset: 142873},
+			pos:  position{line: 4721, col: 1, offset: 143412},
 			expr: &actionExpr{
-				pos: position{line: 4709, col: 19, offset: 142891},
+				pos: position{line: 4721, col: 19, offset: 143430},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4709, col: 19, offset: 142891},
+					pos: position{line: 4721, col: 19, offset: 143430},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4709, col: 19, offset: 142891},
+							pos:        position{line: 4721, col: 19, offset: 143430},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4709, col: 31, offset: 142903},
+							pos:  position{line: 4721, col: 31, offset: 143442},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4709, col: 37, offset: 142909},
+							pos:   position{line: 4721, col: 37, offset: 143448},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4709, col: 41, offset: 142913},
+								pos:  position{line: 4721, col: 41, offset: 143452},
 								name: "QuotedString",
 							},
 						},
@@ -11911,28 +11911,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4727, col: 1, offset: 143384},
+			pos:  position{line: 4739, col: 1, offset: 143923},
 			expr: &actionExpr{
-				pos: position{line: 4727, col: 21, offset: 143404},
+				pos: position{line: 4739, col: 21, offset: 143943},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4727, col: 21, offset: 143404},
+					pos: position{line: 4739, col: 21, offset: 143943},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4727, col: 21, offset: 143404},
+							pos:        position{line: 4739, col: 21, offset: 143943},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4727, col: 34, offset: 143417},
+							pos:  position{line: 4739, col: 34, offset: 143956},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4727, col: 40, offset: 143423},
+							pos:   position{line: 4739, col: 40, offset: 143962},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4727, col: 48, offset: 143431},
+								pos:  position{line: 4739, col: 48, offset: 143970},
 								name: "Boolean",
 							},
 						},
@@ -11942,28 +11942,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4739, col: 1, offset: 143671},
+			pos:  position{line: 4751, col: 1, offset: 144210},
 			expr: &actionExpr{
-				pos: position{line: 4739, col: 16, offset: 143686},
+				pos: position{line: 4751, col: 16, offset: 144225},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4739, col: 16, offset: 143686},
+					pos: position{line: 4751, col: 16, offset: 144225},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4739, col: 16, offset: 143686},
+							pos:        position{line: 4751, col: 16, offset: 144225},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4739, col: 24, offset: 143694},
+							pos:  position{line: 4751, col: 24, offset: 144233},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4739, col: 30, offset: 143700},
+							pos:   position{line: 4751, col: 30, offset: 144239},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4739, col: 38, offset: 143708},
+								pos:  position{line: 4751, col: 38, offset: 144247},
 								name: "Boolean",
 							},
 						},
@@ -11973,28 +11973,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4751, col: 1, offset: 143973},
+			pos:  position{line: 4763, col: 1, offset: 144512},
 			expr: &actionExpr{
-				pos: position{line: 4751, col: 15, offset: 143987},
+				pos: position{line: 4763, col: 15, offset: 144526},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4751, col: 15, offset: 143987},
+					pos: position{line: 4763, col: 15, offset: 144526},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4751, col: 15, offset: 143987},
+							pos:  position{line: 4763, col: 15, offset: 144526},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4751, col: 20, offset: 143992},
+							pos:  position{line: 4763, col: 20, offset: 144531},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4751, col: 30, offset: 144002},
+							pos:   position{line: 4763, col: 30, offset: 144541},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4751, col: 40, offset: 144012},
+								pos: position{line: 4763, col: 40, offset: 144551},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4751, col: 40, offset: 144012},
+									pos:  position{line: 4763, col: 40, offset: 144551},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12005,39 +12005,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4758, col: 1, offset: 144138},
+			pos:  position{line: 4770, col: 1, offset: 144677},
 			expr: &actionExpr{
-				pos: position{line: 4758, col: 23, offset: 144160},
+				pos: position{line: 4770, col: 23, offset: 144699},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4758, col: 23, offset: 144160},
+					pos: position{line: 4770, col: 23, offset: 144699},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4758, col: 23, offset: 144160},
+							pos:  position{line: 4770, col: 23, offset: 144699},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4758, col: 29, offset: 144166},
+							pos:   position{line: 4770, col: 29, offset: 144705},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4758, col: 35, offset: 144172},
+								pos:  position{line: 4770, col: 35, offset: 144711},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4758, col: 49, offset: 144186},
+							pos:   position{line: 4770, col: 49, offset: 144725},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4758, col: 54, offset: 144191},
+								pos: position{line: 4770, col: 54, offset: 144730},
 								expr: &seqExpr{
-									pos: position{line: 4758, col: 55, offset: 144192},
+									pos: position{line: 4770, col: 55, offset: 144731},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4758, col: 55, offset: 144192},
+											pos:  position{line: 4770, col: 55, offset: 144731},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4758, col: 61, offset: 144198},
+											pos:  position{line: 4770, col: 61, offset: 144737},
 											name: "SPathArgument",
 										},
 									},
@@ -12050,26 +12050,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4790, col: 1, offset: 145091},
+			pos:  position{line: 4802, col: 1, offset: 145630},
 			expr: &actionExpr{
-				pos: position{line: 4790, col: 18, offset: 145108},
+				pos: position{line: 4802, col: 18, offset: 145647},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4790, col: 18, offset: 145108},
+					pos:   position{line: 4802, col: 18, offset: 145647},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4790, col: 23, offset: 145113},
+						pos: position{line: 4802, col: 23, offset: 145652},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4790, col: 23, offset: 145113},
+								pos:  position{line: 4802, col: 23, offset: 145652},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4790, col: 36, offset: 145126},
+								pos:  position{line: 4802, col: 36, offset: 145665},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4790, col: 50, offset: 145140},
+								pos:  position{line: 4802, col: 50, offset: 145679},
 								name: "PathField",
 							},
 						},
@@ -12079,28 +12079,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4794, col: 1, offset: 145176},
+			pos:  position{line: 4806, col: 1, offset: 145715},
 			expr: &actionExpr{
-				pos: position{line: 4794, col: 15, offset: 145190},
+				pos: position{line: 4806, col: 15, offset: 145729},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4794, col: 15, offset: 145190},
+					pos: position{line: 4806, col: 15, offset: 145729},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4794, col: 15, offset: 145190},
+							pos:        position{line: 4806, col: 15, offset: 145729},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4794, col: 23, offset: 145198},
+							pos:  position{line: 4806, col: 23, offset: 145737},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4794, col: 29, offset: 145204},
+							pos:   position{line: 4806, col: 29, offset: 145743},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4794, col: 35, offset: 145210},
+								pos:  position{line: 4806, col: 35, offset: 145749},
 								name: "FieldName",
 							},
 						},
@@ -12110,28 +12110,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4797, col: 1, offset: 145266},
+			pos:  position{line: 4809, col: 1, offset: 145805},
 			expr: &actionExpr{
-				pos: position{line: 4797, col: 16, offset: 145281},
+				pos: position{line: 4809, col: 16, offset: 145820},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4797, col: 16, offset: 145281},
+					pos: position{line: 4809, col: 16, offset: 145820},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4797, col: 16, offset: 145281},
+							pos:        position{line: 4809, col: 16, offset: 145820},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4797, col: 25, offset: 145290},
+							pos:  position{line: 4809, col: 25, offset: 145829},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4797, col: 31, offset: 145296},
+							pos:   position{line: 4809, col: 31, offset: 145835},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4797, col: 37, offset: 145302},
+								pos:  position{line: 4809, col: 37, offset: 145841},
 								name: "FieldName",
 							},
 						},
@@ -12141,34 +12141,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4800, col: 1, offset: 145359},
+			pos:  position{line: 4812, col: 1, offset: 145898},
 			expr: &actionExpr{
-				pos: position{line: 4800, col: 14, offset: 145372},
+				pos: position{line: 4812, col: 14, offset: 145911},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4800, col: 15, offset: 145373},
+					pos: position{line: 4812, col: 15, offset: 145912},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4800, col: 15, offset: 145373},
+							pos: position{line: 4812, col: 15, offset: 145912},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4800, col: 15, offset: 145373},
+									pos:        position{line: 4812, col: 15, offset: 145912},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4800, col: 22, offset: 145380},
+									pos:  position{line: 4812, col: 22, offset: 145919},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4800, col: 28, offset: 145386},
+									pos:  position{line: 4812, col: 28, offset: 145925},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 47, offset: 145405},
+							pos:  position{line: 4812, col: 47, offset: 145944},
 							name: "SPathFieldString",
 						},
 					},
@@ -12177,16 +12177,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4812, col: 1, offset: 145817},
+			pos:  position{line: 4824, col: 1, offset: 146356},
 			expr: &choiceExpr{
-				pos: position{line: 4812, col: 21, offset: 145837},
+				pos: position{line: 4824, col: 21, offset: 146376},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4812, col: 21, offset: 145837},
+						pos:  position{line: 4824, col: 21, offset: 146376},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4812, col: 36, offset: 145852},
+						pos:  position{line: 4824, col: 36, offset: 146391},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12194,28 +12194,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4815, col: 1, offset: 145925},
+			pos:  position{line: 4827, col: 1, offset: 146464},
 			expr: &actionExpr{
-				pos: position{line: 4815, col: 16, offset: 145940},
+				pos: position{line: 4827, col: 16, offset: 146479},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4815, col: 16, offset: 145940},
+					pos: position{line: 4827, col: 16, offset: 146479},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4815, col: 16, offset: 145940},
+							pos:  position{line: 4827, col: 16, offset: 146479},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4815, col: 21, offset: 145945},
+							pos:  position{line: 4827, col: 21, offset: 146484},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4815, col: 32, offset: 145956},
+							pos:   position{line: 4827, col: 32, offset: 146495},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4815, col: 46, offset: 145970},
+								pos: position{line: 4827, col: 46, offset: 146509},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4815, col: 46, offset: 145970},
+									pos:  position{line: 4827, col: 46, offset: 146509},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12226,39 +12226,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4837, col: 1, offset: 146579},
+			pos:  position{line: 4849, col: 1, offset: 147118},
 			expr: &actionExpr{
-				pos: position{line: 4837, col: 24, offset: 146602},
+				pos: position{line: 4849, col: 24, offset: 147141},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4837, col: 24, offset: 146602},
+					pos: position{line: 4849, col: 24, offset: 147141},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4837, col: 24, offset: 146602},
+							pos:  position{line: 4849, col: 24, offset: 147141},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4837, col: 30, offset: 146608},
+							pos:   position{line: 4849, col: 30, offset: 147147},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4837, col: 37, offset: 146615},
+								pos:  position{line: 4849, col: 37, offset: 147154},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4837, col: 52, offset: 146630},
+							pos:   position{line: 4849, col: 52, offset: 147169},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4837, col: 57, offset: 146635},
+								pos: position{line: 4849, col: 57, offset: 147174},
 								expr: &seqExpr{
-									pos: position{line: 4837, col: 58, offset: 146636},
+									pos: position{line: 4849, col: 58, offset: 147175},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4837, col: 58, offset: 146636},
+											pos:  position{line: 4849, col: 58, offset: 147175},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4837, col: 64, offset: 146642},
+											pos:  position{line: 4849, col: 64, offset: 147181},
 											name: "FormatArgument",
 										},
 									},
@@ -12271,30 +12271,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 4871, col: 1, offset: 147831},
+			pos:  position{line: 4883, col: 1, offset: 148370},
 			expr: &actionExpr{
-				pos: position{line: 4871, col: 19, offset: 147849},
+				pos: position{line: 4883, col: 19, offset: 148388},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4871, col: 19, offset: 147849},
+					pos:   position{line: 4883, col: 19, offset: 148388},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4871, col: 28, offset: 147858},
+						pos: position{line: 4883, col: 28, offset: 148397},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4871, col: 28, offset: 147858},
+								pos:  position{line: 4883, col: 28, offset: 148397},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4871, col: 46, offset: 147876},
+								pos:  position{line: 4883, col: 46, offset: 148415},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4871, col: 65, offset: 147895},
+								pos:  position{line: 4883, col: 65, offset: 148434},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4871, col: 82, offset: 147912},
+								pos:  position{line: 4883, col: 82, offset: 148451},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12304,28 +12304,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 4875, col: 1, offset: 147962},
+			pos:  position{line: 4887, col: 1, offset: 148501},
 			expr: &actionExpr{
-				pos: position{line: 4875, col: 20, offset: 147981},
+				pos: position{line: 4887, col: 20, offset: 148520},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 4875, col: 20, offset: 147981},
+					pos: position{line: 4887, col: 20, offset: 148520},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4875, col: 20, offset: 147981},
+							pos:        position{line: 4887, col: 20, offset: 148520},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4875, col: 28, offset: 147989},
+							pos:  position{line: 4887, col: 28, offset: 148528},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4875, col: 34, offset: 147995},
+							pos:   position{line: 4887, col: 34, offset: 148534},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4875, col: 38, offset: 147999},
+								pos:  position{line: 4887, col: 38, offset: 148538},
 								name: "QuotedString",
 							},
 						},
@@ -12335,28 +12335,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 4884, col: 1, offset: 148211},
+			pos:  position{line: 4896, col: 1, offset: 148750},
 			expr: &actionExpr{
-				pos: position{line: 4884, col: 21, offset: 148231},
+				pos: position{line: 4896, col: 21, offset: 148770},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 4884, col: 21, offset: 148231},
+					pos: position{line: 4896, col: 21, offset: 148770},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4884, col: 21, offset: 148231},
+							pos:        position{line: 4896, col: 21, offset: 148770},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4884, col: 34, offset: 148244},
+							pos:  position{line: 4896, col: 34, offset: 148783},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4884, col: 40, offset: 148250},
+							pos:   position{line: 4896, col: 40, offset: 148789},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4884, col: 47, offset: 148257},
+								pos:  position{line: 4896, col: 47, offset: 148796},
 								name: "IntegerAsString",
 							},
 						},
@@ -12366,28 +12366,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 4897, col: 1, offset: 148663},
+			pos:  position{line: 4909, col: 1, offset: 149202},
 			expr: &actionExpr{
-				pos: position{line: 4897, col: 19, offset: 148681},
+				pos: position{line: 4909, col: 19, offset: 149220},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 4897, col: 19, offset: 148681},
+					pos: position{line: 4909, col: 19, offset: 149220},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4897, col: 19, offset: 148681},
+							pos:        position{line: 4909, col: 19, offset: 149220},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4897, col: 30, offset: 148692},
+							pos:  position{line: 4909, col: 30, offset: 149231},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4897, col: 36, offset: 148698},
+							pos:   position{line: 4909, col: 36, offset: 149237},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4897, col: 40, offset: 148702},
+								pos:  position{line: 4909, col: 40, offset: 149241},
 								name: "QuotedString",
 							},
 						},
@@ -12397,78 +12397,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 4906, col: 1, offset: 148917},
+			pos:  position{line: 4918, col: 1, offset: 149456},
 			expr: &actionExpr{
-				pos: position{line: 4906, col: 24, offset: 148940},
+				pos: position{line: 4918, col: 24, offset: 149479},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 4906, col: 24, offset: 148940},
+					pos: position{line: 4918, col: 24, offset: 149479},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4906, col: 24, offset: 148940},
+							pos:   position{line: 4918, col: 24, offset: 149479},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 34, offset: 148950},
+								pos:  position{line: 4918, col: 34, offset: 149489},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4906, col: 47, offset: 148963},
+							pos:  position{line: 4918, col: 47, offset: 149502},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4906, col: 53, offset: 148969},
+							pos:   position{line: 4918, col: 53, offset: 149508},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 63, offset: 148979},
+								pos:  position{line: 4918, col: 63, offset: 149518},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4906, col: 76, offset: 148992},
+							pos:  position{line: 4918, col: 76, offset: 149531},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4906, col: 82, offset: 148998},
+							pos:   position{line: 4918, col: 82, offset: 149537},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 95, offset: 149011},
+								pos:  position{line: 4918, col: 95, offset: 149550},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4906, col: 108, offset: 149024},
+							pos:  position{line: 4918, col: 108, offset: 149563},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4906, col: 114, offset: 149030},
+							pos:   position{line: 4918, col: 114, offset: 149569},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 121, offset: 149037},
+								pos:  position{line: 4918, col: 121, offset: 149576},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4906, col: 134, offset: 149050},
+							pos:  position{line: 4918, col: 134, offset: 149589},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4906, col: 140, offset: 149056},
+							pos:   position{line: 4918, col: 140, offset: 149595},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 153, offset: 149069},
+								pos:  position{line: 4918, col: 153, offset: 149608},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4906, col: 166, offset: 149082},
+							pos:  position{line: 4918, col: 166, offset: 149621},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4906, col: 172, offset: 149088},
+							pos:   position{line: 4918, col: 172, offset: 149627},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4906, col: 179, offset: 149095},
+								pos:  position{line: 4918, col: 179, offset: 149634},
 								name: "QuotedString",
 							},
 						},
@@ -12478,28 +12478,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 4924, col: 1, offset: 149671},
+			pos:  position{line: 4936, col: 1, offset: 150210},
 			expr: &actionExpr{
-				pos: position{line: 4924, col: 20, offset: 149690},
+				pos: position{line: 4936, col: 20, offset: 150229},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4924, col: 20, offset: 149690},
+					pos: position{line: 4936, col: 20, offset: 150229},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4924, col: 20, offset: 149690},
+							pos:  position{line: 4936, col: 20, offset: 150229},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4924, col: 25, offset: 149695},
+							pos:  position{line: 4936, col: 25, offset: 150234},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4924, col: 40, offset: 149710},
+							pos:   position{line: 4936, col: 40, offset: 150249},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4924, col: 55, offset: 149725},
+								pos: position{line: 4936, col: 55, offset: 150264},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4924, col: 55, offset: 149725},
+									pos:  position{line: 4936, col: 55, offset: 150264},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12510,42 +12510,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 4931, col: 1, offset: 149878},
+			pos:  position{line: 4943, col: 1, offset: 150417},
 			expr: &actionExpr{
-				pos: position{line: 4931, col: 28, offset: 149905},
+				pos: position{line: 4943, col: 28, offset: 150444},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4931, col: 28, offset: 149905},
+					pos: position{line: 4943, col: 28, offset: 150444},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4931, col: 28, offset: 149905},
+							pos:  position{line: 4943, col: 28, offset: 150444},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4931, col: 34, offset: 149911},
+							pos:   position{line: 4943, col: 34, offset: 150450},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4931, col: 40, offset: 149917},
+								pos: position{line: 4943, col: 40, offset: 150456},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4931, col: 40, offset: 149917},
+									pos:  position{line: 4943, col: 40, offset: 150456},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4931, col: 60, offset: 149937},
+							pos:   position{line: 4943, col: 60, offset: 150476},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4931, col: 65, offset: 149942},
+								pos: position{line: 4943, col: 65, offset: 150481},
 								expr: &seqExpr{
-									pos: position{line: 4931, col: 66, offset: 149943},
+									pos: position{line: 4943, col: 66, offset: 150482},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4931, col: 66, offset: 149943},
+											pos:  position{line: 4943, col: 66, offset: 150482},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4931, col: 72, offset: 149949},
+											pos:  position{line: 4943, col: 72, offset: 150488},
 											name: "EventCountArgument",
 										},
 									},
@@ -12558,30 +12558,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 4987, col: 1, offset: 151826},
+			pos:  position{line: 4999, col: 1, offset: 152365},
 			expr: &actionExpr{
-				pos: position{line: 4987, col: 23, offset: 151848},
+				pos: position{line: 4999, col: 23, offset: 152387},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4987, col: 23, offset: 151848},
+					pos:   position{line: 4999, col: 23, offset: 152387},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4987, col: 28, offset: 151853},
+						pos: position{line: 4999, col: 28, offset: 152392},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4987, col: 28, offset: 151853},
+								pos:  position{line: 4999, col: 28, offset: 152392},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4987, col: 41, offset: 151866},
+								pos:  position{line: 4999, col: 41, offset: 152405},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4987, col: 58, offset: 151883},
+								pos:  position{line: 4999, col: 58, offset: 152422},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4987, col: 76, offset: 151901},
+								pos:  position{line: 4999, col: 76, offset: 152440},
 								name: "ListVixField",
 							},
 						},
@@ -12591,28 +12591,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 4991, col: 1, offset: 151940},
+			pos:  position{line: 5003, col: 1, offset: 152479},
 			expr: &actionExpr{
-				pos: position{line: 4991, col: 15, offset: 151954},
+				pos: position{line: 5003, col: 15, offset: 152493},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 4991, col: 15, offset: 151954},
+					pos: position{line: 5003, col: 15, offset: 152493},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4991, col: 15, offset: 151954},
+							pos:        position{line: 5003, col: 15, offset: 152493},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4991, col: 23, offset: 151962},
+							pos:  position{line: 5003, col: 23, offset: 152501},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4991, col: 29, offset: 151968},
+							pos:   position{line: 5003, col: 29, offset: 152507},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4991, col: 35, offset: 151974},
+								pos:  position{line: 5003, col: 35, offset: 152513},
 								name: "IndexName",
 							},
 						},
@@ -12622,28 +12622,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 4994, col: 1, offset: 152030},
+			pos:  position{line: 5006, col: 1, offset: 152569},
 			expr: &actionExpr{
-				pos: position{line: 4994, col: 19, offset: 152048},
+				pos: position{line: 5006, col: 19, offset: 152587},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4994, col: 19, offset: 152048},
+					pos: position{line: 5006, col: 19, offset: 152587},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4994, col: 19, offset: 152048},
+							pos:        position{line: 5006, col: 19, offset: 152587},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4994, col: 31, offset: 152060},
+							pos:  position{line: 5006, col: 31, offset: 152599},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4994, col: 37, offset: 152066},
+							pos:   position{line: 5006, col: 37, offset: 152605},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4994, col: 43, offset: 152072},
+								pos:  position{line: 5006, col: 43, offset: 152611},
 								name: "Boolean",
 							},
 						},
@@ -12653,28 +12653,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 4997, col: 1, offset: 152148},
+			pos:  position{line: 5009, col: 1, offset: 152687},
 			expr: &actionExpr{
-				pos: position{line: 4997, col: 20, offset: 152167},
+				pos: position{line: 5009, col: 20, offset: 152706},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 4997, col: 20, offset: 152167},
+					pos: position{line: 5009, col: 20, offset: 152706},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4997, col: 20, offset: 152167},
+							pos:        position{line: 5009, col: 20, offset: 152706},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4997, col: 34, offset: 152181},
+							pos:  position{line: 5009, col: 34, offset: 152720},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4997, col: 40, offset: 152187},
+							pos:   position{line: 5009, col: 40, offset: 152726},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4997, col: 46, offset: 152193},
+								pos:  position{line: 5009, col: 46, offset: 152732},
 								name: "Boolean",
 							},
 						},
@@ -12684,28 +12684,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5000, col: 1, offset: 152271},
+			pos:  position{line: 5012, col: 1, offset: 152810},
 			expr: &actionExpr{
-				pos: position{line: 5000, col: 17, offset: 152287},
+				pos: position{line: 5012, col: 17, offset: 152826},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5000, col: 17, offset: 152287},
+					pos: position{line: 5012, col: 17, offset: 152826},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5000, col: 17, offset: 152287},
+							pos:        position{line: 5012, col: 17, offset: 152826},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5000, col: 28, offset: 152298},
+							pos:  position{line: 5012, col: 28, offset: 152837},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5000, col: 34, offset: 152304},
+							pos:   position{line: 5012, col: 34, offset: 152843},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5000, col: 40, offset: 152310},
+								pos:  position{line: 5012, col: 40, offset: 152849},
 								name: "Boolean",
 							},
 						},
@@ -12715,24 +12715,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5004, col: 1, offset: 152386},
+			pos:  position{line: 5016, col: 1, offset: 152925},
 			expr: &actionExpr{
-				pos: position{line: 5004, col: 14, offset: 152399},
+				pos: position{line: 5016, col: 14, offset: 152938},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5004, col: 14, offset: 152399},
+					pos: position{line: 5016, col: 14, offset: 152938},
 					expr: &seqExpr{
-						pos: position{line: 5004, col: 15, offset: 152400},
+						pos: position{line: 5016, col: 15, offset: 152939},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5004, col: 15, offset: 152400},
+								pos: position{line: 5016, col: 15, offset: 152939},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5004, col: 16, offset: 152401},
+									pos:  position{line: 5016, col: 16, offset: 152940},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5004, col: 22, offset: 152407,
+								line: 5016, col: 22, offset: 152946,
 							},
 						},
 					},
@@ -12741,39 +12741,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5009, col: 1, offset: 152480},
+			pos:  position{line: 5021, col: 1, offset: 153019},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 18, offset: 152497},
+				pos: position{line: 5021, col: 18, offset: 153036},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 18, offset: 152497},
+					pos: position{line: 5021, col: 18, offset: 153036},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 18, offset: 152497},
+							pos:  position{line: 5021, col: 18, offset: 153036},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 23, offset: 152502},
+							pos:  position{line: 5021, col: 23, offset: 153041},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 36, offset: 152515},
+							pos:   position{line: 5021, col: 36, offset: 153054},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 49, offset: 152528},
+								pos: position{line: 5021, col: 49, offset: 153067},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5009, col: 49, offset: 152528},
+									pos:  position{line: 5021, col: 49, offset: 153067},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 70, offset: 152549},
+							pos:   position{line: 5021, col: 70, offset: 153088},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 77, offset: 152556},
+								pos: position{line: 5021, col: 77, offset: 153095},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5009, col: 77, offset: 152556},
+									pos:  position{line: 5021, col: 77, offset: 153095},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12784,32 +12784,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5039, col: 1, offset: 153319},
+			pos:  position{line: 5051, col: 1, offset: 153858},
 			expr: &actionExpr{
-				pos: position{line: 5039, col: 24, offset: 153342},
+				pos: position{line: 5051, col: 24, offset: 153881},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5039, col: 24, offset: 153342},
+					pos: position{line: 5051, col: 24, offset: 153881},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 24, offset: 153342},
+							pos:  position{line: 5051, col: 24, offset: 153881},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5039, col: 30, offset: 153348},
+							pos:        position{line: 5051, col: 30, offset: 153887},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 38, offset: 153356},
+							pos:  position{line: 5051, col: 38, offset: 153895},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5039, col: 44, offset: 153362},
+							pos:   position{line: 5051, col: 44, offset: 153901},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5039, col: 48, offset: 153366},
+								pos:  position{line: 5051, col: 48, offset: 153905},
 								name: "String",
 							},
 						},
@@ -12819,22 +12819,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5043, col: 1, offset: 153412},
+			pos:  position{line: 5055, col: 1, offset: 153951},
 			expr: &actionExpr{
-				pos: position{line: 5043, col: 22, offset: 153433},
+				pos: position{line: 5055, col: 22, offset: 153972},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5043, col: 22, offset: 153433},
+					pos: position{line: 5055, col: 22, offset: 153972},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5043, col: 22, offset: 153433},
+							pos:  position{line: 5055, col: 22, offset: 153972},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5043, col: 28, offset: 153439},
+							pos:   position{line: 5055, col: 28, offset: 153978},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5043, col: 38, offset: 153449},
+								pos:  position{line: 5055, col: 38, offset: 153988},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -12844,36 +12844,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5047, col: 1, offset: 153508},
+			pos:  position{line: 5059, col: 1, offset: 154047},
 			expr: &actionExpr{
-				pos: position{line: 5047, col: 18, offset: 153525},
+				pos: position{line: 5059, col: 18, offset: 154064},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5047, col: 18, offset: 153525},
+					pos: position{line: 5059, col: 18, offset: 154064},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5047, col: 18, offset: 153525},
+							pos:  position{line: 5059, col: 18, offset: 154064},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5047, col: 23, offset: 153530},
+							pos:  position{line: 5059, col: 23, offset: 154069},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5047, col: 36, offset: 153543},
+							pos:   position{line: 5059, col: 36, offset: 154082},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5047, col: 42, offset: 153549},
+								pos:  position{line: 5059, col: 42, offset: 154088},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5047, col: 56, offset: 153563},
+							pos:   position{line: 5059, col: 56, offset: 154102},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5047, col: 65, offset: 153572},
+								pos: position{line: 5059, col: 65, offset: 154111},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5047, col: 65, offset: 153572},
+									pos:  position{line: 5059, col: 65, offset: 154111},
 									name: "MvexpandLimit",
 								},
 							},
@@ -12884,22 +12884,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5076, col: 1, offset: 154361},
+			pos:  position{line: 5088, col: 1, offset: 154900},
 			expr: &actionExpr{
-				pos: position{line: 5076, col: 18, offset: 154378},
+				pos: position{line: 5088, col: 18, offset: 154917},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5076, col: 18, offset: 154378},
+					pos: position{line: 5088, col: 18, offset: 154917},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5076, col: 18, offset: 154378},
+							pos:  position{line: 5088, col: 18, offset: 154917},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5076, col: 24, offset: 154384},
+							pos:   position{line: 5088, col: 24, offset: 154923},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5076, col: 34, offset: 154394},
+								pos:  position{line: 5088, col: 34, offset: 154933},
 								name: "FieldName",
 							},
 						},
@@ -12909,32 +12909,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5080, col: 1, offset: 154435},
+			pos:  position{line: 5092, col: 1, offset: 154974},
 			expr: &actionExpr{
-				pos: position{line: 5080, col: 18, offset: 154452},
+				pos: position{line: 5092, col: 18, offset: 154991},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5080, col: 18, offset: 154452},
+					pos: position{line: 5092, col: 18, offset: 154991},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5080, col: 18, offset: 154452},
+							pos:  position{line: 5092, col: 18, offset: 154991},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5080, col: 24, offset: 154458},
+							pos:        position{line: 5092, col: 24, offset: 154997},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5080, col: 32, offset: 154466},
+							pos:  position{line: 5092, col: 32, offset: 155005},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5080, col: 38, offset: 154472},
+							pos:   position{line: 5092, col: 38, offset: 155011},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5080, col: 47, offset: 154481},
+								pos:  position{line: 5092, col: 47, offset: 155020},
 								name: "IntegerAsString",
 							},
 						},
@@ -12944,26 +12944,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5084, col: 1, offset: 154527},
+			pos:  position{line: 5096, col: 1, offset: 155066},
 			expr: &actionExpr{
-				pos: position{line: 5084, col: 16, offset: 154542},
+				pos: position{line: 5096, col: 16, offset: 155081},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5084, col: 16, offset: 154542},
+					pos: position{line: 5096, col: 16, offset: 155081},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5084, col: 16, offset: 154542},
+							pos:  position{line: 5096, col: 16, offset: 155081},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5084, col: 22, offset: 154548},
+							pos:  position{line: 5096, col: 22, offset: 155087},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5084, col: 32, offset: 154558},
+							pos:   position{line: 5096, col: 32, offset: 155097},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5084, col: 42, offset: 154568},
+								pos:  position{line: 5096, col: 42, offset: 155107},
 								name: "BoolExpr",
 							},
 						},
@@ -12973,28 +12973,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5088, col: 1, offset: 154628},
+			pos:  position{line: 5100, col: 1, offset: 155167},
 			expr: &actionExpr{
-				pos: position{line: 5088, col: 28, offset: 154655},
+				pos: position{line: 5100, col: 28, offset: 155194},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5088, col: 28, offset: 154655},
+					pos: position{line: 5100, col: 28, offset: 155194},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5088, col: 28, offset: 154655},
+							pos:        position{line: 5100, col: 28, offset: 155194},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5088, col: 37, offset: 154664},
+							pos:  position{line: 5100, col: 37, offset: 155203},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5088, col: 43, offset: 154670},
+							pos:   position{line: 5100, col: 43, offset: 155209},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5088, col: 51, offset: 154678},
+								pos:  position{line: 5100, col: 51, offset: 155217},
 								name: "Boolean",
 							},
 						},
@@ -13004,28 +13004,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5097, col: 1, offset: 154862},
+			pos:  position{line: 5109, col: 1, offset: 155401},
 			expr: &actionExpr{
-				pos: position{line: 5097, col: 28, offset: 154889},
+				pos: position{line: 5109, col: 28, offset: 155428},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5097, col: 28, offset: 154889},
+					pos: position{line: 5109, col: 28, offset: 155428},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5097, col: 28, offset: 154889},
+							pos:        position{line: 5109, col: 28, offset: 155428},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5097, col: 37, offset: 154898},
+							pos:  position{line: 5109, col: 37, offset: 155437},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5097, col: 43, offset: 154904},
+							pos:   position{line: 5109, col: 43, offset: 155443},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5097, col: 51, offset: 154912},
+								pos:  position{line: 5109, col: 51, offset: 155451},
 								name: "Boolean",
 							},
 						},
@@ -13035,28 +13035,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5106, col: 1, offset: 155096},
+			pos:  position{line: 5118, col: 1, offset: 155635},
 			expr: &actionExpr{
-				pos: position{line: 5106, col: 27, offset: 155122},
+				pos: position{line: 5118, col: 27, offset: 155661},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5106, col: 27, offset: 155122},
+					pos: position{line: 5118, col: 27, offset: 155661},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5106, col: 27, offset: 155122},
+							pos:        position{line: 5118, col: 27, offset: 155661},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5106, col: 35, offset: 155130},
+							pos:  position{line: 5118, col: 35, offset: 155669},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5106, col: 41, offset: 155136},
+							pos:   position{line: 5118, col: 41, offset: 155675},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5106, col: 48, offset: 155143},
+								pos:  position{line: 5118, col: 48, offset: 155682},
 								name: "PositiveInteger",
 							},
 						},
@@ -13066,28 +13066,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5115, col: 1, offset: 155334},
+			pos:  position{line: 5127, col: 1, offset: 155873},
 			expr: &actionExpr{
-				pos: position{line: 5115, col: 25, offset: 155358},
+				pos: position{line: 5127, col: 25, offset: 155897},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5115, col: 25, offset: 155358},
+					pos: position{line: 5127, col: 25, offset: 155897},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5115, col: 25, offset: 155358},
+							pos:        position{line: 5127, col: 25, offset: 155897},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5115, col: 31, offset: 155364},
+							pos:  position{line: 5127, col: 31, offset: 155903},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5115, col: 37, offset: 155370},
+							pos:   position{line: 5127, col: 37, offset: 155909},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5115, col: 44, offset: 155377},
+								pos:  position{line: 5127, col: 44, offset: 155916},
 								name: "PositiveInteger",
 							},
 						},
@@ -13097,30 +13097,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5124, col: 1, offset: 155564},
+			pos:  position{line: 5136, col: 1, offset: 156103},
 			expr: &actionExpr{
-				pos: position{line: 5124, col: 22, offset: 155585},
+				pos: position{line: 5136, col: 22, offset: 156124},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5124, col: 22, offset: 155585},
+					pos:   position{line: 5136, col: 22, offset: 156124},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5124, col: 41, offset: 155604},
+						pos: position{line: 5136, col: 41, offset: 156143},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5124, col: 41, offset: 155604},
+								pos:  position{line: 5136, col: 41, offset: 156143},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5124, col: 67, offset: 155630},
+								pos:  position{line: 5136, col: 67, offset: 156169},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5124, col: 93, offset: 155656},
+								pos:  position{line: 5136, col: 93, offset: 156195},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5124, col: 118, offset: 155681},
+								pos:  position{line: 5136, col: 118, offset: 156220},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13130,35 +13130,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5128, col: 1, offset: 155742},
+			pos:  position{line: 5140, col: 1, offset: 156281},
 			expr: &actionExpr{
-				pos: position{line: 5128, col: 26, offset: 155767},
+				pos: position{line: 5140, col: 26, offset: 156306},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5128, col: 26, offset: 155767},
+					pos: position{line: 5140, col: 26, offset: 156306},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5128, col: 26, offset: 155767},
+							pos:   position{line: 5140, col: 26, offset: 156306},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5128, col: 34, offset: 155775},
+								pos:  position{line: 5140, col: 34, offset: 156314},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5128, col: 53, offset: 155794},
+							pos:   position{line: 5140, col: 53, offset: 156333},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5128, col: 58, offset: 155799},
+								pos: position{line: 5140, col: 58, offset: 156338},
 								expr: &seqExpr{
-									pos: position{line: 5128, col: 59, offset: 155800},
+									pos: position{line: 5140, col: 59, offset: 156339},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5128, col: 59, offset: 155800},
+											pos:  position{line: 5140, col: 59, offset: 156339},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5128, col: 65, offset: 155806},
+											pos:  position{line: 5140, col: 65, offset: 156345},
 											name: "InputLookupOption",
 										},
 									},
@@ -13171,35 +13171,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5170, col: 1, offset: 157252},
+			pos:  position{line: 5182, col: 1, offset: 157791},
 			expr: &actionExpr{
-				pos: position{line: 5170, col: 21, offset: 157272},
+				pos: position{line: 5182, col: 21, offset: 157811},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5170, col: 21, offset: 157272},
+					pos: position{line: 5182, col: 21, offset: 157811},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5170, col: 21, offset: 157272},
+							pos:  position{line: 5182, col: 21, offset: 157811},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5170, col: 26, offset: 157277},
+							pos:  position{line: 5182, col: 26, offset: 157816},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5170, col: 42, offset: 157293},
+							pos:   position{line: 5182, col: 42, offset: 157832},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5170, col: 60, offset: 157311},
+								pos: position{line: 5182, col: 60, offset: 157850},
 								expr: &seqExpr{
-									pos: position{line: 5170, col: 61, offset: 157312},
+									pos: position{line: 5182, col: 61, offset: 157851},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5170, col: 61, offset: 157312},
+											pos:  position{line: 5182, col: 61, offset: 157851},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5170, col: 83, offset: 157334},
+											pos:  position{line: 5182, col: 83, offset: 157873},
 											name: "SPACE",
 										},
 									},
@@ -13207,20 +13207,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5170, col: 91, offset: 157342},
+							pos:   position{line: 5182, col: 91, offset: 157881},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5170, col: 101, offset: 157352},
+								pos:  position{line: 5182, col: 101, offset: 157891},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5170, col: 109, offset: 157360},
+							pos:   position{line: 5182, col: 109, offset: 157899},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5170, col: 121, offset: 157372},
+								pos: position{line: 5182, col: 121, offset: 157911},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5170, col: 122, offset: 157373},
+									pos:  position{line: 5182, col: 122, offset: 157912},
 									name: "WhereClause",
 								},
 							},
@@ -13231,15 +13231,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5193, col: 1, offset: 158061},
+			pos:  position{line: 5205, col: 1, offset: 158600},
 			expr: &actionExpr{
-				pos: position{line: 5193, col: 24, offset: 158084},
+				pos: position{line: 5205, col: 24, offset: 158623},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5193, col: 24, offset: 158084},
+					pos:   position{line: 5205, col: 24, offset: 158623},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5193, col: 41, offset: 158101},
+						pos:  position{line: 5205, col: 41, offset: 158640},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13247,26 +13247,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5204, col: 1, offset: 158500},
+			pos:  position{line: 5216, col: 1, offset: 159039},
 			expr: &actionExpr{
-				pos: position{line: 5204, col: 20, offset: 158519},
+				pos: position{line: 5216, col: 20, offset: 159058},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5204, col: 20, offset: 158519},
+					pos:   position{line: 5216, col: 20, offset: 159058},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5204, col: 28, offset: 158527},
+						pos: position{line: 5216, col: 28, offset: 159066},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5204, col: 28, offset: 158527},
+								pos:  position{line: 5216, col: 28, offset: 159066},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5204, col: 52, offset: 158551},
+								pos:  position{line: 5216, col: 52, offset: 159090},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5204, col: 68, offset: 158567},
+								pos:  position{line: 5216, col: 68, offset: 159106},
 								name: "MaxOutOption",
 							},
 						},
@@ -13276,28 +13276,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5209, col: 1, offset: 158665},
+			pos:  position{line: 5221, col: 1, offset: 159204},
 			expr: &actionExpr{
-				pos: position{line: 5209, col: 26, offset: 158690},
+				pos: position{line: 5221, col: 26, offset: 159229},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5209, col: 26, offset: 158690},
+					pos: position{line: 5221, col: 26, offset: 159229},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5209, col: 26, offset: 158690},
+							pos:        position{line: 5221, col: 26, offset: 159229},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5209, col: 44, offset: 158708},
+							pos:  position{line: 5221, col: 44, offset: 159247},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5209, col: 50, offset: 158714},
+							pos:   position{line: 5221, col: 50, offset: 159253},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5209, col: 58, offset: 158722},
+								pos:  position{line: 5221, col: 58, offset: 159261},
 								name: "Boolean",
 							},
 						},
@@ -13307,28 +13307,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5216, col: 1, offset: 158861},
+			pos:  position{line: 5228, col: 1, offset: 159400},
 			expr: &actionExpr{
-				pos: position{line: 5216, col: 18, offset: 158878},
+				pos: position{line: 5228, col: 18, offset: 159417},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5216, col: 18, offset: 158878},
+					pos: position{line: 5228, col: 18, offset: 159417},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5216, col: 18, offset: 158878},
+							pos:        position{line: 5228, col: 18, offset: 159417},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5216, col: 28, offset: 158888},
+							pos:  position{line: 5228, col: 28, offset: 159427},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5216, col: 34, offset: 158894},
+							pos:   position{line: 5228, col: 34, offset: 159433},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5216, col: 39, offset: 158899},
+								pos:  position{line: 5228, col: 39, offset: 159438},
 								name: "IntegerAsString",
 							},
 						},
@@ -13338,28 +13338,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5227, col: 1, offset: 159200},
+			pos:  position{line: 5239, col: 1, offset: 159739},
 			expr: &actionExpr{
-				pos: position{line: 5227, col: 17, offset: 159216},
+				pos: position{line: 5239, col: 17, offset: 159755},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5227, col: 17, offset: 159216},
+					pos: position{line: 5239, col: 17, offset: 159755},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5227, col: 17, offset: 159216},
+							pos:        position{line: 5239, col: 17, offset: 159755},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5227, col: 26, offset: 159225},
+							pos:  position{line: 5239, col: 26, offset: 159764},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5227, col: 32, offset: 159231},
+							pos:   position{line: 5239, col: 32, offset: 159770},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5227, col: 36, offset: 159235},
+								pos:  position{line: 5239, col: 36, offset: 159774},
 								name: "IntegerAsString",
 							},
 						},
@@ -13369,43 +13369,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5239, col: 1, offset: 159590},
+			pos:  position{line: 5251, col: 1, offset: 160129},
 			expr: &actionExpr{
-				pos: position{line: 5239, col: 14, offset: 159603},
+				pos: position{line: 5251, col: 14, offset: 160142},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5239, col: 14, offset: 159603},
+					pos: position{line: 5251, col: 14, offset: 160142},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5239, col: 14, offset: 159603},
+							pos:        position{line: 5251, col: 14, offset: 160142},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5239, col: 18, offset: 159607},
+							pos: position{line: 5251, col: 18, offset: 160146},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5239, col: 18, offset: 159607},
+								pos:  position{line: 5251, col: 18, offset: 160146},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5239, col: 25, offset: 159614},
+							pos:   position{line: 5251, col: 25, offset: 160153},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5239, col: 32, offset: 159621},
+								pos:  position{line: 5251, col: 32, offset: 160160},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5239, col: 44, offset: 159633},
+							pos: position{line: 5251, col: 44, offset: 160172},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5239, col: 44, offset: 159633},
+								pos:  position{line: 5251, col: 44, offset: 160172},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5239, col: 51, offset: 159640},
+							pos:        position{line: 5251, col: 51, offset: 160179},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13416,35 +13416,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5244, col: 1, offset: 159729},
+			pos:  position{line: 5256, col: 1, offset: 160268},
 			expr: &actionExpr{
-				pos: position{line: 5244, col: 25, offset: 159753},
+				pos: position{line: 5256, col: 25, offset: 160292},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5244, col: 25, offset: 159753},
+					pos: position{line: 5256, col: 25, offset: 160292},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5244, col: 25, offset: 159753},
+							pos:   position{line: 5256, col: 25, offset: 160292},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5244, col: 31, offset: 159759},
+								pos:  position{line: 5256, col: 31, offset: 160298},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5244, col: 47, offset: 159775},
+							pos:   position{line: 5256, col: 47, offset: 160314},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5244, col: 52, offset: 159780},
+								pos: position{line: 5256, col: 52, offset: 160319},
 								expr: &seqExpr{
-									pos: position{line: 5244, col: 53, offset: 159781},
+									pos: position{line: 5256, col: 53, offset: 160320},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5244, col: 53, offset: 159781},
+											pos:  position{line: 5256, col: 53, offset: 160320},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5244, col: 59, offset: 159787},
+											pos:  position{line: 5256, col: 59, offset: 160326},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13457,37 +13457,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5271, col: 1, offset: 160597},
+			pos:  position{line: 5283, col: 1, offset: 161136},
 			expr: &actionExpr{
-				pos: position{line: 5271, col: 16, offset: 160612},
+				pos: position{line: 5283, col: 16, offset: 161151},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5271, col: 16, offset: 160612},
+					pos: position{line: 5283, col: 16, offset: 161151},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5271, col: 16, offset: 160612},
+							pos:  position{line: 5283, col: 16, offset: 161151},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5271, col: 21, offset: 160617},
+							pos:  position{line: 5283, col: 21, offset: 161156},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5271, col: 32, offset: 160628},
+							pos:   position{line: 5283, col: 32, offset: 161167},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5271, col: 40, offset: 160636},
+								pos: position{line: 5283, col: 40, offset: 161175},
 								expr: &seqExpr{
-									pos: position{line: 5271, col: 41, offset: 160637},
+									pos: position{line: 5283, col: 41, offset: 161176},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5271, col: 41, offset: 160637},
+											pos:  position{line: 5283, col: 41, offset: 161176},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5271, col: 57, offset: 160653},
+											pos: position{line: 5283, col: 57, offset: 161192},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5271, col: 57, offset: 160653},
+												pos:  position{line: 5283, col: 57, offset: 161192},
 												name: "SPACE",
 											},
 										},
@@ -13496,10 +13496,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5271, col: 66, offset: 160662},
+							pos:   position{line: 5283, col: 66, offset: 161201},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5271, col: 76, offset: 160672},
+								pos:  position{line: 5283, col: 76, offset: 161211},
 								name: "Subsearch",
 							},
 						},
@@ -13509,128 +13509,128 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5315, col: 1, offset: 162244},
+			pos:  position{line: 5327, col: 1, offset: 162783},
 			expr: &choiceExpr{
-				pos: position{line: 5315, col: 12, offset: 162255},
+				pos: position{line: 5327, col: 12, offset: 162794},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 12, offset: 162255},
+						pos:  position{line: 5327, col: 12, offset: 162794},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 24, offset: 162267},
+						pos:  position{line: 5327, col: 24, offset: 162806},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 36, offset: 162279},
+						pos:  position{line: 5327, col: 36, offset: 162818},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 49, offset: 162292},
+						pos:  position{line: 5327, col: 49, offset: 162831},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 61, offset: 162304},
+						pos:  position{line: 5327, col: 61, offset: 162843},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 81, offset: 162324},
+						pos:  position{line: 5327, col: 81, offset: 162863},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 92, offset: 162335},
+						pos:  position{line: 5327, col: 92, offset: 162874},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 112, offset: 162355},
+						pos:  position{line: 5327, col: 112, offset: 162894},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 123, offset: 162366},
+						pos:  position{line: 5327, col: 123, offset: 162905},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 134, offset: 162377},
+						pos:  position{line: 5327, col: 134, offset: 162916},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 144, offset: 162387},
+						pos:  position{line: 5327, col: 144, offset: 162926},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 154, offset: 162397},
+						pos:  position{line: 5327, col: 154, offset: 162936},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 165, offset: 162408},
+						pos:  position{line: 5327, col: 165, offset: 162947},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 178, offset: 162421},
+						pos:  position{line: 5327, col: 178, offset: 162960},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 194, offset: 162437},
+						pos:  position{line: 5327, col: 194, offset: 162976},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 212, offset: 162455},
+						pos:  position{line: 5327, col: 212, offset: 162994},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 224, offset: 162467},
+						pos:  position{line: 5327, col: 224, offset: 163006},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 235, offset: 162478},
+						pos:  position{line: 5327, col: 235, offset: 163017},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 248, offset: 162491},
+						pos:  position{line: 5327, col: 248, offset: 163030},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 260, offset: 162503},
+						pos:  position{line: 5327, col: 260, offset: 163042},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 273, offset: 162516},
+						pos:  position{line: 5327, col: 273, offset: 163055},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 288, offset: 162531},
+						pos:  position{line: 5327, col: 288, offset: 163070},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 301, offset: 162544},
+						pos:  position{line: 5327, col: 301, offset: 163083},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 318, offset: 162561},
+						pos:  position{line: 5327, col: 318, offset: 163100},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 328, offset: 162571},
+						pos:  position{line: 5327, col: 328, offset: 163110},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 346, offset: 162589},
+						pos:  position{line: 5327, col: 346, offset: 163128},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 361, offset: 162604},
+						pos:  position{line: 5327, col: 361, offset: 163143},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 376, offset: 162619},
+						pos:  position{line: 5327, col: 376, offset: 163158},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 391, offset: 162634},
+						pos:  position{line: 5327, col: 391, offset: 163173},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5315, col: 409, offset: 162652},
+						pos:  position{line: 5327, col: 409, offset: 163191},
 						name: "CMD_APPEND",
 					},
 				},
@@ -13638,18 +13638,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5316, col: 1, offset: 162664},
+			pos:  position{line: 5328, col: 1, offset: 163203},
 			expr: &seqExpr{
-				pos: position{line: 5316, col: 15, offset: 162678},
+				pos: position{line: 5328, col: 15, offset: 163217},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5316, col: 15, offset: 162678},
+						pos:        position{line: 5328, col: 15, offset: 163217},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5316, col: 24, offset: 162687},
+						pos:  position{line: 5328, col: 24, offset: 163226},
 						name: "SPACE",
 					},
 				},
@@ -13657,18 +13657,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5317, col: 1, offset: 162693},
+			pos:  position{line: 5329, col: 1, offset: 163232},
 			expr: &seqExpr{
-				pos: position{line: 5317, col: 14, offset: 162706},
+				pos: position{line: 5329, col: 14, offset: 163245},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5317, col: 14, offset: 162706},
+						pos:        position{line: 5329, col: 14, offset: 163245},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5317, col: 22, offset: 162714},
+						pos:  position{line: 5329, col: 22, offset: 163253},
 						name: "SPACE",
 					},
 				},
@@ -13676,18 +13676,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5318, col: 1, offset: 162720},
+			pos:  position{line: 5330, col: 1, offset: 163259},
 			expr: &seqExpr{
-				pos: position{line: 5318, col: 14, offset: 162733},
+				pos: position{line: 5330, col: 14, offset: 163272},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5318, col: 14, offset: 162733},
+						pos:        position{line: 5330, col: 14, offset: 163272},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5318, col: 22, offset: 162741},
+						pos:  position{line: 5330, col: 22, offset: 163280},
 						name: "SPACE",
 					},
 				},
@@ -13695,18 +13695,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5319, col: 1, offset: 162747},
+			pos:  position{line: 5331, col: 1, offset: 163286},
 			expr: &seqExpr{
-				pos: position{line: 5319, col: 20, offset: 162766},
+				pos: position{line: 5331, col: 20, offset: 163305},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5319, col: 20, offset: 162766},
+						pos:        position{line: 5331, col: 20, offset: 163305},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5319, col: 34, offset: 162780},
+						pos:  position{line: 5331, col: 34, offset: 163319},
 						name: "SPACE",
 					},
 				},
@@ -13714,18 +13714,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5320, col: 1, offset: 162786},
+			pos:  position{line: 5332, col: 1, offset: 163325},
 			expr: &seqExpr{
-				pos: position{line: 5320, col: 15, offset: 162800},
+				pos: position{line: 5332, col: 15, offset: 163339},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5320, col: 15, offset: 162800},
+						pos:        position{line: 5332, col: 15, offset: 163339},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5320, col: 24, offset: 162809},
+						pos:  position{line: 5332, col: 24, offset: 163348},
 						name: "SPACE",
 					},
 				},
@@ -13733,18 +13733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5321, col: 1, offset: 162815},
+			pos:  position{line: 5333, col: 1, offset: 163354},
 			expr: &seqExpr{
-				pos: position{line: 5321, col: 14, offset: 162828},
+				pos: position{line: 5333, col: 14, offset: 163367},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5321, col: 14, offset: 162828},
+						pos:        position{line: 5333, col: 14, offset: 163367},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5321, col: 22, offset: 162836},
+						pos:  position{line: 5333, col: 22, offset: 163375},
 						name: "SPACE",
 					},
 				},
@@ -13752,9 +13752,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5322, col: 1, offset: 162842},
+			pos:  position{line: 5334, col: 1, offset: 163381},
 			expr: &litMatcher{
-				pos:        position{line: 5322, col: 22, offset: 162863},
+				pos:        position{line: 5334, col: 22, offset: 163402},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -13762,16 +13762,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5323, col: 1, offset: 162870},
+			pos:  position{line: 5335, col: 1, offset: 163409},
 			expr: &seqExpr{
-				pos: position{line: 5323, col: 13, offset: 162882},
+				pos: position{line: 5335, col: 13, offset: 163421},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5323, col: 13, offset: 162882},
+						pos:  position{line: 5335, col: 13, offset: 163421},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5323, col: 31, offset: 162900},
+						pos:  position{line: 5335, col: 31, offset: 163439},
 						name: "SPACE",
 					},
 				},
@@ -13779,9 +13779,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5324, col: 1, offset: 162906},
+			pos:  position{line: 5336, col: 1, offset: 163445},
 			expr: &litMatcher{
-				pos:        position{line: 5324, col: 22, offset: 162927},
+				pos:        position{line: 5336, col: 22, offset: 163466},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -13789,16 +13789,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5325, col: 1, offset: 162934},
+			pos:  position{line: 5337, col: 1, offset: 163473},
 			expr: &seqExpr{
-				pos: position{line: 5325, col: 13, offset: 162946},
+				pos: position{line: 5337, col: 13, offset: 163485},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5325, col: 13, offset: 162946},
+						pos:  position{line: 5337, col: 13, offset: 163485},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5325, col: 31, offset: 162964},
+						pos:  position{line: 5337, col: 31, offset: 163503},
 						name: "SPACE",
 					},
 				},
@@ -13806,18 +13806,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5326, col: 1, offset: 162970},
+			pos:  position{line: 5338, col: 1, offset: 163509},
 			expr: &seqExpr{
-				pos: position{line: 5326, col: 13, offset: 162982},
+				pos: position{line: 5338, col: 13, offset: 163521},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5326, col: 13, offset: 162982},
+						pos:        position{line: 5338, col: 13, offset: 163521},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5326, col: 20, offset: 162989},
+						pos:  position{line: 5338, col: 20, offset: 163528},
 						name: "SPACE",
 					},
 				},
@@ -13825,18 +13825,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5327, col: 1, offset: 162995},
+			pos:  position{line: 5339, col: 1, offset: 163534},
 			expr: &seqExpr{
-				pos: position{line: 5327, col: 12, offset: 163006},
+				pos: position{line: 5339, col: 12, offset: 163545},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5327, col: 12, offset: 163006},
+						pos:        position{line: 5339, col: 12, offset: 163545},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5327, col: 18, offset: 163012},
+						pos:  position{line: 5339, col: 18, offset: 163551},
 						name: "SPACE",
 					},
 				},
@@ -13844,18 +13844,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5328, col: 1, offset: 163018},
+			pos:  position{line: 5340, col: 1, offset: 163557},
 			expr: &seqExpr{
-				pos: position{line: 5328, col: 13, offset: 163030},
+				pos: position{line: 5340, col: 13, offset: 163569},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5328, col: 13, offset: 163030},
+						pos:        position{line: 5340, col: 13, offset: 163569},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5328, col: 20, offset: 163037},
+						pos:  position{line: 5340, col: 20, offset: 163576},
 						name: "SPACE",
 					},
 				},
@@ -13863,9 +13863,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5329, col: 1, offset: 163043},
+			pos:  position{line: 5341, col: 1, offset: 163582},
 			expr: &litMatcher{
-				pos:        position{line: 5329, col: 12, offset: 163054},
+				pos:        position{line: 5341, col: 12, offset: 163593},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -13873,9 +13873,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5330, col: 1, offset: 163060},
+			pos:  position{line: 5342, col: 1, offset: 163599},
 			expr: &litMatcher{
-				pos:        position{line: 5330, col: 13, offset: 163072},
+				pos:        position{line: 5342, col: 13, offset: 163611},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -13883,18 +13883,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5331, col: 1, offset: 163079},
+			pos:  position{line: 5343, col: 1, offset: 163618},
 			expr: &seqExpr{
-				pos: position{line: 5331, col: 15, offset: 163093},
+				pos: position{line: 5343, col: 15, offset: 163632},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5331, col: 15, offset: 163093},
+						pos:        position{line: 5343, col: 15, offset: 163632},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5331, col: 24, offset: 163102},
+						pos:  position{line: 5343, col: 24, offset: 163641},
 						name: "SPACE",
 					},
 				},
@@ -13902,18 +13902,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5332, col: 1, offset: 163108},
+			pos:  position{line: 5344, col: 1, offset: 163647},
 			expr: &seqExpr{
-				pos: position{line: 5332, col: 18, offset: 163125},
+				pos: position{line: 5344, col: 18, offset: 163664},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5332, col: 18, offset: 163125},
+						pos:        position{line: 5344, col: 18, offset: 163664},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5332, col: 30, offset: 163137},
+						pos:  position{line: 5344, col: 30, offset: 163676},
 						name: "SPACE",
 					},
 				},
@@ -13921,18 +13921,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5333, col: 1, offset: 163143},
+			pos:  position{line: 5345, col: 1, offset: 163682},
 			expr: &seqExpr{
-				pos: position{line: 5333, col: 12, offset: 163154},
+				pos: position{line: 5345, col: 12, offset: 163693},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5333, col: 12, offset: 163154},
+						pos:        position{line: 5345, col: 12, offset: 163693},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5333, col: 18, offset: 163160},
+						pos:  position{line: 5345, col: 18, offset: 163699},
 						name: "SPACE",
 					},
 				},
@@ -13940,9 +13940,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5334, col: 1, offset: 163166},
+			pos:  position{line: 5346, col: 1, offset: 163705},
 			expr: &litMatcher{
-				pos:        position{line: 5334, col: 13, offset: 163178},
+				pos:        position{line: 5346, col: 13, offset: 163717},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -13950,18 +13950,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5335, col: 1, offset: 163185},
+			pos:  position{line: 5347, col: 1, offset: 163724},
 			expr: &seqExpr{
-				pos: position{line: 5335, col: 20, offset: 163204},
+				pos: position{line: 5347, col: 20, offset: 163743},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5335, col: 20, offset: 163204},
+						pos:        position{line: 5347, col: 20, offset: 163743},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5335, col: 34, offset: 163218},
+						pos:  position{line: 5347, col: 34, offset: 163757},
 						name: "SPACE",
 					},
 				},
@@ -13969,9 +13969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5336, col: 1, offset: 163224},
+			pos:  position{line: 5348, col: 1, offset: 163763},
 			expr: &litMatcher{
-				pos:        position{line: 5336, col: 14, offset: 163237},
+				pos:        position{line: 5348, col: 14, offset: 163776},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -13979,22 +13979,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5337, col: 1, offset: 163245},
+			pos:  position{line: 5349, col: 1, offset: 163784},
 			expr: &seqExpr{
-				pos: position{line: 5337, col: 21, offset: 163265},
+				pos: position{line: 5349, col: 21, offset: 163804},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 21, offset: 163265},
+						pos:  position{line: 5349, col: 21, offset: 163804},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5337, col: 27, offset: 163271},
+						pos:        position{line: 5349, col: 27, offset: 163810},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 36, offset: 163280},
+						pos:  position{line: 5349, col: 36, offset: 163819},
 						name: "SPACE",
 					},
 				},
@@ -14002,9 +14002,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5338, col: 1, offset: 163286},
+			pos:  position{line: 5350, col: 1, offset: 163825},
 			expr: &litMatcher{
-				pos:        position{line: 5338, col: 15, offset: 163300},
+				pos:        position{line: 5350, col: 15, offset: 163839},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14012,9 +14012,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5339, col: 1, offset: 163309},
+			pos:  position{line: 5351, col: 1, offset: 163848},
 			expr: &litMatcher{
-				pos:        position{line: 5339, col: 14, offset: 163322},
+				pos:        position{line: 5351, col: 14, offset: 163861},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14022,9 +14022,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5340, col: 1, offset: 163330},
+			pos:  position{line: 5352, col: 1, offset: 163869},
 			expr: &litMatcher{
-				pos:        position{line: 5340, col: 15, offset: 163344},
+				pos:        position{line: 5352, col: 15, offset: 163883},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14032,9 +14032,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5341, col: 1, offset: 163353},
+			pos:  position{line: 5353, col: 1, offset: 163892},
 			expr: &litMatcher{
-				pos:        position{line: 5341, col: 17, offset: 163369},
+				pos:        position{line: 5353, col: 17, offset: 163908},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14042,9 +14042,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5342, col: 1, offset: 163380},
+			pos:  position{line: 5354, col: 1, offset: 163919},
 			expr: &litMatcher{
-				pos:        position{line: 5342, col: 15, offset: 163394},
+				pos:        position{line: 5354, col: 15, offset: 163933},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14052,9 +14052,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5343, col: 1, offset: 163403},
+			pos:  position{line: 5355, col: 1, offset: 163942},
 			expr: &litMatcher{
-				pos:        position{line: 5343, col: 19, offset: 163421},
+				pos:        position{line: 5355, col: 19, offset: 163960},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14062,9 +14062,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5344, col: 1, offset: 163434},
+			pos:  position{line: 5356, col: 1, offset: 163973},
 			expr: &litMatcher{
-				pos:        position{line: 5344, col: 17, offset: 163450},
+				pos:        position{line: 5356, col: 17, offset: 163989},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14072,9 +14072,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5345, col: 1, offset: 163461},
+			pos:  position{line: 5357, col: 1, offset: 164000},
 			expr: &litMatcher{
-				pos:        position{line: 5345, col: 17, offset: 163477},
+				pos:        position{line: 5357, col: 17, offset: 164016},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14082,18 +14082,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5346, col: 1, offset: 163488},
+			pos:  position{line: 5358, col: 1, offset: 164027},
 			expr: &seqExpr{
-				pos: position{line: 5346, col: 20, offset: 163507},
+				pos: position{line: 5358, col: 20, offset: 164046},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5346, col: 20, offset: 163507},
+						pos:        position{line: 5358, col: 20, offset: 164046},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5346, col: 34, offset: 163521},
+						pos:  position{line: 5358, col: 34, offset: 164060},
 						name: "SPACE",
 					},
 				},
@@ -14101,28 +14101,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5347, col: 1, offset: 163527},
+			pos:  position{line: 5359, col: 1, offset: 164066},
 			expr: &seqExpr{
-				pos: position{line: 5347, col: 16, offset: 163542},
+				pos: position{line: 5359, col: 16, offset: 164081},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5347, col: 16, offset: 163542},
+						pos: position{line: 5359, col: 16, offset: 164081},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5347, col: 16, offset: 163542},
+							pos:  position{line: 5359, col: 16, offset: 164081},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5347, col: 24, offset: 163550},
+						pos: position{line: 5359, col: 24, offset: 164089},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5347, col: 24, offset: 163550},
+								pos:        position{line: 5359, col: 24, offset: 164089},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5347, col: 30, offset: 163556},
+								pos:        position{line: 5359, col: 30, offset: 164095},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14130,9 +14130,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5347, col: 35, offset: 163561},
+						pos: position{line: 5359, col: 35, offset: 164100},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5347, col: 35, offset: 163561},
+							pos:  position{line: 5359, col: 35, offset: 164100},
 							name: "SPACE",
 						},
 					},
@@ -14141,9 +14141,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5348, col: 1, offset: 163568},
+			pos:  position{line: 5360, col: 1, offset: 164107},
 			expr: &litMatcher{
-				pos:        position{line: 5348, col: 17, offset: 163584},
+				pos:        position{line: 5360, col: 17, offset: 164123},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14151,18 +14151,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5349, col: 1, offset: 163595},
+			pos:  position{line: 5361, col: 1, offset: 164134},
 			expr: &seqExpr{
-				pos: position{line: 5349, col: 15, offset: 163609},
+				pos: position{line: 5361, col: 15, offset: 164148},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5349, col: 15, offset: 163609},
+						pos:        position{line: 5361, col: 15, offset: 164148},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5349, col: 24, offset: 163618},
+						pos:  position{line: 5361, col: 24, offset: 164157},
 						name: "SPACE",
 					},
 				},
@@ -14170,115 +14170,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5352, col: 1, offset: 163728},
+			pos:  position{line: 5364, col: 1, offset: 164267},
 			expr: &choiceExpr{
-				pos: position{line: 5352, col: 16, offset: 163743},
+				pos: position{line: 5364, col: 16, offset: 164282},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5352, col: 16, offset: 163743},
+						pos:        position{line: 5364, col: 16, offset: 164282},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 47, offset: 163774},
+						pos:        position{line: 5364, col: 47, offset: 164313},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5352, col: 55, offset: 163782},
+						pos:        position{line: 5364, col: 55, offset: 164321},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 16, offset: 163805},
+						pos:        position{line: 5365, col: 16, offset: 164344},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 26, offset: 163815},
+						pos:        position{line: 5365, col: 26, offset: 164354},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 34, offset: 163823},
+						pos:        position{line: 5365, col: 34, offset: 164362},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 42, offset: 163831},
+						pos:        position{line: 5365, col: 42, offset: 164370},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 50, offset: 163839},
+						pos:        position{line: 5365, col: 50, offset: 164378},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 58, offset: 163847},
+						pos:        position{line: 5365, col: 58, offset: 164386},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5353, col: 66, offset: 163855},
+						pos:        position{line: 5365, col: 66, offset: 164394},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 16, offset: 163877},
+						pos:        position{line: 5366, col: 16, offset: 164416},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 26, offset: 163887},
+						pos:        position{line: 5366, col: 26, offset: 164426},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 34, offset: 163895},
+						pos:        position{line: 5366, col: 34, offset: 164434},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 42, offset: 163903},
+						pos:        position{line: 5366, col: 42, offset: 164442},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 50, offset: 163911},
+						pos:        position{line: 5366, col: 50, offset: 164450},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 58, offset: 163919},
+						pos:        position{line: 5366, col: 58, offset: 164458},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 66, offset: 163927},
+						pos:        position{line: 5366, col: 66, offset: 164466},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5354, col: 74, offset: 163935},
+						pos:        position{line: 5366, col: 74, offset: 164474},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14288,25 +14288,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5355, col: 1, offset: 163941},
+			pos:  position{line: 5367, col: 1, offset: 164480},
 			expr: &choiceExpr{
-				pos: position{line: 5355, col: 16, offset: 163956},
+				pos: position{line: 5367, col: 16, offset: 164495},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5355, col: 16, offset: 163956},
+						pos:        position{line: 5367, col: 16, offset: 164495},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5355, col: 30, offset: 163970},
+						pos:        position{line: 5367, col: 30, offset: 164509},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5355, col: 36, offset: 163976},
+						pos:        position{line: 5367, col: 36, offset: 164515},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14316,18 +14316,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5359, col: 1, offset: 164132},
+			pos:  position{line: 5371, col: 1, offset: 164671},
 			expr: &seqExpr{
-				pos: position{line: 5359, col: 8, offset: 164139},
+				pos: position{line: 5371, col: 8, offset: 164678},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5359, col: 8, offset: 164139},
+						pos:        position{line: 5371, col: 8, offset: 164678},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5359, col: 14, offset: 164145},
+						pos:  position{line: 5371, col: 14, offset: 164684},
 						name: "SPACE",
 					},
 				},
@@ -14335,22 +14335,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5360, col: 1, offset: 164151},
+			pos:  position{line: 5372, col: 1, offset: 164690},
 			expr: &seqExpr{
-				pos: position{line: 5360, col: 7, offset: 164157},
+				pos: position{line: 5372, col: 7, offset: 164696},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5360, col: 7, offset: 164157},
+						pos:  position{line: 5372, col: 7, offset: 164696},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5360, col: 13, offset: 164163},
+						pos:        position{line: 5372, col: 13, offset: 164702},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5360, col: 18, offset: 164168},
+						pos:  position{line: 5372, col: 18, offset: 164707},
 						name: "SPACE",
 					},
 				},
@@ -14358,22 +14358,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5361, col: 1, offset: 164174},
+			pos:  position{line: 5373, col: 1, offset: 164713},
 			expr: &seqExpr{
-				pos: position{line: 5361, col: 8, offset: 164181},
+				pos: position{line: 5373, col: 8, offset: 164720},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5361, col: 8, offset: 164181},
+						pos:  position{line: 5373, col: 8, offset: 164720},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5361, col: 14, offset: 164187},
+						pos:        position{line: 5373, col: 14, offset: 164726},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5361, col: 20, offset: 164193},
+						pos:  position{line: 5373, col: 20, offset: 164732},
 						name: "SPACE",
 					},
 				},
@@ -14381,22 +14381,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5362, col: 1, offset: 164199},
+			pos:  position{line: 5374, col: 1, offset: 164738},
 			expr: &seqExpr{
-				pos: position{line: 5362, col: 9, offset: 164207},
+				pos: position{line: 5374, col: 9, offset: 164746},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5362, col: 9, offset: 164207},
+						pos:  position{line: 5374, col: 9, offset: 164746},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5362, col: 24, offset: 164222},
+						pos:        position{line: 5374, col: 24, offset: 164761},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5362, col: 28, offset: 164226},
+						pos:  position{line: 5374, col: 28, offset: 164765},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14404,22 +14404,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5363, col: 1, offset: 164241},
+			pos:  position{line: 5375, col: 1, offset: 164780},
 			expr: &seqExpr{
-				pos: position{line: 5363, col: 7, offset: 164247},
+				pos: position{line: 5375, col: 7, offset: 164786},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5363, col: 7, offset: 164247},
+						pos:  position{line: 5375, col: 7, offset: 164786},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5363, col: 13, offset: 164253},
+						pos:        position{line: 5375, col: 13, offset: 164792},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5363, col: 19, offset: 164259},
+						pos:  position{line: 5375, col: 19, offset: 164798},
 						name: "SPACE",
 					},
 				},
@@ -14427,22 +14427,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5364, col: 1, offset: 164285},
+			pos:  position{line: 5376, col: 1, offset: 164824},
 			expr: &seqExpr{
-				pos: position{line: 5364, col: 7, offset: 164291},
+				pos: position{line: 5376, col: 7, offset: 164830},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5364, col: 7, offset: 164291},
+						pos:  position{line: 5376, col: 7, offset: 164830},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5364, col: 13, offset: 164297},
+						pos:        position{line: 5376, col: 13, offset: 164836},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5364, col: 19, offset: 164303},
+						pos:  position{line: 5376, col: 19, offset: 164842},
 						name: "SPACE",
 					},
 				},
@@ -14450,22 +14450,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5366, col: 1, offset: 164330},
+			pos:  position{line: 5378, col: 1, offset: 164869},
 			expr: &seqExpr{
-				pos: position{line: 5366, col: 10, offset: 164339},
+				pos: position{line: 5378, col: 10, offset: 164878},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5366, col: 10, offset: 164339},
+						pos:  position{line: 5378, col: 10, offset: 164878},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5366, col: 25, offset: 164354},
+						pos:        position{line: 5378, col: 25, offset: 164893},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5366, col: 29, offset: 164358},
+						pos:  position{line: 5378, col: 29, offset: 164897},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14473,22 +14473,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5367, col: 1, offset: 164373},
+			pos:  position{line: 5379, col: 1, offset: 164912},
 			expr: &seqExpr{
-				pos: position{line: 5367, col: 10, offset: 164382},
+				pos: position{line: 5379, col: 10, offset: 164921},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5367, col: 10, offset: 164382},
+						pos:  position{line: 5379, col: 10, offset: 164921},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5367, col: 25, offset: 164397},
+						pos:        position{line: 5379, col: 25, offset: 164936},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5367, col: 29, offset: 164401},
+						pos:  position{line: 5379, col: 29, offset: 164940},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14496,9 +14496,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5368, col: 1, offset: 164416},
+			pos:  position{line: 5380, col: 1, offset: 164955},
 			expr: &litMatcher{
-				pos:        position{line: 5368, col: 10, offset: 164425},
+				pos:        position{line: 5380, col: 10, offset: 164964},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -14506,18 +14506,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5369, col: 1, offset: 164429},
+			pos:  position{line: 5381, col: 1, offset: 164968},
 			expr: &seqExpr{
-				pos: position{line: 5369, col: 12, offset: 164440},
+				pos: position{line: 5381, col: 12, offset: 164979},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5369, col: 12, offset: 164440},
+						pos:        position{line: 5381, col: 12, offset: 164979},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5369, col: 16, offset: 164444},
+						pos:  position{line: 5381, col: 16, offset: 164983},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14525,16 +14525,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5370, col: 1, offset: 164459},
+			pos:  position{line: 5382, col: 1, offset: 164998},
 			expr: &seqExpr{
-				pos: position{line: 5370, col: 12, offset: 164470},
+				pos: position{line: 5382, col: 12, offset: 165009},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5370, col: 12, offset: 164470},
+						pos:  position{line: 5382, col: 12, offset: 165009},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5370, col: 27, offset: 164485},
+						pos:        position{line: 5382, col: 27, offset: 165024},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -14544,40 +14544,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5372, col: 1, offset: 164490},
+			pos:  position{line: 5384, col: 1, offset: 165029},
 			expr: &notExpr{
-				pos: position{line: 5372, col: 8, offset: 164497},
+				pos: position{line: 5384, col: 8, offset: 165036},
 				expr: &anyMatcher{
-					line: 5372, col: 9, offset: 164498,
+					line: 5384, col: 9, offset: 165037,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5373, col: 1, offset: 164500},
+			pos:  position{line: 5385, col: 1, offset: 165039},
 			expr: &choiceExpr{
-				pos: position{line: 5373, col: 15, offset: 164514},
+				pos: position{line: 5385, col: 15, offset: 165053},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5373, col: 15, offset: 164514},
+						pos:        position{line: 5385, col: 15, offset: 165053},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5373, col: 21, offset: 164520},
+						pos:        position{line: 5385, col: 21, offset: 165059},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5373, col: 28, offset: 164527},
+						pos:        position{line: 5385, col: 28, offset: 165066},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5373, col: 35, offset: 164534},
+						pos:        position{line: 5385, col: 35, offset: 165073},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -14587,37 +14587,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5374, col: 1, offset: 164539},
+			pos:  position{line: 5386, col: 1, offset: 165078},
 			expr: &choiceExpr{
-				pos: position{line: 5374, col: 10, offset: 164548},
+				pos: position{line: 5386, col: 10, offset: 165087},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5374, col: 11, offset: 164549},
+						pos: position{line: 5386, col: 11, offset: 165088},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5374, col: 11, offset: 164549},
+								pos: position{line: 5386, col: 11, offset: 165088},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5374, col: 11, offset: 164549},
+									pos:  position{line: 5386, col: 11, offset: 165088},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5374, col: 23, offset: 164561},
+								pos:  position{line: 5386, col: 23, offset: 165100},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5374, col: 31, offset: 164569},
+								pos: position{line: 5386, col: 31, offset: 165108},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5374, col: 31, offset: 164569},
+									pos:  position{line: 5386, col: 31, offset: 165108},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5374, col: 46, offset: 164584},
+						pos: position{line: 5386, col: 46, offset: 165123},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5374, col: 46, offset: 164584},
+							pos:  position{line: 5386, col: 46, offset: 165123},
 							name: "WHITESPACE",
 						},
 					},
@@ -14626,38 +14626,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5375, col: 1, offset: 164596},
+			pos:  position{line: 5387, col: 1, offset: 165135},
 			expr: &seqExpr{
-				pos: position{line: 5375, col: 12, offset: 164607},
+				pos: position{line: 5387, col: 12, offset: 165146},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5375, col: 12, offset: 164607},
+						pos:        position{line: 5387, col: 12, offset: 165146},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5375, col: 18, offset: 164613},
+						pos: position{line: 5387, col: 18, offset: 165152},
 						expr: &seqExpr{
-							pos: position{line: 5375, col: 19, offset: 164614},
+							pos: position{line: 5387, col: 19, offset: 165153},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5375, col: 19, offset: 164614},
+									pos: position{line: 5387, col: 19, offset: 165153},
 									expr: &litMatcher{
-										pos:        position{line: 5375, col: 21, offset: 164616},
+										pos:        position{line: 5387, col: 21, offset: 165155},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5375, col: 28, offset: 164623,
+									line: 5387, col: 28, offset: 165162,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5375, col: 32, offset: 164627},
+						pos:        position{line: 5387, col: 32, offset: 165166},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -14667,16 +14667,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5376, col: 1, offset: 164633},
+			pos:  position{line: 5388, col: 1, offset: 165172},
 			expr: &choiceExpr{
-				pos: position{line: 5376, col: 20, offset: 164652},
+				pos: position{line: 5388, col: 20, offset: 165191},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5376, col: 20, offset: 164652},
+						pos:  position{line: 5388, col: 20, offset: 165191},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5376, col: 28, offset: 164660},
+						pos:        position{line: 5388, col: 28, offset: 165199},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -14686,16 +14686,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5377, col: 1, offset: 164663},
+			pos:  position{line: 5389, col: 1, offset: 165202},
 			expr: &choiceExpr{
-				pos: position{line: 5377, col: 19, offset: 164681},
+				pos: position{line: 5389, col: 19, offset: 165220},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5377, col: 19, offset: 164681},
+						pos:  position{line: 5389, col: 19, offset: 165220},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5377, col: 27, offset: 164689},
+						pos:  position{line: 5389, col: 27, offset: 165228},
 						name: "SPACE",
 					},
 				},
@@ -15186,14 +15186,26 @@ func (c *current) onCommonAggregatorBlock1(aggs, byFields any) (any, error) {
 
 	if byFields == nil {
 		aggNode.PipeCommandType = structs.MeasureAggsType
+		// TODO: remove the duplication; use StatsExpr instead of MeasureOperations
 		aggNode.MeasureOperations = measureAggs
+		aggNode.StatsExpr = &structs.StatsExpr{
+			MeasureOperations: measureAggs,
+		}
 	} else {
 		aggNode.PipeCommandType = structs.GroupByType
+		// TODO: remove the duplication; use StatsExpr instead of GroupByRequest
 		aggNode.GroupByRequest = &structs.GroupByRequest{
 			MeasureOperations: measureAggs,
 			GroupByColumns:    byFields.([]string),
 		}
 		aggNode.BucketLimit = query.MAX_GRP_BUCKS
+		aggNode.StatsExpr = &structs.StatsExpr{
+			MeasureOperations: measureAggs,
+			GroupByRequest: &structs.GroupByRequest{
+				MeasureOperations: measureAggs,
+				GroupByColumns:    byFields.([]string),
+			},
+		}
 	}
 
 	return aggNode, nil

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -846,14 +846,26 @@ CommonAggregatorBlock <- aggs:AggregationList byFields:(GroupbyBlock)? {
 
     if byFields == nil {
         aggNode.PipeCommandType = structs.MeasureAggsType
+        // TODO: remove the duplication; use StatsExpr instead of MeasureOperations
         aggNode.MeasureOperations = measureAggs
+        aggNode.StatsExpr = &structs.StatsExpr{
+            MeasureOperations: measureAggs,
+        }
     } else {
         aggNode.PipeCommandType = structs.GroupByType
+        // TODO: remove the duplication; use StatsExpr instead of GroupByRequest
         aggNode.GroupByRequest = &structs.GroupByRequest {
             MeasureOperations: measureAggs,
             GroupByColumns: byFields.([]string),
         }
         aggNode.BucketLimit = query.MAX_GRP_BUCKS
+        aggNode.StatsExpr = &structs.StatsExpr{
+            MeasureOperations: measureAggs,
+            GroupByRequest: &structs.GroupByRequest {
+                MeasureOperations: measureAggs,
+                GroupByColumns: byFields.([]string),
+            },
+        }
     }
 
     return aggNode, nil

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -1347,6 +1347,8 @@ TimechartBlock <- PIPE CMD_TIMECHART tcArgs:TimechartArgumentsList limitExpr:(Li
 
     timeBucket := aggregations.InitTimeBucket(bOptions.SpanOptions.SpanLength.Num, bOptions.SpanOptions.SpanLength.TimeScalr, byField, limitExprTmp, len(measureAggs))
     aggNode.TimeHistogram = timeBucket
+    timechartExpr.TimeHistogram = timeBucket
+    timechartExpr.ByField = byField
 
     return aggNode, nil
 }

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -1865,6 +1865,7 @@ StatisticBlock <- PIPE statisticExpr:StatisticExpr {
 
 	if config.IsNewQueryPipelineEnabled() {
 		root.GroupByRequest = aggNode.GroupByRequest
+        root.StatisticExpr = statisticExpr.(*structs.StatisticExpr)
 		return root, nil
 	}
 
@@ -4478,6 +4479,7 @@ TransactionBlock <- PIPE CMD_TRANSACTION txnOptions:TransactionOptions {
     queryAgg := &structs.QueryAggregators{
         PipeCommandType: structs.TransactionType,
         TransactionArguments: txnOptions.(*structs.TransactionArguments),
+        TransactionExpr: txnOptions.(*structs.TransactionArguments),
     }
     return queryAgg, nil
 }

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -1273,6 +1273,7 @@ TimechartBlock <- PIPE CMD_TIMECHART tcArgs:TimechartArgumentsList limitExpr:(Li
     measureAggs := make([]*structs.MeasureAggregator, 0)
 
     timechartExpr := &structs.TimechartExpr{}
+    aggNode.TimechartExpr = timechartExpr
     byField := ""
 
     if tcArgs == nil {
@@ -1321,6 +1322,7 @@ TimechartBlock <- PIPE CMD_TIMECHART tcArgs:TimechartArgumentsList limitExpr:(Li
         MeasureOperations: measureAggs,
         GroupByColumns:    []string{"timestamp"},
     }
+    timechartExpr.GroupBy = aggNode.GroupByRequest
     aggNode.BucketLimit = query.MAX_GRP_BUCKS
 
     if bOptions == nil {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -258,12 +258,6 @@ func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryI
 			timeRange: queryInfo.GetQueryRange(),
 		}
 		return NewTimechartDP(timechartOptions)
-	} else if queryAgg.GroupByRequest != nil {
-		queryAgg.StatsExpr = &structs.StatsExpr{GroupByRequest: queryAgg.GroupByRequest}
-		return NewStatsDP(queryAgg.StatsExpr)
-	} else if queryAgg.MeasureOperations != nil {
-		queryAgg.StatsExpr = &structs.StatsExpr{MeasureOperations: queryAgg.MeasureOperations}
-		return NewStatsDP(queryAgg.StatsExpr)
 	} else if queryAgg.StatsExpr != nil {
 		return NewStatsDP(queryAgg.StatsExpr)
 	} else if queryAgg.TailExpr != nil {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -251,11 +251,11 @@ func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryI
 		return NewRexDP(queryAgg.RexExpr)
 	} else if queryAgg.SortExpr != nil {
 		return NewSortDP(queryAgg.SortExpr)
-	} else if queryAgg.TimeHistogram != nil && queryAgg.TimeHistogram.Timechart != nil {
+	} else if queryAgg.TimechartExpr != nil {
 		timechartOptions := &timechartOptions{
-			aggs:      queryAgg,
-			qid:       queryInfo.GetQid(),
-			timeRange: queryInfo.GetQueryRange(),
+			timeChartExpr: queryAgg.TimechartExpr,
+			qid:           queryInfo.GetQid(),
+			timeRange:     queryInfo.GetQueryRange(),
 		}
 		return NewTimechartDP(timechartOptions)
 	} else if queryAgg.StatsExpr != nil {

--- a/pkg/segment/query/processor/timechartcommand_test.go
+++ b/pkg/segment/query/processor/timechartcommand_test.go
@@ -67,21 +67,19 @@ func getTestInput(timeNow uint64) map[string][]utils.CValueEnclosure {
 func getTimechartProcessor(startTime uint64) *timechartProcessor {
 	endTime := startTime + uint64(15*time.Minute.Milliseconds())
 
-	aggs := &structs.QueryAggregators{
-		TimeHistogram: &structs.TimeBucket{
-			IntervalMillis: uint64(1 * time.Minute.Milliseconds()),
-			Timechart:      &structs.TimechartExpr{},
-		},
-		GroupByRequest: &structs.GroupByRequest{
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "measurecol",
-					MeasureFunc: utils.Sum,
-					StrEnc:      "sum_measurecol",
-				},
+	timeHistogram := &structs.TimeBucket{
+		IntervalMillis: uint64(1 * time.Minute.Milliseconds()),
+		Timechart:      &structs.TimechartExpr{},
+	}
+	groupByRequest := &structs.GroupByRequest{
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "measurecol",
+				MeasureFunc: utils.Sum,
+				StrEnc:      "sum_measurecol",
 			},
-			GroupByColumns: []string{"timestamp"},
 		},
+		GroupByColumns: []string{"timestamp"},
 	}
 
 	timeRange := &dtypeutils.TimeRange{
@@ -90,7 +88,12 @@ func getTimechartProcessor(startTime uint64) *timechartProcessor {
 	}
 
 	timechartOptions := &timechartOptions{
-		aggs:      aggs,
+		timeBucket:     timeHistogram,
+		groupByRequest: groupByRequest,
+		timeChartExpr: &structs.TimechartExpr{
+			TimeHistogram: timeHistogram,
+			GroupBy:       groupByRequest,
+		},
 		timeRange: timeRange,
 		qid:       0,
 	}

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -249,11 +249,13 @@ type ConditionValuePair struct {
 }
 
 type TimechartExpr struct {
-	TcOptions  *TcOptions
-	BinOptions *BinOptions
-	SingleAgg  *SingleAgg
-	ByField    string // group by this field inside each time range bucket (timechart)
-	LimitExpr  *LimitExpr
+	TimeHistogram *TimeBucket
+	GroupBy       *GroupByRequest
+	TcOptions     *TcOptions
+	BinOptions    *BinOptions
+	SingleAgg     *SingleAgg
+	ByField       string // group by this field inside each time range bucket (timechart)
+	LimitExpr     *LimitExpr
 }
 
 type LimitExpr struct {


### PR DESCRIPTION
# Description
With the new query pipeline, we want to parse to these fields: https://github.com/siglens/siglens/blob/develop/pkg/segment/structs/segstructs.go#L180-L202

This fixes a few commands that were only getting parsed to the old fields.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
