### PR TITLE
JS Cache Busting

### DIFF
--- a/RELEASE_README.md
+++ b/RELEASE_README.md
@@ -10,14 +10,13 @@ SigLens executable should support: `linux/arm64, linux/amd64, darwin/arm64, and 
 
 1. The version number in `develop` will have a suffix, for example: “0.1.29d”.
 2. When you are ready to do a release, remove the “d” suffix in the version number `SigLensVersion` located in `pkg/config/version.go`. ***This step is critical. Failure to increment this number will lead to failure in creating a GitHub release.***
-3. Update the `CSSVersion` function in the `startQueryServer` function (located in the `startup.go` file) to return the new version number. This ensures proper cache busting for CSS files.
-4. Create a pull request to merge these changes into `develop`. After merging, `develop` will now have the updated version number without the "d" suffix, for example: “0.1.29”.
-5. Add detailed release notes in the pull request describing the changes, enhancements, and bug fixes in this release.
-6. Merge develop to `main` using Create a Merge Commit. Do NOT Squash and Merge.
-7. GitHub Actions will take care of the following builds:
+3. Create a pull request to merge these changes into `develop`. After merging, `develop` will now have the updated version number without the "d" suffix, for example: “0.1.29”.
+4. Add detailed release notes in the pull request describing the changes, enhancements, and bug fixes in this release.
+5. Merge develop to `main` using Create a Merge Commit. Do NOT Squash and Merge.
+6. GitHub Actions will take care of the following builds:
    1. siglens docker image
       - `linux/amd64, linux/arm64`
       - The docker image build uses buildx to create an image index & the corresponding builds
-8. Once the release completes, increment the version number and CSS version number in `develop`. The version in the `develop` branch should include a suffix, for example: "0.1.30d" for differentiation.
+7. Once the release completes, increment the version number and CSS version number in `develop`. The version in the `develop` branch should include a suffix, for example: "0.1.30d" for differentiation.
 
 Note: The main branch will never have the "d" suffix in the version number. The "d" suffix is only for the develop branch to indicate a development version.

--- a/cmd/startup/startup.go
+++ b/cmd/startup/startup.go
@@ -396,7 +396,7 @@ func startQueryServer(serverAddr string) {
 					emptyHtmlContent := "This feature is available in Enterprise version"
 					return emptyHtmlContent
 				},
-				"CSSVersion": func() string {
+				"AppVersion": func() string {
 					return config.SigLensVersion
 				},
 			})

--- a/static/alert-details.html
+++ b/static/alert-details.html
@@ -79,12 +79,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <button class="btn" type="button" id="delete-alert">Delete</button>
                     </div>
                 </div>
-                <div id="properties-grid" class="ag-theme-mycustomtheme" style="height: 500px; width: 100%; padding-top: 20px;"></div>
+                <div id="properties-grid" class="ag-theme-mycustomtheme"
+                    style="height: 500px; width: 100%; padding-top: 20px;"></div>
                 <div id="history-search-container" style="display: none; margin-left: -5px;">
                     <div class="d-flex align-items-center">
-                        <input type="text" class="form-control" id="history-filter-input" placeholder="Search by Action or State" title="Search history" style="margin-right: 5px;">
+                        <input type="text" class="form-control" id="history-filter-input"
+                            placeholder="Search by Action or State" title="Search history" style="margin-right: 5px;">
                     </div>
-                </div>                       
+                </div>
                 <div id="history-grid" class="ag-theme-mycustomtheme"></div>
             </div>
         </div>
@@ -102,12 +104,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             2024 &copy; SigLens
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/alert-details.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/alert-details.js?cb={{ AppVersion }}"></script>
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}
 </body>

--- a/static/alert-details.html
+++ b/static/alert-details.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/alert.html
+++ b/static/alert.html
@@ -46,9 +46,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/tippy.css" />
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/metrics-explorer.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/metrics-explorer.css?cb={{ AppVersion }}" />
 
     <style>
         .metrics-graph-container{

--- a/static/alert.html
+++ b/static/alert.html
@@ -82,6 +82,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
     <script src="./js/lib/echarts.min.js"></script>
+    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <script src="./js/lib/chartjs-plugin-annotation.min.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -367,21 +370,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/contacts.js?cb=1_1_10"></script>
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./js/metrics-explorer.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/query-builder.js"></script>
-    <script src="./js/alert.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-charts.js"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
-    <script src="./js/lib/chartjs-plugin-annotation.min.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/contacts.js?cb={{ AppVersion }}"></script>
+    <script src="./js/metrics-explorer.js?cb={{ AppVersion }}"></script>
+    <script src="./js/search.js?cb={{ AppVersion }}"></script>
+    <script src="./js/index.js?cb={{ AppVersion }}"></script>
+    <script src="./js/query-builder.js?cb={{ AppVersion }}"></script>
+    <script src="./js/alert.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-charts.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/all-alerts.html
+++ b/static/all-alerts.html
@@ -163,12 +163,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/all-alerts.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/all-alerts.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/all-alerts.html
+++ b/static/all-alerts.html
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/all-slos.html
+++ b/static/all-slos.html
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
     {{ .SLOCss | safeHTML }}
 
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/all-slos.html
+++ b/static/all-slos.html
@@ -85,12 +85,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/all-slos.js"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/all-slos.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/application-version.html
+++ b/static/application-version.html
@@ -92,19 +92,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             2024 &copy; SigLens
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <!-- <script src="./js/cluster-stats.js"></script> -->
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/application-version.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/application-version.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/application-version.html
+++ b/static/application-version.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery.dataTables.min.css" />
     <link rel="stylesheet" href="./css/lib/scroller.dataTables.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -56,6 +56,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/jquery.dataTables.min.js"></script>
     <script src="./js/lib/dataTables.scroller.min.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
+
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -249,17 +251,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/cluster-stats.js"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/cluster-stats.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/contacts.html
+++ b/static/contacts.html
@@ -45,7 +45,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/contacts.html
+++ b/static/contacts.html
@@ -126,14 +126,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/contacts.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/contacts.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -48,10 +48,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/dashboard.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/metrics-explorer.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/dashboard.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/metrics-explorer.css?cb={{ AppVersion }}" />
     
     
     <script src="./js/lib/uuidv4.min.js"></script>

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -67,6 +67,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
     <script src="./js/lib/tippy-bundle.umd.min.js"></script>
     <script src="./js/lib/echarts.min.js"></script>
+    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -821,25 +822,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
         </div>
 
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields-dashboard.js"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-charts.js?cb=1_1_10"></script>
-    <script src="./js/dashboard.js?cb=1_1_10"></script>
-    <script src="./js/edit-panel-screen.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-logs-results-grid.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./component/dashboard/breadcrum.js"></script>
-    <script src="./js/metrics-explorer.js"></script>
-    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
-    <script src="./js/query-builder.js?cb=1_1_10"></script>
+    <script src="./js/lib/chart.umd.min.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/available-fields-dashboard.js?cb={{ AppVersion }}"></script>
+    <script src="./js/log-results-grid.js?cb={{ AppVersion }}"></script>
+    <script src="./js/ag-grid-seg-stats.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/index.js?cb={{ AppVersion }}"></script>
+    <script src="./js/search.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-charts.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard.js?cb={{ AppVersion }}"></script>
+    <script src="./js/edit-panel-screen.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-logs-results-grid.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/breadcrum.js?cb={{ AppVersion }}"></script>
+    <script src="./js/metrics-explorer.js?cb={{ AppVersion }}"></script>
+    <script src="./js/query-builder.js?cb={{ AppVersion }}"></script>
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/dashboards-home.html
+++ b/static/dashboards-home.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./component/dashboard/folders-dropdown.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./component/dashboard/folders-dropdown.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/dashboards-home.html
+++ b/static/dashboards-home.html
@@ -122,22 +122,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
 
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/dashboards-home.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-common.js"></script>
-    <script src="./component/dashboard/add-new.js"></script>
-    <script src="./component/dashboard/dashboard-grid.js"></script>
-    <script src="./component/dashboard/sort-dropdown.js"></script>
-    <script src="./component/dashboard/folders-dropdown.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboards-home.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-common.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/add-new.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/dashboard-grid.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/sort-dropdown.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/folders-dropdown.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/dependency-graph.html
+++ b/static/dependency-graph.html
@@ -127,12 +127,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/dependency-graph.js?cb=1_1_10"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dependency-graph.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/dependency-graph.html
+++ b/static/dependency-graph.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/diagnostics.html
+++ b/static/diagnostics.html
@@ -86,11 +86,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             2024 &copy; SigLens
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/diagnostics.js"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/diagnostics.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/diagnostics.html
+++ b/static/diagnostics.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/feedback.html
+++ b/static/feedback.html
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <meta charset="UTF-8">
     <title>SigLens</title>
 
-    <link href="./css/siglens.css?v={{ CSSVersion }}" rel="stylesheet" />
+    <link href="./css/siglens.css?cb={{ AppVersion }}" rel="stylesheet" />
 
     {{ .RunCheck1 | safeHTML }}
 </head>

--- a/static/folder.html
+++ b/static/folder.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./component/dashboard/folders-dropdown.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./component/dashboard/folders-dropdown.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/folder.html
+++ b/static/folder.html
@@ -144,18 +144,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-common.js"></script>
-    <script src="./js/folder.js"></script>
-    <script src="./component/dashboard/breadcrum.js"></script>
-    <script src="./component/dashboard/add-new.js"></script>
-    <script src="./component/dashboard/dashboard-grid.js"></script>
-    <script src="./component/dashboard/sort-dropdown.js"></script>
-    <script src="./component/dashboard/folders-dropdown.js"></script>
-
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/folder.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/breadcrum.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/add-new.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/dashboard-grid.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/sort-dropdown.js?cb={{ AppVersion }}"></script>
+    <script src="./component/dashboard/folders-dropdown.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/index.html
+++ b/static/index.html
@@ -61,6 +61,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/tippy-bundle.umd.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script src="./js/lib/echarts.min.js"></script>
+
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -455,22 +457,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/download-logs.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/log-search.js?cb=1_1_10"></script>
-    <script src="./js/dashboard-from-logs-metrics.js?cb=1_1_10"></script>
-    <script src="./js/query-builder.js"></script>
-    <script src="./js/pagination.js"></script>
-    <script src="./js/lib/echarts.min.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/available-fields.js?cb={{ AppVersion }}"></script>
+    <script src="./js/log-results-grid.js?cb={{ AppVersion }}"></script>
+    <script src="./js/ag-grid-seg-stats.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/search.js?cb={{ AppVersion }}"></script>
+    <script src="./js/saved-query.js?cb={{ AppVersion }}"></script>
+    <script src="./js/download-logs.js?cb={{ AppVersion }}"></script>
+    <script src="./js/index.js?cb={{ AppVersion }}"></script>
+    <script src="./js/log-search.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-from-logs-metrics.js?cb={{ AppVersion }}"></script>
+    <script src="./js/query-builder.js?cb={{ AppVersion }}"></script>
+    <script src="./js/pagination.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/index.html
+++ b/static/index.html
@@ -47,8 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/infrastructure.html
+++ b/static/infrastructure.html
@@ -47,8 +47,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/infrastructure.html
+++ b/static/infrastructure.html
@@ -95,11 +95,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
     <script>
         $(document).ready(function () {
             $('.theme-btn').on('click', themePickerHandler);

--- a/static/kubernetes-overview.html
+++ b/static/kubernetes-overview.html
@@ -61,6 +61,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/tippy-bundle.umd.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
+    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <script src="./js/lib/chartjs-plugin-annotation.min.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -143,19 +146,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
-    <script src="./js/lib/chartjs-plugin-annotation.min.js"></script>
-    <script src="./js/kubernetes-overview.js"></script>
-    <script src="./component/infrastructure/header-component.js"></script>
-    <script src="./component/infrastructure/big-number-card-component.js"></script>
-    <script src="./component/infrastructure/search-dropdown-component.js"></script>
-    <script src="./component/infrastructure/container-image-card-component.js"></script>
-    <script src="./component/infrastructure/usage-line-chart-component.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/kubernetes-overview.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/header-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/big-number-card-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/search-dropdown-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/container-image-card-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/usage-line-chart-component.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/kubernetes-overview.html
+++ b/static/kubernetes-overview.html
@@ -47,8 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/kubernetes-view.html
+++ b/static/kubernetes-view.html
@@ -112,16 +112,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/kubernetes-view.js"></script>
-    <script src="./component/infrastructure/header-component.js"></script>
-    <script src="./component/infrastructure/big-number-card-component.js"></script>
-    <script src="./component/infrastructure/search-dropdown-component.js"></script>
-    <script src="./component/infrastructure/configuration-page-component.js"></script>
-    <script src="./component/infrastructure/usage-indicator-component.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/kubernetes-view.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/header-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/big-number-card-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/search-dropdown-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/configuration-page-component.js?cb={{ AppVersion }}"></script>
+    <script src="./component/infrastructure/usage-indicator-component.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/kubernetes-view.html
+++ b/static/kubernetes-view.html
@@ -47,8 +47,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/jquery.tagsinput.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/lookups.html
+++ b/static/lookups.html
@@ -128,11 +128,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/lookups.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/lookups.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/lookups.html
+++ b/static/lookups.html
@@ -44,7 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/metric-cardinality.html
+++ b/static/metric-cardinality.html
@@ -145,11 +145,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
 
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/metrics-cardinality.js"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/metrics-cardinality.js?cb={{ AppVersion }}"></script>
+    
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}
 </body>

--- a/static/metric-cardinality.html
+++ b/static/metric-cardinality.html
@@ -33,9 +33,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css">
-    <link rel="stylesheet" href="./css/metrics-explorer.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/metrics-explorer.css?cb={{ AppVersion }}" />
     <style>
         #tagKeysGrid,
         #tagPairsGrid,

--- a/static/metric-summary.html
+++ b/static/metric-summary.html
@@ -23,16 +23,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <meta charset="UTF-8">
     <title>SigLens</title>
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-
-    <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
-    <link rel="stylesheet" href="./css/lib/all.min.css" />
-    <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css" />
-    <link rel="stylesheet" href="./css/tracing.css" />
     <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
     <meta name="msapplication-TileColor" content="#da532c">
+
+    <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
+    <link rel="stylesheet" href="./css/lib/all.min.css" />
+    <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/metric-summary.html
+++ b/static/metric-summary.html
@@ -132,12 +132,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </div>
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/metric-summary.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/ag-grid-seg-stats.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/metric-summary.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/metrics-explorer.html
+++ b/static/metrics-explorer.html
@@ -45,9 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/tippy.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/metrics-explorer.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/metrics-explorer.css?cb={{ AppVersion }}" />
     <style>
         #ui-id-1.ui-widget.ui-widget-content,
         #ui-id-2.ui-widget.ui-widget-content,

--- a/static/metrics-explorer.html
+++ b/static/metrics-explorer.html
@@ -77,6 +77,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/tippy-bundle.umd.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script src="./js/lib/uuidv4.min.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
+    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -255,17 +258,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./js/metrics-explorer.js"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/lib/chartjs-adapter-date-fns.bundle.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
-    <script src="./js/dashboard-from-logs-metrics.js?cb=1_1_10"></script>
-
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/metrics-explorer.js?cb={{ AppVersion }}"></script>
+    <script src="./js/saved-query.js?cb={{ AppVersion }}"></script>
+    <script src="./js/dashboard-from-logs-metrics.js?cb={{ AppVersion }}"></script>
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/metrics-ingestion.html
+++ b/static/metrics-ingestion.html
@@ -113,17 +113,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/test-data.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/test-data.js?cb={{ AppVersion }}"></script>    
     
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/metrics-ingestion.html
+++ b/static/metrics-ingestion.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
     
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/minion-searches.html
+++ b/static/minion-searches.html
@@ -111,10 +111,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/minion-searches.js?cb=1_1_10"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/minion-searches.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/minion-searches.html
+++ b/static/minion-searches.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/org-settings.html
+++ b/static/org-settings.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/org-settings.html
+++ b/static/org-settings.html
@@ -149,18 +149,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/settings.js?cb=1_1_10"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/settings.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/pqs-settings.html
+++ b/static/pqs-settings.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/pqs-settings.html
+++ b/static/pqs-settings.html
@@ -157,11 +157,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/pqs-settings.js?cb=1_1_10"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/pqs-settings.js?cb={{ AppVersion }}"></script>
+    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/query-stats.html
+++ b/static/query-stats.html
@@ -116,11 +116,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-    <script src="./js/query-stats.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/query-stats.js?cb={{ AppVersion }}"></script>
+    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/query-stats.html
+++ b/static/query-stats.html
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/saved-queries.html
+++ b/static/saved-queries.html
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/saved-queries.html
+++ b/static/saved-queries.html
@@ -91,15 +91,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
     </div>
 
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/saved-queries.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/saved-query.js?cb={{ AppVersion }}"></script>
+    <script src="./js/saved-queries.js?cb={{ AppVersion }}"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}
 </body>

--- a/static/search-traces.html
+++ b/static/search-traces.html
@@ -60,6 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/popper.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
+    <script src="./js/lib/echarts.min.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
         $('html').attr('data-theme', defaultTheme);
@@ -149,16 +150,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/search-traces.js?cb=1_1_10"></script>
-    <script src="./component/single-box/single-box.js"></script>
-    <script src="./component/download/download.js"></script>
-    <script src="./component/time-picker/time-picker.js"></script>
-    <script src="./js/lib/echarts.min.js"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/search-traces.js?cb={{ AppVersion }}"></script>
+    <script src="./component/single-box/single-box.js?cb={{ AppVersion }}"></script>
+    <script src="./component/download/download.js?cb={{ AppVersion }}"></script>
+    <script src="./component/time-picker/time-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/search-traces.html
+++ b/static/search-traces.html
@@ -44,11 +44,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./component/single-box/single-box.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./component/download/download.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./component/single-box/single-box.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./component/download/download.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/service-health-overview.html
+++ b/static/service-health-overview.html
@@ -40,8 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/service-health-overview.html
+++ b/static/service-health-overview.html
@@ -43,7 +43,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
     <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
 
-    <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>
     <script src="./js/lib/jquery-ui.min.js"></script>
@@ -52,6 +51,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <script src="./js/lib/date_fns.min.js"></script>
     <script src="./js/lib/popper.min.js"></script>
     <script src="./js/lib/bootstrap.bundle.min.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
     <script src="./js/lib/ag-grid-community.min.noStyle.js"></script>
     <script>
         var defaultTheme = Cookies.get('theme') || 'light';
@@ -157,12 +157,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/lib/chart.umd.min.js"></script>
-    <script src="./js/service-health-overview.js?cb=1_1_10"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/service-health-overview.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/service-health.html
+++ b/static/service-health.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/service-health.html
+++ b/static/service-health.html
@@ -137,13 +137,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/service-health.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./component/upper-navbar/upper-navbar.js"></script>
-
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/service-health.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./component/upper-navbar/upper-navbar.js?cb={{ AppVersion }}"></script>
+    
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}
 </body>

--- a/static/test-data.html
+++ b/static/test-data.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
 
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>

--- a/static/test-data.html
+++ b/static/test-data.html
@@ -127,17 +127,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         2024 &copy; SigLens
     </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/test-data.js"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/test-data.js?cb={{ AppVersion }}"></script>
+    
     
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/trace.html
+++ b/static/trace.html
@@ -40,8 +40,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/tracing.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/tracing.css?cb={{ AppVersion }}" />
 
     <script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
     <script src="./js/lib/lodash.min.js"></script>

--- a/static/trace.html
+++ b/static/trace.html
@@ -87,11 +87,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     </div>
 
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/trace.js?cb=1_1_10"></script>
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/trace.js?cb={{ AppVersion }}"></script>    
 
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}

--- a/static/traces-ingestion.html
+++ b/static/traces-ingestion.html
@@ -163,18 +163,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             2024 &copy; SigLens
         </div>
     </div>
-    <script src="./js/navbar.js?cb=1_1_10"></script>
-    <script src="./js/common.js?cb=1_1_10"></script>
-    <script src="./js/event-handlers.js?cb=1_1_10"></script>
-    <script src="./js/available-fields.js?cb=1_1_10"></script>
-    <script src="./js/log-results-grid.js?cb=1_1_10"></script>
-    <script src="./js/ag-grid-seg-stats.js?cb=1_1_10"></script>
-    <script src="./js/date-picker.js?cb=1_1_10"></script>
-    <script src="./js/search.js?cb=1_1_10"></script>
-    <script src="./js/saved-query.js?cb=1_1_10"></script>
-    <script src="./js/index.js?cb=1_1_10"></script>
-    <script src="./js/test-data.js"></script>
-
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/test-data.js?cb={{ AppVersion }}"></script>
+    
     {{ .RunCheck2 | safeHTML }}
     {{ .RunCheck3 | safeHTML }}
 </body>

--- a/static/traces-ingestion.html
+++ b/static/traces-ingestion.html
@@ -44,8 +44,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="./css/lib/all.min.css" />
     <link rel="stylesheet" href="./css/lib/ag-grid.min.css" />
     <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./css/siglens.css?v={{ CSSVersion }}" />
-    <link rel="stylesheet" href="./css/query-builder.css?v={{ CSSVersion }}" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
     
     <script src="./js/lib/lodash.min.js"></script>
     <script src="./js/lib/jquery-3.6.0.min.js"></script>


### PR DESCRIPTION
# Description
1. Updated script includes to use `cb={{ AppVersion }}` for cache busting instead of hardcoded values.
2. Standardized CSS versioning by replacing `v={{ CSSVersion }}` with `cb={{ AppVersion }}`, ensuring both scripts and styles follow the same format.
3. Updated the release README to remove the manual update step for `CSSVersion`, as it is now derived directly from `version.go`.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
