### PR TITLE
Fix calculation for metrics disk space when it's 0

### DIFF
--- a/pkg/ingest/ingestionStats.go
+++ b/pkg/ingest/ingestionStats.go
@@ -18,6 +18,7 @@
 package ingest
 
 import (
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -227,14 +228,18 @@ func setNumKeysAndValues() {
 func setMetricOnDiskBytes() {
 	tagsTreeHolderDir := filepath.Join(config.GetDataPath(), config.GetHostID(), "final", "tth")
 	tagsTreeHolderSize, err := fileutils.GetDirSize(tagsTreeHolderDir)
-	if err != nil {
+	if os.IsNotExist(err) {
+		tagsTreeHolderSize = 0
+	} else if err != nil {
 		log.Errorf("setMetricOnDiskBytes: failed to get tags tree holder size: %v", err)
 		return
 	}
 
 	timeSeriesDir := filepath.Join(config.GetDataPath(), config.GetHostID(), "final", "ts")
 	timeSeriesSize, err := fileutils.GetDirSize(timeSeriesDir)
-	if err != nil {
+	if os.IsNotExist(err) {
+		timeSeriesSize = 0
+	} else if err != nil {
 		log.Errorf("setMetricOnDiskBytes: failed to get time series size: %v", err)
 		return
 	}


### PR DESCRIPTION
# Description
When there's no metric data, we were getting an error log every minute. Now we don't.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
