### PR TITLE
Implemented estdc and estdc_error 

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -6181,7 +6181,7 @@ var g = &grammar{
 													alternatives: []any{
 														&litMatcher{
 															pos:        position{line: 2915, col: 112, offset: 91900},
-															val:        "termlist",
+															val:        "callonCaseSensitiveString1list",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -298,6 +298,12 @@ func (sr *SearchResults) UpdateNonEvalSegStats(runningSegStat *structs.SegStats,
 		}
 		return runningSegStat, nil
 	case utils.Cardinality:
+		if incomingSegStat == nil || len(incomingSegStat.Records) == 0 {
+			fmt.Println("currSegStat has no records!")
+		} else {
+			fmt.Println("currSegStat has", len(incomingSegStat.Records), "records")
+		}
+
 		sstResult, err = segread.GetSegCardinality(runningSegStat, incomingSegStat)
 	case utils.Count:
 		sstResult, err = segread.GetSegCount(runningSegStat, incomingSegStat)
@@ -305,6 +311,11 @@ func (sr *SearchResults) UpdateNonEvalSegStats(runningSegStat *structs.SegStats,
 		sstResult, err = segread.GetSegSum(runningSegStat, incomingSegStat)
 	case utils.Avg:
 		sstResult, err = segread.GetSegAvg(runningSegStat, incomingSegStat)
+	case utils.Estdc:
+		sstResult, err = segread.GetSegCardinality(runningSegStat, incomingSegStat)
+	case utils.EstdcError:
+		sstResult, err = segread.GetSegEstimatedCardinalityError(runningSegStat, incomingSegStat)
+
 	case utils.Values:
 		// Use GetSegValue to process and get the segment value
 		res, err := segread.GetSegValue(runningSegStat, incomingSegStat)

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -534,7 +534,6 @@ type SegStats struct {
 	NumStats    *NumericStats
 	StringStats *StringStats
 	Records     []*utils.CValueEnclosure
-	
 }
 
 type NumericStats struct {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -534,6 +534,7 @@ type SegStats struct {
 	NumStats    *NumericStats
 	StringStats *StringStats
 	Records     []*utils.CValueEnclosure
+	
 }
 
 type NumericStats struct {
@@ -1430,8 +1431,6 @@ func AddAllColumnsInStreamStatsOptions(cols map[string]struct{}, streamStatsOpti
 }
 
 var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
-	utils.Estdc:        {},
-	utils.EstdcError:   {},
 	utils.ExactPerc:    {},
 	utils.Perc:         {},
 	utils.UpperPerc:    {},

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum','estdc','estdc_error'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description

In this request, we handled the estimation of distinct counts (`estdc`) using HyperLogLog (HLL). Since the existing implementation of `GetSegCardinality` already relied on HLL for distinct count estimation rather than an exact distinct count, we extended the same approach to compute `estdc`.

For `estdc_error`, rather than using the standard deviation-based formula, we adopted the theoretical error bound formula (`1.04 / sqrt(m)`) because the exact distinct count is unavailable. While we attempted to determine the exact distinct count to compute the error more precisely, doing so would have required modifying the `SegStats` structure, which was not feasible.

## Other Changes

- Integrated `estdc` and `estdc_error` options into the **query builder dropdown** (`query-builder.js`).
- Removed `estdc` and `estdc_error` from the list of unsupported statistical functions in **`segstructs.go`**.
- Implemented a dedicated function for `estdc_error` in **`segstatsreader.go`**.
- Updated the switch-case logic in **`segresults.go`** to correctly invoke `estdc` and `estdc_error` computations.

# Testing
- Conducted preliminary checks for `estdc_error` calculations against theoretical expectations.
- Verified that query execution does not fail when selecting `estdc` or `estdc_error`.
- Confirmed that the new options appear in the query builder dropdown.
  
<img width="1440" alt="Screenshot 2025-02-07 at 3 13 20 PM" src="https://github.com/user-attachments/assets/01dc61a6-a28e-42d8-9811-a5663bc83571" />
<img width="1440" alt="Screenshot 2025-02-07 at 3 13 55 PM" src="https://github.com/user-attachments/assets/3077d8d1-8f5f-4793-87d4-ca7748ffd70a" />
<img width="1440" alt="Screenshot 2025-02-07 at 3 15 58 PM" src="https://github.com/user-attachments/assets/72242d50-0100-4e79-8696-ebec650072f6" />


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.


Atharva Khairnar (22110185)
