### PR TITLE
Fix infinite loop in error path

### DIFF
--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -371,7 +371,6 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 
 	retVal := make(map[uint16][]uint64)
 	var retLock sync.Mutex
-	minIdx := 0
 	allReadJob := make(chan *timeBlockRequest)
 	var readerWG sync.WaitGroup
 	for i := int64(0); i < parallelism; i++ {
@@ -379,12 +378,12 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 		go processTimeBlocks(allReadJob, &readerWG, retVal, &retLock)
 	}
 
-	for minIdx < len(allBlocks) {
+	for minIdx, maxIdx := 0, 0; minIdx < len(allBlocks); minIdx = maxIdx + 1 {
 		minBlkNum := allBlocks[minIdx]
 		lastBlkNum := minBlkNum
 		firstBlkOff := blks[minBlkNum].ColumnBlockOffset[tsKey]
 		blkLen := blks[minBlkNum].ColumnBlockLen[tsKey]
-		maxIdx := minIdx
+		maxIdx = minIdx
 		for {
 			nextIdx := maxIdx + 1
 			if nextIdx >= len(allBlocks) {
@@ -414,7 +413,6 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 			numRecs := blockSummaries[currBlk].RecCount
 			allReadJob <- &timeBlockRequest{tsRec: rawBlock, blkNum: currBlk, numRecs: numRecs}
 		}
-		minIdx = maxIdx + 1
 	}
 	close(allReadJob)
 	readerWG.Wait()


### PR DESCRIPTION
# Description
In an error path, there's a loop `continue` (line 406) that caused an infinite loop because the loop index wasn't updated. This PR fixes that.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
