### PR TITLE
Fix determining dirs to delete during retention

### DIFF
--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -43,7 +43,7 @@ import (
 
 const MAXIMUM_WARNINGS_COUNT = 5
 
-const RETENTION_LOOP_SLEEP_TIMER = 30
+const RETENTION_LOOP_SLEEP_MINUTES = 30
 
 const MAX_INODE_USAGE_PERCENT = 85
 
@@ -70,7 +70,7 @@ func internalRetentionCleaner() {
 
 	deletionWarningCounter := 0
 	for {
-		time.Sleep(RETENTION_LOOP_SLEEP_TIMER * time.Minute)
+		time.Sleep(RETENTION_LOOP_SLEEP_MINUTES * time.Minute)
 		if hook := hooks.GlobalHooks.InternalRetentionCleanerHook2; hook != nil {
 			hook(hook1Result, deletionWarningCounter)
 		} else {

--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -449,6 +449,16 @@ func removeSegmetas(segkeysToRemove map[string]struct{}, indexName string) map[s
 	segbaseDirs := make(map[string]struct{})
 	preservedSmEntries := make([]*structs.SegMeta, 0)
 
+	for segkey := range segkeysToRemove {
+		baseDir, err := utils.GetSegBaseDirFromFilename(segkey)
+		if err != nil {
+			log.Errorf("removeSegmetas: Cannot get segbaseDir from segkey=%v; err=%v", segkey, err)
+			continue
+		}
+
+		segbaseDirs[baseDir] = struct{}{}
+	}
+
 	smrLock.Lock()
 	defer smrLock.Unlock()
 
@@ -484,8 +494,6 @@ func removeSegmetas(segkeysToRemove map[string]struct{}, indexName string) map[s
 				continue
 			}
 		}
-
-		segbaseDirs[segMetaData.SegbaseDir] = struct{}{}
 	}
 	err = reader.Err()
 	if err != nil {


### PR DESCRIPTION
# Description
Sometimes during time-based retention, the directory for an index would be on disk but the segmeta.json wouldn't have the entry for that index, so the `segbaseDirs` variable would be missing an entry for that directory; the caller of `removeSegmetas()` uses the `segbaseDirs` return value to delete those directories, so we'd end up with some indexes not getting deleted when they should be.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
