### PR TITLE
Fix - Updated Default Color Palette for Metrics Explorer

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -535,7 +535,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                      </div>
                                      <div id="visualization-options" class="mb-3 mt-3">
                                         <div>Display: <input id="display-input" type="text" value="Line chart"></div>
-                                        <div>Color: <input id="color-input" type="text" value="Classic"></div>
+                                        <div>Color: <input id="color-input" type="text" value="Palette"></div>
                                         <div id="line-style-div">Style: <input id="line-style-input" type="text" value="Solid"></div>
                                         <div id="stroke-div">Stroke: <input id="stroke-input" type="text" value="Normal"></div>
                                     </div>

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -39,7 +39,7 @@ let isAlertScreen, isMetricsURL, isDashboardScreen;
 //eslint-disable-next-line no-unused-vars
 let metricsQueryParams;
 let funcApplied = false;
-let selectedTheme = 'Classic';
+let selectedTheme = 'Palette';
 let selectedLineStyle = 'Solid';
 let selectedStroke = 'Normal';
 var colorPalette = {
@@ -50,7 +50,7 @@ var colorPalette = {
     Warm: ['#f7e288', '#fadb84', '#f1b65d', '#ec954d', '#f65630', '#cf3926', '#aa2827', '#761727'],
     Orange: ['#f8ddbd', '#f4d2a9', '#f0b077', '#ec934f', '#e0722f', '#c85621', '#9b4116', '#72300e'],
     Gray: ['#c6ccd1', '#adb1b9', '#8d8c96', '#93969e', '#7d7c87', '#656571', '#62636a', '#4c4d57'],
-    Palette: ['#5596c8', '#9c86cd', '#f9d038', '#66bfa1', '#c160c9', '#dd905a', '#4476c9', '#c5d741', '#9246b7', '#65d1d5', '#7975da', '#659d33', '#cf777e', '#f2ba46', '#59baee', '#cd92d8', '#508260', '#cf5081', '#a65c93', '#b0be4f'],
+    Palette: ['#5795e4', '#9c86cd', '#f9d038', '#66bfa1', '#c160c9', '#dd905a', '#4476c9', '#c5d741', '#9246b7', '#65d1d5', '#7975da', '#659d33', '#cf777e', '#f2ba46', '#59baee', '#cd92d8', '#508260', '#cf5081', '#a65c93', '#b0be4f'],
 };
 
 let cachedMetrics = [];
@@ -1493,8 +1493,8 @@ function prepareChartData(seriesData, chartDataCollection, queryName) {
             return {
                 label: series.seriesName,
                 data: series.values,
-                borderColor: colorPalette.Classic[index % colorPalette.Classic.length],
-                backgroundColor: colorPalette.Classic[index % colorPalette.Classic.length] + '70',
+                borderColor: colorPalette.Palette[index % colorPalette.Palette.length],
+                backgroundColor: colorPalette.Palette[index % colorPalette.Palette.length] + '70',
                 borderWidth: 2,
                 fill: false,
             };
@@ -1670,7 +1670,7 @@ function initializeChart(canvas, seriesData, queryName, chartType) {
     var ctx = canvas[0].getContext('2d');
     let chartData = prepareChartData(seriesData, chartDataCollection, queryName);
     const { gridLineColor, tickColor } = getGraphGridColors();
-    var selectedPalette = colorPalette[selectedTheme] || colorPalette.Classic;
+    var selectedPalette = colorPalette[selectedTheme] || colorPalette.Palette;
 
     // Calculate max value from data
     const maxDataValue = Math.max(...chartData.datasets.flatMap((d) => Object.values(d.data).filter((v) => v !== null)));
@@ -2140,7 +2140,7 @@ $('#color-input')
 
 function updateChartTheme(theme) {
     selectedTheme = theme; // Store the selected theme
-    var selectedPalette = colorPalette[selectedTheme] || colorPalette.Classic;
+    var selectedPalette = colorPalette[selectedTheme] || colorPalette.Palette;
 
     // Loop through each chart data
     for (var queryName in chartDataCollection) {

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -1537,17 +1537,17 @@ const ChartUtils = (function () {
 
                 // Draw new crosshair lines
                 ctx.beginPath();
-                ctx.setLineDash([5, 5]);
+                ctx.setLineDash([3, 3]);
                 ctx.lineWidth = 1;
-                ctx.strokeStyle = 'rgba(102, 102, 102, 0.8)';
+                ctx.strokeStyle = 'rgba(102, 102, 102, 0.5)';
                 ctx.moveTo(x, top);
                 ctx.lineTo(x, bottom);
                 ctx.stroke();
 
                 ctx.beginPath();
-                ctx.setLineDash([5, 5]);
+                ctx.setLineDash([3, 3]);
                 ctx.lineWidth = 1;
-                ctx.strokeStyle = 'rgba(102, 102, 102, 0.9)';
+                ctx.strokeStyle = 'rgba(102, 102, 102, 0.5)';
                 ctx.moveTo(left, y);
                 ctx.lineTo(right, y);
                 ctx.stroke();

--- a/static/metrics-explorer.html
+++ b/static/metrics-explorer.html
@@ -165,7 +165,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                       Display : <input id="display-input" type="text" value="Line chart">
                     </div>
                     <div>
-                      Color : <input id="color-input" type="text" value="Classic">
+                      Color : <input id="color-input" type="text" value="Palette">
                     </div>
                     <div id="line-style-div">
                       Style : <input id="line-style-input" type="text" value="Solid">


### PR DESCRIPTION
# Description

- The previous default color palette used in Metrics Explorer did not provide distinction between multiple metrics.
- Updated the default color palette to use a more contrasting and visually distinct set of colors.

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/6a3bd6d0-ff2b-4879-a856-d65ce9298089" />


Fixes #<issue-number> (link all the GitHub issues this addresses)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
