### PR TITLE
Fix: Use Custom End Time for Metrics Graph

### DIFF
--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -2232,8 +2232,21 @@ async function convertDataForChart(data) {
     let seriesArray = [];
 
     if (data.series && data.timestamps && data.values) {
-        let chartStartTime = data.startTime;
-        let chartEndTime = Math.floor(Date.now() / 1000);
+        let chartStartTime, chartEndTime;
+
+        // If using custom date range
+        if (typeof filterStartDate === 'number' && typeof filterEndDate === 'number') {
+            chartStartTime = Math.floor(filterStartDate / 1000);
+            chartEndTime = Math.floor(filterEndDate / 1000);
+        } else {
+            chartStartTime = data.startTime;
+            chartEndTime = Math.floor(Date.now() / 1000); // now
+
+            if (data.timestamps && data.timestamps.length > 0) {
+                chartEndTime = Math.max(chartEndTime, data.timestamps[data.timestamps.length - 1]);
+            }
+        }
+
         const timeRange = chartEndTime - chartStartTime;
 
         // Determine the best time unit based on the time range
@@ -2276,7 +2289,18 @@ async function convertDataForChart(data) {
     }
 
     if (seriesArray.length === 0) {
-        const labels = generateEmptyChartLabels(timeUnit, data.startTime, Math.floor(Date.now() / 1000));
+        let startTime, endTime;
+
+        // For custom time range
+        if (typeof filterStartDate === 'number' && typeof filterEndDate === 'number') {
+            startTime = Math.floor(filterStartDate / 1000);
+            endTime = Math.floor(filterEndDate / 1000);
+        } else {
+            startTime = data.startTime;
+            endTime = Math.floor(Date.now() / 1000);
+        }
+
+        const labels = generateEmptyChartLabels(timeUnit, startTime, endTime);
         seriesArray.push({
             seriesName: 'No Data',
             values: labels.reduce((acc, label) => {


### PR DESCRIPTION
# Description
Previously, the metrics graph end time was always set to "now," custom end time set . 
This fix ensures that the graph respects the custom end time provided.

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/fad8c7bf-007b-42f1-8c92-6d8f5f8a4e32" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
