### PR TITLE
Incorrect timestamps for longer functional

### DIFF
--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -295,7 +295,7 @@ func RawSearchPQMResults(req *structs.SegmentSearchRequest, fileParallelism int6
 		allSearchResults.AddError(err)
 		return
 	}
-	defer segread.ReturnTimeBuffers(allTimestamps)
+	// defer segread.ReturnTimeBuffers(allTimestamps)
 
 	sharedReader, err := segread.InitSharedMultiColumnReaders(req.SegmentKey, req.AllPossibleColumns, req.AllBlocksToSearch,
 		req.SearchMetadata.BlockSummaries, int(fileParallelism), req.ConsistentCValLenMap, qid, nodeRes)

--- a/tools/sigclient/pkg/query/validation.go
+++ b/tools/sigclient/pkg/query/validation.go
@@ -636,7 +636,13 @@ func ValidateLogsQueryResults(queryRes *Result, expRes *Result) error {
 	for idx, record := range expRes.Records {
 		err = ValidateRecord(queryRes.Records[idx], record)
 		if err != nil {
-			timestamps := GetTimestampFromRecord(queryRes.Records[:10])
+			maxTimestamps := 10
+			var timestamps []interface{}
+			if len(queryRes.Records) > maxTimestamps {
+				timestamps = GetTimestampFromRecord(queryRes.Records[:maxTimestamps])
+			} else {
+				timestamps = GetTimestampFromRecord(queryRes.Records)
+			}
 			return fmt.Errorf("ValidateLogsQueryResults: Error comparing records at index: %v, partial queryRes Record: %v, expRes Record: %v, err: %v, timestamps: %v",
 				idx, getPartialRecord(queryRes.Records[idx], utils.GetKeysOfMap(record)), record, err, timestamps)
 		}

--- a/tools/sigclient/pkg/query/validation.go
+++ b/tools/sigclient/pkg/query/validation.go
@@ -636,13 +636,7 @@ func ValidateLogsQueryResults(queryRes *Result, expRes *Result) error {
 	for idx, record := range expRes.Records {
 		err = ValidateRecord(queryRes.Records[idx], record)
 		if err != nil {
-			maxTimestamps := 10
-			var timestamps []interface{}
-			if len(queryRes.Records) > maxTimestamps {
-				timestamps = GetTimestampFromRecord(queryRes.Records[:maxTimestamps])
-			} else {
-				timestamps = GetTimestampFromRecord(queryRes.Records)
-			}
+			timestamps := GetTimestampFromRecord(queryRes.Records[:10])
 			return fmt.Errorf("ValidateLogsQueryResults: Error comparing records at index: %v, partial queryRes Record: %v, expRes Record: %v, err: %v, timestamps: %v",
 				idx, getPartialRecord(queryRes.Records[idx], utils.GetKeysOfMap(record)), record, err, timestamps)
 		}


### PR DESCRIPTION
# Description
Summarize the change.
- Longer functional is failing on workflow because incorrect timestamps are being read for the PQMR flow.
- The most probable root cause of this issue is that reusing the buffers is causing overwrite of incorrect timestamps.
- This issue is not reproducible on local machine (8 vCPU), to reproduce this on a lower core machine for longer functional set this parameter [desiredMaxBlocks](https://github.com/siglens/siglens/blob/ae55c4029bde249013f0df3a048dc45cf29ddcea/pkg/segment/query/processor/searcher.go#L163) to 16.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
