### PR TITLE
Compute num sort index records per batch

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -249,6 +249,10 @@ func (s *Searcher) fetchColumnSortedRRCs() (*iqr.IQR, error) {
 		return nil, err
 	}
 
+	if len(qsrs) == 0 {
+		return nil, io.EOF
+	}
+
 	if s.numRecordsPerBatch == 0 {
 		if s.sortExpr == nil {
 			return nil, toputils.TeeErrorf("qid=%v, searcher.fetchColumnSortedRRCs: sortExpr is nil", s.qid)

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -112,11 +112,6 @@ func NewSearcher(queryInfo *query.QueryInformation, querySummary *summary.QueryS
 	qid := queryInfo.GetQid()
 
 	return &Searcher{
-		sortIndexState: sortIndexState{
-			// TODO: find a better way to limit.
-			numRecordsPerBatch: 1000,
-		},
-
 		qid:                   qid,
 		queryInfo:             queryInfo,
 		querySummary:          querySummary,
@@ -252,6 +247,15 @@ func (s *Searcher) fetchColumnSortedRRCs() (*iqr.IQR, error) {
 	if err != nil {
 		log.Errorf("qid=%v, searcher.fetchColumnSortedRRCs: failed to get sorted QSRs: %v", s.qid, err)
 		return nil, err
+	}
+
+	if s.numRecordsPerBatch == 0 {
+		if s.sortExpr == nil {
+			return nil, toputils.TeeErrorf("qid=%v, searcher.fetchColumnSortedRRCs: sortExpr is nil", s.qid)
+		}
+
+		// This is chosen somewhat arbitrarily. We may want to tune this.
+		s.numRecordsPerBatch = max(100, int(s.sortExpr.Limit)/len(qsrs))
 	}
 
 	return s.fetchSortedRRCsFromQSRs(qsrs)


### PR DESCRIPTION
# Description
Previously, whenever we read from a sort index we tried to read 1000 records. Now we try to read `max(100, sort.Limit / numSegments)`; the `sort.Limit` is usually 10k. This computation is kind of arbitrary; assuming a uniform distribution, we do expect to need `sort.Limit/numSegments` from each sort index; if there's filter criteria we'll generally need more than this (the logic for fetching more records as needed is already setup).

# Testing
Manually tested with 0 segments and with more segments, printing the batch size.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
