### PR TITLE
Cleanup segment rotation hook

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -128,7 +128,6 @@ type Hooks struct {
 	AfterWritingToSegment     func(rid uint64, segstore interface{}, record []byte, ts uint64, signalType segutils.SIGNAL_TYPE) error
 	AfterHandlingBulkRequest  func(ctx *fasthttp.RequestCtx, rid uint64) bool
 	RotateSegment             func(segstore interface{}, streamId string, forceRotate bool) (bool, error)
-	AddSegMeta                func(segmeta interface{}) (bool, error)
 	AfterSegmentRotation      func(segmeta interface{}) error
 }
 

--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -367,55 +367,16 @@ func GetVTableCountsForAll(orgid uint64, allSegmetas []*structs.SegMeta) map[str
 	return allvtables
 }
 
-func addNewRotatedSegmeta(segmeta structs.SegMeta) {
-	if hook := hooks.GlobalHooks.AddSegMeta; hook != nil {
-		alreadyHandled, err := hook(&segmeta)
-		if err != nil {
-			log.Errorf("AddNewRotatedSegmeta: hook failed, err=%v", err)
-			return
-		}
-
-		if alreadyHandled {
-			return
-		}
-	}
-
-	addSegmeta(segmeta)
-}
-
 func AddOrReplaceRotatedSegmeta(segmeta structs.SegMeta) {
 	removeSegmetas(map[string]struct{}{segmeta.SegmentKey: struct{}{}}, "")
 	addSegmeta(segmeta)
 }
 
-func BulkAddRotatedSegmetas(segmetas []*structs.SegMeta, shouldWriteSfm bool) {
-	finalSegmetas := make([]*structs.SegMeta, 0, len(segmetas))
-
-	hook := hooks.GlobalHooks.AddSegMeta
-	if hook != nil {
-		for _, segmeta := range segmetas {
-			alreadyHandled, err := hook(segmeta)
-			if err != nil {
-				log.Errorf("BulkAddRotatedSegmetas: hook failed, err=%v", err)
-				continue
-			}
-
-			if !alreadyHandled {
-				finalSegmetas = append(finalSegmetas, segmeta)
-			}
-		}
-	} else {
-		finalSegmetas = segmetas
-	}
-
-	bulkAddSegmetas(finalSegmetas, shouldWriteSfm)
-}
-
 func addSegmeta(segmeta structs.SegMeta) {
-	bulkAddSegmetas([]*structs.SegMeta{&segmeta}, true)
+	BulkAddRotatedSegmetas([]*structs.SegMeta{&segmeta}, true)
 }
 
-func bulkAddSegmetas(finalSegmetas []*structs.SegMeta, shouldWriteSfm bool) {
+func BulkAddRotatedSegmetas(finalSegmetas []*structs.SegMeta, shouldWriteSfm bool) {
 	if len(finalSegmetas) == 0 {
 		return
 	}

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -817,7 +817,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 			BytesReceivedCount: segstore.BytesReceivedCount, OnDiskBytes: segstore.OnDiskBytes,
 			ColumnNames: allColsSizes, AllPQIDs: allPqids, NumBlocks: segstore.numBlocks, OrgId: segstore.OrgId}
 
-		addNewRotatedSegmeta(segmeta)
+		addSegmeta(segmeta)
 		if hook := hooks.GlobalHooks.AfterSegmentRotation; hook != nil {
 			err := hook(&segmeta)
 			if err != nil {


### PR DESCRIPTION
# Description
- Removes Segment Rotation Hook

# Testing

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
