### PR TITLE
Export metrics about metric ingestion

### DIFF
--- a/pkg/common/fileutils/fileutils.go
+++ b/pkg/common/fileutils/fileutils.go
@@ -209,3 +209,17 @@ func DoesFileExist(filePath string) bool {
 	_, err := os.Stat(filePath)
 	return err == nil
 }
+
+func GetDirSize(path string) (uint64, error) {
+	var size uint64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += uint64(info.Size())
+		}
+		return nil
+	})
+	return size, err
+}

--- a/pkg/common/fileutils/fileutils_test.go
+++ b/pkg/common/fileutils/fileutils_test.go
@@ -3,6 +3,7 @@ package fileutils
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,4 +90,40 @@ func Test_GetAllFilesWithSpecificExtensions(t *testing.T) {
 	}
 	assert.Equal(t, 4, len(retVal))
 	assert.ElementsMatch(t, expectedPaths, retVal)
+}
+
+func Test_GetDirSize_empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	size, err := GetDirSize(tmpDir)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), int64(size))
+}
+
+func Test_GetDirSize_nonExistent(t *testing.T) {
+	size, err := GetDirSize("non-existent")
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), int64(size))
+}
+
+func Test_GetDirSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1Size := 100
+	file2Size := 200
+	file3Size := 300
+	expectedSize := int64(file1Size + file2Size + file3Size)
+
+	rootFile := filepath.Join(tmpDir, "root.txt")
+	assert.NoError(t, os.WriteFile(rootFile, []byte(strings.Repeat("a", file1Size)), 0644))
+
+	nestedDir := filepath.Join(tmpDir, "nested")
+	assert.NoError(t, os.Mkdir(nestedDir, 0755))
+
+	file1 := filepath.Join(nestedDir, "file1.txt")
+	file2 := filepath.Join(nestedDir, "file2.txt")
+	assert.NoError(t, os.WriteFile(file1, []byte(strings.Repeat("b", file2Size)), 0644))
+	assert.NoError(t, os.WriteFile(file2, []byte(strings.Repeat("c", file3Size)), 0644))
+
+	size, err := GetDirSize(tmpDir)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSize, int64(size))
 }

--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -76,16 +76,34 @@ func metricsLooper() {
 		time.Sleep(1 * time.Minute)
 
 		setNumMetricNames()
+		setNumSeries()
 	}
 }
 
 func setNumMetricNames() {
-	allTime := &dtu.MetricsTimeRange{}
-	names, err := query.GetAllMetricNamesOverTheTimeRange(allTime, 0)
+	allPreviousTime := &dtu.MetricsTimeRange{
+		StartEpochSec: 0,
+		EndEpochSec:   uint32(time.Now().Unix()),
+	}
+	names, err := query.GetAllMetricNamesOverTheTimeRange(allPreviousTime, 0)
 	if err != nil {
 		log.Errorf("setNumMetricNames: failed to get all metric names: %v", err)
 		return
 	}
 
 	instrumentation.SetTotalMetricNames(int64(len(names)))
+}
+
+func setNumSeries() {
+	allPreviousTime := &dtu.MetricsTimeRange{
+		StartEpochSec: 0,
+		EndEpochSec:   uint32(time.Now().Unix()),
+	}
+	numSeries, err := query.GetSeriesCardinalityOverTimeRange(allPreviousTime, 0)
+	if err != nil {
+		log.Errorf("setNumSeries: failed to get all series: %v", err)
+		return
+	}
+
+	instrumentation.SetTotalTimeSeries(int64(numSeries))
 }

--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -65,6 +65,6 @@ func ingestionMetricsLooper() {
 
 		instrumentation.SetTotalEventCount(currentEventCount)
 		instrumentation.SetTotalBytesReceived(currentBytesReceived)
-		instrumentation.SetTotalOnDiskBytes(currentOnDiskBytes)
+		instrumentation.SetTotalLogOnDiskBytes(currentOnDiskBytes)
 	}
 }

--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -77,13 +77,17 @@ func ingestionMetricsLooper() {
 }
 
 func metricsLooper() {
+	oneMinuteTicker := time.NewTicker(1 * time.Minute)
+	fifteenMinuteTicker := time.NewTicker(15 * time.Minute)
 	for {
-		time.Sleep(1 * time.Minute)
-
-		setNumMetricNames()
-		setNumSeries()
-		setNumKeysAndValues()
-		setMetricOnDiskBytes()
+		select {
+		case <-oneMinuteTicker.C:
+			setNumMetricNames()
+			setMetricOnDiskBytes()
+		case <-fifteenMinuteTicker.C:
+			setNumSeries()
+			setNumKeysAndValues()
+		}
 	}
 }
 

--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -18,9 +18,12 @@
 package ingest
 
 import (
+	"path/filepath"
 	"time"
 
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
+	"github.com/siglens/siglens/pkg/common/fileutils"
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/instrumentation"
 	rutils "github.com/siglens/siglens/pkg/readerUtils"
 	"github.com/siglens/siglens/pkg/segment/query"
@@ -80,6 +83,7 @@ func metricsLooper() {
 		setNumMetricNames()
 		setNumSeries()
 		setNumKeysAndValues()
+		setMetricOnDiskBytes()
 	}
 }
 
