### PR TITLE
Enable IQR to read from Multiple readers

### DIFF
--- a/pkg/segment/metadata/metadata.go
+++ b/pkg/segment/metadata/metadata.go
@@ -583,7 +583,7 @@ func GetColumnsForTheIndexesByTimeRange(timeRange *dtu.TimeRange, indexNames []s
 }
 
 // returns the a map with columns as keys and returns a bool if the segkey/table was found
-func CheckAndGetColsForSegKey(segKey string, vtable string) (map[string]bool, bool) {
+func CheckAndGetColsForSegKey(segKey string) (map[string]bool, bool) {
 
 	globalMetadata.updateLock.RLock()
 	segmentMetadata, segKeyOk := globalMetadata.segmentMetadataReverseIndex[segKey]

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -353,12 +353,12 @@ func setupTestIQRsWithRRCs(t *testing.T) (*IQR, *IQR) {
 	}
 
 	iqr1 := NewIQR(0)
-	iqr1.reader = mockReader
+	iqr1.reader = NewIQRReader(mockReader)
 	err := iqr1.AppendRRCs(allRRCs[:2], map[uint32]string{1: "segKey1"})
 	assert.NoError(t, err)
 
 	iqr2 := NewIQR(0)
-	iqr2.reader = mockReader
+	iqr2.reader = NewIQRReader(mockReader)
 	err = iqr2.AppendRRCs(allRRCs[2:], map[uint32]string{1: "segKey1"})
 	assert.NoError(t, err)
 
@@ -503,7 +503,7 @@ func Test_Sort_multipleColumns(t *testing.T) {
 	}
 
 	iqr := NewIQR(0)
-	iqr.reader = mockReader
+	iqr.reader = NewIQRReader(mockReader)
 	err := iqr.AppendRRCs(rrcs, map[uint32]string{1: "segKey1"})
 	assert.NoError(t, err)
 

--- a/pkg/segment/query/iqr/iqrreader.go
+++ b/pkg/segment/query/iqr/iqrreader.go
@@ -137,7 +137,10 @@ func (iqrRdr *IQRReader) AddSingleIQRReader(iqr *IQR) error {
 
 	otherReaderId := otherRdr.reader.GetReaderId()
 
-	iqrRdr.AddReader(otherReaderId, otherRdr.reader)
+	err := iqrRdr.AddReader(otherReaderId, otherRdr.reader)
+	if err != nil {
+		return fmt.Errorf("iqrReader.AddSingleIQRReader: cannot add reader to iqr; err=%v", err)
+	}
 
 	for segEnc := range iqr.encodingToSegKey {
 		if err := iqrRdr.AddSegEncodingToReader(segEnc, otherReaderId); err != nil {
@@ -180,7 +183,9 @@ func (iqr *IQR) mergeIQRReaders(otherIQR *IQR) error {
 	}
 
 	if otherRdr.IsSingleReader() {
-		iqrRdr.AddSingleIQRReader(otherIQR)
+		if err := iqrRdr.AddSingleIQRReader(otherIQR); err != nil {
+			return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add otherIQR to iqr; err=%v", err)
+		}
 	} else {
 		for readerId, reader := range otherRdr.readerIdToReader {
 			if err := iqrRdr.AddReader(readerId, reader); err != nil {

--- a/pkg/segment/query/iqr/iqrreader.go
+++ b/pkg/segment/query/iqr/iqrreader.go
@@ -39,17 +39,6 @@ type IQRReader struct {
 	reader             record.RRCsReaderI
 }
 
-type rrcWithIndex struct {
-	rrc   *utils.RecordResultContainer
-	index int
-}
-
-type readerResult struct {
-	readerId    utils.T_SegReaderId
-	knownValues map[string][]utils.CValueEnclosure
-	err         error
-}
-
 func NewIQRReader(reader record.RRCsReaderI) *IQRReader {
 	iqrRdr := &IQRReader{
 		readerMode:         ReaderModeSingleReader,

--- a/pkg/segment/query/iqr/iqrreader.go
+++ b/pkg/segment/query/iqr/iqrreader.go
@@ -1,0 +1,386 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package iqr
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/siglens/siglens/pkg/segment/reader/record"
+	"github.com/siglens/siglens/pkg/segment/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type ReaderMode uint8
+
+const (
+	ReaderModeSingleReader ReaderMode = iota
+	ReaderModeMultiReader
+)
+
+type IQRReader struct {
+	readerMode            ReaderMode
+	readerIdToReader      map[utils.T_SegReaderId]record.RRCsReaderI
+	encodingToReaderIndex map[utils.T_SegEncoding]utils.T_SegReaderId
+	reader                record.RRCsReaderI
+}
+
+type rrcWithIndex struct {
+	rrc   *utils.RecordResultContainer
+	index int
+}
+
+type readerResult struct {
+	readerId    utils.T_SegReaderId
+	knownValues map[string][]utils.CValueEnclosure
+	err         error
+}
+
+func NewIQRReader(reader record.RRCsReaderI) *IQRReader {
+	iqrRdr := &IQRReader{
+		readerMode:            ReaderModeSingleReader,
+		readerIdToReader:      make(map[utils.T_SegReaderId]record.RRCsReaderI),
+		encodingToReaderIndex: make(map[utils.T_SegEncoding]utils.T_SegReaderId),
+		reader:                reader,
+	}
+
+	return iqrRdr
+}
+
+func NewMultiIQRReader() *IQRReader {
+	iqrRdr := &IQRReader{
+		readerMode:            ReaderModeMultiReader,
+		readerIdToReader:      make(map[utils.T_SegReaderId]record.RRCsReaderI),
+		encodingToReaderIndex: make(map[utils.T_SegEncoding]utils.T_SegReaderId),
+	}
+
+	return iqrRdr
+}
+
+func (iqrRdr *IQRReader) IsSingleReader() bool {
+	return iqrRdr.readerMode == ReaderModeSingleReader
+}
+
+func (iqrRdr *IQRReader) IsMultiReader() bool {
+	return iqrRdr.readerMode == ReaderModeMultiReader
+}
+
+func (iqrRdr *IQRReader) AddReader(readerId utils.T_SegReaderId, reader record.RRCsReaderI) error {
+	if !iqrRdr.IsMultiReader() {
+		return fmt.Errorf("iqrReader.AddReader: reader mode is not multi reader: %v", iqrRdr.readerMode)
+	}
+
+	if reader, ok := iqrRdr.readerIdToReader[readerId]; ok {
+		if reflect.TypeOf(reader) != reflect.TypeOf(reader) {
+			return fmt.Errorf("iqrReader.AddReader: readerId=%v already exists", readerId)
+		}
+
+		return nil
+	}
+
+	iqrRdr.readerIdToReader[readerId] = reader
+
+	return nil
+}
+
+func (iqrRdr *IQRReader) AddSegEncodingToReader(segEnc utils.T_SegEncoding, readerId utils.T_SegReaderId) error {
+	if !iqrRdr.IsMultiReader() {
+		return fmt.Errorf("iqrReader.AddSegEncodingToReader: reader mode is not multi reader: %v", iqrRdr.readerMode)
+	}
+
+	if _, ok := iqrRdr.readerIdToReader[readerId]; !ok {
+		return fmt.Errorf("iqrReader.AddSegEncodingToReader: readerId=%v not found", readerId)
+	}
+
+	if ri, ok := iqrRdr.encodingToReaderIndex[segEnc]; ok {
+		if ri != readerId {
+			return fmt.Errorf("iqrReader.AddSegEncodingToReader: segEnc=%v already exists for readerId=%v", segEnc, ri)
+		}
+
+		return nil
+	}
+
+	iqrRdr.encodingToReaderIndex[segEnc] = readerId
+
+	return nil
+}
+
+func (iqrRdr *IQRReader) AddSingleIQRReader(iqr *IQR) error {
+	if !iqrRdr.IsMultiReader() {
+		return fmt.Errorf("iqrReader.AddSingleIQRReader: reader mode is not multi reader: %v", iqrRdr.readerMode)
+	}
+
+	otherRdr := iqr.reader
+	if !otherRdr.IsSingleReader() {
+		return fmt.Errorf("iqrReader.AddSingleIQRReader: other reader is not single reader: %v", otherRdr.readerMode)
+	}
+
+	if len(iqr.encodingToSegKey) == 0 {
+		return nil
+	}
+
+	otherReaderId := otherRdr.reader.GetReaderId()
+
+	iqrRdr.AddReader(otherReaderId, otherRdr.reader)
+
+	for segEnc := range iqr.encodingToSegKey {
+		if err := iqrRdr.AddSegEncodingToReader(segEnc, otherReaderId); err != nil {
+			return fmt.Errorf("iqrReader.AddSingleIQRReader: cannot add seg encoding to reader; err=%v", err)
+		}
+	}
+
+	return nil
+}
+
+func (iqr *IQR) mergeIQRReaders(otherIQR *IQR) error {
+	iqrRdr := iqr.reader
+	otherRdr := otherIQR.reader
+
+	if iqrRdr.IsSingleReader() && otherRdr.IsSingleReader() {
+		if reflect.TypeOf(iqrRdr) == reflect.TypeOf(otherRdr) {
+			return nil
+		}
+
+		resultRdr := NewMultiIQRReader()
+
+		err := resultRdr.AddSingleIQRReader(iqr)
+		if err != nil {
+			return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add iqr to resultRdr; err=%v", err)
+		}
+
+		err = resultRdr.AddSingleIQRReader(otherIQR)
+		if err != nil {
+			return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add otherIQR to resultRdr; err=%v", err)
+		}
+
+		iqr.reader = resultRdr
+	}
+
+	if iqrRdr.IsSingleReader() {
+		iqrRdr.readerMode = ReaderModeMultiReader
+		if err := iqrRdr.AddSingleIQRReader(otherIQR); err != nil {
+			return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add otherIQR to iqr; err=%v", err)
+		}
+	}
+
+	if otherRdr.IsSingleReader() {
+		iqrRdr.AddSingleIQRReader(otherIQR)
+	} else {
+		for readerId, reader := range otherRdr.readerIdToReader {
+			if err := iqrRdr.AddReader(readerId, reader); err != nil {
+				return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add reader to iqr; err=%v", err)
+			}
+		}
+
+		for segEnc, readerId := range otherRdr.encodingToReaderIndex {
+			if err := iqrRdr.AddSegEncodingToReader(segEnc, readerId); err != nil {
+				return fmt.Errorf("iqrReader.MergeIQRReaders: cannot add seg encoding to reader; err=%v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (iqrRdr *IQRReader) validate() error {
+	if iqrRdr.IsSingleReader() {
+		if iqrRdr.reader == nil {
+			return fmt.Errorf("iqrReader.validate: reader is nil in single reader mode")
+		}
+		return nil
+	}
+
+	for segEnc, readerId := range iqrRdr.encodingToReaderIndex {
+		if _, ok := iqrRdr.readerIdToReader[readerId]; !ok {
+			return fmt.Errorf("iqrReader.validate: readerId=%v not found for segEnc=%v", readerId, segEnc)
+		}
+	}
+
+	return nil
+}
+
+func (iqrRdr *IQRReader) readColumnsForRRCs(segKey string, vTable string, rrcs []*utils.RecordResultContainer,
+	qid uint64, ignoredCols map[string]struct{}, columnName *string) (map[string][]utils.CValueEnclosure, error) {
+	if len(rrcs) == 0 {
+		return nil, nil
+	}
+
+	if iqrRdr.IsSingleReader() {
+		return nil, fmt.Errorf("iqrReader.ReadAllColsForRRCs: single reader mode not supported")
+	}
+
+	rrcReaderGroups := make(map[utils.T_SegReaderId][]*rrcWithIndex)
+
+	for readerId := range iqrRdr.readerIdToReader {
+		rrcReaderGroups[readerId] = make([]*rrcWithIndex, 0, len(rrcs))
+	}
+
+	for _, rrc := range rrcs {
+		rrcReaderGroups[rrc.SegKeyInfo.ReaderId] = append(rrcReaderGroups[rrc.SegKeyInfo.ReaderId], &rrcWithIndex{rrc: rrc, index: 0})
+	}
+
+	resultChan := make(chan readerResult, len(rrcReaderGroups))
+
+	wg := sync.WaitGroup{}
+
+	for readerId, rrcsWithIndex := range rrcReaderGroups {
+		reader := iqrRdr.readerIdToReader[readerId]
+
+		wg.Add(1)
+		go func(readerId utils.T_SegReaderId, rrcsWithIndex []*rrcWithIndex, reader record.RRCsReaderI) {
+			defer wg.Done()
+
+			rrcs := make([]*utils.RecordResultContainer, len(rrcsWithIndex))
+
+			for i, rrcWithIndex := range rrcsWithIndex {
+				rrcs[i] = rrcWithIndex.rrc
+			}
+
+			var knownValues map[string][]utils.CValueEnclosure
+			var err error
+
+			if columnName != nil {
+				var values []utils.CValueEnclosure
+				values, err = reader.ReadColForRRCs(segKey, rrcs, *columnName, qid)
+				if err == nil {
+					knownValues = map[string][]utils.CValueEnclosure{
+						*columnName: values,
+					}
+				}
+			} else {
+				knownValues, err = reader.ReadAllColsForRRCs(segKey, vTable, rrcs, qid, ignoredCols)
+			}
+
+			resultChan <- readerResult{
+				readerId:    readerId,
+				knownValues: knownValues,
+				err:         fmt.Errorf("readerId=%v; err=%v", readerId, err),
+			}
+
+		}(readerId, rrcsWithIndex, reader)
+	}
+
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	readerResultGroups := make(map[utils.T_SegReaderId]map[string][]utils.CValueEnclosure)
+	var errors []error
+
+	defer func() {
+		if len(errors) > 0 {
+			log.Errorf("iqrReader.ReadAllColsForRRCs: errors=%v", errors)
+		}
+	}()
+
+	for result := range resultChan {
+		if result.err != nil {
+			errors = append(errors, result.err)
+			continue
+		}
+
+		readerResultGroups[result.readerId] = result.knownValues
+	}
+
+	finalKnownValues := make(map[string][]utils.CValueEnclosure)
+
+	for _, knownValues := range readerResultGroups {
+		for cname := range knownValues {
+			if _, ok := finalKnownValues[cname]; !ok {
+				finalKnownValues[cname] = make([]utils.CValueEnclosure, len(rrcs))
+			}
+		}
+	}
+
+	for readerId, rrcsWithIndex := range rrcReaderGroups {
+		knownValues := readerResultGroups[readerId]
+
+		if len(knownValues) != len(rrcsWithIndex) {
+			return nil, fmt.Errorf("iqrReader.ReadAllColsForRRCs: readerId=%v; len(knownValues)=%v != len(rrcsWithIndex)=%v",
+				readerId, len(knownValues), len(rrcsWithIndex))
+		}
+
+		for i, indexedRRC := range rrcsWithIndex {
+			for cname, values := range knownValues {
+				finalKnownValues[cname][indexedRRC.index] = values[i]
+			}
+		}
+	}
+
+	return finalKnownValues, nil
+}
+
+func (iqrRdr *IQRReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs []*utils.RecordResultContainer,
+	qid uint64, ignoredCols map[string]struct{}) (map[string][]utils.CValueEnclosure, error) {
+
+	if iqrRdr.IsSingleReader() {
+		return iqrRdr.reader.ReadAllColsForRRCs(segKey, vTable, rrcs, qid, ignoredCols)
+	}
+
+	knownValues, err := iqrRdr.readColumnsForRRCs(segKey, vTable, rrcs, qid, ignoredCols, nil)
+	if err != nil {
+		return nil, fmt.Errorf("iqrReader.ReadAllColsForRRCs: cannot read columns for segKey=%v; err=%v", segKey, err)
+	}
+
+	return knownValues, nil
+}
+
+func (iqrRdr *IQRReader) getColumnsForSegKey(segKey string, vTable string, segEnc utils.T_SegEncoding) (map[string]struct{}, error) {
+	if iqrRdr.IsSingleReader() {
+		return iqrRdr.reader.GetColsForSegKey(segKey, vTable)
+	}
+
+	readerId, ok := iqrRdr.encodingToReaderIndex[segEnc]
+	if !ok {
+		return nil, fmt.Errorf("iqrReader.GetColsForSegKey: readerID not found for segKey=%v", segKey)
+	}
+
+	reader, ok := iqrRdr.readerIdToReader[readerId]
+	if !ok {
+		return nil, fmt.Errorf("iqrReader.GetColsForSegKey: reader not found for readerID=%v, segkey=%v", readerId, segKey)
+	}
+
+	return reader.GetColsForSegKey(segKey, vTable)
+}
+
+func (iqrRdr *IQRReader) GetColsForSegKey(segKey string, vTable string) (map[string]struct{}, error) {
+	if iqrRdr.IsSingleReader() {
+		return iqrRdr.reader.GetColsForSegKey(segKey, vTable)
+	} else {
+		return nil, fmt.Errorf("iqrReader.GetColsForSegKey: not supported in multi-reader mode")
+	}
+}
+
+func (iqrRdr *IQRReader) ReadColForRRCs(segKey string, rrcs []*utils.RecordResultContainer, cname string, qid uint64) ([]utils.CValueEnclosure, error) {
+	if iqrRdr.IsSingleReader() {
+		return iqrRdr.reader.ReadColForRRCs(segKey, rrcs, cname, qid)
+	}
+
+	knownValues, err := iqrRdr.readColumnsForRRCs(segKey, "", rrcs, qid, nil, &cname)
+	if err != nil {
+		return nil, fmt.Errorf("iqrReader.ReadColForRRCs: cannot read column %v for segKey=%v; err=%v", cname, segKey, err)
+	}
+
+	if values, ok := knownValues[cname]; ok {
+		return values, nil
+	}
+
+	return nil, fmt.Errorf("iqrReader.ReadColForRRCs: column %v not found for segKey=%v", cname, segKey)
+}

--- a/pkg/segment/query/iqr/iqrreader_test.go
+++ b/pkg/segment/query/iqr/iqrreader_test.go
@@ -1,0 +1,343 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package iqr
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/reader/record"
+	"github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestIQRsWithMockReaders() (*IQR, *IQR, *IQR, *IQR) {
+	allRRCs1 := []*utils.RecordResultContainer{
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1}, BlockNum: 1, RecordNum: 1},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1}, BlockNum: 1, RecordNum: 2},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 2}, BlockNum: 1, RecordNum: 3},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 2}, BlockNum: 1, RecordNum: 4},
+	}
+	mockReader1 := &record.MockRRCsReader{
+		RRCs: allRRCs1,
+		FieldToValues: map[string][]utils.CValueEnclosure{
+			"col1": {
+				{Dtype: utils.SS_DT_STRING, CVal: "a"},
+				{Dtype: utils.SS_DT_STRING, CVal: "b"},
+				{Dtype: utils.SS_DT_STRING, CVal: "c"},
+				{Dtype: utils.SS_DT_STRING, CVal: "d"},
+			},
+			"timestamp": {
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(4)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(6)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(1)},
+			},
+		},
+		ReaderId: 1,
+	}
+
+	iqr1 := NewIQRWithReader(0, mockReader1)
+	iqr1.AppendRRCs(allRRCs1[:2], map[uint32]string{1: "r1/seg1"})
+
+	iqr2 := NewIQRWithReader(0, mockReader1)
+	iqr2.AppendRRCs(allRRCs1[2:], map[uint32]string{2: "r1/seg2"})
+
+	allRRCs2 := []*utils.RecordResultContainer{
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1000}, BlockNum: 1, RecordNum: 1},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1000}, BlockNum: 1, RecordNum: 2},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1001}, BlockNum: 1, RecordNum: 3},
+		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1001}, BlockNum: 1, RecordNum: 4},
+	}
+
+	mockReader2 := &record.MockRRCsReader{
+		RRCs: allRRCs2,
+		FieldToValues: map[string][]utils.CValueEnclosure{
+			"col1": {
+				{Dtype: utils.SS_DT_STRING, CVal: "e"},
+				{Dtype: utils.SS_DT_STRING, CVal: "f"},
+				{Dtype: utils.SS_DT_STRING, CVal: "g"},
+				{Dtype: utils.SS_DT_STRING, CVal: "h"},
+			},
+			"timestamp": {
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(7)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(2)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(5)},
+				{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			},
+		},
+		ReaderId: 2,
+	}
+
+	iqr3 := NewIQRWithReader(0, mockReader2)
+	iqr3.AppendRRCs(allRRCs2[:2], map[uint32]string{1000: "r2/seg1"})
+
+	iqr4 := NewIQRWithReader(0, mockReader2)
+	iqr4.AppendRRCs(allRRCs2[2:], map[uint32]string{1001: "r2/seg2"})
+
+	return iqr1, iqr2, iqr3, iqr4
+}
+
+func testSortByTimestampDesc(r1 *Record, r2 *Record) bool {
+	r1Timestamp, err := r1.ReadColumn("timestamp")
+	if err != nil {
+		return false
+	}
+
+	r2Timestamp, err := r2.ReadColumn("timestamp")
+	if err != nil {
+		return true
+	}
+
+	return r1Timestamp.CVal.(uint64) > r2Timestamp.CVal.(uint64)
+}
+
+func Test_MergeIQRReaders_Append(t *testing.T) {
+	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders()
+
+	err := iqr1.Append(iqr2)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 4, iqr1.NumberOfRecords())
+	assert.Equal(t, ReaderModeSingleReader, iqr1.reader.readerMode)
+
+	err = iqr1.Append(iqr3)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 6, iqr1.NumberOfRecords())
+	assert.Equal(t, ReaderModeMultiReader, iqr1.reader.readerMode)
+
+	err = iqr1.Append(iqr4)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 8, iqr1.NumberOfRecords())
+	assert.Equal(t, ReaderModeMultiReader, iqr1.reader.readerMode)
+
+	expectedEncodingToReaderId := map[utils.T_SegEncoding]utils.T_SegReaderId{
+		1:    1,
+		2:    1,
+		1000: 2,
+		1001: 2,
+	}
+
+	assert.Equal(t, expectedEncodingToReaderId, iqr1.reader.encodingToReaderId)
+
+	knownValues, err := iqr1.ReadAllColumns()
+	assert.Nil(t, err)
+
+	expectedKnownValues := map[string][]utils.CValueEnclosure{
+		"col1": {
+			{Dtype: utils.SS_DT_STRING, CVal: "a"},
+			{Dtype: utils.SS_DT_STRING, CVal: "b"},
+			{Dtype: utils.SS_DT_STRING, CVal: "c"},
+			{Dtype: utils.SS_DT_STRING, CVal: "d"},
+			{Dtype: utils.SS_DT_STRING, CVal: "e"},
+			{Dtype: utils.SS_DT_STRING, CVal: "f"},
+			{Dtype: utils.SS_DT_STRING, CVal: "g"},
+			{Dtype: utils.SS_DT_STRING, CVal: "h"},
+		},
+		"timestamp": {
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(4)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(6)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(1)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(2)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(7)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(5)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+		},
+	}
+
+	assert.Equal(t, expectedKnownValues, knownValues)
+}
+
+func Test_MergeIQRReaders_MergeIQRs(t *testing.T) {
+	// iqr1 timestamps: 8, 4
+	// iqr2 timestamps: 6, 1
+	// iqr3 timestamps: 7, 2
+	// iqr4 timestamps: 5, 3
+
+	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders()
+
+	iqrs := []*IQR{iqr1, iqr2, iqr3, iqr4}
+
+	mergedIQR1, exhaustedIQRIndex, err := MergeIQRs(iqrs, testSortByTimestampDesc)
+	assert.Nil(t, err)
+	// iqr1 will be exhausted first
+	assert.Equal(t, 0, exhaustedIQRIndex)
+	assert.Equal(t, 5, mergedIQR1.NumberOfRecords())
+	assert.Equal(t, 0, iqr1.NumberOfRecords())
+	assert.Equal(t, 1, iqr2.NumberOfRecords())
+	assert.Equal(t, 1, iqr3.NumberOfRecords())
+	assert.Equal(t, 1, iqr4.NumberOfRecords())
+
+	readerIdsToExist := []utils.T_SegReaderId{1, 2}
+	readerIdToReader := mergedIQR1.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+
+	expectedEncodingToReaderId := map[utils.T_SegEncoding]utils.T_SegReaderId{
+		1:    1,
+		2:    1,
+		1000: 2,
+		1001: 2,
+	}
+
+	assert.Equal(t, expectedEncodingToReaderId, mergedIQR1.reader.encodingToReaderId)
+
+	// Assume that iqr1 is exhausted
+	iqrs = []*IQR{iqr2, iqr3, iqr4}
+
+	mergedIQR2, exhaustedIQRIndex, err := MergeIQRs(iqrs, testSortByTimestampDesc)
+	assert.Nil(t, err)
+	// iqr4 will be exhausted first
+	assert.Equal(t, 2, exhaustedIQRIndex)
+	assert.Equal(t, 1, mergedIQR2.NumberOfRecords())
+	assert.Equal(t, 0, iqr4.NumberOfRecords())
+	assert.Equal(t, 1, iqr2.NumberOfRecords())
+	assert.Equal(t, 1, iqr3.NumberOfRecords())
+
+	readerIdsToExist = []utils.T_SegReaderId{1, 2}
+	readerIdToReader = mergedIQR2.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+
+	expectedEncodingToReaderId = map[utils.T_SegEncoding]utils.T_SegReaderId{
+		2:    1,
+		1000: 2,
+		1001: 2,
+	}
+
+	assert.Equal(t, expectedEncodingToReaderId, mergedIQR2.reader.encodingToReaderId)
+
+	// Now iqr1 and iqr4 are exhausted
+	iqrs = []*IQR{iqr2, iqr3}
+
+	mergedIQR3, exhaustedIQRIndex, err := MergeIQRs(iqrs, testSortByTimestampDesc)
+	assert.Nil(t, err)
+	// iqr3 will be exhausted first
+	assert.Equal(t, 1, exhaustedIQRIndex)
+	assert.Equal(t, 1, mergedIQR3.NumberOfRecords())
+	assert.Equal(t, 0, iqr3.NumberOfRecords())
+	assert.Equal(t, 1, iqr2.NumberOfRecords())
+
+	readerIdsToExist = []utils.T_SegReaderId{1, 2}
+	readerIdToReader = mergedIQR3.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+
+	expectedEncodingToReaderId = map[utils.T_SegEncoding]utils.T_SegReaderId{
+		2:    1,
+		1000: 2,
+	}
+
+	assert.Equal(t, expectedEncodingToReaderId, mergedIQR3.reader.encodingToReaderId)
+
+	// Now iqr1, iqr4, and iqr3 are exhausted
+	iqrs = []*IQR{iqr2}
+
+	mergedIQR4, exhaustedIQRIndex, err := MergeIQRs(iqrs, testSortByTimestampDesc)
+	assert.Nil(t, err)
+	// iqr2 will be exhausted
+	assert.Equal(t, 0, exhaustedIQRIndex)
+	assert.Equal(t, 1, mergedIQR4.NumberOfRecords())
+	assert.Equal(t, 0, iqr2.NumberOfRecords())
+
+	// Since there is one IQR with only one SingleReaderMode reader, the encodingToReaderId should be empty
+	assert.Equal(t, 0, len(mergedIQR4.reader.readerIdToReader))
+	assert.Equal(t, 0, len(mergedIQR4.reader.encodingToReaderId))
+
+	// Now in the usual query flow: iqr1, iqr2, iqr3, and iqr4 are individual streams for a data processor
+	// The data processor will merge the streams through MergeIQRs
+	// If a stream is exhausted, the mergedIQR till that point will be used for further processing
+	// The remaining streams will be cached and again when more data is needed, the these streams will be fetched
+	// The exhausted streams will be fetched from the source and the non-exhausted streams will be fetched from the cache
+	// This process will continue until all streams are exhausted
+	// And as the mergedIQR is generated for each batch, the mergedIQR will be used for further processing and appended to the final IQR
+
+	finalIQR := mergedIQR1
+	err = finalIQR.Append(mergedIQR2)
+	assert.Nil(t, err)
+	assert.Equal(t, 6, finalIQR.NumberOfRecords())
+	readerIdsToExist = []utils.T_SegReaderId{1, 2}
+	readerIdToReader = finalIQR.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+	expectedEncodingToReaderId = map[utils.T_SegEncoding]utils.T_SegReaderId{
+		1:    1,
+		2:    1,
+		1000: 2,
+		1001: 2,
+	}
+
+	assert.Equal(t, expectedEncodingToReaderId, finalIQR.reader.encodingToReaderId)
+
+	err = finalIQR.Append(mergedIQR3)
+	assert.Nil(t, err)
+	assert.Equal(t, 7, finalIQR.NumberOfRecords())
+	readerIdToReader = finalIQR.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+	assert.Equal(t, expectedEncodingToReaderId, finalIQR.reader.encodingToReaderId)
+
+	err = finalIQR.Append(mergedIQR4)
+	assert.Nil(t, err)
+	assert.Equal(t, 8, finalIQR.NumberOfRecords())
+	readerIdToReader = finalIQR.reader.readerIdToReader
+	for _, readerId := range readerIdsToExist {
+		_, ok := readerIdToReader[readerId]
+		assert.True(t, ok)
+	}
+	assert.Equal(t, expectedEncodingToReaderId, finalIQR.reader.encodingToReaderId)
+
+	knownValues, err := finalIQR.ReadAllColumns()
+	assert.Nil(t, err)
+	expectedKnownValues := map[string][]utils.CValueEnclosure{
+		"timestamp": {
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(7)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(6)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(5)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(4)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(2)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(1)},
+		},
+		"col1": {
+			{Dtype: utils.SS_DT_STRING, CVal: "a"},
+			{Dtype: utils.SS_DT_STRING, CVal: "e"},
+			{Dtype: utils.SS_DT_STRING, CVal: "c"},
+			{Dtype: utils.SS_DT_STRING, CVal: "g"},
+			{Dtype: utils.SS_DT_STRING, CVal: "b"},
+			{Dtype: utils.SS_DT_STRING, CVal: "h"},
+			{Dtype: utils.SS_DT_STRING, CVal: "f"},
+			{Dtype: utils.SS_DT_STRING, CVal: "d"},
+		},
+	}
+
+	assert.Equal(t, expectedKnownValues, knownValues)
+}

