### PR TITLE
Improve default handling in runmod.cfg

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -470,7 +470,11 @@ func SetQueryPort(value uint64) {
 }
 
 func GetQueryTimeoutSecs() int {
-	return runningConfig.QueryTimeoutSecs
+	timeout := runningConfig.QueryTimeoutSecs
+	if timeout <= 0 {
+		return DEFAULT_TIMEOUT_SECONDS
+	}
+	return timeout
 }
 
 func GetDefaultRunModConfig() common.RunModConfig {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -472,6 +472,7 @@ func SetQueryPort(value uint64) {
 func GetQueryTimeoutSecs() int {
 	timeout := runningConfig.QueryTimeoutSecs
 	if timeout <= 0 {
+		log.Warnf("GetQueryTimeoutSecs: Invalid timeout %d, using default %d", timeout, DEFAULT_TIMEOUT_SECONDS)
 		return DEFAULT_TIMEOUT_SECONDS
 	}
 	return timeout

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -659,8 +659,7 @@ func ExtractReadRunModConfig(jsonData []byte) (common.RunModConfig, error) {
 func validateAndApplyConfig(config *common.RunModConfig) {
 	reqData := make(map[string]interface{})
 	jsonData, _ := json.Marshal(config)
-	json.Unmarshal(jsonData, &reqData)
-
+	_ = json.Unmarshal(jsonData, &reqData)
 	// Check if fields exist in runmod json
 	if _, exists := reqData["queryTimeoutSecs"]; !exists {
 		if runningConfig.QueryTimeoutSecs > DEFAULT_TIMEOUT_SECONDS {


### PR DESCRIPTION
# Description
Updated logic for handling missing content in `runmod.cfg`:
- If certain contents are not present in `runmod.cfg`, they will not be defaulted immediately.
- Instead, will check `server.yaml` values before falling back to defaults.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
