### PR TITLE
feat: Add API and handler to get logs related to traces

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -44,7 +44,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const KEY_INDEX_Name string = "indexName"
+const KEY_INDEX_NAME string = "indexName"
 
 /*
 Example incomingBody
@@ -72,7 +72,7 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		}
 	}
 
-	iText, ok := jsonSource[KEY_INDEX_Name]
+	iText, ok := jsonSource[KEY_INDEX_NAME]
 	if !ok || iText == "" {
 		indexName = "*"
 	} else {
@@ -239,7 +239,7 @@ func ProcessAlertsPipeSearchRequest(queryParams alertutils.QueryParams,
 	readJSON := make(map[string]interface{})
 	var err error
 	readJSON["from"] = "0"
-	readJSON[KEY_INDEX_Name] = "*"
+	readJSON[KEY_INDEX_NAME] = "*"
 	readJSON["queryLanguage"] = queryParams.QueryLanguage
 	readJSON["searchText"] = queryParams.QueryText
 	readJSON["startEpoch"] = queryParams.StartTime

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -44,7 +44,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const Key_IndexName string = "indexName"
+const KEY_INDEX_Name string = "indexName"
 
 /*
 Example incomingBody
@@ -72,7 +72,7 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		}
 	}
 
-	iText, ok := jsonSource[Key_IndexName]
+	iText, ok := jsonSource[KEY_INDEX_Name]
 	if !ok || iText == "" {
 		indexName = "*"
 	} else {
@@ -239,7 +239,7 @@ func ProcessAlertsPipeSearchRequest(queryParams alertutils.QueryParams,
 	readJSON := make(map[string]interface{})
 	var err error
 	readJSON["from"] = "0"
-	readJSON[Key_IndexName] = "*"
+	readJSON[KEY_INDEX_Name] = "*"
 	readJSON["queryLanguage"] = queryParams.QueryLanguage
 	readJSON["searchText"] = queryParams.QueryText
 	readJSON["startEpoch"] = queryParams.StartTime

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -18,7 +18,6 @@
 package pipesearch
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -26,7 +25,6 @@ import (
 	"time"
 
 	"github.com/fasthttp/websocket"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/siglens/siglens/pkg/alerts/alertutils"
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
@@ -45,6 +43,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 )
+
+const Key_IndexName string = "indexName"
 
 /*
 Example incomingBody
@@ -72,7 +72,7 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		}
 	}
 
-	iText, ok := jsonSource["indexName"]
+	iText, ok := jsonSource[Key_IndexName]
 	if !ok || iText == "" {
 		indexName = "*"
 	} else {
@@ -239,7 +239,7 @@ func ProcessAlertsPipeSearchRequest(queryParams alertutils.QueryParams,
 	readJSON := make(map[string]interface{})
 	var err error
 	readJSON["from"] = "0"
-	readJSON["indexName"] = "*"
+	readJSON[Key_IndexName] = "*"
 	readJSON["queryLanguage"] = queryParams.QueryLanguage
 	readJSON["searchText"] = queryParams.QueryText
 	readJSON["startEpoch"] = queryParams.StartTime
@@ -362,11 +362,7 @@ func ProcessPipeSearchRequest(ctx *fasthttp.RequestCtx, myid int64) {
 		return
 	}
 
-	readJSON := make(map[string]interface{})
-	var jsonc = jsoniter.ConfigCompatibleWithStandardLibrary
-	decoder := jsonc.NewDecoder(bytes.NewReader(rawJSON))
-	decoder.UseNumber()
-	err := decoder.Decode(&readJSON)
+	readJSON, err := utils.DecodeJsonToMap(rawJSON)
 	if err != nil {
 		ctx.SetStatusCode(fasthttp.StatusBadRequest)
 		_, err = ctx.WriteString(err.Error())

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -976,7 +976,7 @@ func ProcessSearchTraceRelatedLogsRequest(ctx *fasthttp.RequestCtx, myid int64) 
 	}
 
 	// TODO: Set the index name based on the otel-collector indexes
-	jsonDataMap[pipesearch.Key_IndexName] = "*" // for now, set it to all indexes
+	jsonDataMap[pipesearch.KEY_INDEX_Name] = "*" // for now, set it to all indexes
 
 	bytes, err := putils.EncodeMapToJson(jsonDataMap)
 	if err != nil {

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -968,3 +968,23 @@ func writeErrMsg(ctx *fasthttp.RequestCtx, functionName string, errorMsg string,
 	}
 	log.Errorf(functionName, ": failed to decode search request body! Err=%v", err)
 }
+
+func ProcessSearchTraceRelatedLogsRequest(ctx *fasthttp.RequestCtx, myid int64) {
+	jsonDataMap, err := putils.DecodeJsonToMap(ctx.PostBody())
+	if err != nil {
+		putils.SendError(ctx, fmt.Sprintf("json decoding error: %v", err), fmt.Sprintf("request body: %v", ctx.PostBody()), err)
+	}
+
+	// TODO: Set the index name based on the otel-collector indexes
+	jsonDataMap[pipesearch.Key_IndexName] = "*" // for now, set it to all indexes
+
+	bytes, err := putils.EncodeMapToJson(jsonDataMap)
+	if err != nil {
+		putils.SendError(ctx, "json encoding error", fmt.Sprintf("json data: %v", jsonDataMap), err)
+	}
+
+	ctx.Request.SetBody(bytes)
+	ctx.Request.Header.SetContentLength(len(bytes))
+
+	pipesearch.ProcessPipeSearchRequest(ctx, myid)
+}

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -976,7 +976,7 @@ func ProcessSearchTraceRelatedLogsRequest(ctx *fasthttp.RequestCtx, myid int64) 
 	}
 
 	// TODO: Set the index name based on the otel-collector indexes
-	jsonDataMap[pipesearch.KEY_INDEX_Name] = "*" // for now, set it to all indexes
+	jsonDataMap[pipesearch.KEY_INDEX_NAME] = "*" // for now, set it to all indexes
 
 	bytes, err := putils.EncodeMapToJson(jsonDataMap)
 	if err != nil {

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -674,6 +674,12 @@ func searchTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
+func searchTraceRelatedLogsHandler() func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		serverutils.CallWithMyIdQuery(tracinghandler.ProcessSearchTraceRelatedLogsRequest, ctx)
+	}
+}
+
 func totalTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		serverutils.CallWithMyIdQuery(tracinghandler.ProcessTotalTracesRequest, ctx)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -106,8 +106,8 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.POST(server_utils.API_PREFIX+"/search", tracing.TraceMiddleware(hs.Recovery(pipeSearchHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/search/{dbPanel-id}", tracing.TraceMiddleware(hs.Recovery(dashboardPipeSearchHandler())))
 	hs.Router.GET(server_utils.API_PREFIX+"/search/ws", tracing.TraceMiddleware(hs.Recovery(pipeSearchWebsocketHandler())))
-
 	hs.Router.POST(server_utils.API_PREFIX+"/search/ws", tracing.TraceMiddleware(hs.Recovery(pipeSearchWebsocketHandler())))
+
 	hs.Router.POST(server_utils.API_PREFIX+"/sampledataset_bulk", tracing.TraceMiddleware(hs.Recovery(sampleDatasetBulkHandler())))
 
 	// common routes
@@ -251,6 +251,7 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 
 	// tracing api endpoints
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/search", tracing.TraceMiddleware(hs.Recovery(searchTracesHandler())))
+	hs.Router.POST(server_utils.API_PREFIX+"/traces/search/relatedlogs", tracing.TraceMiddleware(hs.Recovery(searchTraceRelatedLogsHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/dependencies", tracing.TraceMiddleware(hs.Recovery(getDependencyGraphHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/generate-dep-graph", hs.Recovery(generateDependencyGraphHandler()))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/ganttChart", tracing.TraceMiddleware(hs.Recovery(ganttChartHandler())))

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -1010,5 +1010,8 @@ func EncodeMapToJson(dataMap map[string]interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+
+	// Encoder adds a newline at the end of the JSON string. Remove it.
+	jsonBytes := bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
+	return jsonBytes, nil
 }

--- a/pkg/utils/httpserverutils.go
+++ b/pkg/utils/httpserverutils.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	"github.com/cespare/xxhash"
+	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
 	"github.com/valyala/fasthttp"
 )
@@ -987,4 +988,27 @@ func GetContentType(ctx *fasthttp.RequestCtx) string {
 
 func SetContentType(ctx *fasthttp.RequestCtx, contentType string) {
 	ctx.Response.Header.Set(contentTypeHeader, contentType)
+}
+
+func DecodeJsonToMap(jsonData []byte) (map[string]interface{}, error) {
+	var jsonDataMap map[string]interface{}
+	var jsonc = jsoniter.ConfigCompatibleWithStandardLibrary
+	decoder := jsonc.NewDecoder(bytes.NewReader(jsonData))
+	decoder.UseNumber()
+	err := decoder.Decode(&jsonDataMap)
+	if err != nil {
+		return nil, err
+	}
+	return jsonDataMap, nil
+}
+
+func EncodeMapToJson(dataMap map[string]interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	var jsonc = jsoniter.ConfigCompatibleWithStandardLibrary
+	encoder := jsonc.NewEncoder(&buf)
+	err := encoder.Encode(dataMap)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/pkg/utils/httpserverutils_test.go
+++ b/pkg/utils/httpserverutils_test.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -159,4 +160,40 @@ func Test_sendErrorWithStatus(t *testing.T) {
 	assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
 	assert.Equal(t, "{\"error\":\"user message\"}", string(ctx.Response.Body()))
 
+}
+
+func Test_DecodeJsonToMap(t *testing.T) {
+	const jsonStr = `{"a": 1, "b": "value", "c": true, "d": [1, 2, 3], "e": {"f": "g"}, "h": null}`
+	expectedMap := map[string]interface{}{
+		"a": json.Number("1"),
+		"b": "value",
+		"c": true,
+		"d": []interface{}{json.Number("1"), json.Number("2"), json.Number("3")},
+		"e": map[string]interface{}{"f": "g"},
+		"h": nil,
+	}
+
+	jsonMap, err := DecodeJsonToMap([]byte(jsonStr))
+	assert.Nil(t, err)
+	assert.Equal(t, expectedMap, jsonMap)
+}
+
+func Test_EncodeMapToJson(t *testing.T) {
+	jsonMap := map[string]interface{}{
+		"a": json.Number("1"),
+		"b": "value",
+		"c": true,
+		"d": []interface{}{json.Number("1"), json.Number("2"), json.Number("3")},
+		"e": map[string]interface{}{"f": "g"},
+		"h": nil,
+	}
+	expectedJson := `{"a":1,"b":"value","c":true,"d":[1,2,3],"e":{"f":"g"},"h":null}`
+
+	jsonBytes, err := EncodeMapToJson(jsonMap)
+	assert.Nil(t, err)
+	assert.Equal(t, string(expectedJson), string(jsonBytes))
+
+	expectedMap, err := DecodeJsonToMap(jsonBytes)
+	assert.Nil(t, err)
+	assert.Equal(t, jsonMap, expectedMap)
 }


### PR DESCRIPTION
# Description
- Added new API to get logs related to the traces. 
- The response would be exactly same as http API response. 

# Testing
- Ingested Logs and Traces through otel-collector-demo
- Executed the api in postman by setting the searchText as `traceId=<id>` and `spanId=<id>` and verified that the results are there.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
