### PR TITLE
fix: promql response format for Instant queries

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -185,7 +185,7 @@ func ProcessPromqlMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid int64) {
 		utils.SendError(ctx, "Error parsing promql query", fmt.Sprintf("qid=%v, Metrics Query: %+v", qid, searchText), err)
 		return
 	}
-	if len(metricQueryRequest) == 0 {
+	if len(metricQueryRequest) == 0 && len(queryArithmetic) == 0 {
 		ctx.SetContentType(ContentJson)
 		WriteJsonResponse(ctx, map[string]interface{}{})
 		return
@@ -203,7 +203,7 @@ func ProcessPromqlMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid int64) {
 	segment.LogMetricsQueryOps("PromQL metrics query parser: Ops: ", queryArithmetic, qid)
 	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryArithmetic, timeRange, qid, false)
 
-	mQResponse, err := res.GetResultsPromQl(&metricQueryRequest[0].MetricsQuery, pqlQuerytype)
+	mQResponse, err := res.GetResultsPromQlInstantQuery(pqlQuerytype, endTime)
 	if err != nil {
 		utils.SendError(ctx, "Failed to get results", fmt.Sprintf("Query: %s", searchText), err)
 		return

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -547,7 +547,7 @@ func getPromQLSeriesFormat(seriesId string) *structs.Result {
 		if idx == 0 {
 			keyValue = strings.SplitN(removeMetricNameFromGroupID(val), ":", 2)
 		} else {
-			keyValue = strings.Split(val, ":")
+			keyValue = strings.SplitN(val, ":", 2)
 		}
 
 		if len(keyValue) > 1 {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -34,6 +34,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	segutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/valyala/bytebufferpool"
 )
 
@@ -535,6 +536,93 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 	return retVal, nil
 }
 
+func getPromQLSeriesFormat(seriesId string) *structs.Result {
+	tagValues := strings.Split(removeTrailingComma(seriesId), tsidtracker.TAG_VALUE_DELIMITER_STR)
+
+	var result structs.Result
+	var keyValue []string
+	result.Metric = make(map[string]string)
+	result.Metric["__name__"] = ExtractMetricNameFromGroupID(seriesId)
+	for idx, val := range tagValues {
+		if idx == 0 {
+			keyValue = strings.SplitN(removeMetricNameFromGroupID(val), ":", 2)
+		} else {
+			keyValue = strings.Split(val, ":")
+		}
+
+		if len(keyValue) > 1 {
+			result.Metric[keyValue[0]] = keyValue[1]
+		}
+	}
+
+	return &result
+}
+
+func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueType, timestamp uint32) (*structs.MetricsQueryResponsePromQl, error) {
+	var pqlData structs.Data
+
+	switch pqlQueryType {
+	case parser.ValueTypeScalar:
+		pqlData.ResultType = pqlQueryType
+		pqlData.Result = make([]structs.Result, 1)
+		pqlData.Result[0] = structs.Result{
+			Metric: map[string]string{},
+			Value:  []interface{}{timestamp, fmt.Sprintf("%v", r.ScalarValue)},
+		}
+	case parser.ValueTypeString:
+		// TODO: Implement this
+		return nil, errors.New("GetResultsPromQlInstantQuery: ValueTypeString is not supported")
+	case parser.ValueTypeVector:
+		pqlData.ResultType = pqlQueryType
+		for seriesId, results := range r.Results {
+			if len(results) == 0 {
+				continue
+			}
+
+			result := getPromQLSeriesFormat(seriesId)
+
+			floatValue, ok := results[timestamp]
+			if ok {
+				result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
+				pqlData.Result = append(pqlData.Result, *result)
+				continue
+			}
+
+			// TODO: Inspect on whether we should ensure that the timestamp is present in the results?
+
+			// In the case where the timestamp is not present in the results
+			if len(results) > 2 {
+				// If the results have more than 2 timestamps, this should not happen.
+				// As the startTime = timestamp - 1 and endTime = timestamp, and intervalSeconds = 1
+				// So, the results should have only 2 timestamps
+				log.Errorf("GetResultsPromQlInstantQuery: More than 2 timestamps found in the results for seriesId: %v", seriesId)
+				return nil, errors.New("error in fetching the results. Multiple timestamps found in the results")
+			}
+
+			maxTimestamp := uint32(0)
+			floatValue = 0
+			for ts, val := range results {
+				if ts > maxTimestamp {
+					maxTimestamp = ts
+					floatValue = val
+				}
+			}
+
+			result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
+			pqlData.Result = append(pqlData.Result, *result)
+		}
+	case parser.ValueTypeMatrix:
+		return nil, errors.New("ValueTypeMatrix is not supported for Instant Queries")
+	default:
+		return nil, fmt.Errorf("GetResultsPromQlInstantQuery: Unsupported PromQL query result type: %v", pqlQueryType)
+	}
+
+	return &structs.MetricsQueryResponsePromQl{
+		Status: "success",
+		Data:   pqlData,
+	}, nil
+}
+
 func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQuerytype parser.ValueType) (*structs.MetricsQueryResponsePromQl, error) {
 	if r.State != AGGREGATED {
 		return nil, fmt.Errorf("GetResultsPromQl: results is not in aggregated state, state: %v", r.State)
@@ -543,29 +631,14 @@ func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQueryt
 
 	switch pqlQuerytype {
 	case parser.ValueTypeVector, parser.ValueTypeMatrix:
-		pqldata.ResultType = parser.ValueType("vector")
-		for grpId, results := range r.Results {
+		pqldata.ResultType = parser.ValueType("matrix")
+		for seriesId, results := range r.Results {
+			result := getPromQLSeriesFormat(seriesId)
 
-			tagValues := strings.Split(removeTrailingComma(grpId), tsidtracker.TAG_VALUE_DELIMITER_STR)
-
-			var result structs.Result
-			var keyValue []string
-			result.Metric = make(map[string]string)
-			result.Metric["__name__"] = ExtractMetricNameFromGroupID(grpId)
-			for idx, val := range tagValues {
-				if idx == 0 {
-					keyValue = strings.Split(removeMetricNameFromGroupID(val), ":")
-				} else {
-					keyValue = strings.Split(val, ":")
-				}
-				if len(keyValue) > 1 {
-					result.Metric[keyValue[0]] = keyValue[1]
-				}
-			}
 			for k, v := range results {
 				result.Value = append(result.Value, []interface{}{int64(k), fmt.Sprintf("%v", v)})
 			}
-			pqldata.Result = append(pqldata.Result, result)
+			pqldata.Result = append(pqldata.Result, *result)
 		}
 	default:
 		return nil, fmt.Errorf("GetResultsPromQl: Unsupported PromQL query result type: %v", pqlQuerytype)

--- a/pkg/utils/dateutils.go
+++ b/pkg/utils/dateutils.go
@@ -189,7 +189,10 @@ func ParseTimeForPromQL(timeParam string) (uint32, error) {
 	// Try to parse as float (Unix timestamp)
 	parsedFloat, err := strconv.ParseFloat(timeParam, 64)
 	if err == nil {
-		return uint32(math.Round(parsedFloat)), nil
+		// If the value is a float, we will floor it to the nearest integer
+		// This is because our timestamps are in seconds. So during ingestion, even if the timestamp
+		// for example is given 1741106611.65, we would store it as 1741106611
+		return uint32(math.Floor(parsedFloat)), nil
 	}
 
 	// Try to parse as RFC3339 timestamp


### PR DESCRIPTION
# Description
- Fixed the response for promql instant query API

# Testing
- Tested by verifying the results from Prometheus response and SigLens response

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
