### PR TITLE
Allow alerting on negative/non-integer thresholds

### DIFF
--- a/static/alert.html
+++ b/static/alert.html
@@ -291,7 +291,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </div>
                                 </div>
                                 <div class="condition-value">
-                                    <input type="number" name="condition-value" min="0" step="1" id="threshold-value"
+                                    <input type="number" name="condition-value" step="any" id="threshold-value"
                                         value="0" class="form-control" tabindex="3">
                                 </div>
                             </div>


### PR DESCRIPTION
# Description
Summarize the change.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Manually added alerts with negative and non-integer thresholds and verified they fired when appropriate.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
