### PR TITLE
Fix: Handle missing "startEpoch" and "endEpoch" keys 

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -705,14 +705,22 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	searchRequestBody.SearchText = "*"
 
 	if val, ok := readJSON["startEpoch"]; ok {
-		searchRequestBody.StartEpoch = val.(string)
+		searchRequestBody.StartEpoch = convertEpochToString(val)
+		if searchRequestBody.StartEpoch == "" {
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for startEpoch")
+			return
+		}
 	} else {
 		log.Errorf("ProcessAggregatedDependencyGraphs : startEpoch is missing")
 		return
 	}
 
 	if val, ok := readJSON["endEpoch"]; ok {
-		searchRequestBody.EndEpoch = val.(string)
+		searchRequestBody.EndEpoch = convertEpochToString(val)
+		if searchRequestBody.EndEpoch == "" {
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for endEpoch")
+			return
+		}
 	} else {
 		log.Errorf("ProcessAggregatedDependencyGraphs : endEpoch is missing")
 		return
@@ -779,6 +787,20 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 		return
 	}
 	ctx.SetStatusCode(fasthttp.StatusOK)
+}
+
+func convertEpochToString(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case int, int8, int16, int32, int64:
+		return fmt.Sprintf("%d", v)
+	case float32, float64:
+		return fmt.Sprintf("%f", v)
+	default:
+		log.Errorf("convertEpochToString: Unsupported data type: %T", v)
+		return ""
+	}
 }
 
 // ProcessGeneratedDepGraph handles the /generate-dep-graph endpoint.

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -704,10 +704,11 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	searchRequestBody.IndexName = "service-dependency"
 	searchRequestBody.SearchText = "*"
 
+	var valueType string
 	if val, ok := readJSON["startEpoch"]; ok {
-		searchRequestBody.StartEpoch = convertEpochToString(val)
+		searchRequestBody.StartEpoch, valueType = convertEpochToString(val)
 		if searchRequestBody.StartEpoch == "" {
-			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for startEpoch : %v", val)
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for startEpoch. Value: %v, Type: %s", val, valueType)
 			return
 		}
 	} else {
@@ -716,9 +717,9 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	}
 
 	if val, ok := readJSON["endEpoch"]; ok {
-		searchRequestBody.EndEpoch = convertEpochToString(val)
+		searchRequestBody.EndEpoch, valueType = convertEpochToString(val)
 		if searchRequestBody.EndEpoch == "" {
-			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for endEpoch : %v", val)
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for endEpoch. Value: %v, Type: %s", val, valueType)
 			return
 		}
 	} else {
@@ -789,17 +790,18 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 }
 
-func convertEpochToString(value interface{}) string {
+func convertEpochToString(value interface{}) (string, string) {
+	valueType := fmt.Sprintf("%T", value)
 	switch v := value.(type) {
 	case string:
-		return v
+		return v, valueType
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v)
+		return fmt.Sprintf("%d", v), valueType
 	case float32, float64:
-		return fmt.Sprintf("%f", v)
+		return fmt.Sprintf("%f", v), valueType
 	default:
 		log.Errorf("convertEpochToString: Unsupported data type: %T, Value: %v", v, v)
-		return ""
+		return "", valueType
 	}
 }
 

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -707,7 +707,7 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	if val, ok := readJSON["startEpoch"]; ok {
 		searchRequestBody.StartEpoch = convertEpochToString(val)
 		if searchRequestBody.StartEpoch == "" {
-			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for startEpoch")
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for startEpoch : %v", val)
 			return
 		}
 	} else {
@@ -718,7 +718,7 @@ func ProcessAggregatedDependencyGraphs(ctx *fasthttp.RequestCtx, myid int64) {
 	if val, ok := readJSON["endEpoch"]; ok {
 		searchRequestBody.EndEpoch = convertEpochToString(val)
 		if searchRequestBody.EndEpoch == "" {
-			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for endEpoch")
+			log.Errorf("ProcessAggregatedDependencyGraphs: Invalid data type for endEpoch : %v", val)
 			return
 		}
 	} else {
@@ -798,7 +798,7 @@ func convertEpochToString(value interface{}) string {
 	case float32, float64:
 		return fmt.Sprintf("%f", v)
 	default:
-		log.Errorf("convertEpochToString: Unsupported data type: %T", v)
+		log.Errorf("convertEpochToString: Unsupported data type: %T, Value: %v", v, v)
 		return ""
 	}
 }

--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -793,7 +793,7 @@ func convertEpochToString(value interface{}) string {
 	switch v := value.(type) {
 	case string:
 		return v
-	case int, int8, int16, int32, int64:
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return fmt.Sprintf("%d", v)
 	case float32, float64:
 		return fmt.Sprintf("%f", v)


### PR DESCRIPTION
# Description
Summarize the change.

Fix: Handle missing "startEpoch" and "endEpoch" keys in request body JSON parsing  
  
  - Sanitized the code so that if a key is not present, it logs an error and returns control.  
  - Replaced hardcoded error messages with constants for better maintainability.

# Testing

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
