### PR TITLE
Histogram quantile

### DIFF
--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -696,6 +696,22 @@ func handleCallExprVectorSelectorNode(expr *parser.Call, mQuery *structs.Metrics
 	case "label_join":
 		// TODO: Implement label_join function
 		return fmt.Errorf("handleCallExprVectorSelectorNode: label_join function is not supported")
+	case "histogram_quantile":
+		if len(expr.Args) != 2 {
+			return fmt.Errorf("handleCallExprVectorSelectorNode: incorrect parameters: %v for the histogram_quantile function", expr.Args.String())
+		}
+
+		quantileLiteral, ok := expr.Args[0].(*parser.NumberLiteral)
+		if !ok {
+			return fmt.Errorf("handleCallExprVectorSelectorNode: incorrect parameters:%v. Expected the quantile to be a number", expr.Args.String())
+		}
+
+		mQuery.Function = structs.Function{
+			FunctionType: structs.HistogramFunction,
+			HistogramBlock: &structs.HistogramBlock{
+				Quantile: quantileLiteral.Val,
+			},
+		}
 	default:
 		return fmt.Errorf("handleCallExprVectorSelectorNode: unsupported function type %v", function)
 	}

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -204,6 +204,12 @@ func ApplyMetricsQuery(mQuery *structs.MetricsQuery, timeRange *dtu.MetricsTimeR
 
 				return mRes
 			}
+		} else if mQuery.SubsequentAggs.AggBlockType == structs.HistogramBlock {
+			err := mRes.ApplyHistogramToResults(parallelism, mQuery.SubsequentAggs.HistogramBlock)
+			if err != nil {
+				mRes.AddError(err)
+				return mRes
+			}
 		} else {
 			log.Errorf("ApplyMetricsQuery: Invalid AggBlockType: %v", mQuery.SubsequentAggs.AggBlockType)
 			mRes.AddError(fmt.Errorf("invalid AggBlockType: %v", mQuery.SubsequentAggs.AggBlockType))

--- a/pkg/segment/results/mresults/histogram.go
+++ b/pkg/segment/results/mresults/histogram.go
@@ -75,10 +75,20 @@ func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
 		return bins[i].count >= target
 	})
 
+	// If the answer is in the first bin and that bin has a negative upper
+	// bound, we don't know the lower bound (and can't assume it's 0), so we
+	// can't interpolate.
 	if i == 0 && bins[i].upperBound <= 0 {
 		return bins[i].upperBound, nil
 	}
 
+	// If the answer is in the last bin, return the upper bound of the previous
+	// bin, since the last bin goes to infinity.
+	if i >= len(bins)-1 {
+		return bins[len(bins)-2].upperBound, nil
+	}
+
+	// Check if it's on a bin boundary.
 	if bins[i].count == target {
 		return bins[i].upperBound, nil
 	}
@@ -95,5 +105,4 @@ func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
 
 	// Linear interpolation
 	return lowerBound + bucketFraction*(bins[i].upperBound-lowerBound), nil
-
 }

--- a/pkg/segment/results/mresults/histogram.go
+++ b/pkg/segment/results/mresults/histogram.go
@@ -17,10 +17,13 @@
 
 package mresults
 
-import "math"
+import (
+	"math"
+	"sort"
+)
 
 type histogramBin struct {
-	upperBound uint64 // inclusive
+	upperBound float64 // inclusive
 	count      float64
 }
 
@@ -32,6 +35,18 @@ func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
 		return math.Inf(1), nil
 	}
 	if math.IsNaN(quantile) {
+		return math.NaN(), nil
+	}
+	if len(bins) < 2 {
+		return math.NaN(), nil
+	}
+
+	sort.Slice(bins, func(i, j int) bool {
+		return bins[i].upperBound < bins[j].upperBound
+	})
+
+	lastBin := bins[len(bins)-1]
+	if !math.IsInf(lastBin.upperBound, 0) || lastBin.count == 0 {
 		return math.NaN(), nil
 	}
 

--- a/pkg/segment/results/mresults/histogram.go
+++ b/pkg/segment/results/mresults/histogram.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mresults
+
+import "math"
+
+type histogramBin struct {
+	upperBound uint64 // inclusive
+	count      float64
+}
+
+func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
+	if quantile < 0 {
+		return math.Inf(-1), nil
+	}
+	if quantile > 1 {
+		return math.Inf(1), nil
+	}
+	if math.IsNaN(quantile) {
+		return math.NaN(), nil
+	}
+
+	return 0, nil // TODO
+}

--- a/pkg/segment/results/mresults/histogram.go
+++ b/pkg/segment/results/mresults/histogram.go
@@ -69,5 +69,30 @@ func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
 		prevCount = bins[i].count
 	}
 
