### PR TITLE
API endpoint to set sort columns & non-API function to retrieve columns name

### DIFF
--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -47,7 +47,6 @@ type SortColumnConfig struct {
 
 var sortConfig = &SortColumnConfig{
 	columns: make([]string, 0),
-	mu:      sync.RWMutex{},
 }
 
 var VERSION_SORT_INDEX = []byte{0}

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -662,6 +662,7 @@ func SetSortColumns(columnNames []string) error {
 	sortConfig.mu.Lock()
 	defer sortConfig.mu.Unlock()
 
+	// TODO: Persist sort column names to disk
 	for _, col := range columnNames {
 		if col == "" {
 			return fmt.Errorf("SetSortColumns: column names must be non-empty strings")

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -561,10 +561,6 @@ func IsEOF(checkpoint *Checkpoint) bool {
 }
 
 func SetSortColumns(columnNames []string) error {
-	if columnNames == nil {
-		columnNames = make([]string, 0)
-	}
-
 	sortConfig.mu.Lock()
 	defer sortConfig.mu.Unlock()
 

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -63,8 +63,6 @@ const MaxAgileTreeNodeCount = 8_000_000
 
 const BS_INITIAL_SIZE = uint32(1000)
 
-var sortIndexCnames = []string{"app_name", "weekday"} // TODO: don't hardcode
-
 // SegStore Individual stream buffer
 type SegStore struct {
 	Lock              sync.Mutex
@@ -852,7 +850,7 @@ func writeSortIndexes(segkey string) {
 		sortedIndexWG.Add(1)
 		defer sortedIndexWG.Done()
 
-		for _, cname := range sortIndexCnames {
+		for _, cname := range sortindex.GetSortColumns() {
 			err := sortindex.WriteSortIndex(segkey, cname, sortindex.AllSortModes)
 			if err != nil {
 				log.Errorf("writeSortIndexes: failed to write sort index for segkey=%v, cname=%v; err=%v",

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -40,6 +40,7 @@ import (
 	"github.com/siglens/siglens/pkg/querytracker"
 	"github.com/siglens/siglens/pkg/sampledataset"
 	"github.com/siglens/siglens/pkg/segment/query"
+	"github.com/siglens/siglens/pkg/segment/sortindex"
 	tracinghandler "github.com/siglens/siglens/pkg/segment/tracing/handler"
 	writer "github.com/siglens/siglens/pkg/segment/writer"
 	serverutils "github.com/siglens/siglens/pkg/server/utils"
@@ -729,5 +730,11 @@ func GetQueryTimeoutHandler() func(ctx *fasthttp.RequestCtx) {
 func UpdateQueryTimeoutHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		cfghandler.UpdateQueryTimeout(ctx)
+	}
+}
+
+func setSortColumnsHandler() func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		sortindex.SetSortColumnsAPI(ctx)
 	}
 }

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -268,6 +268,8 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.POST(server_utils.API_PREFIX+"/update-query-timeout", hs.Recovery(UpdateQueryTimeoutHandler()))
 	hs.Router.GET(server_utils.API_PREFIX+"/get-query-timeout", hs.Recovery(GetQueryTimeoutHandler()))
 
+	hs.Router.POST(server_utils.API_PREFIX+"/sort-columns", hs.Recovery(setSortColumnsHandler()))
+
 	if config.IsPProfEnabled() {
 		hs.Router.GET("/debug/pprof/{profile:*}", pprofhandler.PprofHandler)
 	}


### PR DESCRIPTION
# Description
API endpoint to set sort columns & non-API function to retrieve those columns name.

```
curl -X POST \
  http://localhost:5122/api/sort-columns \ 
  -H 'Content-Type: application/json' \
  -d '["timestamp", "app_name"]'
  ```
  
Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
