### PR TITLE
Rename misleading function

### DIFF
--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -289,7 +289,7 @@ func (mcsr *MultiColSegmentReader) ReadRawRecordFromColumnFile(colKeyIndex int, 
 		return nil, nil
 	}
 
-	return mcsr.allFileReaders[colKeyIndex].ReadRecordFromBlock(blockNum, recordNum)
+	return mcsr.allFileReaders[colKeyIndex].ReadRecord(recordNum)
 }
 
 // Reads the request value and converts it to a *utils.CValueEnclosure

--- a/pkg/segment/reader/segread/segreader.go
+++ b/pkg/segment/reader/segread/segreader.go
@@ -197,10 +197,8 @@ func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]str
 	return nil
 }
 
-// returns the raw bytes of the blockNum:recordNum combination in the current segfile
-// optimized for subsequent calls to have the same blockNum
-// returns : encodedVal, error
-func (sfr *SegmentFileReader) ReadRecordFromBlock(blockNum uint16, recordNum uint16) ([]byte, error) {
+// Returns the raw bytes of the record in the currently loaded block
+func (sfr *SegmentFileReader) ReadRecord(recordNum uint16) ([]byte, error) {
 
 	// if dict encoding, we use the dictmapping
 	if sfr.encType == utils.ZSTD_DICTIONARY_BLOCK[0] {
@@ -213,7 +211,7 @@ func (sfr *SegmentFileReader) ReadRecordFromBlock(blockNum uint16, recordNum uin
 		sfr.currOffset = 0
 		currRecLen, err := sfr.getCurrentRecordLength()
 		if err != nil {
-			log.Errorf("SegmentFileReader.ReadRecordFromBlock: error resetting SegmentFileReader %s. Error: %+v",
+			log.Errorf("SegmentFileReader.ReadRecord: error resetting SegmentFileReader %s. Error: %+v",
 				sfr.fileName, err)
 			return nil, err
 		}
@@ -236,8 +234,8 @@ func (sfr *SegmentFileReader) ReadRecordFromBlock(blockNum uint16, recordNum uin
 	}
 
 	if !sfr.someBlksAbsent {
-		errStr := fmt.Sprintf("SegmentFileReader.ReadRecordFromBlock: reached end of block before matching recNum %+v, currRecordNum: %+v. blockNum %+v, File %+v, colname %v, sfr.currOffset: %v, sfr.currRecLen: %v, sfr.currUncompressedBlockLen: %v",
-			recordNum, sfr.currRecordNum, blockNum, sfr.fileName, sfr.ColName, sfr.currOffset,
+		errStr := fmt.Sprintf("SegmentFileReader.ReadRecord: reached end of block before matching recNum %+v, currRecordNum: %+v. blockNum %+v, File %+v, colname %v, sfr.currOffset: %v, sfr.currRecLen: %v, sfr.currUncompressedBlockLen: %v",
+			recordNum, sfr.currRecordNum, sfr.currBlockNum, sfr.fileName, sfr.ColName, sfr.currOffset,
 			sfr.currRecLen, sfr.currUncompressedBlockLen)
 
 		log.Error(errStr)

--- a/pkg/segment/reader/segread/segreader_test.go
+++ b/pkg/segment/reader/segread/segreader_test.go
@@ -83,11 +83,11 @@ func Test_segReader(t *testing.T) {
 		sfr := multiReader.allFileReaders[colKeyIndex]
 
 		// correct block, incorrect recordNum
-		_, err = sfr.ReadRecordFromBlock(0, uint16(numEntriesInBlock))
+		_, err = sfr.ReadRecord(uint16(numEntriesInBlock))
 		assert.NotNil(t, err, "col %s should not have %+v entries", queryCol, numEntriesInBlock+1)
 
 		// correct block, correct recordNum
-		arr, err := sfr.ReadRecordFromBlock(0, uint16(numEntriesInBlock-3))
+		arr, err := sfr.ReadRecord(uint16(numEntriesInBlock - 3))
 		assert.Nil(t, err)
 		assert.NotNil(t, arr)
 
@@ -162,7 +162,7 @@ func Benchmark_readColumnarFile(b *testing.B) {
 	numRead := 0
 	for blkNum := range allBlockInfo {
 		for i := uint16(0); i < numRecsPerBlock[blkNum]; i++ {
-			rawRec, err := fileReader.ReadRecordFromBlock(blkNum, i)
+			rawRec, err := fileReader.ReadRecord(i)
 			numRead++
 			assert.Nil(b, err)
 			assert.NotNil(b, rawRec)


### PR DESCRIPTION
# Description
Rename `ReadRecordFromBlock()` to `RenameRecord()`; the function used to take the block number as a parameter, but it was only used for logging; the block wasn't loaded if the block number differed from the currently-loaded block number.

I think this function isn't loaded the block as a performance optimization

# Testing
Unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