-	return 0, nil // TODO
+	// Actually compute the quantile.
+	target := quantile * lastBin.count
+	i := sort.Search(len(bins), func(i int) bool {
+		return bins[i].count >= target
+	})
+
+	if i == 0 {
+		return bins[0].upperBound, nil
+	}
+
+	if bins[i].count == target {
+		return bins[i].upperBound, nil
+	}
+
+	// Linear interpolation between buckets
+	lowerBound := 0.0
+	if i > 0 {
+		lowerBound = bins[i-1].upperBound
+	}
+
+	// Calculate the fraction of the way between the two bucket boundaries
+	bucketFraction := (target - bins[i-1].count) / (bins[i].count - bins[i-1].count)
+
+	// Linear interpolation
+	return lowerBound + bucketFraction*(bins[i].upperBound-lowerBound), nil
+
 }

--- a/pkg/segment/results/mresults/histogram.go
+++ b/pkg/segment/results/mresults/histogram.go
@@ -75,22 +75,23 @@ func histogramQuantile(quantile float64, bins []histogramBin) (float64, error) {
 		return bins[i].count >= target
 	})
 
-	if i == 0 {
-		return bins[0].upperBound, nil
+	if i == 0 && bins[i].upperBound <= 0 {
+		return bins[i].upperBound, nil
 	}
 
 	if bins[i].count == target {
 		return bins[i].upperBound, nil
 	}
 
-	// Linear interpolation between buckets
+	// Linear interpolation between bins
 	lowerBound := 0.0
+	LowerBinCount := 0.0
 	if i > 0 {
 		lowerBound = bins[i-1].upperBound
+		LowerBinCount = bins[i-1].count
 	}
 
-	// Calculate the fraction of the way between the two bucket boundaries
-	bucketFraction := (target - bins[i-1].count) / (bins[i].count - bins[i-1].count)
+	bucketFraction := (target - LowerBinCount) / (bins[i].count - LowerBinCount)
 
 	// Linear interpolation
 	return lowerBound + bucketFraction*(bins[i].upperBound-lowerBound), nil

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Most of these tests are based off the documentation at
+// https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile
 func Test_histogramQuantile(t *testing.T) {
 	t.Run("badQuantile", func(t *testing.T) {
 		value, err := histogramQuantile(-0.1, []histogramBin{})
@@ -111,5 +113,17 @@ func Test_histogramQuantile(t *testing.T) {
 		value, err = histogramQuantile(0.1, bins)
 		assert.NoError(t, err)
 		assert.Equal(t, 2.0, value) // Linear interpolation between 0 and 5.
+	})
+
+	t.Run("quantileInLastBucket", func(t *testing.T) {
+		bins := []histogramBin{
+			{upperBound: 10, count: 25},
+			{upperBound: 20, count: 50},
+			{upperBound: 30, count: 75},
+			{upperBound: math.Inf(1), count: 100},
+		}
+		value, err := histogramQuantile(0.9, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, 30.0, value) // Upper bound of last non-infinite bucket.
 	})
 }

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -90,4 +90,26 @@ func Test_histogramQuantile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 24.0, value) // 50th is 20; 75th is 30; so 60th is (20 + (2/5) * 10) = 24
 	})
+
+	t.Run("quantileInFirstBucket", func(t *testing.T) {
+		bins := []histogramBin{
+			{upperBound: -10, count: 25},
+			{upperBound: -5, count: 50},
+			{upperBound: 10, count: 75},
+			{upperBound: math.Inf(1), count: 100},
+		}
+		value, err := histogramQuantile(0.1, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, -10.0, value) // Upper bound of first bucket, since it's negative.
+
+		bins = []histogramBin{
+			{upperBound: 5, count: 25},
+			{upperBound: 10, count: 50},
+			{upperBound: 20, count: 75},
+			{upperBound: math.Inf(1), count: 100},
+		}
+		value, err = histogramQuantile(0.1, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, 2.0, value) // Linear interpolation between 0 and 5.
+	})
 }

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -38,4 +38,28 @@ func Test_histogramQuantile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
 	})
+
+	t.Run("insufficientData", func(t *testing.T) {
+		bins := []histogramBin{}
+		value, err := histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
+
+		bins = []histogramBin{{upperBound: 1, count: 1}}
+		value, err = histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
+
+		bins = []histogramBin{{upperBound: 1, count: 0}, {upperBound: math.Inf(1), count: 0}}
+		value, err = histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
+	})
+
+	t.Run("badHighestBin", func(t *testing.T) {
+		bins := []histogramBin{{upperBound: 1, count: 1}, {upperBound: 10, count: 1}}
+		value, err := histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
+	})
 }

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -73,4 +73,21 @@ func Test_histogramQuantile(t *testing.T) {
 		_, err = histogramQuantile(0.5, bins)
 		assert.NoError(t, err)
 	})
