### PR TITLE
Require exactly one measure agg for log alerts

### DIFF
--- a/pkg/alerts/alertsHandler/alert_test.go
+++ b/pkg/alerts/alertsHandler/alert_test.go
@@ -1,0 +1,39 @@
+package alertsHandler
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/alerts/alertutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateAlertTypeAndQuery(t *testing.T) {
+	assertIsValidLogAlert(t, false, "")
+	assertIsValidLogAlert(t, false, "foo=bar")
+	assertIsValidLogAlert(t, true, "foo=bar | stats count")
+	assertIsValidLogAlert(t, true, "foo=bar | stats count by weekday")
+	assertIsValidLogAlert(t, true, "foo=bar | stats count by weekday, alpha, beta")
+	assertIsValidLogAlert(t, true, "* | stats count by weekday, alpha, beta")
+	assertIsValidLogAlert(t, true, "foo=bar | stats min(latency)")
+}
+
+func assertIsValidLogAlert(t *testing.T, isValid bool, splunkQuery string) {
+	t.Helper()
+
+	alert := &alertutils.AlertDetails{
+		AlertConfig: alertutils.AlertConfig{
+			AlertType: alertutils.AlertTypeLogs,
+			QueryParams: alertutils.QueryParams{
+				QueryLanguage: "Splunk QL",
+				QueryText:     splunkQuery,
+			},
+		},
+	}
+
+	_, err := validateAlertTypeAndQuery(alert)
+	if isValid {
+		assert.NoError(t, err)
+	} else {
+		assert.Error(t, err)
+	}
+}

