### PR TITLE
Handle ambiguous expected results

### DIFF
--- a/tools/sigclient/pkg/query/querymanager.go
+++ b/tools/sigclient/pkg/query/querymanager.go
@@ -19,10 +19,10 @@ package query
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+	"verifier/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -158,14 +158,7 @@ func (qm *queryManager) getLastEpoch(logs []map[string]interface{}) (uint64, boo
 		return 0, false
 	}
 
-	// Convert to uint64
-	s := fmt.Sprintf("%v", timestamp)
-	epoch, err := strconv.ParseUint(s, 10, 64)
-	if err != nil {
-		return 0, false
-	}
-
-	return epoch, true
+	return utils.AsUint64(timestamp)
 }
 
 func (qm *queryManager) canRunMore() bool {

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -230,7 +230,8 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 	}
 
 	if !utils.EqualMaps(expectedColumnsSet, actualColumnsSet) {
-		return fmt.Errorf("FQV.MatchesResult: expected columns %+v, got %+v", expectedColumnsSet, actualColumnsSet)
+		return fmt.Errorf("FQV.MatchesResult: expected columns %+v, got %+v\nactual logs: %+v",
+			expectedColumnsSet, actualColumnsSet, response.Hits.Records)
 	}
 
 	log.Infof("FQV.MatchesResult: successfully matched %d logs", len(f.reversedResults))
@@ -256,6 +257,10 @@ func logsMatch(expectedLogs []map[string]interface{}, actualLogs []map[string]in
 	if len(expectedGroups) != len(actualGroups) {
 		return fmt.Errorf("logsMatch: expected %d unique timestamps, got %d",
 			len(expectedGroups), len(actualGroups))
+	}
+
+	if len(expectedGroups) == 0 {
+		return nil
 	}
 
 	for i := range expectedGroups[:len(expectedGroups)-1] {

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -129,7 +129,27 @@ func (f *filterQueryValidator) HandleLog(log map[string]interface{}) error {
 	f.reversedResults = append(f.reversedResults, log)
 
 	if len(f.reversedResults) > f.head {
-		f.reversedResults = f.reversedResults[1:]
+		lastKeptLog := f.reversedResults[len(f.reversedResults)-f.head]
+		var lastKeptTimestamp uint64
+		if timestamp, ok := lastKeptLog[timestampCol]; !ok {
+			return fmt.Errorf("FQV.HandleLog: missing timestamp column")
+		} else if lastKeptTimestamp, ok = utils.AsUint64(timestamp); !ok {
+			return fmt.Errorf("FQV.HandleLog: invalid timestamp type %T", timestamp)
+		}
+
+		numToDelete := 0
+		for i := range f.reversedResults[:len(f.reversedResults)-f.head] {
+			var thisTimestamp uint64
+			if timestamp, ok := f.reversedResults[i][timestampCol]; !ok {
+				return fmt.Errorf("FQV.HandleLog: missing timestamp column")
+			} else if thisTimestamp, ok = utils.AsUint64(timestamp); !ok {
+				return fmt.Errorf("FQV.HandleLog: invalid timestamp type %T", timestamp)
+			} else if thisTimestamp < lastKeptTimestamp {
+				numToDelete++
+			}
+		}
+
+		f.reversedResults = f.reversedResults[numToDelete:]
 	}
 
 	return nil
@@ -159,9 +179,10 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 		return fmt.Errorf("FQV.MatchesResult: cannot unmarshal %s; err=%v", result, err)
 	}
 
-	if response.Hits.TotalMatched.Value != len(f.reversedResults) {
+	numExpectedLogs := min(len(f.reversedResults), f.head)
+	if response.Hits.TotalMatched.Value != numExpectedLogs {
 		return fmt.Errorf("FQV.MatchesResult: expected %d logs, got %d",
-			len(f.reversedResults), response.Hits.TotalMatched.Value)
+			numExpectedLogs, response.Hits.TotalMatched.Value)
 	}
 
 	if response.Hits.TotalMatched.Relation != "eq" {
@@ -169,9 +190,9 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 			response.Hits.TotalMatched.Relation)
 	}
 
-	if len(response.Hits.Records) != len(f.reversedResults) {
+	if len(response.Hits.Records) != numExpectedLogs {
 		return fmt.Errorf("FQV.MatchesResult: expected %d actual records, got %d",
-			len(f.reversedResults), len(response.Hits.Records))
+			numExpectedLogs, len(response.Hits.Records))
 	}
 
 	// Parsing json treats all numbers as float64, so we need to convert the logs.
@@ -192,6 +213,12 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 	// Compare the columns.
 	expectedColumnsSet := make(map[string]struct{})
 	for _, log := range expectedLogs {
+		if len(expectedLogs) > f.head {
+			// The exact expected logs are ambiguous. Skip logs that weren't in the result.
+			if !utils.SliceContainsItems(response.Hits.Records, []map[string]interface{}{log}, utils.EqualMaps) {
+				continue
+			}
+		}
 		for col := range log {
 			expectedColumnsSet[col] = struct{}{}
 		}
@@ -216,10 +243,6 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 // but it's a valid sorting order; since sorting is on the timestamp, this
 // happens when multiple logs have the same timestamp.
 func logsMatch(expectedLogs []map[string]interface{}, actualLogs []map[string]interface{}) error {
-	if len(expectedLogs) != len(actualLogs) {
-		return fmt.Errorf("logsMatch: expected %d logs, got %d", len(expectedLogs), len(actualLogs))
-	}
-
 	expectedGroups, err := groupBySortColumn(expectedLogs, timestampCol)
 	if err != nil {
 		return fmt.Errorf("logsMatch: failed to group expected logs; err=%v", err)
@@ -235,11 +258,20 @@ func logsMatch(expectedLogs []map[string]interface{}, actualLogs []map[string]in
 			len(expectedGroups), len(actualGroups))
 	}
 
-	for i := range expectedGroups {
+	for i := range expectedGroups[:len(expectedGroups)-1] {
 		if !utils.IsPermutation(expectedGroups[i], actualGroups[i], utils.EqualMaps) {
 			return fmt.Errorf("logsMatch: expected logs in group %v: %+v, got %+v",
 				i, expectedGroups[i], actualGroups[i])
 		}
+	}
+
+	// For the last group, there can be some ambiguity (e.g., the last 3 logs
+	// all have the same timestamp, but 4 logs with that timestamp match the
+	// query, so any 3 of those 4 logs are valid).
+	i := len(expectedGroups) - 1
+	if !utils.SliceContainsItems(expectedGroups[i], actualGroups[i], utils.EqualMaps) {
+		return fmt.Errorf("logsMatch: expected logs in final group: %+v, got %+v",
+			expectedGroups[i], actualGroups[i])
 	}
 
 	return nil

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -343,7 +343,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 		}`)
 		assert.NoError(t, validator.MatchesResult(expectedJson))
 
-		numIters := 10000
+		numIters := 1000
 		waitGroup := &sync.WaitGroup{}
 		waitGroup.Add(2)
 		go func() {

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -262,6 +262,67 @@ func Test_FilterQueryValidator(t *testing.T) {
 		}`)))
 	})
 
