### PR TITLE
Fix bug in removeSegmetas function

### DIFF
--- a/pkg/segment/writer/segmetarw.go
+++ b/pkg/segment/writer/segmetarw.go
@@ -439,9 +439,11 @@ func BulkAddRotatedSegmetas(finalSegmetas []*structs.SegMeta, shouldWriteSfm boo
 	}
 }
 
-// Removes segmetas based on given segkeys and returns the segbasedirs for those segkeys
+// If indexName is provided, remove all segmetas for that index. Otherwise,
+// remove the segmetas for the specified segkeys.
+//
+// Returns the segbaseDirs for the segkeys that were removed
 func removeSegmetas(segkeysToRemove map[string]struct{}, indexName string) map[string]struct{} {
-
 	if segkeysToRemove == nil && indexName == "" {
 		return nil
 	}
@@ -485,6 +487,8 @@ func removeSegmetas(segkeysToRemove map[string]struct{}, indexName string) map[s
 			if segMetaData.VirtualTableName != indexName {
 				preservedSmEntries = append(preservedSmEntries, &segMetaData)
 				continue
+			} else {
+				segbaseDirs[segMetaData.SegbaseDir] = struct{}{}
 			}
 		} else {
 			// check if based on segmetas


### PR DESCRIPTION
# Description
This fixes an issue introduced by #2049 causing a bug when trying to delete all the segmeta entries for a particular index

# Testing
New unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
