### PR TITLE
Fix concurrency bug when storing errors

### DIFF
--- a/pkg/segment/query/querystatus.go
+++ b/pkg/segment/query/querystatus.go
@@ -1293,6 +1293,9 @@ func logGlobalSearchErrors(qid uint64) error {
 	if err != nil {
 		return fmt.Errorf("logGlobalSearchErrors: Error getting query search node result for qid=%v", qid)
 	}
+
+	nodeRes.SearchErrorsLock.RLock()
+	defer nodeRes.SearchErrorsLock.RUnlock()
 	for errMsg, errInfo := range nodeRes.GlobalSearchErrors {
 		if errInfo == nil {
 			continue

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -504,7 +504,7 @@ type RecsAggResults struct {
 type NodeResult struct {
 	AllRecords                  []*utils.RecordResultContainer
 	ErrList                     []error                     // Need to eventually replace ErrList with GlobalSearchErrors to prevent duplicate errors
-	searchErrorsLock            sync.RWMutex                // lock for search errors
+	SearchErrorsLock            sync.RWMutex                // lock for search errors
 	GlobalSearchErrors          map[string]*SearchErrorInfo // maps global error from error message -> error info  (Deprecated: use toputils.BatchError)
 	Histogram                   map[string]*AggregationResult
 	TotalResults                *QueryCount
@@ -1719,8 +1719,8 @@ func (qa *QueryAggregators) GetAllMeasureAggsInChain() [][]*MeasureAggregator {
 
 // TODO: use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
-	nodeRes.searchErrorsLock.Lock()
-	defer nodeRes.searchErrorsLock.Unlock()
+	nodeRes.SearchErrorsLock.Lock()
+	defer nodeRes.SearchErrorsLock.Unlock()
 
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)
 }

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -503,6 +504,7 @@ type RecsAggResults struct {
 type NodeResult struct {
 	AllRecords                  []*utils.RecordResultContainer
 	ErrList                     []error                     // Need to eventually replace ErrList with GlobalSearchErrors to prevent duplicate errors
+	searchErrorsLock            sync.RWMutex                // lock for search errors
 	GlobalSearchErrors          map[string]*SearchErrorInfo // maps global error from error message -> error info  (Deprecated: use toputils.BatchError)
 	Histogram                   map[string]*AggregationResult
 	TotalResults                *QueryCount
@@ -1717,6 +1719,9 @@ func (qa *QueryAggregators) GetAllMeasureAggsInChain() [][]*MeasureAggregator {
 
 // TODO: use toputils.BatchError instead
 func (nodeRes *NodeResult) StoreGlobalSearchError(errMsg string, logLevel log.Level, err error) {
+	nodeRes.searchErrorsLock.Lock()
+	defer nodeRes.searchErrorsLock.Unlock()
+
 	nodeRes.GlobalSearchErrors = StoreError(nodeRes.GlobalSearchErrors, errMsg, logLevel, err)
 }
 


### PR DESCRIPTION
# Description
There's at least one path for concurrently storing errors:
```
github.com/siglens/siglens/pkg/segment/structs.StoreError(...)
        /siglens/pkg/segment/structs/segstructs.go:1729
github.com/siglens/siglens/pkg/segment/structs.(*NodeResult).StoreGlobalSearchError(...)
        /siglens/pkg/segment/structs/segstructs.go:1720
github.com/siglens/siglens/pkg/segment/search.filterRecordsFromSearchQuery(0xc143e0d110, 0xc086e422f0?, 0xc0efdcf940, 0xc0003de700, 0xc0e3c80680, 0x139, 0xc113cc1110, 0x9057, 0xc0d5066f70, 0xc1346ca070, ...)
        /siglens/pkg/segment/search/filtersearch.go:297 +0xb9c
github.com/siglens/siglens/pkg/segment/search.filterBlockRequestFromQuery(0xc0003de700, 0xc143e0d110, 0xc086e422f0, 0xc060e80540, 0xc0efdcf940, 0x44c43d?, 0x1, 0x1, 0x9057, 0xc0d5066f70, ...)
        /siglens/pkg/segment/search/filtersearch.go:136 +0x274
created by github.com/siglens/siglens/pkg/segment/search.RawSearchSingleQuery in goroutine 1262691
        /siglens/pkg/segment/search/filtersearch.go:66 +0x3f2
```

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
