### PR TITLE
Fallback on normal search if missing sort index

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -66,8 +66,6 @@ type sortIndexState struct {
 	exhaustedSegKey    toputils.Option[string]
 	numRecordsSent     uint64
 	didEarlyExit       bool
-	sortIndexQSRs      []*query.QuerySegmentRequest
-	otherQSRs          []*query.QuerySegmentRequest
 }
 
 type segInfo struct {
@@ -186,9 +184,6 @@ func getSubsearchIfNeeded(searcher *Searcher) (*subsearch, error) {
 			otherQSRs = append(otherQSRs, qsr)
 		}
 	}
-
-	searcher.sortIndexState.sortIndexQSRs = sortIndexQSRs
-	searcher.sortIndexState.otherQSRs = otherQSRs
 
 	subsearchers := make([]*Searcher, 2)
 	for i := 0; i < 2; i++ {

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -500,7 +500,6 @@ func initSortIndexDataForTest(sortCname string, sortLimit uint64, numRecordsPerB
 func fetchAllFromQSRsForTest(t *testing.T, searcher *Searcher, qsrs []*query.QuerySegmentRequest) []*segutils.RecordResultContainer {
 	t.Helper()
 
-	searcher.sortIndexState.sortIndexQSRs = qsrs
 	iqr, err := searcher.fetchSortedRRCsFromQSRs()
 	require.True(t, err == nil || err == io.EOF)
 	require.NotNil(t, iqr)

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -491,6 +491,7 @@ func initSortIndexDataForTest(sortCname string, sortLimit uint64, numRecordsPerB
 		queryInfo:   queryInfo,
 		sortExpr:    sortExpr,
 		segEncToKey: utils.NewTwoWayMap[uint32, string](),
+		qsrs:        qsrs,
 	}
 
 	return searcher, qsrs
@@ -501,8 +502,11 @@ func fetchAllFromQSRsForTest(t *testing.T, searcher *Searcher, qsrs []*query.Que
 
 	searcher.sortIndexState.sortIndexQSRs = qsrs
 	iqr, err := searcher.fetchSortedRRCsFromQSRs()
-	require.NoError(t, err)
+	require.True(t, err == nil || err == io.EOF)
 	require.NotNil(t, iqr)
+	if err == io.EOF {
+		return iqr.GetRRCs()
+	}
 
 	for {
 		nextIQR, err := searcher.fetchSortedRRCsFromQSRs()

--- a/pkg/segment/query/processor/searcher_test.go
+++ b/pkg/segment/query/processor/searcher_test.go
@@ -499,12 +499,13 @@ func initSortIndexDataForTest(sortCname string, sortLimit uint64, numRecordsPerB
 func fetchAllFromQSRsForTest(t *testing.T, searcher *Searcher, qsrs []*query.QuerySegmentRequest) []*segutils.RecordResultContainer {
 	t.Helper()
 
-	iqr, err := searcher.fetchSortedRRCsFromQSRs(qsrs)
+	searcher.sortIndexState.sortIndexQSRs = qsrs
+	iqr, err := searcher.fetchSortedRRCsFromQSRs()
 	require.NoError(t, err)
 	require.NotNil(t, iqr)
 
 	for {
-		nextIQR, err := searcher.fetchSortedRRCsFromQSRs(qsrs)
+		nextIQR, err := searcher.fetchSortedRRCsFromQSRs()
 		err2 := iqr.Append(nextIQR)
 		assert.NoError(t, err2)
 

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -49,6 +49,32 @@ const (
 
 var AllSortModes = []SortMode{SortAsAuto, SortAsNumeric, SortAsString}
 
+func (sm SortMode) String() string {
+	switch sm {
+	case SortAsAuto:
+		return "auto"
+	case SortAsNumeric:
+		return "num"
+	case SortAsString:
+		return "str"
+	}
+
+	return "unknown"
+}
+
+func ModeFromString(mode string) (SortMode, error) {
+	switch mode {
+	case "", "auto":
+		return SortAsAuto, nil
+	case "num":
+		return SortAsNumeric, nil
+	case "str":
+		return SortAsString, nil
+	}
+
+	return -1, fmt.Errorf("invalid sort mode: %v", mode)
+}
+
 func getFilename(segkey string, cname string, sortMode SortMode) string {
 	suffix := ""
 	switch sortMode {

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -42,15 +42,14 @@ var VERSION_SORT_INDEX = []byte{0}
 type SortMode int
 
 const (
-	InvalidSortMode SortMode = iota
-	SortAsAuto
+	SortAsAuto SortMode = iota + 1
 	SortAsNumeric
 	SortAsString
 )
 
 var AllSortModes = []SortMode{SortAsAuto, SortAsNumeric, SortAsString}
 
-func getFilename(segkey string, cname string, sortMode SortMode) (string, error) {
+func getFilename(segkey string, cname string, sortMode SortMode) string {
 	suffix := ""
 	switch sortMode {
 	case SortAsAuto:
@@ -59,20 +58,13 @@ func getFilename(segkey string, cname string, sortMode SortMode) (string, error)
 		suffix = "_num"
 	case SortAsString:
 		suffix = "_str"
-	default:
-		return "", fmt.Errorf("getFilename: invalid sort mode: %v", sortMode)
 	}
 
-	return filepath.Join(segkey, cname+suffix+".srt"), nil // srt means "sort", not an acronym
+	return filepath.Join(segkey, cname+suffix+".srt") // srt means "sort", not an acronym
 }
 
-func getTempFilename(segkey string, cname string, sortMode SortMode) (string, error) {
-	filename, err := getFilename(segkey, cname, sortMode)
-	if err != nil {
-		return "", fmt.Errorf("getTempFilename: failed getting filename: %v", err)
-	}
-
-	return filename + ".tmp", nil
+func getTempFilename(segkey string, cname string, sortMode SortMode) string {
+	return getFilename(segkey, cname, sortMode) + ".tmp"
 }
 
 func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
@@ -186,26 +178,16 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 		return fmt.Errorf("writeSortIndex: invalid sort mode: %v", sortMode)
 	}
 
-	filename, err := getFilename(segkey, cname, sortMode)
-	if err != nil {
-		return fmt.Errorf("writeSortIndex: failed getting filename: %v", err)
-	}
+	filename := getFilename(segkey, cname, sortMode)
 
 	dir := filepath.Dir(filename)
-	err = os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err
 	}
 
-	finalName, err := getFilename(segkey, cname, sortMode)
-	if err != nil {
-		return fmt.Errorf("writeSortIndex: failed getting filename: %v", err)
-	}
-
-	tmpFileName, err := getTempFilename(segkey, cname, sortMode)
-	if err != nil {
-		return fmt.Errorf("writeSortIndex: failed getting temp filename: %v", err)
-	}
+	finalName := getFilename(segkey, cname, sortMode)
+	tmpFileName := getTempFilename(segkey, cname, sortMode)
 
 	file, err := os.Create(tmpFileName)
 	if err != nil {
@@ -346,11 +328,7 @@ func ReadSortIndex(segkey string, cname string, sortMode SortMode, maxRecordsToR
 		return nil, nil, fmt.Errorf("ReadSortIndex: invalid sort mode: %v", sortMode)
 	}
 
-	filename, err := getFilename(segkey, cname, sortMode)
-	if err != nil {
-		return nil, nil, fmt.Errorf("ReadSortIndex: failed getting filename: %v", err)
-	}
-
+	filename := getFilename(segkey, cname, sortMode)
 	file, err := os.Open(filename)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -67,6 +67,13 @@ func getTempFilename(segkey string, cname string, sortMode SortMode) string {
 	return getFilename(segkey, cname, sortMode) + ".tmp"
 }
 
+func Exists(segkey string, cname string, sortMode SortMode) bool {
+	filename := getFilename(segkey, cname, sortMode)
+
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
 func WriteSortIndex(segkey string, cname string, sortModes []SortMode) error {
 	blockToRecords, err := segreader.ReadAllRecords(segkey, cname)
 	if err != nil {


### PR DESCRIPTION
# Description
Sort index files are created on rotation, so often (e.g., for an unrotated segment) there won't be a sort index file for a particular segment. In that case, we want to do the typical search and sort flow for that segment but use the sort index files for the other segments, and merge the results. This PR does exactly that. Whenever the Searcher has a query that can use a sort index, it makes two subsearchers—one to use sort index files, and the other to do the normal flow. Then `Fetch()`ing from the searcher internally `Fetch()`es from the subsearchers, merges them, and returns the result.

# Testing
Setup the sort index to use the `address` field, then ran a query to sort on that field. Test with only rotated, only unrotated, and a combination of rotated and unrotated data.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