@@ -140,4 +144,22 @@ func setNumKeysAndValues() {
 
 	instrumentation.SetTotalTagKeyCount(int64(len(keys)))
 	instrumentation.SetTotalTagValueCount(int64(len(values)))
+}
+
+func setMetricOnDiskBytes() {
+	tagsTreeHolderDir := filepath.Join(config.GetDataPath(), config.GetHostID(), "final", "tth")
+	tagsTreeHolderSize, err := fileutils.GetDirSize(tagsTreeHolderDir)
+	if err != nil {
+		log.Errorf("setMetricOnDiskBytes: failed to get tags tree holder size: %v", err)
+		return
+	}
+
+	timeSeriesDir := filepath.Join(config.GetDataPath(), config.GetHostID(), "final", "ts")
+	timeSeriesSize, err := fileutils.GetDirSize(timeSeriesDir)
+	if err != nil {
+		log.Errorf("setMetricOnDiskBytes: failed to get time series size: %v", err)
+		return
+	}
+
+	instrumentation.SetTotalMetricOnDiskBytes(int64(tagsTreeHolderSize + timeSeriesSize))
 }

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -79,22 +79,22 @@ const (
 
 var allSimpleGauges = map[Gauge]*simpleInt64Gauge{
 	TotalEventCount: {
-		name:        "ss.current.event.count",
+		name:        "ss.total.event.count",
 		unit:        "count",
-		description: "Current total number of events",
+		description: "Total number of events",
 	},
 	TotalBytesReceived: {
-		name:        "ss.current.bytes.received",
+		name:        "ss.total.bytes.received",
 		unit:        "bytes",
-		description: "Current count of bytes received",
+		description: "Total number of bytes received",
 	},
 	TotalLogOnDiskBytes: {
-		name:        "ss.current.on.disk.bytes",
+		name:        "ss.total.logs.on.disk.bytes",
 		unit:        "bytes",
-		description: "Current number of bytes on disk",
+		description: "Total number of bytes on disk for log data",
 	},
 	TotalMetricOnDiskBytes: {
-		name:        "ss.total.metric.on.disk.bytes",
+		name:        "ss.total.metrics.on.disk.bytes",
 		unit:        "bytes",
 		description: "Total number of metric bytes on disk",
 	},

--- a/pkg/instrumentation/ssgauges.go
+++ b/pkg/instrumentation/ssgauges.go
@@ -64,11 +64,17 @@ type Gauge int
 const (
 	TotalEventCount Gauge = iota + 1
 	TotalBytesReceived
-	TotalOnDiskBytes
+	TotalLogOnDiskBytes
+	TotalMetricOnDiskBytes
 	TotalSegstoreCount
 	TotalSegmentMicroindexCount
 	TotalEventsSearched
 	TotalEventsMatched
+	TotalMetricNames
+	TotalTimeSeries
+	PastMinuteNumDataPoints
+	TotalTagKeyCount
+	TotalTagValueCount
 )
 
 var allSimpleGauges = map[Gauge]*simpleInt64Gauge{
@@ -82,10 +88,15 @@ var allSimpleGauges = map[Gauge]*simpleInt64Gauge{
 		unit:        "bytes",
 		description: "Current count of bytes received",
 	},
-	TotalOnDiskBytes: {
+	TotalLogOnDiskBytes: {
 		name:        "ss.current.on.disk.bytes",
 		unit:        "bytes",
 		description: "Current number of bytes on disk",
+	},
+	TotalMetricOnDiskBytes: {
+		name:        "ss.total.metric.on.disk.bytes",
+		unit:        "bytes",
+		description: "Total number of metric bytes on disk",
 	},
 	TotalSegstoreCount: {
 		name:        "ss.current.segstore.count",
@@ -107,16 +118,47 @@ var allSimpleGauges = map[Gauge]*simpleInt64Gauge{
 		unit:        "count",
 		description: "Current number of events matched",
 	},
+	TotalMetricNames: {
+		name:        "ss.total.metric.names",
+		unit:        "count",
+		description: "Total number of metric names",
+	},
+	TotalTimeSeries: {
+		name:        "ss.total.time.series",
+		unit:        "count",
+		description: "Total number of time series",
+	},
+	PastMinuteNumDataPoints: {
+		name:        "ss.past.minute.num.data.points",
+		unit:        "count",
+		description: "Number of metric data points ingested in the past minute",
+	},
+	TotalTagKeyCount: {
+		name:        "ss.total.tag.key.count",
+		unit:        "count",
+		description: "Total number of tag keys",
+	},
+	TotalTagValueCount: {
+		name:        "ss.total.tag.value.count",
+		unit:        "count",
+		description: "Total number of tag values",
+	},
 }
 
 var (
 	SetTotalEventCount             = makeGaugeSetter(TotalEventCount)
 	SetTotalBytesReceived          = makeGaugeSetter(TotalBytesReceived)
-	SetTotalOnDiskBytes            = makeGaugeSetter(TotalOnDiskBytes)
+	SetTotalLogOnDiskBytes         = makeGaugeSetter(TotalLogOnDiskBytes)
+	SetTotalMetricOnDiskBytes      = makeGaugeSetter(TotalMetricOnDiskBytes)
 	SetTotalSegstoreCount          = makeGaugeSetter(TotalSegstoreCount)
 	SetTotalSegmentMicroindexCount = makeGaugeSetter(TotalSegmentMicroindexCount)
 	SetTotalEventsSearched         = makeGaugeSetter(TotalEventsSearched)
 	SetTotalEventsMatched          = makeGaugeSetter(TotalEventsMatched)
+	SetTotalMetricNames            = makeGaugeSetter(TotalMetricNames)
+	SetTotalTimeSeries             = makeGaugeSetter(TotalTimeSeries)
+	SetPastMinuteNumDataPoints     = makeGaugeSetter(PastMinuteNumDataPoints)
+	SetTotalTagKeyCount            = makeGaugeSetter(TotalTagKeyCount)
+	SetTotalTagValueCount          = makeGaugeSetter(TotalTagValueCount)
 )
 
 func init() {

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -356,7 +356,7 @@ func getBaseMetricsKey(suffix uint64, mId string) (string, error) {
 /*
 Returns <<dataDir>>/<<hostname>>/final/<<mid>>/suffix
 */
-func getFinalMetricsDir(mId string, suffix uint64) string {
+func GetFinalMetricsDir(mId string, suffix uint64) string {
 	// TODO: use filepath.Join
 	var sb strings.Builder
 	sb.WriteString(config.GetRunningConfig().DataPath)
@@ -1124,7 +1124,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		log.Errorf("rotateSegment: failed to flush metric names for base=%s, suffix=%d, orgid=%v. Error %+v", ms.metricsKeyBase, ms.Suffix, ms.Orgid, err)
 		return err
 	}
-	finalDir := getFinalMetricsDir(ms.Mid, ms.Suffix)
+	finalDir := GetFinalMetricsDir(ms.Mid, ms.Suffix)
 	metaEntry := ms.getMetaEntry(finalDir, ms.Suffix)
 	err = os.MkdirAll(path.Dir(path.Dir(finalDir)), 0764)
 	if err != nil {

--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
+	"github.com/siglens/siglens/pkg/instrumentation"
 	. "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -328,6 +329,8 @@ func logStatSummary(orgid uint64) {
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalLogLinesCount),
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalMetricsDatapointsCount),
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalBytesCount))
+
+		instrumentation.SetPastMinuteNumDataPoints(int64(ustats[orgid].MetricsDatapointsCount))
 	}
 }
 

--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -329,10 +329,6 @@ func logStatSummary(orgid uint64) {
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalLogLinesCount),
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalMetricsDatapointsCount),
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalBytesCount))
-
-		instrumentation.SetTotalLogOnDiskBytes(int64(ustats[orgid].LogsBytesCount))
-		instrumentation.SetPastMinuteNumDataPoints(int64(ustats[orgid].MetricsDatapointsCount))
-		instrumentation.SetTotalMetricOnDiskBytes(int64(ustats[orgid].MetricsBytesCount))
 	}
 }
 
