### PR TITLE
Make flaky test more rare

### DIFF
--- a/pkg/segment/reader/metrics/tagstree/tagstree_test.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstree_test.go
@@ -277,12 +277,13 @@ func Test_ConcurrentReadWrite(t *testing.T) {
 	tagsHolder.Insert(tagKey, []byte("server1"), jsonparser.String)
 
 	firstFlushChan := make(chan struct{})
+	numIters := 1000
 	waitGroup := sync.WaitGroup{}
 	waitGroup.Add(1)
 	go func() {
 		defer waitGroup.Done()
 
-		for i := 0; i < 100; i++ {
+		for i := 0; i < numIters; i++ {
 			metric := []byte(fmt.Sprintf("metric%d", i))
 			tsid, err := tagsHolder.GetTSID(metric)
 			assert.NoError(t, err)
@@ -310,7 +311,7 @@ func Test_ConcurrentReadWrite(t *testing.T) {
 		<-firstFlushChan
 
 		numMetrics := 0
-		for i := 0; i < 100; i++ {
+		for i := 0; i < numIters; i++ {
 			// Read from disk
 			reader, err := InitAllTagsTreeReader(baseDir)
 			assert.NoError(t, err)
@@ -349,7 +350,7 @@ func Test_ConcurrentReadWrite(t *testing.T) {
 
 	metrics, err := reader.GetHashedMetricNames()
 	assert.NoError(t, err)
-	assert.Len(t, metrics, 100)
+	assert.Len(t, metrics, numIters)
 }
 
 func initTestConfig(t *testing.T) {


### PR DESCRIPTION
# Description
The test was occasionally failing here: https://github.com/siglens/siglens/blob/develop/pkg/segment/reader/metrics/tagstree/tagstree_test.go#L337-L344, so I 10x the number of iterations. If this is still flaky, we may need a better way to fix the test

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
