### PR TITLE
Log SigLens version on bootup

### DIFF
--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -275,10 +275,13 @@ func StartSiglensServer(nodeType commonconfig.DeploymentType, nodeID string) err
 	fileutils.InitLogFiles()
 
 	siglensStartupLog := fmt.Sprintf("----- Siglens server type %s starting up ----- \n", nodeType)
+	siglensVersionLog := fmt.Sprintf("----- Siglens version %s ----- \n", config.SigLensVersion)
 	if config.GetLogPrefix() != "" {
 		StdOutLogger.Infof(siglensStartupLog)
+		StdOutLogger.Infof(siglensVersionLog)
 	}
 	log.Infof(siglensStartupLog)
+	log.Infof(siglensVersionLog)
 
 	if hook := hooks.GlobalHooks.StartSiglensExtrasHook; hook != nil {
 		err := hook(nodeID)


### PR DESCRIPTION
# Description
- Logs SigLens version on Bootup

# Testing
- Tested by running the server and verifying that the version is being logged at the server log and also in the `siglens.log` file.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
