### PR TITLE
Add initial queries to longevity test

### DIFF
--- a/tools/sigclient/pkg/query/querymanager.go
+++ b/tools/sigclient/pkg/query/querymanager.go
@@ -194,6 +194,12 @@ func (qm *queryManager) addInitialQueries(logs []map[string]interface{}) {
 	startEpochMs := firstEpoch
 
 	for _, template := range qm.templates {
+		if template.maxInProgress <= 0 {
+			log.Warnf("queryManager.addInitialQueries: maxInProgress is 0 for template %v; skipping",
+				template.validator.Info())
+			continue
+		}
+
 		seconds := template.timeRangeSeconds / uint64(template.maxInProgress)
 		seconds = max(seconds, 1)
 

--- a/tools/sigclient/pkg/query/querymanager.go
+++ b/tools/sigclient/pkg/query/querymanager.go
@@ -195,7 +195,7 @@ func (qm *queryManager) addInitialQueries(logs []map[string]interface{}) {
 
 	for _, template := range qm.templates {
 		seconds := template.timeRangeSeconds / uint64(template.maxInProgress)
-		seconds = max(seconds, 1) // Ensure at least 1 second spacing to avoid burst of queries.
+		seconds = max(seconds, 1)
 
 		for i := 0; i < template.maxInProgress; i++ {
 			validator := template.validator.Copy()


### PR DESCRIPTION
# Description
Previously, if a query in the longevity test required X minutes of data, we'd only run that query once the longevity test had been running for X minutes. With this PR, we'll start that query earlier—if the test's been running for `Y` minutes, we'll start the query and use `min(X, Y)` minutes of lookback.

# Testing
I ran the longevity test with just one query that should run every 5 seconds with a 5 minute lookback. With this PR, it started querying much sooner:
```
INFO[0065] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5s (1743176939160-1743176944160), got 10 matches
INFO[0070] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=10s (1743176939160-1743176949160), got 10 matches
INFO[0075] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=15s (1743176939160-1743176954160), got 10 matches
INFO[0080] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=20s (1743176939160-1743176959160), got 10 matches
```
And once it got to 5 minutes, it kept using a 5 minute lookback
```
INFO[0360] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5m0s (1743176939160-1743177239160), got 10 matches
INFO[0365] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5m0s (1743176944132-1743177244132), got 10 matches
INFO[0370] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5m0s (1743176949092-1743177249092), got 10 matches
INFO[0375] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5m0s (1743176954051-1743177254051), got 10 matches
INFO[0380] queryManager.runQuery: successfully ran query=city_c1="Boston" | head 10, timeSpan=5m0s (1743176959100-1743177259100), got 10 matches
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
