### PR TITLE
Implemented subcmd - sumsq

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -552,7 +552,7 @@ func GetAutoCompleteData(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	resp.ColumnNames = segmetadata.GetAllColNames(sortedIndices)
-	resp.MeasureFunctions = []string{"min", "max", "avg", "count", "sum", "cardinality"}
+	resp.MeasureFunctions = []string{"min", "max", "avg", "count", "sum", "cardinality", "sumsq"}
 	utils.WriteJsonResponse(ctx, resp)
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -125,6 +125,8 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
+	case "sumsq":
+		return utils.Sumsq
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,6 +275,8 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
+	} else if aggType == "sumsq" {
+		aggFunc = utils.Sumsq
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}

--- a/pkg/integrations/otsdb/query/queryparser.go
+++ b/pkg/integrations/otsdb/query/queryparser.go
@@ -261,6 +261,7 @@ func parseAggregatorDownsampler(m string) (segutils.AggregateFunctions, structs.
 		"sum":         segutils.Sum,
 		"cardinality": segutils.Cardinality,
 		"quantile":    segutils.Quantile,
+		"sumsq":       segutils.Sumsq,
 	}
 	agg := structs.Aggregation{AggregatorFunction: aggregatorMapping["avg"]}
 	downsampler := structs.Downsampler{Interval: 1, Unit: "m", Aggregator: agg}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1439,7 +1439,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.Mode:         {},
 	utils.Stdev:        {},
 	utils.Stdevp:       {},
-	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},
 	utils.First:        {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -84,7 +84,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
 		case Sumsq:
-			e1.CVal = e1.CVal.(uint64)*e1.CVal.(uint64) + e2.CVal.(uint64)*e2.CVal.(uint64)
+			e1.CVal = e1.CVal.(uint64) + e2.CVal.(uint64)*e2.CVal.(uint64)
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
@@ -101,7 +101,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
 		case Sumsq:
-			e1.CVal = e1.CVal.(int64)*e1.CVal.(int64) + e2.CVal.(int64)*e2.CVal.(int64)
+			e1.CVal = e1.CVal.(int64) + e2.CVal.(int64)*e2.CVal.(int64)
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
@@ -118,7 +118,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
 			return e1, nil
 		case Sumsq:
-			e1.CVal = e1.CVal.(float64)*e1.CVal.(float64) + e2.CVal.(float64)*e2.CVal.(float64)
+			e1.CVal = e1.CVal.(float64) + e2.CVal.(float64)*e2.CVal.(float64)
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -83,6 +83,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(uint64)*e1.CVal.(uint64) + e2.CVal.(uint64)*e2.CVal.(uint64)
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
@@ -97,6 +100,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(int64)*e1.CVal.(int64) + e2.CVal.(int64)*e2.CVal.(int64)
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
@@ -110,6 +116,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			return e1, nil
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
+			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(float64)*e1.CVal.(float64) + e2.CVal.(float64)*e2.CVal.(float64)
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
@@ -221,6 +230,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
+		case Sumsq:
+			self.IntgrVal += e2int64 * e2int64
+			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported int function: %v", fun)
 		}
@@ -237,6 +249,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Count:
 			self.FloatVal = self.FloatVal + e2float64
+			return nil
+		case Sumsq:
+			self.FloatVal += e2float64 * e2float64
 			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported float function: %v", fun)

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -347,7 +347,7 @@ func ConvertGroupByKeyFromBytes(rec []byte) ([]interface{}, error) {
 // IsNumTypeAgg checks if aggregate function requires numeric type data
 func IsNumTypeAgg(fun AggregateFunctions) bool {
 	switch fun {
-	case Avg, Min, Max, Sum, Range:
+	case Avg, Min, Max, Sum, Range, Sumsq:
 		return true
 	default:
 		return false

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum','sumsq'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
## Description
Added `'sumsq'` aggregation to the stats command, enabling sum of squares calculations
 
Fixes #2074 

## Task implemented

1.  Deleted `utils.Sumsq` from  Struct  `var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{ }`   Filelocation `segstructs.go`
2.  Added  `sumsq` to else if  condition in function `func AggTypeToAggregateFunction`  Filelocation  `structs.go`
3.  Added  `sumsq` to else if  condition in function `func getAggregationSQL`  Filelocation `astsql.go`
4.  Added support for Sumsq aggregation type in Reduce functions and ReduceFast for uint64,float64,int64 type  Filelocation `aggutils.go`
5. Added `sumsq' in `resp.MeasureFunctions ` list Filelocation 'searchHandler.go`
6. Added `sumsq` to available `calculations` list Filelocation `query-builder.js`

## Testing
![Screenshot (164)](https://github.com/user-attachments/assets/f41d7ab4-9d4f-40de-8ae5-83b7a41d8318)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