+	t.Run("AmbiguousTopN", func(t *testing.T) {
+		logs := []map[string]interface{}{
+			{"city": "Boston", "timestamp": uint64(1), "foo": 30},
+			{"city": "Boston", "timestamp": uint64(1), "bar": 36},
+			{"city": "Boston", "timestamp": uint64(1), "baz": 22},
+			{"city": "Boston", "timestamp": uint64(2), "age": 42},
+		}
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+
+		// This is valid: logs[3], logs[2], logs[1]
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 2, "age": 42},
+					{"city": "Boston", "timestamp": 1, "baz": 22},
+					{"city": "Boston", "timestamp": 1, "bar": 36}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age", "baz", "bar"]
+		}`)))
+
+		// This is valid: logs[3], logs[2], logs[0]
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 2, "age": 42},
+					{"city": "Boston", "timestamp": 1, "baz": 22},
+					{"city": "Boston", "timestamp": 1, "foo": 30}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age", "baz", "foo"]
+		}`)))
+
+		// This is valid: logs[3], logs[0], logs[1]
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 2, "age": 42},
+					{"city": "Boston", "timestamp": 1, "foo": 30},
+					{"city": "Boston", "timestamp": 1, "bar": 36}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age", "foo", "bar"]
+		}`)))
+	})
+
 	t.Run("Concurrency", func(t *testing.T) {
 		head, startEpoch, endEpoch := 1, uint64(0), uint64(10)
 		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)

--- a/tools/sigclient/pkg/utils/numbers.go
+++ b/tools/sigclient/pkg/utils/numbers.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func AsUint64(x interface{}) (uint64, bool) {
+	s := fmt.Sprintf("%v", x)
+	result, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return result, true
+}


### PR DESCRIPTION
# Description
With the longevity test, sometimes the expected results for a query are ambiguous; this PR makes the query validator accept any valid set of results.

An example: A query sorts by timestamp and keeps the top 10, but more than 10 logs match the query. Suppose that, when sorted, logs 8-12 all have the same timestamp. Then the correct response requires the first 1-7 logs, and 3 of the logs from 8-12, but any 3 of those logs are valid.

# Testing
New unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
