### PR TITLE
Reduce gauge creation boilerplate

### DIFF
--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -63,8 +63,8 @@ func ingestionMetricsLooper() {
 			instrumentation.SetOnDiskBytesPerIndex(currentOnDiskBytes, "indexname", indexName)
 		}
 
-		instrumentation.SetGauge(instrumentation.TotalEventCount, currentEventCount)
-		instrumentation.SetGauge(instrumentation.TotalBytesReceived, currentBytesReceived)
-		instrumentation.SetGauge(instrumentation.TotalOnDiskBytes, currentOnDiskBytes)
+		instrumentation.SetTotalEventCount(currentEventCount)
+		instrumentation.SetTotalBytesReceived(currentBytesReceived)
+		instrumentation.SetTotalOnDiskBytes(currentOnDiskBytes)
 	}
 }

--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -63,8 +63,8 @@ func ingestionMetricsLooper() {
 			instrumentation.SetOnDiskBytesPerIndex(currentOnDiskBytes, "indexname", indexName)
 		}
 
-		instrumentation.SetGaugeCurrentEventCount(currentEventCount)
-		instrumentation.SetGaugeCurrentBytesReceivedGauge(currentBytesReceived)
-		instrumentation.SetGaugeOnDiskBytesGauge(currentOnDiskBytes)
+		instrumentation.SetGauge(instrumentation.TotalEventCount, currentEventCount)
+		instrumentation.SetGauge(instrumentation.TotalBytesReceived, currentBytesReceived)
+		instrumentation.SetGauge(instrumentation.TotalOnDiskBytes, currentOnDiskBytes)
 	}
 }

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -44,7 +44,10 @@ func InitMetrics() {
 	}
 	log.Info("InitMetrics: Initializing metrics package...")
 
