### PR TITLE
Fix issue updating an alert

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -352,24 +352,14 @@ func ProcessGetAllMinionSearchesRequest(ctx *fasthttp.RequestCtx, orgID int64) {
 }
 
 func ProcessUpdateAlertRequest(ctx *fasthttp.RequestCtx) {
+	type Input struct {
+		alertutils.AlertConfig
+		AlertId string `json:"alert_id"`
+	}
+
 	if databaseObj == nil {
 		utils.SendError(ctx, invalidDatabaseProvider, "", nil)
 		return
-	}
-
-	type Input struct {
-		AlertId      string                         `json:"alert_id" gorm:"primaryKey"`
-		AlertName    string                         `json:"alert_name" gorm:"not null;unique"`
-		AlertType    alertutils.AlertType           `json:"alert_type"`
-		ContactID    string                         `json:"contact_id" gorm:"foreignKey:ContactId;"`
-		ContactName  string                         `json:"contact_name"`
-		Labels       []alertutils.AlertLabel        `json:"labels" gorm:"many2many:label_alerts"`
-		QueryParams  alertutils.QueryParams         `json:"queryParams" gorm:"embedded"`
-		Condition    alertutils.AlertQueryCondition `json:"condition"`
-		Value        float64                        `json:"value"`
-		EvalWindow   uint64                         `json:"eval_for"`      // in minutes
-		EvalInterval uint64                         `json:"eval_interval"` // in minutes
-		Message      string                         `json:"message"`
 	}
 
 	responseBody := make(map[string]interface{})

--- a/pkg/alerts/alertutils/alertutils.go
+++ b/pkg/alerts/alertutils/alertutils.go
@@ -34,29 +34,33 @@ const (
 	AlertTypeMinion
 )
 
+type AlertConfig struct {
+	AlertName    string              `json:"alert_name" gorm:"not null;unique"`
+	AlertType    AlertType           `json:"alert_type"`
+	ContactID    string              `json:"contact_id" gorm:"foreignKey:ContactId;"`
+	ContactName  string              `json:"contact_name"`
+	Labels       []AlertLabel        `json:"labels" gorm:"many2many:label_alerts"`
+	QueryParams  QueryParams         `json:"queryParams" gorm:"embedded"`
+	Condition    AlertQueryCondition `json:"condition"`
+	Value        float64             `json:"value"`
+	EvalWindow   uint64              `json:"eval_for"`      // in minutes; TODO: Rename json field to eval_window
+	EvalInterval uint64              `json:"eval_interval"` // in minutes
+	Message      string              `json:"message"`
+}
+
 type AlertDetails struct {
-	AlertId                  string              `json:"alert_id" gorm:"primaryKey"`
-	AlertType                AlertType           `json:"alert_type"`
-	AlertName                string              `json:"alert_name" gorm:"not null;unique"`
-	State                    AlertState          `json:"state"`
-	CreateTimestamp          time.Time           `json:"create_timestamp" gorm:"autoCreateTime:milli" `
-	ContactID                string              `json:"contact_id" gorm:"foreignKey:ContactId;"`
-	ContactName              string              `json:"contact_name"`
-	Labels                   []AlertLabel        `json:"labels" gorm:"many2many:label_alerts"`
-	SilenceMinutes           uint64              `json:"silence_minutes"`
-	SilenceEndTime           uint64              `json:"silence_end_time"`
-	QueryParams              QueryParams         `json:"queryParams" gorm:"embedded"`
-	MetricsQueryParamsString string              `json:"metricsQueryParams"`
-	Condition                AlertQueryCondition `json:"condition"`
-	Value                    float64             `json:"value"`
-	EvalWindow               uint64              `json:"eval_for"`      // in minutes; TODO: Rename json field to eval_window
-	EvalInterval             uint64              `json:"eval_interval"` // in minutes
-	Message                  string              `json:"message"`
-	CronJob                  gocron.Job          `json:"cron_job" gorm:"embedded"`
-	NodeId                   uint64              `json:"node_id"`
-	NotificationID           string              `json:"notification_id" gorm:"foreignKey:NotificationId;"`
-	OrgId                    int64               `json:"org_id"`
-	NumEvaluationsCount      uint64              `json:"num_evaluations_count"`
+	AlertConfig
+	AlertId                  string     `json:"alert_id" gorm:"primaryKey"`
+	State                    AlertState `json:"state"`
+	CreateTimestamp          time.Time  `json:"create_timestamp" gorm:"autoCreateTime:milli" `
+	SilenceMinutes           uint64     `json:"silence_minutes"`
+	SilenceEndTime           uint64     `json:"silence_end_time"`
+	MetricsQueryParamsString string     `json:"metricsQueryParams"`
+	CronJob                  gocron.Job `json:"cron_job" gorm:"embedded"`
+	NodeId                   uint64     `json:"node_id"`
+	NotificationID           string     `json:"notification_id" gorm:"foreignKey:NotificationId;"`
+	OrgId                    int64      `json:"org_id"`
+	NumEvaluationsCount      uint64     `json:"num_evaluations_count"`
 }
 
 func (AlertDetails) TableName() string {


### PR DESCRIPTION
# Description
Previously when updating an alert, we'd parse the whole alert from the API request and use that as the new version of the alert. However, we only want to update certain fields with this API, so the old way was clearing out some fields that should have been unchanged.

This PR fixes that issue and makes it more clear which fields are expected in the API request.

# Testing
Manually created an alert, then edited it. The new values were updated, and the other fields remained unchanged.


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
