### PR TITLE
Fix issue not adding some tags to tags tree

### DIFF
--- a/pkg/segment/writer/metrics/tagstree.go
+++ b/pkg/segment/writer/metrics/tagstree.go
@@ -115,8 +115,6 @@ Returns a bool indicating if this tsid is new
 Internally, will use the internal bloom to check if the tsid has already been added or not
 */
 func (tth *TagsTreeHolder) AddTagsForTSID(mName []byte, tags *TagsHolder, tsid uint64) error {
-	rawTSID := utils.Uint64ToBytesLittleEndian(tsid)
-
 	tth.rwLock.Lock()
 	defer tth.rwLock.Unlock()
 
@@ -125,8 +123,6 @@ func (tth *TagsTreeHolder) AddTagsForTSID(mName []byte, tags *TagsHolder, tsid u
 		log.Errorf("TagsTreeHolder.AddTagsForTSID: failed to add tags to tree. mName: %v, tsid: %v, tags holder: %+v; err=%v", mName, tsid, tags, err)
 		return err
 	}
-
-	tth.tagBloom.Add(rawTSID)
 
 	return nil
 }

--- a/pkg/segment/writer/metrics/tagstree.go
+++ b/pkg/segment/writer/metrics/tagstree.go
@@ -116,18 +116,18 @@ Internally, will use the internal bloom to check if the tsid has already been ad
 */
 func (tth *TagsTreeHolder) AddTagsForTSID(mName []byte, tags *TagsHolder, tsid uint64) error {
 	rawTSID := utils.Uint64ToBytesLittleEndian(tsid)
-	retVal := tth.tagBloom.Test(rawTSID)
-	if !retVal {
-		tth.rwLock.Lock()
-		defer tth.rwLock.Unlock()
-		err := tth.addTags(mName, tags, tsid)
-		if err != nil {
-			log.Errorf("TagsTreeHolder.AddTagsForTSID: failed to add tags to tree. mName: %v, tsid: %v, tags holder: %+v; err=%v", mName, tsid, tags, err)
-			return err
-		}
-		tth.tagBloom.Add(rawTSID)
-		return nil
+
+	tth.rwLock.Lock()
+	defer tth.rwLock.Unlock()
+
+	err := tth.addTags(mName, tags, tsid)
+	if err != nil {
+		log.Errorf("TagsTreeHolder.AddTagsForTSID: failed to add tags to tree. mName: %v, tsid: %v, tags holder: %+v; err=%v", mName, tsid, tags, err)
+		return err
 	}
+
+	tth.tagBloom.Add(rawTSID)
+
 	return nil
 }
 


### PR DESCRIPTION
# Description
When adding tags to the tags tree for a certain TSID, sometimes we erroneously skipped adding the tags because we got a false positive from a bloom filter, so we thought the TSID was already added.

This just removes the bloom filter check, as `tth.addTags()` should already correctly handle a call for tags that are already there.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
