### PR TITLE
Reduce unneeded logging on each query

### DIFF
--- a/pkg/ast/pipesearch/searchQueryParser.go
+++ b/pkg/ast/pipesearch/searchQueryParser.go
@@ -193,9 +193,9 @@ func parsePipeSearch(searchText string, queryLanguage string, qid uint64) (*ASTN
 
 	result, err := json.MarshalIndent(res, "", "   ")
 	if err == nil {
-		log.Infof("qid=%d, parsePipeSearch output:\n%v\n", qid, string(result))
+		log.Debugf("qid=%d, parsePipeSearch output:\n%v\n", qid, string(result))
 	} else {
-		log.Infof("qid=%d, parsePipeSearch output:\n%v\n", qid, res)
+		log.Debugf("qid=%d, parsePipeSearch output:\n%v\n", qid, res)
 	}
 
 	queryStruct, ok := res.(ast.QueryStruct)

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -718,25 +718,25 @@ func executeQueryInternal(root *structs.ASTNode, aggs *structs.QueryAggregators,
 func LogSearchNode(prefix string, sNode *structs.SearchNode, qid uint64) {
 
 	sNodeJSON, _ := json.Marshal(sNode)
-	log.Infof("qid=%d, SearchNode for %v: %v", qid, prefix, string(sNodeJSON))
+	log.Debugf("qid=%d, SearchNode for %v: %v", qid, prefix, string(sNodeJSON))
 }
 
 func LogASTNode(prefix string, astNode *structs.ASTNode, qid uint64) {
 
 	fullASTNodeJSON, _ := json.Marshal(astNode)
-	log.Infof("qid=%d, ASTNode for %v: %v", qid, prefix, string(fullASTNodeJSON))
+	log.Debugf("qid=%d, ASTNode for %v: %v", qid, prefix, string(fullASTNodeJSON))
 }
 
 func LogNode(prefix string, node any, qid uint64) {
 
 	nodeJSON, _ := json.Marshal(node)
-	log.Infof("qid=%d, Raw value for %v: %v", qid, prefix, string(nodeJSON))
+	log.Debugf("qid=%d, Raw value for %v: %v", qid, prefix, string(nodeJSON))
 }
 
 func LogQueryAggsNode(prefix string, node *structs.QueryAggregators, qid uint64) {
 
 	nodeval, _ := json.Marshal(node)
-	log.Infof("qid=%d, QueryAggregators for %v: %v", qid, prefix, string(nodeval))
+	log.Debugf("qid=%d, QueryAggregators for %v: %v", qid, prefix, string(nodeval))
 }
 
 func LogMetricsQuery(prefix string, mQRequest *structs.MetricsQueryRequest, qid uint64) {


### PR DESCRIPTION
# Description
Previously, running the query:
```
curl -X POST \
    -d '{
    "searchText": "* | stats count",
    "indexName": "*",
    "startEpoch": "now-30d",
    "endEpoch": "now",
    "queryLanguage": "Splunk QL"
}' http://localhost:5122/api/search
```
would give these logs:
```
INFO[2025-03-21 11:00:59] qid=1, ParseAndExecutePipeRequest: index=[Raw Index: [*] Expanded To 11 Entries. There are: 0 Elastic Indices. Sample: [ind-0 ind-1 ind-2 ind-3].....], searchString=[* | stats count] , startEpoch: 1739984459150, endEpoch: 1742576459150
INFO[2025-03-21 11:00:59] qid=1, parsePipeSearch output:
INFO[2025-03-21 11:00:59] qid=1, ASTNode for Splunk QLquery parser: {"AndFilterCondition":{"FilterCriteria":[{"MatchFilter":{"MatchColumn":"*","MatchWords":["Kg=="],"MatchWordsOriginal":[null,"Kg=="],"MatchOperator":1,"MatchPhrase":"Kg==","MatchPhraseOriginal":"Kg==","MatchDictArray":null,"MatchType":2,"NegateMatch":false,"RegexpString":""},"ExpressionFilter":null,"FilterIsCaseInsensitive":true}],"NestedNodes":null},"OrFilterCondition":null,"ExclusionFilterCondition":null,"TimeRange":{"StartEpochMs":1739984459150,"EndEpochMs":1742576459150},"ActiveFileSearch":false,"BucketLimit":0}
INFO[2025-03-21 11:00:59] qid=1, QueryAggregators for Splunk QLaggs parser: {"PipeCommandType":2,"OutputTransforms":null,"MeasureOperations":[{"measureCol":"*","measureFunc":1,"Param":""}],"MathOperations":null,"VectorArithmeticExpr":null,"TimeHistogram":null,"GroupByRequest":null,"Sort":null,"EarlyExit":false,"BucketLimit":0,"ShowRequest":null,"TableName":"","TransactionArguments":null,"StatsOptions":{"Delim":" ","Partitions":1,"DedupSplitvals":false,"Allnum":false},"StreamStatsOptions":null,"GenerateEvent":null,"Next":null,"Limit":0,"BinExpr":null,"DedupExpr":null,"EvalExpr":null,"FieldsExpr":null,"FillNullExpr":null,"GentimesExpr":null,"InputLookupExpr":null,"HeadExpr":null,"MakeMVExpr":null,"MVExpandExpr":null,"RegexExpr":null,"RenameExp":null,"RexExpr":null,"SortExpr":null,"StatsExpr":{"MeasureOperations":[{"measureCol":"*","measureFunc":1,"Param":""}],"GroupByRequest":null},"StreamstatsExpr":null,"TailExpr":null,"TimechartExpr":null,"StatisticExpr":null,"TransactionExpr":null,"WhereExpr":null}
INFO[2025-03-21 11:00:59] qid=1, Extracted node type 0 for query. ParallelismPerFile=5. Starting search...
INFO[2025-03-21 11:00:59] qid=1, Unrotated query time filtering returned 0 segment keys to search out of 0. query elapsed time: 526.833µs
INFO[2025-03-21 11:00:59] qid=1, Rotated query time filtering returned 18 segment keys to search out of 18. query elapsed time: 844.792µs
INFO[2025-03-21 11:00:59] qid=1, GetNodeResultsForSegmentStatsCmd: Received 18 query segment aggs, with 18 raw search 0 distributed, query elapsed time: 867.167µs
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: Finished in  144 ms time. Total number of records searched 0. Total number of records matched=0. Total number of files searched=0. Total number of buckets created=1
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: CMI layer checked 0 total blocks, and 0 blocks passed. Total time: 0ms. min (0ms) max (0ms) avg (NaNms) p95 (0ms)
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Took 0ms time, after searching 0 files. RRCs were generated in 0ms
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Search Time History across all files []ms
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Number of records matched 0, min/segment (0) max/segment (0)
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Finished in 0 ms time, after searching 0 files
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Search Time History across all files []ms
WARN[2025-03-21 11:00:59] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Number of records matched 0, min/segment (0) max/segment (0)
INFO[2025-03-21 11:00:59] qid=1, Finished execution in 144.491417ms
ERRO[2025-03-21 11:01:07] Server shutdown
```

Now we get
```
INFO[2025-03-21 11:00:22] qid=1, ParseAndExecutePipeRequest: index=[Raw Index: [*] Expanded To 11 Entries. There are: 0 Elastic Indices. Sample: [ind-0 ind-1 ind-2 ind-3].....], searchString=[* | stats count] , startEpoch: 1739984422637, endEpoch: 1742576422637
INFO[2025-03-21 11:00:22] qid=1, Extracted node type 0 for query. ParallelismPerFile=5. Starting search...
INFO[2025-03-21 11:00:22] qid=1, Unrotated query time filtering returned 0 segment keys to search out of 0. query elapsed time: 504.083µs
INFO[2025-03-21 11:00:22] qid=1, Rotated query time filtering returned 18 segment keys to search out of 18. query elapsed time: 812.375µs
INFO[2025-03-21 11:00:22] qid=1, GetNodeResultsForSegmentStatsCmd: Received 18 query segment aggs, with 18 raw search 0 distributed, query elapsed time: 838.792µs
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: Finished in  155 ms time. Total number of records searched 0. Total number of records matched=0. Total number of files searched=0. Total number of buckets created=1
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: CMI layer checked 0 total blocks, and 0 blocks passed. Total time: 0ms. min (0ms) max (0ms) avg (NaNms) p95 (0ms)
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Took 0ms time, after searching 0 files. RRCs were generated in 0ms
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Search Time History across all files []ms
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: RawSearch: Number of records matched 0, min/segment (0) max/segment (0)
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Finished in 0 ms time, after searching 0 files
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Search Time History across all files []ms
WARN[2025-03-21 11:00:22] qid=1, pqid 3283873691873996976, QuerySummary: PQS: Number of records matched 0, min/segment (0) max/segment (0)
INFO[2025-03-21 11:00:22] qid=1, Finished execution in 155.227583ms
```

This removes about have the bytes, but doesn't really remove information—we still have the query, and we can determine the AST, etc. that we were logging by doing the parsing locally for that query while running the same siglens version.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
