### PR TITLE
Update docker script for v2 compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -268,7 +268,7 @@ install_docker_compose() {
             post_event "install_failed" "install_docker_compose: apt-get update failed during Docker Compose setup"
             print_error_and_exit "apt-get update failed."
         }
-        $apt_cmd install docker-compose || {
+        $apt_cmd install docker-compose-plugin || {
             post_event "install_failed" "install_docker_compose: apt-get install docker-compose failed during Docker Compose setup"
             print_error_and_exit "Docker Compose installation failed."
         }
@@ -291,7 +291,7 @@ install_docker_compose() {
         echo "---------Docker Compose must be installed manually to proceed---------"
         print_error_and_exit "Docker Compose Not installed"
     fi
-    docker_compose_version=$(docker-compose --version) || {
+    docker_compose_version=$(docker compose --version) || {
         post_event "install_failed" "install_docker_compose: Docker Compose post-installation check failed during Docker Compose setup"
         print_error_and_exit "Docker Compose is not working correctly."
     }
@@ -643,7 +643,7 @@ if [[ $CONTAINER_TOOL == "docker" ]]; then
         fi
     fi
 
-    if ! is_command_present docker-compose; then
+    if ! is_command_present docker compose; then
         if [[ $package_manager == "apt-get" || $package_manager == "yum" ]]; then
             request_sudo
             install_docker_compose

--- a/install.sh
+++ b/install.sh
@@ -269,7 +269,7 @@ install_docker_compose() {
             print_error_and_exit "apt-get update failed."
         }
         $apt_cmd install docker-compose-plugin || {
-            post_event "install_failed" "install_docker_compose: apt-get install docker-compose failed during Docker Compose setup"
+            post_event "install_failed" "install_docker_compose: apt-get install docker-compose-plugin failed during Docker Compose setup"
             print_error_and_exit "Docker Compose installation failed."
         }
     elif [[ $package_manager == yum && $os == 'amazon linux' ]]; then
@@ -813,11 +813,11 @@ elif [ "$SERVERNAME" = "playground" ]; then
 fi
 
 print_success_message "\n Starting Siglens with image: ${IMAGE_NAME}"
-CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${IMAGE_NAME} ${CONTAINER_TOOL}-compose -f $COMPOSE_FILE up -d || {
+CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${IMAGE_NAME} ${CONTAINER_TOOL} compose -f $COMPOSE_FILE up -d || {
     post_event "install_failed" "Failed to start $CONTAINER_TOOL Compose on $os with $COMPOSE_FILE"
     print_error_and_exit "Failed to start $CONTAINER_TOOL Compose"
 }
-CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${IMAGE_NAME} $CONTAINER_TOOL-compose logs -t --tail 20 >> ${CONTAINER_TOOL}_logs.txt
+CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${IMAGE_NAME} $CONTAINER_TOOL compose logs -t --tail 20 >> ${CONTAINER_TOOL}_logs.txt
 
 # Create .env file for docker-compose down
 if [[ $CONTAINER_TOOL == "docker" ]]; then

--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -51,6 +51,9 @@ case "$(uname -sr)" in
    Linux*amzn2*)
      os="amazon linux"
      package_manager="yum" ;;
+   Fedora*)
+     os="linux"
+     package_manager="yum" ;;
    Linux*)
      os="linux"
      package_manager="apt-get" ;;
@@ -196,7 +199,7 @@ install_docker_compose() {
             post_event "install_failed" "install_docker_compose: apt-get update failed during Docker Compose setup"
             print_error_and_exit "apt-get update failed."
         }
-        $apt_cmd install docker-compose || {
+        $apt_cmd install docker-compose-plugin || {
             post_event "install_failed" "install_docker_compose: apt-get install docker-compose failed during Docker Compose setup"
             print_error_and_exit "Docker Compose installation failed."
         }
@@ -219,7 +222,7 @@ install_docker_compose() {
         echo "---------Docker Compose must be installed manually to proceed---------"
         print_error_and_exit "Docker Compose Not installed"
     fi
-    docker_compose_version=$(docker-compose --version) || {
+    docker_compose_version=$(docker compose --version) || {
         post_event "install_failed" "install_docker_compose: Docker Compose post-installation check failed during Docker Compose setup"
         print_error_and_exit "Docker Compose is not working correctly."
     }
@@ -396,11 +399,11 @@ elif [ "$SERVERNAME" = "playground" ]; then
 fi
 
 print_success_message "\n Starting Siglens with image: ${DOCKER_IMAGE_NAME}"
-CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${DOCKER_IMAGE_NAME} docker-compose -f $DOCKER_COMPOSE_FILE up -d || {
+CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${DOCKER_IMAGE_NAME} docker compose -f $DOCKER_COMPOSE_FILE up -d || {
     post_event "install_failed" "Failed to start Docker Compose on $os with $DOCKER_COMPOSE_FILE"
     print_error_and_exit "Failed to start Docker Compose"
 }
-CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${DOCKER_IMAGE_NAME} docker-compose logs -t --tail 20 >> dclogs.txt
+CSI=${csi} UI_PORT=${UI_PORT} CONFIG_FILE=${CFILE} WORK_DIR="$(pwd)" IMAGE_NAME=${DOCKER_IMAGE_NAME} docker compose logs -t --tail 20 >> dclogs.txt
 sample_log_dataset_status=$(curl -s -o /dev/null -I -X HEAD -w "%{http_code}" http://localhost:5122/elastic/sample-log-dataset)
 
 if [ "$sample_log_dataset_status" -eq 200 ]; then

--- a/install_with_docker.sh
+++ b/install_with_docker.sh
@@ -200,7 +200,7 @@ install_docker_compose() {
             print_error_and_exit "apt-get update failed."
         }
         $apt_cmd install docker-compose-plugin || {
-            post_event "install_failed" "install_docker_compose: apt-get install docker-compose failed during Docker Compose setup"
+            post_event "install_failed" "install_docker_compose: apt-get install docker-compose-plugin failed during Docker Compose setup"
             print_error_and_exit "Docker Compose installation failed."
         }
     elif [[ $package_manager == yum && $os == 'amazon linux' ]]; then


### PR DESCRIPTION
# Description
This PR updates the installation shell scripts to replace all references to the deprecated `docker-compose` command with the `docker compose` command, in accordance with Docker’s migration guidelines. This change ensures compatibility with Docker Compose V2, which is now the standard.

Fixes #1311

# Testing
I executed the updated installation script on Fedora Workstation 41.
Verified that Docker is installed by running `docker --version`.
Confirmed that Docker Compose V2 is installed by running `docker compose version` and ensuring the output reflects a V2 version.
Finally, I ran additional commands (such as logs and down) to ensure all Docker Compose operations work as expected.

# Checklist:
- [x] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
