### PR TITLE
Expandable Raw Query Input for Metrics

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -541,9 +541,7 @@
   align-items: center;
   font-size: 24px;
   font-weight: 700;
-  height: 100%;
   width: 100%;
-  background-color: var(--datatable-bg-color);
   border-radius: 5px;
 }
 

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -604,6 +604,8 @@ input:checked+.slider:before {
 
 .raw-query {
     width: 100%;
+    height: auto !important;
+    align-items: flex-start !important;
 }
 
 #metrics-container .refresh-btn {
@@ -612,4 +614,18 @@ input:checked+.slider:before {
     border: 1px solid var(--border-color-regular);
     margin-right: 10px;
     border-radius: 5px !important;
+}
+
+.raw-query-input {
+    width: 100%;
+    min-height: 26px;
+    resize: none;
+    padding: 4px 8px;
+    font-family: monospace;
+    line-height: 18px;
+    border: 1px solid var(--search-input-border);    
+    box-sizing: border-box;
+    overflow: hidden;
+    outline: none;
+    font-size: 11px;
 }

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -151,6 +151,10 @@ $(document).ready(async function () {
     createTooltip('#run-filter-btn', 'Run query');
     createTooltip('.download-all-logs-btn', 'Download');
     createTooltip('.refresh-btn', 'Refresh');
+
+    $(document).on('input', '.raw-query-input', function () {
+        autoResizeTextarea(this);
+    });
 });
 
 function getUrlParameter(name) {
@@ -717,7 +721,7 @@ function createQueryElementTemplate(queryName) {
                 </div>
             </div>
             <div class="raw-query" style="display: none;">
-                <input type="text" class="raw-query-input"><button class="btn run-filter-btn" id="run-filter-btn" title="Run your search" type="button"> </button>
+                <textarea class="raw-query-input" placeholder="Enter your query here"></textarea><button class="btn run-filter-btn" id="run-filter-btn" title="Run your search" type="button"> </button>
             </div>
         </div>
         <div>
@@ -858,6 +862,10 @@ function setupQueryElementEventListeners(queryElement) {
             if (!queryDetails.rawQueryExecuted) {
                 queryDetails.rawQueryInput = queryString;
                 queryElement.find('.raw-query-input').val(queryString);
+
+                setTimeout(function () {
+                    autoResizeTextarea(queryElement.find('.raw-query-input')[0]);
+                }, 10);
             } else {
                 queryElement.find('.raw-query-input').val(queryDetails.rawQueryInput);
             }
@@ -3034,6 +3042,10 @@ async function populateQueryElement(queryElement, queryDetails) {
         queryElement.find('.raw-query-input').val(queryDetails.rawQueryInput);
         queryElement.find('.query-builder').toggle();
         queryElement.find('.raw-query').toggle();
+
+        setTimeout(function () {
+            autoResizeTextarea(queryElement.find('.raw-query-input')[0]);
+        }, 10);
     } else {
         // Set the metric
         queryElement.find('.metrics').val(queryDetails.metrics);
@@ -3349,3 +3361,19 @@ function getMetricsDataForSave(qname, qdesc) {
         metricsQueryParams: JSON.stringify(transformedMetricsQueryParams),
     };
 }
+
+function autoResizeTextarea(textarea) {
+    textarea.style.height = '26px';
+
+    if (textarea.scrollHeight > 26) {
+        textarea.style.height = textarea.scrollHeight + 'px';
+    }
+}
+
+function resizeAllTextareas() {
+    const textareas = document.querySelectorAll('.raw-query-input');
+    textareas.forEach(autoResizeTextarea);
+}
+
+window.addEventListener('resize', resizeAllTextareas);
+document.addEventListener('DOMContentLoaded', resizeAllTextareas);


### PR DESCRIPTION
# Description

- Updated the raw query input field on the Metrics screen from a single-line input to a textarea.
- This allows large or multi-line queries to be easily written, viewed, and edited.
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/58eef574-ad41-45f5-a3f9-9dd90c21d3ce" />
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/141b28ac-1999-4626-b448-59c2f417c0b1" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
