### PR TITLE
refac: Make GetSFMfilename function exported

### DIFF
--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -89,7 +89,7 @@ func initSmr() {
 	go listenBackFillAndEmptyPQSRequests()
 }
 
-func getSegFullMetaFnameFromSegkey(segkey string) string {
+func GetSegFullMetaFnameFromSegkey(segkey string) string {
 	return fmt.Sprintf("%s.sfm", segkey)
 }
 
@@ -162,7 +162,7 @@ func ReadSfm(segkey string) (*structs.SegFullMeta, error) {
 
 	sfm := &structs.SegFullMeta{}
 
-	sfmFname := getSegFullMetaFnameFromSegkey(segkey)
+	sfmFname := GetSegFullMetaFnameFromSegkey(segkey)
 
 	sfmBytes, err := os.ReadFile(sfmFname)
 	if err != nil {
@@ -196,7 +196,7 @@ func ReadSfm(segkey string) (*structs.SegFullMeta, error) {
 func writeSfm(segkey string, sfmData *structs.SegFullMeta) {
 
 	// create a separate individual file for SegFullMeta
-	sfmFname := getSegFullMetaFnameFromSegkey(segkey)
+	sfmFname := GetSegFullMetaFnameFromSegkey(segkey)
 	sfmFd, err := os.OpenFile(sfmFname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		log.Errorf("writeSfm: failed to open a sfm filename=%v: err=%v", sfmFname, err)


### PR DESCRIPTION
# Description
- Exported the function `GetSegFullMetaFnameFromSegkey`


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
