### PR TITLE
Replace min/max helpers with built-in min/max

### DIFF
--- a/pkg/memorypool/memorypool.go
+++ b/pkg/memorypool/memorypool.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -82,7 +81,7 @@ func (self *MemoryPool) Get(minCapacity uint64) []byte {
 	}
 
 	// All items are in use, so make a new item.
-	bufferCapacity := utils.Max(minCapacity, self.defaultBufferCapacity)
+	bufferCapacity := max(minCapacity, self.defaultBufferCapacity)
 	item := newItem(bufferCapacity, true)
 	self.items = append(self.items, item)
 

--- a/pkg/segment/query/processor/inputlookupcommand.go
+++ b/pkg/segment/query/processor/inputlookupcommand.go
@@ -31,7 +31,6 @@ import (
 	"github.com/siglens/siglens/pkg/segment/query/iqr"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
-	putils "github.com/siglens/siglens/pkg/utils"
 )
 
 type inputlookupProcessor struct {
@@ -136,7 +135,7 @@ func (p *inputlookupProcessor) Process(inpIqr *iqr.IQR) (*iqr.IQR, error) {
 	count := uint64(0)
 	records := map[string][]utils.CValueEnclosure{}
 
-	for !p.eof && count < putils.MinUint64(p.options.Max, p.limit) {
+	for !p.eof && count < min(p.options.Max, p.limit) {
 		count++
 		curr++
 		csvRecord, err := reader.Read()

--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -482,7 +482,7 @@ func (str *AgileTreeReader) ApplyGroupByJit(grpColNames []string,
 				grpByCol, err)
 			return err
 		}
-		maxGrpLevel = utils.MaxUint16(maxGrpLevel, uint16(level))
+		maxGrpLevel = max(maxGrpLevel, uint16(level))
 		grpTreeLevels[i] = uint16(level)
 	}
 

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -120,7 +120,7 @@ func InitBlockResults(count uint64, aggs *structs.QueryAggregators, qid uint64) 
 		blockRes.sortResults = true
 		blockRes.SortedResults = sortedRes
 	} else {
-		initialSize := utils.MinUint64(count, utils.MAX_RECS_PER_WIP)
+		initialSize := min(count, utils.MAX_RECS_PER_WIP)
 		blockRes.sortResults = false
 		blockRes.UnsortedResults = make([]*utils.RecordResultContainer, initialSize)
 		blockRes.nextUnsortedIdx = 0

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -78,10 +78,10 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			e1.CVal = e1.CVal.(uint64) + e2.CVal.(uint64)
 			return e1, nil
 		case Min:
-			e1.CVal = MinUint64(e1.CVal.(uint64), e2.CVal.(uint64))
+			e1.CVal = min(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
 		case Max:
-			e1.CVal = MaxUint64(e1.CVal.(uint64), e2.CVal.(uint64))
+			e1.CVal = max(e1.CVal.(uint64), e2.CVal.(uint64))
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for unsigned int", fun)
@@ -92,10 +92,10 @@ func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CVa
 			e1.CVal = e1.CVal.(int64) + e2.CVal.(int64)
 			return e1, nil
 		case Min:
-			e1.CVal = MinInt64(e1.CVal.(int64), e2.CVal.(int64))
+			e1.CVal = min(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
 		case Max:
-			e1.CVal = MaxInt64(e1.CVal.(int64), e2.CVal.(int64))
+			e1.CVal = max(e1.CVal.(int64), e2.CVal.(int64))
 			return e1, nil
 		default:
 			return e1, fmt.Errorf("Reduce: unsupported aggregation type %v for signed int", fun)
@@ -213,10 +213,10 @@ func (self *NumTypeEnclosure) ReduceFast(e2Dtype SS_DTYPE, e2int64 int64,
 			self.IntgrVal = self.IntgrVal + e2int64
 			return nil
 		case Min:
-			self.IntgrVal = MinInt64(self.IntgrVal, e2int64)
+			self.IntgrVal = min(self.IntgrVal, e2int64)
 			return nil
 		case Max:
-			self.IntgrVal = MaxInt64(self.IntgrVal, e2int64)
+			self.IntgrVal = max(self.IntgrVal, e2int64)
 			return nil
 		case Count:
 			self.IntgrVal = self.IntgrVal + e2int64

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -195,9 +195,9 @@ func (n *Number) ReduceFast(other *Number, fun AggregateFunctions) error {
 		case Sum:
 			n.SetInt64(ni + oi)
 		case Min:
-			n.SetInt64(MinInt64(ni, oi))
+			n.SetInt64(min(ni, oi))
 		case Max:
-			n.SetInt64(MaxInt64(ni, oi))
+			n.SetInt64(max(ni, oi))
 		case Count:
 			n.SetInt64(ni + oi)
 		default:

--- a/pkg/segment/utils/segutils.go
+++ b/pkg/segment/utils/segutils.go
@@ -225,48 +225,6 @@ func ConvertFloatBytesToMB(bytes float64) float64 {
 	return bytes / 1048576
 }
 
-func MinUint64(a1 uint64, b1 uint64) uint64 {
-	if a1 < b1 {
-		return a1
-	}
-	return b1
-}
-
-func MaxUint64(a1 uint64, b1 uint64) uint64 {
-	if a1 < b1 {
-		return b1
-	}
-	return a1
-}
-
-func MinInt64(a1 int64, b1 int64) int64 {
-	if a1 < b1 {
-		return a1
-	}
-	return b1
-}
-
-func MaxInt64(a1 int64, b1 int64) int64 {
-	if a1 < b1 {
-		return b1
-	}
-	return a1
-}
-
-func MaxUint32(a1 uint32, b1 uint32) uint32 {
-	if a1 < b1 {
-		return b1
-	}
-	return a1
-}
-
-func MaxUint16(a1 uint16, b1 uint16) uint16 {
-	if a1 < b1 {
-		return b1
-	}
-	return a1
-}
-
 // converts the input byte slice to a string representation of all read values
 // returns array of strings with groupBy values
 func ConvertGroupByKey(rec []byte) ([]string, error) {

--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -1095,7 +1095,7 @@ func (segstore *SegStore) WritePackedRecord(rawJson []byte, ts_millis uint64,
 	}
 
 	for _, cwip := range segstore.wipBlock.colWips {
-		segstore.wipBlock.maxIdx = utils.MaxUint32(segstore.wipBlock.maxIdx, cwip.cbufidx)
+		segstore.wipBlock.maxIdx = max(segstore.wipBlock.maxIdx, cwip.cbufidx)
 	}
 
 	segstore.wipBlock.blockSummary.RecCount += 1

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -497,7 +497,7 @@ func (segstore *SegStore) AddEntry(streamid string, indexName string, flush bool
 		}
 
 		for _, cwip := range segstore.wipBlock.colWips {
-			segstore.wipBlock.maxIdx = MaxUint32(segstore.wipBlock.maxIdx, cwip.cbufidx)
+			segstore.wipBlock.maxIdx = max(segstore.wipBlock.maxIdx, cwip.cbufidx)
 		}
 
 		segstore.wipBlock.blockSummary.RecCount += 1

--- a/pkg/segment/writer/segwriter_test.go
+++ b/pkg/segment/writer/segwriter_test.go
@@ -102,7 +102,7 @@ func Test_isTimeRangeOverlapping(t *testing.T) {
 }
 
 func isTimeRangeOverlapping(start1, end1, start2, end2 uint64) bool {
-	return utils.Max(start1, start2) <= utils.Min(end1, end2)
+	return max(start1, start2) <= min(end1, end2)
 }
 
 func Test_getNumberTypeAndVal(t *testing.T) {

--- a/pkg/segment/writer/startree_test.go
+++ b/pkg/segment/writer/startree_test.go
@@ -271,7 +271,7 @@ func TestStarTree(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, cwip := range ss.wipBlock.colWips {
-			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+			ss.wipBlock.maxIdx = max(ss.wipBlock.maxIdx, cwip.cbufidx)
 		}
 		ss.wipBlock.blockSummary.RecCount += 1
 	}
@@ -372,7 +372,7 @@ func TestStarTreeMedium(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, cwip := range ss.wipBlock.colWips {
-			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+			ss.wipBlock.maxIdx = max(ss.wipBlock.maxIdx, cwip.cbufidx)
 		}
 		ss.wipBlock.blockSummary.RecCount += 1
 	}
@@ -473,7 +473,7 @@ func TestStarTreeMediumEncoding(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, cwip := range ss.wipBlock.colWips {
-			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+			ss.wipBlock.maxIdx = max(ss.wipBlock.maxIdx, cwip.cbufidx)
 		}
 		ss.wipBlock.blockSummary.RecCount += 1
 		ss.RecordCount++
@@ -576,7 +576,7 @@ func TestStarTreeMediumEncodingDecoding(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, cwip := range ss.wipBlock.colWips {
-			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+			ss.wipBlock.maxIdx = max(ss.wipBlock.maxIdx, cwip.cbufidx)
 		}
 
 		ss.wipBlock.blockSummary.RecCount += 1
@@ -935,7 +935,7 @@ func TestStarTree2(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, cwip := range ss.wipBlock.colWips {
-			ss.wipBlock.maxIdx = utils.MaxUint32(ss.wipBlock.maxIdx, cwip.cbufidx)
+			ss.wipBlock.maxIdx = max(ss.wipBlock.maxIdx, cwip.cbufidx)
 		}
 		ss.wipBlock.blockSummary.RecCount += 1
 	}

--- a/pkg/utils/buffer.go
+++ b/pkg/utils/buffer.go
@@ -220,7 +220,7 @@ func (b *Buffer) WriteAt(src []byte, start int) error {
 	numSkippedChunks := start / chunkSize
 	offset := start % chunkSize
 	for i := numSkippedChunks; i < len(b.chunks) && len(src) > 0; i++ {
-		numBytesToCopy := Min(len(src), chunkSize-offset)
+		numBytesToCopy := min(len(src), chunkSize-offset)
 		copy(b.chunks[i][offset:], src[:numBytesToCopy])
 		src = src[numBytesToCopy:]
 		offset = 0

--- a/pkg/utils/mathutils.go
+++ b/pkg/utils/mathutils.go
@@ -30,10 +30,3 @@ func CalculateStandardVariance(values []float64) float64 {
 	}
 	return sumValSquare / length
 }
-
-func MinUint64(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/pkg/utils/segutils.go
+++ b/pkg/utils/segutils.go
@@ -81,36 +81,6 @@ func CreateUniqueIndentifier() string {
 	return UUID_GENERATOR.Hex128()
 }
 
-func Max[T ~int | ~uint64](x, y T) T {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-func Min[T ~int | ~uint64](x, y T) T {
-	if x > y {
-		return y
-	}
-	return x
-}
-
-// TODO: delete these functions (and all similar in the codebase). Use the
-// generic min/max functions instead.
-func MaxInt64(x, y int64) int64 {
-	if x < y {
-		return y
-	}
-	return x
-}
-
-func MinInt64(x, y int64) int64 {
-	if x > y {
-		return y
-	}
-	return x
-}
-
 func HashString(x string) string {
 	return fmt.Sprintf("%d", xxhash.Sum64String(x))
 }


### PR DESCRIPTION
# Description

https://github.com/siglens/siglens/blob/e67725c1f8266d3cf7ed6bdcc6c0cad19f419d2a/pkg/utils/segutils.go#L98-L99

This PR replaces min/max helpers (`MinInt`, `MaxInt`, `MinInt64`, etc.) with built-in `min` and `max` functions. We can use the built-in `min` and `max` functions since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max

# Testing

```
make test
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
