### PR TITLE
Fix issue flushing first metrics block of segment

### DIFF
--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -515,10 +515,10 @@ Format of block summary file
 [version - 1 byte][blk num - 2 bytes][high ts - 4 bytes][low ts - 4 bytes]
 */
 func (mbs *MBlockSummary) FlushSummary(fName string) error {
-	var flag bool = false
+	var isFirstBlock bool = false
 	if _, err := os.Stat(fName); os.IsNotExist(err) {
 		err := os.MkdirAll(path.Dir(fName), os.FileMode(0764))
-		flag = true
+		isFirstBlock = true
 		if err != nil {
 			log.Errorf("MBlockSummary.FlushSummary: Failed to create directory at %s, err: %v", path.Dir(fName), err)
 			return err
@@ -536,7 +536,7 @@ func (mbs *MBlockSummary) FlushSummary(fName string) error {
 	// todo bug here, the highTs/lowTs are of 4bytes, but we do 8 here
 	// once the version is updated, change here and on the reader side to
 	// read both types of version files
-	if flag {
+	if isFirstBlock {
 		mBlkSum = make([]byte, 19)
 		copy(mBlkSum[idx:], utils.VERSION_MBLOCKSUMMARY)
 		idx += 1

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -516,14 +516,19 @@ Format of block summary file
 */
 func (mbs *MBlockSummary) FlushSummary(fName string) error {
 	var isFirstBlock bool = false
-	if _, err := os.Stat(fName); os.IsNotExist(err) {
+	if fInfo, err := os.Stat(fName); os.IsNotExist(err) {
 		err := os.MkdirAll(path.Dir(fName), os.FileMode(0764))
 		isFirstBlock = true
 		if err != nil {
 			log.Errorf("MBlockSummary.FlushSummary: Failed to create directory at %s, err: %v", path.Dir(fName), err)
 			return err
 		}
+	} else if err != nil {
+		return fmt.Errorf("MBlockSummary.FlushSummary: Failed to stat %v, err: %v", fName, err)
+	} else if fInfo.Size() == 0 {
+		isFirstBlock = true
 	}
+
 	fd, err := os.OpenFile(fName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		log.Errorf("MBlockSummary.FlushSummary: Failed to open file: %v, err: %v", fName, err)

--- a/pkg/segment/structs/metricsstructs.go
+++ b/pkg/segment/structs/metricsstructs.go
@@ -517,8 +517,8 @@ Format of block summary file
 func (mbs *MBlockSummary) FlushSummary(fName string) error {
 	var isFirstBlock bool = false
 	if fInfo, err := os.Stat(fName); os.IsNotExist(err) {
-		err := os.MkdirAll(path.Dir(fName), os.FileMode(0764))
 		isFirstBlock = true
+		err := os.MkdirAll(path.Dir(fName), os.FileMode(0764))
 		if err != nil {
 			log.Errorf("MBlockSummary.FlushSummary: Failed to create directory at %s, err: %v", path.Dir(fName), err)
 			return err


### PR DESCRIPTION
# Description
When flushing a metrics block to the `.mbsu` file, the format is `<version> <blockA> <blockB> ...`. When we flush, we had code to detect if it was the first block being flushed by checking if the `.mbsu` file didn't exist. For some reason, this check wasn't enough (we saw a case where it skipped writing the version even though it was the first block written). This PR adds some more checks, to hopefully avoid this issue.

# Testing
Not tested

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
