### PR TITLE
Fix goroutine leak in query summary

### DIFF
--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -70,6 +70,8 @@ func (qp *QueryProcessor) Cleanup() {
 	for _, dp := range qp.chain {
 		go dp.Cleanup()
 	}
+
+	qp.querySummary.Cleanup()
 }
 
 func (qp *QueryProcessor) GetChainedDataProcessors() []*DataProcessor {

--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -236,6 +236,7 @@ func InitQueryInfoAndSummary(searchNode *structs.SearchNode, timeRange *dtu.Time
 	pqid := querytracker.GetHashForQuery(searchNode)
 	allSegFileResults, err := segresults.InitSearchResults(qc.SizeLimit, aggs, qType, qid)
 	if err != nil {
+		querySummary.Cleanup()
 		log.Errorf("qid=%d, InitQueryInfoAndSummary: Failed to InitSearchResults! error %+v", qid, err)
 		return nil, nil, "", false, nil, nil, 0, err
 	}
@@ -251,11 +252,13 @@ func InitQueryInfoAndSummary(searchNode *structs.SearchNode, timeRange *dtu.Time
 	queryInfo, err := InitQueryInformation(searchNode, aggs, timeRange, qc.TableInfo,
 		qc.SizeLimit, parallelismPerFile, qid, dqs, qc.Orgid, qc.Scroll, containsKibana)
 	if err != nil {
+		querySummary.Cleanup()
 		log.Errorf("qid=%d, InitQueryInfoAndSummary: Failed to InitQueryInformation! error %+v", qid, err)
 		return nil, nil, "", false, nil, nil, 0, err
 	}
 	err = AssociateSearchInfoWithQid(qid, allSegFileResults, aggs, dqs, qType, qc.RawQuery)
 	if err != nil {
+		querySummary.Cleanup()
 		log.Errorf("qid=%d, InitQueryInfoAndSummary: Failed to associate search results with qid! Error: %+v", qid, err)
 		return nil, nil, "", false, nil, nil, 0, err
 	}

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -171,8 +171,10 @@ func (qs *QuerySummary) stopTicker() {
 
 func (qs *QuerySummary) tickWatcher() {
 	defer func() {
-		qs.ticker.Stop()
-		qs.ticker = nil
+		if qs.ticker != nil {
+			qs.ticker.Stop()
+			qs.ticker = nil
+		}
 		qs.tickerStopChan = nil
 	}()
 	for {

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -151,6 +151,10 @@ func InitQuerySummary(queryType QueryType, qid uint64) *QuerySummary {
 	return qs
 }
 
+func (qs *QuerySummary) Cleanup() {
+	qs.stopTicker()
+}
+
 func (qs *QuerySummary) startTicker() {
 	qs.ticker = time.NewTicker(TICK_DURATION_SECS * time.Second)
 	qs.tickerStopChan = make(chan bool)
@@ -161,6 +165,7 @@ func (qs *QuerySummary) stopTicker() {
 	if qs.ticker != nil {
 		qs.ticker.Stop()
 		close(qs.tickerStopChan)
+		qs.ticker = nil
 	}
 }
 

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -115,7 +115,7 @@ var activeQSCountForMetrics int64
 
 // InitQuerySummary returns a struct to store query level search stats.
 // This function starts a ticker to log info about long running queries.
-// Caller is responsible for calling LogSummary() function to stop the ticker.
+// The caller must eventually call Cleanup() to avoid a goroutine leak.
 func InitQuerySummary(queryType QueryType, qid uint64) *QuerySummary {
 	lock := &sync.Mutex{}
 	rawSearchTypeSummary := &searchTypeSummary{}
@@ -643,7 +643,7 @@ func (qs *QuerySummary) LogSummaryAndEmitMetrics(qid uint64, pqid string, contai
 	}
 
 	uStats.UpdateQueryStats(1, float64(qs.getQueryTotalTime().Milliseconds()), orgid)
-	qs.stopTicker()
+	qs.Cleanup()
 }
 
 func (qs *QuerySummary) LogMetricsQuerySummary(orgid int64) {
@@ -662,7 +662,7 @@ func (qs *QuerySummary) LogMetricsQuerySummary(orgid int64) {
 	log.Warnf("qid=%d, MetricsQuerySummary: Across %d TSG Files: min (%.3fms) max (%.3fms) avg (%.3fms) p95(%.3fms)", qs.qid, qs.getNumTSGFilesLoaded(), getMinSearchTimeFromArr(qs.metricsQuerySummary.timeLoadingTSGFiles), getMaxSearchTimeFromArr(qs.metricsQuerySummary.timeLoadingTSGFiles), avgTimeLoadingTSGFiles, getPercentileTimeFromArr(95, qs.metricsQuerySummary.timeLoadingTSGFiles))
 
 	uStats.UpdateQueryStats(1, float64(qs.getQueryTotalTime().Milliseconds()), orgid)
-	qs.stopTicker()
+	qs.Cleanup()
 }
 
 func (qs *QuerySummary) UpdateRemainingDistributedQueries(remainingDistributedQueries uint64) {

--- a/pkg/segment/query/summary/querysummary_test.go
+++ b/pkg/segment/query/summary/querysummary_test.go
@@ -17,7 +17,9 @@
 
 package summary
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_IdempotentCleanup(t *testing.T) {
 	qs := InitQuerySummary(LOGS, 0)

--- a/pkg/segment/query/summary/querysummary_test.go
+++ b/pkg/segment/query/summary/querysummary_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package summary
+
+import "testing"
+
+func Test_IdempotentCleanup(t *testing.T) {
+	qs := InitQuerySummary(LOGS, 0)
+	qs.Cleanup()
+	qs.Cleanup() // Just don't panic.
+}

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -657,11 +657,13 @@ func SetupPipeResQuery(root *structs.ASTNode, aggs *structs.QueryAggregators, qi
 
 	queryProcessor, err := processor.NewQueryProcessor(aggs, queryInfo, querySummary, scrollFrom, qc.IncludeNulls, *startTime, true)
 	if err != nil {
+		querySummary.Cleanup()
 		return nil, toputils.TeeErrorf("qid=%v, ExecutePipeResQuery: failed to create query processor, err: %v", qid, err)
 	}
 
 	err = query.SetCleanupCallback(qid, queryProcessor.Cleanup)
 	if err != nil {
+		querySummary.Cleanup()
 		return nil, toputils.TeeErrorf("qid=%v, ExecutePipeResQuery: failed to set cleanup callback, err: %v", qid, err)
 	}
 


### PR DESCRIPTION
# Description
In some error paths, we were starting a goroutine to watch a ticker (started by `InitQuerySummary()`), but we weren't properly closing that goroutine. This PR fixes that with a `Cleanup()` method that's safe to call multiple times.

# Testing
1. New unit test
2. Manually forced an error creating a QueryProcessor (that's one of the error paths we didn't handle properly), and ran a query. Previously, we'd get "still executing" logs every 10 seconds; with this PR, we don't.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
