### PR TITLE
Add support for PromQL without Aggregation operator

### DIFF
--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1551,7 +1551,6 @@ func Test_SimpleMetricQueryGroupByWithout(t *testing.T) {
 
 	res := segment.ExecuteMetricsQuery(&metricQueryRequest[0].MetricsQuery, &metricQueryRequest[0].TimeRange, 0)
 	assert.NotNil(t, res)
-	fmt.Println(res)
 	assert.Equal(t, 2, len(res.Results))
 
 	for seriesId, seriesDp := range res.Results {

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1514,6 +1514,70 @@ func Test_SimpleMetricQuery_Regex_on_TagFilters_Plus_Filter_Plus_GroupByTag_v1(t
 	}
 }
 
+func Test_SimpleMetricQueryGroupByWithout(t *testing.T) {
+	defer cleanUp(t)
+	go query.PullQueriesToRun()
+
+	startTimestamp := dataStartTimestamp
+	allTimeSeries, _, _, _ := GetTestMetricsData(startTimestamp)
+
+	err := initTestConfig(t)
+	assert.Nil(t, err)
+
+	err = ingestTestMetricsData(allTimeSeries)
+	assert.Nil(t, err)
+
+	mSegs, err := rotateMetricsDataAndClearSegStore(true)
+	assert.Nil(t, err)
+	assert.Greater(t, len(mSegs), 0)
+
+	err = initializeMetricsMetaData()
+	assert.Nil(t, err)
+
+	timeRange := &dtypeutils.MetricsTimeRange{
+		StartEpochSec: uint32(startTimestamp),
+		EndEpochSec:   uint32(startTimestamp + 4600),
+	}
+
+	query := `sum without (shape, radius) (testmetric0)`
+	metricQueryRequest, _, _, err := promql.ConvertPromQLToMetricsQuery(query, timeRange.StartEpochSec, timeRange.EndEpochSec, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(metricQueryRequest))
+
+	expectedResults := map[string][]float64{
+		"testmetric0{color:red,size:small,type:solid": {10, 50, 60, 70},
+		"testmetric0{color:red,type:solid":            {40},
+	}
+
+	res := segment.ExecuteMetricsQuery(&metricQueryRequest[0].MetricsQuery, &metricQueryRequest[0].TimeRange, 0)
+	assert.NotNil(t, res)
+	fmt.Println(res)
+	assert.Equal(t, 2, len(res.Results))
+
+	for seriesId, seriesDp := range res.Results {
+		seriesId := mresults.RemoveTrailingComma(seriesId)
+		expectedSeriesDpValues, ok := expectedResults[seriesId]
+		assert.True(t, ok, "SeriesId: ", seriesId)
+
+		seriesDpStructSlice := make([]*seriesDataPoint, 0)
+		for ts, dp := range seriesDp {
+			seriesDpStructSlice = append(seriesDpStructSlice, &seriesDataPoint{ts: ts, val: dp})
+		}
+
+		sort.Slice(seriesDpStructSlice, func(i, j int) bool {
+			return seriesDpStructSlice[i].ts < seriesDpStructSlice[j].ts
+		})
+
+		seriesDpValues := make([]float64, 0)
+		for _, dp := range seriesDpStructSlice {
+			seriesDpValues = append(seriesDpValues, dp.val)
+		}
+
+		assert.EqualValues(t, expectedSeriesDpValues, seriesDpValues)
+	}
+
+}
+
 func Test_metricsPersistAfterGracefulRestart(t *testing.T) {
 	testDir := t.TempDir()
 	dataDir := filepath.Join(testDir, "data")

--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -354,7 +354,7 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 			set[group] = struct{}{}
 		}
 
-		mQuery.FirstAggregator.WithoutFieldsSet = set
+		mQuery.FirstAggregator.GroupByFieldsSet = set
 		mQuery.SelectAllSeries = true
 		mQuery.GetAllLabels = true
 	}

--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -341,6 +341,24 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 	// And this group by Aggregation should not be done on the initial Aggregation.
 	hasAggExpr := hasNestedAggregateExpr(expr.Expr)
 
+	if len(expr.Grouping) > 0 {
+		mQuery.Groupby = true
+	}
+
+	mQuery.FirstAggregator.GroupByFields = sort.StringSlice(expr.Grouping)
+	mQuery.FirstAggregator.Without = expr.Without
+
+	if expr.Without {
+		set := map[string]struct{}{}
+		for _, group := range expr.Grouping {
+			set[group] = struct{}{}
+		}
+
+		mQuery.FirstAggregator.WithoutFieldsSet = set
+		mQuery.SelectAllSeries = true
+		mQuery.GetAllLabels = true
+	}
+
 	// Handle grouping
 	for _, group := range expr.Grouping {
 		if group == "__name__" {
@@ -354,14 +372,11 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 			TagOperator:     segutils.TagOperator(segutils.Equal),
 			LogicalOperator: segutils.And,
 			NotInitialGroup: hasAggExpr,
+			IgnoreTag:       expr.Without,
+			IsGroupByKey:    true,
 		}
 		mQuery.TagsFilters = append(mQuery.TagsFilters, &tagFilter)
 	}
