### PR TITLE
Set minimum step value to 1 second

### DIFF
--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -2,6 +2,7 @@ package promql
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -839,5 +840,6 @@ func updateMetricQueryWithAggs(mQuery *structs.MetricsQuery, mQueryAgg *structs.
 }
 
 func getStepValueFromTimeRange(timeRange *dtu.MetricsTimeRange) float64 {
-	return float64(timeRange.EndEpochSec-timeRange.StartEpochSec) / structs.MAX_POINTS_TO_EVALUATE
+	step := float64(timeRange.EndEpochSec-timeRange.StartEpochSec) / structs.MAX_POINTS_TO_EVALUATE
+	return math.Max(step, 1)
 }


### PR DESCRIPTION
# Description
- Ensures that the minimum step value is 1 second.
- Without this for instant queries, the step is getting set to `0.04s` causing the query to execute very slow.

# Testing
- Tested by running the below query on Grafana by selecting Instant query
```
max without(instance, le) (max_over_time(demo_api_request_duration_seconds_bucket{job="demo"}[1d]))
```

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
