### PR TITLE
Add stats count queries to the longevity test

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -565,6 +565,8 @@ var longevityCmd = &cobra.Command{
 		templates := []*query.QueryTemplate{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 1, 1),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -110,7 +110,7 @@ func (f *filterQueryValidator) Info() string {
 	duration := time.Duration(f.endEpoch-f.startEpoch) * time.Millisecond
 	numResults := min(len(f.reversedResults), f.head)
 
-	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v results",
+	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v matches",
 		f.query, duration, f.startEpoch, f.endEpoch, numResults)
 }
 
@@ -388,7 +388,7 @@ func (c *countQueryValidator) Copy() queryValidator {
 func (c *countQueryValidator) Info() string {
 	duration := time.Duration(c.endEpoch-c.startEpoch) * time.Millisecond
 
-	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v results",
+	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v matches",
 		c.query, duration, c.startEpoch, c.endEpoch, c.numMatches)
 }
 

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -420,5 +420,15 @@ func (c *countQueryValidator) MatchesResult(result []byte) error {
 		return fmt.Errorf("CQV.MatchesResult: cannot unmarshal %s; err=%v", result, err)
 	}
 
-	panic("not implemented")
+	if response.Hits.TotalMatched.Value != c.numMatches {
+		return fmt.Errorf("FQV.MatchesResult: expected %d logs, got %d",
+			c.numMatches, response.Hits.TotalMatched.Value)
+	}
+
+	if response.Hits.TotalMatched.Relation != "eq" {
+		return fmt.Errorf("FQV.MatchesResult: expected relation to be eq, got %s",
+			response.Hits.TotalMatched.Relation)
+	}
+
+	return nil
 }

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -164,7 +164,6 @@ type logsResponse struct {
 	// Used for aggregation queries.
 	MeasureFunctions []string        `json:"measureFunctions,omitempty"`
 	Measure          []measureResult `json:"measure,omitempty"`
-	BucketCount      int             `json:"bucketCount,omitempty"`
 }
 
 type hits struct {

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -160,6 +160,11 @@ func (f *filterQueryValidator) HandleLog(log map[string]interface{}) error {
 type logsResponse struct {
 	Hits       hits     `json:"hits"`
 	AllColumns []string `json:"allColumns"`
+
+	// Used for aggregation queries.
+	MeasureFunctions []string        `json:"measureFunctions,omitempty"`
+	Measure          []measureResult `json:"measure,omitempty"`
+	BucketCount      int             `json:"bucketCount,omitempty"`
 }
 
 type hits struct {
@@ -170,6 +175,11 @@ type hits struct {
 type totalMatched struct {
 	Value    int    `json:"value"`
 	Relation string `json:"relation"`
+}
+
+type measureResult struct {
+	GroupByValues []string               `json:"GroupByValues"`
+	Value         map[string]interface{} `json:"MeasureVal"`
 }
 
 func (f *filterQueryValidator) MatchesResult(result []byte) error {

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -363,8 +363,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 0}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 	})
 
@@ -386,8 +385,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 4}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 	})
 
@@ -410,8 +408,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 4}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 
 		// Bad allColumns.
@@ -427,8 +424,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 4}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 
 		// Bad measureFunctions.
@@ -444,8 +440,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 4}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 
 		// Bad GroupByValues.
@@ -461,8 +456,7 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": [""],
 					"MeasureVal": {"count(*)": 4}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
 
 		// Bad MeasureVal.
