### PR TITLE
refac: Global Metadata get functions

### DIFF
--- a/pkg/segment/metadata/metadata.go
+++ b/pkg/segment/metadata/metadata.go
@@ -74,14 +74,23 @@ func ResetGlobalMetadataForTest() {
 }
 
 func GetAllSegmentMicroIndexForTest() []*SegmentMicroIndex {
+	globalMetadata.updateLock.RLock()
+	defer globalMetadata.updateLock.RUnlock()
+
 	return globalMetadata.allSegmentMicroIndex
 }
 
 func GetSegmentMetadataReverseIndexForTest() map[string]*SegmentMicroIndex {
+	globalMetadata.updateLock.RLock()
+	defer globalMetadata.updateLock.RUnlock()
+
 	return globalMetadata.segmentMetadataReverseIndex
 }
 
-func GetTableSortedMetadataForTest() map[string][]*SegmentMicroIndex {
+func GetTableSortedMetadata() map[string][]*SegmentMicroIndex {
+	globalMetadata.updateLock.RLock()
+	defer globalMetadata.updateLock.RUnlock()
+
 	return globalMetadata.tableSortedMetadata
 }
 

--- a/pkg/segment/metadata/metadata_test.go
+++ b/pkg/segment/metadata/metadata_test.go
@@ -51,8 +51,8 @@ func Test_AddSementInfo(t *testing.T) {
 		log.Infof("i %+v latest: %+v", i, GetAllSegmentMicroIndexForTest()[i].LatestEpochMS)
 		nextVal--
 	}
-	assert.Contains(t, GetTableSortedMetadataForTest(), "test-1")
-	tableSorted := GetTableSortedMetadataForTest()["test-1"]
+	assert.Contains(t, GetTableSortedMetadata(), "test-1")
+	tableSorted := GetTableSortedMetadata()["test-1"]
 	nextVal = uint64(9)
 	for i := 0; i < 10; i++ {
 		assert.Equal(t, tableSorted[i].LatestEpochMS, nextVal)

--- a/pkg/segment/metadata/metaupdater_test.go
+++ b/pkg/segment/metadata/metaupdater_test.go
@@ -33,15 +33,15 @@ func Test_initMockMetadata(t *testing.T) {
 	createMockMetaStore("data/", fileCount)
 	assert.Len(t, GetAllSegmentMicroIndexForTest(), fileCount)
 	assert.Len(t, GetSegmentMetadataReverseIndexForTest(), fileCount)
-	assert.Contains(t, GetTableSortedMetadataForTest(), "evts")
-	assert.Len(t, GetTableSortedMetadataForTest()["evts"], fileCount)
+	assert.Contains(t, GetTableSortedMetadata(), "evts")
+	assert.Len(t, GetTableSortedMetadata()["evts"], fileCount)
 
 	sortedByLatest := sort.SliceIsSorted(GetAllSegmentMicroIndexForTest(), func(i, j int) bool {
 		return GetAllSegmentMicroIndexForTest()[i].LatestEpochMS > GetAllSegmentMicroIndexForTest()[j].LatestEpochMS
 	})
 	assert.True(t, sortedByLatest, "slice is sorted with most recent at the front")
 
-	tableSorted := GetTableSortedMetadataForTest()["evts"]
+	tableSorted := GetTableSortedMetadata()["evts"]
 	isTableSorted := sort.SliceIsSorted(tableSorted, func(i, j int) bool {
 		return tableSorted[i].LatestEpochMS > tableSorted[j].LatestEpochMS
 	})
@@ -54,10 +54,10 @@ func Test_initMockMetadata(t *testing.T) {
 		assert.Contains(t, GetSegmentMetadataReverseIndexForTest(), rawCMI.SegmentKey, "all segkeys in allSegmentMicroIndex exist in revserse index")
 	}
 
-	duplicate := GetTableSortedMetadataForTest()["evts"][0]
+	duplicate := GetTableSortedMetadata()["evts"][0]
 	BulkAddSegmentMicroIndex([]*SegmentMicroIndex{duplicate})
 	assert.Len(t, GetAllSegmentMicroIndexForTest(), fileCount)
 	assert.Len(t, GetSegmentMetadataReverseIndexForTest(), fileCount)
-	assert.Contains(t, GetTableSortedMetadataForTest(), "evts")
-	assert.Len(t, GetTableSortedMetadataForTest()["evts"], fileCount)
+	assert.Contains(t, GetTableSortedMetadata(), "evts")
+	assert.Len(t, GetTableSortedMetadata()["evts"], fileCount)
 }


### PR DESCRIPTION
# Description
- Refactor the function names for Getter functions of Global Metadata
- And Add `RLock` before accessing them.


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
