### PR TITLE
#2074 Implemented SPL stats subcmd - sumsq

### DIFF
--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -113,6 +113,8 @@ func getInTable(exp string) (string, error) {
 func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 	agg = strings.ToLower(agg)
 	switch agg {
+	case "sumsq":
+		return utils.Sumsq
 	case "count":
 		return utils.Count
 	case "avg":
@@ -125,8 +127,6 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
-	case "sumsq":
-		return utils.Sumsq
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0
@@ -146,7 +146,6 @@ func getMathEvaluatorSQL(op string, qid uint64) (utils.MathFunctions, error) {
 		return utils.Sqrt, nil
 	case "exp":
 		return utils.Exp, nil
-		
 	default:
 		log.Errorf("qid=%v, getMathEvaluatorSQL: math evaluator type: %v is not supported!", qid, op)
 		return 0, fmt.Errorf("math evaluator type not supported")

--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -125,6 +125,8 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
+	case "sumsq":
+		return utils.Sumsq
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0
@@ -144,6 +146,7 @@ func getMathEvaluatorSQL(op string, qid uint64) (utils.MathFunctions, error) {
 		return utils.Sqrt, nil
 	case "exp":
 		return utils.Exp, nil
+		
 	default:
 		log.Errorf("qid=%v, getMathEvaluatorSQL: math evaluator type: %v is not supported!", qid, op)
 		return 0, fmt.Errorf("math evaluator type not supported")

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,7 +275,9 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
-	} else {
+	}  else if aggType == "sumsq" {
+		aggFunc = utils.Sumsq
+	}else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}
 	return aggFunc, nil

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -265,7 +265,7 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 
 	if aggType == "sumsq" {
 		aggFunc = utils.Sumsq
-	}else if aggType == "avg" {
+	} else if aggType == "avg" {
 		aggFunc = utils.Avg
 	} else if aggType == "min" {
 		aggFunc = utils.Min

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -263,7 +263,9 @@ func GetGroupByTokens(cols, first, rest interface{}, idx int, limit int) *struct
 func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error) {
 	var aggFunc utils.AggregateFunctions
 
-	if aggType == "avg" {
+	if aggType == "sumsq" {
+		aggFunc = utils.Sumsq
+	}else if aggType == "avg" {
 		aggFunc = utils.Avg
 	} else if aggType == "min" {
 		aggFunc = utils.Min
@@ -275,9 +277,7 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
-	}  else if aggType == "sumsq" {
-		aggFunc = utils.Sumsq
-	}else {
+	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}
 	return aggFunc, nil

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1439,7 +1439,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.Mode:         {},
 	utils.Stdev:        {},
 	utils.Stdevp:       {},
-	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},
 	utils.First:        {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -74,6 +74,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 	switch e1.Dtype {
 	case SS_DT_UNSIGNED_NUM:
 		switch fun {
+		case Sumsq:
+			e1.CVal = e1.CVal.(uint64)+ (e2.CVal.(uint64)*e2.CVal.(uint64))
+			return e1, nil
 		case Sum, Count:
 			e1.CVal = e1.CVal.(uint64) + e2.CVal.(uint64)
 			return e1, nil
@@ -83,14 +86,14 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
-		case Sumsq:
-			e1.CVal = e1.CVal.(uint64)+ (e2.CVal.(uint64)*e2.CVal.(uint64))
-			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
 	case SS_DT_SIGNED_NUM:
 		switch fun {
+		case Sumsq: 
+			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
+			return e1, nil
 		case Sum, Count:
 			e1.CVal = e1.CVal.(int64) + e2.CVal.(int64)
 			return e1, nil
@@ -100,14 +103,14 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
-		case Sumsq: 
-			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
-			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
 	case SS_DT_FLOAT:
 		switch fun {
+		case Sumsq:
+			e1.CVal = e1.CVal.(float64) + (e2.CVal.(float64) * e2.CVal.(float64))
+			return e1, nil
 		case Sum, Count:
 			e1.CVal = e1.CVal.(float64) + e2.CVal.(float64)
 			return e1, nil
@@ -116,9 +119,6 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			return e1, nil
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
-			return e1, nil
-		case Sumsq:
-			e1.CVal = e1.CVal.(float64) + (e2.CVal.(float64) * e2.CVal.(float64))
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
@@ -218,6 +218,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 	switch self.Ntype {
 	case SS_DT_SIGNED_NUM, SS_DT_UNSIGNED_NUM:
 		switch fun {
+		case Sumsq: 
+			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
+			return nil
 		case Sum:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
@@ -230,14 +233,14 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
-		case Sumsq: 
-			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
-			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported int function: %v", fun)
 		}
 	case SS_DT_FLOAT:
 		switch fun {
+		case Sumsq:
+			self.FloatVal = self.FloatVal + (e2float64 * e2float64)
+			return nil
 		case Sum:
 			self.FloatVal = self.FloatVal + e2float64
 			return nil
@@ -249,9 +252,6 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Count:
 			self.FloatVal = self.FloatVal + e2float64
-			return nil
-		case Sumsq:
-			self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported float function: %v", fun)

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -75,7 +75,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 	case SS_DT_UNSIGNED_NUM:
 		switch fun {
 		case Sumsq:
-			e1.CVal = e1.CVal.(uint64)+ (e2.CVal.(uint64)*e2.CVal.(uint64))
+			e1.CVal = e1.CVal.(uint64) + (e2.CVal.(uint64) * e2.CVal.(uint64))
 			return e1, nil
 		case Sum, Count:
 			e1.CVal = e1.CVal.(uint64) + e2.CVal.(uint64)
@@ -91,7 +91,7 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		}
 	case SS_DT_SIGNED_NUM:
 		switch fun {
-		case Sumsq: 
+		case Sumsq:
 			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
 			return e1, nil
 		case Sum, Count:
@@ -218,7 +218,7 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 	switch self.Ntype {
 	case SS_DT_SIGNED_NUM, SS_DT_UNSIGNED_NUM:
 		switch fun {
-		case Sumsq: 
+		case Sumsq:
 			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
 			return nil
 		case Sum:

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -83,6 +83,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(uint64)+ (e2.CVal.(uint64)*e2.CVal.(uint64))
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
 		}
@@ -97,6 +100,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 		case Max:
 			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
+		case Sumsq: 
+			e1.CVal = e1.CVal.(int64) + (e2.CVal.(int64) * e2.CVal.(int64))
+			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
 		}
@@ -110,6 +116,9 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			return e1, nil
 		case Max:
 			e1.CVal = math.Max(e1.CVal.(float64), e2.CVal.(float64))
+			return e1, nil
+		case Sumsq:
+			e1.CVal = e1.CVal.(float64) + (e2.CVal.(float64) * e2.CVal.(float64))
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for float", fun)
@@ -221,6 +230,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
+		case Sumsq: 
+			self.IntgrVal = self.IntgrVal + (e2int64 * e2int64)
+			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported int function: %v", fun)
 		}
@@ -237,6 +249,9 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			return nil
 		case Count:
 			self.FloatVal = self.FloatVal + e2float64
+			return nil
+		case Sumsq:
+			self.FloatVal = self.FloatVal + (e2float64 * e2float64)
 			return nil
 		default:
 			return fmt.Errorf("ReduceFast: unsupported float function: %v", fun)

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -347,7 +347,7 @@ func ConvertGroupByKeyFromBytes(rec []byte) ([]interface{}, error) {
 // IsNumTypeAgg checks if aggregate function requires numeric type data
 func IsNumTypeAgg(fun AggregateFunctions) bool {
 	switch fun {
-	case Avg, Min, Max, Sum, Range, Sumsq:
+	case Sumsq, Avg, Min, Max, Sum, Range:
 		return true
 	default:
 		return false

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -347,7 +347,7 @@ func ConvertGroupByKeyFromBytes(rec []byte) ([]interface{}, error) {
 // IsNumTypeAgg checks if aggregate function requires numeric type data
 func IsNumTypeAgg(fun AggregateFunctions) bool {
 	switch fun {
-	case Avg, Min, Max, Sum, Range:
+	case Avg, Min, Max, Sum, Range, Sumsq:
 		return true
 	default:
 		return false

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg','sumsq'];
+var calculations = ['sumsq','min', 'max', 'count', 'avg','sum'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg','sumsq'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
PR Description: Add Sum of Squares (Sumsq) Aggregation to Stats Command
=======================================================================

Summary of Changes
------------------

This PR introduces the **Sum of Squares (Sumsq)** aggregation function in the stats command. **Sumsq** is a statistical function that evaluates the variance of a dataset by computing the sum of squared values. A higher **Sumsq** value indicates greater variance, signifying that individual values fluctuate significantly from the mean.

### Key Modifications:

#### **1\. Core Aggregation Logic**

*   **aggutils.go**:
    
    *   Implemented the **Sumsq** function for **unsigned integers, signed integers, and floating-point numbers**.
        
    *   Integrated type handling for numerical data to ensure correct aggregation.
        
    *   Modified the Reduce and ReduceFast functions to support squaring operations.
        

#### **2\. Query and Data Processing Enhancements**

*   **astsql.go**:
    
    *   Added **Sumsq** to the getAggregationSQL function to enable SQL-level aggregation.
        
*   **structs.go**:
    
    *   Integrated **Sumsq** into the AggTypeToAggregateFunction method for correct mapping.
        
*   **segutils.go**:
    
    *   Updated the IsNumTypeAgg function to recognize **Sumsq** as a numerical aggregation.
        

#### **3\. User Interface and Query Handling**

*   **query-builder.js**:
    
    *   Added **Sumsq** to the list of available calculations, allowing users to select and utilize this function in queries.
        
*   **segstructs.go**:
    
    *   Removed **Sumsq** from the list of unsupported statistical functions to enable execution without errors.
        

**Fixes**
---------

This PR addresses **#2074**, resolving the issue where **Sumsq** was unavailable in the stats command.

**Testing Plan**
----------------

To validate these changes, I performed the following:

1.  **Query Execution Test**
    
    *   | stats sumsq(latitude), sumsq(longitude) BY city, address
        
    *   Verified that the results correctly represent the sum of squared values for numerical columns.
        
2.  **Unsupported Functions Check**
    
    *   vbnetCopyEditcheckUnsupportedFunctions: using Sumsq in stats cmd is not yet supported
        
    *   After this PR, the error no longer appears.
        
3.  **Type Handling Validation**
    
    *   Ensured **Sumsq** correctly handles **integer, float, and unsigned integer** types in the aggregation logic.
        

**Checklist Before Review**
---------------------------

![Screenshot from 2025-02-07 01-01-19](https://github.com/user-attachments/assets/9244c549-f511-4599-a4f0-aa0fc9550ce8)

![Screenshot from 2025-02-07 01-01-09](https://github.com/user-attachments/assets/cc893d64-1559-489f-9971-9ea7fc2d2392)

![Screenshot from 2025-02-07 01-02-20](https://github.com/user-attachments/assets/649390b6-ef87-4a01-a0d3-5c8c482d24be)

![Screenshot from 2025-02-07 01-02-30](https://github.com/user-attachments/assets/54c18998-3743-4dd1-8219-0a8685d5dd78)

- [x]  Self-reviewed the PR.
    
- [x] Removed all debug prints and unnecessary comments.
    
- [x] Added sufficient comments in complex areas.
    
- [x] Formatted Go code using goimports -w ..
    

### **Name:**

**Aniket Dhoke**
**aniket.22110835@viit.ac.in**

### **PRN:**

(22110835)