### PR TITLE
Setup E2E testing framework

### DIFF
--- a/.github/workflows/uts.yml
+++ b/.github/workflows/uts.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Run Unit Tests
-        run: go test ./...
+        run: go test ./... --tags=e2e_all
       - name: Run Coverage
         run: go test ./... -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage reports to Codecov

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,7 @@ linters:
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
+
+run:
+  build-tags:
+    - e2e_all

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ lint:
 test:
 	$(GO) test ./... -count 1
 
+test_all:
+	$(GO) test ./... -count 1 --tags=e2e_all
+
 build:
 	$(GO) mod tidy
 	$(GO) build -o siglens cmd/siglens/main.go
@@ -39,6 +42,6 @@ gofmt :
 	$(GO) install golang.org/x/tools/cmd/goimports@latest
 	~/go/bin/goimports -w .
 
-all: lint test build
+all: lint test_all build
 
 pr: all gofmt

--- a/pkg/e2etests/e2e_utils.go
+++ b/pkg/e2etests/e2e_utils.go
@@ -100,18 +100,18 @@ func (s *siglensServer) verifyCanBeStopped(t *testing.T) {
 	}
 }
 
-func terminal(t *testing.T, command string) {
+func terminal(t *testing.T, command string) string {
 	t.Helper()
 	t.Logf("$ %s\n", command)
 
-	parts := strings.Split(command, " ")
-	cmd := exec.Command(parts[0], parts[1:]...)
-
+	cmd := exec.Command("bash", "-c", command)
 	output, err := cmd.CombinedOutput()
 	if len(output) > 0 {
 		t.Log(string(output))
 	}
 	require.NoError(t, err)
+
+	return string(output)
 }
 
 func sigclient(t *testing.T, command string) {
@@ -164,17 +164,6 @@ func sigclient(t *testing.T, command string) {
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("Command execution failed: %v", err)
 	}
-}
-
-func curl(t *testing.T, command string) string {
-	t.Helper()
-
-	parts := strings.Split(command, " ")
-	cmd := exec.Command(parts[0], parts[1:]...)
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err)
-
-	return string(output)
 }
 
 func withSiglens(t *testing.T, config *common.Configuration, fn func()) {

--- a/pkg/e2etests/e2e_utils.go
+++ b/pkg/e2etests/e2e_utils.go
@@ -33,8 +33,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const pathToSiglens = "../../" // Relative to this package.
+
 type siglensServer struct {
-	dir       string // Run siglens from this directory
+	dir       string // Where to store info for this server (e.g., config file, data dir)
 	config    *common.Configuration
 	pid       int // Process ID
 	isRunning bool
@@ -59,6 +61,7 @@ func (s *siglensServer) Start(t *testing.T) {
 
 	// Start the server.
 	cmd := exec.Command("go", "run", "cmd/siglens/main.go", "--config", configPath)
+	cmd.Dir = pathToSiglens
 	err = cmd.Start()
 	require.NoError(t, err)
 
@@ -120,7 +123,7 @@ func sigclient(t *testing.T, command string) {
 
 	parts := strings.Split(command, " ")
 	cmd := exec.Command(parts[0], parts[1:]...)
-	cmd.Dir = "tools/sigclient"
+	cmd.Dir = filepath.Join(pathToSiglens, "tools/sigclient")
 
 	// Obtain pipes for the command's stdout and stderr
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/pkg/e2etests/e2e_utils.go
+++ b/pkg/e2etests/e2e_utils.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/siglens/siglens/pkg/config/common"
 	"github.com/stretchr/testify/require"
@@ -167,32 +166,4 @@ func sigclient(t *testing.T, command string) {
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("Command execution failed: %v", err)
 	}
-}
-
-func withSiglens(t *testing.T, config *common.Configuration, fn func()) {
-	testDir := t.TempDir()
-	dataDir := filepath.Join(testDir, "data")
-	config.DataPath = dataDir
-
-	configBytes, err := yaml.Marshal(config)
-	require.NoError(t, err)
-
-	configFile := filepath.Join(testDir, "server.yaml")
-	err = os.WriteFile(configFile, configBytes, 0644)
-	require.NoError(t, err)
-
-	cmd := exec.Command("siglens", "--config", configFile)
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Failed to start siglens: %v", err)
-	}
-
-	defer func() {
-		err := cmd.Process.Kill()
-		require.NoError(t, err)
-	}()
-
-	// TODO: Find a better way to wait for siglens to be ready.
-	time.Sleep(2 * time.Second)
-
-	fn()
 }

--- a/pkg/e2etests/e2e_utils.go
+++ b/pkg/e2etests/e2e_utils.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// # This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package e2etests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/siglens/siglens/pkg/config/common"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func terminal(t *testing.T, command string) {
+	t.Helper()
+	t.Logf("$ %s\n", command)
+
+	parts := strings.Split(command, " ")
+	cmd := exec.Command(parts[0], parts[1:]...)
+
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		t.Log(string(output))
+	}
+	require.NoError(t, err)
+}
+
+func withSiglens(t *testing.T, config *common.Configuration, fn func()) {
+	testDir := t.TempDir()
+	dataDir := filepath.Join(testDir, "data")
+	config.DataPath = dataDir
+
+	configBytes, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	configFile := filepath.Join(testDir, "server.yaml")
+	err = os.WriteFile(configFile, configBytes, 0644)
+	require.NoError(t, err)
+
+	cmd := exec.Command("siglens", "--config", configFile)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start siglens: %v", err)
+	}
+
+	defer func() {
+		err := cmd.Process.Kill()
+		require.NoError(t, err)
+	}()
+
+	// TODO: Find a better way to wait for siglens to be ready.
+	time.Sleep(2 * time.Second)
+
+	fn()
+}

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1503,3 +1503,17 @@ func Test_SimpleMetricQuery_Regex_on_TagFilters_Plus_Filter_Plus_GroupByTag_v1(t
 		}
 	}
 }
