### PR TITLE
fix: PromQL Metrics Nested Queries with Binary Expr Plus other Misc fixes

### DIFF
--- a/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
+++ b/pkg/integrations/prometheus/promql/metricsSearchHandler_test.go
@@ -401,7 +401,7 @@ func Test_ProcessQueryArithmeticAndLogical_v1(t *testing.T) {
 	queryResultsMap[queryHash2] = queryResult2
 	queryResultsMap[queryHash3] = queryResult3
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, false)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, false, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 1, len(mResult.Results))
 
@@ -486,7 +486,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v1(t *testing.T) {
 	queryResultsMap[queryHash1] = queryResult1
 	queryResultsMap[queryHash2] = queryResult2
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 1, len(mResult.Results))
 
@@ -586,7 +586,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v2(t *testing.T) {
 	queryResultsMap[queryHash2] = queryResult2
 	queryResultsMap[queryHash3] = queryResult3
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 1, len(mResult.Results))
 
@@ -678,7 +678,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v3(t *testing.T) {
 	queryResultsMap[queryHash1] = queryResult1
 	queryResultsMap[queryHash2] = queryResult2
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 2, len(mResult.Results))
 
@@ -748,7 +748,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v4(t *testing.T) {
 
 	queryResultsMap := getQueryResultMapForThreeTestQueries("node_cpu_seconds_total", "node_memory_MemTotal_bytes", "node_disk_reads_completed_total")
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 2, len(mResult.Results))
 
@@ -844,7 +844,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_v5(t *testing.T) {
 	queryResultsMap[xxhash.Sum64String("node_disk_reads_completed_total")] = queryResult3
 
 	opLabelsDoNotNeedToMatch := false // Since there are multiple results that have more than one series, the labels need to match.
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, opLabelsDoNotNeedToMatch)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, opLabelsDoNotNeedToMatch, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 1, len(mResult.Results))
 	fmt.Println(mResult.Results)
@@ -1036,7 +1036,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_Scalar_OP_v1(t *testing.T)
 			queryResultsMap[queryTest.Hash] = &queryTest.QueryResult
 		}
 
-		mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+		mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 		assert.NotNil(t, mResult, "At index: %v, mResult is nil", i)
 
 		len_mResults := 1
@@ -1092,7 +1092,7 @@ func Test_ProcessQueryArithmeticAndLogical_TimeSeries_Scalar_OP_v2(t *testing.T)
 
 	queryResultsMap := getQueryResultMapForThreeTestQueries("node_cpu_seconds_total", "node_memory_MemTotal_bytes", "node_disk_reads_completed_total")
 
-	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true)
+	mResult := segment.ProcessQueryArithmeticAndLogical(queryArithmetic, queryResultsMap, true, nil, 0)
 	assert.NotNil(t, mResult)
 	assert.Equal(t, 2, len(mResult.Results))
 