-	initGauges()
+	err := initGauges()
+	if err != nil {
+		log.Errorf("InitMetrics: Failed to initialize gauges; err=%v", err)
+	}
 
 	exporter, err := prometheus.New()
 	if err != nil {
@@ -55,7 +58,6 @@ func InitMetrics() {
 
 	commonAttributes = append(commonAttributes, attribute.String("hostname", conf.GetHostID()))
 	log.Infof("InitMetrics: Added hostname %s as a common attribute to all metrics", conf.GetHostID())
-	registerGaugeCallbacks()
 
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -43,6 +43,9 @@ func InitMetrics() {
 		return
 	}
 	log.Info("InitMetrics: Initializing metrics package...")
+
+	initGauges()
+
 	exporter, err := prometheus.New()
 	if err != nil {
 		log.Errorf("InitMetrics: Failed to initialize prometheus exporter with error: %v", err)

--- a/pkg/instrumentation/metrics.go
+++ b/pkg/instrumentation/metrics.go
@@ -43,12 +43,6 @@ func InitMetrics() {
 		return
 	}
 	log.Info("InitMetrics: Initializing metrics package...")
-
-	err := initGauges()
-	if err != nil {
-		log.Errorf("InitMetrics: Failed to initialize gauges; err=%v", err)
-	}
-
 	exporter, err := prometheus.New()
 	if err != nil {
 		log.Errorf("InitMetrics: Failed to initialize prometheus exporter with error: %v", err)

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -140,7 +140,8 @@ func initGauges() error {
 	}
 
 	// Register the callbacks for each gauge.
-	for _, simpleGauge := range allSimpleGauges {
+	for _, sg := range allSimpleGauges {
+		simpleGauge := sg
 		_, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 			simpleGauge.lock.RLock()
 			defer simpleGauge.lock.RUnlock()
@@ -152,7 +153,6 @@ func initGauges() error {
 		}
 	}
 
-	// Register the callbacks for the other gauges.
 	registerOtherGaugeCallbacks()
 
 	return nil

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -38,7 +38,7 @@ import (
 	For a gauge with labels:
    1. create a var int64
    2. create a rwlock
-   3. create meter.async.guage
+   3. create meter.async.gauge
    4. create SetXXX method for the gauge
    5. register a callback in registerOtherGaugeCallbacks()
 */
@@ -50,7 +50,7 @@ type sumcount struct {
 	labelval string
 }
 
-type simpleInt64Guage struct {
+type simpleInt64Gauge struct {
 	name        string
 	value       int64
 	unit        string
@@ -71,7 +71,7 @@ const (
 	TotalEventsMatched
 )
 
-var allSimpleGauges = map[Gauge]*simpleInt64Guage{
+var allSimpleGauges = map[Gauge]*simpleInt64Gauge{
 	TotalEventCount: {
 		name:        "ss.current.event.count",
 		unit:        "count",
@@ -129,16 +129,16 @@ func init() {
 func initGauges() error {
 	// Finish setting up each gauge.
 	for _, simpleGauge := range allSimpleGauges {
-		guage, err := meter.Int64ObservableGauge(
+		gauge, err := meter.Int64ObservableGauge(
 			simpleGauge.name,
 			metric.WithUnit(simpleGauge.unit),
 			metric.WithDescription(simpleGauge.description),
 		)
 		if err != nil {
-			return utils.TeeErrorf("initGuages: failed to create guage %s; err=%v", simpleGauge.name, err)
+			return utils.TeeErrorf("initGauges: failed to create gauge %s; err=%v", simpleGauge.name, err)
 		}
 
-		simpleGauge.gauge = guage
+		simpleGauge.gauge = gauge
 		simpleGauge.lock = &sync.RWMutex{}
 	}
 
@@ -153,7 +153,7 @@ func initGauges() error {
 			return nil
 		}, simpleGauge.gauge)
 		if err != nil {
-			return utils.TeeErrorf("initGuages: failed to register callback for guage %v; err=%v", simpleGauge.name, err)
+			return utils.TeeErrorf("initGauges: failed to register callback for gauge %v; err=%v", simpleGauge.name, err)
 		}
 	}
 

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -30,13 +30,17 @@ import (
 )
 
 /* Adding a new Gauge
+	For a gauge with no labels:
+	1. Create a new Gauge enum value
+	2. Add a new entry in allSimpleGauges map
+	3. Create a new setter method by calling makeGaugeSetter()
+
+	For a gauge with labels:
    1. create a var int64
    2. create a rwlock
    3. create meter.async.guage
    4. create SetXXX method for the gauge
-   5. register a callback.
-
-   // Anotated example below
+   5. register a callback in registerOtherGaugeCallbacks()
 */
 
 type sumcount struct {

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -115,6 +115,13 @@ var (
 	SetTotalEventsMatched          = makeGaugeSetter(TotalEventsMatched)
 )
 
+func init() {
+	err := initGauges()
+	if err != nil {
+		log.Fatalf("init: failed to initialize gauges; err=%v", err)
+	}
+}
+
 func initGauges() error {
 	// Finish setting up each gauge.
 	for key, simpleGauge := range allSimpleGauges {

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -99,7 +99,7 @@ func queryMetricsLooper() {
 	for {
 		time.Sleep(1 * time.Minute)
 		go func() {
-			instrumentation.SetSegmentMicroindexCountGauge(segmetadata.GetTotalSMICount())
+			instrumentation.SetGauge(instrumentation.TotalSegmentMicroindexCount, segmetadata.GetTotalSMICount())
 		}()
 	}
 }

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -99,7 +99,7 @@ func queryMetricsLooper() {
 	for {
 		time.Sleep(1 * time.Minute)
 		go func() {
-			instrumentation.SetGauge(instrumentation.TotalSegmentMicroindexCount, segmetadata.GetTotalSMICount())
+			instrumentation.SetTotalSegmentMicroindexCount(segmetadata.GetTotalSMICount())
 		}()
 	}
 }

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -524,8 +524,8 @@ func (qs *QuerySummary) LogSummaryAndEmitMetrics(qid uint64, pqid string, contai
 
 	if !containsKibana {
 		instrumentation.SetQueryLatencyMs(int64(qs.getQueryTotalTime()/1_000_000), "pqid", pqid)
-		instrumentation.SetGauge(instrumentation.TotalEventsSearched, int64(qs.getTotNumRecordsSearched()))
-		instrumentation.SetGauge(instrumentation.TotalEventsMatched, int64(qs.getTotNumRecordsMatched()))
+		instrumentation.SetTotalEventsSearched(int64(qs.getTotNumRecordsSearched()))
+		instrumentation.SetTotalEventsMatched(int64(qs.getTotNumRecordsMatched()))
 	}
 
 	if len(qs.allQuerySummaries[RAW].searchTimeHistory) <= 25 {

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -524,8 +524,8 @@ func (qs *QuerySummary) LogSummaryAndEmitMetrics(qid uint64, pqid string, contai
 
 	if !containsKibana {
 		instrumentation.SetQueryLatencyMs(int64(qs.getQueryTotalTime()/1_000_000), "pqid", pqid)
-		instrumentation.SetEventsSearchedGauge(int64(qs.getTotNumRecordsSearched()))
-		instrumentation.SetEventsMatchedGauge(int64(qs.getTotNumRecordsMatched()))
+		instrumentation.SetGauge(instrumentation.TotalEventsSearched, int64(qs.getTotNumRecordsSearched()))
+		instrumentation.SetGauge(instrumentation.TotalEventsMatched, int64(qs.getTotNumRecordsMatched()))
 	}
 
 	if len(qs.allQuerySummaries[RAW].searchTimeHistory) <= 25 {

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -774,7 +774,7 @@ func createSegStore(streamid string, table string, orgId uint64) (*SegStore, err
 	}
 
 	allSegStores[streamid] = segstore
-	instrumentation.SetWriterSegstoreCountGauge(int64(len(allSegStores)))
+	instrumentation.SetGauge(instrumentation.TotalSegstoreCount, int64(len(allSegStores)))
 
 	return segstore, nil
 }

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -774,7 +774,7 @@ func createSegStore(streamid string, table string, orgId uint64) (*SegStore, err
 	}
 
 	allSegStores[streamid] = segstore
-	instrumentation.SetGauge(instrumentation.TotalSegstoreCount, int64(len(allSegStores)))
+	instrumentation.SetTotalSegstoreCount(int64(len(allSegStores)))
 
 	return segstore, nil
 }


### PR DESCRIPTION
# Description
Refactors how we create gauges to reduce boilerplate code and make it easier to add a new gauge. I'll add more gauges in the next PR

# Testing
1. Start siglens
2. Run `curl localhost:2222/metrics` to see our metrics
3. Ingest data
4. Wait 1 minute (`ingestionMetricsLooper()` loops every minute)
5. Run `curl localhost:2222/metrics` again and see the updated values for our ingestion metrics

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
