### PR TITLE
handled indexName = 'otel-index-logs'

### DIFF
--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -72,6 +72,23 @@ func ParseSearchBody(jsonSource map[string]interface{}, nowTs uint64) (string, u
 		}
 	}
 
+	iName, ok := jsonSource["indexName"]
+	if !ok || iName == "" {
+		// how do i handel if the indexName is empty??
+	} else {
+		switch val := iName.(type) {
+		case string:
+			if val == "otel-index-logs" {
+				indexName = "*"
+				searchText += " | SeverityNumber > 17 OR SeverityText=ERROR "
+			} else {
+				indexName = val
+			}
+		default:
+			log.Errorf("ParseSearchBody: indexName is not a string! val: %+v", val)
+		}
+	}
+	
 	iText, ok := jsonSource[KEY_INDEX_NAME]
 	if !ok || iText == "" {
 		indexName = "*"


### PR DESCRIPTION
# Description
Summarize the change.
If the indexName is 'otel-index-logs' then it is chenged to "*" and 
search text is uppended with the " | SeverityNumber > 17 OR SeverityText=ERROR " query.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
