### PR TITLE
Implement SPL stats subcmd - estdc, estdc_error

### DIFF
--- a/pkg/segment/reader/segread/segstatsreader.go
+++ b/pkg/segment/reader/segread/segstatsreader.go
@@ -488,6 +488,32 @@ func getAverage(sum utils.NumTypeEnclosure, count uint64) (float64, error) {
 	return avg, nil
 }
 
+func GetSegEstdcError(runningSegStat *structs.SegStats, currSegStat *structs.SegStats) (*utils.NumTypeEnclosure, error) {
+
+	res := utils.NumTypeEnclosure{
+		Ntype:    utils.SS_DT_FLOAT,
+		FloatVal: 0,
+	}
+
+	if currSegStat == nil {
+		return &res, fmt.Errorf("GetSegEstdcError: currSegStat is nil")
+	}
+
+	// if this is the first segment, then running will be nil, and we return the first seg's stats
+	if runningSegStat == nil {
+		res.FloatVal = currSegStat.ComputeEstdcError()
+		return &res, nil
+	}
+
+	err := runningSegStat.Hll.StrictUnion(currSegStat.Hll.Hll)
+	if err != nil {
+		return nil, fmt.Errorf("GetSegEstdcError: error in Hll.Merge, err: %+v", err)
+	}
+	res.FloatVal = runningSegStat.ComputeEstdcError()
+
+	return &res, nil
+}
+
 func GetSegList(runningSegStat *structs.SegStats,
 	currSegStat *structs.SegStats) (*utils.CValueEnclosure, error) {
 	res := utils.CValueEnclosure{

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -305,6 +305,11 @@ func (sr *SearchResults) UpdateNonEvalSegStats(runningSegStat *structs.SegStats,
 		sstResult, err = segread.GetSegSum(runningSegStat, incomingSegStat)
 	case utils.Avg:
 		sstResult, err = segread.GetSegAvg(runningSegStat, incomingSegStat)
+	case utils.Estdc:
+		//Calling Cardinality function itself because it changes storage type based on threshold, so it will change the storage type to registers once the data crosses the threshold of sparse and goes into dense storage. And if the storage type is registers it will return estimated count. So this will return estimated count for large datasets.
+		sstResult, err = segread.GetSegCardinality(runningSegStat, incomingSegStat)
+	case utils.EstdcError:
+		sstResult, err = segread.GetSegEstdcError(runningSegStat, incomingSegStat)
 	case utils.Values:
 		// Use GetSegValue to process and get the segment value
 		res, err := segread.GetSegValue(runningSegStat, incomingSegStat)

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum', 'estdc', 'estdc_error'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description
This PR consists of the implementation of estdc and estdc_error sub commands of SPL stats. estdc function gives the estimated count of distinct items of that particular field and estdc_error gives the error of estimated distinct count. 

Key changes:
1. Removed estdc, estdc_error from the map of unsupported stat functions in file segstructs.go

2. Implemented functions for estdc and estdc_error in file segstatsreader.go

3. Added the cases for Estdc and EstdcError in the switch in file segresults.go and called appropiate functions to get estdc and estdc_error respectively

For case Estdc in above mentioned point, I have called GetSegCardinalityfunction itself because the Cardinality function of hll library changes storage type based on threshold, so it will change the storage type to registers once the data crosses the threshold of sparse and goes into dense storage. And if the storage type is registers it will return estimated count. So this will return estimated count for large datasets.

4. Added estdc and estdc_error in the dropdown for query builder (frontend: query-builder.js file)

Fixes #2105 

# Testing
I have tested my code on both query-builder mode and code mode. It is working fine. Below attaching the screenshots for reference.
![image](https://github.com/user-attachments/assets/b21dcf32-bb3f-4159-a4ed-1b0ceb7a864a)
![image](https://github.com/user-attachments/assets/468a4ddb-7b45-40b5-8083-205268ae09fc)
![image](https://github.com/user-attachments/assets/240556f7-b094-4ede-b13b-7c1b370f82ee)


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.

Name: Prajwal Mahajan
PRN: 22110401
