### PR TITLE
Added expand icon next to timestamp 

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2869,6 +2869,19 @@ input[type="time"]::-webkit-calendar-picker-indicator {
     padding: 0;
 }
 
+.expand-icon-box {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #e0e0e0;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+
+.ag-cell-wrapper {
+    margin-left: -10px !important;
+}
+
 .odd-popup-textarea {
     background: var(--datatable-odd-row-bg-color) !important;
     color: var(--text-color) !important;

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -84,6 +84,7 @@
     --hits-summary-text-color: var(--black-6);
     --table-or-regular-text-color: var(--black-6);
     --table-or-regular-text-logs-color: var(--black-8);
+    --logs-expand-icon-box-color: var(--black-5);
 
     --border-switch: var(--white-3);
     --border-btn-color: var(--black-5);
@@ -271,6 +272,7 @@
     --table-or-regular-text-color: var(--white-4);
     --table-or-regular-text-logs-color: var(--white-10);
 
+    --logs-expand-icon-box-color: var(--white-2);
     --border-switch: var(--black-5);
     --border-btn-color: var(--white-3);
     --default-tab: var(--white-0);
@@ -2870,10 +2872,25 @@ input[type="time"]::-webkit-calendar-picker-indicator {
 }
 
 .expand-icon-box {
-    display: inline-block;
-    background: var(--white-2);
+    display: inline-flex;
+    background: var(--logs-expand-icon-box-color);
     padding: 1px 6px;
     border-radius: 4px;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+}
+
+.expand-icon-button {
+    background: none;
+    border: none;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
 }
 
 .ag-cell-wrapper {

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2870,12 +2870,10 @@ input[type="time"]::-webkit-calendar-picker-indicator {
 }
 
 .expand-icon-box {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: #e0e0e0;
-    padding: 2px 4px;
-    border-radius: 3px;
+    display: inline-block;
+    background: var(--white-2);
+    padding: 1px 6px;
+    border-radius: 4px;
 }
 
 .ag-cell-wrapper {

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -128,11 +128,17 @@ let logsColumnDefs = [
         cellEditorPopup: true,
         cellEditorPopupPosition: 'under',
         cellRenderer: (params) => {
-            return moment(params.value).format(timestampDateFmt);
+            let timeString = '';
+            let icon = moment(params.value).format(timestampDateFmt);
+            // timeString = `<i class="fa-solid fa-up-right-and-down-left-from-center"></i> <span>${icon}</span>`;
+            timeString = `<span style="display: inline-block; background: #e0e0e0; padding: 4px 6px; border-radius: 4px;">
+                 <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
+              </span> <span>${icon}</span>`;
+            return timeString;
         },
         cellEditorParams: cellEditorParams,
-        maxWidth: 216,
-        minWidth: 216,
+        maxWidth: 250,
+        minWidth: 250,
     },
     {
         field: 'logs',

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -130,10 +130,11 @@ let logsColumnDefs = [
         cellRenderer: (params) => {
             let timeString = '';
             let icon = moment(params.value).format(timestampDateFmt);
-            // timeString = `<i class="fa-solid fa-up-right-and-down-left-from-center"></i> <span>${icon}</span>`;
-            timeString = `<span style="display: inline-block; background: #e0e0e0; padding: 4px 6px; border-radius: 4px;">
-                 <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
-              </span> <span>${icon}</span>`;
+
+            timeString = `<span class="expand-icon-box">
+                <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
+                </span> <span>${icon}</span>`;
+
             return timeString;
         },
         cellEditorParams: cellEditorParams,

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -129,11 +129,15 @@ let logsColumnDefs = [
         cellEditorPopupPosition: 'under',
         cellRenderer: (params) => {
             let timeString = '';
-            let icon = moment(params.value).format(timestampDateFmt);
+            let timestamp = moment(params.value).format(timestampDateFmt);
 
-            timeString = `<span class="expand-icon-box">
-                <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
-                </span> <span>${icon}</span>`;
+            timeString =
+            `<span class="expand-icon-box">
+                <button class="expand-icon-button">
+                    <i class="fa-solid fa-up-right-and-down-left-from-center">
+                </button></i>
+            </span>
+            <span>${timestamp}</span>`;
 
             return timeString;
         },


### PR DESCRIPTION
# Description
Added an expand icon next to timestamo in log table, single line and multi-line view.

Summarize the change.
screen shot for changes:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/35951162-7897-48a5-b57d-e0421956c1de" />


<img width="251" alt="image" src="https://github.com/user-attachments/assets/15a79ca6-51bd-449b-bc63-88d80e074b7d" />


<img width="240" alt="image" src="https://github.com/user-attachments/assets/93980417-b346-42d1-9cbf-e49f641ce2c9" />



Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
