### PR TITLE
Fix: Scrollable Legends with Improved Selection Behavior for Metrics Graph

### DIFF
--- a/static/alert.html
+++ b/static/alert.html
@@ -61,7 +61,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             height: 310px;
         }
         .graph-canvas{
-            padding: 0px 10px 50px 10px;
+            height: calc(310px - 85px);
+            padding: 10px;
         }
         #metrics-explorer, #metrics-graphs{
             display: none;

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -613,3 +613,8 @@ input:checked+.slider:before {
     margin-right: 10px;
     border-radius: 5px !important;
 }
+
+.panelDisplay .panEdit-panel .merged-graph {
+    height: calc(30vh - 65px);
+    padding: 0;
+}

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -424,14 +424,14 @@ input:checked+.slider:before {
 .graph-canvas,
 .merged-graph {
     position: relative;
-    height: 100%;
-    padding: 20px 10px 50px 20px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
+    height: calc(400px - 85px);
+    padding: 16px;
 }
 
+.legend-container {
+    overflow: scroll;
+    height: 50px;
+}
 
 .metrics-query .query-box .tag-container:focus-within,
 .everywhere:focus,


### PR DESCRIPTION
# Description

**Issue:**
Previously, all legends were displayed without scrolling, taking up too much space and making the graph hard to view. Also, clicking a legend would only hide that one, while others remained.

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/e62186a9-dafb-4443-84db-bc2247ad4192" />


**Fix:**
- Scrollable Legends: Legends are now placed inside a scrollable container to avoid taking over the graph space.
- Improved Legend Toggle:
    - Clicking on a legend shows only that legend's line on the graph (hides others).
    - If only one legend is visible and it's toggled, all legends are shown again.
    - Multi-select Support: By pressing Shift and selecting multiple legends, we can view more than one line on the graph at a time.

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/cc2cdc24-7c1a-47af-8db9-f268887a2c14" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
