### PR TITLE
Refactor writing the sort index

### DIFF
--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -429,30 +429,30 @@ func writeSortIndexForTest(t *testing.T) (string, string, string) {
 	segKey2 := filepath.Join(tempDir, "segKey2")
 
 	cname := "color"
-	seg1Data := map[string]map[uint16][]uint16{ // value -> block number -> record numbers
-		"blue": {
+	seg1Data := map[*segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
+		{Dtype: segutils.SS_DT_STRING, CVal: "blue"}: {
 			1: {1},
 			2: {2, 3},
 		},
-		"green": {
+		{Dtype: segutils.SS_DT_STRING, CVal: "green"}: {
 			1: {10, 11},
 			2: {1},
 		},
 	}
-	err := sortindex.WriteSortIndexMock(segKey1, cname, seg1Data)
+	err := sortindex.WriteSortIndexMock(segKey1, cname, sortindex.SortAsString, seg1Data)
 	assert.NoError(t, err)
 
-	seg2Data := map[string]map[uint16][]uint16{ // value -> block number -> record numbers
-		"blue": {
+	seg2Data := map[*segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
+		{Dtype: segutils.SS_DT_STRING, CVal: "blue"}: {
 			1: {1, 2},
 			2: {3},
 		},
-		"red": {
+		{Dtype: segutils.SS_DT_STRING, CVal: "red"}: {
 			1: {10},
 			2: {1, 2},
 		},
 	}
-	err = sortindex.WriteSortIndexMock(segKey2, cname, seg2Data)
+	err = sortindex.WriteSortIndexMock(segKey2, cname, sortindex.SortAsString, seg2Data)
 	assert.NoError(t, err)
 
 	return cname, segKey1, segKey2

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -160,7 +160,7 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 
 	for _, value := range sortedValues {
 		// Write column value
-		err = writeCValEnc(writer, value)
+		err = value.WriteBytes(writer)
 		if err != nil {
 			return fmt.Errorf("writeSortIndex: failed writing CValEnc: %v", err)
 		}
@@ -460,38 +460,4 @@ func IsEOF(checkpoint *Checkpoint) bool {
 	}
 
 	return checkpoint.eof
-}
-
-func writeCValEnc(writer *bufio.Writer, CValEnc *segutils.CValueEnclosure) error {
-	if writer == nil {
-		return fmt.Errorf("writeCValEnc: writer is nil")
-	}
-
-	if CValEnc.Dtype != segutils.SS_DT_STRING {
-		return fmt.Errorf("writeCValEnc: Unsupported Dtype: %v", CValEnc.Dtype)
-	}
-
-	// Write dtype
-	_, err := writer.Write([]byte{byte(CValEnc.Dtype)})
-	if err != nil {
-		return fmt.Errorf("writeCValEnc: failed writing dtype: %v", err)
-	}
-
-	switch CValEnc.Dtype {
-	case segutils.SS_DT_STRING:
-		// Write len of string
-		_, err = writer.Write(utils.Uint16ToBytesLittleEndian(uint16(len(CValEnc.CVal.(string)))))
-		if err != nil {
-			return fmt.Errorf("writeCValEnc: failed writing len of string CValEnc: %v, err: %v", CValEnc, err)
-		}
-		// Write string
-		_, err = writer.Write([]byte(CValEnc.CVal.(string)))
-		if err != nil {
-			return fmt.Errorf("writeCValEnc: failed writing string CValEnc: %v, err: %v", CValEnc, err)
-		}
-	default:
-		return fmt.Errorf("writeCValEnc: Unsupported Dtype: %v", CValEnc.Dtype)
-	}
-
-	return nil
 }

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -21,28 +21,29 @@ import (
 	"path/filepath"
 	"testing"
 
+	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func writeTestData(t *testing.T) (string, string) {
 	t.Helper()
 
-	data := map[string]map[uint16][]uint16{
-		"apple": {
+	data := map[*segutils.CValueEnclosure]map[uint16][]uint16{
+		{Dtype: segutils.SS_DT_STRING, CVal: "apple"}: {
 			1: {1, 2},
 			2: {100, 42},
 		},
-		"zebra": {
+		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}: {
 			1: {7},
 		},
-		"banana": {
+		{Dtype: segutils.SS_DT_STRING, CVal: "banana"}: {
 			2: {13, 2, 7},
 		},
 	}
 
 	segkey := filepath.Join(t.TempDir(), "test-segkey")
 	cname := "col1"
-	err := writeSortIndex(segkey, cname, data)
+	err := writeSortIndex(segkey, cname, SortAsString, data)
 	assert.NoError(t, err)
 
 	return segkey, cname

--- a/pkg/segment/sortindex/sortindexmock.go
+++ b/pkg/segment/sortindex/sortindexmock.go
@@ -1,5 +1,9 @@
 package sortindex
 
-func WriteSortIndexMock(segkey string, cname string, data map[string]map[uint16][]uint16) error {
-	return writeSortIndex(segkey, cname, data)
+import segutils "github.com/siglens/siglens/pkg/segment/utils"
+
+func WriteSortIndexMock(segkey string, cname string, sortMode SortMode,
+	data map[*segutils.CValueEnclosure]map[uint16][]uint16) error {
+
+	return writeSortIndex(segkey, cname, sortMode, data)
 }

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1270,7 +1270,7 @@ func (e *CValueEnclosure) WriteBytes(writer io.Writer) error {
 	return nil
 }
 
-// Returns the number of bytes read and the CValueEnclosure
+// Returns the CValueEnclosure and the number of bytes read
 func CValFromBytes(buf []byte) (*CValueEnclosure, int, error) {
 	if len(buf) == 0 {
 		return nil, 0, errors.New("CValFromBytes: empty buffer")

--- a/pkg/segment/utils/segconsts_test.go
+++ b/pkg/segment/utils/segconsts_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_CVal_Equal(t *testing.T) {
@@ -70,4 +71,29 @@ func Test_CVal_Hash(t *testing.T) {
 		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: nil}).Hash(),
 		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: 123}).Hash(),
 	)
+}
+
+func Test_CValFromBytes(t *testing.T) {
+	original := make([]*CValueEnclosure, 0)
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: int64(-123)})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: uint64(123)})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.456)})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_BOOL, CVal: true})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: nil})
+
+	var bytes []byte
+	idx := 0
+	for _, enclosure := range original {
+		bytes, idx = enclosure.WriteToBytesWithType(bytes, idx)
+	}
+
+	idx = 0
+	for i := 0; i < len(original); i++ {
+		enclosure, numBytesRead, err := CValFromBytes(bytes[idx:])
+		idx += numBytesRead
+
+		require.NoError(t, err, "errored in iteration %d", i)
+		require.Equal(t, original[i], enclosure, "failed in iteration %d", i)
+	}
 }

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -853,7 +853,7 @@ func writeSortIndexes(segkey string) {
 		defer sortedIndexWG.Done()
 
 		for _, cname := range sortIndexCnames {
-			err := sortindex.WriteSortIndex(segkey, cname)
+			err := sortindex.WriteSortIndex(segkey, cname, sortindex.SortAsString) // TODO: write all sort files
 			if err != nil {
 				log.Errorf("writeSortIndexes: failed to write sort index for segkey=%v, cname=%v; err=%v",
 					segkey, cname, err)


### PR DESCRIPTION
# Description
The sort index can currently only be written for columns with string values. This refactors that to make it easier in the next PR to allow numeric columns.

# Testing
Unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
