### PR TITLE
Add sort queries to the longevity test

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -567,8 +567,8 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 1, 1),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency", 10, 0, 0)), 300, 10),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 1, 1),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -563,10 +563,12 @@ var longevityCmd = &cobra.Command{
 		dataGeneratorConfig := utils.InitGeneratorDataConfig(maxCols, true, minCols, uniqueCols)
 
 		templates := []*query.QueryTemplate{
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 300, 10),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", 10, 0, 0)), 1, 1),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", 10, 0, 0)), 300, 10),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", "", 10, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "Boston", "", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency", 10, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency", 10, 0, 0)), 1, 1),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -115,15 +115,20 @@ func NewFilterQueryValidator(key string, value string, numericSortCol string, he
 		finalValue = stringOrRegex{isRegex: true, regex: *regex}
 	}
 
+	var query string
 	if numericSortCol == "" {
 		numericSortCol = timestampCol
+		query = fmt.Sprintf(`%v="%v" | head %v`, key, value, head)
+	} else {
+		// Only sorting by numeric columns is supported for now.
+		query = fmt.Sprintf(`%v="%v" | sort %v num(%v)`, key, value, head, numericSortCol)
 	}
 
 	return &filterQueryValidator{
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
 			endEpoch:   endEpoch,
-			query:      fmt.Sprintf(`%v="%v" | head %v`, key, value, head),
+			query:      query,
 		},
 		key:             key,
 		value:           finalValue,

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -121,7 +121,8 @@ func NewFilterQueryValidator(key string, value string, numericSortCol string, he
 		query = fmt.Sprintf(`%v="%v" | head %v`, key, value, head)
 	} else {
 		// Only sorting by numeric columns is supported for now.
-		query = fmt.Sprintf(`%v="%v" | sort %v num(%v)`, key, value, head, numericSortCol)
+		// Sort so the highest values are first.
+		query = fmt.Sprintf(`%v="%v" | sort %v -num(%v)`, key, value, head, numericSortCol)
 	}
 
 	return &filterQueryValidator{
@@ -147,6 +148,7 @@ func (f *filterQueryValidator) Copy() queryValidator {
 		},
 		key:             f.key,
 		value:           f.value,
+		sortCol:         f.sortCol,
 		head:            f.head,
 		reversedResults: make([]map[string]interface{}, 0),
 	}

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -357,20 +357,15 @@ func groupBySortColumn(logs []map[string]interface{}, sortColumn string) ([][]ma
 	groups := make([][]map[string]interface{}, 0)
 	groups = append(groups, make([]map[string]interface{}, 0))
 
-	curValue, ok := logs[0][sortColumn]
-	if !ok {
-		return nil, fmt.Errorf("groupBySortColumn: missing sort column %v", sortColumn)
-	}
+	curValue, curOk := logs[0][sortColumn]
 
 	for _, log := range logs {
 		value, ok := log[sortColumn]
-		if !ok {
-			return nil, fmt.Errorf("groupBySortColumn: missing sort column %v", sortColumn)
-		}
 
-		if value != curValue {
+		if ok != curOk || (ok && curOk && value != curValue) {
 			groups = append(groups, make([]map[string]interface{}, 0))
 			curValue = value
+			curOk = ok
 		}
 
 		groups[len(groups)-1] = append(groups[len(groups)-1], log)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -65,6 +65,7 @@ type filterQueryValidator struct {
 	basicValidator
 	key             string
 	value           stringOrRegex
+	sortCol         string
 	head            int
 	reversedResults []map[string]interface{}
 	lock            sync.Mutex
@@ -84,8 +85,8 @@ func (s *stringOrRegex) Matches(value string) bool {
 	return value == s.rawString
 }
 
-func NewFilterQueryValidator(key string, value string, head int, startEpoch uint64,
-	endEpoch uint64) (queryValidator, error) {
+func NewFilterQueryValidator(key string, value string, numericSortCol string, head int,
+	startEpoch uint64, endEpoch uint64) (queryValidator, error) {
 
 	if head < 1 || head > 99 {
 		// The 99 limit is to simplify the expected results. If siglens returns
@@ -113,6 +114,10 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 		finalValue = stringOrRegex{isRegex: true, regex: *regex}
 	}
 
+	if numericSortCol == "" {
+		numericSortCol = timestampCol
+	}
+
 	return &filterQueryValidator{
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
@@ -121,6 +126,7 @@ func NewFilterQueryValidator(key string, value string, head int, startEpoch uint
 		},
 		key:             key,
 		value:           finalValue,
+		sortCol:         numericSortCol,
 		head:            head,
 		reversedResults: make([]map[string]interface{}, 0),
 	}, nil

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -53,7 +53,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("FewerThanHeadMatch", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs[:2])
 		assert.NoError(t, validator.MatchesResult(expectedJsonMatchingFirstTwo))
@@ -61,7 +61,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("FilterByValue", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs[:3]) // The third log has a different city, so it should be ignored.
 		assert.NoError(t, validator.MatchesResult(expectedJsonMatchingFirstTwo))
@@ -69,7 +69,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("FilterByTime", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(1), uint64(2)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs)
 		assert.NoError(t, validator.MatchesResult(expectedJsonMatchingFirstTwo))
@@ -77,7 +77,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("MissingColumns", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs[3:])
 
@@ -98,7 +98,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("MoreThanHeadMatch", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs)
 
@@ -120,7 +120,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("BadResponse", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs[:1])
 
@@ -182,7 +182,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 			{"city": "Boston", "timestamp": uint64(2), "age": 22},
 		}
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs)
 
@@ -243,7 +243,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 			{"city": "Boston", "timestamp": uint64(2), "age": 42},
 		}
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs)
 
@@ -298,7 +298,7 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("Wildcard", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "New *", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "New *", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, []map[string]interface{}{
 			{"city": "New York", "timestamp": uint64(1), "age": 30},
@@ -325,21 +325,58 @@ func Test_FilterQueryValidator(t *testing.T) {
 
 	t.Run("MatchLiteralAsterisk", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		_, err := NewFilterQueryValidator("city", "2 \\* 5", head, startEpoch, endEpoch)
+		_, err := NewFilterQueryValidator("city", "2 \\* 5", "", head, startEpoch, endEpoch)
 		assert.Error(t, err) // Change if we want to support this.
 	})
 
 	t.Run("ValueHasSpaces", func(t *testing.T) {
 		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "New York", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "New York", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		query, _, _ := validator.GetQuery()
 		assert.Equal(t, `city="New York" | head 3`, query)
 	})
 
+	t.Run("Sort", func(t *testing.T) {
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		validator, err := NewFilterQueryValidator("city", "Boston", "age", head, startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 2, "age": 36},
+					{"city": "Boston", "timestamp": 1, "age": 30},
+					{"city": "Boston", "timestamp": 4, "age": 22}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age"]
+		}`)))
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 2, "age": 36},
+					{"city": "Boston", "timestamp": 1, "age": 30},
+					{"city": "New York", "timestamp": 3, "age": 22}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age"]
+		}`)))
+	})
+
 	t.Run("Concurrency", func(t *testing.T) {
 		head, startEpoch, endEpoch := 1, uint64(0), uint64(10)
-		validator, err := NewFilterQueryValidator("city", "Boston", head, startEpoch, endEpoch)
+		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)
 		assert.NoError(t, err)
 		addLogsWithoutError(t, validator, logs[:1])
 

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -382,6 +382,28 @@ func Test_FilterQueryValidator(t *testing.T) {
 		}`)))
 	})
 
+	t.Run("CustomSortMissingValues", func(t *testing.T) {
+		head, startEpoch, endEpoch := 3, uint64(0), uint64(10)
+		validator, err := NewFilterQueryValidator("city", "Boston", "latency", head, startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 3,
+					"relation": "eq"
+				},
+				"records": [
+					{"city": "Boston", "timestamp": 5, "latency": 100},
+					{"city": "Boston", "timestamp": 4, "age": 22},
+					{"city": "Boston", "timestamp": 2, "age": 36}
+				]
+			},
+			"allColumns": ["city", "timestamp", "age", "latency"]
+		}`)))
+	})
+
 	t.Run("Concurrency", func(t *testing.T) {
 		head, startEpoch, endEpoch := 1, uint64(0), uint64(10)
 		validator, err := NewFilterQueryValidator("city", "Boston", "", head, startEpoch, endEpoch)

--- a/tools/sigclient/pkg/utils/numbers.go
+++ b/tools/sigclient/pkg/utils/numbers.go
@@ -31,3 +31,13 @@ func AsUint64(x interface{}) (uint64, bool) {
 
 	return result, true
 }
+
+func AsFloat64(x interface{}) (float64, bool) {
+	s := fmt.Sprintf("%v", x)
+	result, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return result, true
+}


### PR DESCRIPTION
# Description
Now the longevity test can run queries similar to `key=value | sort col1`
A few notes:

1. Only numeric sort columns are handled so far
2. When no sort column is specified, we sort on timestamp
3. The sort is always descending (this makes it easy to fallback to sorting on timestamp)

# Testing
New unit tests. Also, running the longevity test seems to work, with output like this:
```
INFO[0286] queryManager.runQuery: successfully ran query=city_c1="New *" | head 10, timeSpan=1s (1742250517363-1742250518363), got 10 matches
INFO[0286] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=1s (1742250517363-1742250518363), got 3 matches
INFO[0287] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=1s (1742250518457-1742250519457), got 6 matches
INFO[0287] queryManager.runQuery: successfully ran query=state_c1="Texas" | sort 10 -num(latency_c1), timeSpan=1s (1742250518457-1742250519457), got 10 matches
INFO[0287] queryManager.runQuery: successfully ran query=city_c1="New *" | head 10, timeSpan=1s (1742250518457-1742250519457), got 10 matches
INFO[0288] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=1s (1742250519350-1742250520350), got 7 matches
INFO[0288] queryManager.runQuery: successfully ran query=state_c1="Texas" | sort 10 -num(latency_c1), timeSpan=1s (1742250519350-1742250520350), got 10 matches
INFO[0288] queryManager.runQuery: successfully ran query=city_c1="New *" | head 10, timeSpan=1s (1742250519350-1742250520350), got 10 matches
```
# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
