### PR TITLE
Only send columns that have data for logs query

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -1311,7 +1311,15 @@ func (iqr *IQR) AsResult(qType structs.QueryType, includeNulls bool) (*structs.P
 		}
 	}
 
-	allCNames := toputils.GetKeysOfMap(records)
+	allCNames := make([]string, 0, len(records))
+	for cname, values := range records {
+		for _, value := range values {
+			if !value.IsNull() {
+				allCNames = append(allCNames, cname)
+				break
+			}
+		}
+	}
 
 	var response *structs.PipeSearchResponseOuter
 	switch qType {


### PR DESCRIPTION
# Description
For a logs query, don't return columns in the `allColumns` field if that column doesn't have any data for the returned logs

# Testing
Ran the longevity test with sigclient:
```
go run main.go longevity -d http://localhost:8081/elastic -q http://localhost:5122/api/search
```
Without this change, it would fail in ~40 seconds. Now it's run for 5 minutes without issue.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
