### PR TITLE
Log memory fetch source

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,9 +170,12 @@ func GetMemoryMax() uint64 {
 	// try to get the memory from the cgroup
 	memoryMax, err := getContainerMemory(memoryValueMax)
 	if err != nil {
-		log.Debugf("GetMemoryMax: Error while getting memory from cgroup: %v", err)
+		log.Warnf("GetMemoryMax: Error while getting memory from cgroup: %v", err)
 		// if we can't get the memory from the cgroup, get it from the OS
 		memoryMax = memory.TotalMemory()
+		log.Infof("GetMemoryMax: Memory from the OS in bytes: %v", memoryMax)
+	} else {
+		log.Infof("GetMemoryMax: Memory from cgroup in bytes: %v", memoryMax)
 	}
 
 	return memoryMax

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,9 +173,9 @@ func GetMemoryMax() uint64 {
 		log.Warnf("GetMemoryMax: Error while getting memory from cgroup: %v", err)
 		// if we can't get the memory from the cgroup, get it from the OS
 		memoryMax = memory.TotalMemory()
-		log.Infof("GetMemoryMax: Memory from the OS in bytes: %v", memoryMax)
+		log.Infof("GetMemoryMax: Memory from the Host in MB: %v", segutils.ConvertUintBytesToMB(memoryMax))
 	} else {
-		log.Infof("GetMemoryMax: Memory from cgroup in bytes: %v", memoryMax)
+		log.Infof("GetMemoryMax: Memory from cgroup in MB: %v", segutils.ConvertUintBytesToMB(memoryMax))
 	}
 
 	return memoryMax


### PR DESCRIPTION
# Description
- Logs whether memory is from `os` or from `cgroups`

# Testing
- Tested by running the siglens server and ensured that the logs were being displayed

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
