### PR TITLE
Fix metric group by queries with Tag Filters And Count without group by

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -67,5 +67,7 @@ days_in_month(testmetric0),now-90d,now,"",gt,"","",false
 "avg ({__name__=~'testmetric(2|3)', fuel_type='LPG', color=~'g.*'}) by (__name__)",now-90d,now,"",approx,"testmetric2,testmetric3","color:gray,fuel_type:LPG,__,color:green,fuel_type:LPG",false
 "count(testmetric0{car_type='Passenger car compact'})",now-90d,now,"11,8,21",eq,"","",false
 "count(group by (car_type) (testmetric0))",now-90d,now,"8,8,8",eq,"","",false
+"count(group by (car_type) (testmetric0{color=~'.+'}))",now-90d,now,"8,8,8",eq,"","",false
+"count(testmetric0{color=~'.+'})",now-90d,now,"69,68,90",eq,"","",false
 "label_replace(testmetric0{model=~'.*[0-9]+ci.*', group='group 1'}, 'model_number', '$1', 'model', '([0-9]+)ci.*')",now-90d,now,"","approx","testmetric0","group:group 1,model: 330ci Convertible,car_type:Passenger car mini,color:aqua,fuel_type:Diesel,model_number:330,__,group:group 1,model: 650ci Convertible,car_type:Van,color:maroon,fuel_type:Gasoline,model_number:650",false
 "label_replace(testmetric0{model=~'.*[0-9]+ci.*', group='group 1'}, 'model', '$number', 'model', '(?P<number>[0-9]+)ci.*')",now-90d,now,"","approx","testmetric0","group:group 1,model:650,car_type:Van,color:maroon,fuel_type:Gasoline,__,group:group 1,model:330,car_type:Passenger car mini,color:aqua,fuel_type:Diesel",false

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -853,7 +853,6 @@ func Test_SimpleMetricQuery_Regex_on_MetricName_Plus_Filter(t *testing.T) {
 		assert.Greater(t, len(seriesDp), 0)
 
 		assert.True(t, strings.Contains(seriesId, "*{"))
-		assert.True(t, strings.Contains(seriesId, "color:red"))
 
 		seriesDpValues := make([]float64, 0)
 		for _, dp := range seriesDp {
@@ -1049,7 +1048,7 @@ func Test_SimpleMetricQuery_Regex_on_MetricName_Plus_Filter_GroupByMetric_v3(t *
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(20), intervalSeconds)
 
-	query := `avg ({__name__=~"testmetric.*", radius="10"}) by (__name__)`
+	query := `avg ({__name__=~"testmetric.*", radius=~".+"}) by (__name__)`
 	metricQueryRequest, _, _, err := promql.ConvertPromQLToMetricsQuery(query, timeRange.StartEpochSec, timeRange.EndEpochSec, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(metricQueryRequest))
@@ -1074,7 +1073,6 @@ func Test_SimpleMetricQuery_Regex_on_MetricName_Plus_Filter_GroupByMetric_v3(t *
 		assert.Greater(t, len(seriesDp), 0)
 
 		assert.True(t, strings.Contains(seriesId, "testmetric0{"))
-		assert.True(t, strings.Contains(seriesId, "radius:10"))
 
 		seriesDpValues := make([]float64, 0)
 		for _, dp := range seriesDp {

--- a/pkg/integrations/otsdb/query/queryparser.go
+++ b/pkg/integrations/otsdb/query/queryparser.go
@@ -100,7 +100,7 @@ func ParseRequest(startStr string, endStr string, m string, myid int64) (*struct
 			MetricName:      metricName,
 			HashedMName:     hashedMName,
 			TagsFilters:     tags,
-			FirstAggregator: structs.Aggregation{AggregatorFunction: aggregator},
+			FirstAggregator: structs.Aggregation{AggregatorFunction: aggregator, Without: true},
 			Downsampler:     downsampler,
 			OrgId:           myid,
 		},

--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -193,7 +193,7 @@ func parsePromQLQuery(query string, startTime, endTime uint32, myid int64) ([]*s
 	if mQuery.SubsequentAggs == nil {
 		mQuery.SubsequentAggs = &structs.MetricQueryAgg{
 			AggBlockType:    structs.AggregatorBlock,
-			AggregatorBlock: &structs.Aggregation{AggregatorFunction: segutils.Avg},
+			AggregatorBlock: &structs.Aggregation{AggregatorFunction: segutils.Avg, Without: true},
 		}
 		if len(mQuery.TagsFilters) == 0 {
 			mQuery.GetAllLabels = true
@@ -205,7 +205,7 @@ func parsePromQLQuery(query string, startTime, endTime uint32, myid int64) ([]*s
 		if mQuery.SubsequentAggs.AggBlockType != structs.AggregatorBlock {
 			mQuery.SubsequentAggs = &structs.MetricQueryAgg{
 				AggBlockType:    structs.AggregatorBlock,
-				AggregatorBlock: &structs.Aggregation{AggregatorFunction: segutils.Avg},
+				AggregatorBlock: &structs.Aggregation{AggregatorFunction: segutils.Avg, Without: true},
 				Next:            mQuery.SubsequentAggs,
 			}
 			mQueryReqs[0].MetricsQuery = mQuery
@@ -299,6 +299,7 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 		mQuery.FirstAggregator.AggregatorFunction = segutils.Avg
 	case "count":
 		mQuery.FirstAggregator.AggregatorFunction = segutils.Count
+		mQuery.GetAllLabels = true
 	case "sum":
 		mQuery.FirstAggregator.AggregatorFunction = segutils.Sum
 	case "max":
@@ -346,8 +347,7 @@ func handleAggregateExpr(expr *parser.AggregateExpr, mQuery *structs.MetricsQuer
 		mQuery.Groupby = true
 	} else {
 		mQuery.AggWithoutGroupBy = true
-		mQuery.SelectAllSeries = false
-		mQuery.GetAllLabels = false
+		mQuery.SelectAllSeries = mQuery.GetAllLabels
 	}
 
 	mQuery.FirstAggregator.GroupByFields = sort.StringSlice(expr.Grouping)

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -1424,6 +1424,8 @@ func Test_GetAllLabels(t *testing.T) {
 	assertGetAllLabels(t, true, `allocated_bytes{app="foo"}`)
 	assertGetAllLabels(t, false, `avg(allocated_bytes)`)
 	assertGetAllLabels(t, false, `group by (app) (allocated_bytes)`)
+	assertGetAllLabels(t, true, `count(allocated_bytes{instance="foo"})`)
+	assertGetAllLabels(t, true, `count by (app) (allocated_bytes{instance="foo"})`)
 }
 
 func assertGetAllLabels(t *testing.T, expected bool, query string) {
@@ -1440,6 +1442,8 @@ func Test_SelectAllSeries(t *testing.T) {
 	assertSelectAllSeries(t, false, `group by (app) (allocated_bytes)`)
 	assertSelectAllSeries(t, false, `avg(allocated_bytes{instance="foo"})`)
 	assertSelectAllSeries(t, false, `avg(allocated_bytes{instance="foo"}) by (app)`)
+	assertSelectAllSeries(t, true, `count(allocated_bytes{instance="foo"})`)
+	assertSelectAllSeries(t, false, `count by (app) (allocated_bytes{instance="foo"})`)
 }
 
 func assertSelectAllSeries(t *testing.T, expected bool, query string) {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -386,8 +386,7 @@ func (r *MetricsResult) ApplyAggregationToResults(parallelism int, aggregation s
 	if aggregation.IsAggregateFromAllTimeseries() {
 		seriesEntriesMap := make(map[string]map[uint32][]RunningEntry, 0)
 
-		for seriesId, timeSeries := range r.Results {
-			aggSeriesId := getAggSeriesId(seriesId, &aggregation)
+		for aggSeriesId, timeSeries := range r.Results {
 			if _, ok := results[aggSeriesId]; !ok {
 				results[aggSeriesId] = make(map[uint32]float64, 0)
 				seriesEntriesMap[aggSeriesId] = make(map[uint32][]RunningEntry, 0)

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func Test_GetResults_AggFn_Sum(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Sum}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Sum, Without: true}
 	mQuery := &structs.MetricsQuery{
 		MetricName:      "test.metric.0",
 		FirstAggregator: aggregator,
@@ -102,7 +102,7 @@ func Test_GetResults_AggFn_Sum(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Avg(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	mQuery := &structs.MetricsQuery{
 		MetricName:      "test.metric.0",
 		FirstAggregator: aggregator,
@@ -130,12 +130,12 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 	series := mresults.InitSeriesHolder(mQuery, tsGroupId)
 
 	// they should all downsample to i
-	avg := float64(0)
+	sum := float64(0)
 	for i := 0; i < 10; i++ {
-		avg += float64(i)
+		sum += float64(i)
 		series.AddEntry(uint32(i), float64(i))
 	}
-	finalAvg := avg // because we have 1 series, with a 1h-sum:avg, the avg does nothing
+	finalAvg := sum / 10
 
 	assert.Equal(t, series.GetIdx(), 10)
 	tsid := uint64(100)
@@ -162,7 +162,7 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 	retVal := metricsResults.Results[tsGroupId.String()]
 	assert.Len(t, retVal, 1)
 	assert.Contains(t, retVal, uint32(0))
-	assert.Equal(t, retVal[0], finalAvg)
+	assert.Equal(t, finalAvg, retVal[0])
 
 	mQResponse, err := metricsResults.GetOTSDBResults(mQuery)
 	assert.NoError(t, err)
@@ -174,7 +174,7 @@ func Test_GetResults_AggFn_Avg(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Count(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Count}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Count, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -208,7 +208,7 @@ func Test_GetResults_AggFn_Count(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Group(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Group}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Group, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -244,7 +244,7 @@ func Test_GetResults_AggFn_Group(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Stdvar(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Stdvar}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Stdvar, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -284,7 +284,7 @@ func Test_GetResults_AggFn_Stdvar(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Stddev(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Stddev}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Stddev, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -325,7 +325,7 @@ func Test_GetResults_AggFn_Stddev(t *testing.T) {
 
 func Test_GetResults_AggFn_Multiple(t *testing.T) {
 	var numSeries int = 5
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	mQuery := &structs.MetricsQuery{
 		MetricName:      "test.metric.0",
 		FirstAggregator: aggregator,
@@ -386,7 +386,7 @@ func Test_GetResults_AggFn_Multiple(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_Quantile(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Quantile, FuncConstant: 0.5}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Quantile, FuncConstant: 0.5, Without: true}
 	mQuery := &structs.MetricsQuery{
 		MetricName:      "test.metric.0",
 		FirstAggregator: aggregator,
@@ -456,7 +456,7 @@ func Test_GetResults_AggFn_Quantile(t *testing.T) {
 }
 
 func Test_GetResults_AggFn_QuantileFloatIndex(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Quantile, FuncConstant: 0.3}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Quantile, FuncConstant: 0.3, Without: true}
 	mQuery := &structs.MetricsQuery{
 		MetricName:      "test.metric.0",
 		FirstAggregator: aggregator,
@@ -527,7 +527,7 @@ func Test_GetResults_AggFn_QuantileFloatIndex(t *testing.T) {
 
 func Test_GetResults_AggFn_TopK(t *testing.T) {
 	// Compute top 2 elements for each timestamp
-	aggregator := structs.Aggregation{AggregatorFunction: utils.TopK, FuncConstant: 2.0}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.TopK, FuncConstant: 2.0, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -570,7 +570,7 @@ func Test_GetResults_AggFn_TopK(t *testing.T) {
 
 func Test_GetResults_AggFn_BottomK(t *testing.T) {
 	// Compute bottom 2 elements for each timestamp
-	aggregator := structs.Aggregation{AggregatorFunction: utils.BottomK, FuncConstant: 2.0}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.BottomK, FuncConstant: 2.0, Without: true}
 	metricName := "test.metric.1"
 	downsampler := structs.Downsampler{
 		Interval:   1,
@@ -1160,9 +1160,10 @@ func Test_GetResults_Comparison_Ops_With_ReturnBool(t *testing.T) {
 
 func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap map[uint32]float64, queryOps []structs.QueryArithmetic, downsampler structs.Downsampler) {
 	mQuery := &structs.MetricsQuery{
-		MetricName:  "test.metric.0",
-		HashedMName: 1,
-		Downsampler: downsampler,
+		MetricName:      "test.metric.0",
+		HashedMName:     1,
+		Downsampler:     downsampler,
+		FirstAggregator: downsampler.Aggregator,
 	}
 	qid := uint64(0)
 	metricsResults := mresults.InitMetricResults(mQuery, qid)
@@ -1198,7 +1199,7 @@ func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap
 }
 
 func Test_GetResults_And(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	expectedResults := make(map[string]map[uint32]float64)
 	// There is the expected result: contains only one matching label set
 	expectedResults["test.metric.1{color:red,type:compact,"] = map[uint32]float64{
@@ -1236,7 +1237,7 @@ func Test_GetResults_And(t *testing.T) {
 }
 
 func Test_GetResults_Or(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	expectedResults := make(map[string]map[uint32]float64)
 	// There is the expected result: contains all unique label sets
 	expectedResults["test.metric.1{color:red,type:compact,"] = map[uint32]float64{
@@ -1280,7 +1281,7 @@ func Test_GetResults_Or(t *testing.T) {
 }
 
 func Test_GetResults_Unless(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	expectedResults := make(map[string]map[uint32]float64)
 	expectedResults["test.metric.1{color:yellow,type:compact,"] = map[uint32]float64{
 		0:    45,
@@ -1381,6 +1382,7 @@ func initialize_Multiple_Metric_Results(t *testing.T, initialEntries1 map[uint32
 		Downsampler:     downsampler,
 		GetAllLabels:    true,
 		SelectAllSeries: true,
+		FirstAggregator: aggregator,
 	}
 	qid = uint64(1)
 	metricsResults2 := mresults.InitMetricResults(mQuery2, qid)
@@ -1434,7 +1436,7 @@ func validateResults(t *testing.T, res map[string]map[uint32]float64, ansMap map
 }
 
 func Test_GetResults_On(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	results := make(map[string]map[uint32]float64)
 	results["test.metric.1{color:red,type:compact,"] = map[uint32]float64{
 		0:    3,
@@ -1479,7 +1481,7 @@ func Test_GetResults_On(t *testing.T) {
 }
 
 func Test_GetResults_Ignoring(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	results := make(map[string]map[uint32]float64)
 	results["test.metric.1{color:red,type:compact,"] = map[uint32]float64{
 		0:    -5,
@@ -1528,7 +1530,7 @@ func Test_GetResults_Ignoring(t *testing.T) {
 }
 
 func Test_GetResults_GroupRight(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	results := make(map[string]map[uint32]float64)
 	results["test.metric.2{color:red,type:compact,"] = map[uint32]float64{
 		0:    100,
@@ -1578,7 +1580,7 @@ func Test_GetResults_GroupRight(t *testing.T) {
 }
 
 func Test_GetResults_GroupLeft(t *testing.T) {
-	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg}
+	aggregator := structs.Aggregation{AggregatorFunction: utils.Avg, Without: true}
 	results := make(map[string]map[uint32]float64)
 	results["test.metric.1{color:red,type:compact,"] = map[uint32]float64{
 		0:    2,


### PR DESCRIPTION
# Description
- Fixes the group by issue when query has tag filters. Example: `count by (gk1) (metric{tk1:v1})`
- Also fixes the issue with `count(testmetric0)`. This should count number of series but we were counting the values.

# Testing
- All unit test cases passed.
- Updated cicd test queries
- Tested by verifying that queries are giving same result in Prometheus and SigLens

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
