### PR TITLE
Check timestamp on match-all queries

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -575,6 +575,8 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("app_version_c1", "1.2.3", 0, 0)), 6*3600, 100),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("state_c1", "Texas", 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("*", "*", 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator("*", "*", 0, 0)), 300, 10),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -431,15 +431,26 @@ type countQueryValidator struct {
 func NewCountQueryValidator(key string, value string, startEpoch uint64,
 	endEpoch uint64) (queryValidator, error) {
 
-	if strings.Contains(value, "*") {
-		return nil, fmt.Errorf("NewCountQueryValidator: wildcards are not supported")
+	var query string
+	if key == "*" {
+		if value == "*" {
+			query = `* | stats count`
+		} else {
+			return nil, fmt.Errorf("NewCountQueryValidator: value must be * if key is *")
+		}
+	} else {
+		if strings.Contains(value, "*") {
+			return nil, fmt.Errorf("NewCountQueryValidator: wildcards are not supported")
+		}
+
+		query = fmt.Sprintf(`%v="%v" | stats count`, key, value)
 	}
 
 	return &countQueryValidator{
 		basicValidator: basicValidator{
 			startEpoch: startEpoch,
 			endEpoch:   endEpoch,
-			query:      fmt.Sprintf(`%v="%v" | stats count`, key, value),
+			query:      query,
 		},
 		key:        key,
 		value:      value,
@@ -472,9 +483,11 @@ func (c *countQueryValidator) HandleLog(log map[string]interface{}) error {
 		return nil
 	}
 
-	value, ok := log[c.key]
-	if !ok || value != fmt.Sprintf("%v", c.value) {
-		return nil
+	if c.key != "*" {
+		value, ok := log[c.key]
+		if !ok || value != fmt.Sprintf("%v", c.value) {
+			return nil
+		}
 	}
 
 	c.lock.Lock()

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -497,6 +497,29 @@ func Test_CountQueryValidator(t *testing.T) {
 		}`)))
 	})
 
+	t.Run("MatchAllQuery", func(t *testing.T) {
+		startEpoch, endEpoch := uint64(0), uint64(10)
+		validator, err := NewCountQueryValidator("*", "*", startEpoch, endEpoch)
+		assert.NoError(t, err)
+		addLogsWithoutError(t, validator, logs)
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 5,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+				"GroupByValues": ["*"],
+				"MeasureVal": {"count(*)": 5}
+			}]
+		}`)))
+
+	})
+
 	t.Run("BadResponse", func(t *testing.T) {
 		startEpoch, endEpoch := uint64(0), uint64(10)
 		validator, err := NewCountQueryValidator("city", "Boston", startEpoch, endEpoch)


### PR DESCRIPTION
# Description
Similar to #2395 and #2393 but for match-all queries

# Testing
Ran the longevity test with the added queries. Running the longevity test with the new queries but without the bug fix causes the test to fail

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
