### PR TITLE
#2074 Implemented SPL stats subcmd - sumsq

### DIFF
--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -146,7 +146,7 @@ func getMathEvaluatorSQL(op string, qid uint64) (utils.MathFunctions, error) {
 		return utils.Sqrt, nil
 	case "exp":
 		return utils.Exp, nil
-	
+
 	default:
 		log.Errorf("qid=%v, getMathEvaluatorSQL: math evaluator type: %v is not supported!", qid, op)
 		return 0, fmt.Errorf("math evaluator type not supported")

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -125,6 +125,8 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
+	case "sumsq":
+		return utils.Sumsq
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0
@@ -144,6 +146,7 @@ func getMathEvaluatorSQL(op string, qid uint64) (utils.MathFunctions, error) {
 		return utils.Sqrt, nil
 	case "exp":
 		return utils.Exp, nil
+	
 	default:
 		log.Errorf("qid=%v, getMathEvaluatorSQL: math evaluator type: %v is not supported!", qid, op)
 		return 0, fmt.Errorf("math evaluator type not supported")

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,7 +275,7 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
-	} else if aggType == "sumsq"{
+	} else if aggType == "sumsq" {
 		aggFunc = utils.Sumsq
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,6 +275,8 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
+	} else if aggType == "sumsq"{
+		aggFunc = utils.Sumsq
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1439,7 +1439,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.Mode:         {},
 	utils.Stdev:        {},
 	utils.Stdevp:       {},
-	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},
 	utils.First:        {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -100,7 +100,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
-		case Sumsq: 
+		case Sumsq:
 			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
 			return e1, nil
 		default:
@@ -230,7 +230,7 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
-		case Sumsq: 
+		case Sumsq:
 			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
 			return nil
 		default:

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -83,6 +83,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(uint64) + (e2.CVal.(uint64) * e2.CVal.(uint64))
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
@@ -97,6 +100,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
+		case Sumsq: 
+			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
@@ -110,6 +116,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			return e1, nil
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
+			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(float64) + (e2.CVal.(float64) * e2.CVal.(float64))
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
@@ -221,6 +230,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
+		case Sumsq: 
+			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
+			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported int function: %v", fun)
 		}
@@ -237,6 +249,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Count:
 			self.FloatVal = self.FloatVal + e2float64
+			return nil
+		case Sumsq:
+			self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported float function: %v", fun)

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -347,7 +347,7 @@ func ConvertGroupByKeyFromBytes(rec []byte) ([]interface{}, error) {
 // IsNumTypeAgg checks if aggregate function requires numeric type data
 func IsNumTypeAgg(fun AggregateFunctions) bool {
 	switch fun {
-	case Avg, Min, Max, Sum, Range,Sumsq:
+	case Avg, Min, Max, Sum, Range, Sumsq:
 		return true
 	default:
 		return false

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -347,7 +347,7 @@ func ConvertGroupByKeyFromBytes(rec []byte) ([]interface{}, error) {
 // IsNumTypeAgg checks if aggregate function requires numeric type data
 func IsNumTypeAgg(fun AggregateFunctions) bool {
 	switch fun {
-	case Avg, Min, Max, Sum, Range:
+	case Avg, Min, Max, Sum, Range,Sumsq:
 		return true
 	default:
 		return false

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum','sumsq'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description

I have added the aggregation attribute of Sum of squares (Sumsq) in the stats command. 

Sum of squares is used to evaluate the variance of a dataset from the dataset mean. A large value of Sumsq indicates large variance, which tells that individual values fluctuate widely from the mean.
Summarize the change.

# Output
![Output](https://github.com/user-attachments/assets/92ed2e1d-7798-47a1-8505-0961ed2f2641)
![graph](https://github.com/user-attachments/assets/1a49fc7f-5e81-4612-9029-78e683cfdd8f)

# Changes Made

To achieve the goal I had to modify the following files:

1. `query-builder.js`: Added sumsq to the array of available calculations.

2. `aggutils.go`: Performed the main calculations to implement sumsq. Also, implementation proper type handling to obtain proper results.

3. `segutils.go`: Added the case of Sumsq in the function IsNumTypeAgg

4. `segstructs.go`: Removed sumsq from unsupported stats structure.

5. `astsql.go`: Added a switch case for sumsq.

6. `structs.go`: Added else if for aggType == "sumsq"

Fixes #2074 

# Testing
* Added sumsq to the array of available calculations in the file `query_builder.js` so that users can see that the feature of Sumsq is available and they can use it.

* Removed sumsq from unsupported stats structure in the file `segstructs.go` as without removing this the following error was obtained: 

          `checkUnsupportedFunctions: using Sumsq in stats cmd is not yet supported`

* Performed the following and multiple queries to check if the obtained output is positive and correct.

           ` * | stats sumsq(http_status), sumsq(latency) BY city, address `

# Checklist:

Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.

---

**Name** : Aryan Amol Lad
**PRN** : 22220131