--- a/pkg/integrations/prometheus/promql/parser.go
+++ b/pkg/integrations/prometheus/promql/parser.go
@@ -515,20 +515,20 @@ func handlePromQLRangeFunctionNode(functionName string, timeWindow, step float64
 	case "count_over_time":
 		mQuery.Function = structs.Function{RangeFunction: segutils.Count_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "stdvar_over_time":
-		mQuery.Function = structs.Function{RangeFunction: segutils.Stdvar_Over_Time, TimeWindow: timeWindow}
+		mQuery.Function = structs.Function{RangeFunction: segutils.Stdvar_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "stddev_over_time":
-		mQuery.Function = structs.Function{RangeFunction: segutils.Stddev_Over_Time, TimeWindow: timeWindow}
+		mQuery.Function = structs.Function{RangeFunction: segutils.Stddev_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "last_over_time":
-		mQuery.Function = structs.Function{RangeFunction: segutils.Last_Over_Time, TimeWindow: timeWindow}
+		mQuery.Function = structs.Function{RangeFunction: segutils.Last_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "present_over_time":
-		mQuery.Function = structs.Function{RangeFunction: segutils.Present_Over_Time, TimeWindow: timeWindow}
+		mQuery.Function = structs.Function{RangeFunction: segutils.Present_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "mad_over_time":
 		mQuery.Function = structs.Function{RangeFunction: segutils.Mad_Over_Time, TimeWindow: timeWindow, Step: step}
 	case "quantile_over_time":
 		if len(expr.Args) != 2 {
 			return fmt.Errorf("parser.Inspect: Incorrect parameters: %v for the quantile_over_time function", expr.Args.String())
 		}
-		mQuery.Function = structs.Function{RangeFunction: segutils.Quantile_Over_Time, TimeWindow: timeWindow, ValueList: []string{expr.Args[0].String()}}
+		mQuery.Function = structs.Function{RangeFunction: segutils.Quantile_Over_Time, TimeWindow: timeWindow, ValueList: []string{expr.Args[0].String()}, Step: step}
 	case "changes":
 		mQuery.Function = structs.Function{RangeFunction: segutils.Changes, TimeWindow: timeWindow, Step: step}
 	case "resets":

--- a/pkg/integrations/prometheus/promql/parser_test.go
+++ b/pkg/integrations/prometheus/promql/parser_test.go
@@ -318,9 +318,9 @@ func Test_parsePromQLQuery_SimpleQueries_v2(t *testing.T) {
 	assert.Equal(t, intervalSeconds, mQueryReqs[0].MetricsQuery.Downsampler.Interval)
 	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggBlockType)
 	assert.Equal(t, segutils.Avg, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
-	assert.NotNil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
-	assert.Equal(t, segutils.Round, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.FunctionBlock.MathFunction)
-	assert.Equal(t, functionValues, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.FunctionBlock.ValueList)
+	assert.Nil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
+	assert.Equal(t, segutils.Round, queryArithmetic[0].MQueryAggsChain.FunctionBlock.MathFunction)
+	assert.Equal(t, functionValues, queryArithmetic[0].MQueryAggsChain.FunctionBlock.ValueList)
 
 	query = "http_requests_total{job='apiserver', handler='/api/comments'}[5m]"
 	mHashedMName = xxhash.Sum64String("http_requests_total")
@@ -893,7 +893,7 @@ func Test_parsePromQLQuery_NestedQueries_v8(t *testing.T) {
 	query := "sum by (app, proc) ( instance_memory_limit_bytes - instance_memory_usage_bytes )"
 	mHashedMName1 := xxhash.Sum64String("instance_memory_limit_bytes")
 	mHashedMName2 := xxhash.Sum64String("instance_memory_usage_bytes")
-	tagKeys := []string{"app", "proc"}
+	groupByKeys := []string{"app", "proc"}
 
 	mQueryReqs, pqlQuerytype, queryArithmetic, err := parsePromQLQuery(query, startTime, endTime, myId)
 	assert.Nil(t, err)
@@ -906,55 +906,25 @@ func Test_parsePromQLQuery_NestedQueries_v8(t *testing.T) {
 	assert.Equal(t, "instance_memory_usage_bytes", mQueryReqs[1].MetricsQuery.MetricName)
 	assert.Equal(t, mHashedMName1, mQueryReqs[0].MetricsQuery.HashedMName)
 	assert.Equal(t, mHashedMName2, mQueryReqs[1].MetricsQuery.HashedMName)
-	assert.False(t, mQueryReqs[0].MetricsQuery.SelectAllSeries)
-	assert.False(t, mQueryReqs[1].MetricsQuery.SelectAllSeries)
-	assert.True(t, mQueryReqs[0].MetricsQuery.Groupby)
-	assert.True(t, mQueryReqs[1].MetricsQuery.Groupby)
+	assert.True(t, mQueryReqs[0].MetricsQuery.SelectAllSeries)
+	assert.True(t, mQueryReqs[1].MetricsQuery.SelectAllSeries)
+	assert.False(t, mQueryReqs[0].MetricsQuery.Groupby)
+	assert.False(t, mQueryReqs[1].MetricsQuery.Groupby)
 	assert.Equal(t, intervalSeconds, mQueryReqs[0].MetricsQuery.Downsampler.Interval)
 	assert.Equal(t, intervalSeconds, mQueryReqs[1].MetricsQuery.Downsampler.Interval)
-	actualTagKeys := []string{}
-	for _, tag := range mQueryReqs[0].MetricsQuery.TagsFilters {
-		actualTagKeys = append(actualTagKeys, tag.TagKey)
-		if tag.TagKey == "app" {
-			assert.Equal(t, "*", tag.RawTagValue)
-		}
-		if tag.TagKey == "proc" {
-			assert.Equal(t, "*", tag.RawTagValue)
-		}
-	}
-	sort.Slice(actualTagKeys, func(i, j int) bool {
-		return actualTagKeys[i] < actualTagKeys[j]
-	})
-	assert.Equal(t, tagKeys, actualTagKeys)
-
-	actualTagKeys = []string{}
-	for _, tag := range mQueryReqs[1].MetricsQuery.TagsFilters {
-		actualTagKeys = append(actualTagKeys, tag.TagKey)
-		if tag.TagKey == "app" {
-			assert.Equal(t, "*", tag.RawTagValue)
-		}
-		if tag.TagKey == "proc" {
-			assert.Equal(t, "*", tag.RawTagValue)
-
-		}
-	}
-	sort.Slice(actualTagKeys, func(i, j int) bool {
-		return actualTagKeys[i] < actualTagKeys[j]
-	})
-	assert.Equal(t, tagKeys, actualTagKeys)
 
 	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggBlockType)
 	assert.Equal(t, segutils.Avg, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
-	assert.NotNil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
-	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggBlockType)
-	assert.Equal(t, segutils.Sum, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggregatorBlock.AggregatorFunction)
+	assert.Nil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
 	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[1].MetricsQuery.SubsequentAggs.AggBlockType)
 	assert.Equal(t, segutils.Avg, mQueryReqs[1].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
-	assert.NotNil(t, mQueryReqs[1].MetricsQuery.SubsequentAggs.Next)
-	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[1].MetricsQuery.SubsequentAggs.Next.AggBlockType)
-	assert.Equal(t, segutils.Sum, mQueryReqs[1].MetricsQuery.SubsequentAggs.Next.AggregatorBlock.AggregatorFunction)
+	assert.Nil(t, mQueryReqs[1].MetricsQuery.SubsequentAggs.Next)
 
 	assert.Equal(t, segutils.LetSubtract, queryArithmetic[0].Operation)
+	assert.NotNil(t, queryArithmetic[0].MQueryAggsChain)
+	assert.Equal(t, structs.AggregatorBlock, queryArithmetic[0].MQueryAggsChain.AggBlockType)
+	assert.Equal(t, segutils.Sum, queryArithmetic[0].MQueryAggsChain.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, groupByKeys, queryArithmetic[0].MQueryAggsChain.AggregatorBlock.GroupByFields)
 }
 
 func Test_parsePromQLQuery_NestedQueries_NestedGroupBy_v1(t *testing.T) {
@@ -1041,7 +1011,7 @@ func Test_parsePromQLQuery_NestedQueries_NestedGroupBy_v2(t *testing.T) {
 	query := "sum by (app, proc) ( sum by (job) (instance_memory_limit_bytes - instance_memory_usage_bytes) )"
 	mHashedMName1 := xxhash.Sum64String("instance_memory_limit_bytes")
 	mHashedMName2 := xxhash.Sum64String("instance_memory_usage_bytes")
-	tagKeys := []string{"app", "job", "proc"}
+	groupByKeysL2 := []string{"app", "proc"}
 
 	mQueryReqs, pqlQuerytype, queryArithmetic, err := parsePromQLQuery(query, startTime, endTime, myId)
 	assert.Nil(t, err)
@@ -1054,69 +1024,29 @@ func Test_parsePromQLQuery_NestedQueries_NestedGroupBy_v2(t *testing.T) {
 	assert.Equal(t, "instance_memory_usage_bytes", mQueryReqs[1].MetricsQuery.MetricName)
 	assert.Equal(t, mHashedMName1, mQueryReqs[0].MetricsQuery.HashedMName)
 	assert.Equal(t, mHashedMName2, mQueryReqs[1].MetricsQuery.HashedMName)
-	assert.False(t, mQueryReqs[0].MetricsQuery.SelectAllSeries)
-	assert.False(t, mQueryReqs[1].MetricsQuery.SelectAllSeries)
-	assert.True(t, mQueryReqs[0].MetricsQuery.Groupby)
-	assert.True(t, mQueryReqs[1].MetricsQuery.Groupby)
+	assert.True(t, mQueryReqs[0].MetricsQuery.SelectAllSeries)
+	assert.True(t, mQueryReqs[1].MetricsQuery.SelectAllSeries)
+	assert.False(t, mQueryReqs[0].MetricsQuery.Groupby)
+	assert.False(t, mQueryReqs[1].MetricsQuery.Groupby)
 	assert.Equal(t, intervalSeconds, mQueryReqs[0].MetricsQuery.Downsampler.Interval)
 	assert.Equal(t, intervalSeconds, mQueryReqs[1].MetricsQuery.Downsampler.Interval)
-	actualTagKeys := []string{}
-	for _, tag := range mQueryReqs[0].MetricsQuery.TagsFilters {
-		actualTagKeys = append(actualTagKeys, tag.TagKey)
-		if tag.TagKey == "app" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, true, tag.NotInitialGroup)
-		}
-		if tag.TagKey == "proc" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, true, tag.NotInitialGroup)
-		}
-		if tag.TagKey == "job" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, false, tag.NotInitialGroup)
-		}
-	}
-	sort.Slice(actualTagKeys, func(i, j int) bool {
-		return actualTagKeys[i] < actualTagKeys[j]
-	})
-	assert.Equal(t, tagKeys, actualTagKeys)
-
-	actualTagKeys = []string{}
-	for _, tag := range mQueryReqs[1].MetricsQuery.TagsFilters {
-		actualTagKeys = append(actualTagKeys, tag.TagKey)
-		if tag.TagKey == "app" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, true, tag.NotInitialGroup)
-		}
-		if tag.TagKey == "proc" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, true, tag.NotInitialGroup)
-		}
-		if tag.TagKey == "job" {
-			assert.Equal(t, "*", tag.RawTagValue)
-			assert.Equal(t, false, tag.NotInitialGroup)
-		}
-	}
-
-	sort.Slice(actualTagKeys, func(i, j int) bool {
-		return actualTagKeys[i] < actualTagKeys[j]
-	})
-
-	assert.Equal(t, tagKeys, actualTagKeys)
 
 	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggBlockType)
 	assert.Equal(t, segutils.Avg, mQueryReqs[0].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
-	assert.NotNil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
-	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggBlockType)
-	assert.Equal(t, segutils.Sum, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggregatorBlock.AggregatorFunction)
-	assert.Equal(t, 1, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggregatorBlock.GroupByFields))
-	assert.Equal(t, "job", mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.AggregatorBlock.GroupByFields[0])
-	assert.NotNil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next)
-	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggBlockType)
-	assert.Equal(t, segutils.Sum, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.AggregatorFunction)
-	assert.Equal(t, 2, len(mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields))
-	assert.Equal(t, "app", mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields[0])
-	assert.Equal(t, "proc", mQueryReqs[0].MetricsQuery.SubsequentAggs.Next.Next.AggregatorBlock.GroupByFields[1])
+	assert.Nil(t, mQueryReqs[0].MetricsQuery.SubsequentAggs.Next)
+
+	assert.Equal(t, segutils.LetSubtract, queryArithmetic[0].Operation)
+	assert.NotNil(t, queryArithmetic[0].MQueryAggsChain)
+
+	assert.Equal(t, structs.AggregatorBlock, queryArithmetic[0].MQueryAggsChain.AggBlockType)
+	assert.Equal(t, segutils.Sum, queryArithmetic[0].MQueryAggsChain.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, 1, len(queryArithmetic[0].MQueryAggsChain.AggregatorBlock.GroupByFields))
+	assert.Equal(t, "job", queryArithmetic[0].MQueryAggsChain.AggregatorBlock.GroupByFields[0])
+	assert.NotNil(t, queryArithmetic[0].MQueryAggsChain.Next)
+	assert.Equal(t, structs.AggregatorBlock, queryArithmetic[0].MQueryAggsChain.Next.AggBlockType)
+	assert.Equal(t, segutils.Sum, queryArithmetic[0].MQueryAggsChain.Next.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, 2, len(queryArithmetic[0].MQueryAggsChain.Next.AggregatorBlock.GroupByFields))
+	assert.Equal(t, groupByKeysL2, queryArithmetic[0].MQueryAggsChain.Next.AggregatorBlock.GroupByFields)
 }
 
 func Test_parsePromQLQuery_Scalar_Op_v1(t *testing.T) {
@@ -1352,6 +1282,95 @@ func Test_parsePromQLQuery_Without(t *testing.T) {
 	assert.True(t, tagFilters[1].IgnoreTag)
 	assert.True(t, tagFilters[1].IsGroupByKey)
 	assert.True(t, tagFilters[1].NotInitialGroup)
+}
+
+func Test_parsePromQLQuery_Binary_With_Nested_Queries(t *testing.T) {
+	endTime := uint32(time.Now().Unix())
+	startTime := endTime - 86400 // 1 day
+
+	myId := int64(0)
+
+	query := `sum by (cluster, namespace) (group by (cluster, namespace, workload) ((label_replace(label_replace(kube_pod_owner{cluster=~".+", namespace=~".+", pod=~".+", owner_kind=~".+", owner_name=~".+"}, "workload", "$1", "owner_name", "^(.*?)(-[a-z0-9]{9,10})?$"), "workload_type", "$1", "owner_kind", "(.*)")) or (label_replace(label_replace(kube_pod_owner{cluster=~".+", namespace=~".+", pod=~".+", owner_kind=""}, "workload", "$1", "pod", "^(.*?)(-[a-z0-9]{9,10})?$"), "workload_type", "pod", "", "")) or (label_replace(label_replace(kube_pod_owner{cluster=~".+", namespace=~".+", pod=~".+", owner_kind="Node"}, "workload", "$1", "pod", "^(.*?)(-[a-z0-9]{9,10})?$"), "workload_type", "staticpod", "", "")))) or on (cluster, namespace) (last_over_time(group by (cluster, namespace) (kube_namespace_status_phase{cluster=~".+", namespace=~".+", phase="Active"} == 1)[1h:]) - 1)`
+	mHashedMName1 := xxhash.Sum64String("kube_pod_owner")
+	mHashedMName2 := mHashedMName1
+	mHashedMName3 := mHashedMName1
+	mHashedMName4 := xxhash.Sum64String("kube_namespace_status_phase")
+
+	mQueryReqs, pqlQuerytype, queryArithmetic, err := ConvertPromQLToMetricsQuery(query, startTime, endTime, myId)
+	assert.Nil(t, err)
+	assert.Equal(t, 4, len(mQueryReqs))
+	assert.Equal(t, 1, len(queryArithmetic))
+	assert.Equal(t, parser.ValueTypeVector, pqlQuerytype)
+	assert.Equal(t, "kube_pod_owner", mQueryReqs[0].MetricsQuery.MetricName)
+	assert.Equal(t, "kube_pod_owner", mQueryReqs[1].MetricsQuery.MetricName)
+	assert.Equal(t, "kube_pod_owner", mQueryReqs[2].MetricsQuery.MetricName)
+	assert.Equal(t, "kube_namespace_status_phase", mQueryReqs[3].MetricsQuery.MetricName)
+	assert.Equal(t, mHashedMName1, mQueryReqs[0].MetricsQuery.HashedMName)
+	assert.Equal(t, mHashedMName2, mQueryReqs[1].MetricsQuery.HashedMName)
+	assert.Equal(t, mHashedMName3, mQueryReqs[2].MetricsQuery.HashedMName)
+	assert.Equal(t, mHashedMName4, mQueryReqs[3].MetricsQuery.HashedMName)
+
+	for i := 0; i < 3; i++ {
+		assert.True(t, mQueryReqs[i].MetricsQuery.SelectAllSeries)
+		assert.False(t, mQueryReqs[i].MetricsQuery.Groupby)
+		assert.Equal(t, structs.AggregatorBlock, mQueryReqs[i].MetricsQuery.SubsequentAggs.AggBlockType)
+		assert.Equal(t, segutils.Avg, mQueryReqs[i].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
+		assert.NotNil(t, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next)
+		assert.Equal(t, structs.FunctionBlock, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.AggBlockType)
+		assert.Equal(t, structs.LabelFunction, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.FunctionBlock.FunctionType)
+		assert.Equal(t, segutils.LabelReplace, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.FunctionBlock.LabelFunction.FunctionType)
+		assert.NotNil(t, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.Next)
+		assert.Equal(t, structs.FunctionBlock, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.Next.AggBlockType)
+		assert.Equal(t, segutils.LabelReplace, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.Next.FunctionBlock.LabelFunction.FunctionType)
+		assert.Nil(t, mQueryReqs[i].MetricsQuery.SubsequentAggs.Next.Next.Next)
+	}
+
+	assert.Equal(t, structs.AggregatorBlock, mQueryReqs[3].MetricsQuery.SubsequentAggs.AggBlockType)
+	assert.Equal(t, segutils.Avg, mQueryReqs[3].MetricsQuery.SubsequentAggs.AggregatorBlock.AggregatorFunction)
+
+	binaryOperation := queryArithmetic[0]
+
+	//  sum by (cluster, namespace) (...) or on (cluster, namespace) (...)
+	assert.NotNil(t, binaryOperation.VectorMatching)
+	assert.Equal(t, segutils.LetOr, binaryOperation.Operation)
+	assert.Equal(t, []string{"cluster", "namespace"}, binaryOperation.VectorMatching.MatchingLabels)
+	assert.True(t, binaryOperation.VectorMatching.On)
+
+	// First let's deal with RHS part ... or on (cluster, namespace) (...)
+	// within on (cluster, namespace) (...)
+	// there are two binary operations
+	assert.NotNil(t, binaryOperation.RHSExpr)
+	assert.Equal(t, segutils.LetSubtract, binaryOperation.RHSExpr.Operation)
+	assert.Equal(t, float64(1), binaryOperation.RHSExpr.Constant)
+	assert.NotNil(t, binaryOperation.RHSExpr.LHSExpr)
+	assert.Equal(t, segutils.LetEquals, binaryOperation.RHSExpr.LHSExpr.Operation)
+	assert.Equal(t, float64(1), binaryOperation.RHSExpr.LHSExpr.Constant)
+	assert.True(t, binaryOperation.RHSExpr.LHSExpr.ConstantOp)
+	assert.NotNil(t, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain)
+	assert.Equal(t, structs.AggregatorBlock, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.AggBlockType)
+	assert.Equal(t, segutils.Group, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, 2, len(binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.AggregatorBlock.GroupByFields))
+	assert.Equal(t, []string{"cluster", "namespace"}, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.AggregatorBlock.GroupByFields)
+	assert.Equal(t, structs.FunctionBlock, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.Next.AggBlockType)
+	assert.Equal(t, segutils.Last_Over_Time, binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.Next.FunctionBlock.RangeFunction)
+	assert.Equal(t, float64(3600), binaryOperation.RHSExpr.LHSExpr.MQueryAggsChain.Next.FunctionBlock.TimeWindow)
+
+	// NOW let's deal with LHS part  sum by (cluster, namespace) (...)
+	assert.NotNil(t, binaryOperation.LHSExpr)
+	// sum by (cluster, namespace) (label_replace(...) or ((...) or (...)))
+	assert.NotNil(t, binaryOperation.LHSExpr.LHSExpr)
+	assert.Equal(t, segutils.LetOr, binaryOperation.LHSExpr.Operation)
+	assert.Equal(t, segutils.LetOr, binaryOperation.LHSExpr.LHSExpr.Operation)
+	assert.NotNil(t, binaryOperation.LHSExpr.MQueryAggsChain)
+	assert.Equal(t, structs.AggregatorBlock, binaryOperation.LHSExpr.MQueryAggsChain.AggBlockType)
+	assert.Equal(t, segutils.Group, binaryOperation.LHSExpr.MQueryAggsChain.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, 3, len(binaryOperation.LHSExpr.MQueryAggsChain.AggregatorBlock.GroupByFields))
+	assert.Equal(t, []string{"cluster", "namespace", "workload"}, binaryOperation.LHSExpr.MQueryAggsChain.AggregatorBlock.GroupByFields)
+	assert.Equal(t, structs.AggregatorBlock, binaryOperation.LHSExpr.MQueryAggsChain.Next.AggBlockType)
+	assert.Equal(t, segutils.Sum, binaryOperation.LHSExpr.MQueryAggsChain.Next.AggregatorBlock.AggregatorFunction)
+	assert.Equal(t, 2, len(binaryOperation.LHSExpr.MQueryAggsChain.Next.AggregatorBlock.GroupByFields))
+	assert.Equal(t, []string{"cluster", "namespace"}, binaryOperation.LHSExpr.MQueryAggsChain.Next.AggregatorBlock.GroupByFields)
+	assert.Nil(t, binaryOperation.LHSExpr.MQueryAggsChain.Next.Next)
 }
 
 func Test_parsePromQLQuery_Parse_Metrics_Test_CSV(t *testing.T) {

--- a/pkg/integrations/prometheus/utils/operatorutils.go
+++ b/pkg/integrations/prometheus/utils/operatorutils.go
@@ -180,7 +180,7 @@ func SetFinalResult(queryOp *structs.QueryArithmetic, finalResult map[string]map
 			}
 		}
 	default:
-		log.Errorf("SetFinalResult: does not support using this operator: %v", queryOp.Operation)
+		log.Debugf("SetFinalResult: does not support using this operator: %v", queryOp.Operation)
 	}
 
 	// Logical ops can only been used between 2 vectors
@@ -193,7 +193,7 @@ func SetFinalResult(queryOp *structs.QueryArithmetic, finalResult map[string]map
 		case utils.LetUnless:
 			finalResult[groupID][timestamp] = valueLHS
 		default:
-			log.Errorf("SetFinalResult: does not support using this operator: %v", queryOp.Operation)
+			log.Debugf("SetFinalResult: does not support using this operator: %v", queryOp.Operation)
 		}
 	}
 }

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -339,6 +339,11 @@ func applyLabelReplace(seriesId string, labelFunction *structs.LabelFunctionExpr
 		return seriesId, fmt.Errorf("applyLabelReplace: labelFunction is nil")
 	}
 