+
+	t.Run("quantileInMiddle", func(t *testing.T) {
+		bins := []histogramBin{
+			{upperBound: 10, count: 250},
+			{upperBound: 20, count: 500},
+			{upperBound: 30, count: 750},
+			{upperBound: math.Inf(1), count: 1000},
+		}
+
+		value, err := histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, 20.0, value)
+
+		value, err = histogramQuantile(0.6, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, 24.0, value) // 50th is 20; 75th is 30; so 60th is (20 + (2/5) * 10) = 24
+	})
 }

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package mresults
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_histogramQuantile(t *testing.T) {
+	t.Run("badQuantile", func(t *testing.T) {
+		value, err := histogramQuantile(-0.1, []histogramBin{})
+		assert.NoError(t, err)
+		assert.True(t, math.IsInf(value, -1), "expected -Inf; got %f", value)
+
+		value, err = histogramQuantile(1.1, []histogramBin{})
+		assert.NoError(t, err)
+		assert.True(t, math.IsInf(value, 1), "expected Inf; got %f", value)
+
+		value, err = histogramQuantile(math.NaN(), []histogramBin{})
+		assert.NoError(t, err)
+		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
+	})
+}

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -126,4 +126,17 @@ func Test_histogramQuantile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 30.0, value) // Upper bound of last non-infinite bucket.
 	})
+
+	t.Run("sortBins", func(t *testing.T) {
+		bins := []histogramBin{
+			{upperBound: 10, count: 25},
+			{upperBound: math.Inf(1), count: 100},
+			{upperBound: 30, count: 75},
+			{upperBound: 20, count: 50},
+		}
+
+		value, err := histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+		assert.Equal(t, 20.0, value)
+	})
 }

--- a/pkg/segment/results/mresults/histogram_test.go
+++ b/pkg/segment/results/mresults/histogram_test.go
@@ -62,4 +62,15 @@ func Test_histogramQuantile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, math.IsNaN(value), "expected NaN; got %f", value)
 	})
+
+	t.Run("monotonicIncreasing", func(t *testing.T) {
+		bins := []histogramBin{{upperBound: 1, count: 4}, {upperBound: math.Inf(1), count: 3}}
+		_, err := histogramQuantile(0.5, bins)
+		assert.Error(t, err)
+
+		// There should be a little room for floating point errors.
+		bins = []histogramBin{{upperBound: 1, count: 2e12}, {upperBound: math.Inf(1), count: 2e12 - 1}}
+		_, err = histogramQuantile(0.5, bins)
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -495,6 +495,24 @@ func (r *MetricsResult) ApplyFunctionsToResults(parallelism int, function struct
 	return nil
 }
 
+func (r *MetricsResult) ApplyHistogramToResults(parallelism int, agg *structs.HistogramAgg) error {
+	if agg == nil {
+		log.Errorf("ApplyHistogramToResults: HistogramAgg is nil")
+		return fmt.Errorf("nil histogram agg")
+	}
+
+	seriesIds := make([]string, 0, len(r.Results))
+	for seriesId := range r.Results {
+		seriesIds = append(seriesIds, seriesId)
+	}
+
+	switch agg.Function {
+
+	}
+
+	return nil
+}
+
 func (r *MetricsResult) AddError(err error) {
 	r.rwLock.Lock()
 	r.ErrList = append(r.ErrList, err)

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -97,6 +97,7 @@ const (
 	RangeFunction
 	TimeFunction
 	LabelFunction
+	HistogramFunction
 )
 
 type LabelReplacementKeyType uint8
@@ -135,6 +136,11 @@ type Function struct {
 	LabelFunction *LabelFunctionExpr
 }
 
+type HistogramAgg struct {
+	Function utils.HistogramFunctions
+	Quantile float64
+}
+
 type Downsampler struct {
 	Interval   int
 	Unit       string
@@ -147,12 +153,14 @@ type MetricQueryAggBlockType int
 const (
 	AggregatorBlock MetricQueryAggBlockType = iota + 1
 	FunctionBlock
+	HistogramBlock
 )
 
 type MetricQueryAgg struct {
 	AggBlockType    MetricQueryAggBlockType
 	AggregatorBlock *Aggregation
 	FunctionBlock   *Function
+	HistogramBlock  *HistogramAgg
 	Next            *MetricQueryAgg
 }
 

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -453,6 +453,12 @@ const (
 	LabelReplace
 )
 
+type HistogramFunctions int
+
+const (
+	HistogramQuantile HistogramFunctions = iota + 1
+)
+
 // For columns used by aggs with eval statements, we should keep their raw values because we need to evaluate them
 // For columns only used by aggs without eval statements, we should not keep their raw values because it is a waste of performance
 // If we only use two modes. Later occurring aggs will overwrite earlier occurring aggs' usage status. E.g. stats dc(eval(lower(state))), dc(state)


### PR DESCRIPTION
# Description
This isn't ready yet, but it begins adding the `histogram_quantile` PromQL function. The commits through `68e69151ffaa2681a41d3e8b2163295a3825b6e2` implement and test the core function. We still need to integrate this into our query parser, then pass the appropriate input, and extract the results. Part of that was started in `96a72dcd07f01a5d8e6ea35069e7ab22d69c7990`

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
