### PR TITLE
UI: Correlation b/w Logs and Traces 

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -437,6 +437,7 @@
     margin: 0;
     text-decoration: none;
     white-space: nowrap;
+    line-height: normal;
 }
 
 .btn:focus {
@@ -446,7 +447,8 @@
 
 /* Save-Button */
 .btn-primary,
-.btn-primary:active {
+.btn-primary:active,
+.btn-primary:focus {
     background-color: var(--btn-regular-bg-color);
     color: var(--white-0);
 }
@@ -490,6 +492,21 @@
 
 .btn-white:hover {
     background: var(--drop-down-btn-bg-hover);
+}
+
+.btn-purple {
+    color: var(--purple-2);
+    padding: 2px 10px;
+    background-color: var(--black1-to-white0);
+    border: 1px solid var(--purple-2);
+    font-size: 11px;
+    text-decoration: none !important;
+    font-weight: bold;
+}
+
+.btn-purple:hover {
+    background-color: var(--purple-15p);
+    color: var(--purple-2)
 }
 
 /* Dropdown-Menu */

--- a/static/css/tracing.css
+++ b/static/css/tracing.css
@@ -486,12 +486,32 @@ a.warn-box-anchor {
 }
 
 .tooltip-design {
-    color: var(--text-color) !important;
+    color: var(--subsection-border);
     background-color: var(--bg-color) !important;
-    padding: 5px !important;
+    padding: 8px !important;
     border-radius: 5px !important;
     font-size: 10px !important;
-    margin-top: -20px;
+    line-height: 14px !important;
+}
+
+.tooltip-design .trace-name {
+    color: var(--text-color);
+    font-size: 11px;
+    font-weight: bold;
+}
+
+.tooltip-design .context-option {
+    color: var(--text-color);
+    height: 24px;
+    border-radius: 4px;
+    background-color: var(--drop-down-btn-bg-regular);
+    padding: 6px 6px;
+    margin-top: 6px;
+    cursor: pointer;
+}
+
+.tooltip-design .context-option:hover {
+    background: var(--drop-down-btn-bg-hover)
 }
 
 circle:hover {
@@ -615,4 +635,8 @@ body.resizing {
 
 .dropdown-menu.daterangepicker.show {
     top: 44px;
+}
+
+.fa-file-text {
+    margin-right: 6px;
 }

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1215,3 +1215,32 @@ function createTooltip(selector, content) {
         animation: 'fade',
     });
 }
+
+function handleRelatedTraces(traceId) {
+    window.location.href = `trace.html?trace_id=${traceId}`;
+
+}
+
+function handleRelatedLogs(id, traceStartTime, type = 'trace') {
+    const traceStartEpoch = Math.floor(Number(traceStartTime) / 1000000);
+    
+    const fifteenMinutesMs = 15 * 60 * 1000;
+    
+    const startEpoch = traceStartEpoch - fifteenMinutesMs;
+    const endEpoch = traceStartEpoch + fifteenMinutesMs;
+
+    const searchQuery = type === 'span' 
+        ? `spanId="${id}"` 
+        : `traceId="${id}"`;
+
+    const searchParams = new URLSearchParams({
+        searchText: searchQuery,
+        startEpoch: startEpoch.toString(),
+        endEpoch: endEpoch.toString(),
+        indexName: 'trace-related-logs',
+        queryLanguage: 'Splunk QL',
+        filterTab: '1',
+    });
+
+    window.open(`index.html?${searchParams.toString()}`, '_blank');
+}

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1230,8 +1230,8 @@ function handleRelatedLogs(id, traceStartTime, type = 'trace') {
     const endEpoch = traceStartEpoch + fifteenMinutesMs;
 
     const searchQuery = type === 'span' 
-        ? `spanId="${id}"` 
-        : `traceId="${id}"`;
+        ? `span_id="${id}"` 
+        : `trace_id="${id}"`;
 
     const searchParams = new URLSearchParams({
         searchText: searchQuery,

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -182,7 +182,6 @@ const gridOptions = {
     singleClickEdit: true,
     headerHeight: 26,
     suppressDragLeaveHidesColumns: true,
-    maintainRowOrder: true,
     defaultColDef: {
         initialWidth: 100,
         sortable: true,

--- a/static/js/search-traces.js
+++ b/static/js/search-traces.js
@@ -339,7 +339,7 @@ function searchTrace(params) {
                     let dataInfo = new Date(milliseconds);
                     let dataStr = dataInfo.toLocaleString().toLowerCase();
                     let duration = Number((json.end_time - json.start_time) / 1000000);
-                    scatterData.push([dataStr, duration, json.span_count, json.span_errors_count, json.service_name, json.operation_name, json.trace_id]);
+                    scatterData.push([dataStr, duration, json.span_count, json.span_errors_count, json.service_name, json.operation_name, json.trace_id, json.start_time]);
                 }
                 showScatterPlot();
                 reSort();
@@ -438,9 +438,28 @@ function showScatterPlot() {
                 var duration = param.value[1];
                 var spans = param.value[2];
                 var errors = param.value[3];
-                var traceId = param.value[6] ? param.value[6].substring(0, 7) : '';
+                var traceId = param.value[6] ? param.value[6] : '';
+                var traceStartTimeMs = param.value[7];
 
-                return '<div>' + green + ': ' + red + '<br>Trace ID: ' + traceId + '<br>Duration: ' + duration + 'ms' + '<br>No. of Spans: ' + spans + '<br>No. of Error Spans: ' + errors + '</div>';
+                return `<div class="custom-tooltip">
+                    <div class="tooltip-content">
+                        <div class="trace-name">${green}: ${red}</div>
+                        <div class="trace-id">Trace ID: ${traceId.substring(0, 7)}</div>
+                        <hr>
+                        <div>Duration: ${duration}ms</div>
+                        <div>No. of Spans: ${spans}</div>
+                        <div>No. of Error Spans: ${errors}</div>
+                    </div>
+                    <hr>
+                    <div class="tooltip-context">
+                        <div class="context-option" onclick="handleRelatedTraces('${traceId}')">View Traces</div>
+                        <div class="context-option" onclick="handleRelatedLogs('${traceId}', ${traceStartTimeMs}, 'trace')">Related Logs</div>
+                    </div>
+                </div>`;
+            },
+            enterable: true,
+            position: function (point) {
+                return [point[0], point[1]];
             },
         },
         series: [

--- a/static/js/trace.js
+++ b/static/js/trace.js
@@ -173,7 +173,11 @@ function traceDetails(res) {
     <div class="d-flex trace-details">
         <div>Trace Start: <span>${convertNanosecondsToDateTime(res.actual_start_time)}</span></div>
         <div>Duration:<span>${nsToMs(res.duration)}ms</span></div>
-    </div>`
+    </div>
+    <button onclick="handleRelatedLogs('${traceId}', ${res.actual_start_time}, 'trace')" class="btn-related-logs btn btn-purple">
+        <i class="fa fa-file-text"></i>
+        Logs for this trace
+    </button>`
     );
 }
 
@@ -668,6 +672,12 @@ function showSpanDetails(node) {
         <div class="details-container">
             <div class="details">
                 <div>Service: <strong>${node.service_name}</strong> | Start Time: <strong>${nsToMs(node.start_time)}ms</strong> | Duration: <strong>${nsToMs(node.duration)}ms </strong></div>
+            </div>
+            <div class="my-3">
+                <button onclick="handleRelatedLogs('${node.span_id}', ${node.actual_start_time}, 'span')" class="btn-related-logs btn btn-purple">
+                    <i class="fa fa-file-text"></i>
+                    Logs for this span
+                </button>
             </div>
             <div><strong>Tags</strong>:</div>
             <table style="border-collapse: collapse; width: 100%; margin-top:6px" >


### PR DESCRIPTION
# Description
1. Tooltip on bubble chart on the search-trace page displaying trace details with two options:
  - View Traces: Navigates to the Gantt chart view.
  - Related Logs: Opens the log search screen in a new tab with prefilled search parameters.
2. On the trace/Gantt chart screen: "Logs for this Trace" and "Logs for this Span" buttons now open the log search screen in a new tab with prefilled search parameters.

- Prefilled search parameters for related logs include:
```
Search Text = traceID=""
StartTime = traceStartTime - 15 mins
EndtTime = traceStartTime + 15 mins
Mode = Code
Query Language = Splunk QL
Index = trace-related-logs
```

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/a3dd1580-cfaa-481e-a847-4630db544391" />
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/b93266de-a3a2-4ed3-b377-967a472ff2bc" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
