### PR TITLE
Always check record timestamps when block is split

### DIFF
--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -182,8 +182,8 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 	}
 
 	blockSummaries := searchReq.SearchMetadata.BlockSummaries
-	isBlkFullyEncosed := queryRange.AreTimesFullyEnclosed(blockSummaries[blockNum].LowTs, blockSummaries[blockNum].HighTs)
-	if !isBlkFullyEncosed {
+	isBlockEnclosed := queryRange.AreTimesFullyEnclosed(blockSummaries[blockNum].LowTs, blockSummaries[blockNum].HighTs)
+	if !isBlockEnclosed {
 		// We need to check if each record is in the query time range.
 		doRecLevelSearch = true
 	}
@@ -260,7 +260,7 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			}
 
 			// Ensure the timestamp is in range.
-			if !isBlkFullyEncosed {
+			if !isBlockEnclosed {
 				recTs, err := multiColReader.GetTimeStampForRecord(blockNum, uint16(i), qid)
 				if err != nil {
 					nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to extract timestamp from record",

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -260,15 +260,17 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 			}
 
 			// Ensure the timestamp is in range.
-			recTs, err := multiColReader.GetTimeStampForRecord(blockNum, uint16(i), qid)
-			if err != nil {
-				nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to extract timestamp from record",
-					log.ErrorLevel, err)
-				break
-			}
-			if !queryRange.CheckInRange(recTs) {
-				recIT.UnsetRecord(i)
-				continue
+			if !isBlkFullyEncosed {
+				recTs, err := multiColReader.GetTimeStampForRecord(blockNum, uint16(i), qid)
+				if err != nil {
+					nodeRes.StoreGlobalSearchError("filterRecordsFromSearchQuery: Failed to extract timestamp from record",
+						log.ErrorLevel, err)
+					break
+				}
+				if !queryRange.CheckInRange(recTs) {
+					recIT.UnsetRecord(i)
+					continue
+				}
 			}
 
 			matched, err := ApplyColumnarSearchQuery(query, multiColReader, blockNum, uint16(i), holderDte,

--- a/pkg/segment/search/filtersearch.go
+++ b/pkg/segment/search/filtersearch.go
@@ -181,6 +181,13 @@ func filterRecordsFromSearchQuery(query *structs.SearchQuery, segmentSearch *Seg
 		}
 	}
 
+	blockSummaries := searchReq.SearchMetadata.BlockSummaries
+	isBlkFullyEncosed := queryRange.AreTimesFullyEnclosed(blockSummaries[blockNum].LowTs, blockSummaries[blockNum].HighTs)
+	if !isBlkFullyEncosed {
+		// We need to check if each record is in the query time range.
+		doRecLevelSearch = true
+	}
+
 	// we skip rawsearching for columns that are dict encoded,
 	// since we already search for them in the above call to applyColumnarSearchUsingDictEnc
 	for dcname := range deCnames {

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -573,6 +573,7 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 3600, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 6*3600, 100),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
 		}
 		maxConcurrentQueries := int32(1)


### PR DESCRIPTION
# Description
This fix is similar to https://github.com/siglens/siglens/pull/2393. However, that PR missed an edge case where we're filtering on a dict-encoded column and so we don't check each record. This PR handles that edge case.

# Testing
Ran the longevity test. Now stats queries on dict-encoded columns also work (e.g., `state=Texas | stats count`)

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
