### PR TITLE
Added Additional Metrics to  Index Summary

### DIFF
--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -411,10 +411,7 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 			counts = &structs.VtableCounts{}
 		}
 
-		// Get CMI/CSG stats
 		indexSegStats, err := writer.GetIndexSizeStats(indexName, myid)
-		log.Errorf("indexName %v, indexSegStats %v", indexName, indexSegStats)
-		log.Errorf("TotalCmiSize %v, TotalCsgSize %v, NumSegFiles %v", indexSegStats.TotalCmiSize, indexSegStats.TotalCsgSize, indexSegStats.NumSegFiles)
 		if err != nil {
 			log.Errorf("getStats: failed to get size stats for index %s: %v", indexName, err)
 			continue

--- a/pkg/health/clusterStatsHandler.go
+++ b/pkg/health/clusterStatsHandler.go
@@ -151,7 +151,7 @@ func calculateStorageSavedPercentage(incomingBytes, onDiskBytes float64) float64
 
 func convertDataToSlice(allIndexStats utils.AllIndexesStats, volumeField, countField,
 	segmentCountField, columnCountField, earliestEpochField, latestEpochField,
-	onDiskBytesField, cmiSizeField, csgSizeField, numSegFilesField, numBlocksField string) []map[string]map[string]interface{} {
+	onDiskBytesField, cmiSizeField, csgSizeField, numIndexFilesField, numBlocksField string) []map[string]map[string]interface{} {
 
 	indices := make([]string, 0)
 	for index := range allIndexStats.IndexToStats {
@@ -179,7 +179,7 @@ func convertDataToSlice(allIndexStats utils.AllIndexesStats, volumeField, countF
 
 		nextVal[index][cmiSizeField] = humanize.Bytes(indexStats.TotalCmiSize)
 		nextVal[index][csgSizeField] = humanize.Bytes(indexStats.TotalCsgSize)
-		nextVal[index][numSegFilesField] = humanize.Comma(int64(indexStats.NumSegFiles))
+		nextVal[index][numIndexFilesField] = humanize.Comma(int64(indexStats.NumIndexFiles))
 		nextVal[index][numBlocksField] = humanize.Comma(int64(indexStats.NumBlocks))
 
 		retVal = append(retVal, nextVal)
@@ -189,11 +189,11 @@ func convertDataToSlice(allIndexStats utils.AllIndexesStats, volumeField, countF
 }
 
 func convertIndexDataToSlice(indexData utils.AllIndexesStats) []map[string]map[string]interface{} {
-	return convertDataToSlice(indexData, "ingestVolume", "eventCount", "segmentCount", "columnCount", "earliestEpoch", "latestEpoch", "onDiskBytes", "cmiSize", "csgSize", "segFiles", "numBlocks")
+	return convertDataToSlice(indexData, "ingestVolume", "eventCount", "segmentCount", "columnCount", "earliestEpoch", "latestEpoch", "onDiskBytes", "cmiSize", "csgSize", "numIndexFiles", "numBlocks")
 }
 
 func convertTraceIndexDataToSlice(traceIndexData utils.AllIndexesStats) []map[string]map[string]interface{} {
-	return convertDataToSlice(traceIndexData, "traceVolume", "traceSpanCount", "segmentCount", "columnCount", "earliestEpoch", "latestEpoch", "onDiskBytes", "cmiSize", "csgSize", "segFiles", "numBlocks")
+	return convertDataToSlice(traceIndexData, "traceVolume", "traceSpanCount", "segmentCount", "columnCount", "earliestEpoch", "latestEpoch", "onDiskBytes", "cmiSize", "csgSize", "numIndexFiles", "numBlocks")
 }
 
 func ProcessClusterIngestStatsHandler(ctx *fasthttp.RequestCtx, orgId uint64) {
@@ -459,7 +459,7 @@ func getStats(myid uint64, filterFunc func(string) bool, allSegMetas []*structs.
 			TotalOnDiskBytes:  totalOnDiskBytesCountForIndex,
 			TotalCmiSize:      indexSegStats.TotalCmiSize,
 			TotalCsgSize:      indexSegStats.TotalCsgSize,
-			NumSegFiles:       indexSegStats.NumSegFiles,
+			NumIndexFiles:     indexSegStats.NumIndexFiles,
 			NumBlocks:         indexSegStats.NumBlocks,
 		}
 

--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -53,6 +53,13 @@ type PQSChanMeta struct {
 	deleteFromEmptyPqMeta bool
 }
 
+type SegmentSizeStats struct {
+	TotalCmiSize uint64
+	TotalCsgSize uint64
+	NumSegFiles  int
+	NumBlocks    int64
+}
+
 var pqsChan = make(chan PQSChanMeta, PQS_CHAN_SIZE)
 
 func initSmr() {
@@ -681,4 +688,91 @@ func writeOverSegMeta(segMetaEntries []*structs.SegMeta) error {
 	}
 
 	return nil
+}
+
+func calculateSegmentSizes(segmentKey string) (*SegmentSizeStats, error) {
+	sfm, err := readSfm(segmentKey)
+	if err != nil {
+		return nil, fmt.Errorf("calculateSegmentSizes: failed to read sfm for segment %s: %v", segmentKey, err)
+	}
+
+	stats := &SegmentSizeStats{}
+	for _, colInfo := range sfm.ColumnNames {
+		if colInfo.CmiSize == 0 && colInfo.CsgSize == 0 {
+			continue
+		}
+		stats.TotalCmiSize += colInfo.CmiSize
+		stats.TotalCsgSize += colInfo.CsgSize
+		stats.NumSegFiles += 2
+	}
+	return stats, nil
+}
+
+func GetIndexSizeStats(indexName string, orgId uint64) (*utils.IndexStats, error) {
+	allSegMetas := ReadGlobalSegmetas()
+	stats := &utils.IndexStats{}
+
+	type result struct {
+		stats *SegmentSizeStats
+		err   error
+	}
+
+	ch := make(chan result, len(allSegMetas))
+	var wg sync.WaitGroup
+
+	for _, meta := range allSegMetas {
+		if meta.VirtualTableName != indexName || (meta.OrgId != orgId && orgId != 10618270676840840323) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(segmentKey string, numBlocks uint16) {
+			defer wg.Done()
+			segStats, err := calculateSegmentSizes(segmentKey)
+			if err == nil {
+				segStats.NumBlocks = int64(numBlocks)
+			}
+			ch <- result{segStats, err}
+		}(meta.SegmentKey, meta.NumBlocks)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	for res := range ch {
+		if res.err != nil {
+			return nil, res.err
+		}
+		stats.TotalCmiSize += res.stats.TotalCmiSize
+		stats.TotalCsgSize += res.stats.TotalCsgSize
+		stats.NumSegFiles += res.stats.NumSegFiles
+		stats.NumBlocks += res.stats.NumBlocks
+	}
+
+	unrotatedStats := getUnrotatedSegmentStats(indexName, orgId)
+	stats.TotalCmiSize += unrotatedStats.TotalCmiSize
+	stats.TotalCsgSize += unrotatedStats.TotalCsgSize
+	stats.NumSegFiles += unrotatedStats.NumSegFiles
+	stats.NumBlocks += unrotatedStats.NumBlocks
+
+	return stats, nil
+}
+
+func getUnrotatedSegmentStats(indexName string, orgId uint64) *SegmentSizeStats {
+	UnrotatedInfoLock.RLock()
+	defer UnrotatedInfoLock.RUnlock()
+
+	stats := &SegmentSizeStats{}
+	for _, usi := range AllUnrotatedSegmentInfo {
+		if usi.TableName == indexName &&
+			(usi.orgid == orgId || orgId == 10618270676840840323) {
+			stats.TotalCmiSize += usi.cmiSize
+			stats.NumSegFiles += len(usi.allColumns) * 2
+
+			stats.NumBlocks += int64(len(usi.blockSummaries))
+		}
+	}
+	return stats
 }

--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -700,8 +700,11 @@ func calculateSegmentSizes(segmentKey string) (*SegmentSizeStats, error) {
 	for _, colInfo := range sfm.ColumnNames {
 		stats.TotalCmiSize += colInfo.CmiSize
 		stats.TotalCsgSize += colInfo.CsgSize
-		if colInfo.CmiSize > 0 && colInfo.CsgSize > 0 {
-			stats.NumIndexFiles += 2
+		if colInfo.CmiSize > 0 {
+			stats.NumIndexFiles++
+		}
+		if colInfo.CsgSize > 0 {
+			stats.NumIndexFiles++
 		}
 	}
 	return stats, nil
@@ -767,9 +770,11 @@ func getUnrotatedSegmentStats(indexName string, orgId uint64) *SegmentSizeStats 
 	for _, usi := range AllUnrotatedSegmentInfo {
 		if usi.TableName == indexName &&
 			(usi.orgid == orgId || orgId == 10618270676840840323) {
-			stats.TotalCmiSize += usi.cmiSize
-			stats.NumIndexFiles += len(usi.allColumns) * 2
-
+			if usi.cmiSize > 0 {
+				stats.TotalCmiSize += usi.cmiSize
+				stats.NumIndexFiles += len(usi.allColumns)
+			}
+			stats.NumIndexFiles += len(usi.allColumns)
 			stats.NumBlocks += int64(len(usi.blockSummaries))
 		}
 	}

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -383,6 +383,10 @@ type IndexStats struct {
 	EarliestTimestamp uint64
 	LatestTimestamp   uint64
 	TotalOnDiskBytes  uint64
+	TotalCmiSize      uint64
+	TotalCsgSize      uint64
+	NumSegFiles       int
+	NumBlocks         int64
 }
 
 type ClusterStatsResponseInfo struct {

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -385,7 +385,7 @@ type IndexStats struct {
 	TotalOnDiskBytes  uint64
 	TotalCmiSize      uint64
 	TotalCsgSize      uint64
-	NumSegFiles       int
+	NumIndexFiles     int
 	NumBlocks         int64
 }
 

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -169,7 +169,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <p><strong>Latest Record:</strong> <span id="latest-record"></span></p>
                                 <p><strong>Total Cmi Size:</strong> <span id="total-cmi-size"></span></p>
                                 <p><strong>Total Csg Size:</strong> <span id="total-csg-size"></span></p>
-                                <p><strong>Num of Seg Files:</strong> <span id="num-seg-files"></span></p>
+                                <p><strong>Num of Index Files:</strong> <span id="num-index-files"></span></p>
                                 <p><strong>Num of Blocks:</strong> <span id="num-blocks"></span></p>
                             </div>
                             <div class="mt-2 d-flex justify-content-end">

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -167,6 +167,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 <p><strong>Column Count:</strong> <span id="column-count"></span></p>
                                 <p><strong>Earliest Record:</strong> <span id="earliest-record"></span></p>
                                 <p><strong>Latest Record:</strong> <span id="latest-record"></span></p>
+                                <p><strong>Total Cmi Size:</strong> <span id="total-cmi-size"></span></p>
+                                <p><strong>Total Csg Size:</strong> <span id="total-csg-size"></span></p>
+                                <p><strong>Num of Seg Files:</strong> <span id="num-seg-files"></span></p>
+                                <p><strong>Num of Blocks:</strong> <span id="num-blocks"></span></p>
                             </div>
                             <div class="mt-2 d-flex justify-content-end">
                                 <button type="button" id="close-popup" class="saveqButton">OK</button>

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -4293,7 +4293,7 @@ color: #C8C7CC;
 
 #index-summary-prompt .summary-content{
     border: 1px solid var(--border-btn-color);
-    padding: 20px;
+    padding: 20px 20px 0px 20px;
     border-radius: 10px;
 }
 

--- a/static/js/cluster-stats.js
+++ b/static/js/cluster-stats.js
@@ -769,6 +769,10 @@ function processClusterStats(res) {
         $('#column-count').text(indexData["columnCount"]);
         $('#earliest-record').text(indexData["earliestEpoch"]);
         $('#latest-record').text(indexData["latestEpoch"]);
+        $('#total-cmi-size').text(indexData["cmiSize"]);
+        $('#total-csg-size').text(indexData["csgSize"]);
+        $('#num-seg-files').text(indexData["segFiles"]);
+        $('#num-blocks').text(indexData["numBlocks"]);
     
         $('.popupOverlay, #index-summary-prompt').addClass('active');
     

--- a/static/js/cluster-stats.js
+++ b/static/js/cluster-stats.js
@@ -771,7 +771,7 @@ function processClusterStats(res) {
         $('#latest-record').text(indexData["latestEpoch"]);
         $('#total-cmi-size').text(indexData["cmiSize"]);
         $('#total-csg-size').text(indexData["csgSize"]);
-        $('#num-seg-files').text(indexData["segFiles"]);
+        $('#num-index-files').text(indexData["numIndexFiles"]);
         $('#num-blocks').text(indexData["numBlocks"]);
     
         $('.popupOverlay, #index-summary-prompt').addClass('active');


### PR DESCRIPTION
# Description
Updated the index summary on the My Org page to include the following new fields:

- CMI Size: Calculated by summing up all cmi sizes from the .sfm file (full segment metadata) for each segment in the index.
- CSG Size: Calculated by summing up all csg sizes from the .sfm file for each segment in the index.
- Number of Segment Files: Total count of cmi + csg files across all segments in the index.
- Number of Blocks: Extracted from segmeta.json to calculate the total number of blocks in the index.

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/4b0d396d-dcbe-4631-b393-34e615b72d06">

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
