### PR TITLE
Handle reverse sort using sort index

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -387,6 +387,7 @@ func (s *Searcher) fetchSortedRRCsForQSR(qsr *query.QuerySegmentRequest, pqmr *p
 	}
 
 	cname := s.sortExpr.SortEles[0].Field
+	reverse := !s.sortExpr.SortEles[0].SortByAsc
 	checkpoint := segInfo.checkpoint
 	var sortMode sortindex.SortMode
 	switch s.sortExpr.SortEles[0].Op {
@@ -401,7 +402,8 @@ func (s *Searcher) fetchSortedRRCsForQSR(qsr *query.QuerySegmentRequest, pqmr *p
 			s.qid, s.sortExpr.SortEles[0].Op)
 	}
 
-	lines, checkpoint, err := sortindex.ReadSortIndex(qsr.GetSegKey(), cname, sortMode, s.numRecordsPerBatch, checkpoint)
+	lines, checkpoint, err := sortindex.ReadSortIndex(qsr.GetSegKey(), cname, sortMode,
+		!reverse, s.numRecordsPerBatch, checkpoint)
 	if err != nil {
 		log.Errorf("qid=%v, searcher.fetchSortedRRCsForQSR: failed to read sort index: err=%v", s.qid, err)
 		return nil, err

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -403,7 +403,7 @@ func (s *Searcher) fetchSortedRRCsForQSR(qsr *query.QuerySegmentRequest, pqmr *p
 	}
 
 	lines, checkpoint, err := sortindex.ReadSortIndex(qsr.GetSegKey(), cname, sortMode,
-		!reverse, s.numRecordsPerBatch, checkpoint)
+		reverse, s.numRecordsPerBatch, checkpoint)
 	if err != nil {
 		log.Errorf("qid=%v, searcher.fetchSortedRRCsForQSR: failed to read sort index: err=%v", s.qid, err)
 		return nil, err

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -264,6 +264,7 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 		if err != nil {
 			return fmt.Errorf("writeSortIndex: failed writing number of blocks for cname: %v, colValue: %v, len(sortedBlockNums): %v, err: %v", cname, value, len(sortedBlockNums), err)
 		}
+		offset += 4
 
 		for _, blockNum := range sortedBlockNums {
 			sortedRecords, ok := valToBlockToRecords[value][blockNum]
@@ -282,12 +283,14 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 			if err != nil {
 				return fmt.Errorf("writeSortIndex: failed writing blockNum, blockNum: %v, err: %v", block.BlockNum, err)
 			}
+			offset += 2
 
 			// Write number of records
 			_, err = writer.Write(utils.Uint32ToBytesLittleEndian(uint32(len(block.RecNums))))
 			if err != nil {
 				return fmt.Errorf("writeSortIndex: failed writing number of records: %v, err: %v", len(block.RecNums), err)
 			}
+			offset += 4
 
 			// Write sortedRecords
 			for _, recNum := range block.RecNums {
@@ -296,6 +299,7 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 				if err != nil {
 					return fmt.Errorf("writeSortIndex: failed writing recNum: %v, err: %v", recNum, err)
 				}
+				offset += 2
 			}
 		}
 	}

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -333,8 +333,8 @@ type Checkpoint struct {
 	eof                 bool
 }
 