@@ -365,6 +361,8 @@ func FlushStatsToFile(orgid uint64) error {
 
 	if _, ok := ustats[orgid]; ok {
 		logStatSummary(orgid)
+		instrumentation.SetPastMinuteNumDataPoints(int64(ustats[orgid].MetricsDatapointsCount))
+
 		if ustats[orgid].BytesCount > 0 {
 			filename := getStatsFilename(GetBaseStatsDir(orgid))
 			fd, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)

--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -330,7 +330,9 @@ func logStatSummary(orgid uint64) {
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalMetricsDatapointsCount),
 			msgPrinter.Sprintf("%v", ustats[orgid].TotalBytesCount))
 
+		instrumentation.SetTotalLogOnDiskBytes(int64(ustats[orgid].LogsBytesCount))
 		instrumentation.SetPastMinuteNumDataPoints(int64(ustats[orgid].MetricsDatapointsCount))
+		instrumentation.SetTotalMetricOnDiskBytes(int64(ustats[orgid].MetricsBytesCount))
 	}
 }
 


### PR DESCRIPTION
# Description
This adds a gauge for each of the following; the gauges are updated each minute.
- Export number of metric names
- Export metric for number of time series
- Number of datapoints per minute
- Number of tag keys (across all metric names)
- Number of tag values 
- Number of bytes on disk for metric data

# Testing
Ingested some data with `go run main.go ingest metrics -d http://localhost:8081/otsdb -t 25_000  -m 5 -p 1` and manually  check the output metrics using `curl localhost:2222/metrics`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
