### PR TITLE
Separate response structs for PromQL Range and Instant Queries

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -276,7 +276,7 @@ func ProcessPromqlMetricsRangeSearchRequest(ctx *fasthttp.RequestCtx, myid int64
 	segment.LogMetricsQueryOps("PromQL metrics query parser: Ops: ", queryArithmetic, qid)
 	res := segment.ExecuteMultipleMetricsQuery(hashList, metricQueriesList, queryArithmetic, timeRange, qid, false)
 
-	var mQResponse *structs.MetricsQueryResponsePromQl
+	var mQResponse *structs.MetricsPromQLRangeQueryResponse
 
 	if res.IsScalar {
 		mQResponse, err = res.GetResultsPromQlForScalarType(pqlQuerytype, startTime, endTime, uint32(step.Seconds()))

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -536,13 +536,12 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 	return retVal, nil
 }
 
-func getPromQLSeriesFormat(seriesId string) *structs.Result {
+func getPromQLSeriesFormat(seriesId string) map[string]string {
 	tagValues := strings.Split(removeTrailingComma(seriesId), tsidtracker.TAG_VALUE_DELIMITER_STR)
 
-	var result structs.Result
 	var keyValue []string
-	result.Metric = make(map[string]string)
-	result.Metric["__name__"] = ExtractMetricNameFromGroupID(seriesId)
+	metric := make(map[string]string)
+	metric["__name__"] = ExtractMetricNameFromGroupID(seriesId)
 	for idx, val := range tagValues {
 		if idx == 0 {
 			keyValue = strings.SplitN(removeMetricNameFromGroupID(val), ":", 2)
@@ -551,24 +550,20 @@ func getPromQLSeriesFormat(seriesId string) *structs.Result {
 		}
 
 		if len(keyValue) > 1 {
-			result.Metric[keyValue[0]] = keyValue[1]
+			metric[keyValue[0]] = keyValue[1]
 		}
 	}
 
-	return &result
+	return metric
 }
 
-func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueType, timestamp uint32) (*structs.MetricsQueryResponsePromQl, error) {
-	var pqlData structs.Data
+func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueType, timestamp uint32) (*structs.MetricsPromQLInstantQueryResponse, error) {
+	var pqlData structs.PromQLInstantData
 
 	switch pqlQueryType {
 	case parser.ValueTypeScalar:
 		pqlData.ResultType = pqlQueryType
-		pqlData.Result = make([]structs.Result, 1)
-		pqlData.Result[0] = structs.Result{
-			Metric: map[string]string{},
-			Value:  []interface{}{timestamp, fmt.Sprintf("%v", r.ScalarValue)},
-		}
+		pqlData.SliceResult = []interface{}{timestamp, fmt.Sprintf("%v", r.ScalarValue)}
 	case parser.ValueTypeString:
 		// TODO: Implement this
 		return nil, errors.New("GetResultsPromQlInstantQuery: ValueTypeString is not supported")
@@ -579,12 +574,16 @@ func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueTy
 				continue
 			}
 
-			result := getPromQLSeriesFormat(seriesId)
+			metricSeries := getPromQLSeriesFormat(seriesId)
+
+			result := structs.InstantVectorResult{
+				Metric: metricSeries,
+			}
 
 			floatValue, ok := results[timestamp]
 			if ok {
 				result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
-				pqlData.Result = append(pqlData.Result, *result)
+				pqlData.VectorResult = append(pqlData.VectorResult, result)
 				continue
 			}
 
@@ -609,7 +608,7 @@ func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueTy
 			}
 
 			result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
-			pqlData.Result = append(pqlData.Result, *result)
+			pqlData.VectorResult = append(pqlData.VectorResult, result)
 		}
 	case parser.ValueTypeMatrix:
 		return nil, errors.New("ValueTypeMatrix is not supported for Instant Queries")
@@ -617,34 +616,35 @@ func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueTy
 		return nil, fmt.Errorf("GetResultsPromQlInstantQuery: Unsupported PromQL query result type: %v", pqlQueryType)
 	}
 
-	return &structs.MetricsQueryResponsePromQl{
+	return &structs.MetricsPromQLInstantQueryResponse{
 		Status: "success",
-		Data:   pqlData,
+		Data:   &pqlData,
 	}, nil
 }
 