+
+func Test_metricsPersistAfterGracefulRestart(t *testing.T) {
+	testDir := t.TempDir()
+	relativeDataDir := "data"
+	config := config.GetTestConfig(relativeDataDir)
+	siglens := newSiglensServer(testDir, &config)
+
+	siglens.Start(t)
+	terminal(t, "go run main.go query pull -d http://localhost:8081/otsdb -m 10 -t 100 -g benchmark")
+	siglens.StopGracefully(t)
+
+	siglens.Start(t)
+	terminal(t, "go run main.go query pull -d http://localhost:8081/otsdb -m 10 -t 100 -g benchmark")
+}

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1521,7 +1521,7 @@ func Test_metricsPersistAfterGracefulRestart(t *testing.T) {
 	siglens.StopGracefully(t)
 
 	siglens.Start(t)
-	result := curl(t, `curl -s -X POST localhost:5122/metrics-explorer/api/v1/metric_names -d {"start":"now-1h","end":"now"}`)
+	result := terminal(t, `curl -s -X POST localhost:5122/metrics-explorer/api/v1/metric_names -d '{"start":"now-1h","end":"now"}'`)
 
 	type AllMetricNames struct {
 		MetricNames []string `json:"metricNames"`

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e_all
+
 // Copyright (c) 2021-2024 SigScalr, Inc.
 //
 // This file is part of SigLens Observability Solution

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1507,9 +1507,6 @@ func Test_SimpleMetricQuery_Regex_on_TagFilters_Plus_Filter_Plus_GroupByTag_v1(t
 }
 
 func Test_metricsPersistAfterGracefulRestart(t *testing.T) {
-	err := os.Chdir("../..")
-	require.Nil(t, err)
-
 	testDir := t.TempDir()
 	dataDir := filepath.Join(testDir, "data")
 	config := config.GetTestConfig(dataDir)
@@ -1529,7 +1526,7 @@ func Test_metricsPersistAfterGracefulRestart(t *testing.T) {
 	}
 
 	allMetricNames := AllMetricNames{}
-	err = json.Unmarshal([]byte(result), &allMetricNames)
+	err := json.Unmarshal([]byte(result), &allMetricNames)
 	require.Nil(t, err)
 
 	assert.Equal(t, 10, allMetricNames.Count)


### PR DESCRIPTION
# Description
This sets up a framework for E2E testing and adds a simple test to verify metrics persist after graceful shutdown and restart

The build directive `//go:build e2e_all` was added so that `make test` skips these tests so it's still easy/quick to run just the unit tests. All the tests can be run with `make test_all`.

# Testing
New test

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
