### PR TITLE
fix panic in SplunkQL query due to Index out of range

### DIFF
--- a/pkg/integrations/prometheus/ingest/putmetrics.go
+++ b/pkg/integrations/prometheus/ingest/putmetrics.go
@@ -149,7 +149,7 @@ func HandlePutMetrics(compressed []byte, myid int64) (uint64, uint64, error) {
 
 			err = writer.AddTimeSeriesEntryToInMemBuf([]byte(modifiedData), SIGNAL_METRICS_OTSDB, myid)
 			if err != nil {
-				log.Errorf("HandlePutMetrics: failed to add time series entry for data=%+v, err=%v", modifiedData, err)
+				log.Errorf("HandlePutMetrics: failed to add time series entry for data=%+v, err=%v", string(modifiedData), err)
 				failedCount++
 			} else {
 				successCount++

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -926,7 +926,7 @@ func CreateMeasResultsFromAggResults(limit int,
 				}
 
 				if len(bucketKeySlice) == 0 {
-					log.Errorf("CreateMeasResultsFromAggResults : bucketKeySlice is empty : %+v", bucketKeySlice)
+					log.Errorf("CreateMeasResultsFromAggResults : bucketKeySlice is empty")
 					continue
 				}
 

--- a/pkg/segment/results/segresults/segresults.go
+++ b/pkg/segment/results/segresults/segresults.go
@@ -918,51 +918,56 @@ func CreateMeasResultsFromAggResults(limit int,
 				break
 			}
 
-			if newQueryPipeline {
-				bucketKeySlice, ok := aggVal.BucketKey.([]interface{})
-				if !ok {
-					batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("expected []interface{} got bucket Key Type as %T", aggVal.BucketKey))
-					continue
-				}
-				for _, bk := range bucketKeySlice {
-					cValue := utils.CValueEnclosure{}
-					err := cValue.ConvertValue(bk)
-					if err != nil {
-						batchErr.AddError("CreateMeasResultsFromAggResults:CONVERT_BUCKET_KEY_ERR", err)
-						cValue = utils.CValueEnclosure{
-							Dtype: utils.SS_DT_STRING,
-							CVal:  fmt.Sprintf("%+v", bk),
-						}
-					}
-					iGroupByValues = append(iGroupByValues, cValue)
-				}
-			}
+			bucketKeySlice, ok := aggVal.BucketKey.([]interface{})
+			if len(bucketKeySlice) > 0 {
+				if newQueryPipeline {
 
-			switch bKey := aggVal.BucketKey.(type) {
-			case float64, uint64, int64:
-				bKeyConv := fmt.Sprintf("%+v", bKey)
-				groupByValues = append(groupByValues, bKeyConv)
-				added++
-			case []string:
-				groupByValues = append(groupByValues, aggVal.BucketKey.([]string)...)
-				added++
-			case string:
-				groupByValues = append(groupByValues, bKey)
-				added++
-			case []interface{}:
-				for _, bk := range aggVal.BucketKey.([]interface{}) {
-					groupByValues = append(groupByValues, fmt.Sprintf("%+v", bk))
+					if !ok {
+						batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("expected []interface{} got bucket Key Type as %T", aggVal.BucketKey))
+						continue
+					}
+					for _, bk := range bucketKeySlice {
+						cValue := utils.CValueEnclosure{}
+						err := cValue.ConvertValue(bk)
+						if err != nil {
+							batchErr.AddError("CreateMeasResultsFromAggResults:CONVERT_BUCKET_KEY_ERR", err)
+							cValue = utils.CValueEnclosure{
+								Dtype: utils.SS_DT_STRING,
+								CVal:  fmt.Sprintf("%+v", bk),
+							}
+						}
+						iGroupByValues = append(iGroupByValues, cValue)
+					}
 				}
-				added++
-			default:
-				batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("got bucket Key Type as %T", bKey))
+
+				switch bKey := aggVal.BucketKey.(type) {
+				case float64, uint64, int64:
+					bKeyConv := fmt.Sprintf("%+v", bKey)
+					groupByValues = append(groupByValues, bKeyConv)
+					added++
+				case []string:
+					groupByValues = append(groupByValues, aggVal.BucketKey.([]string)...)
+					added++
+				case string:
+					groupByValues = append(groupByValues, bKey)
+					added++
+				case []interface{}:
+					for _, bk := range aggVal.BucketKey.([]interface{}) {
+						groupByValues = append(groupByValues, fmt.Sprintf("%+v", bk))
+					}
+					added++
+				default:
+					batchErr.AddError("CreateMeasResultsFromAggResults:UNKNOWN_BUCKET_KEY_TYPE", fmt.Errorf("got bucket Key Type as %T", bKey))
+				}
+				bucketHolder := &structs.BucketHolder{
+					IGroupByValues: iGroupByValues,
+					GroupByValues:  groupByValues,
+					MeasureVal:     measureVal,
+				}
+				bucketHolderArr = append(bucketHolderArr, bucketHolder)
+			} else {
+				log.Errorf("CreateMeasResultsFromAggResults : bucketKeySlice is empty : %+v", bucketKeySlice)
 			}
-			bucketHolder := &structs.BucketHolder{
-				IGroupByValues: iGroupByValues,
-				GroupByValues:  groupByValues,
-				MeasureVal:     measureVal,
-			}
-			bucketHolderArr = append(bucketHolderArr, bucketHolder)
 		}
 	}
 


### PR DESCRIPTION
# Description
fix panic in SplunkQL query due to Index out of range
- Ensured applyAggregationsToResult gracefully skips missing attributes.
- Fixed log line that was printing data as bytes by converting it to string before logging.



# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
