### PR TITLE
Traces to logs through websocket and http handler

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -75,6 +75,9 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 	iText, ok := jsonSource[KEY_INDEX_NAME]
 	if !ok || iText == "" {
 		indexName = "*"
+	} else if iText == KEY_TRACE_RELATED_LOGS_INDEX {
+		// TODO: set indexNameIn to otel-collector indexes
+		indexName = "*"
 	} else {
 		switch val := iText.(type) {
 		case string:
@@ -96,11 +99,6 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		default:
 			log.Errorf("ParseSearchBody: indexName is not a string! val: %+v, type: %T", val, iText)
 		}
-	}
-
-	if indexName == KEY_TRACE_RELATED_LOGS_INDEX {
-		// TODO: set indexNameIn to otel-collector indexes
-		indexName = "*"
 	}
 
 	startE, ok := jsonSource["startEpoch"]

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -98,6 +98,11 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		}
 	}
 
+	if indexName == KEY_TRACE_RELATED_LOGS_INDEX {
+		// TODO: set indexNameIn to otel-collector indexes
+		indexName = "*"
+	}
+
 	startE, ok := jsonSource["startEpoch"]
 	if !ok || startE == nil {
 		startEpoch = nowTs - (15 * 60 * 1000)

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -97,10 +97,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 		return
 	}
 
-	isTraceRelatedLogsIndex := false
-
 	if indexNameIn == KEY_TRACE_RELATED_LOGS_INDEX {
-		isTraceRelatedLogsIndex = true
 		// TODO: set indexNameIn to otel-collector indexes
 		indexNameIn = "*"
 	}
@@ -158,7 +155,6 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 	qc := structs.InitQueryContextWithTableInfo(ti, sizeLimit, scrollFrom, orgid, false)
 	qc.RawQuery = searchText
 	qc.IncludeNulls = includeNulls
-	qc.IsTraceRelatedLogsIndex = isTraceRelatedLogsIndex
 
 	if config.IsNewQueryPipelineEnabled() {
 		RunAsyncQueryForNewPipeline(conn, qid, simpleNode, aggs, qc, sizeLimit, scrollFrom)

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -97,11 +97,6 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 		return
 	}
 
-	if indexNameIn == KEY_TRACE_RELATED_LOGS_INDEX {
-		// TODO: set indexNameIn to otel-collector indexes
-		indexNameIn = "*"
-	}
-
 	ti := structs.InitTableInfo(indexNameIn, orgid, false)
 	log.Infof("qid=%v, ProcessPipeSearchWebsocket: index=[%v] searchString=[%v] scrollFrom=[%v]",
 		qid, ti.String(), searchText, scrollFrom)

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -101,6 +101,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 
 	if indexNameIn == KEY_TRACE_RELATED_LOGS_INDEX {
 		isTraceRelatedLogsIndex = true
+		// TODO: set indexNameIn to otel-collector indexes
 		indexNameIn = "*"
 	}
 

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -37,6 +37,8 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+const KEY_TRACE_RELATED_LOGS_INDEX = "trace-related-logs"
+
 func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp.RequestCtx) {
 
 	qid := rutils.GetNextQid()
@@ -95,6 +97,13 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 		return
 	}
 
+	isTraceRelatedLogsIndex := false
+
+	if indexNameIn == KEY_TRACE_RELATED_LOGS_INDEX {
+		isTraceRelatedLogsIndex = true
+		indexNameIn = "*"
+	}
+
 	ti := structs.InitTableInfo(indexNameIn, orgid, false)
 	log.Infof("qid=%v, ProcessPipeSearchWebsocket: index=[%v] searchString=[%v] scrollFrom=[%v]",
 		qid, ti.String(), searchText, scrollFrom)
@@ -148,6 +157,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 	qc := structs.InitQueryContextWithTableInfo(ti, sizeLimit, scrollFrom, orgid, false)
 	qc.RawQuery = searchText
 	qc.IncludeNulls = includeNulls
