### PR TITLE
Add backend for automatic timechart query

### DIFF
--- a/pkg/ast/pipesearch/addTimechart_test.go
+++ b/pkg/ast/pipesearch/addTimechart_test.go
@@ -24,14 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func shouldRunTimechartQuery(aggs *structs.QueryAggregators) bool {
-	if aggs.HasTimechartInChain() || aggs.HasStatsBlockInChain() || aggs.HasStreamStatsInChain() {
-		return false
-	}
-
-	return true
-}
-
 func Test_shouldRunTimechartQuery(t *testing.T) {
 	assertShouldRunTimechart(t, true, "*")
 	assertShouldRunTimechart(t, false, "* | stats count")

--- a/pkg/ast/pipesearch/addTimechart_test.go
+++ b/pkg/ast/pipesearch/addTimechart_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package pipesearch
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func shouldRunTimechartQuery(aggs *structs.QueryAggregators) bool {
+	if aggs.HasTimechartInChain() || aggs.HasStatsBlockInChain() || aggs.HasStreamStatsInChain() {
+		return false
+	}
+
+	return true
+}
+
+func Test_shouldRunTimechartQuery(t *testing.T) {
+	assertShouldRunTimechart(t, true, "*")
+	assertShouldRunTimechart(t, false, "* | stats count")
+	assertShouldRunTimechart(t, false, "* | streamstats count")
+	assertShouldRunTimechart(t, false, "* | timechart count")
+	assertShouldRunTimechart(t, true, "* | eval x=latency | where x > 100")
+	assertShouldRunTimechart(t, false, "* | eval x=latency | stats count as Count by x | where Count > 100")
+}
+
+func parseSPL(t *testing.T, query string) (*structs.ASTNode, *structs.QueryAggregators) {
+	astNode, aggs, _, err := ParseQuery(query, 0, "Splunk QL")
+	assert.NoError(t, err)
+	return astNode, aggs
+}
+
+func assertShouldRunTimechart(t *testing.T, expectedValue bool, query string) {
+	_, aggs := parseSPL(t, query)
+	runTimechart := shouldRunTimechartQuery(aggs)
+	assert.Equal(t, expectedValue, runTimechart)
+}

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package multiplexer
+
+import (
+	"fmt"
+
+	"github.com/siglens/siglens/pkg/segment/query"
+)
+
+// If any channel gets an error/cancellation/timeout, the multiplexer will send
+// that on the output channel and close it. If any channel gets a COMPLETE
+// state, the multiplexer will change that to QUERY_UPDATE, unless all channels
+// are COMPLETE.
+type QueryStateMultiplexer struct {
+	input  [2]*chanState
+	output chan *QueryStateEnvelope
+}
+
+type chanState struct {
+	channel    chan *query.QueryStateChanData
+	isComplete bool
+}
+
+type QueryStateEnvelope struct {
+	*query.QueryStateChanData
+	channelIndex int
+}
+
+func NewQueryStateMultiplexer(query1Chan, query2Chan chan *query.QueryStateChanData) *QueryStateMultiplexer {
+	return &QueryStateMultiplexer{
+		input: [2]*chanState{
+			{channel: query1Chan},
+			{channel: query2Chan},
+		},
+		output: make(chan *QueryStateEnvelope),
+	}
+}
+
+// This should only be called once per instance of QueryStateMultiplexer.
+func (q *QueryStateMultiplexer) Multiplex() <-chan *QueryStateEnvelope {
+	go func() {
+		defer close(q.output)
+
+		for {
+			outputClosed := false
+			select {
+			case data, ok := <-q.input[0].channel:
+				outputClosed = q.handleMessage(data, ok, 0)
+			case data, ok := <-q.input[1].channel:
+				outputClosed = q.handleMessage(data, ok, 1)
+			}
+
+			if q.allChannelsAreComplete() || outputClosed {
+				return
+			}
+		}
+	}()
+
+	return q.output
+}
+
+func (q *QueryStateMultiplexer) allChannelsAreComplete() bool {
+	return q.input[0].isComplete && q.input[1].isComplete
+}
+
+func (q *QueryStateMultiplexer) handleMessage(data *query.QueryStateChanData, ok bool, chanIndex int) bool {
+	state := q.input[chanIndex]
+	if !ok {
+		if state.isComplete {
+			return false
+		}
+
+		q.errorAndClose(fmt.Errorf("Channel closed unexpectedly"), chanIndex)
+		return true
+	}
+
+	return q.handleData(data, chanIndex)
+}
+
+func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanIndex int) bool {
+	switch data.StateName {
+	case query.READY:
+	case query.RUNNING:
+	case query.QUERY_UPDATE:
+	case query.COMPLETE:
+	case query.CANCELLED:
+	case query.TIMEOUT:
+	case query.ERROR:
+	case query.QUERY_RESTART:
+	}
+}
+
+func (q *QueryStateMultiplexer) errorAndClose(err error, chanIndex int) {
+	q.output <- &QueryStateEnvelope{
+		QueryStateChanData: &query.QueryStateChanData{
+			StateName: query.ERROR,
+			Error:     err,
+		},
+		channelIndex: chanIndex,
+	}
+	close(q.output)
+}
+
+// const (
+// 	READY QueryState = iota + 1
+// 	RUNNING
+// 	QUERY_UPDATE // flush segment counts & aggs & records (if matched)
+// 	COMPLETE
+// 	CANCELLED
+// 	TIMEOUT
+// 	ERROR
+// 	QUERY_RESTART
+// )

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -133,9 +133,7 @@ func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanI
 		case MainIndex:
 			update = data.UpdateWSResp
 		case TimechartIndex:
-			update.RelatedUpdate = &structs.RelatedUpdate{
-				Timechart: data.UpdateWSResp,
-			}
+			update.TimechartUpdate = data.UpdateWSResp
 		}
 
 		data.UpdateWSResp = update
@@ -151,22 +149,16 @@ func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanI
 			q.mainQid = data.Qid
 			savedResponse := data.CompleteWSResp
 			if q.savedCompletion != nil {
-				savedResponse.RelatedComplete = q.savedCompletion.RelatedComplete
+				savedResponse.TimechartComplete = q.savedCompletion.TimechartComplete
 			}
 
 			q.savedCompletion = savedResponse
 		case TimechartIndex:
-			savedResponse := q.savedCompletion
-			if savedResponse == nil {
-				savedResponse = &structs.PipeSearchCompleteResponse{}
+			if q.savedCompletion == nil {
+				q.savedCompletion = &structs.PipeSearchCompleteResponse{}
 			}
 
-			if savedResponse.RelatedComplete == nil {
-				savedResponse.RelatedComplete = &structs.RelatedComplete{}
-			}
-
-			savedResponse.RelatedComplete.Timechart = data.CompleteWSResp
-			q.savedCompletion = savedResponse
+			q.savedCompletion.TimechartComplete = data.CompleteWSResp
 		}
 
 		if q.allChannelsAreComplete() {

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -149,6 +149,25 @@ func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanI
 		switch chanIndex {
 		case MainIndex:
 			q.mainQid = data.Qid
+
+			if data.CompleteWSResp == nil {
+				if data.HttpResponse == nil {
+					q.errorAndClose(fmt.Errorf("No response data found"))
+					return
+				}
+
+				if q.input[TimechartIndex].channel != nil {
+					q.errorAndClose(fmt.Errorf("Non-websocket query with timechart is not yet supported"))
+					return
+				}
+
+				q.output <- &QueryStateEnvelope{
+					QueryStateChanData: data,
+					ChannelIndex:       MainIndex,
+				}
+				return
+			}
+
 			savedResponse := data.CompleteWSResp
 			if q.savedCompletion != nil {
 				savedResponse.TimechartComplete = q.savedCompletion.TimechartComplete

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -31,11 +31,12 @@ const (
 	TimechartIndex
 )
 
+// This reads from two channels and multiplexes the data into a single channel.
 // If any channel gets an error/cancellation/timeout, the multiplexer will send
 // that on the output channel and close it. If any channel gets a COMPLETE
 // state, the multiplexer will save that info but not send anything; once all
 // channels are COMPLETE, the multiplexer will send the COMPLETE state on the
-// output channel with all the saved info.
+// output channel with all the saved info. Other messages simply propagate.
 type QueryStateMultiplexer struct {
 	input           [2]*chanState
 	output          chan *QueryStateEnvelope

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -137,6 +137,7 @@ func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanI
 			update.TimechartUpdate = data.UpdateWSResp
 		}
 
+		update.State = data.StateName.String()
 		data.UpdateWSResp = update
 		q.output <- &QueryStateEnvelope{
 			QueryStateChanData: data,
@@ -163,6 +164,7 @@ func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanI
 		}
 
 		if q.allChannelsAreComplete() {
+			q.savedCompletion.State = data.StateName.String()
 			q.output <- &QueryStateEnvelope{
 				QueryStateChanData: &query.QueryStateChanData{
 					StateName:       query.COMPLETE,

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -67,7 +67,12 @@ func NewQueryStateMultiplexer(mainQueryChan, timechartQueryChan chan *query.Quer
 // This should only be called once per instance of QueryStateMultiplexer.
 func (q *QueryStateMultiplexer) Multiplex() <-chan *QueryStateEnvelope {
 	go func() {
-		defer close(q.output)
+		defer func() {
+			if !q.closedOutput {
+				close(q.output)
+				q.closedOutput = true
+			}
+		}()
 
 		for {
 			select {

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package multiplexer
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/query"
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiplexer_TimechartNil(t *testing.T) {
+	// Create a buffered main query channel.
+	mainChan := make(chan *query.QueryStateChanData, 2)
+	// timechart channel is nil.
+	multiplexer := NewQueryStateMultiplexer(mainChan, nil)
+	outChan := multiplexer.Multiplex()
+
+	// Send a READY message.
+	const qid = uint64(42)
+	readyData := &query.QueryStateChanData{
+		StateName: query.READY,
+		Qid:       qid,
+	}
+	mainChan <- readyData
+
+	// Send a COMPLETE message.
+	completeData := &query.QueryStateChanData{
+		StateName:      query.COMPLETE,
+		Qid:            qid,
+		CompleteWSResp: &structs.PipeSearchCompleteResponse{},
+	}
+	mainChan <- completeData
+
+	// Close the main channel.
+	close(mainChan)
+
+	// Collect all output messages.
+	var messages []*QueryStateEnvelope
+	for msg := range outChan {
+		messages = append(messages, msg)
+	}
+
+	// Expect two messages: one for READY and one for COMPLETE.
+	assert.Len(t, messages, 2)
+	assert.Equal(t, query.READY, messages[0].StateName)
+	assert.Equal(t, qid, messages[0].Qid)
+	assert.Equal(t, query.COMPLETE, messages[1].StateName)
+	assert.Equal(t, qid, messages[1].Qid)
+}

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
@@ -19,6 +19,7 @@ package multiplexer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/siglens/siglens/pkg/segment/query"
 	"github.com/siglens/siglens/pkg/segment/structs"
@@ -63,4 +64,72 @@ func TestMultiplexer_TimechartNil(t *testing.T) {
 	assert.Equal(t, qid, messages[0].Qid)
 	assert.Equal(t, query.COMPLETE, messages[1].StateName)
 	assert.Equal(t, qid, messages[1].Qid)
+}
+
+func TestMultiplexer_MainCompletesFirst(t *testing.T) {
+	mainChan := make(chan *query.QueryStateChanData, 4)
+	timechartChan := make(chan *query.QueryStateChanData, 4)
+	multiplexer := NewQueryStateMultiplexer(mainChan, timechartChan)
+	outChan := multiplexer.Multiplex()
+
+	const qid = uint64(42)
+
+	mainChan <- &query.QueryStateChanData{
+		StateName: query.READY,
+		Qid:       qid,
+	}
+	timechartChan <- &query.QueryStateChanData{
+		StateName: query.READY,
+		Qid:       qid,
+	}
+	mainChan <- &query.QueryStateChanData{
+		StateName:      query.COMPLETE,
+		Qid:            qid,
+		CompleteWSResp: &structs.PipeSearchCompleteResponse{ColumnsOrder: []string{"a", "b"}},
+	}
+
+	// Drain available output for a short period to verify no COMPLETE message is sent yet.
+	completeFound := false
+	timeout := time.After(50 * time.Millisecond)
+DrainLoop:
+	for {
+		select {
+		case msg := <-outChan:
+			if msg.StateName == query.COMPLETE {
+				completeFound = true
+			}
+		case <-timeout:
+			break DrainLoop
+		}
+	}
+	assert.False(t, completeFound, "COMPLETE message should not be sent before timechart channel completes")
+
+	// Now send COMPLETE from the timechart channel.
+	timechartChan <- &query.QueryStateChanData{
+		StateName:      query.COMPLETE,
+		Qid:            qid,
+		CompleteWSResp: &structs.PipeSearchCompleteResponse{ColumnsOrder: []string{"y", "z"}},
+	}
+
+	// Close both channels.
+	close(mainChan)
+	close(timechartChan)
+
+	// Collect all remaining messages.
+	var messages []*QueryStateEnvelope
+	for msg := range outChan {
+		messages = append(messages, msg)
+	}
+
+	// Verify that exactly one COMPLETE message is emitted, and it is the final message.
+	var completeCount int
+	for i, msg := range messages {
+		if msg.StateName == query.COMPLETE {
+			completeCount++
+			if i != len(messages)-1 {
+				t.Errorf("COMPLETE message should be the last message, got index %d", i)
+			}
+		}
+	}
+	assert.Equal(t, 1, completeCount, "Expected exactly one COMPLETE message")
 }

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
@@ -153,6 +153,7 @@ func Test_Multiplexer_MainCompletesLast(t *testing.T) {
 	assert.Equal(t, []string{"m1", "m2"}, msg.CompleteWSResp.ColumnsOrder)
 	assert.NotNil(t, msg.CompleteWSResp.TimechartComplete)
 	assert.Equal(t, []string{"t1", "t2"}, msg.CompleteWSResp.TimechartComplete.ColumnsOrder)
+	assert.Equal(t, query.COMPLETE.String(), msg.CompleteWSResp.State)
 
 	_, ok = <-outChan
 	assert.False(t, ok, "Expected no additional messages after COMPLETE")
@@ -187,12 +188,14 @@ func Test_Multiplexer_QueryUpdate(t *testing.T) {
 			assert.Equal(t, mainQid, msg.Qid)
 			assert.Equal(t, []string{"m1", "m2"}, msg.UpdateWSResp.ColumnsOrder)
 			assert.Nil(t, msg.UpdateWSResp.TimechartUpdate)
+			assert.Equal(t, query.QUERY_UPDATE.String(), msg.UpdateWSResp.State)
 		case TimechartIndex:
 			assert.Equal(t, query.QUERY_UPDATE, msg.StateName)
 			assert.Equal(t, timechartQid, msg.Qid)
 			assert.Empty(t, msg.UpdateWSResp.ColumnsOrder)
 			assert.NotNil(t, msg.UpdateWSResp.TimechartUpdate)
 			assert.Equal(t, []string{"t1", "t2"}, msg.UpdateWSResp.TimechartUpdate.ColumnsOrder)
+			assert.Equal(t, query.QUERY_UPDATE.String(), msg.UpdateWSResp.State)
 		default:
 			t.Fatalf("Unexpected channel index: %d", msg.ChannelIndex)
 			t.FailNow()

--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer_test.go
@@ -101,9 +101,8 @@ func Test_Multiplexer_MainCompletesFirst(t *testing.T) {
 	assert.True(t, ok, "Expected one COMPLETE message")
 	assert.Equal(t, query.COMPLETE, msg.StateName, "Message should be COMPLETE")
 	assert.Equal(t, []string{"m1", "m2"}, msg.CompleteWSResp.ColumnsOrder)
-	assert.NotNil(t, msg.CompleteWSResp.RelatedComplete)
-	assert.NotNil(t, msg.CompleteWSResp.RelatedComplete.Timechart)
-	assert.Equal(t, []string{"t1", "t2"}, msg.CompleteWSResp.RelatedComplete.Timechart.ColumnsOrder)
+	assert.NotNil(t, msg.CompleteWSResp.TimechartComplete)
+	assert.Equal(t, []string{"t1", "t2"}, msg.CompleteWSResp.TimechartComplete.ColumnsOrder)
 
 	_, ok = <-outChan
 	assert.False(t, ok, "Expected no additional messages after COMPLETE")
@@ -152,9 +151,8 @@ func Test_Multiplexer_MainCompletesLast(t *testing.T) {
 	assert.True(t, ok, "Expected one COMPLETE message")
 	assert.Equal(t, query.COMPLETE, msg.StateName, "Message should be COMPLETE")
 	assert.Equal(t, []string{"m1", "m2"}, msg.CompleteWSResp.ColumnsOrder)
-	assert.NotNil(t, msg.CompleteWSResp.RelatedComplete)
-	assert.NotNil(t, msg.CompleteWSResp.RelatedComplete.Timechart)
-	assert.Equal(t, []string{"t1", "t2"}, msg.CompleteWSResp.RelatedComplete.Timechart.ColumnsOrder)
+	assert.NotNil(t, msg.CompleteWSResp.TimechartComplete)
+	assert.Equal(t, []string{"t1", "t2"}, msg.CompleteWSResp.TimechartComplete.ColumnsOrder)
 
 	_, ok = <-outChan
 	assert.False(t, ok, "Expected no additional messages after COMPLETE")
@@ -188,14 +186,13 @@ func Test_Multiplexer_QueryUpdate(t *testing.T) {
 			assert.Equal(t, query.QUERY_UPDATE, msg.StateName)
 			assert.Equal(t, mainQid, msg.Qid)
 			assert.Equal(t, []string{"m1", "m2"}, msg.UpdateWSResp.ColumnsOrder)
-			assert.Nil(t, msg.UpdateWSResp.RelatedUpdate)
+			assert.Nil(t, msg.UpdateWSResp.TimechartUpdate)
 		case TimechartIndex:
 			assert.Equal(t, query.QUERY_UPDATE, msg.StateName)
 			assert.Equal(t, timechartQid, msg.Qid)
 			assert.Empty(t, msg.UpdateWSResp.ColumnsOrder)
-			assert.NotNil(t, msg.UpdateWSResp.RelatedUpdate)
-			assert.NotNil(t, msg.UpdateWSResp.RelatedUpdate.Timechart)
-			assert.Equal(t, []string{"t1", "t2"}, msg.UpdateWSResp.RelatedUpdate.Timechart.ColumnsOrder)
+			assert.NotNil(t, msg.UpdateWSResp.TimechartUpdate)
+			assert.Equal(t, []string{"t1", "t2"}, msg.UpdateWSResp.TimechartUpdate.ColumnsOrder)
 		default:
 			t.Fatalf("Unexpected channel index: %d", msg.ChannelIndex)
 			t.FailNow()

--- a/pkg/ast/pipesearch/searchHandler_test.go
+++ b/pkg/ast/pipesearch/searchHandler_test.go
@@ -33,8 +33,9 @@ func Test_parseSearchBody(t *testing.T) {
 	jssrc["startEpoch"] = "now-15m"
 	jssrc["endEpoch"] = "now"
 	jssrc["scroll"] = 0
+	jssrc[runTimechartFlag] = true
 
-	stext, sepoch, eepoch, fsize, idxname, scroll, includeNulls := ParseSearchBody(jssrc, nowTs)
+	stext, sepoch, eepoch, fsize, idxname, scroll, includeNulls, runTimechart := ParseSearchBody(jssrc, nowTs)
 	assert.Equal(t, "abc def", stext)
 	assert.Equal(t, nowTs-15*60_000, sepoch, "expected=%v, actual=%v", nowTs-15*60_000, sepoch)
 	assert.Equal(t, nowTs, eepoch, "expected=%v, actual=%v", nowTs, eepoch)
@@ -42,13 +43,14 @@ func Test_parseSearchBody(t *testing.T) {
 	assert.Equal(t, "svc-2", idxname, "expected=%v, actual=%v", "svc-2", idxname)
 	assert.Equal(t, 0, scroll, "expected=%v, actual=%v", 0, scroll)
 	assert.False(t, includeNulls, "includeNulls should default to false")
+	assert.True(t, runTimechart, "runTimechart should be true")
 
 	jssrc["from"] = 500
-	_, _, _, finalSize, _, scroll, _ := ParseSearchBody(jssrc, nowTs)
+	_, _, _, finalSize, _, scroll, _, _ := ParseSearchBody(jssrc, nowTs)
 	assert.Equal(t, uint64(700), finalSize, "expected=%v, actual=%v", 700, scroll)
 	assert.Equal(t, 500, scroll, "expected=%v, actual=%v", 500, scroll)
 
 	jssrc["includeNulls"] = true
-	_, _, _, _, _, _, includeNulls = ParseSearchBody(jssrc, nowTs)
+	_, _, _, _, _, _, includeNulls, _ = ParseSearchBody(jssrc, nowTs)
 	assert.True(t, includeNulls, "includeNulls should be true")
 }

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -101,6 +101,9 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 	log.Infof("qid=%v, ProcessPipeSearchWebsocket: index=[%v] searchString=[%v] scrollFrom=[%v]",
 		qid, ti.String(), searchText, scrollFrom)
 
+	var timechartSimpleNode *structs.ASTNode
+	var timechartAggs *structs.QueryAggregators
+
 	queryLanguageType := event["queryLanguage"]
 	var simpleNode *structs.ASTNode
 	var aggs *structs.QueryAggregators
@@ -118,8 +121,24 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 			if wErr != nil {
 				log.Errorf("qid=%d, ProcessPipeSearchWebsocket: failed to write error response to websocket! err: %+v", qid, wErr)
 			}
-		} else {
+		}
+
+		if shouldRunTimechartQuery(aggs) {
+			searchText += " | timechart count"
+			timechartSimpleNode, timechartAggs, _, err = ParseRequest(searchText, startEpoch, endEpoch, qid, "Splunk QL", indexNameIn)
+			if err != nil {
+				wErr := conn.WriteJSON(createErrorResponse(err.Error()))
+				if wErr != nil {
+					log.Errorf("qid=%d, ProcessPipeSearchWebsocket: failed to write error response to websocket! err: %+v", qid, wErr)
+				}
+			}
+		}
+
+		if err == nil {
 			err = structs.CheckUnsupportedFunctions(aggs)
+		}
+		if err == nil {
+			err = structs.CheckUnsupportedFunctions(timechartAggs)
 		}
 	} else {
 		log.Infof("ProcessPipeSearchWebsocket: unknown queryLanguageType: %v; using Splunk QL instead", queryLanguageType)
@@ -152,7 +171,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 	qc.IncludeNulls = includeNulls
 
 	if config.IsNewQueryPipelineEnabled() {
-		RunAsyncQueryForNewPipeline(conn, qid, simpleNode, aggs, qc, sizeLimit, scrollFrom)
+		RunAsyncQueryForNewPipeline(conn, qid, simpleNode, aggs, timechartSimpleNode, timechartAggs, qc, sizeLimit, scrollFrom)
 		return
 	}
 
@@ -204,6 +223,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 }
 
 func RunAsyncQueryForNewPipeline(conn *websocket.Conn, qid uint64, simpleNode *structs.ASTNode, aggs *structs.QueryAggregators,
+	timechartSimpleNode *structs.ASTNode, timechartAggs *structs.QueryAggregators,
 	qc *structs.QueryContext, sizeLimit uint64, scrollFrom int) {
 	websocketR := make(chan map[string]interface{})
 
@@ -226,7 +246,7 @@ func RunAsyncQueryForNewPipeline(conn *websocket.Conn, qid uint64, simpleNode *s
 		websocketR <- map[string]interface{}{"state": "exit"}
 	}()
 
-	_, _, _, err := RunQueryForNewPipeline(conn, qid, simpleNode, aggs, qc)
+	_, _, _, err := RunQueryForNewPipeline(conn, qid, simpleNode, aggs, timechartSimpleNode, timechartAggs, qc)
 	if err != nil {
 		log.Errorf("qid=%d, RunAsyncQueryForNewPipeline: failed to execute query, err: %v", qid, err)
 		wErr := conn.WriteJSON(createErrorResponse(err.Error()))
@@ -563,4 +583,12 @@ func getRawLogsAndColumns(inrrcs []*segutils.RecordResultContainer, skEnc uint32
 		return nil, nil, err
 	}
 	return allJson, allCols, nil
+}
+
+func shouldRunTimechartQuery(aggs *structs.QueryAggregators) bool {
+	if aggs.HasTimechartInChain() || aggs.HasStatsBlockInChain() || aggs.HasStreamStatsInChain() {
+		return false
+	}
+
+	return true
 }

--- a/pkg/ast/pipesearch/wsSearchHandler.go
+++ b/pkg/ast/pipesearch/wsSearchHandler.go
@@ -90,7 +90,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 	}
 
 	nowTs := utils.GetCurrentTimeInMs()
-	searchText, startEpoch, endEpoch, sizeLimit, indexNameIn, scrollFrom, includeNulls := ParseSearchBody(event, nowTs)
+	searchText, startEpoch, endEpoch, sizeLimit, indexNameIn, scrollFrom, includeNulls, runTimechart := ParseSearchBody(event, nowTs)
 
 	if scrollFrom > 10_000 {
 		processMaxScrollComplete(conn, qid)
@@ -123,7 +123,7 @@ func ProcessPipeSearchWebsocket(conn *websocket.Conn, orgid int64, ctx *fasthttp
 			}
 		}
 
-		if shouldRunTimechartQuery(aggs) {
+		if runTimechart && shouldRunTimechartQuery(aggs) {
 			searchText += " | timechart count"
 			timechartSimpleNode, timechartAggs, _, err = ParseRequest(searchText, startEpoch, endEpoch, qid, "Splunk QL", indexNameIn)
 			if err != nil {

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -531,13 +531,13 @@ func ExecuteAsyncQueryForNewPipeline(root *structs.ASTNode, aggs *structs.QueryA
 		err = queryProcessor.GetStreamedResult(rQuery.StateChan)
 		if err != nil {
 			log.Errorf("qid=%v, ExecuteAsyncQueryForNewPipeline: failed to GetStreamedResult, err: %v", qid, err)
-		}
 
-		errorState := query.QueryStateChanData{
-			StateName: query.ERROR,
-			Error:     err,
+			errorState := query.QueryStateChanData{
+				StateName: query.ERROR,
+				Error:     err,
+			}
+			rQuery.StateChan <- &errorState
 		}
-		rQuery.StateChan <- &errorState
 	}()
 	return rQuery.StateChan, nil
 }
@@ -561,15 +561,15 @@ func ExecuteQueryInternalNewPipeline(qid uint64, isAsync bool, root *structs.AST
 		err := queryProcessor.GetStreamedResult(rQuery.StateChan)
 		if err != nil {
 			log.Errorf("qid=%v, ExecuteQueryInternalNewPipeline: failed to GetStreamedResult, err: %v", qid, err)
-		}
 
-		errorState := query.QueryStateChanData{
-			StateName: query.ERROR,
-			Error:     err,
-			Qid:       qid,
-		}
+			errorState := query.QueryStateChanData{
+				StateName: query.ERROR,
+				Error:     err,
+				Qid:       qid,
+			}
 
-		rQuery.StateChan <- &errorState
+			rQuery.StateChan <- &errorState
+		}
 
 		return
 	} else {

--- a/pkg/segment/structs/resultStructs.go
+++ b/pkg/segment/structs/resultStructs.go
@@ -59,7 +59,7 @@ type PipeSearchWSUpdateResponse struct {
 	BucketCount              int                `json:"bucketCount,omitempty"`
 	SortByTimestampAtDefault bool               `json:"sortByTimestampAtDefault"`
 	ColumnsOrder             []string           `json:"columnsOrder,omitempty"`
-	RelatedUpdate            *relatedUpdate     `json:"relatedUpdate,omitempty"`
+	RelatedUpdate            *RelatedUpdate     `json:"relatedUpdate,omitempty"`
 }
 
 type PipeSearchCompleteResponse struct {
@@ -75,13 +75,13 @@ type PipeSearchCompleteResponse struct {
 	BucketCount         int              `json:"bucketCount,omitempty"`
 	IsTimechart         bool             `json:"isTimechart"`
 	ColumnsOrder        []string         `json:"columnsOrder,omitempty"`
-	RelatedComplete     *relatedComplete `json:"relatedComplete,omitempty"`
+	RelatedComplete     *RelatedComplete `json:"relatedComplete,omitempty"`
 }
 
-type relatedUpdate struct {
+type RelatedUpdate struct {
 	Timechart *PipeSearchWSUpdateResponse `json:"timechart,omitempty"`
 }
 
-type relatedComplete struct {
+type RelatedComplete struct {
 	Timechart *PipeSearchCompleteResponse `json:"timechart,omitempty"`
 }

--- a/pkg/segment/structs/resultStructs.go
+++ b/pkg/segment/structs/resultStructs.go
@@ -59,19 +59,29 @@ type PipeSearchWSUpdateResponse struct {
 	BucketCount              int                `json:"bucketCount,omitempty"`
 	SortByTimestampAtDefault bool               `json:"sortByTimestampAtDefault"`
 	ColumnsOrder             []string           `json:"columnsOrder,omitempty"`
+	RelatedUpdate            *relatedUpdate     `json:"relatedUpdate,omitempty"`
 }
 
 type PipeSearchCompleteResponse struct {
-	State               string          `json:"state,omitempty"`
-	TotalMatched        interface{}     `json:"totalMatched,omitempty"`
-	TotalEventsSearched interface{}     `json:"total_events_searched,omitempty"`
-	CanScrollMore       bool            `json:"can_scroll_more"`
-	TotalRRCCount       interface{}     `json:"total_rrc_count,omitempty"`
-	MeasureFunctions    []string        `json:"measureFunctions,omitempty"`
-	MeasureResults      []*BucketHolder `json:"measure,omitempty"`
-	GroupByCols         []string        `json:"groupByCols,omitempty"`
-	Qtype               string          `json:"qtype,omitempty"`
-	BucketCount         int             `json:"bucketCount,omitempty"`
-	IsTimechart         bool            `json:"isTimechart"`
-	ColumnsOrder        []string        `json:"columnsOrder,omitempty"`
+	State               string           `json:"state,omitempty"`
+	TotalMatched        interface{}      `json:"totalMatched,omitempty"`
+	TotalEventsSearched interface{}      `json:"total_events_searched,omitempty"`
+	CanScrollMore       bool             `json:"can_scroll_more"`
+	TotalRRCCount       interface{}      `json:"total_rrc_count,omitempty"`
+	MeasureFunctions    []string         `json:"measureFunctions,omitempty"`
+	MeasureResults      []*BucketHolder  `json:"measure,omitempty"`
+	GroupByCols         []string         `json:"groupByCols,omitempty"`
+	Qtype               string           `json:"qtype,omitempty"`
+	BucketCount         int              `json:"bucketCount,omitempty"`
+	IsTimechart         bool             `json:"isTimechart"`
+	ColumnsOrder        []string         `json:"columnsOrder,omitempty"`
+	RelatedComplete     *relatedComplete `json:"relatedComplete,omitempty"`
+}
+
+type relatedUpdate struct {
+	Timechart *PipeSearchWSUpdateResponse `json:"timechart,omitempty"`
+}
+
+type relatedComplete struct {
+	Timechart *PipeSearchCompleteResponse `json:"timechart,omitempty"`
 }

--- a/pkg/segment/structs/resultStructs.go
+++ b/pkg/segment/structs/resultStructs.go
@@ -46,42 +46,34 @@ type AggregationResults struct {
 }
 
 type PipeSearchWSUpdateResponse struct {
-	Hits                     PipeSearchResponse `json:"hits,omitempty"`
-	AllPossibleColumns       []string           `json:"allColumns,omitempty"`
-	Completion               float64            `json:"percent_complete"`
-	State                    string             `json:"state,omitempty"`
-	TotalEventsSearched      interface{}        `json:"total_events_searched,omitempty"`
-	TotalPossibleEvents      interface{}        `json:"total_possible_events,omitempty"`
-	MeasureFunctions         []string           `json:"measureFunctions,omitempty"`
-	MeasureResults           []*BucketHolder    `json:"measure,omitempty"`
-	GroupByCols              []string           `json:"groupByCols,omitempty"`
-	Qtype                    string             `json:"qtype,omitempty"`
-	BucketCount              int                `json:"bucketCount,omitempty"`
-	SortByTimestampAtDefault bool               `json:"sortByTimestampAtDefault"`
-	ColumnsOrder             []string           `json:"columnsOrder,omitempty"`
-	RelatedUpdate            *RelatedUpdate     `json:"relatedUpdate,omitempty"`
+	Hits                     PipeSearchResponse          `json:"hits,omitempty"`
+	AllPossibleColumns       []string                    `json:"allColumns,omitempty"`
+	Completion               float64                     `json:"percent_complete"`
+	State                    string                      `json:"state,omitempty"`
+	TotalEventsSearched      interface{}                 `json:"total_events_searched,omitempty"`
+	TotalPossibleEvents      interface{}                 `json:"total_possible_events,omitempty"`
+	MeasureFunctions         []string                    `json:"measureFunctions,omitempty"`
+	MeasureResults           []*BucketHolder             `json:"measure,omitempty"`
+	GroupByCols              []string                    `json:"groupByCols,omitempty"`
+	Qtype                    string                      `json:"qtype,omitempty"`
+	BucketCount              int                         `json:"bucketCount,omitempty"`
+	SortByTimestampAtDefault bool                        `json:"sortByTimestampAtDefault"`
+	ColumnsOrder             []string                    `json:"columnsOrder,omitempty"`
+	TimechartUpdate          *PipeSearchWSUpdateResponse `json:"timechartUpdate,omitempty"`
 }
 
 type PipeSearchCompleteResponse struct {
-	State               string           `json:"state,omitempty"`
-	TotalMatched        interface{}      `json:"totalMatched,omitempty"`
-	TotalEventsSearched interface{}      `json:"total_events_searched,omitempty"`
-	CanScrollMore       bool             `json:"can_scroll_more"`
-	TotalRRCCount       interface{}      `json:"total_rrc_count,omitempty"`
-	MeasureFunctions    []string         `json:"measureFunctions,omitempty"`
-	MeasureResults      []*BucketHolder  `json:"measure,omitempty"`
-	GroupByCols         []string         `json:"groupByCols,omitempty"`
-	Qtype               string           `json:"qtype,omitempty"`
-	BucketCount         int              `json:"bucketCount,omitempty"`
-	IsTimechart         bool             `json:"isTimechart"`
-	ColumnsOrder        []string         `json:"columnsOrder,omitempty"`
-	RelatedComplete     *RelatedComplete `json:"relatedComplete,omitempty"`
-}
-
-type RelatedUpdate struct {
-	Timechart *PipeSearchWSUpdateResponse `json:"timechart,omitempty"`
-}
-
-type RelatedComplete struct {
-	Timechart *PipeSearchCompleteResponse `json:"timechart,omitempty"`
+	State               string                      `json:"state,omitempty"`
+	TotalMatched        interface{}                 `json:"totalMatched,omitempty"`
+	TotalEventsSearched interface{}                 `json:"total_events_searched,omitempty"`
+	CanScrollMore       bool                        `json:"can_scroll_more"`
+	TotalRRCCount       interface{}                 `json:"total_rrc_count,omitempty"`
+	MeasureFunctions    []string                    `json:"measureFunctions,omitempty"`
+	MeasureResults      []*BucketHolder             `json:"measure,omitempty"`
+	GroupByCols         []string                    `json:"groupByCols,omitempty"`
+	Qtype               string                      `json:"qtype,omitempty"`
+	BucketCount         int                         `json:"bucketCount,omitempty"`
+	IsTimechart         bool                        `json:"isTimechart"`
+	ColumnsOrder        []string                    `json:"columnsOrder,omitempty"`
+	TimechartComplete   *PipeSearchCompleteResponse `json:"timechartComplete,omitempty"`
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1181,6 +1181,10 @@ func (qa *QueryAggregators) UsedByTimechart() bool {
 	return qa != nil && qa.TimeHistogram != nil && qa.TimeHistogram.Timechart != nil
 }
 
+func (qa *QueryAggregators) HasTimechartInChain() bool {
+	return qa.HasInChain((*QueryAggregators).UsedByTimechart)
+}
+
 func (qa *QueryAggregators) CanLimitBuckets() bool {
 	// We shouldn't limit the buckets if there's other things to do after the
 	// aggregation, like sorting, filtering, making new columns, etc.

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -54,7 +54,7 @@ func ProcessSearchTracesRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	nowTs := putils.GetCurrentTimeInMs()
-	searchText, startEpoch, endEpoch, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
+	searchText, startEpoch, endEpoch, _, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
 
 	page := 1
 	pageVal, ok := readJSON["page"]
@@ -779,7 +779,7 @@ func ProcessGeneratedDepGraph(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	nowTs := putils.GetCurrentTimeInMs()
-	_, startEpoch, endEpoch, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
+	_, startEpoch, endEpoch, _, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
 
 	startEpochInt64 := int64(startEpoch)
 	endEpochInt64 := int64(endEpoch)
@@ -991,7 +991,7 @@ func ProcessSpanGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	nowTs := putils.GetCurrentTimeInMs()
-	searchText, startEpoch, endEpoch, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
+	searchText, startEpoch, endEpoch, _, _, _, _, _ := pipesearch.ParseSearchBody(readJSON, nowTs)
 
 	// Validate query
 	isOnlySpanID, spanId := ExtractSpanID(searchText)


### PR DESCRIPTION
# Description
When we get a websocket query that returns logs, now when a flag is set for that query, we'll also run a timechart version of that query and forward those results to the websocket, along with the results for the original query.

This PR shouldn't change any functionality on the UI, because the new feature is turned off by default.

# Testing
Some new unit tests for individual components of this. For integration testing, I made [these changes](https://github.com/user-attachments/files/18876635/diff.patch) to display the timechart results on the frontend and it sort of worked. Those frontend changes aren't quite correct, so it actually replaced the resulting logs with the timechart results, but I was able to see the timechart in the Visualization tab as expected.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
