### PR TITLE
Add util for atomically writing files

### DIFF
--- a/pkg/utils/fileutils.go
+++ b/pkg/utils/fileutils.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type WriteMode int
+
+const (
+	Append WriteMode = iota
+	Truncate
+)
+
+func AtomicWriteFile(fileName string, data []byte, mode WriteMode) error {
+	tempFileName := fileName + ".tmp"
+	fd, err := os.Create(tempFileName)
+	if err != nil {
+		log.Errorf("AtomicWriteFile: Cannot create temp file %v, err=%v", tempFileName, err)
+		return err
+	}
+	defer fd.Close()
+
+	// Write to the temp file.
+	switch mode {
+	case Append:
+		existingData, err := os.ReadFile(fileName)
+		if err != nil && !os.IsNotExist(err) {
+			log.Errorf("AtomicWriteFile: Cannot read file %v, err=%v", fileName, err)
+			return err
+		}
+
+		_, err = fd.Write(existingData)
+		if err != nil {
+			log.Errorf("AtomicWriteFile: Cannot write to temp file %v, err=%v", tempFileName, err)
+			return err
+		}
+
+		_, err = fd.Write(data)
+		if err != nil {
+			log.Errorf("AtomicWriteFile: Cannot write to temp file %v, err=%v", tempFileName, err)
+			return err
+		}
+	case Truncate:
+		_, err = fd.Write(data)
+		if err != nil {
+			log.Errorf("AtomicWriteFile: Cannot write to temp file %v, err=%v", tempFileName, err)
+			return err
+		}
+	default:
+		err = fmt.Errorf("Invalid write mode %v", mode)
+		log.Errorf("AtomicWriteFile: %v", err)
+		return err
+	}
+
+	// Rename the temp file to the original file.
+	err = os.Rename(tempFileName, fileName)
+	if err != nil {
+		log.Errorf("AtomicWriteFile: Cannot rename temp file %v to %v, err=%v", tempFileName, fileName, err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/fileutils_test.go
+++ b/pkg/utils/fileutils_test.go
@@ -43,3 +43,22 @@ func Test_AtomicWriteFile_Truncate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("banana"), got)
 }
+
+func Test_AtomicWriteFile_Append(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "testfile.txt")
+
+	err := AtomicWriteFile(filePath, []byte("apple"), Append)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("apple"), got)
+
+	err = AtomicWriteFile(filePath, []byte("banana"), Append)
+	assert.NoError(t, err)
+
+	got, err = os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("applebanana"), got)
+}

--- a/pkg/utils/fileutils_test.go
+++ b/pkg/utils/fileutils_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AtomicWriteFile_Truncate(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "testfile.txt")
+
+	err := AtomicWriteFile(filePath, []byte("apple"), Truncate)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("apple"), got)
+
+	err = AtomicWriteFile(filePath, []byte("banana"), Truncate)
+	assert.NoError(t, err)
+
+	got, err = os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("banana"), got)
+}

--- a/pkg/utils/fileutils_test.go
+++ b/pkg/utils/fileutils_test.go
@@ -62,3 +62,18 @@ func Test_AtomicWriteFile_Append(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("applebanana"), got)
 }
+
+func Test_AtomicWriteFile_InvalidMode(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "testfile.txt")
+
+	err := os.WriteFile(filePath, []byte("previous data"), 0644)
+	assert.NoError(t, err)
+
+	err = AtomicWriteFile(filePath, []byte("apple"), WriteMode(42))
+	assert.Error(t, err)
+
+	got, err := os.ReadFile(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("previous data"), got)
+}


### PR DESCRIPTION
# Description
Adds a function to atomically write a file either in append or truncate mode, though the append mode will be inefficient if the file already has a lot of data.

# Testing
New tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
