### PR TITLE
Add support for mTLS

### DIFF
--- a/pkg/config/common/common.go
+++ b/pkg/config/common/common.go
@@ -52,9 +52,11 @@ type LogConfig struct {
 }
 
 type TLSConfig struct {
-	Enabled         bool   `yaml:"enabled"`         // enable/disable tls
-	CertificatePath string `yaml:"certificatePath"` // path to certificate file
-	PrivateKeyPath  string `yaml:"privateKeyPath"`  // path to private key file
+	Enabled         bool                    `yaml:"enabled"`         // enable/disable tls
+	CertificatePath string                  `yaml:"certificatePath"` // path to certificate file
+	PrivateKeyPath  string                  `yaml:"privateKeyPath"`  // path to private key file
+	MtlsEnabled     utils.WithDefault[bool] `yaml:"mtlsEnabled"`
+	ClientCaPath    string                  `yaml:"clientCaPath"` // path to client CA file
 }
 
 type TracingConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -468,13 +468,11 @@ func IsTlsEnabled() bool {
 }
 
 func IsMtlsEnabled() bool {
-	return true // TODO: andrew
+	return runningConfig.TLS.MtlsEnabled.Value()
 }
 
 func GetMtlsClientCaPath() string {
-	// TODO: andrew
-	return "/Users/andrewhess/Library/Application Support/mkcert/rootCA.pem"
-	// return runningConfig.TLS.ClientCAPath
+	return runningConfig.TLS.ClientCaPath
 }
 
 // returns the configured certificate path
@@ -956,6 +954,9 @@ func ExtractConfigData(yamlData []byte) (common.Configuration, error) {
 	config := common.Configuration{
 		MemoryConfig: common.MemoryConfig{
 			LowMemoryMode: utils.DefaultValue(false),
+		},
+		TLS: common.TLSConfig{
+			MtlsEnabled: utils.DefaultValue(false),
 		},
 	}
 	err := yaml.Unmarshal(yamlData, &config)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -467,6 +467,16 @@ func IsTlsEnabled() bool {
 	return runningConfig.TLS.Enabled
 }
 
+func IsMtlsEnabled() bool {
+	return true // TODO: andrew
+}
+
+func GetMtlsClientCaPath() string {
+	// TODO: andrew
+	return "/Users/andrewhess/Library/Application Support/mkcert/rootCA.pem"
+	// return runningConfig.TLS.ClientCAPath
+}
+
 // returns the configured certificate path
 func GetTLSCertificatePath() string {
 	return runningConfig.TLS.CertificatePath

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -96,6 +96,9 @@ func Test_ExtractConfigData(t *testing.T) {
    metricsPercent: 10
    bytesPerQuery: 100
  maxAllowedColumns: 42
+ tls:
+   mtlsEnabled: true
+   clientCaPath: "/path/to/ca.pem"
  `),
 			common.Configuration{
 				IngestListenIP:              "0.0.0.0",
@@ -149,6 +152,10 @@ func Test_ExtractConfigData(t *testing.T) {
 					BytesPerQuery:                100,
 				},
 				MaxAllowedColumns: 42,
+				TLS: common.TLSConfig{
+					MtlsEnabled:  utils.DefaultValue(false).Set(true),
+					ClientCaPath: "/path/to/ca.pem",
+				},
 			},
 		},
 		{ // case 2 - For wrong input type, show error message
@@ -195,6 +202,9 @@ func Test_ExtractConfigData(t *testing.T) {
  compressStatic: bad string
  memoryLimits:
    maxMemoryAllowedToUseInBytes: 10000000000
+ tls:
+   mtlsEnabled: bad string
+   clientCaPath: ""
  `),
 
 			common.Configuration{
@@ -249,6 +259,10 @@ func Test_ExtractConfigData(t *testing.T) {
 				},
 				MaxAllowedColumns: DEFAULT_MAX_ALLOWED_COLUMNS,
 				QueryTimeoutSecs:  DEFAULT_TIMEOUT_SECONDS,
+				TLS: common.TLSConfig{
+					MtlsEnabled:  utils.DefaultValue(false),
+					ClientCaPath: "",
+				},
 			},
 		},
 		{ // case 3 - Error out on bad yaml
@@ -303,6 +317,10 @@ invalid input, we should error out
 				},
 				MaxAllowedColumns: DEFAULT_MAX_ALLOWED_COLUMNS,
 				QueryTimeoutSecs:  DEFAULT_TIMEOUT_SECONDS,
+				TLS: common.TLSConfig{
+					MtlsEnabled:  utils.DefaultValue(false),
+					ClientCaPath: "",
+				},
 			},
 		},
 		{ // case 4 - For no input, pick defaults
@@ -360,6 +378,10 @@ a: b
 				},
 				MaxAllowedColumns: DEFAULT_MAX_ALLOWED_COLUMNS,
 				QueryTimeoutSecs:  DEFAULT_TIMEOUT_SECONDS,
+				TLS: common.TLSConfig{
+					MtlsEnabled:  utils.DefaultValue(false),
+					ClientCaPath: "",
+				},
 			},
 		},
 	}

--- a/pkg/server/ingest/server.go
+++ b/pkg/server/ingest/server.go
@@ -171,8 +171,10 @@ func (hs *ingestionServerCfg) Run() (err error) {
 			return err
 		}
 
