### PR TITLE
Added Usage Stats Screen

### DIFF
--- a/pkg/usageStats/stats.go
+++ b/pkg/usageStats/stats.go
@@ -52,6 +52,7 @@ const (
 	Hourly UsageStatsGranularity = iota + 1
 	Daily
 	ByMinute
+	Monthly
 )
 
 type Stats struct {
@@ -546,6 +547,7 @@ func GetUsageStats(pastXhours uint64, granularity UsageStatsGranularity, orgid i
 	var intervalMinutes uint32
 	var err error
 	runningTs := startEpoch
+
 	if granularity == ByMinute {
 		intervalMinutes, err = CalculateIntervalForStatsByMinute(uint32(pastXhours * 60))
 		if err != nil {
@@ -573,6 +575,18 @@ func GetUsageStats(pastXhours uint64, granularity UsageStatsGranularity, orgid i
 			startTOH = startTOH + segutils.MS_IN_HOUR
 			resultMap[bucketInterval] = &ReadStats{}
 		}
+	} else if granularity == Monthly {
+		startOfMonth := time.Date(startEpoch.Year(), startEpoch.Month(), 1, 0, 0, 0, 0, startEpoch.Location())
+		runningTs = startOfMonth
+
+		endMonth := time.Date(endEpoch.Year(), endEpoch.Month(), 1, 0, 0, 0, 0, endEpoch.Location())
+
+		for !runningTs.After(endMonth) {
+			bucketInterval = runningTs.Format("2006-01")
+			resultMap[bucketInterval] = &ReadStats{}
+
+			runningTs = time.Date(runningTs.Year(), runningTs.Month()+1, 1, 0, 0, 0, 0, runningTs.Location())
+		}
 	}
 
 	allStatsMap, err := readUsageStats(startEpoch, endEpoch, orgid)
@@ -591,6 +605,8 @@ func GetUsageStats(pastXhours uint64, granularity UsageStatsGranularity, orgid i
 			// For example, if rStat.TimeStamp is "20:47" and intervalMinutes is 10,
 			// it will truncate the time to "20:40" and format it as "2006-01-02T20:40" to store in the resultMap.
 			bucketInterval = rStat.TimeStamp.Truncate(time.Duration(intervalMinutes) * time.Minute).Format("2006-01-02T15:04")
+		} else if granularity == Monthly {
+			bucketInterval = rStat.TimeStamp.Format("2006-01")
 		}
 		entry, ok := resultMap[bucketInterval]
 		if !ok {

--- a/static/assets/usage-stats-active.svg
+++ b/static/assets/usage-stats-active.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="18" viewBox="0 0 16 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 17L15 17" stroke="#B4A6E6" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M2 14V8" stroke="#B4A6E6" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M6 14V4" stroke="#B4A6E6" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M10 14V6" stroke="#B4A6E6" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M14 1V14" stroke="#B4A6E6" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/static/assets/usage-stats-regular.svg
+++ b/static/assets/usage-stats-regular.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="18" viewBox="0 0 16 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 17L15 17" stroke="#6F6B7B" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M2 14V8" stroke="#6F6B7B" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M6 14V4" stroke="#6F6B7B" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M10 14V6" stroke="#6F6B7B" stroke-width="1.8" stroke-linecap="round"/>
+<path d="M14 1V14" stroke="#6F6B7B" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -840,6 +840,7 @@ body {
 .icon-live,
 .icon-traces,
 .icon-infrastructure,
+.icon-usage-stats,
 .icon-ingest,
 .icon-help {
     min-height: 28px;
@@ -994,6 +995,12 @@ body {
     width: 24px;
 }
 
+.icon-usage-stats {
+    background-image: url("../assets/usage-stats-regular.svg");
+    height: 24px;
+    width: 24px;
+}
+
 .icon-search:hover,
 .menu.nav-search.active .icon-search,
 .menu.nav-search:hover .icon-search {
@@ -1095,6 +1102,14 @@ body {
 .menu.nav-infrastructure.active .icon-infrastructure,
 .menu.nav-infrastructure:hover .icon-infrastructure {
     background-image: url("../assets/infrastructure-active.svg");
+    height: 24px;
+    width: 24px;
+}
+
+.icon-usage-stats:hover,
+.menu.nav-usage-stats.active .icon-usage-stats,
+.menu.nav-usage-stats:hover .icon-usage-stats {
+    background-image: url("../assets/usage-stats-active.svg");
     height: 24px;
     width: 24px;
 }
@@ -3778,7 +3793,7 @@ input[type="time"]::-webkit-calendar-picker-indicator {
     font-weight: 500;
     font-size: 16px;
     color: var(--datatable-header-text-color);
-    margin-bottom: 0px;
+    margin-bottom: 4px;
 }
 
 .myOrg-inner-container label {
@@ -5601,6 +5616,7 @@ p#versionInfo {
 #app-side-nav .menu:hover .link-myorg,
 #app-side-nav .menu:hover .link-ldb,
 #app-side-nav .menu:hover .link-lookups,
+#app-side-nav .menu:hover .link-usage-stats,
 #app-side-nav .menu:hover .link-infrastructure {
     background-color: var(--side-nav-bg-color-selected);
 }
@@ -5613,6 +5629,7 @@ p#versionInfo {
 #app-side-nav .menu.active .link-myorg,
 #app-side-nav .menu.active .link-ldb,
 #app-side-nav .menu.active .link-lookups,
+#app-side-nav .menu.active .link-usage-stats,
 #app-side-nav .menu.active .link-infrastructure {
     border-left: 5px solid var(--side-nav-selected-border-color) !important;
     background-color: var(--side-nav-bg-color-selected);
@@ -6366,13 +6383,12 @@ p#versionInfo {
     height: 100%;
 }
 
-/* JSON Popup  */
-.nav-tabs {
+.config-container .nav-tabs {
     margin-bottom: 16px;
     border-bottom: 1px solid var(--alerting-table-line-color);
 }
 
-.tab {
+.config-container .tab {
     background: none;
     color: var(--white-4);
     padding: 4px 14px;
@@ -6382,7 +6398,7 @@ p#versionInfo {
     transition: all 0.3s;
 }
 
-.tab.active {
+.config-container .tab.active {
     color: var(--purple-1);
     border-bottom: 2px solid var(--purple-1);
     background: var(--purple-15p);
@@ -6390,7 +6406,7 @@ p#versionInfo {
     font-weight: bold;
 }
 
-[data-theme='dark'] .tab.active {
+.config-container [data-theme='dark'] .tab.active {
     color: var(--white);
 }
 
@@ -7040,4 +7056,59 @@ p#versionInfo {
     color: var(--text-color);
     cursor: text;
     font-weight: bold;
+}
+
+/* Usage Stats Screen  */
+.granularity-tabs {
+    display: flex;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--search-input-border);
+    height: 26px;
+}
+
+.granularity-tabs .tab {
+    flex: 1;
+    text-align: center;
+    background-color: var(--drop-down-btn-bg-regular);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    color: var(--text-color);
+    border-right: 1px solid var(--search-input-border);
+    white-space: nowrap;
+    padding: 4px 14px;
+}
+
+.granularity-tabs .tab:last-child {
+    border-right: none;
+}
+
+.granularity-tabs .tab.active {
+    background-color: var(--purple-15p);
+    color: var(--purple-1);
+    font-weight: 500;
+}
+
+.granularity-tabs .tab-content.active {
+    display: block;
+}
+
+.stats-header {
+    font-size: 14px;
+    font-weight: 500;
+    border-bottom: 1px solid var(--search-input-border);
+    padding: 10px 16px;
+    background-color: var(--alerting-table-bg-color);
+    border-radius: 10px 10px 0 0;
+    display: flex;
+    justify-content: space-between;
+}
+
+.canvas-container {
+    height: calc(300px - 42px);
+    padding: 16px;
+}
+
+#stats-charts-container .dropdown-menu.daterangepicker.show {
+    height: 330px !important;
 }

--- a/static/js/cluster-stats.js
+++ b/static/js/cluster-stats.js
@@ -137,28 +137,6 @@ function drawStatsChart(res, data, chartType) {
     });
 }
 
-function determineUnit(data) {
-    let maxBytes = 0;
-    data.forEach(point => {
-        if (point.y > maxBytes) {
-            maxBytes = point.y;
-        }
-    });
-    
-    if (maxBytes === 0) return { unit: 'Bytes', divisor: 1 };
-    
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
-    
-    const i = Math.min(Math.floor(Math.log(maxBytes) / Math.log(k)), sizes.length - 1);
-    
-    return {
-        unit: sizes[i],
-        divisor: Math.pow(k, i)
-    };
-}
-
-
 function renderBytesCountChart(BytesCountData, gridLineColor, tickColor, chartType) {
     var canvas = $('#bytesCountChart-' + chartType)
         .get(0)

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1469,3 +1469,37 @@ function ExpandableJsonCellRenderer(type = 'events') {
         }
     }
 }
+
+function determineUnit(data) {
+    console.log(data)
+    let maxBytes = 0;
+    data.forEach(point => {
+        if (point.y > maxBytes) {
+            maxBytes = point.y;
+        }
+    });
+    
+    if (maxBytes === 0) return { unit: 'Bytes', divisor: 1 };
+    
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    
+    const i = Math.min(Math.floor(Math.log(maxBytes) / Math.log(k)), sizes.length - 1);
+    
+    return {
+        unit: sizes[i],
+        divisor: Math.pow(k, i)
+    };
+}
+
+function formatByteSize(bytes) {
+    if (bytes === 0) return '0 Bytes';
+    
+    const units = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    
+    // Format with 2 decimal places for larger units, round to integers for bytes
+    return i === 0 
+        ? bytes + ' ' + units[i]
+        : (bytes / Math.pow(1024, i)).toFixed(2) + ' ' + units[i];
+}

--- a/static/js/navbar.js
+++ b/static/js/navbar.js
@@ -97,6 +97,10 @@ let navbarComponent = `
             <a href="./cluster-stats.html" class="nav-links link-myorg"><span class="icon-myorg"></span><span
                     class="nav-link-text">My Org</span></a>
         </div>
+        <div class="menu nav-usage-stats">
+            <a href="./usage-stats.html" class="nav-links link-usage-stats"><span class="icon-usage-stats"></span><span
+                    class="nav-link-text">Usage Stats</span></a>
+        </div>
         <div class="menu nav-lookups">
             <a href="./lookups.html" class="nav-links link-lookups"><span class="icon-search"></span><span
                     class="nav-link-text">Lookups</span></a>
@@ -320,6 +324,10 @@ const navigationStructure = {
     'traces-ingestion.html': {
         activeClass: 'nav-ingest',
         breadcrumbs: [{ name: 'Traces Ingestion Methods'}]
+    },
+    'usage-stats.html': {
+        activeClass: 'nav-usage-stats',
+        breadcrumbs: [{ name: 'Usage Stats'}]
     }
 };
 

--- a/static/js/usage-stats.js
+++ b/static/js/usage-stats.js
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2021-2025 SigScalr, Inc.
+ *
+ * This file is part of SigLens Observability Solution
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+let selectedTab = 'daily';
+
+$(document).ready(() => {
+    $('#app-content-area').hide();
+    setupEventHandlers();
+    $('.theme-btn').on('click', themePickerHandler);
+    $('.theme-btn').on('click', () => {
+        const { gridLineColor, tickColor } = getGraphGridColors();
+        updateChartsTheme(gridLineColor, tickColor);
+    });
+
+    let stDate = 'now-7d';
+    let endDate = 'now';
+    datePickerHandler(stDate, endDate, stDate);
+
+    $('.range-item').on('click', getClusterIngestStats);
+    $('#customrange-btn').on('click', getClusterIngestStats);
+
+    getClusterIngestStats();
+    getClusterStats();
+
+    $('.tab').click(function () {
+        $('.tab').removeClass('active');
+        $('.tab-content').removeClass('active');
+
+        $(this).addClass('active');
+        selectedTab = $(this).data('tab');
+
+        $('#' + $(this).data('tab')).addClass('active');
+        console.log('Selected tab:', selectedTab);
+    });
+});
+
+function getClusterStats() {
+    $.ajax({
+        method: 'get',
+        url: 'api/clusterStats',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            Accept: '*/*',
+        },
+        crossDomain: true,
+        dataType: 'json',
+    })
+        .then((res) => {
+            console.log(res);
+            displayTotal(res);
+        })
+        .catch((err) => {
+            console.error('error:', err);
+        });
+}
+
+function displayTotal(res) {
+    const totalLogsVol = res.ingestionStats['Log Incoming Volume']; // Bytes
+    const totalTracesVol = res.traceStats['Total Trace Volume']; // Bytes
+    const totalDatapoints = res.metricsStats['Datapoints Count'];
+
+    const formattedLogsVol = formatByteSize(totalLogsVol);
+    const formattedTracesVol = formatByteSize(totalTracesVol);
+
+    $('.logs-total').text(formattedLogsVol);
+    $('.traces-total').text(formattedTracesVol);
+    $('.datapoints-total').text(totalDatapoints);
+}
+
+function setupClusterStatsCharts(data) {
+    if (!data || !data.chartStats) {
+        console.error('No chart data available');
+        return;
+    }
+
+    // Process the data for charts
+    const dates = Object.keys(data.chartStats).sort();
+    const processedData = {
+        logs: {
+            dates: dates,
+            gbCount: dates.map((date) => data.chartStats[date].LogsBytesCount),
+        },
+        traces: {
+            dates: dates,
+            gbCount: dates.map((date) => data.chartStats[date].TraceBytesCount),
+        },
+        stacked: {
+            dates: dates,
+            activeSeriesCount: dates.map((date) => data.chartStats[date].ActiveSeriesCount),
+            metricsDatapointsCount: dates.map((date) => data.chartStats[date].MetricsDatapointsCount),
+        },
+    };
+
+    const { gridLineColor, tickColor } = getGraphGridColors();
+
+    renderLogsVolumeChart(processedData.logs, gridLineColor, tickColor);
+    renderTracesVolumeChart(processedData.traces, gridLineColor, tickColor);
+    renderStackedChart(processedData.stacked, gridLineColor, tickColor);
+}
+
+function updateChartsTheme(gridLineColor, tickColor) {
+    if (window.logsVolumeChart) {
+        updateChartColors(window.logsVolumeChart, gridLineColor, tickColor);
+    }
+
+    if (window.tracesVolumeChart) {
+        updateChartColors(window.tracesVolumeChart, gridLineColor, tickColor);
+    }
+
+    if (window.stackedChart) {
+        updateChartColors(window.stackedChart, gridLineColor, tickColor);
+    }
+}
+
+function updateChartColors(chart, gridLineColor, tickColor) {
+    chart.options.scales.x.grid.color = gridLineColor;
+    chart.options.scales.x.ticks.color = tickColor;
+
+    chart.options.scales.y.grid.color = gridLineColor;
+    chart.options.scales.y.ticks.color = tickColor;
+
+    chart.update();
+}
+
+function getGraphGridColors() {
+    const rootStyles = getComputedStyle(document.documentElement);
+    let isDarkTheme = document.documentElement.getAttribute('data-theme') === 'dark';
+    const gridLineColor = isDarkTheme ? rootStyles.getPropertyValue('--black-3') : rootStyles.getPropertyValue('--white-1');
+    const tickColor = isDarkTheme ? rootStyles.getPropertyValue('--white-0') : rootStyles.getPropertyValue('--white-6');
+
+    return { gridLineColor, tickColor };
+}
+
+// Common chart configuration function to avoid repetition
+function createVolumeChart(chartId, data, options) {
+    const ctx = document.getElementById(chartId).getContext('2d');
+    const { chartType, color, gridLineColor, tickColor, title } = options;
+
+    // Destroy existing chart instance if it exists
+    if (window[chartType] && typeof window[chartType].destroy === 'function') {
+        window[chartType].destroy();
+    }
+
+    // Format data properly
+    const bytesData = data.dates.map((date, index) => ({
+        x: date,
+        y: data.gbCount[index],
+    }));
+
+    // Determine appropriate scale
+    const scale = determineUnit(bytesData);
+
+    // Scale the data
+    const scaledData = bytesData.map((point) => ({
+        x: point.x,
+        y: point.y / scale.divisor,
+    }));
+
+    // Create chart configuration
+    const chartConfig = {
+        type: 'bar',
+        data: {
+            labels: data.dates,
+            datasets: [
+                {
+                    label: title,
+                    data: scaledData,
+                    backgroundColor: color,
+                    borderRadius: 4,
+                    barPercentage: 0.5,
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                tooltip: {
+                    mode: 'index',
+                    intersect: false,
+                    callbacks: {
+                        label: function (context) {
+                            let label = context.dataset.label || '';
+                            if (context.parsed.y !== null) {
+                                let value = context.parsed.y;
+                                if (value >= 10) {
+                                    value = Number(value.toFixed()).toLocaleString('en-us');
+                                    label += ' ' + value + ' ' + scale.unit;
+                                } else {
+                                    label += ' ' + value.toFixed(3) + ' ' + scale.unit;
+                                }
+                            }
+                            return label;
+                        },
+                    },
+                },
+                legend: {
+                    display: false,
+                },
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: scale.unit,
+                    },
+                    grid: {
+                        display: true,
+                        color: gridLineColor,
+                    },
+                    ticks: {
+                        color: tickColor,
+                        callback: function (value) {
+                            return value + ' ' + scale.unit;
+                        },
+                    },
+                },
+                x: {
+                    title: {
+                        display: true,
+                        text: 'Time Period',
+                    },
+                    grid: {
+                        display: true,
+                        color: gridLineColor,
+                    },
+                    ticks: {
+                        color: tickColor,
+                        callback: function (val, _index, _ticks) {
+                            let value = this.getLabelForValue(val);
+                            if (value && value.indexOf('T') > -1) {
+                                let parts = value.split('T');
+                                return 'T' + parts[1];
+                            } else if (value) {
+                                let parts = value.split('-');
+                                return parts[1] + '-' + parts[2];
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    // Create and return chart
+    window[chartType] = new Chart(ctx, chartConfig);
+    return window[chartType];
+}
+
+// Simplified volume chart functions using the common approach
+function renderLogsVolumeChart(data, gridLineColor, tickColor) {
+    return createVolumeChart('logsVolumeChart', data, {
+        chartType: 'logsVolumeChart',
+        color: '#36A2EB',
+        gridLineColor,
+        tickColor,
+        title: 'Logs Volume',
+    });
+}
+
+function renderTracesVolumeChart(data, gridLineColor, tickColor) {
+    return createVolumeChart('tracesVolumeChart', data, {
+        chartType: 'tracesVolumeChart',
+        color: '#4BC0C0',
+        gridLineColor,
+        tickColor,
+        title: 'Traces Volume',
+    });
+}
+
+// Render stacked chart for active series and datapoint count
+function renderStackedChart(data, gridLineColor, tickColor) {
+    const ctx = document.getElementById('stackedChart').getContext('2d');
+
+    // Destroy existing chart instance if it exists
+    if (window.stackedChart && typeof window.stackedChart.destroy === 'function') {
+        window.stackedChart.destroy();
+    }
+
+    window.stackedChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: data.dates,
+            datasets: [
+                {
+                    label: 'Active Series Count',
+                    data: data.activeSeriesCount,
+                    backgroundColor: 'rgba(255, 100, 132, 0.2)',
+                    borderColor: '#FF6484',
+                    borderWidth: 2,
+                    tension: 0.3,
+                    pointRadius: 3,
+                    pointHoverRadius: 5,
+                    fill: false
+                },
+                {
+                    label: 'Metrics Datapoints Count',
+                    data: data.metricsDatapointsCount,
+                    backgroundColor: 'rgba(99, 71, 217, 0.2)',
+                    borderColor: 'rgb(99, 71, 217)',
+                    borderWidth: 2,
+                    tension: 0.3,
+                    pointRadius: 3,
+                    pointHoverRadius: 5,
+                    fill: false
+                },
+            ],
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                tooltip: {
+                    mode: 'index',
+                    intersect: false,
+                },
+                legend: {
+                    position: 'bottom',
+                },
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'Count',
+                    },
+                    grid: {
+                        display: true,
+                        color: gridLineColor,
+                    },
+                    ticks: {
+                        color: tickColor,
+                    },
+                },
+                x: {
+                    title: {
+                        display: true,
+                        text: 'Time Period',
+                    },
+                    grid: {
+                        display: true,
+                        color: gridLineColor,
+                    },
+                    ticks: {
+                        color: tickColor,
+                        callback: function (val, _index, _ticks) {
+                            let value = this.getLabelForValue(val);
+                            if (value && value.indexOf('T') > -1) {
+                                let parts = value.split('T');
+                                return 'T' + parts[1];
+                            } else if (value) {
+                                let parts = value.split('-');
+                                return parts[1] + '-' + parts[2];
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    });
+}
+
+// Update the getClusterIngestStats function to use our charting functions
+function getClusterIngestStats() {
+    $.ajax({
+        method: 'post',
+        url: 'api/clusterIngestStats',
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            Accept: '*/*',
+        },
+        crossDomain: true,
+        dataType: 'json',
+        data: JSON.stringify({
+            startEpoch: filterStartDate,
+            endEpoch: filterEndDate,
+        }),
+    })
+        .then((res) => {
+            console.log(res);
+            setupClusterStatsCharts(res);
+        })
+        .catch((err) => {
+            console.error('error:', err);
+        });
+}

--- a/static/usage-stats.html
+++ b/static/usage-stats.html
@@ -1,0 +1,185 @@
+<!-- 
+Copyright (c) 2021-2025 SigScalr, Inc.
+
+This file is part of SigLens Observability Solution
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-5SBJC04YFB"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-5SBJC04YFB');
+</script>
+
+<head>
+    <meta charset="UTF-8">
+    <title>SigLens</title>
+
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-16x16.png">
+    <link rel="manifest" href="assets/site.webmanifest">
+    <link rel="mask-icon" href="assets/safari-pinned-tab.svg" color="#5bbad5">
+    <meta name="msapplication-TileColor" content="#da532c">
+
+    <link rel="stylesheet" href="./css/lib/bootstrap.min.css" />
+    <link rel="stylesheet" href="./css/lib/jquery-ui.min.css" />
+    <link rel="stylesheet" href="./css/siglens.css?cb={{ AppVersion }}" />
+    <link rel="stylesheet" href="./css/query-builder.css?cb={{ AppVersion }}" />
+    <style>
+        .chart-container {
+            height: 300px;
+            padding: 0px;
+        }
+    </style>
+
+    <script src="./js/lib/jquery-3.6.0.min.js"></script>
+    <script src="./js/lib/jquery-ui.min.js"></script>
+    <script src="./js/lib/js.cookie.min.js"></script>
+    <script src="./js/lib/moment.min.js"></script>
+    <script src="./js/lib/date_fns.min.js"></script>
+    <script src="./js/lib/popper.min.js"></script>
+    <script src="./js/lib/bootstrap.bundle.min.js"></script>
+    <script src="./js/lib/chart.umd.min.js"></script>
+    <script>
+        var defaultTheme = Cookies.get('theme') || 'light';
+        $('html').attr('data-theme', defaultTheme);
+    </script>
+    {{ .RunCheck1 | safeHTML }}
+</head>
+
+<body>
+    <div id="app-container">
+        <div id="app-side-nav">
+        </div>
+        <div id="dashboard">
+            <div id="stats-charts-container" class="myOrg-container p-4">
+                <div class="d-flex justify-content-between mb-3 align-items-center">
+                    <div>
+                        <h1 class="myOrg-heading">Usage Stats</h1>
+                        <p class="caption">Track ingestion volume across time periods </p>
+                    </div>
+                    <div class="d-flex align-items-center gap-3">
+                        <div class="d-flex align-items-center gap-2">
+                            Granularity:
+                            <div class="granularity-tabs">
+                                <div class="tab" data-tab="hourly">Per Hour</div>
+                                <div class="tab active" data-tab="daily">Per Day</div>
+                                <div class="tab" data-tab="monthly">Per Month</div>
+                            </div>
+                        </div>
+                        <div class="dropdown">
+                            <button class="btn dropdown-toggle" type="button" id="date-picker-btn"
+                                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                                data-bs-toggle="dropdown">
+                                <span>Time Picker</span>
+                                <i class="dropdown-arrow"></i>
+                            </button>
+                            <div class="dropdown-menu daterangepicker" aria-labelledby="index-btn"
+                                id="daterangepicker ">
+                                <p class="dt-header">Search the last</p>
+                                <div class="ranges">
+                                    <div class="inner-range">
+                                        <div id="now-1h" class="range-item">1 Hr</div>
+                                        <div id="now-3h" class="range-item">3 Hrs</div>
+                                        <div id="now-6h" class="range-item">6 Hrs</div>
+                                    </div>
+                                    <div class="inner-range">
+                                        <div id="now-12h" class="range-item">12 Hrs</div>
+                                        <div id="now-24h" class="range-item">24 Hrs</div>
+                                        <div id="now-2d" class="range-item">2 Days</div>
+                                    </div>
+                                    <div class="inner-range">
+                                        <div id="now-7d" class="range-item active">7 Days</div>
+                                        <div id="now-30d" class="range-item">30 Days</div>
+                                        <div id="now-90d" class="range-item">90 Days</div>
+                                    </div>
+                                    <hr>
+                                    </hr>
+                                    <div class="dt-header">Custom Search <span id="reset-timepicker"
+                                            type="reset">Reset</span>
+                                    </div>
+                                    <div id="daterange-from"> <span id="dt-from-text"> From</span> <br />
+                                        <input type="date" id="date-start" />
+                                        <input type="time" id="time-start" value="00:00" />
+                                    </div>
+                                    <div id="daterange-to"> <span id="dt-to-text"> To </span> <br />
+                                        <input type="date" id="date-end">
+                                        <input type="time" id="time-end" value="00:00">
+                                    </div>
+                                    <div class="drp-buttons">
+                                        <button class="applyBtn btn btn-sm btn-primary" id="customrange-btn"
+                                            type="button">Apply</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <div class="chart-container">
+                        <div class="stats-header">
+                            <div>Logs Volume</div>
+                            <div>Total: <span class="logs-total"></span></div>
+                        </div>
+                        <div class="canvas-container">
+                            <canvas id="logsVolumeChart"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container mt-5">
+                        <div class="stats-header">
+                            <div>Traces Volume</div>
+                            <div>Total: <span class="traces-total"></span></div>
+                        </div>
+                        <div class="canvas-container">
+                            <canvas id="tracesVolumeChart"></canvas>
+                        </div>
+                    </div>
+                    <div class="chart-container mt-5">
+                        <div class="stats-header">
+                            <div>Active Series & Datapoints</div>
+                            <div>Total Datapoints: <span class="datapoints-total"></span></div>
+                        </div>
+                        <div class="canvas-container">
+                            <canvas id="stackedChart"></canvas>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id="app-footer">
+            2024 &copy; SigLens
+        </div>
+
+    </div>
+
+    <script src="./js/navbar.js?cb={{ AppVersion }}"></script>
+    <script src="./js/common.js?cb={{ AppVersion }}"></script>
+    <script src="./js/event-handlers.js?cb={{ AppVersion }}"></script>
+    <script src="./js/date-picker.js?cb={{ AppVersion }}"></script>
+    <script src="./js/usage-stats.js?cb={{ AppVersion }}"></script>
+
+    {{ .RunCheck2 | safeHTML }}
+    {{ .RunCheck3 | safeHTML }}
+
+</body>
+
+</html>


### PR DESCRIPTION
# Description
**Frontend Changes:**
  1. Added a new "Usage Stats" link in the navbar.
  2. Displays logs volume, traces volume, active series count for metrics, and datapoints.
  3. Implemented timepicker (supports both relative and custom time ranges).
  4. Added an option to select granularity (hourly, daily, monthly).
  5. Graphs update dynamically when time range or granularity is changed.

**Backend Changes:**
  1. `api/clusterIngestStats` API now supports fetching stats for a custom time range.
  2. Added Granularity in Request Body:
  If no granularity is provided, the backend auto adjusts the granularity according to the time range. (used for the cluster page).
  3. Added support for fetching stats with monthly granularity.

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/984641d5-d9ae-4158-97da-170465050e57" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/243edf85-b837-4a09-8625-4537f76072e0" />
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/7815e745-3e0f-4a69-85ef-963dae005b76" />

Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
