### PR TITLE
Fix metrics regex queries

### DIFF
--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -249,12 +249,8 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 				}
 
 				if !more {
-					if mQuery.GetAllLabels {
-						numValueFiltersNonZero := mQuery.GetNumValueFilters() > 0
-						initMetricName := fmt.Sprintf("%v{", mQuery.MetricName)
-						err = tracker.BulkAddStar(rawTagValueToTSIDs, initMetricName, tf.TagKey, numValueFiltersNonZero)
-					} else if !mQuery.SelectAllSeries || mQuery.ExitAfterTagsSearch {
-						numValueFiltersNonZero := mQuery.GetNumValueFilters() > 0
+					numValueFiltersNonZero := mQuery.GetNumValueFilters() > 0
+					if mQuery.GetAllLabels || !mQuery.SelectAllSeries || mQuery.ExitAfterTagsSearch {
 						var initMetricName string
 						if mQuery.ExitAfterTagsSearch {
 							initMetricName = mQuery.MetricName
@@ -273,6 +269,7 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 							}
 						}
 					}
+
 					if err != nil {
 						log.Errorf("FindTSIDS: failed to bulk add tsids to tracker for the tag Key: %v! Error %+v", tf.TagKey, err)
 						return nil, err

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -263,7 +263,7 @@ func (attr *AllTagTreeReaders) FindTSIDS(mQuery *structs.MetricsQuery) (*tsidtra
 						} else {
 							initMetricName = fmt.Sprintf("%v{", metricName)
 							if tf.IsRegex() {
-								err = tracker.BulkAdd(rawTagValueToTSIDs, mQuery.MetricName, tf.TagKey)
+								err = tracker.BulkAdd(rawTagValueToTSIDs, metricName, tf.TagKey)
 							} else {
 								err = tracker.BulkAddStar(rawTagValueToTSIDs, initMetricName, tf.TagKey, numValueFiltersNonZero)
 							}

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -268,11 +268,14 @@ func ExtractGroupByFieldsFromSeriesId(seriesId string, groupByFields []string) [
 }
 
 // getAggSeriesId returns the group seriesId for the aggregated series based on the given seriesId and groupByFields
+// The seriesId is in the format of "metricName{key1:value1,key2:value2,..."
 // If groupByFields is empty, it returns the "metricName{" as the group seriesId
 // If groupByFields is not empty, it returns the "metricName{key1:value1,key2:value2,..." as the group seriesId
 // Where key1, key2, ... are the groupByFields and value1, value2, ... are the values of the groupByFields in the seriesId
 // The groupByFields are extracted from the seriesId
-func getAggSeriesId(metricName string, seriesId string, groupByFields []string) string {
+func getAggSeriesId(seriesId string, groupByFields []string) string {
+	metricName := ExtractMetricNameFromGroupID(seriesId)
+
 	if len(groupByFields) == 0 {
 		return metricName + "{"
 	}
@@ -310,7 +313,7 @@ func (r *MetricsResult) ApplyAggregationToResults(parallelism int, aggregation s
 	seriesEntriesMap := make(map[string]map[uint32][]RunningEntry, 0)
 
 	for seriesId, timeSeries := range r.Results {
-		aggSeriesId := getAggSeriesId(r.MetricName, seriesId, aggregation.GroupByFields)
+		aggSeriesId := getAggSeriesId(seriesId, aggregation.GroupByFields)
 		if _, ok := results[aggSeriesId]; !ok {
 			results[aggSeriesId] = make(map[uint32]float64, 0)
 			seriesEntriesMap[aggSeriesId] = make(map[uint32][]RunningEntry, 0)
@@ -819,7 +822,7 @@ func (r *MetricsResult) computeAggCount(aggregation structs.Aggregation) {
 	seriesIdEntriesMap := make(map[string]map[uint32]map[string]struct{})
 
 	for grpID, runningDS := range r.DsResults {
-		seriesId := getAggSeriesId(r.MetricName, grpID, aggregation.GroupByFields)
+		seriesId := getAggSeriesId(grpID, aggregation.GroupByFields)
 		_, exists := seriesIdEntriesMap[seriesId]
 		if !exists {
 			seriesIdEntriesMap[seriesId] = make(map[uint32]map[string]struct{})

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -27,41 +27,37 @@ import (
 )
 
 func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
-	metricName := "test"
 	seriesId := "test{tk1:v1,tk2:v2"
 	groupByFields := []string{"tk1", "tk2"}
 
-	aggSeriesId := getAggSeriesId(metricName, seriesId, groupByFields)
+	aggSeriesId := getAggSeriesId(seriesId, groupByFields)
 	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
 
 	// trailing comma
 	seriesId = "test{tk1:v1,tk2:v2,"
-	aggSeriesId = getAggSeriesId(metricName, seriesId, groupByFields)
+	aggSeriesId = getAggSeriesId(seriesId, groupByFields)
 	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupBy(t *testing.T) {
-	metricName := "test"
 	seriesId := "test{"
 
-	aggSeriesId := getAggSeriesId(metricName, seriesId, nil)
+	aggSeriesId := getAggSeriesId(seriesId, nil)
 	assert.Equal(t, "test{", aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithGroupByAndNoGroupByFields(t *testing.T) {
-	metricName := "test"
 	seriesId := "test{tk1:v1,tk2:v2"
 	groupByFields := make([]string, 0)
 
-	aggSeriesId := getAggSeriesId(metricName, seriesId, groupByFields)
+	aggSeriesId := getAggSeriesId(seriesId, groupByFields)
 	assert.Equal(t, "test{", aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupByAndEmptyGroupByFields(t *testing.T) {
-	metricName := "test"
 	seriesId := "test{"
 
-	aggSeriesId := getAggSeriesId(metricName, seriesId, make([]string, 0))
+	aggSeriesId := getAggSeriesId(seriesId, make([]string, 0))
 	assert.Equal(t, "test{", aggSeriesId)
 }
 


### PR DESCRIPTION
# Description
- Fixed issue with regex tag filtering for queries that require fetching of all labels.
- Fixed issue with regex querying on both metric name and tags.

# Testing
- Added Unit test cases that test cases 
   - regex tag filtering with group by
   - regex on metric name with regex tag filtering with group by on tags
   - regex on metric name with regex tag filtering with group by on tags + metric
   - regex on metric name with negative regex tag filtering with group by on tags
 - Ran queries like below on UI:
 ```
count by (job, jvm_thread_state) (jvm_thread_count{job=~"kafka", jvm_thread_state=~".+"})
```

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
