### PR TITLE
Fix: Calculation of In Memory Metrics size

### DIFF
--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -89,10 +89,10 @@ func printMemoryManagerSummary() {
 		memory.GlobalMemoryTracker.SegStoreSummary.InMemoryMetricsBSumSizeMB)
 
 	metricsSizeInfo := metrics.GetMetricsEncodedSizeInfo()
-	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSizeInBytes(AllBlock): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB, InMemoryMSegEncSize + TotalTagsTreeSize: %.4f MB",
+	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSize(AllBlocks): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB, InMemoryMSegEncSize + TotalTagsTreeSize: %.4f MB",
 		metricsSizeInfo.TotalTagTreesCount, metricsSizeInfo.TotalLeafNodesCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalTagsTreeSizeInBytes)),
 		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegmentsEncodedSizeInBytes)),
-		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes)), utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes+metricsSizeInfo.TotalTagsTreeSizeInBytes)))
+		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegBlocksEncodedSizeInBytes)), utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegBlocksEncodedSizeInBytes+metricsSizeInfo.TotalTagsTreeSizeInBytes)))
 
 	log.Infof("GlobalMemoryTracker: Unrotated metadata has %v total segKeys. %+v have loaded metadata in memory. This accounts for %v MB",
 		totalUnrotated, numLoadedUnrotated, utils.ConvertUintBytesToMB(unrotaedSize))

--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -89,9 +89,10 @@ func printMemoryManagerSummary() {
 		memory.GlobalMemoryTracker.SegStoreSummary.InMemoryMetricsBSumSizeMB)
 
 	metricsSizeInfo := metrics.GetMetricsEncodedSizeInfo()
-	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalEncodedSize: %.4f MB",
+	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSizeInBytes(AllBlock): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB",
 		metricsSizeInfo.TotalTagTreesCount, metricsSizeInfo.TotalLeafNodesCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalTagsTreeSizeInBytes)),
-		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegmentsEncodedSizeInBytes)))
+		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegmentsEncodedSizeInBytes)),
+		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes)))
 
 	log.Infof("GlobalMemoryTracker: Unrotated metadata has %v total segKeys. %+v have loaded metadata in memory. This accounts for %v MB",
 		totalUnrotated, numLoadedUnrotated, utils.ConvertUintBytesToMB(unrotaedSize))

--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -89,10 +89,10 @@ func printMemoryManagerSummary() {
 		memory.GlobalMemoryTracker.SegStoreSummary.InMemoryMetricsBSumSizeMB)
 
 	metricsSizeInfo := metrics.GetMetricsEncodedSizeInfo()
-	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSizeInBytes(AllBlock): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB",
+	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSizeInBytes(AllBlock): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB, InMemoryMSegEncSize + TotalTagsTreeSize: %.4f MB",
 		metricsSizeInfo.TotalTagTreesCount, metricsSizeInfo.TotalLeafNodesCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalTagsTreeSizeInBytes)),
 		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegmentsEncodedSizeInBytes)),
-		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes)))
+		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes)), utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalInMemoryMSegEncodedSizeInBytes+metricsSizeInfo.TotalTagsTreeSizeInBytes)))
 
 	log.Infof("GlobalMemoryTracker: Unrotated metadata has %v total segKeys. %+v have loaded metadata in memory. This accounts for %v MB",
 		totalUnrotated, numLoadedUnrotated, utils.ConvertUintBytesToMB(unrotaedSize))

--- a/pkg/segment/memory/limit/memorylimit.go
+++ b/pkg/segment/memory/limit/memorylimit.go
@@ -91,7 +91,7 @@ func printMemoryManagerSummary() {
 	metricsSizeInfo := metrics.GetMetricsEncodedSizeInfo()
 	log.Infof("GlobalMemoryTracker: MetricsEncodedSizeInfo: TotalTagTrees: %d, TotalLeafNodes: %d, TotalTagsTreeSize: %.4f MB. TotalSeriesCount: %d, TotalTSIDs: %d, TotalTSIDLookup (reverse Index): %d, TotalMSegmentsEncodedSize(AllBlocks): %.4f MB, TotalInMemoryMSegEncodedSize: %.4f MB, InMemoryMSegEncSize + TotalTagsTreeSize: %.4f MB",
 		metricsSizeInfo.TotalTagTreesCount, metricsSizeInfo.TotalLeafNodesCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalTagsTreeSizeInBytes)),
