### PR TITLE
Fix: Reset segment search memory to Initial Allocated Value during rebalance

### DIFF
--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -33,7 +33,7 @@ import (
 
 const MINUTES_UPDATE_METADATA_MEM_ALLOC = 1
 
-var AllocatedSegSearchBytes uint64 // Should not be changed after initialization
+var SegSearchAllocatedBytes uint64 // Should not be changed after initialization
 
 var LOG_GLOBAL_MEM_FREQUENCY = 5
 
@@ -43,7 +43,7 @@ func InitMemoryLimiter() {
 
 	memLimits := config.GetMemoryConfig()
 
-	AllocatedSegSearchBytes = uint64(float64(totalAvailableSizeBytes*memLimits.SearchPercent) / 100)
+	SegSearchAllocatedBytes = uint64(float64(totalAvailableSizeBytes*memLimits.SearchPercent) / 100)
 	rotatedCMIBytes := uint64(float64(totalAvailableSizeBytes*memLimits.CMIPercent) / 100)
 	metricsInMemory := uint64(float64(totalAvailableSizeBytes*memLimits.MetricsPercent) / 100)
 
@@ -54,7 +54,7 @@ func InitMemoryLimiter() {
 	memory.GlobalMemoryTracker = &structs.MemoryTracker{
 		TotalAllocatableBytes:   totalAvailableSizeBytes,
 		RotatedCMIBytesInMemory: rotatedCMIBytes,
-		SegSearchRequestedBytes: AllocatedSegSearchBytes,
+		SegSearchRequestedBytes: SegSearchAllocatedBytes,
 		MetricsSegmentMaxSize:   metricsInMemory,
 
 		SegWriterUsageBytes: 0,
@@ -135,9 +135,9 @@ func rebalanceMemoryAllocation() {
 	totalSsmMemory := uint64(float64(memoryAvailable*memLimits.MetadataPercent) / 100)
 	segmetadata.RebalanceInMemorySsm(totalSsmMemory)
 
-	if memory.GlobalMemoryTracker.SegSearchRequestedBytes < AllocatedSegSearchBytes {
+	if memory.GlobalMemoryTracker.SegSearchRequestedBytes < SegSearchAllocatedBytes {
 		// reset the allocatedSegSearchBytes as we may have freed up memory
-		atomic.StoreUint64(&memory.GlobalMemoryTracker.SegSearchRequestedBytes, AllocatedSegSearchBytes)
+		atomic.StoreUint64(&memory.GlobalMemoryTracker.SegSearchRequestedBytes, SegSearchAllocatedBytes)
 	}
 
 	if memory.GlobalMemoryTracker.SegSearchRequestedBytes > memoryAvailable {

--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -33,6 +33,8 @@ import (
 
 const MINUTES_UPDATE_METADATA_MEM_ALLOC = 1
 
+var AllocatedSegSearchBytes uint64 // Should not be changed after initialization
+
 var LOG_GLOBAL_MEM_FREQUENCY = 5
 
 func InitMemoryLimiter() {
@@ -41,7 +43,7 @@ func InitMemoryLimiter() {
 
 	memLimits := config.GetMemoryConfig()
 
-	segSearchBytes := uint64(float64(totalAvailableSizeBytes*memLimits.SearchPercent) / 100)
+	AllocatedSegSearchBytes = uint64(float64(totalAvailableSizeBytes*memLimits.SearchPercent) / 100)
 	rotatedCMIBytes := uint64(float64(totalAvailableSizeBytes*memLimits.CMIPercent) / 100)
 	metricsInMemory := uint64(float64(totalAvailableSizeBytes*memLimits.MetricsPercent) / 100)
 
@@ -52,7 +54,7 @@ func InitMemoryLimiter() {
 	memory.GlobalMemoryTracker = &structs.MemoryTracker{
 		TotalAllocatableBytes:   totalAvailableSizeBytes,
 		RotatedCMIBytesInMemory: rotatedCMIBytes,
-		SegSearchRequestedBytes: segSearchBytes,
+		SegSearchRequestedBytes: AllocatedSegSearchBytes,
 		MetricsSegmentMaxSize:   metricsInMemory,
 
 		SegWriterUsageBytes: 0,
@@ -132,6 +134,11 @@ func rebalanceMemoryAllocation() {
 	memLimits := config.GetMemoryConfig()
 	totalSsmMemory := uint64(float64(memoryAvailable*memLimits.MetadataPercent) / 100)
 	segmetadata.RebalanceInMemorySsm(totalSsmMemory)
+
+	if memory.GlobalMemoryTracker.SegSearchRequestedBytes < AllocatedSegSearchBytes {
+		// reset the allocatedSegSearchBytes as we may have freed up memory
+		atomic.StoreUint64(&memory.GlobalMemoryTracker.SegSearchRequestedBytes, AllocatedSegSearchBytes)
+	}
 
 	if memory.GlobalMemoryTracker.SegSearchRequestedBytes > memoryAvailable {
 		memoryAvailable = 0


### PR DESCRIPTION
# Description
- Resets the segment search bytes value to the initial allocated search bytes during rebalance. 
- While rebalancing the memory assigned to segment search can be lower than the initial assignment and it needs to be reset to the initial value in the next rebalancing.

# Testing
- Tested by running siglens on a docker container with `2GB` of ram.
- Set the memory threshold to `10%` and ran logs and metrics ingestion.
- Quickly the allocated memory for search became `0` and through logs I have verified it is being reset and may become `0` again depending on the ingestion or writer memory.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
