### PR TITLE
Reload TLS cert when it gets updated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fasthttp/router v1.4.1
 	github.com/fasthttp/websocket v1.5.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/google/gofuzz v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/fasthttp/router v1.4.1 h1:3xPUO+hy/HAkgGDSd5sX5w18cyGDIFbC7vip8KwPDk8
 github.com/fasthttp/router v1.4.1/go.mod h1:4P0Kq4C882tA2evBKDW7De7hGfWmvV8FN+zqt8Lu49Q=
 github.com/fasthttp/websocket v1.5.0 h1:B4zbe3xXyvIdnqjOZrafVFklCUq5ZLo/TqCt5JA1wLE=
 github.com/fasthttp/websocket v1.5.0/go.mod h1:n0BlOQvJdPbTuBkZT0O5+jk/sp/1/VCzquR1BehI2F4=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-co-op/gocron v1.31.1 h1:LZAuBlU0t3SPGUMJGhrJ6VuCc3CsrYzkzicygvVWlfA=
 github.com/go-co-op/gocron v1.31.1/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=

--- a/pkg/server/certreloader.go
+++ b/pkg/server/certreloader.go
@@ -37,15 +37,13 @@ func NewCertReloader(certPath string, privateKeyPath string) (*CertReloader, err
 
 	if err := reloader.reload(); err != nil {
 		log.Errorf("NewCertReloader: Error loading certificate: %v", err)
-		return reloader, err
-		// return nil, err
+		return nil, err
 	}
 
 	return reloader, nil
 }
 
 func (cr *CertReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	log.Errorf("andrew inside GetCertificate ===============================")
 	cr.mu.RLock()
 	defer cr.mu.RUnlock()
 

--- a/pkg/server/certreloader.go
+++ b/pkg/server/certreloader.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -22,22 +25,27 @@ func NewCertReloader(certPath string, privateKeyPath string) (*CertReloader, err
 	}
 
 	err := utils.OnFileChange([]string{certPath, privateKeyPath}, func() {
-		log.Infof("NewCertReloader: Reloading certificate")
+		log.Infof("NewCertReloader: Reloading certificate at %v with key at %v", certPath, privateKeyPath)
 		err := reloader.reload()
 		if err != nil {
-			log.Errorf("NewCertReloader: Error reloading certificate: %v", err)
+			log.Errorf("NewCertReloader: Error reloading certificate at %v with key at %v; err=%v",
+				certPath, privateKeyPath, err)
 		} else {
-			log.Infof("NewCertReloader: Successfully reloaded certificate")
+			log.Infof("NewCertReloader: Successfully reloaded certificate at %v with key at %v", certPath, privateKeyPath)
 		}
 	})
 	if err != nil {
-		log.Errorf("NewCertReloader: Error setting up certificate reloading: %v", err)
+		log.Errorf("NewCertReloader: Error setting up certificate reloading for certificate at %v with key at %v; err=%v",
+			certPath, privateKeyPath, err)
 		return nil, err
 	}
 
 	if err := reloader.reload(); err != nil {
-		log.Errorf("NewCertReloader: Error loading certificate: %v", err)
+		log.Errorf("NewCertReloader: Error loading certificate at %v with key at %v; err=%v",
+			certPath, privateKeyPath, err)
 		return nil, err
+	} else {
+		log.Infof("NewCertReloader: Successfully loaded certificate at %v with key at %v", certPath, privateKeyPath)
 	}
 
 	return reloader, nil
@@ -53,8 +61,26 @@ func (cr *CertReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, 
 func (cr *CertReloader) reload() error {
 	cert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
 	if err != nil {
-		log.Errorf("reload: Error loading certificate: %v", err)
+		log.Errorf("reload: Error loading certificate at %v with key at %v; err=%v",
+			cr.certPath, cr.keyPath, err)
 		return err
+	}
+
+	// Check if the certificate time is valid
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		log.Errorf("reload: Error parsing certificate: %v", err)
+		return err
+	}
+
+	now := time.Now()
+	if now.Before(leaf.NotBefore) {
+		return fmt.Errorf("reload: certificate at %v is not valid yet (not before: %v)",
+			cr.certPath, leaf.NotBefore)
+	}
+	if now.After(leaf.NotAfter) {
+		return fmt.Errorf("reload: certificate at %v has expired (not after: %v)",
+			cr.certPath, leaf.NotAfter)
 	}
 
 	cr.mu.Lock()

--- a/pkg/server/certreloader.go
+++ b/pkg/server/certreloader.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"crypto/tls"
+	"sync"
+
+	"github.com/siglens/siglens/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type CertReloader struct {
+	certPath string
+	keyPath  string
+	mu       sync.RWMutex
+	cert     *tls.Certificate
+}
+
+func NewCertReloader(certPath string, privateKeyPath string) (*CertReloader, error) {
+	reloader := &CertReloader{
+		certPath: certPath,
+		keyPath:  privateKeyPath,
+	}
+
+	err := utils.OnFileChange([]string{certPath, privateKeyPath}, func() {
+		log.Infof("NewCertReloader: Reloading certificate")
+		err := reloader.reload()
+		if err != nil {
+			log.Errorf("NewCertReloader: Error reloading certificate: %v", err)
+		} else {
+			log.Infof("NewCertReloader: Successfully reloaded certificate")
+		}
+	})
+	if err != nil {
+		log.Errorf("NewCertReloader: Error setting up certificate reloading: %v", err)
+		return nil, err
+	}
+
+	if err := reloader.reload(); err != nil {
+		log.Errorf("NewCertReloader: Error loading certificate: %v", err)
+		return reloader, err
+		// return nil, err
+	}
+
+	return reloader, nil
+}
+
+func (cr *CertReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	log.Errorf("andrew inside GetCertificate ===============================")
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+
+	return cr.cert, nil
+}
+
+func (cr *CertReloader) reload() error {
+	cert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
+	if err != nil {
+		log.Errorf("reload: Error loading certificate: %v", err)
+		return err
+	}
+
+	cr.mu.Lock()
+	cr.cert = &cert
+	cr.mu.Unlock()
+
+	return nil
+}

--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -169,9 +169,8 @@ func (hs *ingestionServerCfg) Run() (err error) {
 	if config.IsTlsEnabled() {
 		certReloader, err := server.NewCertReloader(config.GetTLSCertificatePath(), config.GetTLSPrivateKeyPath())
 		if err != nil {
-			// log.Fatalf("Run: error in loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
-			log.Errorf("Run: error in loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
-			// return err
+			log.Fatalf("Run: error loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
+			return err
 		}
 
 		cfg := &tls.Config{

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -329,9 +329,8 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	if config.IsTlsEnabled() {
 		certReloader, err := server.NewCertReloader(config.GetTLSCertificatePath(), config.GetTLSPrivateKeyPath())
 		if err != nil {
-			// log.Fatalf("Run: error in loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
-			log.Errorf("Run: error in loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
-			// return err
+			log.Fatalf("Run: error loading TLS certificate: %v, err=%v", config.GetTLSCertificatePath(), err)
+			return err
 		}
 
 		cfg := &tls.Config{

--- a/pkg/utils/eventutils.go
+++ b/pkg/utils/eventutils.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+)
+
+func OnFileChange(files []string, callback func()) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("OnFileChange: Error creating file watcher: %v", err)
+	}
+
+	// Add the files to the watcher
+	for _, file := range files {
+		err = watcher.Add(file)
+		if err != nil {
+			return fmt.Errorf("OnFileChange: Error adding file to watcher: %v", err)
+		}
+	}
+
+	// Watch for changes
+	go func() {
+		defer watcher.Close()
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					log.Errorf("OnFileChange: Watcher events channel closed for files: %v", files)
+					return
+				}
+				if event.Has(fsnotify.Write) {
+					log.Infof("OnFileChange: File %v changed", event.Name)
+					callback()
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					log.Errorf("OnFileChange: Watcher errors channel closed for files: %v", files)
+					return
+				}
+				log.Errorf("OnFileChange: Watcher error=%v for files %v", err, files)
+				return
+			}
+		}
+	}()
+
+	return err
+}

--- a/pkg/utils/eventutils_test.go
+++ b/pkg/utils/eventutils_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OnFileChange(t *testing.T) {
+	dir := t.TempDir()
+
+	file1 := filepath.Join(dir, "file1")
+	err := os.WriteFile(file1, []byte("file1 content"), 0644)
+	require.NoError(t, err)
+
+	file2 := filepath.Join(dir, "file2")
+	err = os.WriteFile(file2, []byte("file2 content"), 0644)
+	require.NoError(t, err)
+
+	updateChan := make(chan struct{}, 10)
+	err = OnFileChange([]string{file1, file2}, func() {
+		updateChan <- struct{}{}
+	})
+	require.NoError(t, err)
+
+	err = os.WriteFile(file1, []byte("new content"), 0644)
+	require.NoError(t, err)
+	readChannelOrFail(t, updateChan)
+
+	// Ensure another change triggers it again
+	err = os.WriteFile(file1, []byte("hello world"), 0644)
+	require.NoError(t, err)
+	readChannelOrFail(t, updateChan)
+
+	// Write to the other file.
+	err = os.WriteFile(file2, []byte("new content"), 0644)
+	require.NoError(t, err)
+	readChannelOrFail(t, updateChan)
+
+	// There should be no more updates.
+	assert.Equal(t, 0, len(updateChan), "unexpected updates")
+}
+
+func readChannelOrFail(t *testing.T, updateChan chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-updateChan:
+		// Do nothing.
+	case <-time.After(time.Second):
+		t.Fatal("reached timeout")
+	}
+}

--- a/pkg/utils/eventutils_test.go
+++ b/pkg/utils/eventutils_test.go
@@ -30,16 +30,19 @@ func Test_OnFileChange(t *testing.T) {
 	err = os.WriteFile(file1, []byte("new content"), 0644)
 	require.NoError(t, err)
 	readChannelOrFail(t, updateChan)
+	drainChannel(updateChan)
 
 	// Ensure another change triggers it again
 	err = os.WriteFile(file1, []byte("hello world"), 0644)
 	require.NoError(t, err)
 	readChannelOrFail(t, updateChan)
+	drainChannel(updateChan)
 
 	// Write to the other file.
 	err = os.WriteFile(file2, []byte("new content"), 0644)
 	require.NoError(t, err)
 	readChannelOrFail(t, updateChan)
+	drainChannel(updateChan)
 
 	// There should be no more updates.
 	assert.Equal(t, 0, len(updateChan), "unexpected updates")
@@ -53,5 +56,11 @@ func readChannelOrFail(t *testing.T, updateChan chan struct{}) {
 		// Do nothing.
 	case <-time.After(time.Second):
 		t.Fatal("reached timeout")
+	}
+}
+
+func drainChannel(ch chan struct{}) {
+	for len(ch) > 0 {
+		<-ch
 	}
 }


### PR DESCRIPTION
# Description
Previously, when you wanted to use a new TLS certificate (e.g., it's going to expire soon), you had to copy the new certificate to the correct file and restart siglens. Now you just have to copy the new certificate to the correct file. Siglens automatically reloads it when the certificate or private key changes.

# Testing
1. Create a certificate that expires soon (see below)
2. Setup TLS config in server.yaml:
```
tls:
  enabled: true   # Set to true to enable TLS
  certificatePath: "certs/localhost.short.crt"  # Path to the certificate file
  privateKeyPath: "certs/localhost.key"   # Path to the private key file
```
3. Start siglens
4. Start continuous ingestion to https
```
go run main.go ingest esbulk -n 1 -g benchmark -d https://localhost:8081/elastic -c
```
6. Wait for the certificate to expire, then see errors in the ingestion job
7. Replace the certificate with a new valid one
8. Observe that ingestion starts working again

I also tested ingestion 1 million records with some getting ingested before the expiration, and some getting ingested after the new cert is setup. All 1 million records got ingested.

I also tested with creating a new certificate before the first one expired; in this case, ingestion wasn't interrupted.

## Creating development certificates
There's some tools for making dev certificates, but not an easy way to make them with expiration times less than 1 day. On mac, I did it this way:
### Initial setup
First install `mkcert` and `openssl`. Then go into a new directory where you'll store certificates and run this setup code:
```
CAROOT=$(mkcert -CAROOT)

# Create localhost key and CSR as before
openssl genpkey -algorithm RSA -out localhost.key
openssl req -new -key localhost.key \
  -subj "/C=US/ST=State/L=City/O=Org/CN=localhost" \
  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
  -out localhost.csr

# Create CA config using mkcert's CA
cat > ca.cnf << EOF
[ ca ]
default_ca = CA_default

[ CA_default ]
dir               = .
database          = index.txt
new_certs_dir     = .
certificate       = ${CAROOT}/rootCA.pem
serial            = serial.txt
private_key       = ${CAROOT}/rootCA-key.pem
default_md        = sha256
policy            = policy_anything
x509_extensions   = v3_req

[ policy_anything ]
countryName            = optional
stateOrProvinceName    = optional
localityName           = optional
organizationName       = optional
organizationalUnitName = optional
commonName             = supplied
emailAddress          = optional

[ v3_req ]
subjectAltName = @alt_names
basicConstraints = CA:FALSE
keyUsage = nonRepudiation, digitalSignature, keyEncipherment

[ alt_names ]
DNS.1 = localhost
IP.1 = 127.0.0.1
EOF
```

### Make a new certificate
From the same certificate dir, run:
```
echo "01" > serial.txt && rm -f index.txt && touch index.txt

STARTTIME=$(date -u "+%y%m%d%H%M%SZ")
ENDTIME=$(date -u -v+1M "+%y%m%d%H%M%SZ")

openssl ca -config ca.cnf \
  -policy policy_anything \
  -in localhost.csr \
  -out localhost.short.crt \
  -startdate $STARTTIME \
  -enddate $ENDTIME \
  -batch
```
**Note:** The `v+1M` in `ENDTIME` means it will expire in 1 minute

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