--- a/pkg/segment/query/iqr/iqrreader_test.go
+++ b/pkg/segment/query/iqr/iqrreader_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestIQRsWithMockReaders() (*IQR, *IQR, *IQR, *IQR) {
+func getTestIQRsWithMockReaders(t *testing.T) (*IQR, *IQR, *IQR, *IQR) {
 	allRRCs1 := []*utils.RecordResultContainer{
 		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1}, BlockNum: 1, RecordNum: 1},
 		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1}, BlockNum: 1, RecordNum: 2},
@@ -52,10 +52,12 @@ func getTestIQRsWithMockReaders() (*IQR, *IQR, *IQR, *IQR) {
 	}
 
 	iqr1 := NewIQRWithReader(0, mockReader1)
-	iqr1.AppendRRCs(allRRCs1[:2], map[uint32]string{1: "r1/seg1"})
+	err := iqr1.AppendRRCs(allRRCs1[:2], map[uint32]string{1: "r1/seg1"})
+	assert.Nil(t, err)
 
 	iqr2 := NewIQRWithReader(0, mockReader1)
-	iqr2.AppendRRCs(allRRCs1[2:], map[uint32]string{2: "r1/seg2"})
+	err = iqr2.AppendRRCs(allRRCs1[2:], map[uint32]string{2: "r1/seg2"})
+	assert.Nil(t, err)
 
 	allRRCs2 := []*utils.RecordResultContainer{
 		{SegKeyInfo: utils.SegKeyInfo{SegKeyEnc: 1000}, BlockNum: 1, RecordNum: 1},
@@ -84,10 +86,12 @@ func getTestIQRsWithMockReaders() (*IQR, *IQR, *IQR, *IQR) {
 	}
 
 	iqr3 := NewIQRWithReader(0, mockReader2)
-	iqr3.AppendRRCs(allRRCs2[:2], map[uint32]string{1000: "r2/seg1"})
+	err = iqr3.AppendRRCs(allRRCs2[:2], map[uint32]string{1000: "r2/seg1"})
+	assert.Nil(t, err)
 
 	iqr4 := NewIQRWithReader(0, mockReader2)
-	iqr4.AppendRRCs(allRRCs2[2:], map[uint32]string{1001: "r2/seg2"})
+	err = iqr4.AppendRRCs(allRRCs2[2:], map[uint32]string{1001: "r2/seg2"})
+	assert.Nil(t, err)
 
 	return iqr1, iqr2, iqr3, iqr4
 }