--- a/pkg/alerts/alertsHandler/alert_test.go
+++ b/pkg/alerts/alertsHandler/alert_test.go
@@ -17,6 +17,10 @@ func Test_ValidateAlertTypeAndQuery(t *testing.T) {
 	assertIsValidLogAlert(t, true, "foo=bar | stats min(latency)")
 	assertIsValidLogAlert(t, false, "foo=bar | stats min(latency), max(latency)")
 	assertIsValidLogAlert(t, false, "foo=bar | stats min(latency), avg(size)")
+	assertIsValidLogAlert(t, false, "foo=bar | stats min(latency), avg(size) by alpha")
+	assertIsValidLogAlert(t, true, "foo=bar | stats min(latency) by alpha")
+	assertIsValidLogAlert(t, true, "foo=bar | stats min(latency) as minLatency by alpha")
+	assertIsValidLogAlert(t, true, "* | eval latencyMs = latency / 1000 | stats avg(latencyMs) as avgLatencyMs by alpha")
 }
 
 func assertIsValidLogAlert(t *testing.T, isValid bool, splunkQuery string) {

--- a/pkg/alerts/alertsHandler/alert_test.go
+++ b/pkg/alerts/alertsHandler/alert_test.go
@@ -15,6 +15,8 @@ func Test_ValidateAlertTypeAndQuery(t *testing.T) {
 	assertIsValidLogAlert(t, true, "foo=bar | stats count by weekday, alpha, beta")
 	assertIsValidLogAlert(t, true, "* | stats count by weekday, alpha, beta")
 	assertIsValidLogAlert(t, true, "foo=bar | stats min(latency)")
+	assertIsValidLogAlert(t, false, "foo=bar | stats min(latency), max(latency)")
+	assertIsValidLogAlert(t, false, "foo=bar | stats min(latency), avg(size)")
 }
 
 func assertIsValidLogAlert(t *testing.T, isValid bool, splunkQuery string) {

--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -109,6 +109,15 @@ func validateAlertTypeAndQuery(alertToBeCreated *alertutils.AlertDetails) (strin
 		if !isStatsQuery {
 			return queryTextAndLanguage(alertToBeCreated), fmt.Errorf("query does not contain any aggregation. Expected Stats Query")
 		}
+
+		allMeasureAggGroups := queryAggs.GetAllMeasureAggsInChain()
+		if len(allMeasureAggGroups) == 0 || len(allMeasureAggGroups[0]) == 0 {
+			return queryTextAndLanguage(alertToBeCreated), fmt.Errorf("query does not contain any measure aggregation")
+		}
+
+		if len(allMeasureAggGroups) > 1 || len(allMeasureAggGroups[0]) > 1 {
+			return queryTextAndLanguage(alertToBeCreated), fmt.Errorf("query contains more than one measure aggregation")
+		}
 	case alertutils.AlertTypeMetrics:
 		_, _, _, _, errorLog, _, err := promql.ParseMetricTimeSeriesRequest([]byte(alertToBeCreated.MetricsQueryParamsString))
 		if err != nil {

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -239,7 +239,7 @@ func ProcessAlertsPipeSearchRequest(queryParams alertutils.QueryParams,
 	readJSON := make(map[string]interface{})
 	var err error
 	readJSON["from"] = "0"
-	readJSON[KEY_INDEX_NAME] = "*"
+	readJSON[KEY_INDEX_NAME] = queryParams.Index
 	readJSON["queryLanguage"] = queryParams.QueryLanguage
 	readJSON["searchText"] = queryParams.QueryText
 	readJSON["startEpoch"] = queryParams.StartTime

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1675,6 +1675,34 @@ func (qa *QueryAggregators) IsStatsAggPresentInChain() bool {
 	return qa.HasInChain(statsAggPresentInCur)
 }
 
+func (qa *QueryAggregators) GetAllMeasureAggsInChain() [][]*MeasureAggregator {
+	measureAggGroups := make([][]*MeasureAggregator, 0)
+	getCur := func(obj *QueryAggregators) []*MeasureAggregator {
+		if obj.MeasureOperations != nil {
+			return obj.MeasureOperations
+		} else if obj.GroupByRequest != nil && obj.GroupByRequest.MeasureOperations != nil {
+			return obj.GroupByRequest.MeasureOperations
+		}
+
+		return nil
+	}
+
+	for {
+		measureAggs := getCur(qa)
+		if measureAggs != nil {
+			measureAggGroups = append(measureAggGroups, measureAggs)
+		}
+
+		if qa.Next == nil {
+			break
+		}
+
+		qa = qa.Next
+	}
+
+	return measureAggGroups
+}
+
 // TODO: use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)

--- a/pkg/segment/structs/segstructs_test.go
+++ b/pkg/segment/structs/segstructs_test.go
@@ -491,6 +491,50 @@ func Test_HasTail_OnlyInLastQA(t *testing.T) {
 	assert.True(t, qa.HasTailInChain())
 }
 
+func Test_GetAllMeasureAggsInChain(t *testing.T) {
+	qa := &QueryAggregators{
+		MeasureOperations: []*MeasureAggregator{
+			{MeasureCol: "measure1"},
+		},
+	}
+
+	actual := qa.GetAllMeasureAggsInChain()
+	assert.Equal(t, [][]*MeasureAggregator{{{MeasureCol: "measure1"}}}, actual)
+
+	qa = &QueryAggregators{
+		Next: &QueryAggregators{
+			MeasureOperations: []*MeasureAggregator{
+				{MeasureCol: "measure2"},
+			},
+		},
+	}
+
+	actual = qa.GetAllMeasureAggsInChain()
+	assert.Equal(t, [][]*MeasureAggregator{{{MeasureCol: "measure2"}}}, actual)
+
+	qa = &QueryAggregators{
+		MeasureOperations: []*MeasureAggregator{
+			{MeasureCol: "measure1"},
+			{MeasureCol: "measure2"},
+		},
+		Next: &QueryAggregators{
+			Sort: &SortRequest{},
+			Next: &QueryAggregators{
+				GroupByRequest: &GroupByRequest{
+					GroupByColumns:    []string{"column1"},
+					MeasureOperations: []*MeasureAggregator{{MeasureCol: "measure3"}},
+				},
+			},
+		},
+	}
+
+	actual = qa.GetAllMeasureAggsInChain()
+	assert.Equal(t, [][]*MeasureAggregator{
+		{{MeasureCol: "measure1"}, {MeasureCol: "measure2"}},
+		{{MeasureCol: "measure3"}},
+	}, actual)
+}
+
 func Test_GetBucketValueForGivenField_StatRes(t *testing.T) {
 	br := &BucketResult{
 		StatRes: map[string]utils.CValueEnclosure{


### PR DESCRIPTION
# Description
1. Requires queries for log alerts to contain exactly one measure column
2. Fixes a bug: all indexes were being searched for log alerts; now the correct indexes are searched
3. Adds unit tests

Previously, we were able to create an alert that has multiple measure columns, but then the alert would fail when it was evaluated. Now we reject those queries when creating/updating an alert

**Note:** There's still an issue with queries that have something before a `stats` block (e.g., `* | eval latencyMs = latency / 1000 | stats avg(latencyMs) as avgLatencyMs by weekday`). We're able to create these alerts, but then the evaluation fails and so the alert never fires. I didn't find an easy fix for this, so I'll make a ticket for it.

# Testing
New unit tests, and manually tested creating/updating alerts on the UI

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
