### PR TITLE
Fix bug causing duplicate sort keys

### DIFF
--- a/.github/workflows/nightly-clickbench.yml
+++ b/.github/workflows/nightly-clickbench.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - name: Install dependencies
         run: |
           sudo yum install python3-pip

--- a/.github/workflows/nightly-longer-functional.yml
+++ b/.github/workflows/nightly-longer-functional.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - uses: actions/checkout@v3
       - name: Build Siglens
         run: make build

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.21'
 
       - name: Build SigLens
         run: |

--- a/.github/workflows/uts.yml
+++ b/.github/workflows/uts.yml
@@ -23,7 +23,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.21
       - uses: actions/checkout@v3
       - name: Check goimports
         run: |

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -429,7 +429,7 @@ func writeSortIndexForTest(t *testing.T) (string, string, string) {
 	segKey2 := filepath.Join(tempDir, "segKey2")
 
 	cname := "color"
-	seg1Data := map[*segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
+	seg1Data := map[segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
 		{Dtype: segutils.SS_DT_STRING, CVal: "blue"}: {
 			1: {1},
 			2: {2, 3},
@@ -442,7 +442,7 @@ func writeSortIndexForTest(t *testing.T) (string, string, string) {
 	err := sortindex.WriteSortIndexMock(segKey1, cname, sortindex.SortAsAuto, seg1Data)
 	assert.NoError(t, err)
 
-	seg2Data := map[*segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
+	seg2Data := map[segutils.CValueEnclosure]map[uint16][]uint16{ // value -> block number -> record numbers
 		{Dtype: segutils.SS_DT_STRING, CVal: "blue"}: {
 			1: {1, 2},
 			2: {3},

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -90,7 +90,7 @@ func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 					segkey, cname, blockNum, recNum)
 			}
 
-			_, err := enclosure.CValFromBytes(recBytes)
+			_, err := enclosure.FromBytes(recBytes)
 			if err != nil {
 				return fmt.Errorf("WriteSortIndex: failed to decode CValueEnclosure for segkey=%v, cname=%v, blockNum=%v, recNum=%v; err=%v",
 					segkey, cname, blockNum, recNum, err)

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -81,7 +81,8 @@ func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 		return fmt.Errorf("WriteSortIndex: failed reading all records for segkey=%v, cname=%v; err=%v", segkey, cname, err)
 	}
 
-	valToBlockToRecords := make(map[*segutils.CValueEnclosure]map[uint16][]uint16)
+	valToBlockToRecords := make(map[segutils.CValueEnclosure]map[uint16][]uint16)
+	enclosure := segutils.CValueEnclosure{}
 	for blockNum, records := range blockToRecords {
 		for recNum, recBytes := range records {
 			if len(recBytes) == 0 {
@@ -89,7 +90,7 @@ func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 					segkey, cname, blockNum, recNum)
 			}
 
-			enclosure, _, err := segutils.CValFromBytes(recBytes)
+			_, err := enclosure.CValFromBytes(recBytes)
 			if err != nil {
 				return fmt.Errorf("WriteSortIndex: failed to decode CValueEnclosure for segkey=%v, cname=%v, blockNum=%v, recNum=%v; err=%v",
 					segkey, cname, blockNum, recNum, err)
@@ -118,7 +119,7 @@ func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 	return nil
 }
 
-func sortEnclosures(values []*segutils.CValueEnclosure, sortMode SortMode) error {
+func sortEnclosures(values []segutils.CValueEnclosure, sortMode SortMode) error {
 	switch sortMode {
 	case SortAsAuto:
 		// TODO: when IP sorting is handled, don't fall through.
@@ -177,7 +178,7 @@ func sortEnclosures(values []*segutils.CValueEnclosure, sortMode SortMode) error
 // [If string]
 // DType NumBytes ColValue1 NumBlocks BlockNum3 NumRecords Rec1, Rec2, … BlockNum4 NumRecords Rec1, Rec2
 func writeSortIndex(segkey string, cname string, sortMode SortMode,
-	valToBlockToRecords map[*segutils.CValueEnclosure]map[uint16][]uint16) error {
+	valToBlockToRecords map[segutils.CValueEnclosure]map[uint16][]uint16) error {
 
 	switch sortMode {
 	case SortAsAuto, SortAsNumeric, SortAsString: // Do nothing.

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -29,7 +29,7 @@ import (
 func writeTestData(t *testing.T) (string, string) {
 	t.Helper()
 
-	data := map[*segutils.CValueEnclosure]map[uint16][]uint16{
+	data := map[segutils.CValueEnclosure]map[uint16][]uint16{
 		{Dtype: segutils.SS_DT_STRING, CVal: "apple"}: {
 			1: {1, 2},
 			2: {100, 42},
@@ -138,7 +138,7 @@ func Test_readFromCheckpointInMiddleOfBlock(t *testing.T) {
 }
 
 func Test_sort(t *testing.T) {
-	enclosures := []*segutils.CValueEnclosure{
+	enclosures := []segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_STRING, CVal: "apple"},
@@ -150,7 +150,7 @@ func Test_sort(t *testing.T) {
 
 	err := sortEnclosures(enclosures, SortAsString)
 	assert.NoError(t, err)
-	assert.Equal(t, []*segutils.CValueEnclosure{
+	assert.Equal(t, []segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
@@ -167,7 +167,7 @@ func Test_sort(t *testing.T) {
 
 	err = sortEnclosures(enclosures, SortAsNumeric)
 	assert.NoError(t, err)
-	assert.Equal(t, []*segutils.CValueEnclosure{
+	assert.Equal(t, []segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
 		{Dtype: segutils.SS_DT_STRING, CVal: "10"},
@@ -184,7 +184,7 @@ func Test_sort(t *testing.T) {
 
 	err = sortEnclosures(enclosures, SortAsAuto)
 	assert.NoError(t, err)
-	assert.Equal(t, []*segutils.CValueEnclosure{
+	assert.Equal(t, []segutils.CValueEnclosure{
 		{Dtype: segutils.SS_DT_STRING, CVal: "5"},
 		{Dtype: segutils.SS_DT_UNSIGNED_NUM, CVal: uint64(8)},
 		{Dtype: segutils.SS_DT_STRING, CVal: "10"},

--- a/pkg/segment/sortindex/sortindexmock.go
+++ b/pkg/segment/sortindex/sortindexmock.go
@@ -3,7 +3,7 @@ package sortindex
 import segutils "github.com/siglens/siglens/pkg/segment/utils"
 
 func WriteSortIndexMock(segkey string, cname string, sortMode SortMode,
-	data map[*segutils.CValueEnclosure]map[uint16][]uint16) error {
+	data map[segutils.CValueEnclosure]map[uint16][]uint16) error {
 
 	return writeSortIndex(segkey, cname, sortMode, data)
 }

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1273,9 +1273,9 @@ func (e *CValueEnclosure) WriteBytes(writer io.Writer) error {
 }
 
 // Returns the number of bytes read
-func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
+func (e *CValueEnclosure) FromBytes(buf []byte) (int, error) {
 	if len(buf) == 0 {
-		return 0, errors.New("CValFromBytes: empty buffer")
+		return 0, errors.New("CVal.FromBytes: empty buffer")
 	}
 
 	valtype := buf[0]
@@ -1284,7 +1284,7 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 	switch valtype {
 	case VALTYPE_ENC_BOOL[0]:
 		if len(buf) < idx+1 {
-			return 0, errors.New("CValFromBytes: not enough bytes for bool")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for bool")
 		}
 		boolVal := buf[idx]
 		idx += 1
@@ -1292,7 +1292,7 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 		e.Dtype = SS_DT_BOOL
 	case VALTYPE_ENC_UINT64[0]:
 		if len(buf) < idx+8 {
-			return 0, errors.New("CValFromBytes: not enough bytes for uint64")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for uint64")
 		}
 		uint64Val := toputils.BytesToUint64LittleEndian(buf[idx : idx+8])
 		idx += 8
@@ -1300,7 +1300,7 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 		e.Dtype = SS_DT_UNSIGNED_NUM
 	case VALTYPE_ENC_INT64[0]:
 		if len(buf) < idx+8 {
-			return 0, errors.New("CValFromBytes: not enough bytes for int64")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for int64")
 		}
 		int64Val := toputils.BytesToInt64LittleEndian(buf[idx : idx+8])
 		idx += 8
@@ -1308,7 +1308,7 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 		e.Dtype = SS_DT_SIGNED_NUM
 	case VALTYPE_ENC_FLOAT64[0]:
 		if len(buf) < idx+8 {
-			return 0, errors.New("CValFromBytes: not enough bytes for float64")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for float64")
 		}
 		float64Val := toputils.BytesToFloat64LittleEndian(buf[idx : idx+8])
 		idx += 8
@@ -1316,12 +1316,12 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 		e.Dtype = SS_DT_FLOAT
 	case VALTYPE_ENC_SMALL_STRING[0]:
 		if len(buf) < idx+2 {
-			return 0, errors.New("CValFromBytes: not enough bytes for string length")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for string length")
 		}
 		strLen := int(toputils.BytesToUint16LittleEndian(buf[idx : idx+2]))
 		idx += 2
 		if len(buf) < idx+strLen {
-			return 0, errors.New("CValFromBytes: not enough bytes for string")
+			return 0, errors.New("CVal.FromBytes: not enough bytes for string")
 		}
 		strVal := string(buf[idx : idx+strLen])
 		idx += strLen
@@ -1331,7 +1331,7 @@ func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 		e.CVal = nil
 		e.Dtype = SS_DT_BACKFILL
 	default:
-		return 0, fmt.Errorf("CValFromBytes: unsupported Dtype: %v", valtype)
+		return 0, fmt.Errorf("CVal.FromBytes: unsupported Dtype: %v", valtype)
 	}
 
 	return idx, nil

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1272,13 +1272,11 @@ func (e *CValueEnclosure) WriteBytes(writer io.Writer) error {
 	return nil
 }
 
-// Returns the CValueEnclosure and the number of bytes read
-func CValFromBytes(buf []byte) (*CValueEnclosure, int, error) {
+// Returns the number of bytes read
+func (e *CValueEnclosure) CValFromBytes(buf []byte) (int, error) {
 	if len(buf) == 0 {
-		return nil, 0, errors.New("CValFromBytes: empty buffer")
+		return 0, errors.New("CValFromBytes: empty buffer")
 	}
-
-	enclosure := &CValueEnclosure{}
 
 	valtype := buf[0]
 	idx := 1
@@ -1286,57 +1284,57 @@ func CValFromBytes(buf []byte) (*CValueEnclosure, int, error) {
 	switch valtype {
 	case VALTYPE_ENC_BOOL[0]:
 		if len(buf) < idx+1 {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for bool")
+			return 0, errors.New("CValFromBytes: not enough bytes for bool")
 		}
 		boolVal := buf[idx]
 		idx += 1
-		enclosure.CVal = (boolVal == 1)
-		enclosure.Dtype = SS_DT_BOOL
+		e.CVal = (boolVal == 1)
+		e.Dtype = SS_DT_BOOL
 	case VALTYPE_ENC_UINT64[0]:
 		if len(buf) < idx+8 {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for uint64")
+			return 0, errors.New("CValFromBytes: not enough bytes for uint64")
 		}
 		uint64Val := toputils.BytesToUint64LittleEndian(buf[idx : idx+8])
 		idx += 8
-		enclosure.CVal = uint64Val
-		enclosure.Dtype = SS_DT_UNSIGNED_NUM
+		e.CVal = uint64Val
+		e.Dtype = SS_DT_UNSIGNED_NUM
 	case VALTYPE_ENC_INT64[0]:
 		if len(buf) < idx+8 {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for int64")
+			return 0, errors.New("CValFromBytes: not enough bytes for int64")
 		}
 		int64Val := toputils.BytesToInt64LittleEndian(buf[idx : idx+8])
 		idx += 8
-		enclosure.CVal = int64Val
-		enclosure.Dtype = SS_DT_SIGNED_NUM
+		e.CVal = int64Val
+		e.Dtype = SS_DT_SIGNED_NUM
 	case VALTYPE_ENC_FLOAT64[0]:
 		if len(buf) < idx+8 {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for float64")
+			return 0, errors.New("CValFromBytes: not enough bytes for float64")
 		}
 		float64Val := toputils.BytesToFloat64LittleEndian(buf[idx : idx+8])
 		idx += 8
-		enclosure.CVal = float64Val
-		enclosure.Dtype = SS_DT_FLOAT
+		e.CVal = float64Val
+		e.Dtype = SS_DT_FLOAT
 	case VALTYPE_ENC_SMALL_STRING[0]:
 		if len(buf) < idx+2 {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for string length")
+			return 0, errors.New("CValFromBytes: not enough bytes for string length")
 		}
 		strLen := int(toputils.BytesToUint16LittleEndian(buf[idx : idx+2]))
 		idx += 2
 		if len(buf) < idx+strLen {
-			return nil, 0, errors.New("CValFromBytes: not enough bytes for string")
+			return 0, errors.New("CValFromBytes: not enough bytes for string")
 		}
 		strVal := string(buf[idx : idx+strLen])
 		idx += strLen
-		enclosure.CVal = strVal
-		enclosure.Dtype = SS_DT_STRING
+		e.CVal = strVal
+		e.Dtype = SS_DT_STRING
 	case VALTYPE_ENC_BACKFILL[0]:
-		enclosure.CVal = nil
-		enclosure.Dtype = SS_DT_BACKFILL
+		e.CVal = nil
+		e.Dtype = SS_DT_BACKFILL
 	default:
-		return nil, 0, fmt.Errorf("CValFromBytes: unsupported Dtype: %v", valtype)
+		return 0, fmt.Errorf("CValFromBytes: unsupported Dtype: %v", valtype)
 	}
 
-	return enclosure, idx, nil
+	return idx, nil
 }
 
 func (e *CValueEnclosure) IsNull() bool {

--- a/pkg/segment/utils/segconsts_test.go
+++ b/pkg/segment/utils/segconsts_test.go
@@ -89,8 +89,9 @@ func Test_CValFromBytes(t *testing.T) {
 	}
 
 	idx = 0
+	enclosure := &CValueEnclosure{}
 	for i := 0; i < len(original); i++ {
-		enclosure, numBytesRead, err := CValFromBytes(bytes[idx:])
+		numBytesRead, err := enclosure.CValFromBytes(bytes[idx:])
 		idx += numBytesRead
 
 		require.NoError(t, err, "errored in iteration %d", i)

--- a/pkg/segment/utils/segconsts_test.go
+++ b/pkg/segment/utils/segconsts_test.go
@@ -91,7 +91,7 @@ func Test_CValFromBytes(t *testing.T) {
 	idx = 0
 	enclosure := &CValueEnclosure{}
 	for i := 0; i < len(original); i++ {
-		numBytesRead, err := enclosure.CValFromBytes(bytes[idx:])
+		numBytesRead, err := enclosure.FromBytes(bytes[idx:])
 		idx += numBytesRead
 
 		require.NoError(t, err, "errored in iteration %d", i)


### PR DESCRIPTION
# Description

For the sort index keys/values, we were using a `map[*K]T` instead of `map[K]T`. So for `k1==k2`, if we did `map[&k1] = t1` and `map[&k2]=t2` we'd end up with two entries instead of just one, since the pointers are different.

# Testing
Manual testing. I wrote the sort indexes for a column with some duplicates. Without this fix, there was one entry per record, and the file size was larger than expected. With the fix, sorting happened much faster (since there's fewer keys) and the file size is the same as when I was using `string` instead of `CValueEnclosure` for keys

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
