### PR TITLE
Implemented stdev and stdevp

### DIFF
--- a/pkg/ast/sql/astsql.go
+++ b/pkg/ast/sql/astsql.go
@@ -125,6 +125,10 @@ func getAggregationSQL(agg string, qid uint64) utils.AggregateFunctions {
 		return utils.Sum
 	case "cardinality":
 		return utils.Cardinality
+	case "stdev":
+		return utils.Stdev
+	case "stdevp":
+		return utils.Stdevp
 	default:
 		log.Errorf("qid=%v, getAggregationSQL: aggregation type: %v is not supported!", qid, agg)
 		return 0

--- a/pkg/ast/structs.go
+++ b/pkg/ast/structs.go
@@ -275,6 +275,10 @@ func AggTypeToAggregateFunction(aggType string) (utils.AggregateFunctions, error
 		aggFunc = utils.Count
 	} else if aggType == "cardinality" {
 		aggFunc = utils.Cardinality
+	} else if aggType == "stdev" {
+		aggFunc = utils.Stdev
+	} else if aggType == "stdevp" {
+		aggFunc = utils.Stdevp
 	} else {
 		return aggFunc, fmt.Errorf("AggTypeToAggregateFunction: unsupported statistic aggregation type %v", aggType)
 	}

--- a/pkg/segment/aggregations/evalaggs.go
+++ b/pkg/segment/aggregations/evalaggs.go
@@ -570,6 +570,239 @@ func ComputeAggEvalForAvg(measureAgg *structs.MeasureAggregator, sstMap map[stri
 	return nil
 }
 
+func PerformEvalAggForStdev(measureAgg *structs.MeasureAggregator, currResultExists bool, currStdevStat structs.StdevStat, fieldToValue map[string]utils.CValueEnclosure, isPopulation bool) (structs.StdevStat, error) {
+    
+    fields := measureAgg.ValueColRequest.GetFields()
+    finalStdevStat := structs.StdevStat{
+        Sum:   0,
+        SumSq: 0,
+        Count: 0,
+    }
+
+    if len(fields) == 0 {
+        floatValue, _, isNumeric, err := GetFloatValueAfterEvaluation(measureAgg, fieldToValue)
+        // We cannot compute stdev if constant is not numeric
+        if err != nil || !isNumeric {
+            return currStdevStat, fmt.Errorf("PerformEvalAggForStdev: Error while evaluating value col request to a numeric value, err: %v", err)
+        }
+        finalStdevStat.Sum = floatValue
+        finalStdevStat.SumSq = floatValue * floatValue
+        finalStdevStat.Count = 1
+    } else {
+        if measureAgg.ValueColRequest.BooleanExpr != nil {
+            boolResult, err := measureAgg.ValueColRequest.BooleanExpr.Evaluate(fieldToValue)
+            if err != nil {
+                return currStdevStat, fmt.Errorf("PerformEvalAggForStdev: there are some errors in the eval function: %v", err)
+            }
+            if boolResult {
+                finalStdevStat.Sum = 1
+                finalStdevStat.SumSq = 1
+                finalStdevStat.Count = 1
+            }
+        } else {
+            floatValue, _, isNumeric, err := GetFloatValueAfterEvaluation(measureAgg, fieldToValue)
+            if err != nil {
+                return currStdevStat, fmt.Errorf("PerformEvalAggForStdev: Error while evaluating value col request, err: %v", err)
+            }
+            // records that are not float will be ignored
+            if isNumeric {
+                finalStdevStat.Sum = floatValue
+                finalStdevStat.SumSq = floatValue * floatValue
+                finalStdevStat.Count = 1
+            }
+        }
+    }
+
+    if currResultExists {
+        finalStdevStat.Sum += currStdevStat.Sum
+        finalStdevStat.SumSq += currStdevStat.SumSq
+        finalStdevStat.Count += currStdevStat.Count
+    }
+
+    return finalStdevStat, nil
+}
+
+func ComputeAggEvalForStdev(measureAgg *structs.MeasureAggregator, sstMap map[string]*structs.SegStats, 
+    measureResults map[string]utils.CValueEnclosure, runningEvalStats map[string]interface{}, isPopulation bool) error {
+    
+    fields := measureAgg.ValueColRequest.GetFields()
+    var stdevStat structs.StdevStat
+    var err error
+
+    stdevStatVal, currResultExists := runningEvalStats[measureAgg.String()]
+    if currResultExists {
+        stat := stdevStatVal.(*structs.StdevStat)
+        stdevStat.Sum = stat.Sum
+        stdevStat.SumSq = stat.SumSq
+        stdevStat.Count = stat.Count
+    }
+
+    if len(fields) == 0 {
+        stdevStat, err = PerformEvalAggForStdev(measureAgg, currResultExists, stdevStat, nil, isPopulation)
+        if err != nil {
+            return fmt.Errorf("ComputeAggEvalForStdev: Error while performing eval agg for stdev, err: %v", err)
+        }
+    } else {
+        sst, ok := sstMap[fields[0]]
+        if !ok {
+            return fmt.Errorf("ComputeAggEvalForStdev: sstMap did not have segstats for field %v", fields[0])
+        }
+
+        length := len(sst.Records)
+        for i := 0; i < length; i++ {
+            fieldToValue := make(map[string]utils.CValueEnclosure)
+            err := PopulateFieldToValueFromSegStats(fields, measureAgg, sstMap, fieldToValue, i)
+            if err != nil {
+                return fmt.Errorf("ComputeAggEvalForStdev: Error populating fieldToValue, err: %v", err)
+            }
+
+            stdevStat, err = PerformEvalAggForStdev(measureAgg, currResultExists, stdevStat, fieldToValue, isPopulation)
+            currResultExists = true
+            if err != nil {
+                return fmt.Errorf("ComputeAggEvalForStdev: Error performing eval agg for stdev, err: %v", err)
+            }
+        }
+    }
+
+    runningEvalStats[measureAgg.String()] = &stdevStat
+
+    var stdev float64
+    if stdevStat.Count > 0 {
+        mean := stdevStat.Sum / float64(stdevStat.Count)
+        variance := (stdevStat.SumSq / float64(stdevStat.Count)) - (mean * mean)
+        
+        if !isPopulation && stdevStat.Count > 1 {
+            variance = variance * float64(stdevStat.Count) / float64(stdevStat.Count-1)
+        }
+        
+        if variance > 0 {
+            stdev = math.Sqrt(variance)
+        }
+    }
+
+    measureResults[measureAgg.String()] = utils.CValueEnclosure{
+        Dtype: utils.SS_DT_FLOAT,
+        CVal:  stdev,
+    }
+
+    return nil
+}
+
+func PerformEvalAggForStdevp(measureAgg *structs.MeasureAggregator, currResultExists bool, 
+    currStdevStat structs.StdevStat, fieldToValue map[string]utils.CValueEnclosure) (structs.StdevStat, error) {
+    
+    fields := measureAgg.ValueColRequest.GetFields()
+    finalStdevStat := structs.StdevStat{
+        Sum:   0,
+        SumSq: 0,
+        Count: 0,
+    }
+
+    if len(fields) == 0 {
+        floatValue, _, isNumeric, err := GetFloatValueAfterEvaluation(measureAgg, fieldToValue)
+        // We cannot compute stdevp if constant is not numeric
+        if err != nil || !isNumeric {
+            return currStdevStat, fmt.Errorf("PerformEvalAggForStdevp: Error while evaluating value col request to a numeric value, err: %v", err)
+        }
+        finalStdevStat.Sum = floatValue
+        finalStdevStat.SumSq = floatValue * floatValue
+        finalStdevStat.Count = 1
+    } else {
+        if measureAgg.ValueColRequest.BooleanExpr != nil {
+            boolResult, err := measureAgg.ValueColRequest.BooleanExpr.Evaluate(fieldToValue)
+            if err != nil {
+                return currStdevStat, fmt.Errorf("PerformEvalAggForStdevp: there are some errors in the eval function that is inside the stdevp function: %v", err)
+            }
+            if boolResult {
+                finalStdevStat.Sum = 1
+                finalStdevStat.SumSq = 1
+                finalStdevStat.Count = 1
+            }
+        } else {
+            floatValue, _, isNumeric, err := GetFloatValueAfterEvaluation(measureAgg, fieldToValue)
+            if err != nil {
+                return currStdevStat, fmt.Errorf("PerformEvalAggForStdevp: Error while evaluating value col request, err: %v", err)
+            }
+            // records that are not float will be ignored
+            if isNumeric {
+                finalStdevStat.Sum = floatValue
+                finalStdevStat.SumSq = floatValue * floatValue
+                finalStdevStat.Count = 1
+            }
+        }
+    }
+
+    if currResultExists {
+        finalStdevStat.Sum += currStdevStat.Sum
+        finalStdevStat.SumSq += currStdevStat.SumSq
+        finalStdevStat.Count += currStdevStat.Count
+    }
+
+    return finalStdevStat, nil
+}
+
+func ComputeAggEvalForStdevp(measureAgg *structs.MeasureAggregator, sstMap map[string]*structs.SegStats, 
+    measureResults map[string]utils.CValueEnclosure, runningEvalStats map[string]interface{}) error {
+    
+    fields := measureAgg.ValueColRequest.GetFields()
+    var stdevpStat structs.StdevStat
+    var err error
+
+    stdevpStatVal, currResultExists := runningEvalStats[measureAgg.String()]
+    if currResultExists {
+        stat := stdevpStatVal.(*structs.StdevStat)
+        stdevpStat.Sum = stat.Sum
+        stdevpStat.SumSq = stat.SumSq
+        stdevpStat.Count = stat.Count
+    }
+
+    if len(fields) == 0 {
+        stdevpStat, err = PerformEvalAggForStdevp(measureAgg, currResultExists, stdevpStat, nil)
+        if err != nil {
+            return fmt.Errorf("ComputeAggEvalForStdevp: Error while performing eval agg for stdevp, err: %v", err)
+        }
+    } else {
+        sst, ok := sstMap[fields[0]]
+        if !ok {
+            return fmt.Errorf("ComputeAggEvalForStdevp: sstMap did not have segstats for field %v, measureAgg: %v", fields[0], measureAgg.String())
+        }
+
+        length := len(sst.Records)
+        for i := 0; i < length; i++ {
+            fieldToValue := make(map[string]utils.CValueEnclosure)
+            err := PopulateFieldToValueFromSegStats(fields, measureAgg, sstMap, fieldToValue, i)
+            if err != nil {
+                return fmt.Errorf("ComputeAggEvalForStdevp: Error while populating fieldToValue from sstMap, err: %v", err)
+            }
+
+            stdevpStat, err = PerformEvalAggForStdevp(measureAgg, currResultExists, stdevpStat, fieldToValue)
+            currResultExists = true
+            if err != nil {
+                return fmt.Errorf("ComputeAggEvalForStdevp: Error while performing eval agg for stdevp, err: %v", err)
+            }
+        }
+    }
+
+    runningEvalStats[measureAgg.String()] = &stdevpStat
+
+    // Calculate population standard deviation (stdevp)
+    var stdevp float64
+    if stdevpStat.Count > 0 {
+        mean := stdevpStat.Sum / float64(stdevpStat.Count)
+        variance := (stdevpStat.SumSq / float64(stdevpStat.Count)) - (mean * mean)
+        if variance > 0 {
+            stdevp = math.Sqrt(variance)
+        }
+    }
+
+    measureResults[measureAgg.String()] = utils.CValueEnclosure{
+        Dtype: utils.SS_DT_FLOAT,
+        CVal:  stdevp,
+    }
+
+    return nil
+}
+
 // Always pass a non-nil strSet when using this function
 func PerformAggEvalForCardinality(measureAgg *structs.MeasureAggregator, strSet map[string]struct{}, fieldToValue map[string]utils.CValueEnclosure) (float64, error) {
 	fields := measureAgg.ValueColRequest.GetFields()

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -578,9 +578,9 @@ type AvgStat struct {
 }
 
 type StdevStat struct {
-    Sum     float64
-    SumSq   float64  
-    Count   int64
+	Sum   float64
+	SumSq float64
+	Count int64
 }
 
 type FieldGetter interface {

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -577,6 +577,12 @@ type AvgStat struct {
 	Sum   float64
 }
 
+type StdevStat struct {
+    Sum     float64
+    SumSq   float64  
+    Count   int64
+}
+
 type FieldGetter interface {
 	GetFields() []string
 }
@@ -1437,8 +1443,6 @@ var unsupportedStatsFuncs = map[utils.AggregateFunctions]struct{}{
 	utils.UpperPerc:    {},
 	utils.Median:       {},
 	utils.Mode:         {},
-	utils.Stdev:        {},
-	utils.Stdevp:       {},
 	utils.Sumsq:        {},
 	utils.Var:          {},
 	utils.Varp:         {},

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -154,7 +154,7 @@ $(document).mouseup(function (e) {
         ThirdCancelInfo(e);
     }
 });
-var calculations = ['min', 'max', 'count', 'avg', 'sum'];
+var calculations = ['min', 'max', 'count', 'avg', 'sum', 'stdev', 'stdevp'];
 var numericColumns = [];
 var ifCurIsNum = false;
 var availSymbol = [];


### PR DESCRIPTION
# Description
- Added functions for stdev and stdevp calculation in evalaggs.go.
- Removed stdev and stdevp from unsupportedStatsFuncs in segstructs.go.

Fixes #2104 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
