### PR TITLE
Reduce memory from errors parsing float

### DIFF
--- a/pkg/segment/query/processor/sortcommand.go
+++ b/pkg/segment/query/processor/sortcommand.go
@@ -155,10 +155,13 @@ func getRank(CValEnc *segutils.CValueEnclosure, op string) dTypeRank {
 	case segutils.SS_DT_STRING:
 		switch op {
 		case "num", "auto", "":
-			_, err := strconv.ParseFloat(CValEnc.CVal.(string), 64)
-			if err == nil {
-				// If floatValue is possible then it is considered as a number
-				return RANK_NUMERIC
+			strVal := CValEnc.CVal.(string)
+			if utils.MightBeFloat(strVal) {
+				_, err := strconv.ParseFloat(CValEnc.CVal.(string), 64)
+				if err == nil {
+					// If floatValue is possible then it is considered as a number
+					return RANK_NUMERIC
+				}
 			}
 			return RANK_STRING
 		case "str":

--- a/pkg/segment/query/processor/sortcommand.go
+++ b/pkg/segment/query/processor/sortcommand.go
@@ -157,7 +157,7 @@ func getRank(CValEnc *segutils.CValueEnclosure, op string) dTypeRank {
 		case "num", "auto", "":
 			strVal := CValEnc.CVal.(string)
 			if utils.MightBeFloat(strVal) {
-				_, err := strconv.ParseFloat(CValEnc.CVal.(string), 64)
+				_, err := strconv.ParseFloat(strVal, 64)
 				if err == nil {
 					// If floatValue is possible then it is considered as a number
 					return RANK_NUMERIC

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1015,7 +1015,12 @@ func (e *CValueEnclosure) GetFloatValue() (float64, error) {
 func (e *CValueEnclosure) GetFloatValueIfPossible() (float64, bool) {
 	switch e.Dtype {
 	case SS_DT_STRING:
-		floatVal, err := strconv.ParseFloat(e.CVal.(string), 64)
+		strVal := e.CVal.(string)
+		if !toputils.MightBeFloat(strVal) {
+			return 0, false
+		}
+
+		floatVal, err := strconv.ParseFloat(strVal, 64)
 		if err != nil {
 			return 0, false
 		}

--- a/pkg/utils/stringutils.go
+++ b/pkg/utils/stringutils.go
@@ -77,3 +77,22 @@ func DecodeFromBase64(s string) (string, error) {
 
 	return string(data), nil
 }
+
+func MightBeFloat(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	switch s {
+	case "NaN", "nan", "Inf", "inf", "-Inf", "-inf":
+		return true
+	}
+
+	for _, ch := range s {
+		if (ch < '0' || ch > '9') && !strings.ContainsRune(".-+eE", ch) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/utils/stringutils_test.go
+++ b/pkg/utils/stringutils_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import "testing"
+
+func Test_MightBeFloat(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"1.0", true},
+		{"1", true},
+		{"1:10:50", false},
+		{"v1.0", false},
+		{"-1E-10", true},
+		{"+42", true},
+	}
+	for _, test := range tests {
+		if got := MightBeFloat(test.input); got != test.expected {
+			t.Errorf("MightBeFloat(%q) = %v, want %v", test.input, got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
# Description
When `strconv.ParseFloat()` errors, it takes some memory on the heap to store the error. We've been calling `ParseFloat()` sometimes just to check if the string can be converted to a float. This leads to a lot of unnecessary allocations.

With this PR, when writing sort index files the memory usage is decreased to about 60% of the original usage, and writing the sort index is about 10% faster.

# Testing
I have 7.5 million records ingested in one segment, and added a loop on startup to write the sort index for a column with values like `2013-07-03 12:09:10` 5 times, and used pprof to check total allocations. There were about 200k unique values in the column

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
