### PR TITLE
Fix issue with storing large uint64 in SQL

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -132,7 +132,7 @@ func ProcessCreateAlertRequest(ctx *fasthttp.RequestCtx, org_id uint64) {
 		utils.SendError(ctx, "Received empty request", "", nil)
 		return
 	}
-	alertToBeCreated.OrgId = org_id
+	alertToBeCreated.OrgId = int64(org_id)
 	err := json.Unmarshal(rawJSON, &alertToBeCreated)
 	if err != nil {
 		utils.SendError(ctx, fmt.Sprintf("Failed to unmarshal json. Error=%v", err), "", err)
@@ -504,7 +504,7 @@ func ProcessCreateContactRequest(ctx *fasthttp.RequestCtx, org_id uint64) {
 		utils.SendError(ctx, fmt.Sprintf("Failed to unmarshal json. Error=%v", err), "", err)
 		return
 	}
-	contactToBeCreated.OrgId = org_id
+	contactToBeCreated.OrgId = int64(org_id)
 	err = databaseObj.CreateContact(contactToBeCreated)
 	if err != nil {
 		utils.SendError(ctx, fmt.Sprintf("Failed to create contact. Error=%v", err), fmt.Sprintf("contact name: %v", contactToBeCreated.ContactName), err)
@@ -665,7 +665,7 @@ func ProcessCreateLogMinionSearchRequest(ctx *fasthttp.RequestCtx, org_id uint64
 	}
 	minionSearches := convertToSiglensAlert(LogLinesEntry)
 	for _, searchToBeCreated := range minionSearches {
-		searchToBeCreated.OrgId = org_id
+		searchToBeCreated.OrgId = int64(org_id)
 		searchDataObj, err := databaseObj.CreateMinionSearch(searchToBeCreated)
 		if err != nil {
 			utils.SendError(ctx, fmt.Sprintf("Failed to create alert. Error=%v", err), fmt.Sprintf("alert name: %v", searchToBeCreated.AlertName), err)

--- a/pkg/alerts/alertsHandler/cronJobHandler.go
+++ b/pkg/alerts/alertsHandler/cronJobHandler.go
@@ -311,7 +311,7 @@ func evaluateMetricsAlert(alertToEvaluate *alertutils.AlertDetails, job gocron.J
 		return
 	}
 
-	queryRes, _, _, extraMsgToLog, err := promql.ProcessMetricsQueryRequest(queries, formulas, start, end, alertToEvaluate.OrgId, qid)
+	queryRes, _, _, extraMsgToLog, err := promql.ProcessMetricsQueryRequest(queries, formulas, start, end, uint64(alertToEvaluate.OrgId), qid)
 	if err != nil {
 		log.Errorf("ALERTSERVICE: evaluateMetricsAlert: Error processing metrics query. Alert=%+v, ExtraMsgToLog=%v, err=%+v", alertToEvaluate.AlertName, extraMsgToLog, err)
 		return

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -295,7 +295,7 @@ func (p Sqlite) GetAlert(alert_id string) (*alertutils.AlertDetails, error) {
 
 func (p Sqlite) GetAllAlerts(orgId uint64) ([]*alertutils.AlertDetails, error) {
 	alerts := make([]*alertutils.AlertDetails, 0)
-	err := p.db.Model(&alerts).Preload("Labels").Where("org_id = ?", orgId).Find(&alerts).Error
+	err := p.db.Model(&alerts).Preload("Labels").Where("org_id = ?", int64(orgId)).Find(&alerts).Error
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +500,7 @@ func (p Sqlite) CreateContact(newContact *alertutils.Contact) error {
 
 func (p Sqlite) GetAllContactPoints(org_id uint64) ([]alertutils.Contact, error) {
 	contacts := make([]alertutils.Contact, 0)
-	if err := p.db.Preload("Slack").Preload("Webhook").Where("org_id = ?", org_id).Find(&contacts).Error; err != nil {
+	if err := p.db.Preload("Slack").Preload("Webhook").Where("org_id = ?", int64(org_id)).Find(&contacts).Error; err != nil {
 		return nil, err
 	}
 
@@ -749,7 +749,7 @@ func (p Sqlite) GetEmailAndChannelID(contact_id string) ([]string, []alertutils.
 func (p Sqlite) GetAllMinionSearches(orgId uint64) ([]alertutils.MinionSearch, error) {
 
 	alerts := make([]alertutils.MinionSearch, 0)
-	err := p.db.Model(&alerts).Where("org_id = ?", orgId).Find(&alertutils.MinionSearch{}).Error
+	err := p.db.Model(&alerts).Where("org_id = ?", int64(orgId)).Find(&alertutils.MinionSearch{}).Error
 	return alerts, err
 }
 

--- a/pkg/alerts/alertutils/alertutils.go
+++ b/pkg/alerts/alertutils/alertutils.go
@@ -55,7 +55,7 @@ type AlertDetails struct {
 	CronJob                  gocron.Job          `json:"cron_job" gorm:"embedded"`
 	NodeId                   uint64              `json:"node_id"`
 	NotificationID           string              `json:"notification_id" gorm:"foreignKey:NotificationId;"`
-	OrgId                    uint64              `json:"org_id"`
+	OrgId                    int64               `json:"org_id"`
 	NumEvaluationsCount      uint64              `json:"num_evaluations_count"`
 }
 
@@ -130,7 +130,7 @@ type Contact struct {
 	Slack       []SlackTokenConfig `json:"slack" gorm:"many2many:slack_contact;auto_preload"`
 	PagerDuty   string             `json:"pager_duty"`
 	Webhook     []WebHookConfig    `json:"webhook" gorm:"many2many:webhook_contact;auto_preload"`
-	OrgId       uint64             `json:"org_id"`
+	OrgId       int64              `json:"org_id"`
 }
 
 type SlackTokenConfig struct {
@@ -238,7 +238,7 @@ type MinionSearch struct {
 	LogText         string              `json:"log_text,omitempty"`
 	LogTextHash     string              `json:"log_text_hash,omitempty"`
 	LogLevel        string              `json:"log_level,omitempty"`
-	OrgId           uint64              `json:"org_id"`
+	OrgId           int64               `json:"org_id"`
 }
 
 type MetricAlertData struct {


### PR DESCRIPTION
# Description
Apparently, SQL doesn't support storing uint64 values when the sign bit is set. This caused issues adding alert contact points.

There might be a better way to solve this. In this PR, I'm just converting uint64 to int64. This works but has the downside that `Where("org_id = ?", int64(orgId)` is required for it to work (where `orgId` is of type uint64), but `Where("org_id = ?", orgId)` will compile fine but silently fail to find the records.

Maybe later we want to change the type everywhere from uint64 to int64. Or maybe there's a better solution.

I also tried storing the ID as TEXT in the database, but then the conversion from uint64 to string was still necessary in the `Where()` function to retrieve data.

# Testing
Added and listed contact points and alert rules with an ID value of more than 2^63.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
