### PR TITLE
Create tag on release

### DIFF
--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -2,7 +2,7 @@ name: siglens-docker-release
 on:
   push:
     branches:
-      - 'main'
+      - 'auto-tag'
 jobs:
   create-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -2,7 +2,7 @@ name: siglens-docker-release
 on:
   push:
     branches:
-      - 'auto-tag'
+      - 'main'
 jobs:
   create-tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -21,12 +21,12 @@ jobs:
           git config user.email "actions@github.com"
 
           # Check if tag already exists
-          if ! git rev-parse "v${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
-            git tag "v${{ steps.version.outputs.VERSION }}"
-            git push origin "v${{ steps.version.outputs.VERSION }}"
-            echo "Created and pushed tag v${{ steps.version.outputs.VERSION }}"
+          if ! git rev-parse "${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
+            git tag "${{ steps.version.outputs.VERSION }}"
+            git push origin "${{ steps.version.outputs.VERSION }}"
+            echo "Created and pushed tag ${{ steps.version.outputs.VERSION }}"
           else
-            echo "Tag v${{ steps.version.outputs.VERSION }} already exists"
+            echo "Tag ${{ steps.version.outputs.VERSION }} already exists"
           fi
   siglens-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prod-images.yml
+++ b/.github/workflows/publish-prod-images.yml
@@ -4,6 +4,30 @@ on:
     branches:
       - 'main'
 jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(sed -n 's/const SigLensVersion = "\(.*\)"/\1/p' pkg/config/version.go)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Create and push tag
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          # Check if tag already exists
+          if ! git rev-parse "v${{ steps.version.outputs.VERSION }}" >/dev/null 2>&1; then
+            git tag "v${{ steps.version.outputs.VERSION }}"
+            git push origin "v${{ steps.version.outputs.VERSION }}"
+            echo "Created and pushed tag v${{ steps.version.outputs.VERSION }}"
+          else
+            echo "Tag v${{ steps.version.outputs.VERSION }} already exists"
+          fi
   siglens-docker:
     runs-on: ubuntu-latest
     environment: build-environment
@@ -79,6 +103,7 @@ jobs:
   sigscalr-release-assets:
       runs-on: ubuntu-latest
       environment: build-environment
+      needs: create-tag
       permissions:
         id-token: write
         contents: read
@@ -191,7 +216,7 @@ jobs:
 
   check-status:
     runs-on: ubuntu-latest
-    needs: [siglens-docker, sigclient-docker, sigscalr-release-assets]
+    needs: [create-tag, siglens-docker, sigclient-docker, sigscalr-release-assets]
     steps:
       - name: Check previous jobs' results
         if: ${{ failure() }}


### PR DESCRIPTION
# Description
Our github workflow on releases broke. This is an attempt to fix that. The issue appears to be that when we try to make the release, the tag does not exist. So this PR creates the tag if it doesn't exist already. I'm not sure if this will fully fix our release workflow

# Testing
Manually tested on my fork, and the tag creation job ran correctly: https://github.com/AndrewHess/siglens/actions/runs/12873074246

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
