### PR TITLE
Tidy alert validation function

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -93,7 +93,8 @@ func Disconnect() {
 	databaseObj.CloseDb()
 }
 func validateAlertTypeAndQuery(alertToBeCreated *alertutils.AlertDetails) (string, error) {
-	if alertToBeCreated.AlertType == alertutils.AlertTypeLogs {
+	switch alertToBeCreated.AlertType {
+	case alertutils.AlertTypeLogs:
 		_, queryAggs, _, err := pipesearch.ParseQuery(alertToBeCreated.QueryParams.QueryText, 0, alertToBeCreated.QueryParams.QueryLanguage)
 		if err != nil {
 			return fmt.Sprintf("QuerySearchText: %v, QueryLanguage: %v", alertToBeCreated.QueryParams.QueryText, alertToBeCreated.QueryParams.QueryLanguage), fmt.Errorf("error Parsing logs Query. Error=%v", err)
@@ -107,15 +108,15 @@ func validateAlertTypeAndQuery(alertToBeCreated *alertutils.AlertDetails) (strin
 		if !isStatsQuery {
 			return fmt.Sprintf("QuerySearchText: %v, QueryLanguage: %v", alertToBeCreated.QueryParams.QueryText, alertToBeCreated.QueryParams.QueryLanguage), fmt.Errorf("query does not contain any aggregation. Expected Stats Query")
 		}
-
-	} else if alertToBeCreated.AlertType == alertutils.AlertTypeMetrics {
+	case alertutils.AlertTypeMetrics:
 		_, _, _, _, errorLog, _, err := promql.ParseMetricTimeSeriesRequest([]byte(alertToBeCreated.MetricsQueryParamsString))
 		if err != nil {
 			return errorLog, err
 		}
-	} else {
-		return fmt.Sprintf("Alert Type: %v", alertToBeCreated.AlertType), fmt.Errorf("invalid Alert Type. Alert Type must be logs or Metrics")
+	case alertutils.AlertTypeMinion:
+		return fmt.Sprintf("Alert Type: %v", alertToBeCreated.AlertType), fmt.Errorf("minion alerts are not supported")
 	}
+
 	return "", nil
 }
 


### PR DESCRIPTION
# Description
Mostly cosmetic changes. The one change in behavior is that there's a different error returned when making an invalid type of alert

# Testing
Not tested
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
