### PR TITLE
Check time range of records in stats query

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -916,7 +916,7 @@ func computeSegStatsFromRawRecords(segReq *QuerySegmentRequest, qs *summary.Quer
 	// rawSearchSSR should be of size 1 or 0
 	for _, req := range rawSearchSSR {
 		req.ConsistentCValLenMap = segReq.ConsistentCValLenMap
-		sstMap, err = search.RawComputeSegmentStats(req, segReq.parallelismPerFile, segReq.sNode, segReq.segKeyTsRange, segReq.aggs.MeasureOperations, allSegFileResults, qid, qs, nodeRes)
+		sstMap, err = search.RawComputeSegmentStats(req, segReq.parallelismPerFile, segReq.sNode, segReq.queryRange, segReq.aggs.MeasureOperations, allSegFileResults, qid, qs, nodeRes)
 		if err != nil {
 			return sstMap, fmt.Errorf("qid=%d, computeSegStatsFromRawRecords: Failed to get segment level stats for segKey %+v! Error: %v", qid, segReq.segKey, err)
 		}
@@ -946,7 +946,7 @@ func applyAggOpOnSegments(sortedQSRSlice []*QuerySegmentRequest, allSegFileResul
 		if isCancelled {
 			break
 		}
-		isSegmentFullyEnclosed := segReq.segKeyTsRange.AreTimesFullyEnclosed(segReq.segKeyTsRange.StartEpochMs, segReq.segKeyTsRange.EndEpochMs)
+		isSegmentFullyEnclosed := segReq.queryRange.AreTimesFullyEnclosed(segReq.segKeyTsRange.StartEpochMs, segReq.segKeyTsRange.EndEpochMs)
 
 		// For Unrotated search, Check if the segment is rotated and update the search type accordingly
 		if segReq.sType == structs.UNROTATED_SEGMENT_STATS_SEARCH {

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -109,12 +109,12 @@ func filterBlockRequestFromQuery(multiColReader *segread.MultiColSegmentReader, 
 		switch queryType {
 		case structs.MatchAllQuery:
 			// time should have been checked before, and recsToSearch
+			// TODO: check if time range actually was checked before.
 			for i := uint(0); i < uint(recIT.AllRecLen); i++ {
 				if recIT.ShouldProcessRecord(i) {
 					blockHelper.AddMatchedRecord(i)
 				}
 			}
-			// TODO: check time range
 		case structs.ColumnValueQuery:
 			filterRecordsFromSearchQuery(query, segmentSearch, blockHelper, multiColReader, recIT,
 				blockReq.BlockNum, holderDte, qid, allSearchResults, searchReq, nodeRes, queryRange)

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"sync"
 
+	dtu "github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/reader/segread"
 	"github.com/siglens/siglens/pkg/segment/results/segresults"
@@ -32,10 +33,11 @@ import (
 // Search a single SearchQuery and returns which records passes the filter
 func RawSearchSingleQuery(query *structs.SearchQuery, searchReq *structs.SegmentSearchRequest, segmentSearch *SegmentSearchStatus,
 	allBlockSearchHelpers []*structs.BlockSearchHelper, op utils.LogicalOperator, queryMetrics *structs.QueryProcessingMetrics, qid uint64,
-	allSearchResults *segresults.SearchResults, nodeRes *structs.NodeResult) *SegmentSearchStatus {
+	allSearchResults *segresults.SearchResults, nodeRes *structs.NodeResult, queryRange *dtu.TimeRange) *SegmentSearchStatus {
 
 	queryType := query.GetQueryType()
 	searchCols := getAllColumnsNeededForSearch(query, searchReq.AllPossibleColumns)
+	searchCols[config.GetTimeStampKey()] = true
 	sharedMultiReader, err := segread.InitSharedMultiColumnReaders(searchReq.SegmentKey, searchCols, searchReq.AllBlocksToSearch,
 		searchReq.SearchMetadata.BlockSummaries, len(allBlockSearchHelpers), searchReq.ConsistentCValLenMap, qid, nodeRes)
 
@@ -62,7 +64,7 @@ func RawSearchSingleQuery(query *structs.SearchQuery, searchReq *structs.Segment
 		runningBlockManagers.Add(1)
 		go filterBlockRequestFromQuery(sharedMultiReader.MultiColReaders[i], query, segmentSearch,
 			filterBlockRequestsChan, blockHelper, &runningBlockManagers, op, queryType, qid,
-			allSearchResults, searchReq, nodeRes)
+			allSearchResults, searchReq, nodeRes, queryRange)
 	}
 	runningBlockManagers.Wait()
 	logSingleQuerySummary(segmentSearch, op, qid)
@@ -91,7 +93,7 @@ func filterBlockRequestFromQuery(multiColReader *segread.MultiColSegmentReader, 
 	segmentSearch *SegmentSearchStatus, resultsChan chan *BlockSearchStatus, blockHelper *structs.BlockSearchHelper,
 	runningBlockManagers *sync.WaitGroup, op utils.LogicalOperator, queryType structs.SearchNodeType,
 	qid uint64, allSearchResults *segresults.SearchResults, searchReq *structs.SegmentSearchRequest,
-	nodeRes *structs.NodeResult) {
+	nodeRes *structs.NodeResult, queryRange *dtu.TimeRange) {
 
 	defer runningBlockManagers.Done() // defer in case of panics
 
@@ -112,9 +114,10 @@ func filterBlockRequestFromQuery(multiColReader *segread.MultiColSegmentReader, 
 					blockHelper.AddMatchedRecord(i)
 				}
 			}
+			// TODO: check time range
 		case structs.ColumnValueQuery:
 			filterRecordsFromSearchQuery(query, segmentSearch, blockHelper, multiColReader, recIT,
-				blockReq.BlockNum, holderDte, qid, allSearchResults, searchReq, nodeRes)
+				blockReq.BlockNum, holderDte, qid, allSearchResults, searchReq, nodeRes, queryRange)
 		case structs.InvalidQuery:
 			// don't match any records
 		}
@@ -131,7 +134,7 @@ func filterBlockRequestFromQuery(multiColReader *segread.MultiColSegmentReader, 
 func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *SegmentSearchStatus,
 	blockHelper *structs.BlockSearchHelper, multiColReader *segread.MultiColSegmentReader, recIT *BlockRecordIterator,
 	blockNum uint16, holderDte *utils.DtypeEnclosure, qid uint64, allSearchResults *segresults.SearchResults,
-	searchReq *structs.SegmentSearchRequest, nodeRes *structs.NodeResult) {
+	searchReq *structs.SegmentSearchRequest, nodeRes *structs.NodeResult, queryRange *dtu.TimeRange) {
 
 	// first we walk through the search checking if this query can be satisfied by looking at the
 	// dict encoding file for the column/s
@@ -245,24 +248,38 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 
 		for _, i := range recordNums {
 			i := uint(i)
-			if recIT.ShouldProcessRecord(i) {
-				matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
-					qid, searchReq, cmiPassedNonDictColKeyIndices,
-					queryInfoColKeyIndex, compiledRegex)
-				if err != nil {
-					nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to ApplyColumnarSearchQuery", log.ErrorLevel, err)
-					break
-				}
-				if query.MatchFilter != nil && query.MatchFilter.NegateMatch {
-					if matched || blockHelper.DoesRecordMatch(i) {
-						blockHelper.ClearBit(i)
-					} else {
-						blockHelper.AddMatchedRecord(i)
-					}
+			if !recIT.ShouldProcessRecord(i) {
+				continue
+			}
+
+			// Ensure the timestamp is in range.
+			recTs, err := multiColReader.GetTimeStampForRecord(blockNum, uint16(i), qid)
+			if err != nil {
+				nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to extract timestamp from record",
+					log.ErrorLevel, err)
+				break
+			}
+			if !queryRange.CheckInRange(recTs) {
+				recIT.UnsetRecord(i)
+				continue
+			}
+
+			matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,
+				qid, searchReq, cmiPassedNonDictColKeyIndices,
+				queryInfoColKeyIndex, compiledRegex)
+			if err != nil {
+				nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to ApplyColumnarSearchQuery", log.ErrorLevel, err)
+				break
+			}
+			if query.MatchFilter != nil && query.MatchFilter.NegateMatch {
+				if matched || blockHelper.DoesRecordMatch(i) {
+					blockHelper.ClearBit(i)
 				} else {
-					if matched {
-						blockHelper.AddMatchedRecord(i)
-					}
+					blockHelper.AddMatchedRecord(i)
+				}
+			} else {
+				if matched {
+					blockHelper.AddMatchedRecord(i)
 				}
 			}
 		}

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -535,7 +535,7 @@ func applyRawSearchToConditions(cond *structs.SearchCondition, searchReq *struct
 	if cond.SearchQueries != nil {
 		for _, query := range cond.SearchQueries {
 			RawSearchSingleQuery(query, searchReq, searchRes, allBlockSearchHelpers, op, queryMetrics,
-				qid, allSearchResults, nodeRes)
+				qid, allSearchResults, nodeRes, timeRange)
 		}
 	}
 

--- a/pkg/segment/search/segsearch_test.go
+++ b/pkg/segment/search/segsearch_test.go
@@ -126,7 +126,15 @@ func Test_simpleRawSearch(t *testing.T) {
 		block, _ := pqmrReadResults.GetBlockResults(blkNum)
 		numOfRecs += block.GetNumberOfSetBits()
 	}
-	assert.Equal(t, uint(numBuffers*numEntriesForBuffer), numOfRecs)
+
+	// The expected number of records depends on:
+	// 1. How the mock data is generated.
+	// 2. The time range of the search.
+	// The mock data timestamp for the i-th record in a block is (i + 1).
+	minRecord := max(int(timeRange.StartEpochMs), 1)
+	maxRecord := min(int(timeRange.EndEpochMs), numEntriesForBuffer)
+	expectedNumRecs := uint(numBuffers * (maxRecord - minRecord + 1))
+	assert.Equal(t, expectedNumRecs, numOfRecs)
 
 	config.SetPQSEnabled(false)
 

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -569,6 +569,8 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 1, 1),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -569,8 +569,11 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("city_c1", "New *", "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator("state_c1", "Texas", "latency_c1", 10, 0, 0)), 1, 1),
-			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 3600, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 6*3600, 100),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -439,7 +439,7 @@ func NewCountQueryValidator(key string, value string, startEpoch uint64,
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
 			endEpoch:   endEpoch,
-			query:      fmt.Sprintf("%v=%v | stats count", key, value),
+			query:      fmt.Sprintf(`%v="%v" | stats count`, key, value),
 		},
 		key:        key,
 		value:      value,


### PR DESCRIPTION
# Description
Previously, running this query
```
curl -X POST \
    -d '{
    "searchText": "app_version_c1=\"1.2.3\" | stats count",
    "indexName": "*",
    "startEpoch": 1742406660826,
    "endEpoch": 1742406669826,
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search | python -m json.tool | less
```
would incorrectly give 8 results while running the corresponding non-stats query:
```
curl -X POST \
    -d '{
    "searchText": "app_version_c1=\"1.2.3\"",
    "indexName": "*",
    "startEpoch": 1742406660826,
    "endEpoch": 1742406669826,
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search | python -m json.tool | less
```
would correctly give 4 results.

Additionally, both queries incorrectly logged that 8 records matched in the QuerySummary:
```
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: Finished in  1 ms time. Total number of records searched 19,600. Total number of records matched=8. Total number of files searched=1. Total number of buckets created=1
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: CMI layer checked 4 total blocks, and 1 blocks passed. Total time: 0.041125ms. min (0.041125ms) max (0.041125ms) avg (0ms) p95 (0.041125ms)
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: RawSearch: Took 1ms time, after searching 1 files. RRCs were generated in 0ms
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: RawSearch: Search Time History across all files [1.46]ms
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: RawSearch: File raw search time: min (1.460167ms) max (1.460167ms) avg (1ms) p95 (1.460167ms)
WARN[2025-03-20 12:39:29] qid=2, pqid 4417048619338014975, QuerySummary: RawSearch: Number of records matched 8, min/segment (8) max/segment (8)
```

With this PR:
1. The `... | stats count` query correctly gives 4 results
2. The non-stats query still correctly gives 4 results
3. For both querys, the QuerySummary logs that 4 records matched.

The issue was that for stats queries, we weren't checking the timestamp of records; we would check the time range to determine which segments/blocks to search, but if the query time range was in the middle of a block, we were incorrectly including all of the matching records in that block regardless of their timestamp.

There were also a few places where we were using the segment's time range where we should have been using the query's time range. I believe I fixed all those cases, but I may have missed some.

# Testing
Ran the longevity test. Previously, it would fail on the first stats query. Now the 1 second stats queries are working, but the 5 minute query still failed.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
