### PR TITLE
Fix: [#2104] Implemented SPL stats subcmds - stdev & stdevp

### DIFF
--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,6 +275,10 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
+	} else if aggType == "stdev" {
+		aggFunc = utils.Stdev
+	} else if aggType == "stdevp" {
+		aggFunc = utils.Stdevp
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1437,8 +1437,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.UpperPerc:    {},
 	utils.Median:       {},
 	utils.Mode:         {},
-	utils.Stdev:        {},
-	utils.Stdevp:       {},
 	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -111,6 +111,17 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
 			return e1, nil
+		case Stdev, Stdevp:
+			if e1.Count < 2 {
+				return e1, fmt.Errorf("Reduce: not enough data for standard deviation")
+			}
+			mean := e1.Sum / float64(e1.Count)
+			variance := (e1.SumSq/float64(e1.Count) - mean*mean)
+			if fun == Stdev {
+				variance *= float64(e1.Count) / float64(e1.Count-1) // Sample variance adjustment
+			}
+			e1.CVal = math.Sqrt(variance)
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
 		}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -859,6 +859,9 @@ func (dte *DtypeEnclosure) GetValue() (interface{}, error) {
 type CValueEnclosure struct {
 	Dtype SS_DTYPE
 	CVal  interface{}
+	Sum   float64
+	SumSq float64
+	Count int64
 }
 
 func (e *CValueEnclosure) Equal(other *CValueEnclosure) bool {

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum','stdev','stdevp'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description
Implemented SPL stats subcmds  - stdev & stdevp.
Fixes #2104 
It introduces improvements and fixes to ensure that the functionality works as expected.

### Changes Made
- Implemented logic for calculating sample standard deviation (stdev) & population standard deviation (stdevp).

- Removed stdev and stdevp from unsupportedStatsFuncs map.

- Added options for the same in query builder's UI.

# Testing
- Tested the changes locally and confirmed that they resolve the issue.

- Verified that the new changes do not affect existing features.

### Screenshots 

![image](https://github.com/user-attachments/assets/7c28b511-95e8-48db-a491-60d2fb2f4481)


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