+	if labelFunction.SourceLabel == "" {
+		seriesId = fmt.Sprintf("%s,%s:%s", seriesId, labelFunction.DestinationLabel, labelFunction.Replacement.NameBasedVal)
+		return seriesId, nil
+	}
+
 	_, values := ExtractGroupByFieldsFromSeriesId(seriesId, []string{labelFunction.SourceLabel})
 	if len(values) == 0 {
 		return seriesId, nil

--- a/pkg/segment/results/mresults/tests/metricsresults_test.go
+++ b/pkg/segment/results/mresults/tests/metricsresults_test.go
@@ -1180,7 +1180,7 @@ func test_GetResults_Ops(t *testing.T, initialEntries map[uint32]float64, ansMap
 
 	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], map[uint64]*mresults.MetricsResult{
 		1: metricsResults,
-	}, false)
+	}, false, nil, 0)
 	assert.Nil(t, err)
 	assert.Len(t, res, 1)
 	for _, resMap := range res {
@@ -1406,7 +1406,7 @@ func initialize_Multiple_Metric_Results(t *testing.T, initialEntries1 map[uint32
 }
 
 func test_GetResults_LogicalAndVectorMatchingOps(t *testing.T, initialEntries1 map[uint32]float64, initialEntries2 map[uint32]float64, labelStrs1 []string, labelStrs2 []string, ansMap map[string]map[uint32]float64, queryOps []structs.QueryArithmetic, downsampler structs.Downsampler, aggregator structs.Aggregation) {
-	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], initialize_Multiple_Metric_Results(t, initialEntries1, initialEntries2, labelStrs1, labelStrs2, queryOps, downsampler, aggregator), false)
+	res, _, err := segment.HelperQueryArithmeticAndLogical(&queryOps[0], initialize_Multiple_Metric_Results(t, initialEntries1, initialEntries2, labelStrs1, labelStrs2, queryOps, downsampler, aggregator), false, nil, 0)
 	assert.Nil(t, err)
 	validateResults(t, res, ansMap)
 }

