### PR TITLE
Add low memory mode

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -84,8 +84,9 @@ type DatabaseConfig struct {
 }
 
 type MemoryConfig struct {
-	MaxUsagePercent uint64 `yaml:"maxUsagePercent"`
-	BytesPerQuery   uint64 `yaml:"bytesPerQuery"`
+	MaxUsagePercent uint64                  `yaml:"maxUsagePercent"`
+	BytesPerQuery   uint64                  `yaml:"bytesPerQuery"`
+	LowMemoryMode   utils.WithDefault[bool] `yaml:"lowMemoryMode"`
 
 	// These should sum to 100.
 	SearchPercent   uint64 `yaml:"searchPercent"`
@@ -149,7 +150,6 @@ type Configuration struct {
 	UseNewPipelineConverted     bool
 	UseNewQueryPipeline         string                  `yaml:"isNewQueryPipelineEnabled"`
 	EnableSortIndex             utils.WithDefault[bool] `yaml:"enableSortIndex"`
-	LowMemoryMode               utils.WithDefault[bool] `yaml:"lowMemoryMode"`
 	QueryTimeoutSecs            int                     `yaml:"queryTimeoutSecs"`
 }
 

--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -149,6 +149,7 @@ type Configuration struct {
 	UseNewPipelineConverted     bool
 	UseNewQueryPipeline         string                  `yaml:"isNewQueryPipelineEnabled"`
 	EnableSortIndex             utils.WithDefault[bool] `yaml:"enableSortIndex"`
+	LowMemoryMode               utils.WithDefault[bool] `yaml:"lowMemoryMode"`
 	QueryTimeoutSecs            int                     `yaml:"queryTimeoutSecs"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -370,7 +370,7 @@ func IsSortIndexEnabled() bool {
 }
 
 func IsLowMemoryModeEnabled() bool {
-	return runningConfig.LowMemoryMode.Value()
+	return runningConfig.MemoryConfig.LowMemoryMode.Value()
 }
 
 // returns a map of s3 config
@@ -702,7 +702,9 @@ func ReadConfigFile(fileName string) (common.Configuration, error) {
 func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	config := common.Configuration{
 		EnableSortIndex: utils.DefaultValue(false),
-		LowMemoryMode:   utils.DefaultValue(false),
+		MemoryConfig: common.MemoryConfig{
+			LowMemoryMode: utils.DefaultValue(false),
+		},
 	}
 	err := yaml.Unmarshal(yamlData, &config)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -369,6 +369,10 @@ func IsSortIndexEnabled() bool {
 	return runningConfig.EnableSortIndex.Value()
 }
 
+func IsLowMemoryModeEnabled() bool {
+	return runningConfig.LowMemoryMode.Value()
+}
+
 // returns a map of s3 config
 func GetS3ConfigMap() map[string]interface{} {
 	data, err := json.Marshal(runningConfig.S3)
@@ -698,6 +702,7 @@ func ReadConfigFile(fileName string) (common.Configuration, error) {
 func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	config := common.Configuration{
 		EnableSortIndex: utils.DefaultValue(false),
+		LowMemoryMode:   utils.DefaultValue(false),
 	}
 	err := yaml.Unmarshal(yamlData, &config)
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,7 +76,6 @@ func Test_ExtractConfigData(t *testing.T) {
  agileAggsEnabled: false
  isNewQueryPipelineEnabled: false
  enableSortIndex: true
- lowMemoryMode: true
  queryTimeoutSecs: 600
  safeMode: true
  tracing:
@@ -90,6 +89,7 @@ func Test_ExtractConfigData(t *testing.T) {
  compressStatic: false
  memoryLimits:
    maxUsagePercent: 80
+   lowMemoryMode: true
    searchPercent: 50
    microIndexPercent: 20
    metadataPercent: 20
@@ -139,10 +139,10 @@ func Test_ExtractConfigData(t *testing.T) {
 				UseNewQueryPipeline:         "false",
 				UseNewPipelineConverted:     false,
 				EnableSortIndex:             utils.DefaultValue(false).Set(true),
-				LowMemoryMode:               utils.DefaultValue(false).Set(true),
 				QueryTimeoutSecs:            600,
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
+					LowMemoryMode:   utils.DefaultValue(false).Set(true),
 					SearchPercent:   50,
 					CMIPercent:      20,
 					MetadataPercent: 20,
@@ -196,7 +196,6 @@ func Test_ExtractConfigData(t *testing.T) {
    compressLogFile: true
  compressStatic: bad string
  enableSortIndex: bad string
- lowMemoryMode: bad string
  `),
 
 			common.Configuration{
@@ -241,9 +240,9 @@ func Test_ExtractConfigData(t *testing.T) {
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
 				EnableSortIndex:             utils.DefaultValue(false),
-				LowMemoryMode:               utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
+					LowMemoryMode:   utils.DefaultValue(false),
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
 					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
@@ -297,9 +296,9 @@ invalid input, we should error out
 				UseNewQueryPipeline:        "true",
 				UseNewPipelineConverted:    true,
 				EnableSortIndex:            utils.DefaultValue(false),
-				LowMemoryMode:              utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
+					LowMemoryMode:   utils.DefaultValue(false),
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
 					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,
@@ -356,9 +355,9 @@ a: b
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
 				EnableSortIndex:             utils.DefaultValue(false),
-				LowMemoryMode:               utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
+					LowMemoryMode:   utils.DefaultValue(false),
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
 					CMIPercent:      DEFAULT_ROTATED_CMI_MEM_PERCENT,
 					MetadataPercent: DEFAULT_METADATA_MEM_PERCENT,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,6 +76,7 @@ func Test_ExtractConfigData(t *testing.T) {
  agileAggsEnabled: false
  isNewQueryPipelineEnabled: false
  enableSortIndex: true
+ lowMemoryMode: true
  queryTimeoutSecs: 600
  safeMode: true
  tracing:
@@ -138,6 +139,7 @@ func Test_ExtractConfigData(t *testing.T) {
 				UseNewQueryPipeline:         "false",
 				UseNewPipelineConverted:     false,
 				EnableSortIndex:             utils.DefaultValue(false).Set(true),
+				LowMemoryMode:               utils.DefaultValue(false).Set(true),
 				QueryTimeoutSecs:            600,
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
@@ -194,6 +196,7 @@ func Test_ExtractConfigData(t *testing.T) {
    compressLogFile: true
  compressStatic: bad string
  enableSortIndex: bad string
+ lowMemoryMode: bad string
  `),
 
 			common.Configuration{
@@ -238,6 +241,7 @@ func Test_ExtractConfigData(t *testing.T) {
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
 				EnableSortIndex:             utils.DefaultValue(false),
+				LowMemoryMode:               utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
@@ -293,6 +297,7 @@ invalid input, we should error out
 				UseNewQueryPipeline:        "true",
 				UseNewPipelineConverted:    true,
 				EnableSortIndex:            utils.DefaultValue(false),
+				LowMemoryMode:              utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,
@@ -351,6 +356,7 @@ a: b
 				UseNewQueryPipeline:         "true",
 				UseNewPipelineConverted:     true,
 				EnableSortIndex:             utils.DefaultValue(false),
+				LowMemoryMode:               utils.DefaultValue(false),
 				MemoryConfig: common.MemoryConfig{
 					MaxUsagePercent: 80,
 					SearchPercent:   DEFAULT_SEG_SEARCH_MEM_PERCENT,

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -562,6 +562,9 @@ func (segstore *SegStore) AppendWipToSegfile(streamid string, forceRotate bool, 
 
 		//readjust workBufComp size based on num of columns in this wip
 		flushParallelism := runtime.GOMAXPROCS(0) * 2
+		if config.IsLowMemoryModeEnabled() {
+			flushParallelism = 1
+		}
 		segstore.workBufForCompression = toputils.ResizeSlice(segstore.workBufForCompression,
 			flushParallelism)
 		// now make each of these bufs of atleast WIP_SIZE


### PR DESCRIPTION
# Description
Now adding this to server.yaml:
```
memoryLimits:
  lowMemoryMode: true
```
will cause siglens to use slightly less memory, but be slightly slower. The only place this config matters right now is when data is flushed to disk, but we may want to make similar changes other places as well.

# Testing
Ingested some data, waited for it to flush to disk, then ran `go tool pprof -http :8080 localhost:5122/debug/pprof/heap`. Without this change, I saw about 40MB used for `ResizeSlice()` on my 10-CPU machine; with this PR, it went down to 2MB

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
