### PR TITLE
Add RemoveUsageForRotatedSegmentForQidHook

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -98,17 +98,18 @@ type Hooks struct {
 	ExtractKibanaRequestsHook func(kibanaIndices []string, qid uint64) map[string]interface{}
 
 	// Ingest server
-	IngestMiddlewareRecoveryHook      func(ctx *fasthttp.RequestCtx) error
-	KibanaIngestHandlerHook           func(ctx *fasthttp.RequestCtx)
-	EsBulkIngestInternalHook          func(*fasthttp.RequestCtx, map[string]interface{}, string, bool, string, uint64, uint64) error
-	GetIdsConditionHook               func() (bool, []uint64)
-	ExtraIngestEndpointsHook          func(router *router.Router, recovery func(next func(ctx *fasthttp.RequestCtx)) func(ctx *fasthttp.RequestCtx))
-	OverrideIngestRequestHook         func(ctx *fasthttp.RequestCtx, myid uint64, ingestFunc grpc.IngestFuncEnum, useIngestHook bool) bool
-	OverrideDeleteIndexRequestHook    func(ctx *fasthttp.RequestCtx, myid uint64, indexName string) bool
-	GetNextSuffixHook                 func(uint64, func(uint64) string) (uint64, error)
-	GetOwnedSegmentsHook              func() map[string]struct{}
-	AddUsageForRotatedSegmentsHook    func(qid uint64, rotatedSegments map[string]struct{})
-	RemoveUsageForRotatedSegmentsHook func(qid uint64)
+	IngestMiddlewareRecoveryHook           func(ctx *fasthttp.RequestCtx) error
+	KibanaIngestHandlerHook                func(ctx *fasthttp.RequestCtx)
+	EsBulkIngestInternalHook               func(*fasthttp.RequestCtx, map[string]interface{}, string, bool, string, uint64, uint64) error
+	GetIdsConditionHook                    func() (bool, []uint64)
+	ExtraIngestEndpointsHook               func(router *router.Router, recovery func(next func(ctx *fasthttp.RequestCtx)) func(ctx *fasthttp.RequestCtx))
+	OverrideIngestRequestHook              func(ctx *fasthttp.RequestCtx, myid uint64, ingestFunc grpc.IngestFuncEnum, useIngestHook bool) bool
+	OverrideDeleteIndexRequestHook         func(ctx *fasthttp.RequestCtx, myid uint64, indexName string) bool
+	GetNextSuffixHook                      func(uint64, func(uint64) string) (uint64, error)
+	GetOwnedSegmentsHook                   func() map[string]struct{}
+	AddUsageForRotatedSegmentsHook         func(qid uint64, rotatedSegments map[string]struct{})
+	RemoveUsageForRotatedSegmentsHook      func(qid uint64)
+	RemoveUsageForRotatedSegmentForQidHook func(qid uint64, segKey string)
 
 	// Query server
 	QueryMiddlewareRecoveryHook func(ctx *fasthttp.RequestCtx) error


### PR DESCRIPTION
# Description
- Adds hook for remove usage for a segment

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
