### PR TITLE
Fix bug with query text in alert message

### DIFF
--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -576,10 +576,10 @@ func resolveTemplate(template string, alertName string, condition alertutils.Ale
 	message := strings.ReplaceAll(template, "{{alert_rule_name}}", alertName)
 	message = strings.ReplaceAll(message, "{{query_string}}", queryText)
 	if condition == 0 {
-		val := "above " + fmt.Sprintf("%1.0f", value)
+		val := "is above " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 1 {
-		val := "below " + fmt.Sprintf("%1.0f", value)
+		val := "is below " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 2 {
 		val := "is equal to " + fmt.Sprintf("%1.0f", value)

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -561,6 +561,12 @@ func (p Sqlite) GetContactDetails(alert_id string) (string, string, string, erro
 		return "", "", "", err
 	}
 
+	err := alert.DecodeQueryParamFromBase64()
+	if err != nil {
+		log.Errorf("GetContactDetails: unable to decode query params for Alert: %v, Error=%v", alert.AlertName, err)
+		// Don't return error; we can still return some useful info.
+	}
+
 	alert_name := alert.AlertName
 	contact_id := alert.ContactID
 	condition := alert.Condition

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -563,29 +563,36 @@ func (p Sqlite) GetContactDetails(alert_id string) (string, string, string, erro
 
 	alert_name := alert.AlertName
 	contact_id := alert.ContactID
-	message := alert.Message
 	condition := alert.Condition
 	value := alert.Value
+	message := resolveTemplate(alert.Message, alert_name, condition, value, alert.QueryParams.QueryLanguage, alert.QueryParams.QueryText)
 
-	newMessage := strings.ReplaceAll(message, "{{alert_rule_name}}", alert_name)
-	newMessage = strings.ReplaceAll(newMessage, "{{query_string}}", alert.QueryParams.QueryLanguage)
+	return contact_id, message, alert_name, nil
+}
+
+func resolveTemplate(template string, alertName string, condition alertutils.AlertQueryCondition,
+	value float64, queryLanguage string, queryText string) string {
+
+	message := strings.ReplaceAll(template, "{{alert_rule_name}}", alertName)
+	message = strings.ReplaceAll(message, "{{query_string}}", queryText)
 	if condition == 0 {
 		val := "above " + fmt.Sprintf("%1.0f", value)
-		newMessage = strings.ReplaceAll(newMessage, "{{condition}}", val)
+		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 1 {
 		val := "below " + fmt.Sprintf("%1.0f", value)
-		newMessage = strings.ReplaceAll(newMessage, "{{condition}}", val)
+		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 2 {
 		val := "is equal to " + fmt.Sprintf("%1.0f", value)
-		newMessage = strings.ReplaceAll(newMessage, "{{condition}}", val)
+		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 3 {
 		val := "is not equal to " + fmt.Sprintf("%1.0f", value)
-		newMessage = strings.ReplaceAll(newMessage, "{{condition}}", val)
+		message = strings.ReplaceAll(message, "{{condition}}", val)
 	} else if condition == 4 {
-		newMessage = strings.ReplaceAll(newMessage, "{{condition}}", "has no value")
+		message = strings.ReplaceAll(message, "{{condition}}", "has no value")
 	}
-	newMessage = strings.ReplaceAll(newMessage, "{{queryLanguage}}", alert.QueryParams.QueryLanguage)
-	return contact_id, newMessage, alert_name, nil
+	message = strings.ReplaceAll(message, "{{queryLanguage}}", queryLanguage)
+
+	return message
 }
 
 func (p Sqlite) GetCoolDownDetails(alert_id string) (uint64, time.Time, error) {

--- a/pkg/alerts/alertsqlite/alerts_sqlite.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite.go
@@ -575,19 +575,20 @@ func resolveTemplate(template string, alertName string, condition alertutils.Ale
 
 	message := strings.ReplaceAll(template, "{{alert_rule_name}}", alertName)
 	message = strings.ReplaceAll(message, "{{query_string}}", queryText)
-	if condition == 0 {
+	switch condition {
+	case alertutils.IsAbove:
 		val := "is above " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
-	} else if condition == 1 {
+	case alertutils.IsBelow:
 		val := "is below " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
-	} else if condition == 2 {
+	case alertutils.IsEqualTo:
 		val := "is equal to " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
-	} else if condition == 3 {
+	case alertutils.IsNotEqualTo:
 		val := "is not equal to " + fmt.Sprintf("%1.0f", value)
 		message = strings.ReplaceAll(message, "{{condition}}", val)
-	} else if condition == 4 {
+	case alertutils.HasNoValue:
 		message = strings.ReplaceAll(message, "{{condition}}", "has no value")
 	}
 	message = strings.ReplaceAll(message, "{{queryLanguage}}", queryLanguage)

--- a/pkg/alerts/alertsqlite/alerts_sqlite_test.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package alertsqlite
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/alerts/alertutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_resolveTemplate(t *testing.T) {
+	template := `{{alert_rule_name}}: "{{query_string}}" ({{queryLanguage}}) {{condition}}`
+
+	actual := resolveTemplate(template, "alert1", alertutils.IsAbove, 42, "Splunk QL", "* | stats count")
+	expected := `alert1: "* | stats count" (Splunk QL) is above 42`
+	assert.Equal(t, expected, actual)
+
+	actual = resolveTemplate(template, "alert2", alertutils.IsBelow, 42, "Splunk QL", "* | stats count")
+	expected = `alert2: "* | stats count" (Splunk QL) is below 42`
+	assert.Equal(t, expected, actual)
+
+	actual = resolveTemplate(template, "alert3", alertutils.IsEqualTo, 42, "Splunk QL", "* | stats count")
+	expected = `alert3: "* | stats count" (Splunk QL) is equal to 42`
+	assert.Equal(t, expected, actual)
+
+	actual = resolveTemplate(template, "alert4", alertutils.IsNotEqualTo, 42, "Splunk QL", "* | stats count")
+	expected = `alert4: "* | stats count" (Splunk QL) is not equal to 42`
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/alerts/alertsqlite/alerts_sqlite_test.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite_test.go
@@ -28,22 +28,17 @@ func Test_resolveTemplate(t *testing.T) {
 	template := `{{alert_rule_name}}: "{{query_string}}" ({{queryLanguage}}) {{condition}}`
 
 	actual := resolveTemplate(template, "alert1", alertutils.IsAbove, 42, "Splunk QL", "* | stats count")
-	expected := `alert1: "* | stats count" (Splunk QL) is above 42`
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, `alert1: "* | stats count" (Splunk QL) is above 42`, actual)
 
 	actual = resolveTemplate(template, "alert2", alertutils.IsBelow, 42, "Splunk QL", "* | stats count")
-	expected = `alert2: "* | stats count" (Splunk QL) is below 42`
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, `alert2: "* | stats count" (Splunk QL) is below 42`, actual)
 
 	actual = resolveTemplate(template, "alert3", alertutils.IsEqualTo, 42, "Splunk QL", "* | stats count")
-	expected = `alert3: "* | stats count" (Splunk QL) is equal to 42`
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, `alert3: "* | stats count" (Splunk QL) is equal to 42`, actual)
 
 	actual = resolveTemplate(template, "alert4", alertutils.IsNotEqualTo, 42, "Splunk QL", "* | stats count")
-	expected = `alert4: "* | stats count" (Splunk QL) is not equal to 42`
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, `alert4: "* | stats count" (Splunk QL) is not equal to 42`, actual)
 
 	actual = resolveTemplate("static message", "alert5", alertutils.IsAbove, 42, "Splunk QL", "* | stats count")
-	expected = "static message"
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, "static message", actual)
 }

--- a/pkg/alerts/alertsqlite/alerts_sqlite_test.go
+++ b/pkg/alerts/alertsqlite/alerts_sqlite_test.go
@@ -42,4 +42,8 @@ func Test_resolveTemplate(t *testing.T) {
 	actual = resolveTemplate(template, "alert4", alertutils.IsNotEqualTo, 42, "Splunk QL", "* | stats count")
 	expected = `alert4: "* | stats count" (Splunk QL) is not equal to 42`
 	assert.Equal(t, expected, actual)
+
+	actual = resolveTemplate("static message", "alert5", alertutils.IsAbove, 42, "Splunk QL", "* | stats count")
+	expected = "static message"
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
# Description
1. Extract a helper function for replacing the alert message template with the final message
2. Test that function
3. Decode the base64 query text (we store it encoded in the SQL DB) so the final message shows the proper text

# Testing
New unit tests. Also tested manually by making an alert with a template message

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
