### PR TITLE
Fix overflow issue in TSO file

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -135,7 +135,7 @@ var VALTYPE_RAW_JSON = []byte{0x15}
 
 var VERSION_TAGSTREE = []byte{0x01}
 var VERSION_TSOFILE_V1 = []byte{0x01}
-var VERSION_TSOFILE_V2 = []byte{0x01} // Current version
+var VERSION_TSOFILE_V2 = []byte{0x02} // Current version
 var VERSION_TSGFILE = []byte{0x01}
 var VERSION_MBLOCKSUMMARY = []byte{0x01}
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -134,7 +134,8 @@ var VALTYPE_DICT_ARRAY = []byte{0x14}
 var VALTYPE_RAW_JSON = []byte{0x15}
 
 var VERSION_TAGSTREE = []byte{0x01}
-var VERSION_TSOFILE = []byte{0x01}
+var VERSION_TSOFILE_V1 = []byte{0x01}
+var VERSION_TSOFILE_V2 = []byte{0x01} // Current version
 var VERSION_TSGFILE = []byte{0x01}
 var VERSION_MBLOCKSUMMARY = []byte{0x01}
 

--- a/pkg/segment/writer/metrics/metricssegment.go
+++ b/pkg/segment/writer/metrics/metricssegment.go
@@ -1087,8 +1087,13 @@ func (ms *MetricsSegment) CheckAndRotate(forceRotate bool) error {
 
 /*
 Format of TSO file:
+Version 1
 [version - 1 byte][number of tsids - 2 bytes][tsid - 8bytes][offset - 4 bytes][tsid - 8bytes]...
-Formar of TSG file:
+
+Version 2: 8 bytes for number of tsids
+[version - 1 byte][number of tsids - 8 bytes][tsid - 8bytes][offset - 4 bytes][tsid - 8bytes]...
+
+Format of TSG file:
 [version - 1 byte][tsid - 8bytes][len - 4 bytes][raw series - n bytes][tsid - 8 bytes]...
 */
 func (mb *MetricsBlock) FlushTSOAndTSGFiles(file string) error {
@@ -1102,7 +1107,7 @@ func (mb *MetricsBlock) FlushTSOAndTSGFiles(file string) error {
 		return mb.sortedTsids[i] < mb.sortedTsids[j]
 	})
 
-	_, err := tsoBuffer.Write(utils.VERSION_TSOFILE)
+	_, err := tsoBuffer.Write(utils.VERSION_TSOFILE_V2)
 	if err != nil {
 		log.Infof("FlushTSOAndTSGFiles: Could not write version byte to file %v. Err %v", tsoFileName, err)
 		return err
@@ -1115,7 +1120,7 @@ func (mb *MetricsBlock) FlushTSOAndTSGFiles(file string) error {
 	}
 
 	size := uint32(0)
-	_, err = tsoBuffer.Write(toputils.Uint16ToBytesLittleEndian(uint16(length)))
+	_, err = tsoBuffer.Write(toputils.Uint64ToBytesLittleEndian(uint64(length)))
 	if err != nil {
 		log.Infof("FlushTSOAndTSGFiles: Could not write tsid to file %v. Err %v", tsoFileName, err)
 		return err

--- a/pkg/segment/writer/metrics/metricssegment_test.go
+++ b/pkg/segment/writer/metrics/metricssegment_test.go
@@ -160,28 +160,22 @@ func Test_ReadWriteTsoTsgFiles(t *testing.T) {
 	series_2 := writeToTimeSeries(mb, 1)
 
 	err = mb.FlushTSOAndTSGFiles("data/mock_0")
-	if err != nil {
-		log.Errorf("Test_ReadWriteTsoTsgFiles: Error writing mock metrics block %v", err)
-	}
+	assert.NoError(t, err)
 
 	tssr, err := series.InitTimeSeriesReader("data/mock")
-	if err != nil {
-		log.Errorf("Test_ReadWriteTsoTsgFiles: Error initialising a time series reader. Err %v", err)
-	}
+	assert.NoError(t, err)
+
 	queryMetrics := &structs.MetricsQueryProcessingMetrics{
 		UpdateLock: &sync.Mutex{},
 	}
 	tssr_block, err := tssr.InitReaderForBlock(uint16(0), queryMetrics)
-	if err != nil {
-		log.Errorf("Test_ReadWriteTsoTsgFiles: Error initialising a time series reader for block. Err %v", err)
-	}
+	assert.NoError(t, err)
 
 	// verify series 1
 	ts_itr, exists, err := tssr_block.GetTimeSeriesIterator(tsid_1)
-	if err != nil {
-		log.Errorf("Test_ReadWriteTsoTsgFiles: Error initialising a time series iterator for tsid %v", tsid_1)
-	}
+	assert.NoError(t, err)
 	assert.True(t, exists)
+
 	count_1 := 0
 	for ts_itr.Next() {
 		ts, val := ts_itr.At()
@@ -192,10 +186,8 @@ func Test_ReadWriteTsoTsgFiles(t *testing.T) {
 
 	// verify series 2
 	ts_itr, exists, err = tssr_block.GetTimeSeriesIterator(tsid_2)
-	if err != nil {
-		assert.NoError(t, err)
-		log.Errorf("Test_ReadWriteTsoTsgFiles: Error initialising a time series iterator for tsid %v", tsid_2)
-	}
+	assert.NoError(t, err)
+
 	assert.True(t, exists)
 	count_2 := 0
 	for ts_itr.Next() {


### PR DESCRIPTION
# Description
The previous TSO file format reserved 2 bytes for the number of TSIDs, which caused an overflow issue when there were too many. Now we reserve 8 bytes.

# Testing
Existing and new unit tests. I also tested manually that I could still query metrics that were ingested using the old TSO format, and that I could query metrics ingested using the new format.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