@@ -107,7 +111,7 @@ func testSortByTimestampDesc(r1 *Record, r2 *Record) bool {
 }
 
 func Test_MergeIQRReaders_Append(t *testing.T) {
-	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders()
+	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders(t)
 
 	err := iqr1.Append(iqr2)
 	assert.Nil(t, err)
@@ -155,8 +159,8 @@ func Test_MergeIQRReaders_Append(t *testing.T) {
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(4)},
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(6)},
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(1)},
-			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(2)},
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(7)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(2)},
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(5)},
 			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
 		},
@@ -171,7 +175,7 @@ func Test_MergeIQRReaders_MergeIQRs(t *testing.T) {
 	// iqr3 timestamps: 7, 2
 	// iqr4 timestamps: 5, 3
 
-	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders()
+	iqr1, iqr2, iqr3, iqr4 := getTestIQRsWithMockReaders(t)
 
 	iqrs := []*IQR{iqr1, iqr2, iqr3, iqr4}
 

--- a/pkg/segment/query/segqueryhelpers.go
+++ b/pkg/segment/query/segqueryhelpers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/search"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
+	toputils "github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -49,6 +50,7 @@ type QueryInformation struct {
 	orgId              uint64
 	alreadyDistributed bool
 	containsKibana     bool
+	batchErr           *toputils.BatchError
 }
 
 type QuerySegmentRequest struct {
@@ -135,6 +137,10 @@ func (qi *QueryInformation) ContainsKibana() bool {
 	return qi.containsKibana
 }
 
+func (qi *QueryInformation) GetBatchError() *toputils.BatchError {
+	return qi.batchErr
+}
+
 func (qsr *QuerySegmentRequest) GetSegKey() string {
 	return qsr.segKey
 }
@@ -190,6 +196,7 @@ func InitQueryInformation(s *structs.SearchNode, aggs *structs.QueryAggregators,
 		qType:              qType,
 		orgId:              orgid,
 		containsKibana:     containsKibana,
+		batchErr:           toputils.GetOrCreateBatchErrorWithQid(qid),
 	}, nil
 }
 

