### PR TITLE
 [STORY] Implement test metrics generation in sigclient for k8s…

### DIFF
--- a/tools/sigclient/README.md
+++ b/tools/sigclient/README.md
@@ -11,60 +11,92 @@ Options:
 ```
   -b, --batchSize int        Batch size (default 100)
   -d, --dest string          Destination URL. Client will append /_bulk
-  -g, --generator string     type of generator to use. Options=[static,dynamic-user,file,benchmark]. If file is selected, -x/--filePath must be specified (default "static")
+  -g, --generator string     Type of generator to use. Options=[static,dynamic-user,file,benchmark,k8s]. If file is selected, -x/--filePath must be specified (default "static")
+  --ksm                      Generate only Kubernetes (kube-state-metrics) metrics (default false)
+  --node                     Generate only node-exporter metrics (default false)
+  --both                     Generate both Kubernetes and node-exporter metrics (default false)
   
-  -x, --filePath string      path to json file containing loglines to send to server
-  -h, --help                 help for ingest
+  -x, --filePath string      Path to JSON file containing log lines to send to server
+  -h, --help                 Help for ingest
   -i, --indexPrefix string   Index prefix to ingest (default "ind")
   -r, --bearerToken string   Bearer token of your org to ingest (default "")
-  -n, --numIndices int       number of indices to ingest to (default 1)
-  -p, --processCount int     Number of parallel process to ingest data from. (default 1)
+  -n, --numIndices int       Number of indices to ingest to (default 1)
+  -p, --processCount int     Number of parallel processes to ingest data from. (default 1)
   -t, --totalEvents int      Total number of events to send (default 1000000)
   -s, --timestamp            If set, adds "timestamp" to the static/dynamic generators
   -e, --eventsPerDay uint    Number of events to ingest per day. If set, the ingestion mode will be assumed to be continuous.
 
   -c  continuous             If true, ignores -t and will continuously send docs to the destination
-  -o  --outputFile           filepath to output the query response Time results in csv format.
-  -t  --runResponseTime      If true, then the queries will be run and the response time will be recorded in the given/default outputFile in CSV Format.
-      --enableVariableNumColumns bool  Set this to true to generate variable number of columns per record. Each record will have a random number of columns between minColumns and maxColumns
-      --maxColumns  int      Maximum number of Columns to generate. By Default this value is set to 100.
-      --minColumns int       Minimum number of Columns to generate. Default value is 0. If 0, it will be set to maxColumns value.
+  -o  --outputFile           Filepath to output the query response time results in CSV format.
+  -t  --runResponseTime      If true, then the queries will be run and the response time will be recorded in the given/default outputFile in CSV format.
+      --enableVariableNumColumns bool  Set this to true to generate a variable number of columns per record. Each record will have a random number of columns between minColumns and maxColumns
+      --maxColumns  int      Maximum number of columns to generate. By default, this value is set to 100.
+      --minColumns int       Minimum number of columns to generate. Default value is 0. If 0, it will be set to maxColumns value.
 ```
 
-Different Types of Readers:
+### Kubernetes Metrics Generator (k8s)
+The k8s generator simulates Kubernetes and node-exporter metrics. Use the following flags to control the type of metrics generated:
 
-1. Static: Sends the same payload over and over
-2. Dynamic User: Randomly Generates user events. These random events are generated using [gofakeit](github.com/brianvoe/gofakeit/v6).
-3. File: Reads a file line by line. Expects each line is a new json. Will loop over file if necessary
+- `--ksm`: Generate only Kubernetes (kube-state-metrics) metrics.
+- `--node`: Generate only node-exporter metrics.
+- `--both`: Generate both Kubernetes and node-exporter metrics.
 
-To Ingest 200 columns per record:
+Example commands:
+```bash
+# Generate only Kubernetes metrics
+go run main.go ingest esbulk -g k8s --ksm -d http://localhost:8081/elastic -t 1000
 
+# Generate only node-exporter metrics
+go run main.go ingest esbulk -g k8s --node -d http://localhost:8081/elastic -t 1000
+
+# Generate both Kubernetes and node-exporter metrics
+go run main.go ingest esbulk -g k8s --both -d http://localhost:8081/elastic -t 1000
+```
+
+### Different Types of Readers
+- **Static**: Sends the same payload over and over.
+- **Dynamic User**: Randomly generates user events using [gofakeit](github.com/brianvoe/gofakeit/v6).
+- **File**: Reads a file line by line. Expects each line is a new JSON. Will loop over the file if necessary.
+- **Kubernetes (k8s)**: Generates Kubernetes (kube-state-metrics) and node-exporter metrics.
+
+Examples:
+To ingest 200 columns per record:
 ```bash
 go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 1000 -p 1 --enableVariableNumColumns true --maxColumns 200
 ```
 
