### PR TITLE
Reduce memory from sorting

### DIFF
--- a/pkg/segment/sortindex/sortindex.go
+++ b/pkg/segment/sortindex/sortindex.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/siglens/siglens/pkg/segment/reader/segread/segreader"
@@ -241,7 +242,7 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 		}
 
 		sortedBlockNums := utils.GetKeysOfMap(valToBlockToRecords[value])
-		sort.Slice(sortedBlockNums, func(i, j int) bool { return sortedBlockNums[i] < sortedBlockNums[j] })
+		slices.Sort(sortedBlockNums)
 
 		// Write number of blocks
 		_, err = writer.Write(utils.Uint32ToBytesLittleEndian(uint32(len(sortedBlockNums))))
@@ -255,7 +256,7 @@ func writeSortIndex(segkey string, cname string, sortMode SortMode,
 				return fmt.Errorf("writeSortIndex: missing records for value %v block %d", value, blockNum)
 			}
 
-			sort.Slice(sortedRecords, func(i, j int) bool { return sortedRecords[i] < sortedRecords[j] })
+			slices.Sort(sortedRecords)
 			block := Block{
 				BlockNum: blockNum,
 				RecNums:  sortedRecords,


### PR DESCRIPTION
# Description
pprof showed that `sort.Slice()` was using a fair amount of memory (a few 100 MBs). After switching to `slices.Sort()`, pprof doesn't show any memory allocations for these lines. This also reduced the time for writing the sort index file by about 8%.

In my test, I was often sorting two-element slices, or a slice of about 10 elements; not sure if that makes any difference.

# Testing
Same as #2001 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
