### PR TITLE
fix: Global Unrotated Metadata Size Tracker

### DIFF
--- a/pkg/segment/writer/unrotatedquery.go
+++ b/pkg/segment/writer/unrotatedquery.go
@@ -85,9 +85,9 @@ func RebalanceUnrotatedMetadata(totalAvailableSize uint64) uint64 {
 		if removedSize >= sizeToRemove {
 			break
 		}
-		sizeToRemove = ss[i].removeInMemoryMetadata()
-		if sizeToRemove > 0 {
-			removedSize += sizeToRemove
+		size := ss[i].removeInMemoryMetadata()
+		if size > 0 {
+			removedSize += size
 			count++
 		}
 	}


### PR DESCRIPTION
# Description
- This is not being tracked correctly before because when rebalancing, we set the `cmiLoaded` to false, and then from next rebalancing the allocated memory for that segment is not being deleted.
- And even when at the final stage when the segment is being removed, since the `cmiLoaded` is set to `false`, the cmi size won't be included.
- This made the `TotalUnrotatedMetadataSizeBytes` increase in value.

# Testing
- Tested by keeping the memory usage to 10% and memory size to `2GB`
- Ran the ingestion. And verified that the `TotalUnrotatedMetadataSizeBytes` was being removed properly during rebalance and removal of segment in memory after rotation

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