-func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQuerytype parser.ValueType) (*structs.MetricsQueryResponsePromQl, error) {
+func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQuerytype parser.ValueType) (*structs.MetricsPromQLRangeQueryResponse, error) {
 	if r.State != AGGREGATED {
 		return nil, fmt.Errorf("GetResultsPromQl: results is not in aggregated state, state: %v", r.State)
 	}
-	var pqldata structs.Data
+	var pqldata structs.PromQLRangeData
 
 	switch pqlQuerytype {
 	case parser.ValueTypeVector, parser.ValueTypeMatrix:
 		pqldata.ResultType = parser.ValueType("matrix")
 		for seriesId, results := range r.Results {
-			result := getPromQLSeriesFormat(seriesId)
+			metricSeries := getPromQLSeriesFormat(seriesId)
 
-			result.Value = make([]interface{}, len(results))
-			index := 0
-
-			for k, v := range results {
-				result.Value[index] = []interface{}{int64(k), fmt.Sprintf("%v", v)}
-				index++
+			result := &structs.RangeVectorResult{
+				Metric: metricSeries,
+				Values: make([]interface{}, 0, len(results)),
 			}
 
-			sort.Slice(result.Value, func(i, j int) bool {
-				return result.Value[i].([]interface{})[0].(int64) < result.Value[j].([]interface{})[0].(int64)
+			for k, v := range results {
+				result.Values = append(result.Values, []interface{}{int64(k), fmt.Sprintf("%v", v)})
+			}
+
+			sort.Slice(result.Values, func(i, j int) bool {
+				return result.Values[i].([]interface{})[0].(int64) < result.Values[j].([]interface{})[0].(int64)
 			})
 
 			pqldata.Result = append(pqldata.Result, *result)
@@ -652,25 +652,25 @@ func (r *MetricsResult) GetResultsPromQl(mQuery *structs.MetricsQuery, pqlQueryt
 	default:
 		return nil, fmt.Errorf("GetResultsPromQl: Unsupported PromQL query result type: %v", pqlQuerytype)
 	}
-	return &structs.MetricsQueryResponsePromQl{
+	return &structs.MetricsPromQLRangeQueryResponse{
 		Status: "success",
-		Data:   pqldata,
+		Data:   &pqldata,
 	}, nil
 }
 
-func (r *MetricsResult) GetResultsPromQlForScalarType(pqlQueryType parser.ValueType, startTime, endTime uint32, step uint32) (*structs.MetricsQueryResponsePromQl, error) {
+func (r *MetricsResult) GetResultsPromQlForScalarType(pqlQueryType parser.ValueType, startTime, endTime uint32, step uint32) (*structs.MetricsPromQLRangeQueryResponse, error) {
 	if pqlQueryType != parser.ValueTypeScalar {
 		return nil, fmt.Errorf("GetResultsPromQlForScalarType: Unsupported PromQL query result type: %v", pqlQueryType)
 	}
 
-	var pqlData structs.Data
+	var pqlData structs.PromQLRangeData
 	pqlData.ResultType = parser.ValueType("matrix")
 
 	scalarValue := r.ScalarValue
 
 	evalTime := startTime
 
-	pqlData.Result = make([]structs.Result, 1)
+	pqlData.Result = make([]structs.RangeVectorResult, 1)
 
 	values := make([]interface{}, 0)
 
@@ -679,14 +679,14 @@ func (r *MetricsResult) GetResultsPromQlForScalarType(pqlQueryType parser.ValueT
 		evalTime += step
 	}
 
-	pqlData.Result[0] = structs.Result{
+	pqlData.Result[0] = structs.RangeVectorResult{
 		Metric: map[string]string{},
-		Value:  values,
+		Values: values,
 	}
 
-	return &structs.MetricsQueryResponsePromQl{
+	return &structs.MetricsPromQLRangeQueryResponse{
 		Status: "success",
-		Data:   pqlData,
+		Data:   &pqlData,
 	}, nil
 }
 

--- a/pkg/segment/structs/metricsstructs_test.go
+++ b/pkg/segment/structs/metricsstructs_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package structs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_PromQLInstantResponseMarshal(t *testing.T) {
+	promQlResp := &MetricsPromQLInstantQueryResponse{
+		Status: "success",
+		Data: &PromQLInstantData{
+			ResultType: parser.ValueTypeVector,
+			VectorResult: []InstantVectorResult{
+				{
+					Metric: map[string]string{
+						"__name__": "up",
+						"job":      "prometheus",
+					},
+					Value: []interface{}{
+						1, "123",
+					},
+				},
+				{
+					Metric: map[string]string{
+						"__name__": "up",
+						"job":      "node",
+					},
+					Value: []interface{}{
+						1, "345",
+					},
+				},
+			},
+		},
+	}
+
+	expectedMarshal := `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"prometheus"},"value":[1,"123"]},{"metric":{"__name__":"up","job":"node"},"value":[1,"345"]}]}}`
+
+	marshaled, err := json.Marshal(promQlResp)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedMarshal, string(marshaled))
+
+	promQlResp.Data.ResultType = parser.ValueTypeScalar
+	promQlResp.Data.SliceResult = []interface{}{1, "123"}
+	expectedMarshal = `{"status":"success","data":{"resultType":"scalar","result":[1,"123"]}}`
+
+	marshaled, err = json.Marshal(promQlResp)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedMarshal, string(marshaled))
+}


### PR DESCRIPTION
# Description
- Separated the response formats for Range and Instant Queries
- Added a custom Marshaling for Instant Response Query

# Testing
- Added unit test for custom Marshaling.
- Tested by adding SigLens as a Prometheus data source on Grafana.
- Tested by running queries manually on Prometheus and SigLens

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
