### PR TITLE
New format for sort index files

### DIFF
--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -161,13 +161,13 @@ func writeSortIndex(segkey string, cname string, valToBlockToRecords map[string]
 			// Write blockNum
 			_, err = writer.Write(utils.Uint16ToBytesLittleEndian(block.BlockNum))
 			if err != nil {
-				return fmt.Errorf("writeSortIndex: failed writing blockNum: %v", err)
+				return fmt.Errorf("writeSortIndex: failed writing blockNum, blockNum: %v, err: %v", block.BlockNum, err)
 			}
 
 			// Write number of records
 			_, err = writer.Write(utils.Uint32ToBytesLittleEndian(uint32(len(block.RecNums))))
 			if err != nil {
-				return fmt.Errorf("writeSortIndex: failed writing number of records: %v", err)
+				return fmt.Errorf("writeSortIndex: failed writing number of records: %v, err: %v", len(block.RecNums), err)
 			}
 
 			// Write sortedRecords
@@ -175,7 +175,7 @@ func writeSortIndex(segkey string, cname string, valToBlockToRecords map[string]
 				// Write recNum
 				_, err = writer.Write(utils.Uint16ToBytesLittleEndian(recNum))
 				if err != nil {
-					return fmt.Errorf("writeSortIndex: failed writing recNum: %v", err)
+					return fmt.Errorf("writeSortIndex: failed writing recNum: %v, err: %v", recNum, err)
 				}
 			}
 		}

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -66,7 +66,7 @@ func Test_writeAndRead(t *testing.T) {
 	expected = []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
-			{BlockNum: 2, RecNums: []uint16{42, 100}},
+			{BlockNum: 2, RecNums: []uint16{42}},
 		}},
 	}
 


### PR DESCRIPTION
# Description
Summarize the change.
- JSON marshaling and unmarshaling takes a lot of time for large srt files.
- With this new format we should be able to read information quickly.
- Currently, we are only supporting strings so `writeCValEnc` method is only handling strings. Later we should add support for numbers. The format for the same is specified in the comments.
- Morevoer, when maxRecords are specified, we would want to restrict the number of records to this value and not read anything extra, in the earlier format we were reading all the records in a block. In this new format we would skip reading once we reach `maxRecords`.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
- Ran query `SearchPhrase != "" | sort -str(SearchPhrase) | head 10 | fields SearchPhrase` clickbench dataset (10M), earlier it was taking around 1400ms. Now, it only takes 350ms.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
