### PR TITLE
Refactor OTLP trace ingestion

### DIFF
--- a/pkg/otlp/otlp.go
+++ b/pkg/otlp/otlp.go
@@ -46,8 +46,8 @@ func ProcessTraceIngest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	// All requests and responses should be protobufs.
-	setContentType(ctx, protobufContentType)
-	if contentType := getContentType(ctx); contentType != protobufContentType {
+	utils.SetContentType(ctx, utils.ContentProtobuf)
+	if contentType := utils.GetContentType(ctx); contentType != utils.ContentProtobuf {
 		log.Infof("ProcessTraceIngest: got a non-protobuf request. Got Content-Type: %s", contentType)
 		setFailureResponse(ctx, fasthttp.StatusBadRequest, "Expected a protobuf request")
 		return

--- a/pkg/otlp/otlp.go
+++ b/pkg/otlp/otlp.go
@@ -45,19 +45,10 @@ func ProcessTraceIngest(ctx *fasthttp.RequestCtx, myid int64) {
 		}
 	}
 
-	// All requests and responses should be protobufs.
-	utils.SetContentType(ctx, utils.ContentProtobuf)
-	if contentType := utils.GetContentType(ctx); contentType != utils.ContentProtobuf {
-		log.Infof("ProcessTraceIngest: got a non-protobuf request. Got Content-Type: %s", contentType)
-		setFailureResponse(ctx, fasthttp.StatusBadRequest, "Expected a protobuf request")
-		return
-	}
-
-	// Get the data from the request.
-	data, err := getUncompressedData(ctx)
+	data, err := getDataToUnmarshal(ctx)
 	if err != nil {
-		log.Errorf("ProcessTraceIngest: failed to get uncompressed data: %v", err)
-		setFailureResponse(ctx, fasthttp.StatusBadRequest, "Unable to gzip decompress the data")
+		log.Errorf("ProcessTraceIngest: failed to get data to unmarshal: %v", err)
+		setFailureResponse(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/pkg/otlp/utils.go
+++ b/pkg/otlp/utils.go
@@ -16,8 +16,7 @@ import (
 func getDataToUnmarshal(ctx *fasthttp.RequestCtx) ([]byte, error) {
 	// We don't support JSON requests yet.
 	if contentType := utils.GetContentType(ctx); contentType != utils.ContentProtobuf {
-		log.Errorf("getDataToUnmarshal: got a non-protobuf request. Got Content-Type: %s", contentType)
-		return nil, fmt.Errorf("Expected a protobuf request")
+		return nil, fmt.Errorf("getDataToUnmarshal: got a non-protobuf request. Got Content-Type: %s", contentType)
 	}
 
 	// From https://opentelemetry.io/docs/specs/otlp/#otlphttp-response:
@@ -26,8 +25,7 @@ func getDataToUnmarshal(ctx *fasthttp.RequestCtx) ([]byte, error) {
 
 	data, err := getUncompressedData(ctx)
 	if err != nil {
-		log.Errorf("getDataToUnmarshal: failed to uncompress data: %v", err)
-		return nil, fmt.Errorf("Unable to gzip decompress the data")
+		return nil, fmt.Errorf("getDataToUnmarshal: failed to uncompress data: %v", err)
 	}
 
 	return data, nil

--- a/pkg/otlp/utils.go
+++ b/pkg/otlp/utils.go
@@ -12,17 +12,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const contentTypeHeader = "Content-Type"
-const protobufContentType = "application/x-protobuf" // This might be OTLP specific.
-
-func getContentType(ctx *fasthttp.RequestCtx) string {
-	return string(ctx.Request.Header.Peek(contentTypeHeader))
-}
-
-func setContentType(ctx *fasthttp.RequestCtx, contentType string) {
-	ctx.Response.Header.Set(contentTypeHeader, contentType)
-}
-
 func getUncompressedData(ctx *fasthttp.RequestCtx) ([]byte, error) {
 	data := ctx.PostBody()
 	if requiresGzipDecompression(ctx) {

--- a/pkg/otlp/utils.go
+++ b/pkg/otlp/utils.go
@@ -1,0 +1,72 @@
+package otlp
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/valyala/fasthttp"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+const contentTypeHeader = "Content-Type"
+const protobufContentType = "application/x-protobuf" // This might be OTLP specific.
+
+func getContentType(ctx *fasthttp.RequestCtx) string {
+	return string(ctx.Request.Header.Peek(contentTypeHeader))
+}
+
+func setContentType(ctx *fasthttp.RequestCtx, contentType string) {
+	ctx.Response.Header.Set(contentTypeHeader, contentType)
+}
+
+func getUncompressedData(ctx *fasthttp.RequestCtx) ([]byte, error) {
+	data := ctx.PostBody()
+	if requiresGzipDecompression(ctx) {
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("cannot gzip decompress: err=%v", err)
+		}
+
+		data, err = io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("cannot gzip decompress: err=%v", err)
+		}
+	}
+
+	return data, nil
+}
+
+func requiresGzipDecompression(ctx *fasthttp.RequestCtx) bool {
+	encoding := string(ctx.Request.Header.Peek("Content-Encoding"))
+	if encoding == "gzip" {
+		return true
+	}
+
+	if encoding != "" && encoding != "none" {
+		log.Errorf("requiresGzipDecompression: invalid content encoding: %s. Request headers: %v", encoding, ctx.Request.Header.String())
+	}
+
+	return false
+}
+
+func setFailureResponse(ctx *fasthttp.RequestCtx, statusCode int, message string) {
+	ctx.SetStatusCode(statusCode)
+
+	failureStatus := status.Status{
+		Code:    int32(statusCode),
+		Message: message,
+	}
+
+	bytes, err := proto.Marshal(&failureStatus)
+	if err != nil {
+		log.Errorf("setFailureResponse: failed to marshal failure status. err: %v. Status: %+v", err, &failureStatus)
+	}
+	_, err = ctx.Write(bytes)
+	if err != nil {
+		log.Errorf("sendFailureResponse: failed to write failure status: %v", err)
+	}
+}

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -35,8 +35,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const contentTypeHeader = "Content-Type"
+
 const (
-	ContentJson = "application/json; charset=utf-8"
+	ContentJson     = "application/json; charset=utf-8"
+	ContentProtobuf = "application/x-protobuf"
 )
 
 type HttpServerResponse struct {
@@ -976,4 +979,12 @@ func EncodeURL(str string) (string, error) {
 	}
 	u.RawQuery = url.QueryEscape(u.RawQuery)
 	return u.String(), nil
+}
+
+func GetContentType(ctx *fasthttp.RequestCtx) string {
+	return string(ctx.Request.Header.Peek(contentTypeHeader))
+}
+
+func SetContentType(ctx *fasthttp.RequestCtx, contentType string) {
+	ctx.Response.Header.Set(contentTypeHeader, contentType)
 }


### PR DESCRIPTION
# Description
This shouldn't change any behavior. It's intended to make it easier to add OTLP log ingestion in the next PR. Then the package structure will be something like
- utils.go
- traces.go
- logs.go
- (eventually) metrics.go

# Testing
I was still able to manually ingest traces using the OpenTelemetry Demo with this config
```
exporters:
  otlphttp/siglens:
    endpoint: "http://host.docker.internal:8081/otlp"
  prometheusremotewrite:
    endpoint: "http://host.docker.internal:8081/promql/api/v1/write"

processors:
  batch:
    send_batch_size: 5000
    timeout: 10s

service:
  pipelines:
    traces:
      exporters: [spanmetrics, otlphttp/siglens]
    metrics:
      processors: [batch]
      exporters: [prometheusremotewrite]
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