-func ReadSortIndex(segkey string, cname string, sortMode SortMode, maxRecordsToRead int,
-	fromCheckpoint *Checkpoint) ([]Line, *Checkpoint, error) {
+func ReadSortIndex(segkey string, cname string, sortMode SortMode, reverse bool,
+	maxRecordsToRead int, fromCheckpoint *Checkpoint) ([]Line, *Checkpoint, error) {
 
 	if IsEOF(fromCheckpoint) {
 		return nil, fromCheckpoint, nil

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -176,12 +176,14 @@ func sortEnclosures(values []segutils.CValueEnclosure, sortMode SortMode) error 
 	return nil
 }
 
-// Version Number
-// NumOfUniqueColValues
-// [If numeric]
-// DType ColValue1 NumBlocks BlockNum1 NumRecords Rec1, Rec2, … BlockNum2 NumRecords Rec1, Rec2
-// [If string]
-// DType NumBytes ColValue1 NumBlocks BlockNum3 NumRecords Rec1, Rec2, … BlockNum4 NumRecords Rec1, Rec2
+// File format:
+//
+//	 Metadata
+//	   Version Number
+//	     Number of unique column values
+//		 List of offsets in the file where each unique column value starts
+//	 Data
+//	   [CValueEnclosure encoding] NumBlocks BlockNum1 NumRecords Rec1, Rec2, … BlockNum2 NumRecords Rec1, Rec2
 func writeSortIndex(segkey string, cname string, sortMode SortMode,
 	valToBlockToRecords map[segutils.CValueEnclosure]map[uint16][]uint16) error {
 

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -37,7 +37,7 @@ type Block struct {
 	RecNums  []uint16 `json:"recNums"`
 }
 
-var VERSION_SORT_INDEX = []byte{0}
+var VERSION_SORT_INDEX = []byte{1}
 
 type metadata struct {
 	version      uint8
@@ -394,7 +394,8 @@ func ReadSortIndex(segkey string, cname string, sortMode SortMode, reverse bool,
 
 	if reverse && fromCheckpoint == nil {
 		fromCheckpoint = &Checkpoint{
-			lineNum: int64(len(metadata.valueOffsets)) - 1,
+			lineNum:     int64(len(metadata.valueOffsets)) - 1,
+			totalOffset: metadata.valueOffsets[len(metadata.valueOffsets)-1],
 		}
 	}
 

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -65,20 +65,20 @@ func Test_writeAndRead(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, false, 100, nil, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, false, 3, nil, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42}},
 		}},
@@ -89,17 +89,17 @@ func Test_readFromCheckpointAtStartOfLine(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, false, 4, nil, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, false, 4, checkpoint, []Line{
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
 	})
@@ -109,13 +109,13 @@ func Test_readFromCheckpointInMiddleOfLine(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, false, 2, nil, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, false, 2, checkpoint, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
@@ -125,13 +125,13 @@ func Test_readFromCheckpointInMiddleOfBlock(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, false, 1, nil, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, false, 1, checkpoint, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{2}},
 		}},
 	})
@@ -199,20 +199,20 @@ func Test_readReverse(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, true, 100, nil, []Line{
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, true, 1, nil, []Line{
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
 	})
@@ -222,16 +222,16 @@ func Test_readReverseFromEndOfLineCheckpoint(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 4, nil, []Line{
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, true, 4, checkpoint, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
@@ -242,19 +242,19 @@ func Test_readReverseFromEndOfBlockCheckpoint(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 6, nil, []Line{
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
 		}},
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{1, 2}},
 		}},
 	})
 
 	_ = readAndAssert(t, segkey, cname, SortAsString, true, 2, checkpoint, []Line{
-		{Value: "apple", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
@@ -264,17 +264,30 @@ func Test_readReverseFromMiddleOfBlockCheckpoint(t *testing.T) {
 	segkey, cname := writeTestData(t)
 
 	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 2, nil, []Line{
-		{Value: "zebra", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "zebra"}, Blocks: []Block{
 			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
-		{Value: "banana", Blocks: []Block{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{2}},
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, SortAsString, true, 2, checkpoint, []Line{
-		{Value: "banana", Blocks: []Block{
+	checkpoint = readAndAssert(t, segkey, cname, SortAsString, true, 2, checkpoint, []Line{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "banana"}, Blocks: []Block{
 			{BlockNum: 2, RecNums: []uint16{7, 13}},
+		}},
+	})
+
+	checkpoint = readAndAssert(t, segkey, cname, SortAsString, true, 1, checkpoint, []Line{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{1}},
+		}},
+	})
+
+	_ = readAndAssert(t, segkey, cname, SortAsString, true, 3, checkpoint, []Line{
+		{Value: segutils.CValueEnclosure{Dtype: segutils.SS_DT_STRING, CVal: "apple"}, Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{2}},
+			{BlockNum: 2, RecNums: []uint16{42, 100}},
 		}},
 	})
 }

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -259,3 +259,22 @@ func Test_readReverseFromEndOfBlockCheckpoint(t *testing.T) {
 		}},
 	})
 }
