### PR TITLE
Promql instant query Support

### DIFF
--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -1769,7 +1769,7 @@ func Test_SimpleMetricInstantQuery(t *testing.T) {
 	assert.JSONEq(t, string(marshalExpectedResp), string(resp))
 
 	// Now since this is more than the DEFAULT_LOOKBACK_FOR_INSTANT_QUERIES(5m), the query will not return any results.
-	endTime = startTimestamp + 4600
+	endTime = startTimestamp + 3600 + promql.DEFAULT_LOOKBACK_FOR_INSTANT_QUERIES + 1
 
 	fastCtx = &fasthttp.RequestCtx{}
 	fastCtx.Request.PostArgs().Add("query", query)

--- a/pkg/e2etests/metrics_e2e_test.go
+++ b/pkg/e2etests/metrics_e2e_test.go
@@ -28,11 +28,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/integrations/prometheus/promql"
@@ -41,6 +43,7 @@ import (
 	segmetadata "github.com/siglens/siglens/pkg/segment/metadata"
 	"github.com/siglens/siglens/pkg/segment/query"
 	"github.com/siglens/siglens/pkg/segment/results/mresults"
+	"github.com/siglens/siglens/pkg/segment/structs"
 	"github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
 	"github.com/siglens/siglens/pkg/segment/writer/metrics"
@@ -48,6 +51,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 /*
@@ -1703,6 +1707,67 @@ func Test_SimpleMetricQueryUnrotatedBlockData(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, len(expectedResults))
+}
+
+func Test_SimpleMetricInstantQuery(t *testing.T) {
+	defer cleanUp(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go query.PullQueriesToRun(ctx)
+	defer cancel()
+
+	startTimestamp := dataStartTimestamp
+	allTimeSeries, _, _, _ := GetTestMetricsData(startTimestamp)
+
+	err := initTestConfig(t)
+	assert.Nil(t, err)
+
+	err = ingestTestMetricsData(allTimeSeries)
+	assert.Nil(t, err)
+
+	mSegs, err := rotateMetricsDataAndClearSegStore(true)
+	assert.Nil(t, err)
+	assert.Greater(t, len(mSegs), 0)
+
+	err = initializeMetricsMetaData()
+	assert.Nil(t, err)
+
+	endTime := startTimestamp + 3601
+	query := `(testmetric0)`
+
+	fastCtx := &fasthttp.RequestCtx{}
+	fastCtx.Request.PostArgs().Add("query", query)
+	fastCtx.Request.PostArgs().Add("time", strconv.Itoa(int(endTime)))
+
+	promql.ProcessPromqlMetricsSearchRequest(fastCtx, 0)
+	assert.Equal(t, 200, fastCtx.Response.StatusCode())
+
+	resp := fastCtx.Response.Body()
+	assert.NotNil(t, resp)
+	fmt.Println(string(resp))
+
+	expectedPromQLResp := &structs.MetricsPromQLInstantQueryResponse{
+		Status: "success",
+		Data: &structs.PromQLInstantData{
+			ResultType: parser.ValueTypeVector,
+			VectorResult: []structs.InstantVectorResult{
+				{
+					Metric: map[string]string{
+						"__name__": "testmetric0",
+						"color":    "red",
+						"shape":    "circle",
+						"size":     "small",
+						"type":     "solid",
+					},
+					Value: []interface{}{endTime, "70"},
+				},
+			},
+		},
+	}
+
+	marshalExpectedResp, err := json.Marshal(expectedPromQLResp)
+	assert.Nil(t, err)
+	assert.JSONEq(t, string(marshalExpectedResp), string(resp))
 }
 
 func Test_metricsPersistAfterGracefulRestart(t *testing.T) {

--- a/pkg/integrations/prometheus/promql/metricsSearchHandler.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler.go
@@ -54,7 +54,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const DEFAULT_LOOKBACK uint32 = 5 * 60 // 5 mins
+const DEFAULT_LOOKBACK_FOR_INSTANT_QUERIES uint32 = 5 * 60 // 5 mins
 
 func parseSearchBody(jsonSource map[string]interface{}) (string, uint32, uint32, time.Duration, usageStats.UsageStatsGranularity, error) {
 	searchText := ""
@@ -182,7 +182,7 @@ func ProcessPromqlMetricsSearchRequest(ctx *fasthttp.RequestCtx, myid int64) {
 		}
 	}
 
-	startTime := endTime - DEFAULT_LOOKBACK
+	startTime := endTime - DEFAULT_LOOKBACK_FOR_INSTANT_QUERIES
 	log.Infof("qid=%v, ProcessPromqlMetricsSearchRequest: InstantQuery; searchString=[%v] startEpochs=[%v] endEpochs=[%v]", qid, searchText, startTime, endTime)
 	metricQueryRequest, pqlQuerytype, queryArithmetic, err := ConvertPromQLToMetricsQuery(searchText, startTime, endTime, myid)
 	if err != nil {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -803,9 +803,7 @@ func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueTy
 					result.Value = []interface{}{timestamp, fmt.Sprintf("%v", val)}
 					pqlData.VectorResult = append(pqlData.VectorResult, result)
 				}
-			}
-
-			if len(results) >= 2 {
+			} else if len(results) > 1 {
 				// If the results have more than 1 timestamp, then return an error
 				log.Errorf("GetResultsPromQlInstantQuery: More than 1 timestamp found in the results for seriesId: %v", seriesId)
 				return nil, errors.New("error in fetching the results. Multiple timestamps found in the results")

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -73,6 +73,8 @@ type MetricsResult struct {
 	IsScalar    bool
 	ScalarValue float64
 
+	IsInstantQuery bool
+
 	State bucketState
 
 	rwLock               *sync.RWMutex
@@ -93,6 +95,7 @@ func InitMetricResults(mQuery *structs.MetricsQuery, qid uint64) *MetricsResult 
 		rwLock:               &sync.RWMutex{},
 		ErrList:              make([]error, 0),
 		AllSeriesTagsOnlyMap: make(map[uint64]*tsidtracker.AllMatchedTSIDsInfo, 0),
+		IsInstantQuery:       mQuery.IsInstantQuery,
 	}
 }
 
@@ -108,7 +111,10 @@ func (r *MetricsResult) AddSeries(series *Series, tsid uint64, tsGroupId *bytebu
 		r.AllSeries[tsid] = series
 		return
 	}
-	currSeries.Merge(series)
+	err := currSeries.Merge(series)
+	if err != nil {
+		r.AddError(err)
+	}
 }
 
 func (r *MetricsResult) AddAllSeriesTagsOnlyMap(tsidInfoMap map[uint64]*tsidtracker.AllMatchedTSIDsInfo) {
@@ -677,7 +683,10 @@ func (r *MetricsResult) Merge(localRes *MetricsResult) error {
 			r.AllSeries[tsid] = series
 			continue
 		}
-		currSeries.Merge(series)
+		err := currSeries.Merge(series)
+		if err != nil {
+			r.AddError(err)
+		}
 	}
 	return nil
 }
@@ -788,35 +797,19 @@ func (r *MetricsResult) GetResultsPromQlInstantQuery(pqlQueryType parser.ValueTy
 				Metric: metricSeries,
 			}
 
-			floatValue, ok := results[timestamp]
-			if ok {
-				result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
-				pqlData.VectorResult = append(pqlData.VectorResult, result)
-				continue
-			}
-
-			// TODO: Inspect on whether we should ensure that the timestamp is present in the results?
-
-			// In the case where the timestamp is not present in the results
-			if len(results) > 2 {
-				// If the results have more than 2 timestamps, this should not happen.
-				// As the startTime = timestamp - 1 and endTime = timestamp, and intervalSeconds = 1
-				// So, the results should have only 2 timestamps
-				log.Errorf("GetResultsPromQlInstantQuery: More than 2 timestamps found in the results for seriesId: %v", seriesId)
-				return nil, errors.New("error in fetching the results. Multiple timestamps found in the results")
-			}
-
-			maxTimestamp := uint32(0)
-			floatValue = 0
-			for ts, val := range results {
-				if ts > maxTimestamp {
-					maxTimestamp = ts
-					floatValue = val
+			if len(results) == 1 {
+				// Instant Query is expected to have only one timestamp
+				for _, val := range results {
+					result.Value = []interface{}{timestamp, fmt.Sprintf("%v", val)}
+					pqlData.VectorResult = append(pqlData.VectorResult, result)
 				}
 			}
 
-			result.Value = []interface{}{timestamp, fmt.Sprintf("%v", floatValue)}
-			pqlData.VectorResult = append(pqlData.VectorResult, result)
+			if len(results) >= 2 {
+				// If the results have more than 1 timestamp, then return an error
+				log.Errorf("GetResultsPromQlInstantQuery: More than 1 timestamp found in the results for seriesId: %v", seriesId)
+				return nil, errors.New("error in fetching the results. Multiple timestamps found in the results")
+			}
 		}
 	case parser.ValueTypeMatrix:
 		return nil, errors.New("ValueTypeMatrix is not supported for Instant Queries")

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -79,6 +79,7 @@ type MetricsQuery struct {
 	Groupby             bool // flag to group by tags
 	GroupByMetricName   bool // flag to group by metric name
 	AggWithoutGroupBy   bool // flag that indicates aggregation without group by anywhere in the query
+	IsInstantQuery      bool // flag that indicates if the query is an instant query
 }
 
 // This is used to aggregate multiple things into fewer things. Currently, two


### PR DESCRIPTION
# Description
- Implements the Instant Query for Metrics similar to Prometheus, except the reset of data when the `up` metric for the instance is `0`.


# Testing
- Tested by ingesting data into  Prometheus and SigLens
- Ran same instant query through Grafana. 
- Verified that the values are same for some queries.
- Added a new unit test case.

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
