### PR TITLE
Fixed: #2074 Implemented subcmd- sumsq

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -552,7 +552,7 @@ func GetAutoCompleteData(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	resp.ColumnNames = segmetadata.GetAllColNames(sortedIndices)
-	resp.MeasureFunctions = []string{"min", "max", "avg", "count", "sum", "cardinality"}
+	resp.MeasureFunctions = []string{"min", "max", "avg", "count", "sum", "cardinality", "sumsq"}
 	utils.WriteJsonResponse(ctx, resp)
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -125,6 +125,8 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
+	case "sumsq":
+		return utils.Sumsq
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,6 +275,8 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
+	} else if aggType == "sumsq" {
+		aggFunc = utils.Sumsq
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1439,7 +1439,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.Mode:         {},
 	utils.Stdev:        {},
 	utils.Stdevp:       {},
-	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},
 	utils.First:        {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -245,18 +245,18 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
 		case Sumsq:
-			if self.Ntype == SS_DT_SIGNED_NUM {
+			if self.Ntype == SS_DT_SIGNED_NUM {// For integer types, use uint64 to prevent overflow				
 				val1 := uint64(self.IntgrVal)
 				val2 := uint64(e2int64)
 				result := val1 + (val2 * val2)
 				self.Ntype = SS_DT_UNSIGNED_NUM
 				self.IntgrVal = int64(result)
 				return nil
-			} else if self.Ntype == SS_DT_FLOAT {
+			} else if self.Ntype == SS_DT_FLOAT {// For float types, continue using float64				
 				self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 				return nil
-			}
-			if self.Ntype == SS_INVALID {
+			}		
+			if self.Ntype == SS_INVALID {// Initialize for first value
 				self.Ntype = SS_DT_UNSIGNED_NUM
 				self.IntgrVal = int64(uint64(e2int64 * e2int64))
 				return nil

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -246,7 +246,6 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Sumsq:
 			if self.Ntype == SS_DT_SIGNED_NUM {
-				// For integer types, use uint64 to prevent overflow
 				val1 := uint64(self.IntgrVal)
 				val2 := uint64(e2int64)
 				result := val1 + (val2 * val2)
@@ -254,11 +253,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 				self.IntgrVal = int64(result)
 				return nil
 			} else if self.Ntype == SS_DT_FLOAT {
-				// For float types, continue using float64
 				self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 				return nil
 			}
-			// Initialize for first value
 			if self.Ntype == SS_INVALID {
 				self.Ntype = SS_DT_UNSIGNED_NUM
 				self.IntgrVal = int64(uint64(e2int64 * e2int64))

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -245,18 +245,21 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
 		case Sumsq:
-			if self.Ntype == SS_DT_SIGNED_NUM {// For integer types, use uint64 to prevent overflow				
+			if self.Ntype == SS_DT_SIGNED_NUM {
+				// For integer types, use uint64 to prevent overflow
 				val1 := uint64(self.IntgrVal)
 				val2 := uint64(e2int64)
 				result := val1 + (val2 * val2)
 				self.Ntype = SS_DT_UNSIGNED_NUM
 				self.IntgrVal = int64(result)
 				return nil
-			} else if self.Ntype == SS_DT_FLOAT {// For float types, continue using float64				
+			} else if self.Ntype == SS_DT_FLOAT {
+				// For float types, continue using float64
 				self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 				return nil
-			}		
-			if self.Ntype == SS_INVALID {// Initialize for first value
+			}
+			// Initialize for first value
+			if self.Ntype == SS_INVALID {
 				self.Ntype = SS_DT_UNSIGNED_NUM
 				self.IntgrVal = int64(uint64(e2int64 * e2int64))
 				return nil

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -83,6 +83,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(uint64)*e1.CVal.(uint64) + e2.CVal.(uint64)*e2.CVal.(uint64)
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
@@ -97,6 +100,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(int64)*e1.CVal.(int64) + e2.CVal.(int64)*e2.CVal.(int64)
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
@@ -110,6 +116,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			return e1, nil
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
+			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(float64)*e1.CVal.(float64) + e2.CVal.(float64)*e2.CVal.(float64)
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
@@ -221,6 +230,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
+		case Sumsq:
+			self.IntgrVal = self.IntgrVal*self.IntgrVal + e2int64*e2int64
+			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported int function: %v", fun)
 		}
@@ -237,6 +249,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Count:
 			self.FloatVal = self.FloatVal + e2float64
+			return nil
+		case Sumsq:
+			self.FloatVal = self.FloatVal*self.FloatVal + e2float64*e2float64
 			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported float function: %v", fun)

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum', 'sumsq'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description
Added support for `sumsq` (sum of squares) aggregation function in the stats command. This allows users to calculate the sum of squares of numeric fields, particularly useful for statistical analysis and variance calculations.

Fixes #2074 

# Changes Made
Modified the following files:
1. `aggutils.go`: Implemented `sumsq` calculation in [Reduce] and [ReduceFast] functions, using proper type handling to prevent overflow
2. `structs.go`: Added `sumsq` support in `AggTypeToAggregateFunction`
3. `segstructs.go`: Removed `sumsq` from unsupported stats functions
4. `query-builder.js`: Added `sumsq` to available calculations list
5. `astsql.go`: Added  `sumsq` in function getAggregationSQL 
6. `searchHandler.go`: Added `sumsq` in MeasureFunctions 


#Screenshot
<img width="1415" alt="Screenshot 2025-02-06 at 4 40 37 PM" src="https://github.com/user-attachments/assets/f639aea4-b8aa-418b-b40d-d02e7cc1a2bf" />

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.


Name:Siddhant Thaware
PRN:12110937


