### PR TITLE
Fix segkey encoding when lacking sort index file

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -179,6 +179,8 @@ func getSubsearchIfNeeded(searcher *Searcher) (*subsearch, error) {
 		}
 	}
 
+	// Make two subsearchers. One handles segments that have the required sort
+	// index files; the other handles the segments lacking them.
 	subsearchers := make([]*Searcher, 2)
 	for i := 0; i < 2; i++ {
 		subsearchers[i], err = newSearcherHelper(searcher.queryInfo, searcher.querySummary,
@@ -193,7 +195,7 @@ func getSubsearchIfNeeded(searcher *Searcher) (*subsearch, error) {
 	subsearchers[1].qsrs = otherQSRs
 	subsearchers[1].initUnprocessedQSRs()
 	subsearchers[1].sortIndexState.forceNormalSearch = true
-	subsearchers[1].segEncToKeyBaseValue = uint32(len(sortIndexQSRs))
+	subsearchers[1].segEncToKeyBaseValue += uint32(len(sortIndexQSRs))
 
 	query.InitProgressForRRCCmd(uint64(metadata.GetTotalBlocksInSegments(getAllSegKeysInQSRS(qsrs))), searcher.qid)
 


### PR DESCRIPTION
# Description
The old code had a bug when `subsearchers[1].segEncToKeyBaseValue` was non-zero when `subsearchers[1]` was initialized, which caused merging results to fail because the same encoding was used for two different segkeys.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