+
+func Test_readReverseFromMiddleOfBlockCheckpoint(t *testing.T) {
+	segkey, cname := writeTestData(t)
+
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 2, nil, []Line{
+		{Value: "zebra", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{7}},
+		}},
+		{Value: "banana", Blocks: []Block{
+			{BlockNum: 2, RecNums: []uint16{2}},
+		}},
+	})
+
+	_ = readAndAssert(t, segkey, cname, SortAsString, true, 2, checkpoint, []Line{
+		{Value: "banana", Blocks: []Block{
+			{BlockNum: 2, RecNums: []uint16{7, 13}},
+		}},
+	})
+}

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -237,3 +237,25 @@ func Test_readReverseFromEndOfLineCheckpoint(t *testing.T) {
 		}},
 	})
 }
+
+func Test_readReverseFromEndOfBlockCheckpoint(t *testing.T) {
+	segkey, cname := writeTestData(t)
+
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 6, nil, []Line{
+		{Value: "zebra", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{7}},
+		}},
+		{Value: "banana", Blocks: []Block{
+			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
+		}},
+		{Value: "apple", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{1, 2}},
+		}},
+	})
+
+	_ = readAndAssert(t, segkey, cname, SortAsString, true, 2, checkpoint, []Line{
+		{Value: "apple", Blocks: []Block{
+			{BlockNum: 2, RecNums: []uint16{42, 100}},
+		}},
+	})
+}

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -217,3 +217,23 @@ func Test_readReverse(t *testing.T) {
 		}},
 	})
 }
+
+func Test_readReverseFromEndOfLineCheckpoint(t *testing.T) {
+	segkey, cname := writeTestData(t)
+
+	checkpoint := readAndAssert(t, segkey, cname, SortAsString, true, 4, nil, []Line{
+		{Value: "zebra", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{7}},
+		}},
+		{Value: "banana", Blocks: []Block{
+			{BlockNum: 2, RecNums: []uint16{2, 7, 13}},
+		}},
+	})
+
+	_ = readAndAssert(t, segkey, cname, SortAsString, true, 4, checkpoint, []Line{
+		{Value: "apple", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{1, 2}},
+			{BlockNum: 2, RecNums: []uint16{42, 100}},
+		}},
+	})
+}

--- a/pkg/segment/sortindex/sortindex_test.go
+++ b/pkg/segment/sortindex/sortindex_test.go
@@ -211,10 +211,9 @@ func Test_readReverse(t *testing.T) {
 		}},
 	})
 
-	_ = readAndAssert(t, segkey, cname, SortAsString, true, 3, nil, []Line{
-		{Value: "apple", Blocks: []Block{
-			{BlockNum: 1, RecNums: []uint16{1, 2}},
-			{BlockNum: 2, RecNums: []uint16{42}},
+	_ = readAndAssert(t, segkey, cname, SortAsString, true, 1, nil, []Line{
+		{Value: "zebra", Blocks: []Block{
+			{BlockNum: 1, RecNums: []uint16{7}},
 		}},
 	})
 }


### PR DESCRIPTION
# Description
Previously, using a sort index file would always return the results sorted lowest to highest. Now it can also be used when sorting highest to lowest. To do this, a metadata section is added near the beginning of the sort index file; this metadata specifies the offset within the file for each "line" (see the `type line`).

Note: If the forward sorting of records 1, 2, 3 is 1, 2, 3 and `val(1) < val(2) == val(3)`, then the reverse sort we get from the sort index file will be 2, 3, 1 rather than 3, 2, 1, because both orders are correct but 2, 3, 1 makes reading the sort index file easier.

# Testing
Unit tests for writing/reading the sort index file both forward and reversed, both with and without a previous checkpoint.

I also manually tested with `* | sort str(EventTime)` and `* | sort -str(EventTime)`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
