### PR TITLE
Fix Performance Issues with Metrics Name Dropdown

### DIFF
--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -2879,12 +2879,10 @@ async function getFunctions() {
 async function refreshMetricsGraphs() {
     dayCnt7 = 0;
     dayCnt2 = 0;
-    const newMetricNames = await getMetricNames();
-    newMetricNames.metricNames.sort();
+    await getMetricNames();
 
     isLoadingMore = false;
 
-    $('.metrics').autocomplete('option', 'source', newMetricNames.metricNames);
     const firstKey = Object.keys(queries)[0];
 
     if (queries[firstKey].metrics || queries[firstKey].state === 'raw') {

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -155,7 +155,6 @@ $(document).ready(async function () {
 
 function getUrlParameter(name) {
     //eslint-disable-next-line no-useless-escape
-
     name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
     let regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
     let results = regex.exec(location.search);
@@ -1448,7 +1447,7 @@ function loadMoreItems(menu, input) {
 
         menu.append(fragment);
 
-        menu.off('mousedown.loadmore').on('mousedown.loadmore', '.ui-menu-item-wrapper', function (e) {
+        menu.off('mousedown.loadmore').on('mousedown.loadmore', '.ui-menu-item-wrapper', function () {
             const value = $(this).text();
 
             input.val(value);

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1418,43 +1418,6 @@ async function initializeAutocomplete(queryElement, previousQuery = {}) {
     previousQuery = queryDetails;
 }
 
-async function getMetricNames() {
-    try {
-        $('body').css('cursor', 'wait');
-
-        const data = {
-            start: filterStartDate,
-            end: filterEndDate,
-        };
-
-        const res = await $.ajax({
-            method: 'post',
-            url: 'http://sandbox2.siglens.com:5122/metrics-explorer/api/v1/metric_names',
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-                Accept: '*/*',
-            },
-            crossDomain: true,
-            dataType: 'json',
-            data: JSON.stringify(data),
-        });
-
-        if (res) {
-            // Store the full list of metrics
-            availableMetrics = res.metricNames.sort();
-            cachedMetrics = res.metricNames.slice();
-
-            // Reset loading state
-            isLoadingMore = false;
-        }
-
-        return res;
-    } finally {
-        $('body').css('cursor', 'default');
-    }
-}
-
-// Fix for the loadMoreItems function
 function loadMoreItems(menu, input) {
     if (isLoadingMore) return;
     isLoadingMore = true;
@@ -2468,7 +2431,7 @@ async function getMetricNames() {
 
         const res = await $.ajax({
             method: 'post',
-            url: 'http://sandbox2.siglens.com:5122/metrics-explorer/api/v1/metric_names',
+            url: 'metrics-explorer/api/v1/metric_names',
             headers: {
                 'Content-Type': 'application/json; charset=utf-8',
                 Accept: '*/*',
@@ -2479,7 +2442,6 @@ async function getMetricNames() {
         });
 
         if (res) {
-            // Store the full list of metrics
             availableMetrics = res.metricNames.sort();
             cachedMetrics = res.metricNames.slice();
 
@@ -2692,7 +2654,6 @@ async function fetchTimeSeriesData(data) {
         $('body').css('cursor', 'wait');
 
         const response = await fetch('metrics-explorer/api/v1/timeseries', {
-            // const response = await fetch('http://sandbox2.siglens.com:5122/metrics-explorer/api/v1/timeseries', {
             method: 'post',
             headers: { 'Content-Type': 'application/json', Accept: '*/*' },
             body: JSON.stringify(data),
@@ -2725,7 +2686,6 @@ function getTagKeyValue(metricName) {
             $.ajax({
                 method: 'post',
                 url: 'metrics-explorer/api/v1/all_tags',
-                // url: 'http://sandbox2.siglens.com:5122/metrics-explorer/api/v1/all_tags',
                 headers: {
                     'Content-Type': 'application/json; charset=utf-8',
                     Accept: '*/*',


### PR DESCRIPTION
# Description
**Issue:** 
The metrics name dropdown lags significantly when loading and filtering options. This performance issue occurs because we're loading all metrics names (2500+) into the dropdown at once, causing the UI to become unresponsive during initialization and filtering operations.

**Fix:** 
- Implemented a lazy loading approach for the metrics dropdown
- Initially show only the first 20 items when dropdown opens
- Added scroll detection to dynamically load more items as the user scrolls down

# Testing
Tested with 2500+ metrics names from the sandbox2.siglens.com machine

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
