### PR TITLE
Do not thrown err when tags tree file does not exist

### DIFF
--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -102,6 +102,9 @@ func InitAllTagsTreeReader(tagsTreeBaseDir string) (*AllTagTreeReaders, error) {
 		// This also inserts the tagTreeReader into the tagTrees map.
 		_, err = attr.initTagsTreeReader(tagKey)
 		if err != nil {
+			if utils.IsNotExistError(err) {
+				continue
+			}
 			err = fmt.Errorf("InitAllTagsTreeReader: failed to initialize tag tree reader for tag key %s in base dir %v; err=%v", tagKey, tagsTreeBaseDir, err)
 			log.Errorf(err.Error())
 			return nil, err
@@ -116,8 +119,7 @@ func (attr *AllTagTreeReaders) initTagsTreeReader(tagKey string) (*TagTreeReader
 
 	fd, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 	if err != nil {
-		log.Errorf("initTagsTreeReader: failed to open file %s. Error: %v.", fName, err)
-		return nil, err
+		return nil, utils.NewErrorWithCode(os.ErrNotExist.Error(), fmt.Errorf("initTagsTreeReader: failed to open file %s", fName))
 	}
 
 	err = syscall.Flock(int(fd.Fd()), syscall.LOCK_SH)
@@ -255,6 +257,10 @@ func processExactFilter(mQuery *structs.MetricsQuery,
 	if attr != nil {
 		_, _, rawTagValueToTSIDs, err = attr.getOrInsertMatchingTSIDs(mQuery.HashedMName, tf.TagKey, tf.HashTagValue, tf.TagOperator, nil)
 		if err != nil {
+			if utils.IsNotExistError(err) {
+				return nil
+			}
+
 			log.Errorf("processExactFilter: failed to get matching tsids for mNAme %v and tag key %v. Error: %v. TagVAlH %+v tagVal %+v",
 				mQuery.MetricName, tf.TagKey, err, tf.HashTagValue, tf.RawTagValue)
 			return err
@@ -269,6 +275,9 @@ func processExactFilter(mQuery *structs.MetricsQuery,
 		_, _, rawTagValueToTSIDs, err = tth.GetOrInsertMatchingTSIDs(mQuery.HashedMName,
 			tf.TagKey, tf.HashTagValue, tf.TagOperator, nil)
 		if err != nil {
+			if utils.IsNotExistError(err) {
+				return nil
+			}
 			log.Errorf("processExactFilter: unrotated, failed to get matching tsids for mNAme %v and tag key %v. Error: %v. TagVAlH %+v tagVal %+v",
 				mQuery.MetricName, tf.TagKey, err, tf.HashTagValue, tf.RawTagValue)
 			return err
@@ -311,8 +320,15 @@ func processWildcardOrRegexFilter(mQuery *structs.MetricsQuery,
 		}
 		uItr, mNameExists, err = tth.GetValueIteratorForMetric(mQuery.HashedMName, tf.TagKey)
 	}
-	if err != nil || !mNameExists {
-		return err
+	if err != nil {
+		if utils.IsNotExistError(err) {
+			return nil
+		}
+		return utils.WrapErrorf(err, "processWildcardOrRegexFilter: failed to get value iterator for metric %v and tag key %v. Error: %v", mQuery.MetricName, tf.TagKey, err)
+	}
+
+	if !mNameExists {
+		return nil
 	}
 
 	rawTagValueToTSIDs := make(map[string]map[uint64]struct{})
@@ -440,7 +456,7 @@ func (attr *AllTagTreeReaders) getOrInsertMatchingTSIDs(mName uint64, tagKey str
 	if !ok {
 		ttr, err := attr.initTagsTreeReader(tagKey)
 		if err != nil {
-			return false, false, nil, fmt.Errorf("getOrInsertMatchingTSIDs: failed to initialize tags tree reader for key %s, error: %v", tagKey, err)
+			return false, false, nil, utils.WrapErrorf(err, "getOrInsertMatchingTSIDs: failed to initialize tags tree reader for key %s, error: %v", tagKey, err)
 		} else {
 			return ttr.getOrInsertMatchingTSIDs(mName, tagValue, tagOperator, tsidCard)
 		}
@@ -675,7 +691,7 @@ func (attr *AllTagTreeReaders) getValueIteratorForMetric(mName uint64, tagKey st
 	if !ok {
 		ttr, err := attr.initTagsTreeReader(tagKey)
 		if err != nil {
-			return nil, false, fmt.Errorf("getValueIteratorForMetric: failed to initialize tags tree reader for key %s, error: %v", tagKey, err)
+			return nil, false, utils.WrapErrorf(err, "getValueIteratorForMetric: failed to initialize tags tree reader for key %s, error: %v", tagKey, err)
 		} else {
 			return ttr.getValueIteratorForMetric(mName)
 		}

--- a/pkg/segment/reader/metrics/tagstree/tagstreereader.go
+++ b/pkg/segment/reader/metrics/tagstree/tagstreereader.go
@@ -119,7 +119,11 @@ func (attr *AllTagTreeReaders) initTagsTreeReader(tagKey string) (*TagTreeReader
 
 	fd, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 	if err != nil {
-		return nil, utils.NewErrorWithCode(os.ErrNotExist.Error(), fmt.Errorf("initTagsTreeReader: failed to open file %s", fName))
+		toLogErr := fmt.Errorf("initTagsTreeReader: failed to open file %s", fName)
+		if os.IsNotExist(err) {
+			return nil, utils.NewErrorWithCode(os.ErrNotExist.Error(), toLogErr)
+		}
+		return nil, utils.NewErrorWithCode(err.Error(), toLogErr)
 	}
 
 	err = syscall.Flock(int(fd.Fd()), syscall.LOCK_SH)

--- a/pkg/segment/writer/metrics/tagstree.go
+++ b/pkg/segment/writer/metrics/tagstree.go
@@ -637,7 +637,7 @@ func (tth *TagsTreeHolder) GetOrInsertMatchingTSIDs(mName uint64, tagKey string,
 
 	tt, ok := tth.allTrees[tagKey]
 	if !ok {
-		return false, false, nil, fmt.Errorf("GetOrInsertMatchingTSIDs: unrotated tagtree not present for tagkey: %s", tagKey)
+		return false, false, nil, utils.NewErrorWithCode(os.ErrNotExist.Error(), fmt.Errorf("GetOrInsertMatchingTSIDs: unrotated tagtree not present for tagkey: %s", tagKey))
 	}
 
 	allTis, ok := tt.rawValues[mName]

--- a/pkg/utils/errorutils.go
+++ b/pkg/utils/errorutils.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"fmt"
+	"io/fs"
 	"sync"
 	"sync/atomic"
 
@@ -221,6 +222,14 @@ func IsNonNilValueError(err error) bool {
 func IsRPCUnavailableError(err error) bool {
 	if ewc, ok := err.(*ErrorWithCode); ok {
 		return ewc.code == "RPC__Unavailable"
+	}
+
+	return false
+}
+
+func IsNotExistError(err error) bool {
+	if ewc, ok := err.(*ErrorWithCode); ok {
+		return ewc.code == fs.ErrNotExist.Error()
 	}
 
 	return false

--- a/pkg/utils/errorutils.go
+++ b/pkg/utils/errorutils.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"sync"
 	"sync/atomic"
 
@@ -232,5 +233,5 @@ func IsNotExistError(err error) bool {
 		return ewc.code == fs.ErrNotExist.Error()
 	}
 
-	return false
+	return os.IsNotExist(err)
 }


### PR DESCRIPTION
# Description
- Checks if the error is due to file not found, if it is continue processing next tags, otherwise return error
- Reduced error log flooding


# Testing
- Tested by ingesting some metrics data for sometime.
- Ingest different types of metrics. Run the query and make sure new metrics can be queried.
- Kill the server and Ingest metrics again. And query to ensure there are no errors

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
