### PR TITLE
Log Metrics Query Summary With Query State

### DIFF
--- a/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
+++ b/pkg/ast/pipesearch/multiplexer/queryStateMultiplexer.go
@@ -123,6 +123,8 @@ func (q *QueryStateMultiplexer) handleMessage(data *query.QueryStateChanData, ok
 
 func (q *QueryStateMultiplexer) handleData(data *query.QueryStateChanData, chanIndex channelIndex) {
 	switch data.StateName {
+	case query.WAITING:
+		// do nothing
 	case query.READY, query.RUNNING, query.QUERY_RESTART:
 		q.output <- &QueryStateEnvelope{
 			QueryStateChanData: data,

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -643,6 +643,8 @@ func RunQueryForNewPipeline(conn *websocket.Conn, qid uint64, root *structs.ASTN
 			continue
 		}
 
+		rQuery.SetLatestQueryState(queryStateData.StateName)
+
 		switch queryStateData.StateName {
 		case query.WAITING:
 			// do nothing

--- a/pkg/ast/pipesearch/searchHandler.go
+++ b/pkg/ast/pipesearch/searchHandler.go
@@ -644,6 +644,8 @@ func RunQueryForNewPipeline(conn *websocket.Conn, qid uint64, root *structs.ASTN
 		}
 
 		switch queryStateData.StateName {
+		case query.WAITING:
+			// do nothing
 		case query.READY:
 			switch queryStateData.ChannelIndex {
 			case multiplexer.MainIndex:

--- a/pkg/otlp/logs_test.go
+++ b/pkg/otlp/logs_test.go
@@ -18,7 +18,6 @@
 package otlp
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/siglens/siglens/pkg/config"
@@ -388,8 +387,6 @@ func Test_extractLogRecord_K8seventsIndex(t *testing.T) {
 	recordInfo, actualIndexName, err := extractLogRecord(protobuf.ResourceLogs[0].ScopeLogs[0].LogRecords[0], nil, nil, indexName)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedInexName, actualIndexName)
-
-	fmt.Println("recordInfo.attributes: ", recordInfo.Attributes)
 
 	assert.Equal(t, uint64(1234567890), recordInfo.TimeUnixNano)
 	assert.Equal(t, "INFO", recordInfo.SeverityText)

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -245,9 +245,7 @@ func (qs *QuerySummary) processTick() {
 	} else if qs.queryType == METRICS {
 		queryState := "executing"
 		if qs.fetchQueryStateFn != nil {
-			fmt.Println("fetchQueryStateFn is not nil, calling it: ")
 			queryState = qs.fetchQueryStateFn()
-			fmt.Println("queryState: ", queryState)
 		}
 		log.Infof("qid=%d, Query is in %v State. Time Elapsed (%v). searched numMetricSegs=%+v, numTSIDMatched=%+v numTagTreesSearched=%+v, numTSOsTSGs loaded=%+v, activeQSCountForMetrics: %v",
 			qs.qid, queryState, time.Since(qs.startTime), qs.getNumMetricsSegmentsSearched(), qs.getNumTSIDsMatched(),

--- a/pkg/segment/query/summary/querysummary.go
+++ b/pkg/segment/query/summary/querysummary.go
@@ -105,6 +105,7 @@ type QuerySummary struct {
 	totalDistributedQueries     uint64
 	tickCount                   uint32
 	closeOnce                   sync.Once
+	fetchQueryStateFn           func() string
 }
 
 const TICK_DURATION_SECS = 10
@@ -155,6 +156,12 @@ func InitQuerySummary(queryType QueryType, qid uint64) *QuerySummary {
 
 func (qs *QuerySummary) Cleanup() {
 	qs.stopTicker()
+}
+
+func (qs *QuerySummary) SetFetchQueryStateFn(fetchQueryStateFn func() string) {
+	qs.updateLock.Lock()
+	defer qs.updateLock.Unlock()
+	qs.fetchQueryStateFn = fetchQueryStateFn
 }
 
 func (qs *QuerySummary) startTicker() {
@@ -236,8 +243,14 @@ func (qs *QuerySummary) processTick() {
 			remainingDQsString,
 			activeQSCountForLogs)
 	} else if qs.queryType == METRICS {
-		log.Infof("qid=%d, still executing. Time Elapsed (%v). searched numMetricSegs=%+v, numTSIDMatched=%+v numTagTreesSearched=%+v, numTSOsTSGs loaded=%+v, activeQSCountForMetrics: %v",
-			qs.qid, time.Since(qs.startTime), qs.getNumMetricsSegmentsSearched(), qs.getNumTSIDsMatched(),
+		queryState := "executing"
+		if qs.fetchQueryStateFn != nil {
+			fmt.Println("fetchQueryStateFn is not nil, calling it: ")
+			queryState = qs.fetchQueryStateFn()
+			fmt.Println("queryState: ", queryState)
+		}
+		log.Infof("qid=%d, Query is in %v State. Time Elapsed (%v). searched numMetricSegs=%+v, numTSIDMatched=%+v numTagTreesSearched=%+v, numTSOsTSGs loaded=%+v, activeQSCountForMetrics: %v",
+			qs.qid, queryState, time.Since(qs.startTime), qs.getNumMetricsSegmentsSearched(), qs.getNumTSIDsMatched(),
 			qs.getNumTagsTreesSearched(), qs.getNumTSOFilesLoaded(), activeQSCountForMetrics)
 	}
 }


### PR DESCRIPTION
# Description
- Log the Metrics Query Summary every 10 seconds by fetching metrics query state.
- This is so that we know whether the query is actually or waiting in the queue.

# Testing
- Tested by running multiple metrics query through K8s dashboard UI.
- Observed that the logs were being printed query state (WAITING, RUNNING)

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
