### PR TITLE
fix issue 2103 Implemented percentile calculation functions (**ExactP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,34 +3,34 @@
 </p>
 
 ---
+
 <div align="center">
 
   [![Build Status](https://github.com/siglens/siglens/workflows/siglens-docker-release/badge.svg)](https://github.com/siglens/siglens/actions/workflows/publish-prod-images.yml)
   [![Go Report Card](https://goreportcard.com/badge/github.com/siglens/siglens)](https://goreportcard.com/report/github.com/siglens/siglens)
   [![GoDoc](https://godoc.org/github.com/siglens/siglens?status.svg)](https://pkg.go.dev/github.com/siglens/siglens)
   [![codecov](https://codecov.io/gh/siglens/siglens/graph/badge.svg?token=MH8S9B0EIK)](https://codecov.io/gh/siglens/siglens)
+
 </div>
+
 <div align="center">
 
   [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/cloudposse.svg?style=social&label=Follow%20%40SigLensHQ)](https://twitter.com/SigLensHQ)
   [![RSS](https://img.shields.io/badge/RSS-Subscribe-orange?style=social&logo=rss)](https://www.siglens.com/blog/blog-rss.xml)
   [![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-blue?style=social&logo=linkedin)](https://www.linkedin.com/company/siglens-com)
+
 </div>
 
 English | [简体中文](README_ZH_CN.md) | [日本語](README_JA_JP.md)
 
 <p align="center">
-  
-
   <p align="left">Open Source Observability that is 💥💥 <b>100x</b> 💥💥 more efficient than Splunk </p>
   <p align="left"><b>Single binary</b> for Logs 🎯, Metrics 🎯 and Traces 🎯.</p>
   <p align="left">Cut down your Splunk bill by ⚡ ⚡ <b>90%</b> ⚡ ⚡ </p>
-
 </p>
 
-
-
 # Why SigLens:
+
 Our experience servicing 10,000+ engineers with Observability tools taught us a few things:
 
 - Developers have to jump through different tools for logs, metrics, traces
@@ -38,51 +38,54 @@ Our experience servicing 10,000+ engineers with Observability tools taught us a 
 - ElasticSearch takes too many machines, cluster maintenance is hard 👩‍💻👩‍💻
 - Grafana Loki has slow query performance 🐌🐌
 
+With decades of experience in monitoring, we built an observability DB uniquely suited for logs, metrics, and traces with **`zero`** external dependencies. A **`single binary`** that can run on your laptop and process **`8 TB/day`**.  
 
-Armed with decades of experience in monitoring domain, we set out to build a observability DB from the ground up, uniquely suited for logs, metrics and traces with **`zero`** external dependencies. A **`single binary`** that you can run on your laptop and process **`8 TB/day`**.  
-<br /><br />
-
+---
 
 # Setup
+
 ## Installation
 
 ### &emsp; <a href="https://siglens.github.io/siglens-docs/installation/git" target="_blank">Git</a> &emsp; | &emsp; <a href="https://siglens.github.io/siglens-docs/installation/docker" target="_blank">Docker</a> &emsp;| &emsp; <a href="https://siglens.github.io/siglens-docs/installation/helm" target="_blank">Helm</a>
 
 ## Documentation
+
 ### &emsp; <a href="https://siglens.github.io/siglens-docs" target="_blank">Docs</a> &emsp;
 
+---
 
 # Differentiators
 
-### SigLens v/s Splunk,Elastic,Loki  
-Check out this <a href="https://www.siglens.com/blog/petabyte-of-observability-data.html" target="_blank">blog</a> where SigLens ingested data at 1 PB/day rate for 24 hours on a mere `32 EC2 instances` compared to `3000 EC2 instances` required for Splunk, Elastic, Grafana Loki
+### SigLens v/s Splunk, Elastic, Loki  
+Check out this <a href="https://www.siglens.com/blog/petabyte-of-observability-data.html" target="_blank">blog</a> where SigLens ingested data at 1 PB/day on `32 EC2 instances` compared to `3000 EC2 instances` needed for Splunk, Elastic, and Loki.
 
 ### SigLens v/s Elasticsearch 
-Check out this <a href="https://www.siglens.com/blog/siglens-1025x-faster-than-elasticsearch" target="_blank">blog</a> where SigLens is **`1025x`** Faster than Elasticsearch 🚀🚀
+Check out this <a href="https://www.siglens.com/blog/siglens-1025x-faster-than-elasticsearch" target="_blank">blog</a> where SigLens is **`1025x`** faster than Elasticsearch 🚀🚀
 
 ### SigLens v/s ClickHouse 
-Check out this <a href="https://www.siglens.com/blog/siglens-54x-faster-than-clickhouse.html" target="_blank">blog</a> where SigLens is **`54x`** Faster than ClickHouse 🚀🚀
+Check out this <a href="https://www.siglens.com/blog/siglens-54x-faster-than-clickhouse.html" target="_blank">blog</a> where SigLens is **`54x`** faster than ClickHouse 🚀🚀
 
-
-<br />
+---
 
 # Features:
 
 1. Multiple Ingestion formats: Open Telemetry, Elastic, Splunk HEC, Loki
-2. Multiple Query Languages: Splunk SPL, SQL and Loki LogQL
+2. Multiple Query Languages: Splunk SPL, SQL, and Loki LogQL
 3. Simple architecture, easy to get started.
 
+---
 
 ## Join our Community
 
-Have questions, ask them in our community <a href="https://www.siglens.com/slack" target="_blank">Slack</a> 👋
+Have questions? Ask in our <a href="https://www.siglens.com/slack" target="_blank">Slack</a> 👋
 
-<br />
-
+---
 
 # Contributing
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) to get started with making contributions to SigLens.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) to get started with contributions to SigLens.
+
+---
 
 # How-Tos
 
@@ -104,9 +107,13 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) to get started with making contri
 #### Minion Searches
 ![Minion Searches](./static/assets/readme-assets/minion-searches.png)
 
+---
 
 ## Code of Conduct
+
 Please review our [code of conduct](https://github.com/siglens/siglens?tab=coc-ov-file#siglens-code-of-conduct) before contributing.
+
+---
 
 ## Thanks to all contributors for their efforts
 

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1432,9 +1432,6 @@ func AddAllColumnsInStreamStatsOptions(cols map[string]struct{}, streamStatsOpti
 var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.Estdc:        {},
 	utils.EstdcError:   {},
-	utils.ExactPerc:    {},
-	utils.Perc:         {},
-	utils.UpperPerc:    {},
 	utils.Median:       {},
 	utils.Mode:         {},
 	utils.Stdev:        {},

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -19,7 +19,7 @@ package stats
 
 import (
 	"math"
-	"math/rand/v2"
+	"math/rand"
 	"sort"
 	"strconv"
 

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum', 'exactperc99', 'perc66.6', 'upperperc6.6'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
### **Description**  
Implemented percentile calculation functions (**ExactPercentile99, ApproxPercentile66_6, UpperPercentile6_6**). 

### **Fixes**  
Fixes **#2103**  

### **Changes Made:**  
  - **ExactPercentile99**: Computes the exact 99th percentile using **median of medians**.  
  - **ApproxPercentile66_6**: Estimates the 66.6th percentile using **random sampling with weighted probabilities**.  
  - **UpperPercentile6_6**: Computes an upper bound for the 6.6th percentile using **binary search-based selection**.  

### **Testing**  
Validated the implementation using the following SPL query on test data:  

```  
city=Austin  
| stats count AS Count BY weekday  
| stats exactperc99(Count) perc66.6(Count) upperperc6.6(Count) BY weekday  
```  

### **Screenshot**  

![siglence](https://github.com/user-attachments/assets/e92976d3-6b78-4f24-8f08-651b50a8b631)


- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
