### PR TITLE
Maintain Virtual table names and avoid duplicate appends to virtual table files.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -122,7 +122,7 @@ func Benchmark_EndToEnd(b *testing.B) {
 
 	limit.InitMemoryLimiter()
 
-	err := vtable.InitVTable()
+	err := vtable.InitVTable(serverutils.GetMyIds)
 	if err != nil {
 		b.Fatalf("Failed to initialize vtable: %v", err)
 	}
@@ -316,7 +316,7 @@ func Benchmark_RRCToJson(b *testing.B) {
 
 func Benchmark_esBulkIngest(b *testing.B) {
 	config.InitializeDefaultConfig(b.TempDir())
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(serverutils.GetMyIds)
 
 	querytracker.InitQT()
 
@@ -390,7 +390,7 @@ func Benchmark_agileTreeIngest(b *testing.B) {
 	config.SetAggregationsFlag(true)
 	config.SetPQSEnabled(true)
 
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(serverutils.GetMyIds)
 
 	measureInfoUsage := make(map[string]bool)
 	finalGrpCols := make(map[string]bool)

--- a/pkg/es/reader/resolveIndexHandler_test.go
+++ b/pkg/es/reader/resolveIndexHandler_test.go
@@ -24,13 +24,14 @@ import (
 
 	"github.com/siglens/siglens/pkg/config"
 	esutils "github.com/siglens/siglens/pkg/es/utils"
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ExpandAndReturnIndexNames(t *testing.T) {
 	config.InitializeDefaultConfig(t.TempDir())
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	vTableBaseDir := "vtabbase/"
 	vTableMappingsDir := "vtabbase/mappings/"

--- a/pkg/es/writer/esBulkHandler_test.go
+++ b/pkg/es/writer/esBulkHandler_test.go
@@ -27,6 +27,7 @@ import (
 	jp "github.com/buger/jsonparser"
 	"github.com/siglens/siglens/pkg/config"
 	segwriter "github.com/siglens/siglens/pkg/segment/writer"
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +60,7 @@ func Test_IngestMultipleTypesIntoOneColumn(t *testing.T) {
 	}
 
 	config.InitializeTestingConfig(t.TempDir())
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	// Ingest some data that can all be converted to numbers.
 	jsons := [][]byte{

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -44,6 +44,7 @@ type Hooks struct {
 	GetNodeIdHook             func() string
 	ExtractConfigHook         func(yamlData []byte) (commonconfig.Configuration, error)
 	LogConfigHook             func()
+	SigLensDBExtrasHook       func() error
 	StartSiglensExtrasHook    func(nodeID string) error
 	ShutdownSiglensExtrasHook func()
 	ShutdownSiglensPreHook    func()

--- a/pkg/segment/query/queryrefresh.go
+++ b/pkg/segment/query/queryrefresh.go
@@ -126,16 +126,7 @@ func RefreshGlobalMetadata(fnMyids func() []int64, ownedSegments map[string]stru
 		}
 	}
 
-	default_id := int64(0)
-	// myids should also include the default_id
 	myids := fnMyids()
-	if len(myids) == 0 {
-		myids = append(myids, default_id)
-	}
-
-	if myids[0] != default_id {
-		myids = append(myids, default_id)
-	}
 
 	allSfmFiles := make([]string, len(ingestNodes))
 

--- a/pkg/segment/segexecution_test.go
+++ b/pkg/segment/segexecution_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/utils"
 	. "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	serverutils "github.com/siglens/siglens/pkg/server/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 	log "github.com/sirupsen/logrus"
@@ -1548,7 +1549,7 @@ func Test_unrotatedQuery(t *testing.T) {
 	writer.InitWriterNode()
 	numBatch := 10
 	numRec := 100
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	// disable dict encoding globally
 	writer.SetCardinalityLimit(0)

--- a/pkg/segment/writer/unrotatedquery_test.go
+++ b/pkg/segment/writer/unrotatedquery_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/siglens/siglens/pkg/querytracker"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -42,7 +43,7 @@ func Test_writePQSFiles(t *testing.T) {
 	numBatch := 10
 	numRec := 100
 	numStreams := 10
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	value1, _ := utils.CreateDtypeEnclosure("batch-0", 0)
 	query := &structs.SearchQuery{

--- a/pkg/server/ingest/entryHandlers_test.go
+++ b/pkg/server/ingest/entryHandlers_test.go
@@ -31,6 +31,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/siglens/siglens/pkg/config"
+	server_utils "github.com/siglens/siglens/pkg/server/utils"
 	vtable "github.com/siglens/siglens/pkg/virtualtable"
 )
 
@@ -42,7 +43,7 @@ func cleanupOutDir() {
 func TestPartial_esBulkPostHandler(t *testing.T) {
 
 	config.InitializeDefaultConfig(t.TempDir())
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 	// init a webServer to use the post handler method
 	// setup listener , it's fasthttp in memory listener for TESTING only
 	ln := fasthttputil.NewInmemoryListener()
@@ -119,7 +120,7 @@ func TestPartial_esBulkPostHandler(t *testing.T) {
 }
 
 func TestOk_esBulkPostHandler(t *testing.T) {
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 	config.InitializeDefaultConfig(t.TempDir())
 	// init a webServer to use the post handler method
 	// setup listener , it's fasthttp in memory listener for TESTING only
@@ -191,7 +192,7 @@ func TestOk_esBulkPostHandler(t *testing.T) {
 }
 
 func TestDelete_esBulkPostHandler(t *testing.T) {
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 	config.InitializeDefaultConfig(t.TempDir())
 	// init a webServer to use the post handler method
 	// setup listener , it's fasthttp in memory listener for TESTING only
@@ -254,7 +255,7 @@ func TestDelete_esBulkPostHandler(t *testing.T) {
 }
 
 func TestUpdate_esBulkPostHandler(t *testing.T) {
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	// init a webServer to use the post handler method
 	// setup listener , it's fasthttp in memory listener for TESTING only
@@ -319,7 +320,7 @@ func TestUpdate_esBulkPostHandler(t *testing.T) {
 }
 
 func Test_HealthHandler(t *testing.T) {
-	_ = vtable.InitVTable()
+	_ = vtable.InitVTable(server_utils.GetMyIds)
 
 	// init a webServer to use the post handler method
 	// setup listener , it's fasthttp in memory listener for TESTING only

--- a/pkg/virtualtable/virtualtable.go
+++ b/pkg/virtualtable/virtualtable.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/siglens/siglens/pkg/blob"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
@@ -55,7 +56,7 @@ var allVirtualTables map[uint64]map[string]bool
 
 var excludedInternalIndices = [...]string{"traces", "red-traces", "service-dependency"}
 
-func InitVTable() error {
+func InitVTable(fnMyIds func() []uint64) error {
 	allVirtualTables = make(map[uint64]map[string]bool)
 	var sb strings.Builder
 	sb.WriteString(config.GetDataPath() + "ingestnodes/" + config.GetHostID() + "/vtabledata")
@@ -80,7 +81,8 @@ func InitVTable() error {
 		return err
 	}
 
-	go refreshInMemoryTable()
+	refreshInMemoryTableForAllIds(fnMyIds)
+	go refreshInMemoryTable(fnMyIds)
 	return nil
 }
 
@@ -94,16 +96,35 @@ func getVirtualTableFileName(orgid uint64) string {
 	return vTableFileName
 }
 
-func refreshInMemoryTable() {
+func refreshInMemoryTableForAllIds(fnMyIds func() []uint64) {
+	myids := fnMyIds()
+
+	globalTableAccessLock.Lock()
+	defer globalTableAccessLock.Unlock()
+
+	wg := sync.WaitGroup{}
+
+	for _, myid := range myids {
+		vTableMap := make(map[string]bool)
+		allVirtualTables[myid] = vTableMap
+
+		wg.Add(1)
+		go func(myid uint64, vTableMap map[string]bool) {
+			defer wg.Done()
+
+			err := getVirtualTableNamesInternal(myid, vTableMap)
+			if err != nil {
+				log.Errorf("refreshInMemoryTableForAllIds: Failed to get virtual table names! err=%v", err)
+			}
+		}(myid, vTableMap)
+	}
+
+	wg.Wait()
+}
+
+func refreshInMemoryTable(fnMyIds func() []uint64) {
 	for {
-		allReadTables, err := GetVirtualTableNames(0)
-		if err != nil {
-			log.Errorf("refreshInMemoryTable: Failed to get virtual table names! err=%v", err)
-		} else {
-			globalTableAccessLock.Lock()
-			allVirtualTables[uint64(0)] = allReadTables
-			globalTableAccessLock.Unlock()
-		}
+		refreshInMemoryTableForAllIds(fnMyIds)
 		time.Sleep(1 * time.Minute)
 	}
 }
@@ -151,54 +172,125 @@ func CreateVirtTableBaseDirs(vTableBaseDir string, vTableMappingsDir string,
 	return nil
 }
 
-func addVirtualTableHelper(tname *string, orgid uint64) error {
-	var tableExists bool
-	globalTableAccessLock.RLock()
-	_, tableExists = allVirtualTables[orgid][*tname]
-	globalTableAccessLock.RUnlock()
-	if tableExists {
-		return nil
-	}
+// addVirtualTableHelper adds the given virtual table to the global virtual table map and writes it to the file
+// It returns true if a virtual table was added to the file, false otherwise
+func addVirtualTableHelper(vTableMap map[string]struct{}, orgid uint64) (bool, error) {
+	vTablesToAppend := make(map[string]struct{})
 
 	globalTableAccessLock.Lock()
-	if _, orgExists := allVirtualTables[orgid]; !orgExists {
-		allVirtualTables[orgid] = make(map[string]bool)
+	orgVTableMap, exists := allVirtualTables[orgid]
+	if !exists {
+		orgVTableMap = make(map[string]bool)
+		allVirtualTables[orgid] = orgVTableMap
 	}
-	allVirtualTables[orgid][*tname] = true
+
+	for tname := range vTableMap {
+		if _, exists := orgVTableMap[tname]; !exists {
+			vTablesToAppend[tname] = struct{}{}
+			orgVTableMap[tname] = true
+		}
+	}
 	globalTableAccessLock.Unlock()
+
+	if len(vTablesToAppend) == 0 {
+		return false, nil
+	}
 
 	vTableFileName := getVirtualTableFileName(orgid)
 	fd, err := os.OpenFile(vTableFileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		log.Errorf("AddVirtualTable: Failed to open virtual tablename=%v, in file=%v, err=%v", *tname, vTableFileName, err)
-		return err
+		log.Errorf("AddVirtualTable: Failed to open virtual table file=%v, err=%v", vTableFileName, err)
+		return false, err
 	}
 	defer fd.Close()
-	if _, err := fd.WriteString(*tname); err != nil {
-		log.Errorf("AddVirtualTable: Failed to write virtual tablename=%v, in file=%v, err=%v", *tname, vTableFileName, err)
 
-		return err
+	for tname := range vTablesToAppend {
+		if _, err := fd.WriteString(tname); err != nil {
+			log.Errorf("AddVirtualTable: Failed to write virtual tablename=%v, in file=%v, err=%v", tname, vTableFileName, err)
+
+			return false, err
+		}
+		if _, err := fd.WriteString("\n"); err != nil {
+			log.Errorf("AddVirtualTable: Failed to write \n to virtual tablename=%v, in file=%v, err=%v", tname, vTableFileName, err)
+			return false, err
+		}
 	}
-	if _, err := fd.WriteString("\n"); err != nil {
-		log.Errorf("AddVirtualTable: Failed to write \n to virtual tablename=%v, in file=%v, err=%v", *tname, vTableFileName, err)
-		return err
-	}
+
 	if err = fd.Sync(); err != nil {
-		log.Errorf("AddVirtualTable: Failed to sync virtual tablename=%v, in file=%v, err=%v", *tname, vTableFileName, err)
-		return err
+		log.Errorf("AddVirtualTable: Failed to sync virtual table file=%v, err=%v", vTableFileName, err)
+		return false, err
 	}
-	return nil
+
+	return true, nil
 }
 
 func AddVirtualTable(tname *string, orgid uint64) error {
+	vTableMap := make(map[string]struct{})
+	vTableMap[*tname] = struct{}{}
 
 	vTableRawFileAccessLock.Lock()
-	err := addVirtualTableHelper(tname, orgid)
+	vTableFileUpdated, err := addVirtualTableHelper(vTableMap, orgid)
 	vTableRawFileAccessLock.Unlock()
 	if err != nil {
 		log.Errorf("AddVirtualTable: Error in adding virtual table=%v to the file!. Err: %v", tname, err)
 		return err
 	}
+
+	if vTableFileUpdated {
+		go func() {
+			err := blob.UploadIngestNodeDir()
+			if err != nil {
+				log.Errorf("AddVirtualTable: Failed to upload vtable data to blob store, err=%v", err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+func BulkAddVirtualTableNames(myIdToVTableMap map[uint64]map[string]struct{}) error {
+	vTableRawFileAccessLock.Lock()
+	defer vTableRawFileAccessLock.Unlock()
+
+	wg := sync.WaitGroup{}
+
+	shouldUpload := false
+	mu := sync.RWMutex{}
+
+	for myid, vTableNamesMap := range myIdToVTableMap {
+		wg.Add(1)
+		go func(id uint64, vTableMap map[string]struct{}) {
+			defer wg.Done()
+
+			vTableFileUpdated, err := addVirtualTableHelper(vTableMap, id)
+			if err != nil {
+				log.Errorf("RefreshGlobalMetadata: Error in adding virtual table names for myid=%d, err:%v", id, err)
+			}
+
+			mu.RLock()
+			curentShouldUploadValue := shouldUpload
+			mu.RUnlock()
+
+			if vTableFileUpdated && !curentShouldUploadValue {
+				mu.Lock()
+				shouldUpload = true
+				mu.Unlock()
+			}
+
+		}(myid, vTableNamesMap)
+	}
+
+	wg.Wait()
+
+	if shouldUpload {
+		go func() {
+			err := blob.UploadIngestNodeDir()
+			if err != nil {
+				log.Errorf("AddVirtualTable: Failed to upload vtable data to blob store, err=%v", err)
+			}
+		}()
+	}
+
 	return nil
 }
 
@@ -260,19 +352,34 @@ func AddMapping(tname *string, mapping *string, orgid uint64) error {
 }
 
 func GetVirtualTableNames(orgid uint64) (map[string]bool, error) {
-	vTableFileName := getVirtualTableFileName(orgid)
-	return getVirtualTableNamesHelper(vTableFileName)
+	vTableMap := make(map[string]bool)
+	err := getVirtualTableNamesInternal(orgid, vTableMap)
+	if err != nil {
+		return nil, utils.TeeErrorf("GetVirtualTableNames: Error in getting virtual table names for orgid=%v, err=%v", orgid, err)
+	}
+	return vTableMap, nil
 }
 
-func getVirtualTableNamesHelper(fileName string) (map[string]bool, error) {
-	var result = make(map[string]bool)
+func getVirtualTableNamesInternal(orgid uint64, vTableMap map[string]bool) error {
+	vTableFileName := getVirtualTableFileName(orgid)
+	err := LoadVirtualTableNamesFromFile(vTableFileName, vTableMap)
+	if err != nil {
+		return fmt.Errorf("getVirtualTableNamesInternal: Error in loading virtual table names for orgid=%v, err=%v", orgid, err)
+	}
+	return nil
+}
+
+func LoadVirtualTableNamesFromFile(fileName string, vTableMap map[string]bool) error {
+	if vTableMap == nil {
+		return fmt.Errorf("GetVirtualTableNamesHelper: vTableMap is nil")
+	}
 	fd, err := os.OpenFile(fileName, os.O_RDONLY, 0644)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return result, nil
+			return nil
 		}
 		log.Errorf("GetVirtualTableNames: Failed to open file=%v, err=%v", fileName, err)
-		return nil, err
+		return err
 	}
 
 	defer fd.Close()
@@ -280,12 +387,12 @@ func getVirtualTableNamesHelper(fileName string) (map[string]bool, error) {
 	scanner := bufio.NewScanner(fd)
 	for scanner.Scan() {
 		rawbytes := scanner.Bytes()
-		result[string(rawbytes)] = true
+		vTableMap[string(rawbytes)] = true
 	}
 	if err := scanner.Err(); err != nil {
-		return result, utils.TeeErrorf("getVirtualTableNamesHelper: Error scanning file %v, err: %v", fileName, err)
+		return fmt.Errorf("getVirtualTableNamesHelper: Error scanning file %v, err: %v", fileName, err)
 	}
-	return result, nil
+	return nil
 }
 
 func AddAliases(indexName string, aliases []string, orgid uint64) error {

--- a/pkg/virtualtable/virtualtable_test.go
+++ b/pkg/virtualtable/virtualtable_test.go
@@ -28,10 +28,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func MockGetMyIds() []uint64 {
+	return []uint64{0}
+}
+
 func Test_AddGetVTables(t *testing.T) {
 
 	config.InitializeDefaultConfig(t.TempDir())
-	_ = InitVTable()
+	_ = InitVTable(MockGetMyIds)
 
 	VTableBaseDir = "vtabbase/"
 	VTableMappingsDir = "vtabbase/mappings/"
@@ -69,7 +73,7 @@ func Test_AddGetVTables(t *testing.T) {
 
 func Test_AddAliases(t *testing.T) {
 
-	_ = InitVTable()
+	_ = InitVTable(MockGetMyIds)
 	// special test code only to override the default paths and have idempotent tests
 
 	VTableBaseDir = "vtabbase/"
@@ -101,7 +105,7 @@ func Test_AddAliases(t *testing.T) {
 
 func Test_GetIndexNameFromAlias(t *testing.T) {
 
-	_ = InitVTable()
+	_ = InitVTable(MockGetMyIds)
 	os.RemoveAll(VTableBaseDir)
 
 	// special test code only to ove\rride the default paths and have idempotent tests
@@ -132,7 +136,7 @@ func Test_GetIndexNameFromAlias(t *testing.T) {
 
 func Test_AddRemoveAlias(t *testing.T) {
 
-	_ = InitVTable()
+	_ = InitVTable(MockGetMyIds)
 	os.RemoveAll(VTableBaseDir)
 
 	// special test code only to ove\rride the default paths and have idempotent tests
@@ -171,7 +175,7 @@ func Test_DeleteVirtualTable(t *testing.T) {
 
 	indexName := "valtix2"
 
-	_ = InitVTable()
+	_ = InitVTable(MockGetMyIds)
 
 	var check string
 	var sb strings.Builder


### PR DESCRIPTION
# Description
- Currently there is an issue that the we update the virtual table file with the same table names when the server is started.
- This PR fixes that issue.
- And also uses go routines to update the data all at once as bulk, instead of doing one at a time.
- Refactors and removed some of the other code.

# Testing
- Tested by starting the server with no data and ingested across multiple indexes.
- Kill the server, verify the local file with proper index names.
- Restart the server and verify that the indexnames are not duplicated.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