--- a/pkg/segment/segexecution.go
+++ b/pkg/segment/segexecution.go
@@ -139,10 +139,11 @@ func ExecuteMultipleMetricsQuery(hashList []uint64, mQueries []*structs.MetricsQ
 		opLabelsDoNotNeedToMatch = false
 	}
 
-	return ProcessQueryArithmeticAndLogical(queryOps, resMap, opLabelsDoNotNeedToMatch)
+	return ProcessQueryArithmeticAndLogical(queryOps, resMap, opLabelsDoNotNeedToMatch, timeRange, qid)
 }
 
-func ProcessQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, opLabelsDoNotNeedToMatch bool) *mresults.MetricsResult {
+func ProcessQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, opLabelsDoNotNeedToMatch bool,
+	timeRange *dtu.MetricsTimeRange, qid uint64) *mresults.MetricsResult {
 
 	if len(queryOps) > 1 {
 		log.Errorf("processQueryArithmeticAndLogical: len(queryOps) should be 1, but got %d", len(queryOps))
@@ -153,7 +154,7 @@ func ProcessQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap
 	IsScalar := false
 	var scalarValue float64
 
-	finalResult, scalarValuePtr, err := processQueryArithmeticNodeOp(&queryOps[0], resMap, &operationCounter, opLabelsDoNotNeedToMatch)
+	finalResult, scalarValuePtr, err := processQueryArithmeticNodeOp(&queryOps[0], resMap, &operationCounter, opLabelsDoNotNeedToMatch, timeRange, qid)
 	if err != nil {
 		log.Errorf("ProcessQueryArithmeticAndLogical: Error processing query arithmetic node operation: %v", err)
 		return &mresults.MetricsResult{
@@ -174,7 +175,8 @@ func ProcessQueryArithmeticAndLogical(queryOps []structs.QueryArithmetic, resMap
 	return &mresults.MetricsResult{Results: finalResult, State: mresults.AGGREGATED, ScalarValue: scalarValue, IsScalar: IsScalar}
 }
 
-func processQueryArithmeticNodeOp(queryOp *structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, operationCounter *int, opLabelsDoNotNeedToMatch bool) (map[string]map[uint32]float64, *float64, error) {
+func processQueryArithmeticNodeOp(queryOp *structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, operationCounter *int,
+	opLabelsDoNotNeedToMatch bool, timeRange *dtu.MetricsTimeRange, qid uint64) (map[string]map[uint32]float64, *float64, error) {
 	if queryOp == nil {
 		return nil, nil, fmt.Errorf("processQueryArithmeticNodeOp: queryOp is nil")
 	}
@@ -188,7 +190,7 @@ func processQueryArithmeticNodeOp(queryOp *structs.QueryArithmetic, resMap map[u
 		var scalarValue float64
 		isScalar := false
 
-		result, scalarValuePtr, err := processQueryArithmeticNodeOp(expr, resMap, operationCounter, opLabelsDoNotNeedToMatch)
+		result, scalarValuePtr, err := processQueryArithmeticNodeOp(expr, resMap, operationCounter, opLabelsDoNotNeedToMatch, timeRange, qid)
 		if err != nil {
 			return err
 		}
@@ -230,16 +232,37 @@ func processQueryArithmeticNodeOp(queryOp *structs.QueryArithmetic, resMap map[u
 
 	*operationCounter++
 
-	return HelperQueryArithmeticAndLogical(queryOp, resMap, opLabelsDoNotNeedToMatch)
+	return HelperQueryArithmeticAndLogical(queryOp, resMap, opLabelsDoNotNeedToMatch, timeRange, qid)
 }
 
-func HelperQueryArithmeticAndLogical(queryOp *structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, opLabelsDoNotNeedToMatch bool) (map[string]map[uint32]float64, *float64, error) {
+func HelperQueryArithmeticAndLogical(queryOp *structs.QueryArithmetic, resMap map[uint64]*mresults.MetricsResult, opLabelsDoNotNeedToMatch bool,
+	timeRange *dtu.MetricsTimeRange, qid uint64) (map[string]map[uint32]float64, *float64, error) {
 
 	finalResult := make(map[string]map[uint32]float64)
 
 	resultLHS, leftOk := resMap[queryOp.LHS]
 	resultRHS, rightOk := resMap[queryOp.RHS]
 	swapped := false
+
+	var referenceMetricRes *mresults.MetricsResult
+
+	returnfunc := func(scalarValuePt *float64, err error) (map[string]map[uint32]float64, *float64, error) {
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if queryOp.MQueryAggsChain != nil && finalResult != nil && referenceMetricRes != nil {
+			referenceMetricRes.Results = finalResult
+			query.ProcessMQueryAggsChain(&structs.MetricsQuery{
+				IsInstantQuery: referenceMetricRes.IsInstantQuery,
+				SubsequentAggs: queryOp.MQueryAggsChain,
+			}, timeRange, referenceMetricRes, qid)
+
+			finalResult = referenceMetricRes.Results
+		}
+
+		return finalResult, scalarValuePt, nil
+	}
 
 	if queryOp.ConstantOp {
 		resultLHS, ok := resMap[queryOp.LHS]
@@ -314,6 +337,8 @@ func HelperQueryArithmeticAndLogical(queryOp *structs.QueryArithmetic, resMap ma
 			scalarValuePtr = &resultRHS.ScalarValue
 		}
 
+		referenceMetricRes = resultLHS
+
 		if scalarValuePtr != nil {
 			for groupID, tsLHS := range resultLHS.Results {
 				finalResult[groupID] = make(map[uint32]float64)
@@ -322,7 +347,7 @@ func HelperQueryArithmeticAndLogical(queryOp *structs.QueryArithmetic, resMap ma
 				}
 			}
 
-			return finalResult, nil, nil
+			return returnfunc(nil, nil)
 		}
 
 		// Since each grpID is unique and contains label set information, we can map lGrpID to labelSet and labelSet to rGrpID.
@@ -468,7 +493,7 @@ func HelperQueryArithmeticAndLogical(queryOp *structs.QueryArithmetic, resMap ma
 
 	}
 
-	return finalResult, nil, nil
+	return returnfunc(nil, nil)
 }
 
 func ExecuteQuery(root *structs.ASTNode, aggs *structs.QueryAggregators, qid uint64, qc *structs.QueryContext) *structs.NodeResult {

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -246,9 +246,10 @@ type QueryArithmetic struct {
 	ReturnBool  bool // If a comparison operator, return 0/1 rather than filtering.
 	Constant    float64
 	// maps groupid to a map of ts to value. This aggregates DsResults based on the aggregation function
-	Results        map[string]map[uint32]float64
-	OperatedState  bool //true if operation has been executed
-	VectorMatching *VectorMatching
+	Results         map[string]map[uint32]float64
+	OperatedState   bool //true if operation has been executed
+	VectorMatching  *VectorMatching
+	MQueryAggsChain *MetricQueryAgg
 }
 
 // VectorMatching describes how elements from two Vectors in a binary


### PR DESCRIPTION
# Description
- Fixes issue when `label_replace` function does not have source label.
- Fixes issue with `last_over_time` function
- Fixes parser for Nested queries containing Binary Expr.
- Added the ability to execute Metric Query Aggs Chain after an Binary Operation is executed.

# Testing
- Able to parse and execute the following query:
```
  sum by (cluster, namespace) (
    group by (cluster, namespace, workload) (
          (
            label_replace(
              label_replace(
                kube_pod_owner{cluster=~".+",namespace=~".+",owner_kind=~".+",owner_name=~".+",pod=~".+"},
                "workload",
                "$1",
                "owner_name",
                "^(.*?)(-[a-z0-9]{9,10})?$"
              ),
              "workload_type",
              "$1",
              "owner_kind",
              "(.*)"
            )
          )
        or
          (
            label_replace(
              label_replace(
                kube_pod_owner{cluster=~".+",namespace=~".+",owner_kind="",pod=~".+"},
                "workload",
                "$1",
                "pod",
                "^(.*?)(-[a-z0-9]{9,10})?$"
              ),
              "workload_type",
              "pod",
              "",
              ""
            )
          )
      or
        (
          label_replace(
            label_replace(
              kube_pod_owner{cluster=~".+",namespace=~".+",owner_kind="Node",pod=~".+"},
              "workload",
              "$1",
              "pod",
              "^(.*?)(-[a-z0-9]{9,10})?$"
            ),
            "workload_type",
            "staticpod",
            "",
            ""
          )
        )
    )
  )
or 
  (
      last_over_time(
        group by (cluster, namespace) (
          kube_namespace_status_phase{cluster=~".+",namespace=~".+",phase="Active"} == 1
        )[1h:]
      )
    -
      1
  )
  ```
- The results are same as Prometheus, we got some extra series included because of this Binary Expr: `(kube_namespace_status_phase{cluster=~".+", namespace=~".+", phase="Active"} == 1`. 
- But removing this block : `(last_over_time(group by (cluster, namespace) (kube_namespace_status_phase{cluster=~".+", namespace=~".+", phase="Active"} == 1)[1h:]) - 1)` gives the exact result as Prometheus
- Updated unit tests and added new unit test.
- Fixed most of the unit tests that were failing.
- **Still probably need to E2E tests**

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
