### PR TITLE
Reduce memory by starting pool with no elements

### DIFF
--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -64,7 +64,7 @@ type SharedTimeSeriesSegmentReader struct {
 	rwLock                       *sync.Mutex
 }
 
-var globalPool = memorypool.NewMemoryPool(4, segutils.METRICS_SEARCH_ALLOCATE_BLOCK)
+var globalPool = memorypool.NewMemoryPool(0, segutils.METRICS_SEARCH_ALLOCATE_BLOCK)
 
 /*
 Exposes init functions for timeseries block readers.


### PR DESCRIPTION
# Description
Each pool element is 150MB, so we can save a lot of RAM when metrics aren't used by starting the pool with no elements. The pool should still create elements as needed.

# Testing
Started siglens and ingested some data, then ran `go tool pprof -http :8080 localhost:5122/debug/pprof/heap`. Previously, we used 570MB for this pool; now we use 0 when we're not using metrics.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
