### PR TITLE
fix: Reading of columns

### DIFF
--- a/pkg/common/fileutils/fileutils.go
+++ b/pkg/common/fileutils/fileutils.go
@@ -150,3 +150,8 @@ func ReadLineByLine(filePath string, processLine func(line []byte) error) error 
 
 	return nil
 }
+
+func DoesFileExist(filePath string) bool {
+	_, err := os.Stat(filePath)
+	return err == nil
+}

--- a/pkg/segment/query/iqr/iqrreader.go
+++ b/pkg/segment/query/iqr/iqrreader.go
@@ -248,7 +248,7 @@ func (iqrRdr *IQRReader) readColumnsForRRCs(segKey string, vTable string, rrcs [
 
 	if columnName != nil {
 		var values []utils.CValueEnclosure
-		values, err = reader.ReadColForRRCs(segKey, rrcs, *columnName, qid)
+		values, err = reader.ReadColForRRCs(segKey, rrcs, *columnName, qid, true)
 		if err == nil {
 			knownValues = map[string][]utils.CValueEnclosure{
 				*columnName: values,
@@ -307,7 +307,7 @@ func (iqrRdr *IQRReader) GetColsForSegKey(segKey string, vTable string) (map[str
 
 func (iqrRdr *IQRReader) ReadColForRRCs(segKey string, rrcs []*utils.RecordResultContainer, cname string, qid uint64) ([]utils.CValueEnclosure, error) {
 	if iqrRdr.IsSingleReader() {
-		return iqrRdr.reader.ReadColForRRCs(segKey, rrcs, cname, qid)
+		return iqrRdr.reader.ReadColForRRCs(segKey, rrcs, cname, qid, true)
 	}
 
 	knownValues, err := iqrRdr.readColumnsForRRCs(segKey, "", rrcs, qid, nil, &cname)

--- a/pkg/segment/reader/record/mockrecordreader.go
+++ b/pkg/segment/reader/record/mockrecordreader.go
@@ -48,7 +48,7 @@ func (mocker *MockRRCsReader) ReadAllColsForRRCs(segKey string, vTable string, r
 
 	results := make(map[string][]utils.CValueEnclosure)
 	for cname := range columns {
-		values, err := mocker.ReadColForRRCs(segKey, rrcs, cname, qid)
+		values, err := mocker.ReadColForRRCs(segKey, rrcs, cname, qid, false)
 		if err != nil {
 			log.Errorf("ReadAllColsForRRCs: cannot read column %v; err=%v", cname, err)
 			return nil, err
@@ -68,7 +68,7 @@ func (mocker *MockRRCsReader) GetColsForSegKey(_segKey string, _vTable string) (
 }
 
 func (mocker *MockRRCsReader) ReadColForRRCs(_segKey string, rrcs []*utils.RecordResultContainer,
-	cname string, _qid uint64) ([]utils.CValueEnclosure, error) {
+	cname string, _qid uint64, _fetchFromBlob bool) ([]utils.CValueEnclosure, error) {
 
 	if _, ok := mocker.FieldToValues[cname]; !ok {
 		return nil, nil

--- a/pkg/segment/reader/record/mockrecordreader_test.go
+++ b/pkg/segment/reader/record/mockrecordreader_test.go
@@ -72,12 +72,12 @@ func Test_ReadOneColumn(t *testing.T) {
 		{Dtype: utils.SS_DT_STRING, CVal: "val4"},
 	}
 
-	values, err := mocker.ReadColForRRCs("segKey", rrcs, "col1", 0)
+	values, err := mocker.ReadColForRRCs("segKey", rrcs, "col1", 0, false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, values)
 
 	// Test reading a non-existent column.
-	values, err = mocker.ReadColForRRCs("segKey", rrcs, "col2", 0)
+	values, err = mocker.ReadColForRRCs("segKey", rrcs, "col2", 0, false)
 	assert.NoError(t, err)
 	assert.Nil(t, values)
 
@@ -96,7 +96,7 @@ func Test_ReadOneColumn(t *testing.T) {
 		{Dtype: utils.SS_DT_STRING, CVal: "val3"},
 	}
 
-	values, err = mocker.ReadColForRRCs("segKey", rrcs, "col1", 0)
+	values, err = mocker.ReadColForRRCs("segKey", rrcs, "col1", 0, false)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, values)
 }

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -194,8 +194,7 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool, block
 	if len(bulkDownloadFiles) > 0 {
 		err = blob.BulkDownloadSegmentBlob(bulkDownloadFiles, true)
 		if err != nil {
-			log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to bulk download seg files. err: %v", qid, err)
-			return nil, err
+			nodeRes.StoreGlobalSearchError("Error Downloading Segment Files", log.ErrorLevel, err)
 		}
 	}
 

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -169,9 +169,11 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool, block
 		log.Errorf("qid=%d, InitSharedMultiColumnReaders: Failed to acquire resources to be able to open %+v FDs. Error: %+v", qid, maxOpenFds, err)
 		return sharedReader, err
 	}
+	csgFileToColNameMap := make(map[string]string)
 	bulkDownloadFiles := make(map[string]string)
+
 	var fName string
-	for cname := range colNames {
+	for cname, fetchFromBlob := range colNames {
 		if cname == "" {
 			return nil, fmt.Errorf("InitSharedMultiColumnReaders: unknown seg set col")
 		} else if cname == "*" {
@@ -179,15 +181,25 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool, block
 		} else {
 			fName = fmt.Sprintf("%v_%v.csg", segKey, xxhash.Sum64String(cname))
 		}
-		bulkDownloadFiles[fName] = cname
-	}
-	err = blob.BulkDownloadSegmentBlob(bulkDownloadFiles, true)
-	if err != nil {
-		log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to bulk download seg files. err: %v", qid, err)
-		return nil, err
+		csgFileToColNameMap[fName] = cname
+
+		if fetchFromBlob {
+			// Check if the file exists in local storage
+			if !fileutils.DoesFileExist(fName) {
+				bulkDownloadFiles[fName] = cname
+			}
+		}
 	}
 
-	for fName, colName := range bulkDownloadFiles {
+	if len(bulkDownloadFiles) > 0 {
+		err = blob.BulkDownloadSegmentBlob(bulkDownloadFiles, true)
+		if err != nil {
+			log.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to bulk download seg files. err: %v", qid, err)
+			return nil, err
+		}
+	}
+
+	for fName, colName := range csgFileToColNameMap {
 		fName := fName
 		currFd, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 		if err != nil {


### PR DESCRIPTION
# Description
- This PR needs to be merged before. #1961 
- `GetColsForSegKey` is returning empty columns map because, the `.sfm` file is not present when populating the micro indices during the loadup. 
- Now this PR fixes this issue.

# Testing
- Tested by ingesting some data, and then rotating the data.
- All unit test cases pass.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
