### PR TITLE
Add Diagnostic Data Collection Feature

### DIFF
--- a/pkg/diagnostics/diagnosticCollector.go
+++ b/pkg/diagnostics/diagnosticCollector.go
@@ -64,12 +64,12 @@ func CollectDiagnosticsAPI(ctx *fasthttp.RequestCtx) {
 			}
 		}
 	}
-    
-    if err := zipWriter.Close(); err != nil {
-        ctx.SetStatusCode(fasthttp.StatusInternalServerError)
-        ctx.SetBodyString("Failed to close zip file: " + err.Error())
-        return
-    }
+
+	if err := zipWriter.Close(); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBodyString("Failed to close zip file: " + err.Error())
+		return
+	}
 
 	ctx.SetContentType("application/zip")
 	ctx.Response.Header.Set("Content-Disposition",

--- a/pkg/diagnostics/diagnosticCollector.go
+++ b/pkg/diagnostics/diagnosticCollector.go
@@ -1,0 +1,79 @@
+package diagnostics
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
+	"github.com/valyala/fasthttp"
+)
+
+func CollectDiagnosticsAPI(ctx *fasthttp.RequestCtx) {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	serverAddr := ctx.URI().Host()
+	req.SetRequestURI(fmt.Sprintf("http://%s%s/clusterStats", serverAddr, server_utils.API_PREFIX))
+	req.Header.SetMethod("GET")
+
+	if err := fasthttp.Do(req, resp); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBodyString("Failed to get cluster stats: " + err.Error())
+		return
+	}
+
+	var clusterStats map[string]interface{}
+	if err := json.Unmarshal(resp.Body(), &clusterStats); err != nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBodyString("Failed to parse cluster stats: " + err.Error())
+		return
+	}
+
+	if indexStats, ok := clusterStats["indexStats"].([]interface{}); ok {
+		for _, indexData := range indexStats {
+			if indexMap, ok := indexData.(map[string]interface{}); ok {
+				for indexName, stats := range indexMap {
+					indexBytes, err := json.MarshalIndent(stats, "", "  ")
+					if err != nil {
+						ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+						ctx.SetBodyString("Failed to marshal index stats: " + err.Error())
+						return
+					}
+
+					indexFile, err := zipWriter.Create(fmt.Sprintf("%s.json", indexName))
+					if err != nil {
+						ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+						ctx.SetBodyString("Failed to create zip entry: " + err.Error())
+						return
+					}
+
+					if _, err := indexFile.Write(indexBytes); err != nil {
+						ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+						ctx.SetBodyString("Failed to write to zip entry: " + err.Error())
+						return
+					}
+				}
+			}
+		}
+	}
+    
+    if err := zipWriter.Close(); err != nil {
+        ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+        ctx.SetBodyString("Failed to close zip file: " + err.Error())
+        return
+    }
+
+	ctx.SetContentType("application/zip")
+	ctx.Response.Header.Set("Content-Disposition",
+		fmt.Sprintf("attachment; filename=siglens-diagnostics-%s.zip",
+			time.Now().Format("2006-01-02-15-04-05")))
+	ctx.SetBody(buf.Bytes())
+}

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siglens/siglens/pkg/cfghandler"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/dashboards"
+	"github.com/siglens/siglens/pkg/diagnostics"
 	esreader "github.com/siglens/siglens/pkg/es/reader"
 	esutils "github.com/siglens/siglens/pkg/es/utils"
 	eswriter "github.com/siglens/siglens/pkg/es/writer"
@@ -754,5 +755,11 @@ func UpdateQueryTimeoutHandler() func(ctx *fasthttp.RequestCtx) {
 func setSortColumnsHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		sortindex.SetSortColumnsAPI(ctx)
+	}
+}
+
+func collectDiagnosticsHandler() func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		diagnostics.CollectDiagnosticsAPI(ctx)
 	}
 }

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -274,6 +274,8 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 
 	hs.Router.POST(server_utils.API_PREFIX+"/sort-columns", hs.Recovery(setSortColumnsHandler()))
 
+	hs.Router.GET(server_utils.API_PREFIX+"/collect-diagnostics", hs.Recovery(collectDiagnosticsHandler()))
+
 	if config.IsPProfEnabled() {
 		hs.Router.GET("/debug/pprof/{profile:*}", pprofhandler.PprofHandler)
 	}

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2066,6 +2066,21 @@ div.dts div.dataTables_scrollBody table {
     margin-left: 0px;
 }
 
