### PR TITLE
Add wildcard searches to the longevity test

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -565,6 +565,8 @@ var longevityCmd = &cobra.Command{
 		templates := []*query.QueryTemplate{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", 10, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", 10, 0, 0)), 1, 1),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -392,6 +392,10 @@ type countQueryValidator struct {
 func NewCountQueryValidator(key string, value string, startEpoch uint64,
 	endEpoch uint64) (queryValidator, error) {
 
+	if strings.Contains(value, "*") {
+		return nil, fmt.Errorf("NewCountQueryValidator: wildcards are not supported")
+	}
+
 	return &countQueryValidator{
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -20,7 +20,9 @@ package query
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 	"verifier/pkg/utils"
@@ -62,10 +64,24 @@ func (b *basicValidator) PastEndTime(timestamp uint64) bool {
 type filterQueryValidator struct {
 	basicValidator
 	key             string
-	value           string
+	value           stringOrRegex
 	head            int
 	reversedResults []map[string]interface{}
 	lock            sync.Mutex
+}
+
+type stringOrRegex struct {
+	isRegex   bool
+	rawString string
+	regex     regexp.Regexp
+}
+
+func (s *stringOrRegex) Matches(value string) bool {
+	if s.isRegex {
+		return s.regex.MatchString(value)
+	}
+
+	return value == s.rawString
 }
 
 func NewFilterQueryValidator(key string, value string, head int, startEpoch uint64,
@@ -79,6 +95,22 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 		return nil, fmt.Errorf("NewFilterQueryValidator: head must be between 1 and 99 inclusive")
 	}
 
+	// Don't allow matching literal asterisks.
+	if strings.Contains(value, "\\*") {
+		return nil, fmt.Errorf("NewFilterQueryValidator: matching literal asterisks is not implemented")
+	}
+
+	finalValue := stringOrRegex{isRegex: false, rawString: value}
+	if strings.Contains(finalValue.rawString, "*") {
+		regex, err := regexp.Compile(strings.ReplaceAll(finalValue.rawString, "*", ".*"))
+		if err != nil {
+			return nil, fmt.Errorf("NewFilterQueryValidator: invalid regex %v; err=%v",
+				finalValue.rawString, err)
+		}
+
+		finalValue = stringOrRegex{isRegex: true, regex: *regex}
+	}
+
 	return &filterQueryValidator{
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
@@ -86,7 +118,7 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 			query:      fmt.Sprintf("%v=%v | head %v", key, value, head),
 		},
 		key:             key,
-		value:           value,
+		value:           finalValue,
 		head:            head,
 		reversedResults: make([]map[string]interface{}, 0),
 	}, nil
@@ -121,7 +153,7 @@ func (f *filterQueryValidator) HandleLog(log map[string]interface{}) error {
 	}
 
 	value, ok := log[f.key]
-	if !ok || value != fmt.Sprintf("%v", f.value) {
+	if !ok || !f.value.Matches(fmt.Sprintf("%v", value)) {
 		return nil
 	}
 

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -102,7 +102,9 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 
 	finalValue := stringOrRegex{isRegex: false, rawString: value}
 	if strings.Contains(finalValue.rawString, "*") {
-		regex, err := regexp.Compile(strings.ReplaceAll(finalValue.rawString, "*", ".*"))
+		s := strings.ReplaceAll(finalValue.rawString, "*", ".*")
+		s = fmt.Sprintf("^%v$", s)
+		regex, err := regexp.Compile(s)
 		if err != nil {
 			return nil, fmt.Errorf("NewFilterQueryValidator: invalid regex %v; err=%v",
 				finalValue.rawString, err)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -115,7 +115,7 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
 			endEpoch:   endEpoch,
-			query:      fmt.Sprintf("%v=%v | head %v", key, value, head),
+			query:      fmt.Sprintf(`%v="%v" | head %v`, key, value, head),
 		},
 		key:             key,
 		value:           finalValue,

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -507,6 +507,12 @@ func Test_CountQueryValidator(t *testing.T) {
 			}]
 		}`)))
 	})
+
+	t.Run("Wildcard", func(t *testing.T) {
+		startEpoch, endEpoch := uint64(0), uint64(10)
+		_, err := NewCountQueryValidator("city", "*", startEpoch, endEpoch)
+		assert.Error(t, err) // Change if we want to support this.
+	})
 }
 
 func addLogsWithoutError(t *testing.T, validator queryValidator, logs []map[string]interface{}) {

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -328,6 +328,14 @@ func Test_FilterQueryValidator(t *testing.T) {
 		assert.Error(t, err) // Change if we want to support this.
 	})
 
+	t.Run("ValueHasSpaces", func(t *testing.T) {
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		validator, err := NewFilterQueryValidator("city", "New York", head, startEpoch, endEpoch)
+		assert.NoError(t, err)
+		query, _, _ := validator.GetQuery()
+		assert.Equal(t, `city="New York" | head 3`, query)
+	})
+
 	t.Run("Concurrency", func(t *testing.T) {
 		head, startEpoch, endEpoch := 1, uint64(0), uint64(10)
 		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -302,9 +302,10 @@ func Test_FilterQueryValidator(t *testing.T) {
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, []map[string]interface{}{
 			{"city": "New York", "timestamp": uint64(1), "age": 30},
-			{"city": "Newark", "timestamp": uint64(2), "age": 22},
-			{"city": "Boston", "timestamp": uint64(3), "age": 22},
-			{"city": "New Orleans", "timestamp": uint64(4), "age": 36},
+			{"city": "Hello New York", "timestamp": uint64(2), "age": 30},
+			{"city": "Newark", "timestamp": uint64(3), "age": 22},
+			{"city": "Boston", "timestamp": uint64(4), "age": 22},
+			{"city": "New Orleans", "timestamp": uint64(5), "age": 36},
 		})
 
 		assert.NoError(t, validator.MatchesResult([]byte(`{
@@ -314,7 +315,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 					"relation": "eq"
 				},
 				"records": [
-					{"city": "New Orleans", "timestamp": 4, "age": 36},
+					{"city": "New Orleans", "timestamp": 5, "age": 36},
 					{"city": "New York", "timestamp": 1, "age": 30}
 				]
 			},

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -296,6 +296,38 @@ func Test_FilterQueryValidator(t *testing.T) {
 		}`)))
 	})
 
+	t.Run("Wildcard", func(t *testing.T) {
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		validator, err := NewFilterQueryValidator("city", "New *", head, startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, []map[string]interface{}{
+			{"city": "New York", "timestamp": uint64(1), "age": 30},
+			{"city": "Newark", "timestamp": uint64(2), "age": 22},
+			{"city": "Boston", "timestamp": uint64(3), "age": 22},
+			{"city": "New Orleans", "timestamp": uint64(4), "age": 36},
+		})
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 2,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "New Orleans", "timestamp": 4, "age": 36},
+					{"city": "New York", "timestamp": 1, "age": 30}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age"]
+		}`)))
+	})
+
+	t.Run("MatchLiteralAsterisk", func(t *testing.T) {
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		_, err := NewFilterQueryValidator("city", "2 \\* 5", head, startEpoch, endEpoch)
+		assert.Error(t, err) // Change if we want to support this.
+	})
+
 	t.Run("Concurrency", func(t *testing.T) {
 		head, startEpoch, endEpoch := 1, uint64(0), uint64(10)
 		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)


### PR DESCRIPTION
# Description
1. Handle wildcard queries in the longevity test, and add some to the suite
2. Fix an issue with `key=value` queries where `value` has spaces

# Testing
New unit tests, and manually ran longevity

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
