### PR TITLE
Make longevity test only select ASCII values

### DIFF
--- a/tools/sigclient/pkg/query/queryvalidator.go
+++ b/tools/sigclient/pkg/query/queryvalidator.go
@@ -143,6 +143,11 @@ func (df *dynamicFilter) setFrom(log map[string]interface{}) {
 	for key, value := range log {
 		switch v := value.(type) {
 		case string:
+			if !utils.IsAscii(v) {
+				// TODO: remove this once we support searching for non-ascii.
+				continue
+			}
+
 			df.filter = &kvFilter{
 				key:   key,
 				value: stringOrRegex{isRegex: false, rawString: v},

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -703,6 +703,14 @@ func Test_dynamicFilter_setFrom(t *testing.T) {
 
 	df.setFrom(map[string]interface{}{"city": 123}) // No string values.
 	assert.Equal(t, `*`, fmt.Sprintf("%v", df))
+
+	df.setFrom(map[string]interface{}{"country": "Åland Islands"}) // Non-ASCII value.
+	assert.Equal(t, `*`, fmt.Sprintf("%v", df))
+
+	for i := 0; i < 10; i++ {
+		df.setFrom(map[string]interface{}{"city": "Boston", "country": "Åland Islands"})
+		assert.Equal(t, `city="Boston"`, fmt.Sprintf("%v", df)) // Only the ASCII value is valid.
+	}
 }
 
 func Test_dynamicFilter_query(t *testing.T) {

--- a/tools/sigclient/pkg/utils/strings.go
+++ b/tools/sigclient/pkg/utils/strings.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import "unicode"
+
+func IsAscii(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > unicode.MaxASCII {
+			return false
+		}
+	}
+
+	return true
+}

--- a/tools/sigclient/pkg/utils/strings_test.go
+++ b/tools/sigclient/pkg/utils/strings_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsAscii(t *testing.T) {
+	assert.True(t, IsAscii("Hello, World!"))
+	assert.False(t, IsAscii("Hello, 世界!"))
+	assert.False(t, IsAscii("Åland Islands"))
+}


### PR DESCRIPTION
# Description
We don't yet support searching for non-ASCII values, but the longevity test had some dynamically generated queries that would occasionally choose non-ASCII values to query for. This PR fixes that.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [ ] I have self-reviewed this PR.
- [ ] I have removed all print-debugging and commented-out code that should not be merged.
- [ ] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [ ] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