+.white-download-icon{
+    background-image: url(../assets/download-icon-dark.svg);
+    height: 13px;
+    background-repeat: no-repeat;
+    width: 20px;
+    cursor: pointer;
+    background-color: transparent;
+    border-width: 0;
+    margin-left: 0px;
+    padding-bottom: 0;
+    background-size: contain;
+    background-position: center;
+    margin-right: 2px;
+}
+
 /* Delete confimation popup */
 .popupOverlay,.mypopupOverlay {
   visibility: hidden;

--- a/static/diagnostics.html
+++ b/static/diagnostics.html
@@ -1,0 +1,99 @@
+<!-- 
+Copyright (c) 2021-2024 SigScalr, Inc.
+
+This file is part of SigLens Observability Solution
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-5SBJC04YFB"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-5SBJC04YFB');
+</script>
+
+<head>
+    <meta charset="UTF-8">
+    <title>SigLens</title>
+
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="apple-touch-icon" sizes="180x180" href="./assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon-16x16.png">
+    <link rel="manifest" href="./assets/site.webmanifest">
+    <link rel="mask-icon" href="./assets/safari-pinned-tab.svg" color="#5bbad5">
+    <meta name="msapplication-TileColor" content="#da532c">
+
+    <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
+    <link rel="stylesheet" href="./css/lib/all.min.css" />
+    <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
+    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+
+    <script src="./js/lib/lodash.min.js"></script>
+    <script src="./js/lib/jquery-3.6.0.min.js"></script>
+    <script src="./js/lib/jquery-ui.min.js"></script>
+    <script src="./js/lib/js.cookie.min.js"></script>
+    <script src="./js/lib/moment.min.js"></script>
+    <script src="./js/lib/date_fns.min.js"></script>
+    <script src="./js/lib/popper.min.js"></script>
+    <script src="./js/lib/bootstrap.bundle.min.js"></script>
+    <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script>
+        var defaultTheme = Cookies.get('theme') || 'light';
+        $('html').attr('data-theme', defaultTheme);
+    </script>
+    {{ .RunCheck1 | safeHTML }}
+</head>
+
+<body>
+    <div id="app-container">
+        <div id="app-side-nav">
+        </div>
+
+        <div class="myOrg">
+            <div class="myOrg-container">
+                <div class="org-nav-tab">
+                    {{ .Button1 | safeHTML }}
+                </div>
+
+                <div class="myOrg-inner-container">
+                    <div class="mt-3">
+                        <button class="primary-btn btn" id="diagnostics-btn">
+                            <span class="white-download-icon"></span>
+                            Download Diagnostic Data</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="app-footer">
+            2024 &copy; SigLens
+        </div>
+    </div>
+    <script src="./js/navbar.js?cb=1_1_10"></script>
+    <script src="./js/common.js?cb=1_1_10"></script>
+    <script src="./js/event-handlers.js?cb=1_1_10"></script>
+    <script src="./js/diagnostics.js"></script>
+    <script src="./component/upper-navbar/upper-navbar.js"></script>
+
+    {{ .RunCheck2 | safeHTML }}
+    {{ .RunCheck3 | safeHTML }}
+</body>
+
+</html>

--- a/static/js/diagnostics.js
+++ b/static/js/diagnostics.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021-2024 SigScalr, Inc.
+ *
+ * This file is part of SigLens Observability Solution
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$(document).ready(function () {
+    $('.theme-btn').on('click', themePickerHandler);
+});
+
+$('#diagnostics-btn').on('click', function () {
+    const originalHtml = '<span class="white-download-icon"></span> Download Diagnostic Data';
+    $(this).attr('disabled', true).html('<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Downloading...');
+
+    $.ajax({
+        url: '/api/collect-diagnostics',
+        method: 'GET',
+        xhrFields: {
+            responseType: 'blob',
+        },
+        success: function (blob) {
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `siglens-diagnostics-${new Date().toISOString()}.zip`;
+            document.body.appendChild(a);
+            a.click();
+
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(a);
+        },
+        error: function () {
+            showToast('Failed to fetch diagnostic data', 'error');
+        },
+        complete: function () {
+            $('#diagnostics-btn').attr('disabled', false).html(originalHtml);
+        },
+    });
+});

--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -140,6 +140,7 @@ let orgUpperNavTabs = [
     { name: 'PQS', url: './pqs-settings.html', class: 'pqs-settings' },
     { name: 'Query Stats', url: './query-stats.html', class: 'query-stats' },
     { name: 'Version', url: './application-version.html', class: 'application-version' },
+    { name: 'Diagnostics', url: './diagnostics.html', class: 'diagnostics' },
 ];
 
 let tracingUpperNavTabs = [
@@ -180,7 +181,8 @@ $(document).ready(function () {
     } else if (currentUrl.includes('all-slos.html')) {
         $('.nav-slos').addClass('active');
         $('.alerts-nav-tab').appendOrgNavTabs('SLOs', []);
-    } else if (currentUrl.includes('cluster-stats.html') || currentUrl.includes('org-settings.html') || currentUrl.includes('application-version.html')|| currentUrl.includes('query-stats.html')  || currentUrl.includes('pqs-settings.html') {{ .OrgUpperNavUrls }} ) {
+    } else if (currentUrl.includes('cluster-stats.html') || currentUrl.includes('org-settings.html') || currentUrl.includes('application-version.html')|| currentUrl.includes('query-stats.html')  || currentUrl.includes('pqs-settings.html') {{ .OrgUpperNavUrls }}
+    ||  currentUrl.includes('diagnostics.html')) {
         $('.nav-myorg').addClass('active');
         $('.org-nav-tab').appendOrgNavTabs('My Org', orgUpperNavTabs);
     } else if (currentUrl.includes('minion-searches.html')) {


### PR DESCRIPTION
# Description
Added a new backend API (`api/collect-diagnostics`) to facilitate the collection of diagnostic data. Currently, the API gathers basic index details displayed on the Cluster Stats page for each index. We will add more diagnostic data collection to the API later.

The backend API calls the `api/clusterStats` endpoint to retrieve cluster data, organizes it into separate JSON files for each index, compresses the files into a ZIP archive, and makes the archive available for download.

Also, added a new "Diagnostics" tab to the "My Org" page in the UI. Users can download the collected diagnostic data.

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/098e9685-af36-46a6-aec1-5c32787338c8" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
