### PR TITLE
Log Traces and myid in the per minute stats

### DIFF
--- a/pkg/integrations/prometheus/ingest/putmetrics.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics.go
@@ -180,7 +180,7 @@ func HandlePutMetrics(compressed []byte, myid int64) (uint64, uint64, error) {
 		}
 	}
 	bytesReceived := uint64(len(compressed))
-	usageStats.UpdateMetricsStats(bytesReceived, successCount, 0)
+	usageStats.UpdateMetricsStats(bytesReceived, successCount, myid)
 	return successCount, failedCount, nil
 }
 

--- a/pkg/otlp/otlp.go
+++ b/pkg/otlp/otlp.go
@@ -138,7 +138,7 @@ func ProcessTraceIngest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	log.Debugf("ProcessTraceIngest: %v spans in the request and failed to ingest %v of them", numSpans, numFailedSpans)
-	usageStats.UpdateTracesStats(uint64(len(data)), uint64(numSpans), 0)
+	usageStats.UpdateTracesStats(uint64(len(data)), uint64(numSpans), myid)
 	// Send the appropriate response.
 	handleTraceIngestionResponse(ctx, numSpans, numFailedSpans)
 }

--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -65,6 +65,7 @@ type Stats struct {
 	MetricsBytesCount           uint64
 	TraceBytesCount             uint64
 	TraceSpanCount              uint64
+	TotalTraceSpanCount         uint64
 }
 
 var ustats = make(map[int64]*Stats)
@@ -318,17 +319,21 @@ func ForceFlushStatstoFile() {
 	}
 }
 
-func logStatSummary(orgid int64) {
-	if _, ok := ustats[orgid]; ok {
-		log.Infof("Ingest stats: past minute : events=%v, metrics=%v, bytes=%v",
-			msgPrinter.Sprintf("%v", ustats[orgid].LogLinesCount),
-			msgPrinter.Sprintf("%v", ustats[orgid].MetricsDatapointsCount),
-			msgPrinter.Sprintf("%v", ustats[orgid].BytesCount))
+func logStatSummary(myid int64) {
+	if _, ok := ustats[myid]; ok {
+		log.Infof("Ingest stats: past minute : myid=%v, events=%v, metrics=%v, traces=%v, bytes=%v",
+			myid,
+			msgPrinter.Sprintf("%v", ustats[myid].LogLinesCount),
+			msgPrinter.Sprintf("%v", ustats[myid].MetricsDatapointsCount),
+			msgPrinter.Sprintf("%v", ustats[myid].TraceSpanCount),
+			msgPrinter.Sprintf("%v", ustats[myid].BytesCount))
 
-		log.Infof("Ingest stats: total so far: events=%v, metrics=%v, bytes=%v",
-			msgPrinter.Sprintf("%v", ustats[orgid].TotalLogLinesCount),
-			msgPrinter.Sprintf("%v", ustats[orgid].TotalMetricsDatapointsCount),
-			msgPrinter.Sprintf("%v", ustats[orgid].TotalBytesCount))
+		log.Infof("Ingest stats: total so far: myid=%v, events=%v, metrics=%v, traces=%v, bytes=%v",
+			myid,
+			msgPrinter.Sprintf("%v", ustats[myid].TotalLogLinesCount),
+			msgPrinter.Sprintf("%v", ustats[myid].TotalMetricsDatapointsCount),
+			msgPrinter.Sprintf("%v", ustats[myid].TotalTraceSpanCount),
+			msgPrinter.Sprintf("%v", ustats[myid].TotalBytesCount))
 	}
 }
 
@@ -422,6 +427,7 @@ func UpdateTracesStats(traceBytesCount uint64, traceSpanCount uint64, orgid int6
 	atomic.AddUint64(&ustats[orgid].BytesCount, traceBytesCount)
 	atomic.AddUint64(&ustats[orgid].TraceBytesCount, traceBytesCount)
 	atomic.AddUint64(&ustats[orgid].TraceSpanCount, traceSpanCount)
+	atomic.AddUint64(&ustats[orgid].TotalTraceSpanCount, traceSpanCount)
 	atomic.AddUint64(&ustats[orgid].TotalBytesCount, traceBytesCount)
 }
 


### PR DESCRIPTION
# Description
- Now Traces Ingest Stats will be logged in the per-minute stats.


# Testing
- Tested by ingesting some traces
- Verified that I see the traces stats.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
