### PR TITLE
Metrics Explorer UI Fix

### DIFF
--- a/static/alert.html
+++ b/static/alert.html
@@ -90,7 +90,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
 
         <div id="alerting">
-            <div class="dashboard-names mb-2">
+            <div class="d-flex align-items-center gap-2 mb-2">
                 <h4 class="all-dashboards" id="all-alerts-text">All Alerts</h4>
                 <span class="dashboard-arrow"></span>
                 <h3 class="name-dashboard" id="alert-name">New Alert</h3>

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -138,7 +138,7 @@ input:checked + .slider:before {
 }
 .metrics-query .query-box{
     align-items: flex-start;
-    width: 100%;
+    width: calc(100% - 195px);
     padding: 0px;
 }
 .metrics-query .query-box .query-builder{

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2104,7 +2104,7 @@ div.dts div.dataTables_scrollBody table {
     color: var(--text-color);
     font-size: 1em;
     height: fit-content;
-    width: 464px !important;
+    width: 436px !important;
     z-index: 10;
 }
 .delete-dialog{
@@ -2129,7 +2129,7 @@ div.dts div.dataTables_scrollBody table {
 
 .popupContent .header,.delete-dialog .header ,.mypopupContent .header{
   color: var(--text-color);
-  margin-bottom: 25px;
+  margin-bottom: 16px;
   font-weight: bold;
   font-size: 18px;
 }
@@ -2469,7 +2469,7 @@ input[type="text"].active {
 
 .saveqButton,
 .cancelqButton {
-    width: 195px !important;
+    width: 183px !important;
     height: 32px !important;
     border-radius: 5px;
     border: none;

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -289,6 +289,7 @@ async function editAlert(alertId) {
         crossDomain: true,
     });
     if (window.location.href.includes('alert-details.html')) {
+        $('.alert-name').empty().text(res.alert.alert_name);
         fetchAlertProperties(res);
         fetchAlertHistory();
         return false;
@@ -542,9 +543,9 @@ async function displayAlert(res) {
     $(`.alert-condition-options #option-${res.condition}`).addClass('active');
 
     $('#alert-condition span').text(conditionType);
-    $('#threshold-value').val(res.value);
-    $('#evaluate-every').val(res.eval_interval);
-    $('#evaluate-for').val(res.eval_for);
+    $('#threshold-value').val(res.value || 0);
+    $('#evaluate-every').val(res.eval_interval || 1);
+    $('#evaluate-for').val(res.eval_for || 1);
     $('.message').val(res.message);
 
     if (alertEditFlag && !alertFromMetricsExplorerFlag) {

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -937,9 +937,11 @@ function setIndexDisplayValue(selectedSearchIndex) {
         selectedIndexes.forEach(function (index) {
             addSelectedIndex(index);
             // Remove the selectedSearchIndex from indexValues
-            const indexIndex = indexValues.indexOf(index);
-            if (indexIndex !== -1) {
-                indexValues.splice(indexIndex, 1);
+            if(indexValues && indexValues.length > 0){
+                const indexIndex = indexValues.indexOf(index);
+                if (indexIndex !== -1) {
+                    indexValues.splice(indexIndex, 1);
+                }
             }
         });
     }

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -927,10 +927,6 @@ async function initializeAutocomplete(queryElement, previousQuery = {}) {
         .autocomplete({
             source: availableMetrics.sort(),
             minLength: 0,
-            focus: function (event, ui) {
-                $(this).val(ui.item.value);
-                return false;
-            },
             select: async function (event, ui) {
                 queryDetails.metrics = ui.item.value;
                 getQueryDetails(queryName, queryDetails);


### PR DESCRIPTION
# Description
1. Resolved the issue on the Metrics Explorer screen where opening the function dropdown caused the window to slide when the query was large.
2. Fixed the bug where hovering over a metric name and clicking outside would change the metric name but not update the data.
3. Corrected the issue where the alert name was not displaying in the Alert Details and Edit screens.

Screenshots of the issues - 
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/1c518c5f-48bc-4787-8b91-b2b4b4d65fbd" />
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/bc8e2f9a-0dd6-448b-94d4-f2acfbd06912" />
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/3d435e9f-5754-40a5-a329-d29314ea7c01" />



Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
