### PR TITLE
Add iNodes Usage Information to System Configuration

### DIFF
--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -684,6 +684,12 @@ func getSystemInfoHandler() func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
+func getInodesStatsHandler() func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		systemconfig.GetInodeStats(ctx)
+	}
+}
+
 func uploadLookupFileHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		lookups.UploadLookupFile(ctx)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -262,6 +262,7 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.DELETE(server_utils.API_PREFIX+"/lookup-files/{lookupFilename}", hs.Recovery(deleteLookupFileHandler()))
 
 	hs.Router.GET(server_utils.API_PREFIX+"/system-info", tracing.TraceMiddleware(hs.Recovery(getSystemInfoHandler())))
+	hs.Router.GET(server_utils.API_PREFIX+"/inode-stats", tracing.TraceMiddleware(hs.Recovery(getInodesStatsHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/query-stats", hs.Recovery(getQueryStatsHandler()))
 
 	hs.Router.POST(server_utils.API_PREFIX+"/update-query-timeout", hs.Recovery(UpdateQueryTimeoutHandler()))


### PR DESCRIPTION
# Description
Updated the "System Configuration" section on the Settings page under "My Org" to include a new row displaying:

- iNodes Total: The number of total iNodes.
- iNodes Used: The number of iNodes currently in use.
- iNodes Available: The number of iNodes still available.

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/2ac6db7b-e674-408f-91cd-24ff6f025587">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
