### PR TITLE
Handle sorting as numbers

### DIFF
--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -439,7 +439,7 @@ func writeSortIndexForTest(t *testing.T) (string, string, string) {
 			2: {1},
 		},
 	}
-	err := sortindex.WriteSortIndexMock(segKey1, cname, sortindex.SortAsString, seg1Data)
+	err := sortindex.WriteSortIndexMock(segKey1, cname, sortindex.SortAsAuto, seg1Data)
 	assert.NoError(t, err)
 
 	seg2Data := map[*segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
@@ -452,7 +452,7 @@ func writeSortIndexForTest(t *testing.T) (string, string, string) {
 			2: {1, 2},
 		},
 	}
-	err = sortindex.WriteSortIndexMock(segKey2, cname, sortindex.SortAsString, seg2Data)
+	err = sortindex.WriteSortIndexMock(segKey2, cname, sortindex.SortAsAuto, seg2Data)
 	assert.NoError(t, err)
 
 	return cname, segKey1, segKey2

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -43,13 +43,12 @@ type SortMode int
 
 const (
 	InvalidSortMode SortMode = iota
-	AllSortModes
 	SortAsAuto
 	SortAsNumeric
 	SortAsString
 )
 
-var allSortModes = []SortMode{SortAsAuto, SortAsNumeric, SortAsString}
+var AllSortModes = []SortMode{SortAsAuto, SortAsNumeric, SortAsString}
 
 func getFilename(segkey string, cname string, sortMode SortMode) (string, error) {
 	suffix := ""
@@ -76,7 +75,7 @@ func getTempFilename(segkey string, cname string, sortMode SortMode) (string, er
 	return filename + ".tmp", nil
 }
 
-func WriteSortIndex(segkey string, cname string, sortMode SortMode) error {
+func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 	blockToRecords, err := segreader.ReadAllRecords(segkey, cname)
 	if err != nil {
 		return fmt.Errorf("WriteSortIndex: failed reading all records for segkey=%v, cname=%v; err=%v", segkey, cname, err)
@@ -106,11 +105,6 @@ func WriteSortIndex(segkey string, cname string, sortMode SortMode) error {
 
 			valToBlockToRecords[enclosure][blockNum] = append(valToBlockToRecords[enclosure][blockNum], uint16(recNum))
 		}
-	}
-
-	sortModes := allSortModes
-	if sortMode != AllSortModes {
-		sortModes = []SortMode{sortMode}
 	}
 
 	for _, mode := range sortModes {

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -173,7 +173,10 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 	defer file.Close()
 
 	sortedValues := utils.GetKeysOfMap(valToBlockToRecords)
-	sortEnclosures(sortedValues, sortMode)
+	err = sortEnclosures(sortedValues, sortMode)
+	if err != nil {
+		return fmt.Errorf("writeSortIndex: failed to sort column values: %v", err)
+	}
 
 	writer := bufio.NewWriter(file)
 

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -50,11 +50,11 @@ func writeTestData(t *testing.T) (string, string) {
 	return segkey, cname
 }
 
-func readAndAssert(t *testing.T, segkey, cname string, maxRecords int, checkpoint *Checkpoint,
-	expected []Line) *Checkpoint {
+func readAndAssert(t *testing.T, segkey, cname string, sortMode SortMode, maxRecords int,
+	checkpoint *Checkpoint, expected []Line) *Checkpoint {
 
 	t.Helper()
-	actual, checkpoint, err := ReadSortIndex(segkey, cname, maxRecords, checkpoint)
+	actual, checkpoint, err := ReadSortIndex(segkey, cname, sortMode, maxRecords, checkpoint)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 
@@ -64,7 +64,7 @@ func readAndAssert(t *testing.T, segkey, cname string, maxRecords int, checkpoin
 func Test_writeAndRead(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
-	_ = readAndAssert(t, segkey, cname, 100, nil, []Line{
+	_ = readAndAssert(t, segkey, cname, SortAsString, 100, nil, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
@@ -77,7 +77,7 @@ func Test_writeAndRead(t *testing.T) {
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, 3, nil, []Line{
+	_ = readAndAssert(t, segkey, cname, SortAsString, 3, nil, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42}},
@@ -88,14 +88,14 @@ func Test_writeAndRead(t *testing.T) {
 func Test_readFromCheckpointAtStartOfLine(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
-	checkpoint := readAndAssert(t, segkey, cname, 4, nil, []Line{
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, 4, nil, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, 4, checkpoint, []Line{
+	_ = readAndAssert(t, segkey, cname, SortAsString, 4, checkpoint, []Line{
 		{Value: "banana", Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
@@ -108,13 +108,13 @@ func Test_readFromCheckpointAtStartOfLine(t *testing.T) {
 func Test_readFromCheckpointInMiddleOfLine(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
-	checkpoint := readAndAssert(t, segkey, cname, 2, nil, []Line{
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, 2, nil, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, 2, checkpoint, []Line{
+	_ = readAndAssert(t, segkey, cname, SortAsString, 2, checkpoint, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
@@ -124,13 +124,13 @@ func Test_readFromCheckpointInMiddleOfLine(t *testing.T) {
 func Test_readFromCheckpointInMiddleOfBlock(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
-	checkpoint := readAndAssert(t, segkey, cname, 1, nil, []Line{
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, 1, nil, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1}},
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, 1, checkpoint, []Line{
+	_ = readAndAssert(t, segkey, cname, SortAsString, 1, checkpoint, []Line{
 		{Value: "apple", Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{2}},
 		}},

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -174,4 +174,20 @@ func Test_sort(t *testing.T) {
 		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"},
 		{Dtype: segutils.SS_DT_BACKFILL, CVal: nil},
 	}, enclosures)
+
+	rand.Seed(42)
+	rand.Shuffle(len(enclosures), func(i, j int) {
+		enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
+	})
+
+	sortEnclosures(enclosures, SortAsAuto)
+	assert.Equal(t, []*segutils.CValueEnclosure{
+		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
+		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "apple"},
+		{Dtype: segutils.SS_DT_BOOL, CVal: true},
+		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"},
+		{Dtype: segutils.SS_DT_BACKFILL, CVal: nil},
+	}, enclosures)
 }

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -23,6 +23,7 @@ import (
 
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/rand"
 )
 
 func writeTestData(t *testing.T) (string, string) {
@@ -134,4 +135,43 @@ func Test_readFromCheckpointInMiddleOfBlock(t *testing.T) {
 			{BlockNum: 1, RecNums: []uint16{2}},
 		}},
 	})
+}
+
+func Test_sort(t *testing.T) {
+	enclosures := []*segutils.CValueEnclosure{
+		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "apple"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"},
+		{Dtype: segutils.SS_DT_BACKFILL, CVal: nil},
+		{Dtype: segutils.SS_DT_BOOL, CVal: true},
+		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+	}
+
+	sortEnclosures(enclosures, SortAsString)
+	assert.Equal(t, []*segutils.CValueEnclosure{
+		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
+		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+		{Dtype: segutils.SS_DT_STRING, CVal: "apple"},
+		{Dtype: segutils.SS_DT_BOOL, CVal: true},
+		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"},
+		{Dtype: segutils.SS_DT_BACKFILL, CVal: nil},
+	}, enclosures)
+
+	rand.Seed(42)
+	rand.Shuffle(len(enclosures), func(i, j int) {
+		enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
+	})
+
+	sortEnclosures(enclosures, SortAsNumeric)
+	assert.Equal(t, []*segutils.CValueEnclosure{
+		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
+		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
+		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
+		{Dtype: segutils.SS_DT_STRING, CVal: "apple"},
+		{Dtype: segutils.SS_DT_BOOL, CVal: true},
+		{Dtype: segutils.SS_DT_STRING, CVal: "zebra"},
+		{Dtype: segutils.SS_DT_BACKFILL, CVal: nil},
+	}, enclosures)
 }

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -148,7 +148,8 @@ func Test_sort(t *testing.T) {
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
 	}
 
-	sortEnclosures(enclosures, SortAsString)
+	err := sortEnclosures(enclosures, SortAsString)
+	assert.NoError(t, err)
 	assert.Equal(t, []*segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
@@ -164,7 +165,8 @@ func Test_sort(t *testing.T) {
 		enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
 	})
 
-	sortEnclosures(enclosures, SortAsNumeric)
+	err = sortEnclosures(enclosures, SortAsNumeric)
+	assert.NoError(t, err)
 	assert.Equal(t, []*segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
@@ -180,7 +182,8 @@ func Test_sort(t *testing.T) {
 		enclosures[i], enclosures[j] = enclosures[j], enclosures[i]
 	})
 
-	sortEnclosures(enclosures, SortAsAuto)
+	err = sortEnclosures(enclosures, SortAsAuto)
+	assert.NoError(t, err)
 	assert.Equal(t, []*segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -853,7 +853,7 @@ func writeSortIndexes(segkey string) {
 		defer sortedIndexWG.Done()
 
 		for _, cname := range sortIndexCnames {
-			err := sortindex.WriteSortIndex(segkey, cname, sortindex.SortAsString) // TODO: write all sort files
+			err := sortindex.WriteSortIndex(segkey, cname, sortindex.AllSortModes)
 			if err != nil {
 				log.Errorf("writeSortIndexes: failed to write sort index for segkey=%v, cname=%v; err=%v",
 					segkey, cname, err)


### PR DESCRIPTION
# Description
Previously the sort index only worked for string columns; now it can also handle cases where you sort by numbers or as auto. Each of these sorts has a different sort index file, and the correct file is chosen based on the query.

# Testing
Some new unit tests. I also manually tested that all the sort index files get written, and that the correct file is read during query.


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
