### PR TITLE
Returns error if parsing a metric expression in PromQL fails

### DIFF
--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -158,6 +158,10 @@ func parsePromQLQuery(query string, startTime, endTime uint32, myid int64) ([]*s
 		return err
 	})
 
+	if err != nil {
+		return []*structs.MetricsQueryRequest{}, "", []*structs.QueryArithmetic{}, err
+	}
+
 	if len(mQueryReqs) == 0 {
 		return mQueryReqs, pqlQuerytype, queryArithmetic, nil
 	}


### PR DESCRIPTION
# Description
In parsePromQLQuery, we parse an expression using parsePromQLExprNode. However if this fails and returns an error, we weren't returning an error and instead continued the function, resulting in a divide by zero error when using a faulty expression or one that wasn't implemented yet.

This change returns an error and reports a Syntax Error if this function fails. 

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