-	if len(expr.Grouping) > 0 {
-		mQuery.Groupby = true
-	}
-
-	mQuery.FirstAggregator.GroupByFields = sort.StringSlice(expr.Grouping)
 
 	mQueryAgg := &structs.MetricQueryAgg{
 		AggBlockType:    structs.AggregatorBlock,
@@ -450,7 +465,17 @@ func handleCallExprMatrixSelectorNode(expr *parser.Call, mQueryReq *structs.Metr
 
 	mQuery := &mQueryReq.MetricsQuery
 
-	if mQuery.TagsFilters != nil {
+	if len(mQuery.TagsFilters) > 0 {
+		if mQuery.Groupby {
+			// If group by is already set, then the tagFilters that are added because of the group by should not be initial group
+			// As this grouping affects this range function group by
+			for _, tag := range mQuery.TagsFilters {
+				if tag.IsGroupByKey {
+					tag.NotInitialGroup = true
+				}
+			}
+		}
+
 		mQuery.Groupby = true
 	}
 

--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -349,12 +349,6 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 	mQuery.FirstAggregator.Without = expr.Without
 
 	if expr.Without {
-		set := map[string]struct{}{}
-		for _, group := range expr.Grouping {
-			set[group] = struct{}{}
-		}
-
-		mQuery.FirstAggregator.GroupByFieldsSet = set
 		mQuery.SelectAllSeries = true
 		mQuery.GetAllLabels = true
 	}

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -1267,7 +1267,7 @@ func Test_parsePromQLQuery_Without(t *testing.T) {
 	assert.Equal(t, 1, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFields))
 	assert.Equal(t, "instance", mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFields[0])
 	assert.True(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.Without)
-	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.WithoutFieldsSet)
+	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFieldsSet)
 
 	tagFilters := mQueryReqs[0].MetricsQuery.TagsFilters
 	assert.Equal(t, 1, len(tagFilters))
@@ -1307,7 +1307,7 @@ func Test_parsePromQLQuery_Without(t *testing.T) {
 	assert.Equal(t, 1, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields))
 	assert.Equal(t, "instance", mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields[0])
 	assert.True(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.Without)
-	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.WithoutFieldsSet)
+	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFieldsSet)
 
 	tagFilters = mQueryReqs[0].MetricsQuery.TagsFilters
 	assert.Equal(t, 2, len(tagFilters))

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -1267,7 +1267,6 @@ func Test_parsePromQLQuery_Without(t *testing.T) {
 	assert.Equal(t, 1, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFields))
 	assert.Equal(t, "instance", mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFields[0])
 	assert.True(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.Without)
-	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.GroupByFieldsSet)
 
 	tagFilters := mQueryReqs[0].MetricsQuery.TagsFilters
 	assert.Equal(t, 1, len(tagFilters))
@@ -1307,7 +1306,6 @@ func Test_parsePromQLQuery_Without(t *testing.T) {
 	assert.Equal(t, 1, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields))
 	assert.Equal(t, "instance", mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields[0])
 	assert.True(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.Without)
-	assert.Equal(t, map[string]struct{}{"instance": {}}, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFieldsSet)
 
 	tagFilters = mQueryReqs[0].MetricsQuery.TagsFilters
 	assert.Equal(t, 2, len(tagFilters))

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -990,11 +990,11 @@ func Test_parsePromQLQuery_NestedQueries_NestedGroupBy_v1(t *testing.T) {
 		actualTagKeys = append(actualTagKeys, tag.TagKey)
 		if tag.TagKey == "job" {
 			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, false, tag.NotInitialGroup)
+			assert.Equal(t, true, tag.NotInitialGroup)
 		}
 		if tag.TagKey == "handler" {
 			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, false, tag.NotInitialGroup)
