### PR TITLE
Add dynamic queries to the longevity suite

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -583,9 +583,9 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 3600, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 6*3600, 100),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 10, 0, 0)), 1, 1),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 300, 10),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 3600, 10),
-			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 6*3600, 100),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 50, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 50, 0, 0)), 3600, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "latency_c1", 50, 0, 0)), 6*3600, 100),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl, failOnError)

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -584,6 +584,8 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 6*3600, 100),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 3600, 10),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 6*3600, 100),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl, failOnError)

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -579,6 +579,11 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("state_c1", "Texas")), 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.MatchAll(), 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.MatchAll(), 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 300, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 3600, 10),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 6*3600, 100),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 10, 0, 0)), 1, 1),
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 100, 0, 0)), 300, 10),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl, failOnError)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -132,6 +132,9 @@ func (df *dynamicFilter) Matches(log map[string]interface{}) bool {
 }
 
 func (df *dynamicFilter) setFrom(log map[string]interface{}) {
+	// Choose a random key=value pair from the log to filter on. Currently,
+	// the validator only supports string values. Map iterations in Go are
+	// nondeterministic, so we should get a variety of keys over time.
 	for key, value := range log {
 		switch v := value.(type) {
 		case string:

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -634,6 +634,16 @@ func Test_filterToString(t *testing.T) {
 	assert.Equal(t, `*`, fmt.Sprintf("%v", filter))
 }
 
+func Test_dynamicFilter_setFrom(t *testing.T) {
+	df := &dynamicFilter{}
+
+	df.setFrom(map[string]interface{}{"city": "New York"})
+	assert.Equal(t, `city="New York"`, fmt.Sprintf("%v", df))
+
+	df.setFrom(map[string]interface{}{"city": 123}) // No string values.
+	assert.Equal(t, `*`, fmt.Sprintf("%v", df))
+}
+
 func addLogsWithoutError(t *testing.T, validator queryValidator, logs []map[string]interface{}) {
 	t.Helper()
 


### PR DESCRIPTION
# Description
Now instead of hardcoding all the queries in the longevity test, we have some queries that will look at the data being ingested and choose a random, valid filter—either a `key=value` pair that matches at least one log, or a match-all if there is no such pair.

# Testing
New unit tests. I also ran the test with just some of the dynamic queries, and got a good variety of `key=value` pairs:
```
INFO[0448] queryManager.runQuery: successfully ran query=hobby_c5="Frisbee" | stats count, timeSpan=1s (1743184958697-1743184959697), got 1 matches
INFO[0449] queryManager.runQuery: successfully ran query=gender_c4="male" | stats count, timeSpan=1s (1743184959708-1743184960708), got 341 matches
INFO[0449] queryManager.runQuery: successfully ran query=image_c3="https://picsum.photos/135/349" | head 10, timeSpan=1s (1743184959708-1743184960708), got 1 matches
INFO[0450] queryManager.runQuery: successfully ran query=job_description_c5="Legacy" | stats count, timeSpan=1s (1743184960719-1743184961719), got 18 matches
INFO[0450] queryManager.runQuery: successfully ran query=job_title_c2="Architect" | head 10, timeSpan=1s (1743184960719-1743184961719), got 10 matches
INFO[0451] queryManager.runQuery: successfully ran query=batch_c2="batch-340" | stats count, timeSpan=1s (1743184961735-1743184962735), got 1 matches
INFO[0451] queryManager.runQuery: successfully ran query=street_c2="49990 Lake Corner berg" | head 10, timeSpan=1s (1743184961735-1743184962735), got 1 matches
INFO[0451] queryManager.runQuery: successfully ran query=user_agent_c1="Mozilla/5.0 (X11; Linux i686) AppleWebKit/5312 (KHTML, like Gecko) Chrome/39.0.839.0 Mobile Safari/5312" | stats count, timeSpan=1s (1743184962654-1743184963654), got 1 matches
```

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