+	qc.IsTraceRelatedLogsIndex = isTraceRelatedLogsIndex
 
 	if config.IsNewQueryPipelineEnabled() {
 		RunAsyncQueryForNewPipeline(conn, qid, simpleNode, aggs, qc, sizeLimit, scrollFrom)

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -35,12 +35,13 @@ import (
 
 // New struct for passin query params
 type QueryContext struct {
-	TableInfo    *TableInfo
-	SizeLimit    uint64
-	Scroll       int
-	Orgid        int64
-	RawQuery     string
-	IncludeNulls bool
+	TableInfo               *TableInfo
+	SizeLimit               uint64
+	Scroll                  int
+	Orgid                   int64
+	RawQuery                string
+	IncludeNulls            bool
+	IsTraceRelatedLogsIndex bool
 }
 
 // Input for filter operator can either be the result of a ASTNode or an expression

--- a/pkg/segment/structs/querystructs.go
+++ b/pkg/segment/structs/querystructs.go
@@ -35,13 +35,12 @@ import (
 
 // New struct for passin query params
 type QueryContext struct {
-	TableInfo               *TableInfo
-	SizeLimit               uint64
-	Scroll                  int
-	Orgid                   int64
-	RawQuery                string
-	IncludeNulls            bool
-	IsTraceRelatedLogsIndex bool
+	TableInfo    *TableInfo
+	SizeLimit    uint64
+	Scroll       int
+	Orgid        int64
+	RawQuery     string
+	IncludeNulls bool
 }
 
 // Input for filter operator can either be the result of a ASTNode or an expression

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -968,23 +968,3 @@ func writeErrMsg(ctx *fasthttp.RequestCtx, functionName string, errorMsg string,
 	}
 	log.Errorf(functionName, ": failed to decode search request body! Err=%v", err)
 }
-
-func ProcessSearchTraceRelatedLogsRequest(ctx *fasthttp.RequestCtx, myid int64) {
-	jsonDataMap, err := putils.DecodeJsonToMap(ctx.PostBody())
-	if err != nil {
-		putils.SendError(ctx, fmt.Sprintf("json decoding error: %v", err), fmt.Sprintf("request body: %v", ctx.PostBody()), err)
-	}
-
-	// TODO: Set the index name based on the otel-collector indexes
-	jsonDataMap[pipesearch.KEY_INDEX_NAME] = "*" // for now, set it to all indexes
-
-	bytes, err := putils.EncodeMapToJson(jsonDataMap)
-	if err != nil {
-		putils.SendError(ctx, "json encoding error", fmt.Sprintf("json data: %v", jsonDataMap), err)
-	}
-
-	ctx.Request.SetBody(bytes)
-	ctx.Request.Header.SetContentLength(len(bytes))
-
-	pipesearch.ProcessPipeSearchRequest(ctx, myid)
-}

--- a/pkg/server/query/entryHandlers.go
+++ b/pkg/server/query/entryHandlers.go
@@ -674,12 +674,6 @@ func searchTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
-func searchTraceRelatedLogsHandler() func(ctx *fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
-		serverutils.CallWithMyIdQuery(tracinghandler.ProcessSearchTraceRelatedLogsRequest, ctx)
-	}
-}
-
 func totalTracesHandler() func(ctx *fasthttp.RequestCtx) {
 	return func(ctx *fasthttp.RequestCtx) {
 		serverutils.CallWithMyIdQuery(tracinghandler.ProcessTotalTracesRequest, ctx)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -251,7 +251,6 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 
 	// tracing api endpoints
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/search", tracing.TraceMiddleware(hs.Recovery(searchTracesHandler())))
-	hs.Router.POST(server_utils.API_PREFIX+"/traces/search/relatedlogs", tracing.TraceMiddleware(hs.Recovery(searchTraceRelatedLogsHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/dependencies", tracing.TraceMiddleware(hs.Recovery(getDependencyGraphHandler())))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/generate-dep-graph", hs.Recovery(generateDependencyGraphHandler()))
 	hs.Router.POST(server_utils.API_PREFIX+"/traces/ganttChart", tracing.TraceMiddleware(hs.Recovery(ganttChartHandler())))


### PR DESCRIPTION
# Description
- Added the changes to identify trace-related-logs index and replaced it as `*`

UPDATE:
- Added this replacement of indexname to `*` at `ParseSearchBody` as this function is being used by both websocket and http handler.


# Testing
- Tested by running ingestion through otel-collector.
- And verified traces to logs through the UI.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
