### PR TITLE
Get span and trace IDs from otel log attributes

### DIFF
--- a/pkg/otlp/logs.go
+++ b/pkg/otlp/logs.go
@@ -261,6 +261,18 @@ func extractLogRecord(logRecord *logpb.LogRecord, resource *resourceInfo, scope 
 		record.Attributes[key] = value
 	}
 
+	if record.TraceId == "" {
+		if traceId, ok := record.Attributes["trace_id"]; ok {
+			record.TraceId = fmt.Sprintf("%v", traceId)
+		}
+	}
+
+	if record.SpanId == "" {
+		if spanId, ok := record.Attributes["span_id"]; ok {
+			record.SpanId = fmt.Sprintf("%v", spanId)
+		}
+	}
+
 	return &record, nil
 }
 


### PR DESCRIPTION
# Description
Now if the TraceID/SpanID is not set in the otel log, but the corresponding `attribute` _is_ set, then we'll use that value. The purpose of this is to make it easier for people to associate a log with a trace/span when they're sending otel logs to siglens and the trace/span isn't already set.

# Testing
Manually tested with the otel demo with this config
```
exporters:
  otlphttp/siglens:
    endpoint: "http://host.docker.internal:8081/otlp"
  prometheusremotewrite:
    endpoint: "http://host.docker.internal:8081/promql/api/v1/write"

processors:
  batch:
    timeout: 10s
  attributes:
    actions:
      - key: "span_id"
        value: "123"
        action: "insert"
      - key: "trace_id"
        value: "abc"
        action: "insert"

service:
  pipelines:
    traces:
      exporters: [spanmetrics, otlphttp/siglens]
    metrics:
      processors: [batch]
      exporters: [prometheusremotewrite]
    logs:
      processors: [batch, attributes]
      exporters: [otlphttp/siglens]
```
I got some logs with the original trace/span ID and some with my hardcoded values
<img width="685" alt="image" src="https://github.com/user-attachments/assets/03e48bb7-3e71-46a4-b583-7c0084d22789" />


# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