@@ -478,10 +472,8 @@ func Test_CountQueryValidator(t *testing.T) {
 			"measure": [{
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 42}
-			}],
-			"bucketCount": 1
+			}]
 		}`)))
-
 	})
 }
 

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_implmentsQueryValidator(t *testing.T) {
+func Test_implementsQueryValidator(t *testing.T) {
 	var _ queryValidator = &filterQueryValidator{}
 	var _ queryValidator = &countQueryValidator{}
 }

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -26,6 +26,7 @@ import (
 
 func Test_implmentsQueryValidator(t *testing.T) {
 	var _ queryValidator = &filterQueryValidator{}
+	var _ queryValidator = &countQueryValidator{}
 }
 
 func Test_FilterQueryValidator(t *testing.T) {
@@ -334,6 +335,39 @@ func Test_FilterQueryValidator(t *testing.T) {
 		}()
 
 		waitGroup.Wait()
+	})
+}
+
+func Test_CountQueryValidator(t *testing.T) {
+	logs := []map[string]interface{}{
+		{"city": "Boston", "timestamp": uint64(1), "age": 30},
+		{"city": "Boston", "timestamp": uint64(2), "age": 36},
+		{"city": "New York", "timestamp": uint64(3), "age": 22},
+		{"city": "Boston", "timestamp": uint64(4), "age": 22},
+		{"city": "Boston", "timestamp": uint64(5), "latency": 100},
+	}
+
+	t.Run("NoMatches", func(t *testing.T) {
+		startEpoch, endEpoch := uint64(0), uint64(10)
+		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 0,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"IGroupByValues": [{"Dtype": 5, "CVal": "*"}],
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 0}
+			}],
+			"bucketCount": 1
+		}`)))
 	})
 }
 

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -339,19 +339,10 @@ func Test_FilterQueryValidator(t *testing.T) {
 }
 
 func Test_CountQueryValidator(t *testing.T) {
-	logs := []map[string]interface{}{
-		{"city": "Boston", "timestamp": uint64(1), "age": 30},
-		{"city": "Boston", "timestamp": uint64(2), "age": 36},
-		{"city": "New York", "timestamp": uint64(3), "age": 22},
-		{"city": "Boston", "timestamp": uint64(4), "age": 22},
-		{"city": "Boston", "timestamp": uint64(5), "latency": 100},
-	}
-
 	t.Run("NoMatches", func(t *testing.T) {
 		startEpoch, endEpoch := uint64(0), uint64(10)
 		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)
 		assert.NoError(t, err)
-		addLogsWithoutError(t, validator, logs)
 		assert.NoError(t, validator.MatchesResult([]byte(`{
 			"hits": {
 				"totalMatched": {
@@ -362,7 +353,6 @@ func Test_CountQueryValidator(t *testing.T) {
 			"allColumns": ["count(*)"],
 			"measureFunctions": ["count(*)"],
 			"measure": [{
-					"IGroupByValues": [{"Dtype": 5, "CVal": "*"}],
 					"GroupByValues": ["*"],
 					"MeasureVal": {"count(*)": 0}
 			}],

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -339,6 +339,14 @@ func Test_FilterQueryValidator(t *testing.T) {
 }
 
 func Test_CountQueryValidator(t *testing.T) {
+	logs := []map[string]interface{}{
+		{"city": "Boston", "timestamp": uint64(1), "age": 30},
+		{"city": "Boston", "timestamp": uint64(2), "age": 36},
+		{"city": "New York", "timestamp": uint64(3), "age": 22},
+		{"city": "Boston", "timestamp": uint64(4), "age": 22},
+		{"city": "Boston", "timestamp": uint64(5), "latency": 100},
+	}
+
 	t.Run("NoMatches", func(t *testing.T) {
 		startEpoch, endEpoch := uint64(0), uint64(10)
 		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)
@@ -364,13 +372,7 @@ func Test_CountQueryValidator(t *testing.T) {
 		startEpoch, endEpoch := uint64(0), uint64(10)
 		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)
 		assert.NoError(t, err)
-		addLogsWithoutError(t, validator, []map[string]interface{}{
-			{"city": "Boston", "timestamp": uint64(1), "age": 30},
-			{"city": "Boston", "timestamp": uint64(2), "age": 36},
-			{"city": "New York", "timestamp": uint64(3), "age": 22},
-			{"city": "Boston", "timestamp": uint64(4), "age": 22},
-			{"city": "Boston", "timestamp": uint64(5), "latency": 100},
-		})
+		addLogsWithoutError(t, validator, logs)
 
 		assert.NoError(t, validator.MatchesResult([]byte(`{
 			"hits": {
@@ -387,6 +389,99 @@ func Test_CountQueryValidator(t *testing.T) {
 			}],
 			"bucketCount": 1
 		}`)))
+	})
+
+	t.Run("BadResponse", func(t *testing.T) {
+		startEpoch, endEpoch := uint64(0), uint64(10)
+		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+
+		// Incorrect totalMatched.
+		assert.Error(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 2,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 4}
+			}],
+			"bucketCount": 1
+		}`)))
+
+		// Bad allColumns.
+		assert.Error(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 4,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["total"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 4}
+			}],
+			"bucketCount": 1
+		}`)))
+
+		// Bad measureFunctions.
+		assert.Error(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 4,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["someFunc"],
+			"measure": [{
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 4}
+			}],
+			"bucketCount": 1
+		}`)))
+
+		// Bad GroupByValues.
+		assert.Error(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 4,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"GroupByValues": [""],
+					"MeasureVal": {"count(*)": 4}
+			}],
+			"bucketCount": 1
+		}`)))
+
+		// Bad MeasureVal.
+		assert.Error(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 4,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 42}
+			}],
+			"bucketCount": 1
+		}`)))
+
 	})
 }
 


### PR DESCRIPTION
# Description
This adds the following queries to the longevity test suite:
```
state_c1=Texas | stats count
app_version_c1=1.2.3 | stats count
```
It's also easy to any other query like `key=value | stats count`

# Testing
New unit tests 

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