-To Ingest variable number of Columns between 50 to 200. Each record will have columns count between 50 and 200.
-
+To ingest a variable number of columns between 50 and 200:
 ```bash
 go run main.go ingest esbulk -n 1 -g benchmark -d http://localhost:8081/elastic -t 1000 -p 1 --enableVariableNumColumns true --maxColumns 200 --minColumns 50
 ```
 
-
-### OTSDB
+## OTSDB
 To send ingestion traffic to a server using OTSDB:
 ```bash
 go run main.go ingest metrics -d http://localhost:8081/otsdb -t 10_000  -m 5 -p 1
 ```
 Options:
 ```
-  -m, --metrics int   Number of different metric names to send (default 1000)
+  -m, --metrics int          Number of different metric names to send (default 1000)
   -r, --bearerToken string   Bearer token of your org to ingest (default "")
   -b, --batchSize int        Batch size (default 100)
   -d, --dest string          Server URL.
-  -p, --processCount int     Number of parallel process to ingest data from. (default 1)
+  -p, --processCount int     Number of parallel processes to ingest data from. (default 1)
   -t, --totalEvents int      Total number of events to send (default 1000000)
   -u, --uniqueness int       Cardinality (uniqueness) of the data (default 2000000)
   -e, --eventsPerDay uint    Number of events to ingest per day. If set, the ingestion mode will be assumed to be continuous.
+```
+
+Example commands:
+```bash
+# Generate only Kubernetes metrics
+go run main.go ingest metrics -g k8s --ksm -d http://localhost:8081/otsdb -t 1000
+
+# Generate only node-exporter metrics
+go run main.go ingest metrics -g k8s --node -d http://localhost:8081/otsdb -t 1000
+
+# Generate both Kubernetes and node-exporter metrics
+go run main.go ingest metrics -g k8s --both -d http://localhost:8081/otsdb -t 1000
 ```
 
 ## Query

--- a/tools/sigclient/cmd/root.go
+++ b/tools/sigclient/cmd/root.go
@@ -24,10 +24,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var generatorType string
+
 var rootCmd = &cobra.Command{
 	Use:   "sigscalr-client",
 	Short: "sigscalr client",
 	Long:  `Client to send data to sigscalr and other related storages`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if generatorType != "" {
+			handleGenerator()
+			return
+		}
+		fmt.Println("Use -h to see available commands")
+	},
 }
 
 func Execute() {
@@ -35,4 +44,19 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+func handleGenerator() {
+	switch generatorType {
+	case "k8s":
+		fmt.Println("Kubernetes metrics generator is initialized via the ingest command.")
+	default:
+		fmt.Printf("Unsupported generator type: %s\n", generatorType)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&generatorType, "generator", "g", "",
+		"Metrics generator type (k8s)")
 }

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -118,8 +118,6 @@ var esBulkCmd = &cobra.Command{
 			log.Infof("minColumns : %+v\n", dataGeneratorConfig.MinColumns)
 		}
 
-		// ingest.StartIngestion(ingest.ESBulk, generatorType, dataFile, totalEvents, continuous, batchSize, dest, indexPrefix, indexName, numIndices, processCount, ts, 0, bearerToken, 0, eventsPerDay, dataGeneratorConfig)
-		// ingest.StartIngestion(ingest.ESBulk, generatorType, dataFile, totalEvents, continuous, batchSize, dest, indexPrefix, indexName, numIndices, processCount, ts, 0, bearerToken, 0, eventsPerDay, dataGeneratorConfig, false, false, true)
 		ingest.StartIngestion(ingest.ESBulk, generatorType, dataFile, totalEvents, continuous, batchSize, dest, indexPrefix, indexName, numIndices, processCount, ts, 0, bearerToken, 0, eventsPerDay, dataGeneratorConfig, ksmOnly, nodeOnly, bothMetrics)
 
 	},
