### PR TITLE
Ingest metrics using proper ID

### DIFF
--- a/pkg/integrations/prometheus/ingest/putmetrics_test.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics_test.go
@@ -58,7 +58,7 @@ func Test_PutMetrics(t *testing.T) {
 	totalSuccess := uint64(0)
 	for i := 0; i < 100; i++ {
 		postData := FixtureSamplePayload(i)
-		success, fail, err := HandlePutMetrics(postData)
+		success, fail, err := HandlePutMetrics(postData, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, success, uint64(1))
 		assert.Equal(t, fail, uint64(0))

--- a/pkg/server/ingest/entryHandlers.go
+++ b/pkg/server/ingest/entryHandlers.go
@@ -154,7 +154,7 @@ func esGreetHandler() func(ctx *fasthttp.RequestCtx) {
 
 func prometheusPutMetricsHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
-		prometheuswriter.PutMetrics(ctx)
+		serverutils.CallWithMyId(prometheuswriter.PutMetrics, ctx)
 	}
 }
 


### PR DESCRIPTION
# Description
Fixes issue ingesting metrics when the ID is not zero

# Testing
Tested by running the OpenTelemetry Demo as described in https://github.com/siglens/siglens/pull/2098

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
