### PR TITLE
fix: Allocate remaining memory to SegSearch during rebalance

### DIFF
--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -141,8 +141,8 @@ func rebalanceMemoryAllocation() {
 	}
 
 	if memory.GlobalMemoryTracker.SegSearchRequestedBytes > memoryAvailable {
-		memoryAvailable = 0
 		memory.GlobalMemoryTracker.SegSearchRequestedBytes = memoryAvailable
+		memoryAvailable = 0
 	} else {
 		memoryAvailable = memoryAvailable - memory.GlobalMemoryTracker.SegSearchRequestedBytes
 	}


### PR DESCRIPTION
# Description
- Allocated available memory to `segsearch` and then make available memory to `0`.


# Testing

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