@@ -166,9 +164,6 @@ var functionalTestCmd = &cobra.Command{
 		if doIngest {
 
 			dataGeneratorConfig := utils.InitFunctionalTestGeneratorDataConfig(numFixedCols, maxVariableCols)
-
-			// ingest.StartIngestion(ingest.ESBulk, "functional", "", totalEvents, false, batchSize, dest, indexPrefix,
-			// 	indexName, numIndices, processCount, true, 0, bearerToken, 0, 0, dataGeneratorConfig)
 
 			ingest.StartIngestion(ingest.ESBulk, "functional", "", totalEvents, false, batchSize, dest, indexPrefix, indexName, numIndices, processCount, true, 0, bearerToken, 0, 0, dataGeneratorConfig, false, false, true)
 
@@ -220,8 +215,7 @@ var performanceTestCmd = &cobra.Command{
 		go func(cancel context.CancelFunc) {
 			defer cancel()
 			// addTs should be false for performance testing
-			// ingest.StartIngestion(ingest.ESBulk, "performance", "", totalEvents, false, batchSize, dest, indexPrefix,
-			// 	indexName, numIndices, processCount, false, 0, bearerToken, 0, 0, dataGenConfig)
+
 			ingest.StartIngestion(ingest.ESBulk, "performance", "", totalEvents, false, batchSize, dest, indexPrefix, indexName, numIndices, processCount, false, 0, bearerToken, 0, 0, dataGenConfig, false, false, true)
 		}(cancel)
 
@@ -278,43 +272,6 @@ var clickBenchTestCmd = &cobra.Command{
 	},
 }
 
-// metricsIngestCmd represents the metrics ingestion
-// var metricsIngestCmd = &cobra.Command{
-// 	Use:   "metrics",
-// 	Short: "ingest metrics to /api/put in OTSDB format",
-// 	Run: func(cmd *cobra.Command, args []string) {
-// 		processCount, _ := cmd.Flags().GetInt("processCount")
-// 		dest, _ := cmd.Flags().GetString("dest")
-// 		totalEvents, _ := cmd.Flags().GetInt("totalEvents")
-// 		continuous, _ := cmd.Flags().GetBool("continuous")
-// 		batchSize, _ := cmd.Flags().GetInt("batchSize")
-// 		nMetrics, _ := cmd.Flags().GetInt("metrics")
-// 		bearerToken, _ := cmd.Flags().GetString("bearerToken")
-// 		generatorType, _ := cmd.Flags().GetString("generator")
-// 		cardinality, _ := cmd.Flags().GetUint64("cardinality")
-// 		eventsPerDay, _ := cmd.Flags().GetUint64("eventsPerDay")
-
-// 		if eventsPerDay > 0 {
-// 			if cmd.Flags().Changed("totalEvents") {
-// 				log.Fatalf("You cannot use totalEvents and eventsPerDay together; you must choose one.")
-// 				return
-// 			}
-// 			continuous = true
-// 		}
-
-// 		log.Infof("processCount : %+v\n", processCount)
-// 		log.Infof("dest : %+v\n", dest)
-// 		log.Infof("totalEvents : %+v. Continuous: %+v\n", totalEvents, continuous)
-// 		log.Infof("batchSize : %+v. Num metrics: %+v\n", batchSize, nMetrics)
-// 		log.Infof("bearerToken : %+v\n", bearerToken)
-// 		log.Infof("generatorType : %+v.\n", generatorType)
-// 		log.Infof("cardinality : %+v.\n", cardinality)
-// 		log.Infof("eventsPerDay : %+v\n", eventsPerDay)
-
-// 		ingest.StartIngestion(ingest.OpenTSDB, generatorType, "", totalEvents, continuous, batchSize, dest, "", "", 0, processCount, false, nMetrics, bearerToken, cardinality, eventsPerDay, nil)
-// 	},
-// }
-
 var metricsIngestCmd = &cobra.Command{
 	Use:   "metrics",
 	Short: "ingest metrics to /api/put in OTSDB format",
@@ -364,7 +321,7 @@ var metricsIngestCmd = &cobra.Command{
 		log.Infof("bothMetrics : %+v\n", bothMetrics)
 
 		// Pass the configuration to StartIngestion
-		// ingest.StartIngestion(ingest.OpenTSDB, generatorType, "", totalEvents, continuous, batchSize, dest, "", "", 0, processCount, false, nMetrics, bearerToken, cardinality, eventsPerDay, nil, ksmOnly, nodeOnly, bothMetrics)
+
 		ingest.StartIngestion(ingest.OpenTSDB, generatorType, "", totalEvents, continuous, batchSize, dest, "", "", 0, processCount, false, nMetrics, bearerToken, cardinality, eventsPerDay, nil, ksmOnly, nodeOnly, bothMetrics)
 	},
 }
@@ -611,7 +568,7 @@ func init() {
 
 	esBulkCmd.Flags().BoolP("timestamp", "s", false, "Add timestamp in payload")
 	esBulkCmd.PersistentFlags().IntP("numIndices", "n", 1, "number of indices to ingest to")
-	// esBulkCmd.PersistentFlags().StringP("generator", "g", "dynamic-user", "type of generator to use. Options=[static,dynamic-user,file]. If file is selected, -x/--filePath must be specified")
+
 	esBulkCmd.PersistentFlags().StringP("generator", "g", "dynamic-user",
 		"type of generator to use. Options=[static,dynamic-user,file,benchmark,k8s]. If file is selected, -x/--filePath must be specified")
 	esBulkCmd.PersistentFlags().StringP("filePath", "x", "", "path to json file to use as logs")

--- a/tools/sigclient/main.go
+++ b/tools/sigclient/main.go
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// updated package
+
 package main
 
 import (

--- a/tools/sigclient/pkg/ingest/ingest.go
+++ b/tools/sigclient/pkg/ingest/ingest.go
@@ -57,11 +57,9 @@ func (q IngestType) String() string {
 
 const PRINT_FREQ = 100_000
 
-// returns any errors encountered. It is the caller's responsibility to attempt retries
+// Send a request to the server and return any errors encountered.
 func sendRequest(iType IngestType, client *http.Client, lines []byte, url string, bearerToken string) error {
-
 	bearerToken = "Bearer " + strings.TrimSpace(bearerToken)
-
 	buf := bytes.NewBuffer(lines)
 
 	var requestStr string
@@ -70,7 +68,6 @@ func sendRequest(iType IngestType, client *http.Client, lines []byte, url string
 		requestStr = url + "/_bulk"
 	case OpenTSDB:
 		requestStr = url + "/api/put"
-
 	default:
 		log.Fatalf("unknown ingest type %+v", iType)
 		return fmt.Errorf("unknown ingest type %+v", iType)
@@ -97,7 +94,6 @@ func sendRequest(iType IngestType, client *http.Client, lines []byte, url string
 		log.Errorf("sendRequest: client.Do ERROR: %v", err)
 		return err
 	}
-	// Check if the Status code is not 200
 	if resp.StatusCode != http.StatusOK {
 		log.Errorf("sendRequest: client.Do ERROR Response: %v", "StatusCode: "+fmt.Sprint(resp.StatusCode)+": "+string(respBody))
 		return fmt.Errorf("sendRequest: client.Do ERROR Response: %v", "StatusCode: "+fmt.Sprint(resp.StatusCode)+": "+string(respBody))
@@ -105,6 +101,7 @@ func sendRequest(iType IngestType, client *http.Client, lines []byte, url string
 	return nil
 }
 
+// Generate the body for the request based on the ingest type.
 func generateBody(iType IngestType, recs int, i int, rdr utils.Generator,
 	actLines []string, bb *bytebufferpool.ByteBuffer) ([]byte, error) {
 	switch iType {
@@ -119,9 +116,9 @@ func generateBody(iType IngestType, recs int, i int, rdr utils.Generator,
 	return nil, fmt.Errorf("unsupported ingest type %s", iType.String())
 }
 
+// Generate the body for Elasticsearch Bulk API requests.
 func generateESBody(recs int, actionLine string, rdr utils.Generator,
 	bb *bytebufferpool.ByteBuffer) ([]byte, error) {
-
 	for i := 0; i < recs; i++ {
 		_, _ = bb.WriteString(actionLine)
 		logline, err := rdr.GetLogLine()
@@ -135,6 +132,7 @@ func generateESBody(recs int, actionLine string, rdr utils.Generator,
 	return payLoad, nil
 }
 
+// Generate the body for OpenTSDB API requests.
 func generateOpenTSDBBody(recs int, rdr utils.Generator) ([]byte, error) {
 	finalPayLoad := make([]interface{}, recs)
 	for i := 0; i < recs; i++ {
@@ -155,6 +153,7 @@ var preGeneratedSeries []map[string]interface{}
 var uniqueSeriesMap = make(map[string]struct{})
 var seriesId uint64
 
+// Generate a unique payload for OpenTSDB metrics.
 func generateUniquePayload(rdr *utils.MetricsGenerator) (map[string]interface{}, error) {
 	var currPayload map[string]interface{}
 	var err error
@@ -178,10 +177,10 @@ func generateUniquePayload(rdr *utils.MetricsGenerator) (map[string]interface{},
 			break
 		}
 	}
-
 	return currPayload, nil
 }
 
+// Pre-generate unique series for OpenTSDB metrics.
 func generatePredefinedSeries(nMetrics int, cardinality uint64, gentype string) error {
 	preGeneratedSeries = make([]map[string]interface{}, cardinality)
 	rdr, err := utils.InitMetricsGenerator(nMetrics, gentype)
@@ -203,6 +202,7 @@ func generatePredefinedSeries(nMetrics int, cardinality uint64, gentype string) 
 	return nil
 }
 
+// Generate the body from pre-defined series for OpenTSDB.
 func generateBodyFromPredefinedSeries(recs int, preGeneratedSeriesLength uint64) ([]byte, error) {
 	finalPayLoad := make([]interface{}, recs)
 	for i := 0; i < recs; i++ {
@@ -216,6 +216,7 @@ func generateBodyFromPredefinedSeries(recs int, preGeneratedSeriesLength uint64)
 	return retVal, nil
 }
 
+// Run the ingestion process.
 func runIngestion(iType IngestType, rdr utils.Generator, wg *sync.WaitGroup, url string, totalEvents int, continuous bool,
 	batchSize, processNo int, indexPrefix string, ctr *uint64, bearerToken string, indexName string, numIndices int,
 	eventsPerDayPerProcess int, totalBytes *uint64) {
@@ -311,6 +312,7 @@ func runIngestion(iType IngestType, rdr utils.Generator, wg *sync.WaitGroup, url
 	}
 }
 
+// Send performance data if the generator supports it.
 func SendPerformanceData(rdr utils.Generator) {
 	dynamicUserGen, isDUG := rdr.(*utils.DynamicUserGenerator)
 	if !isDUG || dynamicUserGen.DataConfig == nil {
@@ -319,6 +321,7 @@ func SendPerformanceData(rdr utils.Generator) {
 	dynamicUserGen.DataConfig.SendLog()
 }
 
+// Populate action lines for Elasticsearch Bulk API.
 func populateActionLines(idxPrefix string, indexName string, numIndices int) []string {
 	if numIndices == 0 {
 		log.Fatalf("number of indices cannot be zero!")
@@ -337,8 +340,8 @@ func populateActionLines(idxPrefix string, indexName string, numIndices int) []s
 	return actionLines
 }
 
-func getReaderFromArgs(iType IngestType, nummetrics int, gentype string, str string, ts bool, generatorDataConfig *utils.GeneratorDataConfig, processIndex int) (utils.Generator, error) {
-
+// Get the appropriate reader based on the generator type.
+func getReaderFromArgs(iType IngestType, nummetrics int, gentype string, str string, ts bool, generatorDataConfig *utils.GeneratorDataConfig, processIndex int, ksmOnly, nodeOnly, bothMetrics bool) (utils.Generator, error) {
 	if iType == OpenTSDB {
 		rdr, err := utils.InitMetricsGenerator(nummetrics, gentype)
 		if err != nil {
@@ -377,8 +380,8 @@ func getReaderFromArgs(iType IngestType, nummetrics int, gentype string, str str
 		rdr, err = utils.InitPerfTestGenerator(ts, seed, accFakerSeed, generatorDataConfig, processIndex)
 	case "k8s":
 		log.Infof("Initializing k8s reader")
-		seed := int64(1001)
-		rdr = utils.InitK8sGenerator(ts, seed)
+		seed := int64(1001 + processIndex)
+		rdr = InitK8sGenerator(seed, ksmOnly, nodeOnly, bothMetrics) // Pass flags to K8sGenerator
 	default:
 		return nil, fmt.Errorf("unsupported reader type %s. Options=[static,dynamic-user,file,benchmark]", gentype)
 	}
@@ -389,13 +392,16 @@ func getReaderFromArgs(iType IngestType, nummetrics int, gentype string, str str
 	return rdr, err
 }
 
+// Initialize the generator data configuration.
 func GetGeneratorDataConfig(maxColumns int, variableColums bool, minColumns int, uniqColumns int) *utils.GeneratorDataConfig {
 	return utils.InitGeneratorDataConfig(maxColumns, variableColums, minColumns, uniqColumns)
 }
 
+// Start the ingestion process.
 func StartIngestion(iType IngestType, generatorType, dataFile string, totalEvents int, continuous bool,
 	batchSize int, url string, indexPrefix string, indexName string, numIndices, processCount int, addTs bool,
-	nMetrics int, bearerToken string, cardinality uint64, eventsPerDay uint64, iDataGeneratorConfig interface{}) {
+	nMetrics int, bearerToken string, cardinality uint64, eventsPerDay uint64, iDataGeneratorConfig interface{},
+	ksmOnly, nodeOnly, bothMetrics bool) {
 	log.Printf("Starting ingestion at %+v for %+v", url, iType.String())
 	if iType == OpenTSDB {
 		err := generatePredefinedSeries(nMetrics, cardinality, generatorType)
@@ -424,7 +430,7 @@ func StartIngestion(iType IngestType, generatorType, dataFile string, totalEvent
 
 	readers := make([]utils.Generator, processCount)
 	for i := 0; i < processCount; i++ {
-		reader, err := getReaderFromArgs(iType, nMetrics, generatorType, dataFile, addTs, dataGeneratorConfig, i)
+		reader, err := getReaderFromArgs(iType, nMetrics, generatorType, dataFile, addTs, dataGeneratorConfig, i, ksmOnly, nodeOnly, bothMetrics)
 		if err != nil {
 			log.Fatalf("StartIngestion: failed to initalize reader! %+v", err)
 		}

--- a/tools/sigclient/pkg/ingest/k8s_generator.go
+++ b/tools/sigclient/pkg/ingest/k8s_generator.go
@@ -1,0 +1,250 @@
+package ingest
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+)
+
+type K8sGenerator struct {
+	faker         *gofakeit.Faker
+	metricCounter int
+	nodes         []string
+	namespaces    []string
+	pods          []podInfo
+	seed          int64
+	ksmOnly       bool
+	nodeOnly      bool
+	bothMetrics   bool
+}
+
+type podInfo struct {
+	name       string
+	namespace  string
+	node       string
+	phase      string
+	conditions map[string]bool
+}
+
+func InitK8sGenerator(seed int64, ksmOnly, nodeOnly, bothMetrics bool) *K8sGenerator {
+	g := &K8sGenerator{
+		seed:        seed,
+		ksmOnly:     ksmOnly,
+		nodeOnly:    nodeOnly,
+		bothMetrics: bothMetrics,
+		nodes:       []string{"node-01", "node-02", "node-03"},
+		namespaces: []string{
+			"default", "kube-system", "monitoring",
+			"prod-backend", "prod-database",
+		},
+	}
+
+	rand.Seed(seed)
+	g.faker = gofakeit.NewUnlocked(seed)
+	g.initializeClusterState()
+	return g
+}
+
+func (g *K8sGenerator) initializeClusterState() {
+	// Generate realistic cluster state
+	g.pods = make([]podInfo, 0)
+	for i := 0; i < 50; i++ {
+		g.pods = append(g.pods, podInfo{
+			name:      fmt.Sprintf("%s-%d", g.faker.AppName(), i),
+			namespace: g.namespaces[rand.Intn(len(g.namespaces))],
+			node:      g.nodes[rand.Intn(len(g.nodes))],
+			phase:     randomPodPhase(),
+			conditions: map[string]bool{
+				"Ready":          rand.Float32() < 0.8,
+				"MemoryPressure": rand.Float32() < 0.1,
+				"DiskPressure":   rand.Float32() < 0.05,
+			},
+		})
+	}
+}
+
+func (g *K8sGenerator) GetLogLine() ([]byte, error) {
+	raw, err := g.GetRawLog()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(raw)
+}
+
+func (g *K8sGenerator) GetRawLog() (map[string]interface{}, error) {
+	g.metricCounter++
+
+	if g.bothMetrics {
+		// Generate both KSM and node-exporter metrics
+		ksmMetric := g.generateKSMMetric()
+		nodeMetric := g.generateNodeExporterMetric()
+		return map[string]interface{}{
+			"ksm_metric":  ksmMetric,
+			"node_metric": nodeMetric,
+		}, nil
+	}
+
+	if g.ksmOnly {
+		return g.generateKSMMetric(), nil
+	}
+
+	if g.nodeOnly {
+		return g.generateNodeExporterMetric(), nil
+	}
+
+	// Default to alternating behavior if no flags are set
+	if g.metricCounter%2 == 0 {
+		return g.generateKSMMetric(), nil
+	}
+	return g.generateNodeExporterMetric(), nil
+}
+
+func (g *K8sGenerator) Init(...string) error { return nil }
+
+func (g *K8sGenerator) generateKSMMetric() map[string]interface{} {
+	metricType := rand.Intn(5)
+	pod := g.pods[rand.Intn(len(g.pods))]
+
+	switch metricType {
+	case 0: // kube_pod_info
+		return map[string]interface{}{
+			"metric": "kube_pod_info",
+			"value":  1,
+			"tags": map[string]string{
+				"pod":             pod.name,
+				"namespace":       pod.namespace,
+				"node":            pod.node,
+				"phase":           pod.phase,
+				"created_by_kind": "Deployment",
+				"created_by_name": fmt.Sprintf("%s-deployment", g.faker.AppName()),
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 1: // kube_node_status_condition
+		node := g.nodes[rand.Intn(len(g.nodes))]
+		return map[string]interface{}{
+			"metric": "kube_node_status_condition",
+			"value":  boolFloat(rand.Float32() < 0.95),
+			"tags": map[string]string{
+				"node":      node,
+				"condition": "Ready",
+				"status":    "true",
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 2: // kube_deployment_status_replicas
+		return map[string]interface{}{
+			"metric": "kube_deployment_status_replicas",
+			"value":  float64(rand.Intn(10) + 1),
+			"tags": map[string]string{
+				"namespace":  g.namespaces[rand.Intn(len(g.namespaces))],
+				"deployment": fmt.Sprintf("%s-deployment", g.faker.AppName()),
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 3: // kube_service_info
+		return map[string]interface{}{
+			"metric": "kube_service_info",
+			"value":  1,
+			"tags": map[string]string{
+				"namespace":  g.namespaces[rand.Intn(len(g.namespaces))],
+				"service":    fmt.Sprintf("%s-service", g.faker.AppName()),
+				"cluster_ip": g.faker.IPv4Address(),
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	default: // kube_namespace_labels
+		return map[string]interface{}{
+			"metric": "kube_namespace_labels",
+			"value":  1,
+			"tags": map[string]string{
+				"namespace": g.namespaces[rand.Intn(len(g.namespaces))],
+				"label_env": []string{"prod", "staging", "dev"}[rand.Intn(3)],
+			},
+			"timestamp": time.Now().Unix(),
+		}
+	}
+}
+
+func (g *K8sGenerator) generateNodeExporterMetric() map[string]interface{} {
+	metricType := rand.Intn(5)
+	node := g.nodes[rand.Intn(len(g.nodes))]
+
+	switch metricType {
+	case 0: // node_cpu_seconds_total
+		return map[string]interface{}{
+			"metric": "node_cpu_seconds_total",
+			"value":  g.faker.Float64Range(1000, 100000),
+			"tags": map[string]string{
+				"node": node,
+				"cpu":  fmt.Sprintf("%d", rand.Intn(8)),
+				"mode": []string{"user", "system", "iowait"}[rand.Intn(3)],
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 1: // node_memory_MemFree_bytes
+		return map[string]interface{}{
+			"metric": "node_memory_MemFree_bytes",
+			"value":  g.faker.Float64Range(1e9, 16e9),
+			"tags": map[string]string{
+				"node": node,
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 2: // node_filesystem_avail_bytes
+		return map[string]interface{}{
+			"metric": "node_filesystem_avail_bytes",
+			"value":  g.faker.Float64Range(100e9, 500e9),
+			"tags": map[string]string{
+				"node":   node,
+				"device": []string{"/dev/sda1", "/dev/nvme0n1p1"}[rand.Intn(2)],
+				"fstype": "ext4",
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	case 3: // node_network_up
+		return map[string]interface{}{
+			"metric": "node_network_up",
+			"value":  boolFloat(rand.Float32() < 0.99),
+			"tags": map[string]string{
+				"node":     node,
+				"device":   "eth0",
+				"instance": fmt.Sprintf("%s:9100", node),
+			},
+			"timestamp": time.Now().Unix(),
+		}
+
+	default: // node_disk_io_time_seconds_total
+		return map[string]interface{}{
+			"metric": "node_disk_io_time_seconds_total",
+			"value":  g.faker.Float64Range(1000, 50000),
+			"tags": map[string]string{
+				"node":   node,
+				"device": []string{"sda", "nvme0n1"}[rand.Intn(2)],
+			},
+			"timestamp": time.Now().Unix(),
+		}
+	}
+}
+
+func boolFloat(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}
+
+func randomPodPhase() string {
+	phases := []string{"Running", "Pending", "Succeeded", "Failed"}
+	return phases[rand.Intn(len(phases))]
+}

--- a/tools/sigclient/pkg/utils/metricsreader.go
+++ b/tools/sigclient/pkg/utils/metricsreader.go
@@ -38,7 +38,6 @@ type MetricsGenerator struct {
 }
 
 func InitMetricsGenerator(nmetrics int, gentype string) (*MetricsGenerator, error) {
-
 	multiTimestampsEnabled := false
 	seed := int64(fastrand.Uint32n(1_000))
 	switch gentype {
@@ -50,8 +49,12 @@ func InitMetricsGenerator(nmetrics int, gentype string) (*MetricsGenerator, erro
 		log.Infof("Initializing benchmark reader")
 		seed = int64(1001)
 		multiTimestampsEnabled = true
+	case "k8s":
+		log.Infof("Initializing k8s reader")
+		seed = int64(1001)
+		multiTimestampsEnabled = true
 	default:
-		return nil, fmt.Errorf("unsupported reader type %s. Options=[static,benchmark]", gentype)
+		return nil, fmt.Errorf("unsupported reader type %s. Options=[static,benchmark,k8s]", gentype)
 	}
 
 	return &MetricsGenerator{

--- a/tools/sigclient/pkg/utils/reader.go
+++ b/tools/sigclient/pkg/utils/reader.go
@@ -249,7 +249,7 @@ func InitFunctionalUserGenerator(ts bool, seed int64, accFakerSeed int64, dataCo
 	varFaker := gofakeit.NewUnlocked(int64(varFakerSeed))
 
 	if dataConfig.functionalTest == nil {
-		return nil, fmt.Errorf("Functional test config is nil")
+		return nil, fmt.Errorf("functional test config is nil")
 	}
 
 	functionalTest := &FunctionalTestConfig{
@@ -281,7 +281,7 @@ func InitFunctionalUserGenerator(ts bool, seed int64, accFakerSeed int64, dataCo
 
 func InitPerfTestGenerator(ts bool, seed int64, accFakerSeed int64, dataConfig *GeneratorDataConfig, processIndex int) (*DynamicUserGenerator, error) {
 	if dataConfig.perfTestConfig == nil {
-		return nil, fmt.Errorf("Perf test config is nil")
+		return nil, fmt.Errorf("perf test config is nil")
 	}
 	gen, err := InitFunctionalUserGenerator(ts, seed, accFakerSeed, dataConfig, processIndex)
 	if err != nil {


### PR DESCRIPTION
**Fixes**: #2181  

---

## Testing Approach  
To ensure the new **k8s generator** works as expected, I performed the following tests:  

### **Unit Testing**  
- Verified the `generateKSMMetric` and `generateNodeExporterMetric` methods to ensure:  
  - Metrics have the correct structure and tags.  
  - Expected values are correctly generated.  

### **Integration Testing**  
- Ran the `sigclient` tool with the `-g k8s` flag and validated that:  
  - The generated metrics were successfully ingested into the destination server.  
  - Various metric generation modes functioned correctly:  
    - **Kubernetes metrics only** (`--ksm`).  
    - **Node-exporter metrics only** (`--node`).  
    - **Both Kubernetes and node-exporter metrics** (`--both`).  

### **Manual Testing**  
Executed the following commands to validate functionality:  

```bash
# Generate only Kubernetes metrics
go run main.go ingest esbulk -g k8s --ksm -d http://localhost:8081/elastic -t 100 --indexName k8sOnly

# Generate only node-exporter metrics
go run main.go ingest esbulk -g k8s --node -d http://localhost:8081/elastic -t 100 --indexName nodeexporter

# Generate both Kubernetes and node-exporter metrics
go run main.go ingest esbulk -g k8s --both -d http://localhost:8081/elastic -t 100 --indexName both
