### PR TITLE
Fix: Tracing Scatter Chart Timeline

### DIFF
--- a/static/css/tracing.css
+++ b/static/css/tracing.css
@@ -488,7 +488,6 @@ a.warn-box-anchor {
 .tooltip-design {
     color: var(--subsection-border);
     background-color: var(--bg-color) !important;
-    padding: 8px !important;
     border-radius: 5px !important;
     font-size: 10px !important;
     line-height: 14px !important;

--- a/static/js/search-traces.js
+++ b/static/js/search-traces.js
@@ -485,7 +485,7 @@ function showScatterPlot() {
 
                     // For traces with errors
                     if (val[3] > 0) {
-                        return baseSize + 5;
+                        return baseSize + 2;
                     }
 
                     return baseSize;

--- a/static/js/search-traces.js
+++ b/static/js/search-traces.js
@@ -393,6 +393,9 @@ function showScatterPlot() {
     let errorColor = theme == 'light' ? 'rgba(233, 49, 37, 0.6)' : 'rgba(233, 49, 37, 1)';
     let axisLineColor = theme == 'light' ? '#DCDBDF' : '#383148';
     let axisLabelColor = theme == 'light' ? '#160F29' : '#FFFFFF';
+
+    scatterData.sort((a, b) => a[7] - b[7]);
+
     chart.setOption({
         xAxis: {
             type: 'category',
@@ -408,6 +411,9 @@ function showScatterPlot() {
             },
             axisLabel: {
                 color: axisLabelColor,
+                formatter: function (value) {
+                    return value.split(' ')[1];
+                },
             },
             splitLine: { show: false },
         },
@@ -433,20 +439,22 @@ function showScatterPlot() {
             show: true,
             className: 'tooltip-design',
             formatter: function (param) {
-                var green = param.value[4];
-                var red = param.value[5];
+                var service = param.value[4];
+                var operation = param.value[5];
                 var duration = param.value[1];
                 var spans = param.value[2];
                 var errors = param.value[3];
                 var traceId = param.value[6] ? param.value[6] : '';
                 var traceTimestamp = param.value[7];
+                var date = new Date(traceTimestamp / 1000000).toLocaleString();
 
                 return `<div class="custom-tooltip">
                     <div class="tooltip-content">
-                        <div class="trace-name">${green}: ${red}</div>
+                        <div class="trace-name">${service}: ${operation}</div>
                         <div class="trace-id">Trace ID: ${traceId.substring(0, 7)}</div>
+                        <div class="trace-time">Time: ${date}</div>
                         <hr>
-                        <div>Duration: ${duration}ms</div>
+                        <div>Duration: ${duration.toFixed(2)}ms</div>
                         <div>No. of Spans: ${spans}</div>
                         <div>No. of Error Spans: ${errors}</div>
                     </div>
@@ -467,32 +475,31 @@ function showScatterPlot() {
                 type: 'effectScatter',
                 showEffectOn: 'emphasis',
                 rippleEffect: {
-                    scale: 1,
+                    scale: 1.2,
                 },
-                data: scatterData.filter((data) => data[3] == 0),
+                data: scatterData,
                 symbolSize: function (val) {
-                    return val[2] < 5 ? 5 : val[2];
+                    // Use logarithmic scaling for span count to prevent extremely large bubbles
+                    let spanCount = val[2] || 0;
+                    let baseSize = Math.max(5, Math.log10(spanCount + 1) * 10);
+
+                    // For traces with errors
+                    if (val[3] > 0) {
+                        return baseSize + 5;
+                    }
+
+                    return baseSize;
                 },
                 itemStyle: {
-                    color: normalColor,
-                },
-            },
-            {
-                type: 'effectScatter',
-                showEffectOn: 'emphasis',
-                rippleEffect: {
-                    scale: 1,
-                },
-                data: scatterData.filter((data) => data[3] > 0),
-                symbolSize: function (val) {
-                    return val[3] < 5 ? 5 : val[3];
-                },
-                itemStyle: {
-                    color: errorColor,
+                    color: function (params) {
+                        // Color based on whether there are errors
+                        return params.data[3] > 0 ? errorColor : normalColor;
+                    },
                 },
             },
         ],
     });
+
     // Open Gantt Chart when click on Scatter Chart
     chart.on('click', function (params) {
         const traceId = params.data[6];
@@ -500,6 +507,7 @@ function showScatterPlot() {
         window.location.href = `trace.html?trace_id=${traceId}&timestamp=${traceTimestamp}`;
     });
 }
+
 function reSort() {
     $('.warn-box').remove();
     for (let i = 0; i < returnResTotal.length; i++) {


### PR DESCRIPTION
# Description
Issues Fixed: 
1. Previously, the scatter chart displayed normal trace bubbles and then another timeline specifically for errors, causing redundancy.
2. When there were too many spans, the bubble size became too large, making the chart unreadable.
Fix: Implemented a logarithmic scaling function to dynamically adjust bubble sizes based on the span count.

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
