### PR TITLE
Feat: Implemented SPL stats subcmd - stdev, stdevp

### DIFF
--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1437,8 +1437,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.UpperPerc:    {},
 	utils.Median:       {},
 	utils.Mode:         {},
-	utils.Stdev:        {},
-	utils.Stdevp:       {},
 	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -83,6 +83,16 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
+		case Stdev,Stdevp:
+			e1.SQsum += e2.SQsum
+			e1.Sum += e2.Sum
+			e1.Count += e2.Count
+			mean := e1.Sum / float64(e1.Count) 
+			result := e1.SQsum + float64(e1.Count) * ( mean * mean) - ( 2 * mean * e1.Sum )
+			result = result / float64(e1.Count)
+			result = math.Sqrt(result) 
+			e1.CVal = uint64(result)
+			return e1,nil	
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
@@ -97,6 +107,16 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
+		case Stdev,Stdevp:
+			e1.SQsum += e2.SQsum
+			e1.Sum += e2.Sum
+			e1.Count += e2.Count
+			mean := e1.Sum / float64(e1.Count) 
+			result := e1.SQsum + float64(e1.Count) * ( mean * mean) - ( 2 * mean * e1.Sum )
+			result = result / float64(e1.Count)
+			result = math.Sqrt(result) 
+			e1.CVal = int64(result)
+			return e1,nil	
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
@@ -111,6 +131,16 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
 			return e1, nil
+		case Stdev,Stdevp:
+			e1.SQsum += e2.SQsum
+			e1.Sum += e2.Sum
+			e1.Count += e2.Count
+			mean := e1.Sum / float64(e1.Count) 
+			result := e1.SQsum + float64(e1.Count) * ( mean * mean) - ( 2 * mean * e1.Sum )
+			result = result / float64(e1.Count)
+			result = math.Sqrt(result) 
+			e1.CVal = result
+			return e1,nil	
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
 		}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -859,6 +859,9 @@ func (dte *DtypeEnclosure) GetValue() (interface{}, error) {
 type CValueEnclosure struct {
 	Dtype SS_DTYPE
 	CVal  interface{}
+	Sum float64
+	SQsum float64
+	Count float64
 }
 
 func (e *CValueEnclosure) Equal(other *CValueEnclosure) bool {

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum','stdev','stdevp'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description
1. Removed stdev and stdevp from unsupportedStatsFuncs map.
2. Added stdev and stdevp in stats dropdown (UI).

Fixes #2104 

# Testing
I have the tested the changes in both builder and code modes of UI.

![image](https://github.com/user-attachments/assets/22c49cf0-1238-4971-ba36-008494c7c712)

![image](https://github.com/user-attachments/assets/4b3abb4c-f528-4ecb-849e-f8bee18efae8)


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