--- a/pkg/segment/reader/record/mockrecordreader.go
+++ b/pkg/segment/reader/record/mockrecordreader.go
@@ -28,6 +28,10 @@ type MockRRCsReader struct {
 	FieldToValues map[string][]utils.CValueEnclosure
 }
 
+func (mocker *MockRRCsReader) GetReaderId() utils.T_SegReaderId {
+	return 0
+}
+
 func (mocker *MockRRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs []*utils.RecordResultContainer,
 	qid uint64, ignoredCols map[string]struct{}) (map[string][]utils.CValueEnclosure, error) {
 

--- a/pkg/segment/reader/record/mockrecordreader.go
+++ b/pkg/segment/reader/record/mockrecordreader.go
@@ -26,10 +26,11 @@ import (
 type MockRRCsReader struct {
 	RRCs          []*utils.RecordResultContainer
 	FieldToValues map[string][]utils.CValueEnclosure
+	ReaderId      utils.T_SegReaderId
 }
 
 func (mocker *MockRRCsReader) GetReaderId() utils.T_SegReaderId {
-	return 0
+	return mocker.ReaderId
 }
 
 func (mocker *MockRRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs []*utils.RecordResultContainer,

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -42,9 +42,14 @@ type RRCsReaderI interface {
 		qid uint64, ignoredCols map[string]struct{}) (map[string][]utils.CValueEnclosure, error)
 	GetColsForSegKey(segKey string, vTable string) (map[string]struct{}, error)
 	ReadColForRRCs(segKey string, rrcs []*utils.RecordResultContainer, cname string, qid uint64) ([]utils.CValueEnclosure, error)
+	GetReaderId() utils.T_SegReaderId
 }
 
 type RRCsReader struct{}
+
+func (reader *RRCsReader) GetReaderId() utils.T_SegReaderId {
+	return utils.T_SegReaderId(0)
+}
 
 func (reader *RRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs []*utils.RecordResultContainer,
 	qid uint64, ignoredCols map[string]struct{}) (map[string][]utils.CValueEnclosure, error) {
@@ -78,7 +83,7 @@ func (reader *RRCsReader) GetColsForSegKey(segKey string, vTable string) (map[st
 	var allCols map[string]bool
 	allCols, exists := writer.CheckAndGetColsForUnrotatedSegKey(segKey)
 	if !exists {
-		allCols, exists = segmetadata.CheckAndGetColsForSegKey(segKey, vTable)
+		allCols, exists = segmetadata.CheckAndGetColsForSegKey(segKey)
 		if !exists {
 			return nil, toputils.TeeErrorf("GetColsForSegKey: globalMetadata does not have segKey: %s", segKey)
 		}
@@ -280,7 +285,7 @@ func getRecordsFromSegmentHelperOldPipeline(segKey string, vTable string, blkRec
 	var exists bool
 	allCols, exists = writer.CheckAndGetColsForUnrotatedSegKey(segKey)
 	if !exists {
-		allCols, exists = segmetadata.CheckAndGetColsForSegKey(segKey, vTable)
+		allCols, exists = segmetadata.CheckAndGetColsForSegKey(segKey)
 		if !exists {
 			log.Errorf("getRecordsFromSegmentHelperOldPipeline: globalMetadata does not have segKey: %s", segKey)
 			return nil, allCols, errors.New("failed to get column names for segkey in rotated and unrotated files")

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1285,9 +1285,6 @@ type SegKeyInfo struct {
 	IsRemote bool
 	// if IsRemote, Record will be initialized to a string of the form <<node_id>>-<<segkey>>-<<block_num>>-<<record_num>>
 	RecordId string
-
-	// If the RRC came from a remote node, the remote Reader Index
-	ReaderId T_SegReaderId
 }
 
 type RecordResultContainer struct {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -147,6 +147,9 @@ const INCONSISTENT_CVAL_SIZE uint32 = math.MaxUint32
 
 const MAX_SIMILAR_ERRORS_TO_LOG = 5 // max number of similar errors to log: This is used to avoid flooding the logs with similar errors
 
+type T_SegReaderId = uint16
+type T_SegEncoding = uint32
+
 type SS_DTYPE uint8
 
 const (
@@ -1282,6 +1285,9 @@ type SegKeyInfo struct {
 	IsRemote bool
 	// if IsRemote, Record will be initialized to a string of the form <<node_id>>-<<segkey>>-<<block_num>>-<<record_num>>
 	RecordId string
+
+	// If the RRC came from a remote node, the remote Reader Index
+	ReaderId T_SegReaderId
 }
 
 type RecordResultContainer struct {


### PR DESCRIPTION
# Description
- Now the IQR reader can read from Multiple readers, each tracked with the readerId.
- `IQRReader` has two modes: `ReaderModeSingleReader` and `ReaderModeMultiReader`. In `ReaderModeSingleReader`, the flow is exactly same as now.
- For `ReaderModeMultiReader`, the `IQRReader` will group the RRCs based on the `readerId` and call respective readers with these RRCs and then finally merge the results maintaining the order.

# Testing
- Added unit tests for the IQR reader

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