+			assert.Equal(t, true, tag.NotInitialGroup)
 		}
 		if tag.TagKey == "proc" {
 			assert.Equal(t, "*", tag.RawTagValue)

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -120,9 +120,18 @@ func ApplyMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTimeR
 	}
 
 	if mQuery.SelectAllSeries {
+		filteredTags := make([]*structs.TagsFilter, 0, len(allTagKeys))
 		for _, v := range mQuery.TagsFilters {
 			delete(allTagKeys, v.TagKey)
+			if v.IgnoreTag && !v.NotInitialGroup {
+				continue
+			}
+
+			filteredTags = append(filteredTags, v)
 		}
+
+		mQuery.TagsFilters = filteredTags
+
 		for tkey, present := range allTagKeys {
 			if present {
 				mQuery.TagsFilters = append(mQuery.TagsFilters, &structs.TagsFilter{

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -558,7 +558,7 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 
 	for grpId, results := range r.Results {
 		tags := make(map[string]string)
-		tagValues := strings.Split(removeTrailingComma(grpId), tsidtracker.TAG_VALUE_DELIMITER_STR)
+		tagValues := strings.Split(RemoveTrailingComma(grpId), tsidtracker.TAG_VALUE_DELIMITER_STR)
 		if len(tagKeys) != len(tagValues) {
 			err := fmt.Errorf("GetResults: the length of tag key and tag value pair must match. Tag Key: %v; Tag Value: %v", tagKeys, tagValues)
 			return nil, err
@@ -579,7 +579,7 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 }
 
 func getPromQLSeriesFormat(seriesId string) *structs.Result {
-	tagValues := strings.Split(removeTrailingComma(seriesId), tsidtracker.TAG_VALUE_DELIMITER_STR)
+	tagValues := strings.Split(RemoveTrailingComma(seriesId), tsidtracker.TAG_VALUE_DELIMITER_STR)
 
 	var result structs.Result
 	var keyValue []string
@@ -822,7 +822,7 @@ func (r *MetricsResult) GetResultsPromQlForUi(mQuery *structs.MetricsQuery, pqlQ
 	return httpResp, nil
 }
 
-func removeTrailingComma(s string) string {
+func RemoveTrailingComma(s string) string {
 	return strings.TrimSuffix(s, ",")
 }
 
@@ -880,7 +880,7 @@ func (r *MetricsResult) FetchPromqlMetricsForUi(mQuery *structs.MetricsQuery, pq
 
 	for grpId, results := range r.Results {
 		groupId := grpId
-		groupId = removeTrailingComma(groupId)
+		groupId = RemoveTrailingComma(groupId)
 		groupId += "}"
 		httpResp.Series = append(httpResp.Series, groupId)
 

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -334,7 +334,7 @@ func getAggSeriesId(seriesId string, aggregation *structs.Aggregation) string {
 	}
 
 	if aggregation.Without {
-		return GetSeriesIdWithoutFields(seriesId, aggregation.WithoutFieldsSet)
+		return GetSeriesIdWithoutFields(seriesId, aggregation.GroupByFieldsSet)
 	}
 
 	metricName := ExtractMetricNameFromGroupID(seriesId)

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -290,9 +290,14 @@ func ExtractGroupByFieldsFromSeriesId(seriesId string, groupByFields []string) (
 	return groupKeyValuePairs, values
 }
 
-func GetSeriesIdWithoutFields(seriesId string, fieldsSet map[string]struct{}) string {
-	if len(fieldsSet) == 0 {
+func GetSeriesIdWithoutFields(seriesId string, fields []string) string {
+	if len(fields) == 0 {
 		return seriesId
+	}
+
+	fieldsSet := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		fieldsSet[field] = struct{}{}
 	}
 
 	parts := strings.Split(seriesId, ",")
@@ -334,7 +339,7 @@ func getAggSeriesId(seriesId string, aggregation *structs.Aggregation) string {
 	}
 
 	if aggregation.Without {
-		return GetSeriesIdWithoutFields(seriesId, aggregation.GroupByFieldsSet)
+		return GetSeriesIdWithoutFields(seriesId, aggregation.GroupByFields)
 	}
 
 	metricName := ExtractMetricNameFromGroupID(seriesId)

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -30,12 +30,16 @@ func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
 	seriesId := "test{tk1:v1,tk2:v2"
 	groupByFields := []string{"tk1", "tk2"}
 
-	aggSeriesId := getAggSeriesId(seriesId, groupByFields)
+	aggregation := &structs.Aggregation{
+		GroupByFields: groupByFields,
+	}
+
+	aggSeriesId := getAggSeriesId(seriesId, aggregation)
 	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
 
 	// trailing comma
 	seriesId = "test{tk1:v1,tk2:v2,"
-	aggSeriesId = getAggSeriesId(seriesId, groupByFields)
+	aggSeriesId = getAggSeriesId(seriesId, aggregation)
 	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
 }
 
@@ -50,15 +54,44 @@ func Test_getAggSeriesId_SeriesWithGroupByAndNoGroupByFields(t *testing.T) {
 	seriesId := "test{tk1:v1,tk2:v2"
 	groupByFields := make([]string, 0)
 
-	aggSeriesId := getAggSeriesId(seriesId, groupByFields)
+	aggregation := &structs.Aggregation{
+		GroupByFields: groupByFields,
+	}
+
+	aggSeriesId := getAggSeriesId(seriesId, aggregation)
 	assert.Equal(t, "test{", aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupByAndEmptyGroupByFields(t *testing.T) {
 	seriesId := "test{"
 
-	aggSeriesId := getAggSeriesId(seriesId, make([]string, 0))
+	aggregation := &structs.Aggregation{
+		GroupByFields: []string{},
+	}
+
+	aggSeriesId := getAggSeriesId(seriesId, aggregation)
 	assert.Equal(t, "test{", aggSeriesId)
+}
+
+func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
+	seriesId := "test{tk1:v1,tk2:v2,tk3:v3,tk4:v4,tk5:v5"
+
+	aggregation := &structs.Aggregation{
+		Without: true,
+		WithoutFieldsSet: map[string]struct{}{
+			"tk1": {},
+			"tk3": {},
+			"tk5": {},
+		},
+	}
+
+	aggSeriesId := getAggSeriesId(seriesId, aggregation)
+	assert.Equal(t, "test{tk2:v2,tk4:v4", aggSeriesId)
+
+	// value has `:` in it
+	seriesId = "test{tk1:v1:1,tk2:v2,tk3:v3:3,tk4:v4,tk5:v5:5"
+	aggSeriesId = getAggSeriesId(seriesId, aggregation)
+	assert.Equal(t, "test{tk2:v2,tk4:v4", aggSeriesId)
 }
 
 func Test_ApplyAggregationToResults_NoGroupBy_Single_Series(t *testing.T) {

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -78,10 +78,10 @@ func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
 
 	aggregation := &structs.Aggregation{
 		Without: true,
-		GroupByFieldsSet: map[string]struct{}{
-			"tk1": {},
-			"tk3": {},
-			"tk5": {},
+		GroupByFields: []string{
+			"tk1",
+			"tk3",
+			"tk5",
 		},
 	}
 

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -78,7 +78,7 @@ func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
 
 	aggregation := &structs.Aggregation{
 		Without: true,
-		WithoutFieldsSet: map[string]struct{}{
+		GroupByFieldsSet: map[string]struct{}{
 			"tk1": {},
 			"tk3": {},
 			"tk5": {},

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -86,7 +86,7 @@ type Aggregation struct {
 	FuncConstant       float64
 	GroupByFields      []string            // group by fields will be sorted
 	Without            bool                // if set exclude the above group by fields
-	WithoutFieldsSet   map[string]struct{} // set of fields to exclude; only used when Without is set
+	GroupByFieldsSet   map[string]struct{} // same as GroupByFields, but it is a map; only used or set when Without is set
 }
 
 type MetricsFunctionType uint8

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -86,9 +86,8 @@ type MetricsQuery struct {
 type Aggregation struct {
 	AggregatorFunction utils.AggregateFunctions //aggregator function
 	FuncConstant       float64
-	GroupByFields      []string            // group by fields will be sorted
-	Without            bool                // if set exclude the above group by fields
-	GroupByFieldsSet   map[string]struct{} // same as GroupByFields, but it is a map; only used or set when Without is set
+	GroupByFields      []string // group by fields will be sorted
+	Without            bool     // if set exclude the above group by fields
 }
 
 type MetricsFunctionType uint8

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -84,7 +84,9 @@ type MetricsQuery struct {
 type Aggregation struct {
 	AggregatorFunction utils.AggregateFunctions //aggregator function
 	FuncConstant       float64
-	GroupByFields      []string // group by fields will be sorted
+	GroupByFields      []string            // group by fields will be sorted
+	Without            bool                // if set exclude the above group by fields
+	WithoutFieldsSet   map[string]struct{} // set of fields to exclude; only used when Without is set
 }
 
 type MetricsFunctionType uint8
@@ -163,6 +165,8 @@ type TagsFilter struct {
 	TagOperator     utils.TagOperator
 	LogicalOperator utils.LogicalOperator
 	NotInitialGroup bool
+	IgnoreTag       bool
+	IsGroupByKey    bool
 }
 
 type MetricsQueryResponse struct {


### PR DESCRIPTION
# Description
- Add support for PromQL without aggregation.

# Testing
- Tested on UI by running the below queries
   1. `sum without (instance) (demo_api_http_requests_in_progress)`
   2. `sum  without(instance) (avg_over_time(demo_api_http_requests_in_progress[3h:30m]))`
- Added few functional unit tests.
- TODO: Need to add tests for parser and other functional unit tests.

### Update
- Added Tests for parser and an e2e test.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
