### PR TITLE
Fix longevity test validator parsing large numbers

### DIFF
--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -538,6 +538,31 @@ func Test_CountQueryValidator(t *testing.T) {
 		}`)))
 	})
 
+	t.Run("LargeCount", func(t *testing.T) {
+		startEpoch, endEpoch := uint64(0), uint64(10)
+		validator, err := NewCountQueryValidator(bostonFilter, startEpoch, endEpoch)
+		assert.NoError(t, err)
+
+		for i := 0; i < 1_000_000; i++ {
+			addLogsWithoutError(t, validator, logs)
+		}
+
+		assert.NoError(t, validator.MatchesResult([]byte(`{
+			"hits": {
+				"totalMatched": {
+					"value": 4000000,
+					"relation": "eq"
+				}
+			},
+			"allColumns": ["count(*)"],
+			"measureFunctions": ["count(*)"],
+			"measure": [{
+					"GroupByValues": ["*"],
+					"MeasureVal": {"count(*)": 4000000}
+			}]
+		}`)))
+	})
+
 	t.Run("MatchAllQuery", func(t *testing.T) {
 		startEpoch, endEpoch := uint64(0), uint64(10)
 		validator, err := NewCountQueryValidator(MatchAll(), startEpoch, endEpoch)

--- a/tools/sigclient/pkg/utils/numbers_test.go
+++ b/tools/sigclient/pkg/utils/numbers_test.go
@@ -18,32 +18,17 @@
 package utils
 
 import (
-	"fmt"
-	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func AsUint64(x interface{}) (uint64, bool) {
-	s := fmt.Sprintf("%v", x)
-	result, err := strconv.ParseUint(s, 10, 64)
-	if err == nil {
-		return result, true
-	}
+func Test_AsUint64(t *testing.T) {
+	v, ok := AsUint64("123")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(123), v)
 
-	// Try to parse as float.
-	f, ok := AsFloat64(x)
-	if !ok {
-		return 0, false
-	}
-
-	return uint64(f), true
-}
-
-func AsFloat64(x interface{}) (float64, bool) {
-	s := fmt.Sprintf("%v", x)
-	result, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, false
-	}
-
-	return result, true
+	v, ok = AsUint64("1.04475e+06")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(1044750), v)
 }


### PR DESCRIPTION
# Description
This fixes the query validators in the longevity test from incorrectly failing with:
```
msg="queryManager.runQuery: incorrect results for query=gender_c2=\"male\" | stats count, timeSpan=32m24s (1743743499409-1743745443409), validation=strict, got 1044750 matches; err=CQV.MatchesResult: invalid count type float64 in measure[0] value map[count(*):1.04475e+06]"
```
The issue was that `1.04475e+06` is large enough that it got formatted in a way that can't directly be parsed as a uint.

# Testing
New unit tests

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
