### PR TITLE
Skip CMI if PQS data can handle entire segment

### DIFF
--- a/pkg/segment/metadata/metadata.go
+++ b/pkg/segment/metadata/metadata.go
@@ -99,6 +99,15 @@ func BulkAddSegmentMicroIndex(allMetadata []*SegmentMicroIndex) {
 	globalMetadata.bulkAddSegmentMicroIndex(allMetadata)
 }
 
+func GetNumBlocksInSegment(segKey string) uint64 {
+	globalMetadata.updateLock.RLock()
+	defer globalMetadata.updateLock.RUnlock()
+	if segMeta, ok := globalMetadata.segmentMetadataReverseIndex[segKey]; ok {
+		return uint64(segMeta.NumBlocks)
+	}
+	return 0
+}
+
 func (hm *allSegmentMetadata) bulkAddSegmentMicroIndex(allMetadata []*SegmentMicroIndex) {
 	hm.updateLock.Lock()
 	defer hm.updateLock.Unlock()

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -398,6 +398,12 @@ func (s *Searcher) getBlocks() ([]*block, error) {
 			for _, block := range blocks {
 				pqmrBlockNumbers[block.BlkNum] = struct{}{}
 			}
+
+			totalBlocksInSegment := metadata.GetNumBlocksInSegment(qsr.GetSegKey())
+			if len(pqmrBlockNumbers) == int(totalBlocksInSegment) {
+				// All blocks in the segment are covered by the PQMR, so we can skip the raw search.
+				continue
+			}
 		}
 
 		fileToSSR, err := query.GetSSRsFromQSR(qsr, s.querySummary)


### PR DESCRIPTION
# Description
Summarize the change.
- We need to skip CMI checks if the results can be obtained from PQMR.
- This [PR](https://github.com/siglens/siglens/pull/1805), fixed a bug regarding results being incorrect because we were skipping even the results if a PQMR result irrespective of the timerange filter. When a large time range is given, this approach can cause issues with some of the blocks in the segment being skipped even though they might have valid results.
- Check if the total number of blocks in the segment is equal to the total number of blocks in the PQMR result. If so, we can safely assume that all of the data in the PQMR result can serve the query correctly without missing any result that could have been expected.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Send timestamps for all the records with `gender=male` to be 2 days ago.
- Change the `MAX_RECS_PER_WIP` to be 1.
- Send 20 records.
- Rotate the data.
- Set the time range to be 5 mins, run the query `http_method=GET`
- Notice that only records with `gender=female` are present.
- Verify that PQMR results have less number of blocks.
- Change the time range to be 90 days.
- Run the same query and notice that records having `gender=male` also show up as expected.

Current downside of this PQS result is that, even if we set the timeRange to be 5 mins for the test mentioned above, the totalBlocks in the segment would be greater than the number of blocks in PQMR and due to this we would still conduct raw search. There is no other way to conclusively verify that the PQMR contains all the blocks that are/should be picked up for query without reading CMI file.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
