### PR TITLE
Fix for incorrect timestamps being read when PQS is enabled

### DIFF
--- a/.github/workflows/nightly-longer-functional.yml
+++ b/.github/workflows/nightly-longer-functional.yml
@@ -2,7 +2,7 @@ name: Nightly-Longer-Functional-Test
 
 on:
   schedule:
-    - cron: '0 5 * * *'  # Every day at midnight EST (UTC-5)
+    - cron: '0 0 * * *'  # TODO: Every day at midnight EST (UTC-5)
   workflow_dispatch:  # Allows manual trigger as well
 
 jobs:

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -422,12 +422,11 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 
 func ReturnTimeBuffers(og map[uint16][]uint64) {
 	for k := range og {
-		// Due to a bug in Go 1.19, when looping over the values of a map using a range loop,
-		// the scope of the loop variable is per loop and not iteration which was causing the
-		// same slices to be inserted multiple times causing the pool to return same slices for multiple
-		// subsequent Get calls. This is a workaround to fix the issue.
+		// Due to a bug in Go 1.19, scope of the loop variable is per loop not per iteration
+		// and thus inserting the same value multiple times in the pool which can cause the same pointer
+		// to a slice being returned multiple times.
 		// Refer https://go.dev/blog/loopvar-preview and https://github.com/golang/go/discussions/56010 for more details.
-		timestamps := og[k]
-		rawTimestampsBufferPool.Put(&timestamps)
+		timeBuffer := og[k]
+		rawTimestampsBufferPool.Put(&timeBuffer)
 	}
 }

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -421,7 +421,13 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 }
 
 func ReturnTimeBuffers(og map[uint16][]uint64) {
-	for _, v := range og {
-		rawTimestampsBufferPool.Put(&v)
+	for k := range og {
+		// Due to a bug in Go 1.19, when looping over the values of a map using a range loop,
+		// the scope of the loop variable is per loop and not iteration which was causing the
+		// same slices to be inserted multiple times causing the pool to return same slices for multiple
+		// subsequent Get calls. This is a workaround to fix the issue.
+		// Refer https://go.dev/blog/loopvar-preview and https://github.com/golang/go/discussions/56010 for more details.
+		timestamps := og[k]
+		rawTimestampsBufferPool.Put(&timestamps)
 	}
 }


### PR DESCRIPTION
# Description
Summarize the change.
Due to a bug in Go 1.19, scope of the loop variable is per loop not per iteration and thus inserting the same value multiple times in the pool which can cause the same pointer to a slice being returned multiple times.
Refer https://go.dev/blog/loopvar-preview and https://github.com/golang/go/discussions/56010 for more details.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
After this fix longer functional should pass for github actions

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