-		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegmentsEncodedSizeInBytes)),
+		metricsSizeInfo.TotalSeriesCount, metricsSizeInfo.TotalSortedTSIDCount, metricsSizeInfo.TotalTSIDLookupCount, utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalAllMSegmentsEncodedSizeInBytes)),
 		utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegBlocksEncodedSizeInBytes)), utils.ConvertFloatBytesToMB(float64(metricsSizeInfo.TotalMSegBlocksEncodedSizeInBytes+metricsSizeInfo.TotalTagsTreeSizeInBytes)))
 
 	log.Infof("GlobalMemoryTracker: Unrotated metadata has %v total segKeys. %+v have loaded metadata in memory. This accounts for %v MB",

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -88,18 +88,18 @@ var totalTagsTreeSizeInBytes uint64
 var totalSeriesCount int
 var totalSortedTSIDCount int
 var totalTSIDLookupCount int
-var totalAllMSegmentsEncodedSizeInBytes uint64
-var totalMSegBlocksEncodedSizeInBytes uint64
+var totalAllMSegmentsEncodedSizeInBytes uint64 // Size of all blocks in all metrics segments including the blocks that are rotated
+var totalMSegBlocksEncodedSizeInBytes uint64   // Size of blocks in all metrics segments that are in memory. Unrotated blocks
 
 type MetricsEncodedSizeInfo struct {
-	TotalTagTreesCount                int
-	TotalLeafNodesCount               int
-	TotalTagsTreeSizeInBytes          uint64
-	TotalSeriesCount                  int
-	TotalSortedTSIDCount              int
-	TotalTSIDLookupCount              int
-	TotalMSegmentsEncodedSizeInBytes  uint64
-	TotalMSegBlocksEncodedSizeInBytes uint64
+	TotalTagTreesCount                  int
+	TotalLeafNodesCount                 int
+	TotalTagsTreeSizeInBytes            uint64
+	TotalSeriesCount                    int
+	TotalSortedTSIDCount                int
+	TotalTSIDLookupCount                int
+	TotalAllMSegmentsEncodedSizeInBytes uint64
+	TotalMSegBlocksEncodedSizeInBytes   uint64
 }
 
 /*
@@ -1464,14 +1464,14 @@ func GetUniqueTagKeysForUnrotated(tRange *dtu.MetricsTimeRange, myid uint64) (ma
 
 func GetMetricsEncodedSizeInfo() *MetricsEncodedSizeInfo {
 	return &MetricsEncodedSizeInfo{
-		TotalMSegmentsEncodedSizeInBytes:  totalAllMSegmentsEncodedSizeInBytes,
-		TotalMSegBlocksEncodedSizeInBytes: totalMSegBlocksEncodedSizeInBytes,
-		TotalTagsTreeSizeInBytes:          totalTagsTreeSizeInBytes,
-		TotalTagTreesCount:                totalTagTreesCount,
-		TotalLeafNodesCount:               totalLeafNodesCount,
-		TotalSeriesCount:                  totalSeriesCount,
-		TotalSortedTSIDCount:              totalSortedTSIDCount,
-		TotalTSIDLookupCount:              totalTSIDLookupCount,
+		TotalAllMSegmentsEncodedSizeInBytes: totalAllMSegmentsEncodedSizeInBytes,
+		TotalMSegBlocksEncodedSizeInBytes:   totalMSegBlocksEncodedSizeInBytes,
+		TotalTagsTreeSizeInBytes:            totalTagsTreeSizeInBytes,
+		TotalTagTreesCount:                  totalTagTreesCount,
+		TotalLeafNodesCount:                 totalLeafNodesCount,
+		TotalSeriesCount:                    totalSeriesCount,
+		TotalSortedTSIDCount:                totalSortedTSIDCount,
+		TotalTSIDLookupCount:                totalTSIDLookupCount,
 	}
 }
 

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -88,16 +88,18 @@ var totalTagsTreeSizeInBytes uint64
 var totalSeriesCount int
 var totalSortedTSIDCount int
 var totalTSIDLookupCount int
-var totalMSegmentsEncodedSizeInBytes uint64
+var totalAllMSegmentsEncodedSizeInBytes uint64
+var totalInMemoryMSegEncodedSizeInBytes uint64
 
 type MetricsEncodedSizeInfo struct {
-	TotalTagTreesCount               int
-	TotalLeafNodesCount              int
-	TotalTagsTreeSizeInBytes         uint64
-	TotalSeriesCount                 int
-	TotalSortedTSIDCount             int
-	TotalTSIDLookupCount             int
-	TotalMSegmentsEncodedSizeInBytes uint64
+	TotalTagTreesCount                  int
+	TotalLeafNodesCount                 int
+	TotalTagsTreeSizeInBytes            uint64
+	TotalSeriesCount                    int
+	TotalSortedTSIDCount                int
+	TotalTSIDLookupCount                int
+	TotalMSegmentsEncodedSizeInBytes    uint64
+	TotalInMemoryMSegEncodedSizeInBytes uint64
 }
 
 /*
@@ -115,20 +117,20 @@ A metrics segment generate the following set of files:
 TODO: this metrics segment should reject samples not in 2hr window
 */
 type MetricsSegment struct {
-	metricsKeyBase   string             // base string of this metric segment's key
-	Suffix           uint64             // current suffix
-	Mid              string             // metrics id for this metric segment
-	highTS           uint32             // highest epoch timestamp seen across this segment
-	lowTS            uint32             // lowest epoch timestamp seen across this segment
-	mBlock           *MetricsBlock      // current in memory block
-	currBlockNum     uint16             // current block number
-	mNamesBloom      *bloom.BloomFilter // all metric names bloom across segment
-	mNamesMap        map[string]bool    // all metric names seen across segment
-	totalEncodedSize uint64             // total size of all metric blocks. TODO: this should include tagsTree & mNames blooms
-	bytesReceived    uint64             // total size of incoming data
-	rwLock           *sync.RWMutex      // read write lock for access
-	datapointCount   uint64             // total number of datapoints across all series in the block
-	Orgid            uint64
+	metricsKeyBase string             // base string of this metric segment's key
+	Suffix         uint64             // current suffix
+	Mid            string             // metrics id for this metric segment
+	highTS         uint32             // highest epoch timestamp seen across this segment
+	lowTS          uint32             // lowest epoch timestamp seen across this segment
+	mBlock         *MetricsBlock      // current in memory block
+	currBlockNum   uint16             // current block number
+	mNamesBloom    *bloom.BloomFilter // all metric names bloom across segment
+	mNamesMap      map[string]bool    // all metric names seen across segment
+	mSegEncodeSize uint64             // total size of all metric blocks. TODO: this should include tagsTree & mNames blooms
+	bytesReceived  uint64             // total size of incoming data
+	rwLock         *sync.RWMutex      // read write lock for access
+	datapointCount uint64             // total number of datapoints across all series in the block
+	Orgid          uint64
 }
 
 /*
@@ -141,11 +143,11 @@ Every 5s, this metrics buffer should persist to disk and will create / update tw
  2. TSID offset file. Format [tsid][soff]
 */
 type MetricsBlock struct {
-	tsidLookup    map[uint64]int
-	allSeries     []*TimeSeries
-	sortedTsids   []uint64
-	mBlockSummary *structs.MBlockSummary
-	encodedSize   uint64 // total encoded size of the block
+	tsidLookup     map[uint64]int
+	allSeries      []*TimeSeries
+	sortedTsids    []uint64
+	mBlockSummary  *structs.MBlockSummary
+	blkEncodedSize uint64 // total encoded size of the block
 }
 
 // Represents a single timeseries
@@ -246,7 +248,7 @@ func GetUnrotatedMetricStats(orgid uint64) (uint64, uint64, uint64) {
 
 	for _, m := range orgMetrics {
 		totalIncoming += m.bytesReceived
-		totalOnDisk += m.totalEncodedSize
+		totalOnDisk += m.mSegEncodeSize
 		totalDPS += m.datapointCount
 	}
 	return totalIncoming, totalOnDisk, totalDPS
@@ -270,7 +272,7 @@ func timeBasedRotate() {
 	for {
 		time.Sleep(METRICS_BLK_ROTATE_SLEEP_DURATION * time.Second)
 		for _, ms := range GetAllMetricsSegments() {
-			encSize := atomic.LoadUint64(&ms.mBlock.encodedSize)
+			encSize := atomic.LoadUint64(&ms.mBlock.blkEncodedSize)
 			if encSize > utils.MAX_BYTES_METRICS_BLOCK {
 				ms.rwLock.Lock()
 				err := ms.CheckAndRotate(false)
@@ -289,7 +291,7 @@ func timeBasedMetricsFlush() {
 		time.Sleep(METRICS_BLK_FLUSH_SLEEP_DURATION * time.Second)
 		for _, ms := range GetAllMetricsSegments() {
 
-			encSize := atomic.LoadUint64(&ms.mBlock.encodedSize)
+			encSize := atomic.LoadUint64(&ms.mBlock.blkEncodedSize)
 			if encSize > 0 {
 				ms.rwLock.Lock()
 				err := ms.mBlock.rotateBlock(ms.metricsKeyBase, ms.Suffix, ms.currBlockNum)
@@ -345,16 +347,16 @@ func InitMetricsSegment(orgid uint64, mId string) (*MetricsSegment, error) {
 				HighTs: 0,
 				LowTs:  math.MaxInt32,
 			},
-			encodedSize: 0,
+			blkEncodedSize: 0,
 		},
-		rwLock:           &sync.RWMutex{},
-		metricsKeyBase:   mKey,
-		Suffix:           suffix,
-		Mid:              mId,
-		totalEncodedSize: 0,
-		highTS:           0,
-		lowTS:            math.MaxUint32,
-		Orgid:            orgid,
+		rwLock:         &sync.RWMutex{},
+		metricsKeyBase: mKey,
+		Suffix:         suffix,
+		Mid:            mId,
+		mSegEncodeSize: 0,
+		highTS:         0,
+		lowTS:          math.MaxUint32,
+		Orgid:          orgid,
 	}, nil
 }
 
@@ -518,8 +520,8 @@ func EncodeDatapoint(mName []byte, tags *TagsHolder, dp float64, timestamp uint3
 
 	mSeg.updateTimeRange(timestamp)
 	mSeg.mBlock.mBlockSummary.UpdateTimeRange(timestamp)
-	atomic.AddUint64(&mSeg.mBlock.encodedSize, bytesWritten)
-	atomic.AddUint64(&mSeg.totalEncodedSize, bytesWritten)
+	atomic.AddUint64(&mSeg.mBlock.blkEncodedSize, bytesWritten)
+	atomic.AddUint64(&mSeg.mSegEncodeSize, bytesWritten)
 	atomic.AddUint64(&mSeg.bytesReceived, nBytes)
 	atomic.AddUint64(&mSeg.datapointCount, 1)
 
@@ -948,7 +950,7 @@ Caller is responsible for acquiring locks
 */
 func (ms *MetricsSegment) CheckAndRotate(forceRotate bool) error {
 
-	encSize := atomic.LoadUint64(&ms.mBlock.encodedSize)
+	encSize := atomic.LoadUint64(&ms.mBlock.blkEncodedSize)
 	if encSize > utils.MAX_BYTES_METRICS_BLOCK || (encSize > 0 && forceRotate) {
 		err := ms.mBlock.rotateBlock(ms.metricsKeyBase, ms.Suffix, ms.currBlockNum)
 		if err != nil {
@@ -961,7 +963,7 @@ func (ms *MetricsSegment) CheckAndRotate(forceRotate bool) error {
 		}
 	}
 
-	totalEncSize := atomic.LoadUint64(&ms.totalEncodedSize)
+	totalEncSize := atomic.LoadUint64(&ms.mSegEncodeSize)
 	if totalEncSize > utils.MAX_BYTES_METRICS_SEGMENT || (totalEncSize > 0 && forceRotate) {
 		err := ms.rotateSegment(forceRotate)
 		if err != nil {
@@ -1119,7 +1121,7 @@ func (mb *MetricsBlock) rotateBlock(basePath string, suffix uint64, bufId uint16
 	// we can't do mb.allSeries = mb.allSeries[:0], as the other entries of the slice won't be GC'ed
 	newSeries := make([]*TimeSeries, 0, len(mb.allSeries))
 	mb.allSeries = newSeries
-	mb.encodedSize = 0
+	mb.blkEncodedSize = 0
 	mb.sortedTsids = make([]uint64, 0)
 	mb.mBlockSummary.Blknum++
 	mb.mBlockSummary.HighTs = 0
@@ -1158,7 +1160,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		return err
 	}
 
-	log.Infof("rotating segment of size %v that created %v metrics blocks to %+v", ms.totalEncodedSize, ms.currBlockNum+1, finalDir)
+	log.Infof("rotating segment of size %v that created %v metrics blocks to %+v", ms.mSegEncodeSize, ms.currBlockNum+1, finalDir)
 	if !forceRotate {
 		nextSuffix, err := suffix.GetNextSuffix(ms.Mid, "ts")
 		if err != nil {
@@ -1181,7 +1183,7 @@ func (ms *MetricsSegment) rotateSegment(forceRotate bool) error {
 		ms.lowTS = math.MaxUint32
 		ms.currBlockNum = 0
 		ms.mNamesBloom = bloom.NewWithEstimates(mNamesCount, 0.001)
-		ms.totalEncodedSize = 0
+		ms.mSegEncodeSize = 0
 		ms.datapointCount = 0
 		ms.bytesReceived = 0
 		ms.mBlock.mBlockSummary.Reset()
@@ -1308,7 +1310,7 @@ func (ms *MetricsSegment) getMetaEntry(finalDir string, suffix uint64) *structs.
 		MSegmentDir:        fmt.Sprintf("%s%d", finalDir, suffix),
 		NumBlocks:          ms.currBlockNum,
 		BytesReceivedCount: ms.bytesReceived,
-		OnDiskBytes:        ms.totalEncodedSize,
+		OnDiskBytes:        ms.mSegEncodeSize,
 		TagKeys:            tKeys,
 		EarliestEpochSec:   ms.lowTS,
 		LatestEpochSec:     ms.highTS,
@@ -1320,7 +1322,7 @@ func (ms *MetricsSegment) getMetaEntry(finalDir string, suffix uint64) *structs.
 func ForceFlushMetricsBlock() {
 	wg := sync.WaitGroup{}
 	for _, mSegment := range GetAllMetricsSegments() {
-		if mSegment.totalEncodedSize == 0 {
+		if mSegment.mSegEncodeSize == 0 {
 			continue
 		}
 		wg.Add(1)
@@ -1462,18 +1464,20 @@ func GetUniqueTagKeysForUnrotated(tRange *dtu.MetricsTimeRange, myid uint64) (ma
 
 func GetMetricsEncodedSizeInfo() *MetricsEncodedSizeInfo {
 	return &MetricsEncodedSizeInfo{
-		TotalMSegmentsEncodedSizeInBytes: totalMSegmentsEncodedSizeInBytes,
-		TotalTagsTreeSizeInBytes:         totalTagsTreeSizeInBytes,
-		TotalTagTreesCount:               totalTagTreesCount,
-		TotalLeafNodesCount:              totalLeafNodesCount,
-		TotalSeriesCount:                 totalSeriesCount,
-		TotalSortedTSIDCount:             totalSortedTSIDCount,
-		TotalTSIDLookupCount:             totalTSIDLookupCount,
+		TotalMSegmentsEncodedSizeInBytes:    totalAllMSegmentsEncodedSizeInBytes,
+		TotalInMemoryMSegEncodedSizeInBytes: totalInMemoryMSegEncodedSizeInBytes,
+		TotalTagsTreeSizeInBytes:            totalTagsTreeSizeInBytes,
+		TotalTagTreesCount:                  totalTagTreesCount,
+		TotalLeafNodesCount:                 totalLeafNodesCount,
+		TotalSeriesCount:                    totalSeriesCount,
+		TotalSortedTSIDCount:                totalSortedTSIDCount,
+		TotalTSIDLookupCount:                totalTSIDLookupCount,
 	}
 }
 
 func GetTotalEncodedSize() uint64 {
-	totalSize := uint64(0)
+	allMsegEncodedSize := uint64(0)
+	inMemoryMSegEncodedSize := uint64(0)
 	totalTagsTreeSize := uint64(0)
 	totalLeafNodes := 0
 	totaltsidlookup := 0
@@ -1491,7 +1495,8 @@ func GetTotalEncodedSize() uint64 {
 		totaltsidlookup += len(mBuf.tsidLookup)
 		totalSeries += len(mBuf.allSeries)
 		numSeries := len(mBuf.allSeries)
-		totalSize += mSeg.totalEncodedSize
+		allMsegEncodedSize += mSeg.mSegEncodeSize
+		inMemoryMSegEncodedSize += mBuf.blkEncodedSize
 		tt := GetTagsTreeHolder(mSeg.Orgid, mSeg.Mid)
 		if tt == nil {
 			continue
@@ -1504,7 +1509,8 @@ func GetTotalEncodedSize() uint64 {
 		}
 	}
 
-	totalMSegmentsEncodedSizeInBytes = totalSize
+	totalAllMSegmentsEncodedSizeInBytes = allMsegEncodedSize
+	totalInMemoryMSegEncodedSizeInBytes = inMemoryMSegEncodedSize
 	totalTagsTreeSizeInBytes = totalTagsTreeSize
 	totalTagTreesCount = totalTagTrees
 	totalLeafNodesCount = totalLeafNodes
@@ -1512,7 +1518,7 @@ func GetTotalEncodedSize() uint64 {
 	totalSortedTSIDCount = totalSortedTSID
 	totalTSIDLookupCount = totaltsidlookup
 
-	return totalSize + totalTagsTreeSize
+	return inMemoryMSegEncodedSize + totalTagsTreeSize
 }
 
 func GetMetricSegments(orgid uint64) []*MetricsSegment {

--- a/pkg/segment/writer/metrics/metricssegment_test.go
+++ b/pkg/segment/writer/metrics/metricssegment_test.go
@@ -220,7 +220,7 @@ func initFakeMetricsBlock() *MetricsBlock {
 			HighTs: 1676089340,
 			LowTs:  1676089310,
 		},
-		encodedSize: 0,
+		blkEncodedSize: 0,
 	}
 	return mb
 }


### PR DESCRIPTION
# Description
- Included only the current block size for metrics in memory calculation, ignoring the flushed or rotated blocks.

# Testing
- Tested by running some ingestion and observed the global memory print summary. And the values keep changing.
- When the ingestion is stopped, the metrics in memory size came to `0`.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