-		cfg := &tls.Config{
-			GetCertificate: certReloader.GetCertificate,
+		cfg, err := server_utils.GetTlsConfig(certReloader.GetCertificate)
+		if err != nil {
+			log.Fatalf("Run: error getting TLS config; err=%v", err)
+			return err
 		}
 
 		hs.ln = tls.NewListener(hs.ln, cfg)

--- a/pkg/server/query/server.go
+++ b/pkg/server/query/server.go
@@ -334,8 +334,10 @@ func (hs *queryserverCfg) Run(htmlTemplate *htmltemplate.Template, textTemplate 
 			return err
 		}
 
-		cfg := &tls.Config{
-			GetCertificate: certReloader.GetCertificate,
+		cfg, err := server_utils.GetTlsConfig(certReloader.GetCertificate)
+		if err != nil {
+			log.Fatalf("Run: error getting TLS config; err=%v", err)
+			return err
 		}
 
 		hs.ln = tls.NewListener(hs.ln, cfg)

--- a/pkg/server/utils/utils.go
+++ b/pkg/server/utils/utils.go
@@ -20,6 +20,7 @@ package server_utils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 
 	"github.com/siglens/siglens/pkg/config"
@@ -105,6 +106,10 @@ func GetTlsConfig(getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, e
 		}
 
 		clientCaPath := config.GetMtlsClientCaPath()
+		if clientCaPath == "" {
+			return nil, fmt.Errorf("mTLS is enabled but the client CA path is not set")
+		}
+
 		customCa, err := os.ReadFile(clientCaPath)
 		if err != nil {
 			return nil, err

--- a/pkg/server/utils/utils.go
+++ b/pkg/server/utils/utils.go
@@ -18,6 +18,11 @@
 package server_utils
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+
+	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/utils"
@@ -86,4 +91,30 @@ func GetMyIds() []int64 {
 	}
 
 	return []int64{0}
+}
+
+func GetTlsConfig(getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)) (*tls.Config, error) {
+	cfg := &tls.Config{
+		GetCertificate: getCertificate,
+	}
+
+	if config.IsMtlsEnabled() {
+		systemPool, _ := x509.SystemCertPool()
+		if systemPool == nil {
+			systemPool = x509.NewCertPool()
+		}
+
+		clientCaPath := config.GetMtlsClientCaPath()
+		customCa, err := os.ReadFile(clientCaPath)
+		if err != nil {
+			return nil, err
+		}
+
+		systemPool.AppendCertsFromPEM(customCa)
+
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+		cfg.ClientCAs = systemPool
+	}
+
+	return cfg, nil
 }

--- a/server.yaml
+++ b/server.yaml
@@ -39,7 +39,7 @@ tls:
   enabled: false   # Set to true to enable TLS
   certificatePath: ""  # Path to the certificate file
   privateKeyPath: ""   # Path to the private key file
-  mtlsEnabled: true
+  mtlsEnabled: false
   clientCaPath: ""  # Path to the client Certificate Authority file. Required for mTLS.
 
 # SigLens server hostname

--- a/server.yaml
+++ b/server.yaml
@@ -39,6 +39,8 @@ tls:
   enabled: false   # Set to true to enable TLS
   certificatePath: ""  # Path to the certificate file
   privateKeyPath: ""   # Path to the private key file
+  mtlsEnabled: true
+  clientCaPath: ""  # Path to the client Certificate Authority file. Required for mTLS.
 
 # SigLens server hostname
 queryHostname: ""


### PR DESCRIPTION
# Description
Adds the ability to configure siglens to run with mTLS. If enabled, the clientCA file must also be provided.

# Testing
Manually tested with dummy certificates. For the normal TLS certificate: 
```
mkcert localhost
```
For the client cert and key I ran this:
```
CAROOT=$(mkcert -CAROOT)

# Create client key and CSR
openssl genpkey -algorithm RSA -out client.key
openssl req -new -key client.key \
  -subj "/C=US/ST=State/L=City/O=Org/CN=client@example.com" \
  -out client.csr

# Create CA config for client cert
cat > ca.cnf << EOF
[ ca ]
default_ca = CA_default

[ CA_default ]
dir               = .
database          = index.txt
new_certs_dir     = .
certificate       = ${CAROOT}/rootCA.pem
serial            = serial.txt
private_key       = ${CAROOT}/rootCA-key.pem
default_md        = sha256
policy            = policy_anything
x509_extensions   = v3_client

[ policy_anything ]
countryName            = optional
stateOrProvinceName    = optional
localityName           = optional
organizationName       = optional
organizationalUnitName = optional
commonName             = supplied
emailAddress          = optional

[ v3_client ]
basicConstraints = CA:FALSE
keyUsage = nonRepudiation, digitalSignature, keyEncipherment
extendedKeyUsage = clientAuth
EOF

# Set up the CA database
echo "01" > serial.txt && rm -f index.txt && touch index.txt

# Sign the client cert
STARTTIME=$(date -u "+%y%m%d%H%M%SZ")
ENDTIME=$(date -u -v+24H "+%y%m%d%H%M%SZ")

openssl ca -config ca.cnf \
  -policy policy_anything \
  -extensions v3_client \
  -in client.csr \
  -out client.crt \
  -startdate $STARTTIME \
  -enddate $ENDTIME \
  -batch
```
For the clientCA file, I found mine at `~/Library/Application\ Support/mkcert/rootCA.pem`

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
