### PR TITLE
fix: flooding of error log lines

### DIFF
--- a/pkg/integrations/prometheus/ingest/putmetrics.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics.go
@@ -137,7 +137,7 @@ func HandlePutMetrics(compressed []byte, myid int64) (uint64, uint64, error) {
 			modifiedData, err := ConvertToOTSDBFormat(data, s.Timestamp, s.Value)
 			if err != nil {
 				failedCount++
-				log.Errorf("HandlePutMetrics: failed to convert data=%+v to OTSDB format, err=%v", data, err)
+				log.Errorf("HandlePutMetrics: failed to convert data=%+v to OTSDB format, err=%v", string(data), err)
 				continue
 			}
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -752,7 +752,9 @@ func (dte *DtypeEnclosure) AddStringAsByteSlice() {
 	case SS_DT_STRING:
 		dte.StringValBytes = []byte(dte.StringVal)
 	default:
-		log.Errorf("AddStringAsByteSlice: unsupported Dtype: %v", dte.Dtype)
+		// This function is only for string dtype. And converts only string to byte slice.
+		// We do not want to log error for other dtypes. So we will just log debug message.
+		log.Debugf("AddStringAsByteSlice: unsupported Dtype: %v", dte.Dtype)
 	}
 }
 


### PR DESCRIPTION
# Description
- Fixes log error flooding


# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
