### PR TITLE
Add queries with long time range to longevity suite

### DIFF
--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -571,21 +571,28 @@ var longevityCmd = &cobra.Command{
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(unwrap(query.Filter("city_c1", "New *")), "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(unwrap(query.Filter("state_c1", "Texas")), "latency_c1", 10, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(unwrap(query.Filter("state_c1", "Texas")), "latency_c1", 10, 0, 0)), 1, 1),
+
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("app_version_c1", "1.2.3")), 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("app_version_c1", "1.2.3")), 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("app_version_c1", "1.2.3")), 0, 0)), 3600, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("app_version_c1", "1.2.3")), 0, 0)), 6*3600, 100),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("state_c1", "Texas")), 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(unwrap(query.Filter("state_c1", "Texas")), 0, 0)), 300, 10),
+
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.MatchAll(), 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.MatchAll(), 0, 0)), 300, 10),
+
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 3600, 10),
 			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)), 6*3600, 100),
+
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 10, 0, 0)), 1, 1),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 50, 0, 0)), 300, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 50, 0, 0)), 3600, 10),
 			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "latency_c1", 50, 0, 0)), 6*3600, 100),
+
+			query.NewQueryTemplate(unwrap(query.NewFilterQueryValidator(query.DynamicFilter(), "", 10, 0, 0)).WithAllowAllStartTimes(), 30*24*3600, 10000),
+			query.NewQueryTemplate(unwrap(query.NewCountQueryValidator(query.DynamicFilter(), 0, 0)).WithAllowAllStartTimes(), 30*24*3600, 10000),
 		}
 		maxConcurrentQueries := int32(1)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl, failOnError)

--- a/tools/sigclient/pkg/query/querymanager.go
+++ b/tools/sigclient/pkg/query/querymanager.go
@@ -198,13 +198,13 @@ func (qm *queryManager) addInitialQueries(logs []map[string]interface{}) {
 			continue
 		}
 
-		startEpochMs := firstEpoch
 		seconds := template.timeRangeSeconds / uint64(template.maxInProgress)
 		seconds = max(seconds, 1)
 
 		for i := 0; i < template.maxInProgress; i++ {
 			validator := template.validator.Copy()
 
+			startEpochMs := firstEpoch
 			endEpochMs := startEpochMs + uint64((i+1)*int(seconds)*1000)
 			if validator.AllowsAllStartTimes() {
 				startEpochMs = endEpochMs - uint64(template.timeRangeSeconds*1000)

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -261,8 +261,9 @@ func (f *filterQueryValidator) GetQuery() (string, uint64, uint64) {
 func (f *filterQueryValidator) Copy() queryValidator {
 	return &filterQueryValidator{
 		basicValidator: basicValidator{
-			startEpoch: f.startEpoch,
-			endEpoch:   f.endEpoch,
+			startEpoch:         f.startEpoch,
+			endEpoch:           f.endEpoch,
+			allowAllStartTimes: f.allowAllStartTimes,
 		},
 		filter:  f.filter.Copy(),
 		sortCol: f.sortCol,
@@ -582,8 +583,9 @@ func (c *countQueryValidator) GetQuery() (string, uint64, uint64) {
 func (c *countQueryValidator) Copy() queryValidator {
 	return &countQueryValidator{
 		basicValidator: basicValidator{
-			startEpoch: c.startEpoch,
-			endEpoch:   c.endEpoch,
+			startEpoch:         c.startEpoch,
+			endEpoch:           c.endEpoch,
+			allowAllStartTimes: c.allowAllStartTimes,
 		},
 		filter:     c.filter.Copy(),
 		numMatches: c.numMatches,

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -296,6 +296,12 @@ func (f *filterQueryValidator) HandleLog(log map[string]interface{}) error {
 		return nil
 	}
 
+	if f.allowAllStartTimes {
+		// We're doing minimal validation, so don't update our expected
+		// results, to avoid unneeded computation.
+		return nil
+	}
+
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -276,8 +276,13 @@ func (f *filterQueryValidator) Info() string {
 	numResults := min(len(f.results), f.head)
 	query, startEpoch, endEpoch := f.GetQuery()
 
-	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v matches",
-		query, duration, startEpoch, endEpoch, numResults)
+	validation := "strict"
+	if f.allowAllStartTimes {
+		validation = "minimal"
+	}
+
+	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), validation=%v, got %v matches",
+		query, duration, startEpoch, endEpoch, validation, numResults)
 }
 
 // Note: this assumes successive calls to this are for logs with increasing timestamps.
@@ -589,8 +594,13 @@ func (c *countQueryValidator) Info() string {
 	duration := time.Duration(c.endEpoch-c.startEpoch) * time.Millisecond
 	query, startEpoch, endEpoch := c.GetQuery()
 
-	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), got %v matches",
-		query, duration, startEpoch, endEpoch, c.numMatches)
+	validation := "strict"
+	if c.allowAllStartTimes {
+		validation = "minimal"
+	}
+
+	return fmt.Sprintf("query=%v, timeSpan=%v (%v-%v), validation=%v, got %v matches",
+		query, duration, startEpoch, endEpoch, validation, c.numMatches)
 }
 
 func (c *countQueryValidator) WithAllowAllStartTimes() queryValidator {

--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -391,6 +391,12 @@ func (f *filterQueryValidator) MatchesResult(result []byte) error {
 		return fmt.Errorf("FQV.MatchesResult: cannot unmarshal %s; err=%v", result, err)
 	}
 
+	if f.allowAllStartTimes {
+		// Skip the rest of the validation, since we're not sure what the
+		// expected result is.
+		return nil
+	}
+
 	numExpectedLogs := min(len(f.results), f.head)
 	if response.Hits.TotalMatched.Value != numExpectedLogs {
 		return fmt.Errorf("FQV.MatchesResult: expected %d logs, got %d",
@@ -616,6 +622,12 @@ func (c *countQueryValidator) MatchesResult(result []byte) error {
 	response := logsResponse{}
 	if err := json.Unmarshal(result, &response); err != nil {
 		return fmt.Errorf("CQV.MatchesResult: cannot unmarshal %s; err=%v", result, err)
+	}
+
+	if c.allowAllStartTimes {
+		// Skip the rest of the validation, since we're not sure what the
+		// expected result is.
+		return nil
 	}
 
 	if response.Hits.TotalMatched.Value != c.numMatches {


### PR DESCRIPTION
# Description
Previously the queries in the longevity suite would only query over the time range that the longevity test was running, so that we'd know exactly what the expected result is. This PR adds some other queries that run over a much longer time range (30 days), but have less validation since we're not sure what the expected result is (e.g., siglens could have preexisting data before the longevity test is started)

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
