### PR TITLE
Cleanup clickbench results and schedule longer functional

### DIFF
--- a/.github/workflows/nightly-longer-functional.yml
+++ b/.github/workflows/nightly-longer-functional.yml
@@ -2,7 +2,8 @@ name: Nightly-Longer-Functional-Test
 
 on:
   schedule:
-    - cron: '0 * * * *'  # TODO: Every day at midnight EST (UTC-5)
+    - cron: '0 20 * * *'  # Every day at 3PM EST (UTC-5)
+    - cron: '0 2 * * *'  # Every day at 9PM EST (UTC-5)
   workflow_dispatch:  # Allows manual trigger as well
 
 jobs:


### PR DESCRIPTION
# Description
Summarize the change.
- Cleanup the logs for clickbench results.
- Ensure it to run all queries and print summary at the end.
- Run longer functional at 3PM and 9PM EST daily.

<img width="736" alt="image" src="https://github.com/user-attachments/assets/e27424cb-91a4-4acd-bc3f-fc1516ce8ff2">


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
