### PR TITLE
Enabled IQR to store stats in Aggregated format

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -1691,13 +1691,12 @@ func (iqr *IQR) GobDecode(data []byte) error {
 			return fmt.Errorf("IQR.GobDecode: error initializing search results: %v", err)
 		}
 		groupByBuckets := searchResults.BlockResults.GroupByAggregation
-		timeBuckets := searchResults.BlockResults.TimeAggregation
 		iqr.statsResults = &IQRStatsResults{
 			statsType:      serializableIQR.StatsResults.StatsType,
 			aggs:           serializableIQR.StatsResults.Aggs,
 			segStatsMap:    serializableIQR.StatsResults.SegStatsMap,
 			groupByBuckets: serializableIQR.StatsResults.GroupByBuckets.ToGroupByBuckets(groupByBuckets, iqr.qid),
-			timeBuckets:    serializableIQR.StatsResults.TimeBuckets.ToTimeBuckets(timeBuckets, iqr.qid),
+			timeBuckets:    serializableIQR.StatsResults.TimeBuckets.ToTimeBuckets(iqr.qid),
 		}
 	}
 

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -907,7 +907,7 @@ func (iqr *IQR) MergeIQRStatsResults(iqrs []*IQR) (bool, error) {
 		}
 	}
 
-	if statsType.IsInvalid() {
+	if statsType.IsNotStatsType() {
 		// This means that the IQRs don't have any stats results.
 		return false, nil
 	}

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -1197,7 +1197,7 @@ func Test_ReadColumnsWithBackfill(t *testing.T) {
 }
 
 func Test_IQRBytesEncodeDecode(t *testing.T) {
-	iqr := NewIQR(1)
+	iqr := NewIQR(0)
 	knownValues := map[string][]utils.CValueEnclosure{
 		"col1": {
 			utils.CValueEnclosure{Dtype: utils.SS_DT_STRING, CVal: "a1"},
@@ -1236,22 +1236,11 @@ func Test_IQRBytesEncodeDecode(t *testing.T) {
 		Max:       utils.CValueEnclosure{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(10)},
 		Hll:       structs.CreateNewHll(),
 		NumStats: &structs.NumericStats{
-			Min: utils.NumTypeEnclosure{
-				Ntype:    utils.SS_DT_SIGNED_NUM,
-				IntgrVal: int64(1),
-				FloatVal: float64(1),
-			},
-			Max: utils.NumTypeEnclosure{
-				Ntype:    utils.SS_DT_SIGNED_NUM,
-				IntgrVal: int64(10),
-				FloatVal: float64(10),
-			},
 			Sum: utils.NumTypeEnclosure{
 				Ntype:    utils.SS_DT_SIGNED_NUM,
 				IntgrVal: int64(55),
 				FloatVal: float64(55),
 			},
-			Dtype: utils.SS_DT_SIGNED_NUM,
 		},
 		StringStats: &structs.StringStats{
 			StrSet: map[string]struct{}{
@@ -1277,6 +1266,7 @@ func Test_IQRBytesEncodeDecode(t *testing.T) {
 	}
 
 	statsRes := &IQRStatsResults{
+		aggs:           &structs.QueryAggregators{},
 		segStatsMap:    segStatsMap,
 		timeBuckets:    timeBuckets,
 		groupByBuckets: groupByBuckets,
@@ -1296,7 +1286,7 @@ func Test_IQRBytesEncodeDecode(t *testing.T) {
 	bytes, err := iqr.GobEncode()
 	assert.NoError(t, err)
 
-	decodedIQR := NewIQRWithReader(1, &record.RRCsReader{})
+	decodedIQR := NewIQRWithReader(0, &record.RRCsReader{})
 
 	err = decodedIQR.GobDecode(bytes)
 	assert.NoError(t, err)
@@ -1309,7 +1299,7 @@ func Test_IQRBytesEncodeDecode(t *testing.T) {
 	bytes, err = iqr.GobEncode()
 	assert.NoError(t, err)
 
-	decodedIQR = NewIQRWithReader(1, &record.RRCsReader{})
+	decodedIQR = NewIQRWithReader(0, &record.RRCsReader{})
 
 	err = decodedIQR.GobDecode(bytes)
 	assert.NoError(t, err)

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -590,7 +590,24 @@ func NewStatsDP(options *structs.StatsExpr) *DataProcessor {
 	}
 }
 
-func NewStatisticExprDP(options *structs.QueryAggregators) *DataProcessor {
+func NewStatisticExprDP(options *structs.QueryAggregators, isDistributed bool) *DataProcessor {
+	statsExpr := &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
+	options.StatsExpr = statsExpr
+
+	if isDistributed && !options.StatisticExpr.ExprSplitDone {
+		// Split the Aggs into two data processors, the first one is the stats processor
+		// and the second one will perform the actual statisticExpr.
+		nextAgg := &structs.QueryAggregators{
+			GroupByRequest: options.GroupByRequest,
+			StatisticExpr:  options.StatisticExpr,
+		}
+		nextAgg.Next = options.Next
+		options.Next = nextAgg
+		nextAgg.StatisticExpr.ExprSplitDone = true
+
+		return NewStatsDP(statsExpr)
+	}
+
 	if options.HasTopExpr() {
 		return NewTopDP(options)
 	} else if options.HasRareExpr() {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -258,24 +258,7 @@ func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryI
 	} else if queryAgg.MVExpandExpr != nil {
 		return NewMVExpandDP(queryAgg.MVExpandExpr)
 	} else if queryAgg.StatisticExpr != nil {
-		statsExpr := &structs.StatsExpr{GroupByRequest: queryAgg.GroupByRequest}
-		queryAgg.StatsExpr = statsExpr
-
-		if queryInfo.IsDistributed() && !queryAgg.StatisticExpr.ExprSplitDone {
-			// Split the Aggs into two data processors, the first one is the stats processor
-			// and the second one will perform the actual statisticExpr.
-			nextAgg := &structs.QueryAggregators{
-				GroupByRequest: queryAgg.GroupByRequest,
-				StatisticExpr:  queryAgg.StatisticExpr,
-			}
-			nextAgg.Next = queryAgg.Next
-			queryAgg.Next = nextAgg
-			nextAgg.StatisticExpr.ExprSplitDone = true
-
-			return NewStatsDP(statsExpr)
-		}
-
-		return NewStatisticExprDP(queryAgg)
+		return NewStatisticExprDP(queryAgg, queryInfo.IsDistributed())
 	} else if queryAgg.RegexExpr != nil {
 		return NewRegexDP(queryAgg.RegexExpr)
 	} else if queryAgg.RexExpr != nil {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -119,6 +119,7 @@ func NewQueryProcessor(firstAgg *structs.QueryAggregators, queryInfo *query.Quer
 					StatisticExpr:  firstAgg.StatisticExpr,
 				}
 				nextAgg.Next = firstAgg.Next
+				nextAgg.StatisticExpr.ExprSplitDone = true
 				firstAgg.Next = nextAgg
 			}
 		}
@@ -165,7 +166,7 @@ func NewQueryProcessor(firstAgg *structs.QueryAggregators, queryInfo *query.Quer
 		lastStreamer = dataProcessors[len(dataProcessors)-1]
 	}
 
-	queryProcessor, err := newQueryProcessorHelper(queryType, lastStreamer, dataProcessors, queryInfo.GetQid(), scrollFrom, includeNulls)
+	queryProcessor, err := newQueryProcessorHelper(queryType, lastStreamer, dataProcessors, queryInfo.GetQid(), scrollFrom, includeNulls, shouldDistribute)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func NewQueryProcessor(firstAgg *structs.QueryAggregators, queryInfo *query.Quer
 }
 
 func newQueryProcessorHelper(queryType structs.QueryType, input Streamer,
-	chain []*DataProcessor, qid uint64, scrollFrom int, includeNulls bool) (*QueryProcessor, error) {
+	chain []*DataProcessor, qid uint64, scrollFrom int, includeNulls bool, shoulDistribute bool) (*QueryProcessor, error) {
 
 	var limit uint64
 	switch queryType {
@@ -190,22 +191,36 @@ func newQueryProcessorHelper(queryType structs.QueryType, input Streamer,
 		return nil, utils.TeeErrorf("newQueryProcessorHelper: invalid query type %v", queryType)
 	}
 
-	headDP := NewHeadDP(&structs.HeadExpr{MaxRows: limit})
-	if headDP == nil {
-		return nil, utils.TeeErrorf("newQueryProcessorHelper: failed to create head data processor")
+	var fetchDp *DataProcessor
+
+	if len(chain) > 0 {
+		fetchDp = chain[len(chain)-1]
 	}
 
-	headDP.streams = append(headDP.streams, &CachedStream{input, nil, false})
+	if shoulDistribute {
+		headDP := NewHeadDP(&structs.HeadExpr{MaxRows: limit})
+		if headDP == nil {
+			return nil, utils.TeeErrorf("newQueryProcessorHelper: failed to create head data processor")
+		}
 
-	scrollerDP := NewScrollerDP(uint64(scrollFrom), qid)
-	if scrollerDP == nil {
-		return nil, utils.TeeErrorf("newQueryProcessorHelper: failed to create scroller data processor")
+		headDP.streams = append(headDP.streams, &CachedStream{input, nil, false})
+
+		scrollerDP := NewScrollerDP(uint64(scrollFrom), qid)
+		if scrollerDP == nil {
+			return nil, utils.TeeErrorf("newQueryProcessorHelper: failed to create scroller data processor")
+		}
+		scrollerDP.streams = append(scrollerDP.streams, &CachedStream{headDP, nil, false})
+
+		fetchDp = scrollerDP
 	}
-	scrollerDP.streams = append(scrollerDP.streams, &CachedStream{headDP, nil, false})
+
+	if fetchDp == nil {
+		return nil, utils.TeeErrorf("newQueryProcessorHelper: the last data processor is nil")
+	}
 
 	return &QueryProcessor{
 		queryType:     queryType,
-		DataProcessor: *scrollerDP,
+		DataProcessor: *fetchDp,
 		chain:         chain,
 		qid:           qid,
 		scrollFrom:    uint64(scrollFrom),

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -243,7 +243,23 @@ func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryI
 	} else if queryAgg.MVExpandExpr != nil {
 		return NewMVExpandDP(queryAgg.MVExpandExpr)
 	} else if queryAgg.StatisticExpr != nil {
-		queryAgg.StatsExpr = &structs.StatsExpr{GroupByRequest: queryAgg.GroupByRequest}
+		statsExpr := &structs.StatsExpr{GroupByRequest: queryAgg.GroupByRequest}
+		queryAgg.StatsExpr = statsExpr
+
+		if queryInfo.IsDistributed() && !queryAgg.StatisticExpr.ExprSplitDone {
+			// Split the Aggs into two data processors, the first one is the stats processor
+			// and the second one will perform the actual statisticExpr.
+			nextAgg := &structs.QueryAggregators{
+				GroupByRequest: queryAgg.GroupByRequest,
+				StatisticExpr:  queryAgg.StatisticExpr,
+			}
+			nextAgg.Next = queryAgg.Next
+			queryAgg.Next = nextAgg
+			nextAgg.StatisticExpr.ExprSplitDone = true
+
+			return NewStatsDP(statsExpr)
+		}
+
 		return NewStatisticExprDP(queryAgg)
 	} else if queryAgg.RegexExpr != nil {
 		return NewRegexDP(queryAgg.RegexExpr)

--- a/pkg/segment/query/processor/queryprocessor_test.go
+++ b/pkg/segment/query/processor/queryprocessor_test.go
@@ -73,7 +73,7 @@ func Test_GetFullResult_notTruncated(t *testing.T) {
 	queryInfo, err := query.InitQueryInformation(searchNode, nil, nil, nil, 0, 0, qid, nil, 0, 0, false)
 	assert.NoError(t, err)
 
-	queryProcessor, err := newQueryProcessorHelper(structs.RRCCmd, stream, nil, qid, 0, false)
+	queryProcessor, err := newQueryProcessorHelper(structs.RRCCmd, stream, nil, qid, 0, false, true)
 	assert.NoError(t, err)
 	queryProcessor.queryInfo = queryInfo
 	queryProcessor.querySummary = querySummary
@@ -121,7 +121,7 @@ func Test_GetFullResult_truncated(t *testing.T) {
 	queryInfo, err := query.InitQueryInformation(searchNode, nil, nil, nil, 0, 0, qid, nil, 0, 0, false)
 	assert.NoError(t, err)
 
-	queryProcessor, err := newQueryProcessorHelper(structs.RRCCmd, stream, nil, qid, 0, false)
+	queryProcessor, err := newQueryProcessorHelper(structs.RRCCmd, stream, nil, qid, 0, false, true)
 	assert.NoError(t, err)
 	queryProcessor.queryInfo = queryInfo
 	queryProcessor.querySummary = querySummary

--- a/pkg/segment/query/processor/rarecommand.go
+++ b/pkg/segment/query/processor/rarecommand.go
@@ -34,6 +34,10 @@ func NewRareProcessor(options *structs.QueryAggregators) *rareProcessor {
 	}
 }
 
+func (p *rareProcessor) SetAsIqrStatsResults() {
+	p.statisticExprProcessor.SetAsIqrStatsResults()
+}
+
 func (p *rareProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 	return p.statisticExprProcessor.Process(iqr)
 }

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/query/iqr"
 	"github.com/siglens/siglens/pkg/segment/query/pqs"
 	"github.com/siglens/siglens/pkg/segment/query/summary"
+	"github.com/siglens/siglens/pkg/segment/results/blockresults"
 	"github.com/siglens/siglens/pkg/segment/results/segresults"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
@@ -66,6 +67,8 @@ type Searcher struct {
 	unsentRRCs           []*segutils.RecordResultContainer
 	segEncToKey          *toputils.TwoWayMap[uint32, string]
 	segEncToKeyBaseValue uint32
+
+	setAsIqrStatsResults bool
 }
 
 func NewSearcher(queryInfo *query.QueryInformation, querySummary *summary.QuerySummary,
@@ -91,6 +94,10 @@ func NewSearcher(queryInfo *query.QueryInformation, querySummary *summary.QueryS
 		segEncToKey:           toputils.NewTwoWayMap[uint32, string](),
 		segEncToKeyBaseValue:  queryInfo.GetSegEncToKeyBaseValue(),
 	}, nil
+}
+
+func (s *Searcher) SetAsIqrStatsResults() {
+	s.setAsIqrStatsResults = true
 }
 
 func (s *Searcher) Rewind() {
@@ -259,9 +266,11 @@ func (s *Searcher) fetchStatsResults() (*iqr.IQR, error) {
 	}
 
 	var nodeResult *structs.NodeResult
+	var groupByBuckets *blockresults.GroupByBuckets
+	var timeBuckets *blockresults.TimeBuckets
 
 	if qType == structs.SegmentStatsCmd {
-		nodeResult = query.GetNodeResultsForSegmentStatsCmd(s.queryInfo, s.startTime, searchResults, nil, s.querySummary, orgId)
+		nodeResult = query.GetNodeResultsForSegmentStatsCmd(s.queryInfo, s.startTime, searchResults, nil, s.querySummary, orgId, s.setAsIqrStatsResults)
 	} else if qType == structs.GroupByCmd {
 		nodeResult, err = s.fetchGroupByResults(searchResults, aggs)
 		if err != nil {
@@ -271,6 +280,15 @@ func (s *Searcher) fetchStatsResults() (*iqr.IQR, error) {
 				return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: failed to get group by results: %v", s.qid, err)
 			}
 		}
+		if s.setAsIqrStatsResults {
+			var isGroupByBuckets, isTimeBuckets bool
+			groupByBuckets, isGroupByBuckets = nodeResult.GroupByBuckets.(*blockresults.GroupByBuckets)
+			timeBuckets, isTimeBuckets = nodeResult.TimeBuckets.(*blockresults.TimeBuckets)
+			if !isGroupByBuckets || !isTimeBuckets {
+				return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: Expected GroupByBuckets and TimeBuckets, got %T and %T",
+					qid, nodeResult.GroupByBuckets, nodeResult.TimeBuckets)
+			}
+		}
 	} else {
 		return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: invalid query type: %v", qid, qType)
 	}
@@ -278,9 +296,20 @@ func (s *Searcher) fetchStatsResults() (*iqr.IQR, error) {
 	// post getting of stats results
 	iqr := iqr.NewIQR(s.queryInfo.GetQid())
 
-	err = iqr.CreateStatsResults(nodeResult.MeasureResults, nodeResult.MeasureFunctions, nodeResult.GroupByCols, nodeResult.BucketCount)
-	if err != nil {
-		return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: failed to create stats results: %v", qid, err)
+	if s.setAsIqrStatsResults {
+		err := iqr.SetIqrStatsResults(qType, nodeResult.SegStatsMap, groupByBuckets, timeBuckets, aggs)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: failed to set IQR stats results: %v", qid, err)
+		}
+	} else {
+		if aggs.StatisticExpr != nil {
+			iqr.SetStatsAggregationResult(nodeResult.Histogram)
+		}
+
+		err = iqr.CreateStatsResults(nodeResult.MeasureResults, nodeResult.MeasureFunctions, nodeResult.GroupByCols, nodeResult.BucketCount)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: failed to create stats results: %v", qid, err)
+		}
 	}
 
 	s.qsrs = s.qsrs[0:] // Clear the QSRs so we don't process them again.
@@ -306,10 +335,9 @@ func (s *Searcher) fetchGroupByResults(searchResults *segresults.SearchResults, 
 	}
 	aggs.BucketLimit = bucketLimit
 
-	nodeResult := query.GetNodeResultsFromQSRS(s.qsrs, s.queryInfo, s.startTime, searchResults, s.querySummary)
-
-	if aggs.StatisticExpr != nil {
-		aggs.StatisticExpr.AggregationResult = nodeResult.Histogram
+	nodeResult := query.GetNodeResultsFromQSRS(s.qsrs, s.queryInfo, s.startTime, searchResults, s.querySummary, s.setAsIqrStatsResults)
+	if s.setAsIqrStatsResults {
+		return nodeResult, nil
 	}
 
 	bucketHolderArr, measureFuncs, aggGroupByCols, _, bucketCount := searchResults.GetGroupyByBuckets(int(utils.QUERY_MAX_BUCKETS))

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -282,9 +282,17 @@ func (s *Searcher) fetchStatsResults() (*iqr.IQR, error) {
 		}
 		if s.setAsIqrStatsResults {
 			var isGroupByBuckets, isTimeBuckets bool
-			groupByBuckets, isGroupByBuckets = nodeResult.GroupByBuckets.(*blockresults.GroupByBuckets)
-			timeBuckets, isTimeBuckets = nodeResult.TimeBuckets.(*blockresults.TimeBuckets)
-			if !isGroupByBuckets || !isTimeBuckets {
+			isGroupByBucketNil, isTimeBucketsNil := true, true
+			if nodeResult.GroupByBuckets != nil {
+				isGroupByBucketNil = false
+				groupByBuckets, isGroupByBuckets = nodeResult.GroupByBuckets.(*blockresults.GroupByBuckets)
+			}
+			if nodeResult.TimeBuckets != nil {
+				isTimeBucketsNil = false
+				timeBuckets, isTimeBuckets = nodeResult.TimeBuckets.(*blockresults.TimeBuckets)
+			}
+
+			if (!isGroupByBucketNil && !isGroupByBuckets) || (!isTimeBucketsNil && !isTimeBuckets) {
 				return nil, toputils.TeeErrorf("qid=%v, searcher.fetchStatsResults: Expected GroupByBuckets and TimeBuckets, got %T and %T",
 					qid, nodeResult.GroupByBuckets, nodeResult.TimeBuckets)
 			}

--- a/pkg/segment/query/processor/statisticexprcommand.go
+++ b/pkg/segment/query/processor/statisticexprcommand.go
@@ -61,9 +61,9 @@ func (p *statisticExprProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 	}
 
 	// if the queryType is GroupByCMD, the AggregationResult is already set by the searcher
-	if p.options.AggregationResult != nil && inputIQR != nil {
+	if inputIQR != nil && inputIQR.GetStatsAggregationResult() != nil {
 		p.qid = inputIQR.GetQID()
-		return p.processAggregationResult(p.options.AggregationResult)
+		return p.processAggregationResult(inputIQR.GetStatsAggregationResult())
 	}
 
 	if inputIQR != nil {

--- a/pkg/segment/query/processor/statisticexprcommand.go
+++ b/pkg/segment/query/processor/statisticexprcommand.go
@@ -36,6 +36,7 @@ type statisticExprProcessor struct {
 	qid                     uint64
 	finalAggregationResults map[string]*structs.AggregationResult
 	hasFinalResult          bool
+	setAsIqrStatsResults    bool
 }
 
 func NewStatisticExprProcessor(options *structs.QueryAggregators) *statisticExprProcessor {
@@ -47,6 +48,11 @@ func NewStatisticExprProcessor(options *structs.QueryAggregators) *statisticExpr
 	processor.statsProcessor = NewStatsProcessor(processor.statsExpr)
 
 	return processor
+}
+
+func (p *statisticExprProcessor) SetAsIqrStatsResults() {
+	p.statsProcessor.SetAsIqrStatsResults()
+	p.setAsIqrStatsResults = true
 }
 
 func (p *statisticExprProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
@@ -69,6 +75,16 @@ func (p *statisticExprProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 
 	if p.statsProcessor.searchResults == nil {
 		return nil, io.EOF
+	}
+
+	if p.setAsIqrStatsResults {
+		p.statsProcessor.searchResults.GetAggs().StatisticExpr = p.options
+		iqr, err := p.statsProcessor.extractFinalStatsResults()
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("statisticExprProcessor.Process: Error extracting stats as IqrStatsResults: %v", err)
+		}
+
+		return iqr, err
 	}
 
 	aggResults := p.statsProcessor.searchResults.GetBucketResults()

--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -40,15 +40,16 @@ type ErrorData struct {
 }
 
 type statsProcessor struct {
-	options             *structs.StatsExpr
-	bucketKeyWorkingBuf []byte
-	byteBuffer          *bbp.ByteBuffer
-	searchResults       *segresults.SearchResults
-	statsResults        *segresults.StatsResults
-	qid                 uint64
-	processorType       structs.QueryType
-	errorData           *ErrorData
-	hasFinalResult      bool
+	options              *structs.StatsExpr
+	bucketKeyWorkingBuf  []byte
+	byteBuffer           *bbp.ByteBuffer
+	searchResults        *segresults.SearchResults
+	statsResults         *segresults.StatsResults
+	qid                  uint64
+	processorType        structs.QueryType
+	errorData            *ErrorData
+	hasFinalResult       bool
+	setAsIqrStatsResults bool
 }
 
 func NewStatsProcessor(options *structs.StatsExpr) *statsProcessor {
@@ -65,6 +66,10 @@ func NewStatsProcessor(options *structs.StatsExpr) *statsProcessor {
 	}
 
 	return processor
+}
+
+func (p *statsProcessor) SetAsIqrStatsResults() {
+	p.setAsIqrStatsResults = true
 }
 
 func (p *statsProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
@@ -200,13 +205,19 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 
 func (p *statsProcessor) extractGroupByResults(iqr *iqr.IQR) (*iqr.IQR, error) {
 	// load and convert the bucket results
-	_ = p.searchResults.GetBucketResults()
 
-	bucketHolderArr, measureFuncs, aggGroupByCols, _, bucketCount := p.searchResults.GetGroupyByBuckets(int(utils.QUERY_MAX_BUCKETS))
-
-	err := iqr.CreateStatsResults(bucketHolderArr, measureFuncs, aggGroupByCols, bucketCount)
-	if err != nil {
-		return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractGroupByResults: cannot create stats results; err=%v", iqr.GetQID(), err)
+	if p.setAsIqrStatsResults {
+		aggs := p.searchResults.GetAggs()
+		groupByBuckets, TimeBuckets := p.searchResults.BlockResults.GroupByAggregation, p.searchResults.BlockResults.TimeAggregation
+		err := iqr.SetIqrStatsResults(structs.GroupByCmd, nil, groupByBuckets, TimeBuckets, aggs)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractGroupByResults: cannot set iqr stats results; err=%v", iqr.GetQID(), err)
+		}
+	} else {
+		err := iqr.CreateGroupByStatsResults(p.searchResults)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractGroupByResults: cannot create group by stats results; err=%v", iqr.GetQID(), err)
+		}
 	}
 
 	p.hasFinalResult = true
@@ -297,16 +308,17 @@ func (p *statsProcessor) extractSegmentStatsResults(iqr *iqr.IQR) (*iqr.IQR, err
 
 	segStatsMap := p.statsResults.GetSegStats()
 
-	err := p.searchResults.UpdateSegmentStats(segStatsMap, p.options.MeasureOperations)
-	if err != nil {
-		return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractSegmentStatsResults: cannot update segment stats; err=%v", iqr.GetQID(), err)
-	}
-
-	aggMeasureRes, aggMeasureFunctions, groupByCols, _, bucketCount := p.searchResults.GetSegmentStatsResults(0, false)
-
-	err = iqr.CreateStatsResults(aggMeasureRes, aggMeasureFunctions, groupByCols, bucketCount)
-	if err != nil {
-		return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractSegmentStatsResults: cannot create stats results; err=%v", iqr.GetQID(), err)
+	if p.setAsIqrStatsResults {
+		aggs := p.searchResults.GetAggs()
+		err := iqr.SetIqrStatsResults(structs.SegmentStatsCmd, segStatsMap, nil, nil, aggs)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractSegmentStatsResults: cannot set iqr stats results; err=%v", iqr.GetQID(), err)
+		}
+	} else {
+		err := iqr.CreateSegmentStatsResults(p.searchResults, segStatsMap, p.options.MeasureOperations)
+		if err != nil {
+			return nil, toputils.TeeErrorf("qid=%v, statsProcessor.extractSegmentStatsResults: cannot create segment stats results; err=%v", iqr.GetQID(), err)
+		}
 	}
 
 	p.hasFinalResult = true

--- a/pkg/segment/query/processor/statscommand_test.go
+++ b/pkg/segment/query/processor/statscommand_test.go
@@ -363,8 +363,9 @@ func Test_ProcessGroupByRequest_MergeIqrStats(t *testing.T) {
 	iqrs := []*iqr.IQR{resultIqr1, resultIqr2, resultIqr3}
 
 	resultIqr := iqr.NewIQR(0)
-	err = resultIqr.MergeIQRStatsResults(iqrs)
+	statsExists, err := resultIqr.MergeIQRStatsResults(iqrs)
 	assert.NoError(t, err)
+	assert.True(t, statsExists)
 
 	knownValues, err = resultIqr.ReadAllColumns()
 	assert.NoError(t, err)
@@ -555,8 +556,9 @@ func Test_ProcessSegmentStats_MergeIqrStats(t *testing.T) {
 	iqrs := []*iqr.IQR{resultIqr1, resultIqr2, resultIqr3}
 
 	resultIqr := iqr.NewIQR(0)
-	err = resultIqr.MergeIQRStatsResults(iqrs)
+	statsExists, err := resultIqr.MergeIQRStatsResults(iqrs)
 	assert.NoError(t, err)
+	assert.True(t, statsExists)
 
 	knownValues, err = resultIqr.ReadAllColumns()
 	assert.NoError(t, err)

--- a/pkg/segment/query/processor/statscommand_test.go
+++ b/pkg/segment/query/processor/statscommand_test.go
@@ -303,6 +303,123 @@ func Test_ProcessGroupByRequest_SomeColsMissing(t *testing.T) {
 	}
 }
 
+func Test_ProcessGroupByRequest_MergeIqrStats(t *testing.T) {
+	config.InitializeTestingConfig(t.TempDir())
+	config.GetRunningConfig().UseNewPipelineConverted = true
+
+	knownValues := getTestData()
+	processor := getGroupByProcessor()
+	processor.setAsIqrStatsResults = true
+
+	iqr1 := iqr.NewIQR(0)
+
+	err := iqr1.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr1)
+	assert.NoError(t, err)
+
+	resultIqr1, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr1)
+
+	_, groupByBuckets, _ := resultIqr1.GetIQRStatsResults()
+	assert.NotNil(t, groupByBuckets)
+
+	iqr2 := iqr.NewIQR(0)
+	processor = getGroupByProcessor()
+	processor.setAsIqrStatsResults = true
+
+	err = iqr2.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr2)
+	assert.NoError(t, err)
+
+	resultIqr2, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr2)
+
+	_, groupByBuckets, _ = resultIqr2.GetIQRStatsResults()
+	assert.NotNil(t, groupByBuckets)
+
+	iqr3 := iqr.NewIQR(0)
+	processor = getGroupByProcessor()
+	processor.setAsIqrStatsResults = true
+
+	err = iqr3.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr3)
+	assert.NoError(t, err)
+
+	resultIqr3, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr3)
+
+	_, groupByBuckets, _ = resultIqr3.GetIQRStatsResults()
+	assert.NotNil(t, groupByBuckets)
+
+	iqrs := []*iqr.IQR{resultIqr1, resultIqr2, resultIqr3}
+
+	resultIqr := iqr.NewIQR(0)
+	err = resultIqr.MergeIQRStatsResults(iqrs)
+	assert.NoError(t, err)
+
+	knownValues, err = resultIqr.ReadAllColumns()
+	assert.NoError(t, err)
+
+	expectedKnownValues := map[string][]utils.CValueEnclosure{
+		"count(col2)": {
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+			{Dtype: utils.SS_DT_UNSIGNED_NUM, CVal: uint64(3)},
+		},
+		"sum(col2)": {
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(3)},
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(6)},
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(9)},
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(12)},
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(15)},
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(18)},
+		},
+		"avg(col2)": {
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(1)},
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(2)},
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(3)},
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(4)},
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(5)},
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(6)},
+		},
+		"col1": {
+			{Dtype: utils.SS_DT_STRING, CVal: "c"},
+			{Dtype: utils.SS_DT_STRING, CVal: "a"},
+			{Dtype: utils.SS_DT_STRING, CVal: "b"},
+			{Dtype: utils.SS_DT_STRING, CVal: "e"},
+			{Dtype: utils.SS_DT_STRING, CVal: "a"},
+			{Dtype: utils.SS_DT_STRING, CVal: "b"},
+		},
+		"col3": {
+			{Dtype: utils.SS_DT_STRING, CVal: "z"},
+			{Dtype: utils.SS_DT_STRING, CVal: "y"},
+			{Dtype: utils.SS_DT_STRING, CVal: "x"},
+			{Dtype: utils.SS_DT_STRING, CVal: "w"},
+			{Dtype: utils.SS_DT_STRING, CVal: "v"},
+			{Dtype: utils.SS_DT_STRING, CVal: "u"},
+		},
+	}
+
+	columnNames := []string{"count(col2)", "sum(col2)", "avg(col2)", "col1", "col3"}
+	for _, colName := range columnNames {
+		actualValues, ok := knownValues[colName]
+		assert.True(t, ok)
+		assert.ElementsMatch(t, expectedKnownValues[colName], actualValues)
+	}
+}
+
 func getStatsMeasureProcessor() *statsProcessor {
 	measureOperations := []*structs.MeasureAggregator{
 		{
@@ -378,6 +495,85 @@ func Test_ProcessSegmentStats(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, len(actualAvgRes))
 	assert.Equal(t, expectedAvgRes, actualAvgRes)
+}
+
+func Test_ProcessSegmentStats_MergeIqrStats(t *testing.T) {
+	knownValues := getTestData()
+	processor := getStatsMeasureProcessor()
+	processor.setAsIqrStatsResults = true
+
+	iqr1 := iqr.NewIQR(0)
+
+	err := iqr1.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr1)
+	assert.NoError(t, err)
+
+	resultIqr1, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr1)
+
+	segStatsMap, _, _ := resultIqr1.GetIQRStatsResults()
+	assert.NotNil(t, segStatsMap)
+	assert.Equal(t, 1, len(segStatsMap))
+
+	iqr2 := iqr.NewIQR(0)
+	processor = getStatsMeasureProcessor()
+	processor.setAsIqrStatsResults = true
+
+	err = iqr2.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr2)
+	assert.NoError(t, err)
+
+	resultIqr2, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr2)
+
+	segStatsMap, _, _ = resultIqr2.GetIQRStatsResults()
+	assert.NotNil(t, segStatsMap)
+
+	iqr3 := iqr.NewIQR(0)
+	processor = getStatsMeasureProcessor()
+	processor.setAsIqrStatsResults = true
+
+	err = iqr3.AppendKnownValues(knownValues)
+	assert.NoError(t, err)
+
+	_, err = processor.Process(iqr3)
+	assert.NoError(t, err)
+
+	resultIqr3, err := processor.Process(nil)
+	assert.Equal(t, io.EOF, err)
+	assert.NotNil(t, resultIqr3)
+
+	segStatsMap, _, _ = resultIqr3.GetIQRStatsResults()
+	assert.NotNil(t, segStatsMap)
+
+	iqrs := []*iqr.IQR{resultIqr1, resultIqr2, resultIqr3}
+
+	resultIqr := iqr.NewIQR(0)
+	err = resultIqr.MergeIQRStatsResults(iqrs)
+	assert.NoError(t, err)
+
+	knownValues, err = resultIqr.ReadAllColumns()
+	assert.NoError(t, err)
+
+	expectedKnownValues := map[string][]utils.CValueEnclosure{
+		"count(col2)": {
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(18)},
+		},
+		"sum(col2)": {
+			{Dtype: utils.SS_DT_SIGNED_NUM, CVal: int64(63)},
+		},
+		"avg(col2)": {
+			{Dtype: utils.SS_DT_FLOAT, CVal: float64(3.5)},
+		},
+	}
+
+	assert.Equal(t, expectedKnownValues, knownValues)
 }
 
 func Test_ProcessGroupByRequestFullBuffer(t *testing.T) {

--- a/pkg/segment/query/processor/topcommand.go
+++ b/pkg/segment/query/processor/topcommand.go
@@ -34,6 +34,10 @@ func NewTopProcessor(options *structs.QueryAggregators) *topProcessor {
 	}
 }
 
+func (p *topProcessor) SetAsIqrStatsResults() {
+	p.statisticExprProcessor.SetAsIqrStatsResults()
+}
+
 func (p *topProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 	return p.statisticExprProcessor.Process(iqr)
 }

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -881,7 +881,7 @@ func computeSegStatsFromRawRecords(segReq *QuerySegmentRequest, qs *summary.Quer
 }
 
 func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResults *segresults.SearchResults, qid uint64, qs *summary.QuerySummary,
-	searchType structs.SearchNodeType, measureOperations []*structs.MeasureAggregator, getSsstMap bool) map[string]*structs.SegStats {
+	searchType structs.SearchNodeType, measureOperations []*structs.MeasureAggregator, getSstMap bool) map[string]*structs.SegStats {
 
 	nodeRes, err := GetOrCreateQuerySearchNodeResult(qid)
 	if err != nil {
@@ -954,7 +954,7 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 
 	finalSstMap := statsRes.GetSegStats()
 
-	if !getSsstMap {
+	if !getSstMap {
 		err = allSegFileResults.UpdateSegmentStats(finalSstMap, measureOperations)
 		if err != nil {
 			log.Errorf("qid=%d,  applyAggOpOnSegments : ReadSegStats: Failed to update segment stats for segKey! Error: %v", qid, err)

--- a/pkg/segment/query/segqueryhelpers.go
+++ b/pkg/segment/query/segqueryhelpers.go
@@ -122,6 +122,9 @@ func (qi *QueryInformation) GetOrgId() uint64 {
 }
 
 func (qi *QueryInformation) IsDistributed() bool {
+	if qi.dqs == nil {
+		return false
+	}
 	return qi.dqs.IsDistributed()
 }
 

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -1052,7 +1052,7 @@ func (tb *TimeBuckets) ToSerializedTimeBuckets() *SerializedTimeBuckets {
 	}
 }
 
-func (sgb *SerializedGroupByBuckets) ToGroupByBuckets() *GroupByBuckets {
+func (sgb *SerializedGroupByBuckets) ToGroupByBuckets(groupByBuckets *GroupByBuckets, qid uint64) *GroupByBuckets {
 	if sgb == nil {
 		return nil
 	}
@@ -1060,17 +1060,21 @@ func (sgb *SerializedGroupByBuckets) ToGroupByBuckets() *GroupByBuckets {
 	allRunningBuckets := make([]*RunningBucketResults, len(sgb.AllRunningBuckets))
 
 	for i, bucket := range sgb.AllRunningBuckets {
-		allRunningBuckets[i] = bucket.ToRunningBucketResults()
+		allRunningBuckets[i] = bucket.ToRunningBucketResults(qid)
 	}
 
 	return &GroupByBuckets{
-		AllRunningBuckets: allRunningBuckets,
-		StringBucketIdx:   sgb.StringBucketIdx,
-		GroupByColValCnt:  sgb.GroupByColValCnt,
+		AllRunningBuckets:   allRunningBuckets,
+		StringBucketIdx:     sgb.StringBucketIdx,
+		GroupByColValCnt:    sgb.GroupByColValCnt,
+		allMeasureCols:      groupByBuckets.allMeasureCols,
+		internalMeasureFns:  groupByBuckets.internalMeasureFns,
+		reverseMeasureIndex: groupByBuckets.reverseMeasureIndex,
+		maxBuckets:          groupByBuckets.maxBuckets,
 	}
 }
 
-func (stb *SerializedTimeBuckets) ToTimeBuckets() *TimeBuckets {
+func (stb *SerializedTimeBuckets) ToTimeBuckets(timeBuckets *TimeBuckets, qid uint64) *TimeBuckets {
 	if stb == nil {
 		return nil
 	}
@@ -1078,7 +1082,7 @@ func (stb *SerializedTimeBuckets) ToTimeBuckets() *TimeBuckets {
 	allRunningBuckets := make([]*RunningBucketResults, len(stb.AllRunningBuckets))
 
 	for i, bucket := range stb.AllRunningBuckets {
-		allRunningBuckets[i] = bucket.ToRunningBucketResults()
+		allRunningBuckets[i] = bucket.ToRunningBucketResults(qid)
 	}
 
 	return &TimeBuckets{

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -40,8 +40,19 @@ type GroupByBuckets struct {
 	GroupByColValCnt    map[string]int               // calculate freq for group by col val
 }
 
+type SerializedGroupByBuckets struct {
+	AllRunningBuckets []*SerializedRunningBucketResults
+	StringBucketIdx   map[string]int
+	GroupByColValCnt  map[string]int
+}
+
 type TimeBuckets struct {
 	AllRunningBuckets []*RunningBucketResults
+	UnsignedBucketIdx map[uint64]int
+}
+
+type SerializedTimeBuckets struct {
+	AllRunningBuckets []*SerializedRunningBucketResults
 	UnsignedBucketIdx map[uint64]int
 }
 
@@ -1005,4 +1016,73 @@ func (rb *RunningBucketResultsJSON) Convert() (*RunningBucketResults, error) {
 	}
 	newBucket.runningStats = currRunningStats
 	return newBucket, nil
+}
+
+func (gb *GroupByBuckets) ToSerializedGroupByBuckets() *SerializedGroupByBuckets {
+	if gb == nil {
+		return nil
+	}
+
+	allRunningBuckets := make([]*SerializedRunningBucketResults, len(gb.AllRunningBuckets))
+	for i, bucket := range gb.AllRunningBuckets {
+		allRunningBuckets[i] = bucket.ToSerializedRunningBucketResults()
+	}
+
+	return &SerializedGroupByBuckets{
+		AllRunningBuckets: allRunningBuckets,
+		StringBucketIdx:   gb.StringBucketIdx,
+		GroupByColValCnt:  gb.GroupByColValCnt,
+	}
+}
+
+func (tb *TimeBuckets) ToSerializedTimeBuckets() *SerializedTimeBuckets {
+	if tb == nil {
+		return nil
+	}
+
+	allRunningBuckets := make([]*SerializedRunningBucketResults, len(tb.AllRunningBuckets))
+
+	for i, bucket := range tb.AllRunningBuckets {
+		allRunningBuckets[i] = bucket.ToSerializedRunningBucketResults()
+	}
+
+	return &SerializedTimeBuckets{
+		AllRunningBuckets: allRunningBuckets,
+		UnsignedBucketIdx: tb.UnsignedBucketIdx,
+	}
+}
+
+func (sgb *SerializedGroupByBuckets) ToGroupByBuckets() *GroupByBuckets {
+	if sgb == nil {
+		return nil
+	}
+
+	allRunningBuckets := make([]*RunningBucketResults, len(sgb.AllRunningBuckets))
+
+	for i, bucket := range sgb.AllRunningBuckets {
+		allRunningBuckets[i] = bucket.ToRunningBucketResults()
+	}
+
+	return &GroupByBuckets{
+		AllRunningBuckets: allRunningBuckets,
+		StringBucketIdx:   sgb.StringBucketIdx,
+		GroupByColValCnt:  sgb.GroupByColValCnt,
+	}
+}
+
+func (stb *SerializedTimeBuckets) ToTimeBuckets() *TimeBuckets {
+	if stb == nil {
+		return nil
+	}
+
+	allRunningBuckets := make([]*RunningBucketResults, len(stb.AllRunningBuckets))
+
+	for i, bucket := range stb.AllRunningBuckets {
+		allRunningBuckets[i] = bucket.ToRunningBucketResults()
+	}
+
+	return &TimeBuckets{
+		AllRunningBuckets: allRunningBuckets,
+		UnsignedBucketIdx: stb.UnsignedBucketIdx,
+	}
 }

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -1057,6 +1057,10 @@ func (sgb *SerializedGroupByBuckets) ToGroupByBuckets(groupByBuckets *GroupByBuc
 		return nil
 	}
 
+	if groupByBuckets == nil {
+		groupByBuckets = &GroupByBuckets{}
+	}
+
 	allRunningBuckets := make([]*RunningBucketResults, len(sgb.AllRunningBuckets))
 
 	for i, bucket := range sgb.AllRunningBuckets {
@@ -1074,7 +1078,7 @@ func (sgb *SerializedGroupByBuckets) ToGroupByBuckets(groupByBuckets *GroupByBuc
 	}
 }
 
-func (stb *SerializedTimeBuckets) ToTimeBuckets(timeBuckets *TimeBuckets, qid uint64) *TimeBuckets {
+func (stb *SerializedTimeBuckets) ToTimeBuckets(qid uint64) *TimeBuckets {
 	if stb == nil {
 		return nil
 	}

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -710,7 +710,7 @@ func (rs *runningStats) ToSerializedRunningStats() *SerializedRunningStats {
 	}
 }
 
-func (srb *SerializedRunningBucketResults) ToRunningBucketResults() *RunningBucketResults {
+func (srb *SerializedRunningBucketResults) ToRunningBucketResults(qid uint64) *RunningBucketResults {
 	runStats := make([]runningStats, len(srb.RunningStats))
 	for i := 0; i < len(srb.RunningStats); i++ {
 		runStats[i] = *srb.RunningStats[i].ToRunningStats()
@@ -727,6 +727,7 @@ func (srb *SerializedRunningBucketResults) ToRunningBucketResults() *RunningBuck
 		currStats:           srb.CurrStats,
 		groupedRunningStats: groupedRunningStats,
 		count:               srb.Count,
+		qid:                 qid,
 	}
 }
 

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -952,12 +952,27 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 					}
 					stats.AddSegStatsStr(localStats, cname, str, bb, aggColUsage, hasValuesFunc, hasListFunc)
 				} else {
-					fVal, err := cValEnc.GetFloatValue()
+					var floatVal float64
+					var intVal int64
+					var valueType utils.SS_IntUintFloatTypes
+					var numStr string
+					var err error
+					if cValEnc.IsFloat() {
+						valueType = utils.SS_FLOAT64
+						floatVal, err = cValEnc.GetFloatValue()
+						numStr = fmt.Sprintf("%v", floatVal)
+					} else {
+						valueType = utils.SS_INT64
+						intVal, err = cValEnc.GetIntValue()
+						numStr = fmt.Sprintf("%v", intVal)
+					}
+
 					if err != nil {
-						log.Errorf("qid=%d, segmentStatsWorker failed to extract numerical value for type %+v. Err: %v", qid, cValEnc.Dtype, err)
+						log.Errorf("qid=%d, segmentStatsWorker failed to extract numerical value for CValueEnc %+v. Err: %v", qid, cValEnc, err)
 						continue
 					}
-					stats.AddSegStatsNums(localStats, cname, utils.SS_FLOAT64, 0, 0, fVal, fmt.Sprintf("%v", fVal), bb, aggColUsage, hasValuesFunc, hasListFunc)
+
+					stats.AddSegStatsNums(localStats, cname, valueType, intVal, 0, floatVal, numStr, bb, aggColUsage, hasValuesFunc, hasListFunc)
 				}
 			}
 		}

--- a/pkg/segment/search/segsearch_test.go
+++ b/pkg/segment/search/segsearch_test.go
@@ -418,10 +418,10 @@ func testAggsQuery(t *testing.T, numEntriesForBuffer int, searchReq *structs.Seg
 	key6Block0Stats := block0["key6"]
 	assert.True(t, key6Block0Stats.IsNumeric)
 	assert.Equal(t, key6Block0Stats.Count, uint64(numEntriesForBuffer))
-	assert.Equal(t, key6Block0Stats.Min.Dtype, utils.SS_DT_FLOAT)
-	assert.Equal(t, key6Block0Stats.Min.CVal, float64(0))
-	assert.Equal(t, key6Block0Stats.Max.Dtype, utils.SS_DT_FLOAT)
-	assert.Equal(t, key6Block0Stats.Max.CVal, float64(numEntriesForBuffer-1)*2)
+	assert.Equal(t, key6Block0Stats.Min.Dtype, utils.SS_DT_SIGNED_NUM)
+	assert.Equal(t, key6Block0Stats.Min.CVal, int64(0))
+	assert.Equal(t, key6Block0Stats.Max.Dtype, utils.SS_DT_SIGNED_NUM)
+	assert.Equal(t, key6Block0Stats.Max.CVal, int64(numEntriesForBuffer-1)*2)
 }
 
 type BenchQueryConds struct {

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -96,6 +96,7 @@ type StatisticExpr struct {
 	FieldList             []string //Must have FieldList
 	ByClause              []string
 	AggregationResult     map[string]*AggregationResult
+	ExprSplitDone         bool
 }
 
 type StatisticOptions struct {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1210,6 +1210,22 @@ func (qtype QueryType) String() string {
 	}
 }
 
+func (qtype QueryType) IsRRCCmd() bool {
+	return qtype == RRCCmd
+}
+
+func (qtype QueryType) IsGroupByCmd() bool {
+	return qtype == GroupByCmd
+}
+
+func (qtype QueryType) IsSegmentStatsCmd() bool {
+	return qtype == SegmentStatsCmd
+}
+
+func (qtype QueryType) IsInvalid() bool {
+	return qtype == InvalidCmd
+}
+
 func (qa *QueryAggregators) HasTopExpr() bool {
 	return qa != nil && qa.StatisticExpr != nil && qa.StatisticExpr.StatisticFunctionMode == SFMTop
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1234,6 +1234,10 @@ func (qtype QueryType) IsInvalid() bool {
 	return qtype == InvalidCmd
 }
 
+func (qtype QueryType) IsNotStatsType() bool {
+	return qtype != SegmentStatsCmd && qtype != GroupByCmd
+}
+
 func (qa *QueryAggregators) HasTopExpr() bool {
 	return qa != nil && qa.StatisticExpr != nil && qa.StatisticExpr.StatisticFunctionMode == SFMTop
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -501,6 +501,9 @@ type NodeResult struct {
 	GroupByCols                 []string        `json:"groupByCols,omitempty"`
 	Qtype                       string          `json:"qtype,omitempty"`
 	BucketCount                 int             `json:"bucketCount,omitempty"`
+	SegStatsMap                 map[string]*SegStats
+	GroupByBuckets              interface{}     // *blockresults.GroupByBuckets
+	TimeBuckets                 interface{}     // *blockresults.TimeBuckets
 	PerformAggsOnRecs           bool            // if true, perform aggregations on records that are returned from rrcreader.go
 	RecsAggsType                PipeCommandType // To determine Whether it is GroupByType or MeasureAggsType
 	GroupByRequest              *GroupByRequest

--- a/pkg/utils/sliceutils.go
+++ b/pkg/utils/sliceutils.go
@@ -399,3 +399,11 @@ func SelectFromSlice[T any](slice []T, shouldKeep func(T) bool) []T {
 
 	return result
 }
+
+func NormalizeSlice[T any](slice []T) []T {
+	if slice == nil {
+		return []T{}
+	}
+
+	return slice
+}


### PR DESCRIPTION
# Description
- Now the IQR will also have `statsResults` that contains Group By and Segment Stats cmd results in Aggregated format.
- Updated the Gob encoding
- MergeIQRs now also merge these stats from multiple IQR streams.
- Added tests to test the merging of IQR stats.
- Refactored the code for `stats`, `timechart`, `top`, and `rare` commands.

# Testing
- Added new tests to test the merging of IQR and updated gob encoding/decoding test of IQR.
- All test cases are passed.
- Tested by running some of stats and top/rare queries

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
