### PR TITLE
Generate Gantt Chart by SpanID

### DIFF
--- a/API_README.md
+++ b/API_README.md
@@ -884,16 +884,61 @@ For Gantt chart data specific to a trace ID, modify the request body accordingly
         }
 
 ## 5. Gantt Chart Data
-    endpoint: api/traces/ganttchart
+    endpoint: api/traces/ganttChart
     method: POST
 
     Example:
-    request: http://localhost:5122/api/traces/ganttchart
+    request: http://localhost:5122/api/traces/ganttChart
     body:
         {
             "startEpoch": "now-1h",
             "endEpoch": "now",
             "searchText": "trace_id=95db2d5796f8986dbeccec3d1582ee85"
+        }
+    response:
+        {
+            "span_id": "a98166653c6f7f44",
+            "actual_start_time": 1702310799070961452,
+            "start_time": 0,
+            "end_time": 2088875,
+            "duration": 2088875,
+            "service_name": "featureflagservice",
+            "operation_name": "/",
+            "is_anomalous": false,
+            "tags": {
+                "http.client_ip": "127.0.0.1",
+                "http.flavor": "1.1",
+                "http.method": "GET",
+                "http.route": "/",
+                "http.scheme": "http",
+                "http.status_code": 200,
+                "http.target": "/",
+                "http.user_agent": "curl/7.64.0",
+                "net.host.name": "localhost",
+                "net.host.port": 8081,
+                "net.peer.port": 60928,
+                "net.sock.host.addr": "127.0.0.1",
+                "net.sock.peer.addr": "127.0.0.1",
+                "net.transport": "IP.TCP",
+                "phoenix.action": "index",
+                "phoenix.plug": "Elixir.FeatureflagserviceWeb.PageController"
+            },
+            "children": [
+                // ... more records ...
+            ]
+        }
+
+## 6. Gantt Chart Data From Span ID
+    endpoint: api/traces/span/ganttChart
+    method: POST
+
+    Example:
+    request: http://localhost:5122/api/traces/span/ganttChart
+    body:
+        {
+            "startEpoch": "now-1h",
+            "endEpoch": "now",
+            "searchText": "span_id=a98166653c6f7f44"
         }
     response:
         {

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -280,10 +280,7 @@ func ExtractTraceID(searchText string) (bool, string) {
 func ExtractSpanID(searchText string) (bool, string) {
 	pattern := `^span_id=([a-zA-Z0-9]+)$`
 
-	regex, err := regexp.Compile(pattern)
-	if err != nil {
-		return false, ""
-	}
+	regex := regexp.MustCompile(pattern)
 
 	matches := regex.FindStringSubmatch(searchText)
 	if len(matches) != 2 {
@@ -1025,9 +1022,7 @@ func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 
 	page := 1
 	pageVal, ok := readJSON["page"]
-	if !ok || pageVal == 0 {
-		page = 1
-	} else {
+	if ok && pageVal != 0 {
 		switch val := pageVal.(type) {
 		case json.Number:
 			pageInt, err := val.Int64()

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -1040,8 +1040,7 @@ func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 		}
 	}
 
-	// TODO: Set the index name based on the otel-collector indexes
-	searchRequestBody.IndexName = "traces" // for now, set it to all indexes
+	searchRequestBody.IndexName = "traces"
 
 	// Find all unique Trace IDs for the spanId
 	searchRequestBody.SearchText = "span_id=" + spanId + " | stats count BY trace_id"

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -1041,10 +1041,10 @@ func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	// TODO: Set the index name based on the otel-collector indexes
-	searchRequestBody.IndexName = "*" // for now, set it to all indexes
+	searchRequestBody.IndexName = "traces" // for now, set it to all indexes
 
 	// Find all unique Trace IDs for the spanId
-	searchRequestBody.SearchText = "spanId=" + spanId + " | stats count BY traceId"
+	searchRequestBody.SearchText = "span_id=" + spanId + " | stats count BY trace_id"
 	pipeSearchResponseOuter, err := processSearchRequest(searchRequestBody, myid)
 	if err != nil {
 		writeErrMsg(ctx, "ProcessSpanGanttChartRequest", err.Error(), nil)
@@ -1070,7 +1070,7 @@ func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	requestBody := map[string]interface{}{
-		"indexName":     "*",
+		"indexName":     "traces",
 		"startEpoch":    searchRequestBody.StartEpoch,
 		"endEpoch":      searchRequestBody.EndEpoch,
 		"searchText":    "trace_id=" + traceId,

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -983,26 +983,6 @@ func writeErrMsg(ctx *fasthttp.RequestCtx, functionName string, errorMsg string,
 	log.Errorf(functionName, ": failed to decode search request body! Err=%v", err)
 }
 
-func ProcessSearchTraceRelatedLogsRequest(ctx *fasthttp.RequestCtx, myid int64) {
-	jsonDataMap, err := putils.DecodeJsonToMap(ctx.PostBody())
-	if err != nil {
-		putils.SendError(ctx, fmt.Sprintf("json decoding error: %v", err), fmt.Sprintf("request body: %v", ctx.PostBody()), err)
-	}
-
-	// TODO: Set the index name based on the otel-collector indexes
-	jsonDataMap[pipesearch.KEY_INDEX_NAME] = "*" // for now, set it to all indexes
-
-	bytes, err := putils.EncodeMapToJson(jsonDataMap)
-	if err != nil {
-		putils.SendError(ctx, "json encoding error", fmt.Sprintf("json data: %v", jsonDataMap), err)
-	}
-
-	ctx.Request.SetBody(bytes)
-	ctx.Request.Header.SetContentLength(len(bytes))
-
-	pipesearch.ProcessPipeSearchRequest(ctx, myid)
-}
-
 func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	searchRequestBody, readJSON, err := ParseAndValidateRequestBody(ctx)
 	if err != nil {

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -680,6 +680,12 @@ func searchTraceRelatedLogsHandler() func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
+func spanGanttChartHandler() func(ctx *fasthttp.RequestCtx) {
+	return func(ctx *fasthttp.RequestCtx) {
+		serverutils.CallWithMyIdQuery(tracinghandler.ProcessSpanGanttChartRequest, ctx)
+	}
+}
+
 func totalTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		serverutils.CallWithMyIdQuery(tracinghandler.ProcessTotalTracesRequest, ctx)

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -674,12 +674,6 @@ func searchTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
-func searchTraceRelatedLogsHandler() func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		serverutils.CallWithMyIdQuery(tracinghandler.ProcessSearchTraceRelatedLogsRequest, ctx)
-	}
-}
-
 func spanGanttChartHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		serverutils.CallWithMyIdQuery(tracinghandler.ProcessSpanGanttChartRequest, ctx)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -255,6 +255,7 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/dependencies", tracing.TraceMiddleware(hs.Recovery(getDependencyGraphHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/generate-dep-graph", hs.Recovery(generateDependencyGraphHandler()))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/ganttChart", tracing.TraceMiddleware(hs.Recovery(ganttChartHandler())))
+	hs.Router.POST(server_utils.API_PREFIX+"/traces/span/ganttChart", tracing.TraceMiddleware(hs.Recovery(spanGanttChartHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/count", tracing.TraceMiddleware(hs.Recovery((totalTracesHandler()))))
 	// query server should still setup ES APIs for Kibana integration
 	hs.Router.POST(server_utils.ELASTIC_PREFIX+"/_bulk", hs.Recovery(esPostBulkHandler()))


### PR DESCRIPTION
# Description
    endpoint: api/traces/span/ganttChart
    method: POST

    Example:
    request: http://localhost:5122/api/traces/span/ganttChart
    body:
        {
            "startEpoch": "now-1h",
            "endEpoch": "now",
            "searchText": "span_id=a98166653c6f7f44"
        }

Finds the corresponding trace_id from the span_id and generates a gantt chart according to it. If the span_id does not have a corresponding trace_id, it returns an error of an orphaned span_id state. 

Right now it only logs a comment if there are more than 1 associated traces to a span_id, but later on this case should be handled properly. 

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
