### PR TITLE
fix: Metrics range vector query through Instant Query

### DIFF
--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -50,8 +50,6 @@ type Series struct {
 	// If the original Downsampler Aggregator is Avg, the convertedDownsampleAggFn is set to Sum; otherwise, it is set to the original Downsampler Aggregator.
 	convertedDownsampleAggFn utils.AggregateFunctions
 	aggregationConstant      float64
-
-	isInstantQuery bool
 }
 
 type DownsampleSeries struct {
@@ -106,7 +104,6 @@ func InitSeriesHolder(mQuery *structs.MetricsQuery, tsGroupId *bytebufferpool.By
 		convertedDownsampleAggFn: convertedDownsampleAggFn,
 		aggregationConstant:      aggregationConstant,
 		grpID:                    tsGroupId,
-		isInstantQuery:           mQuery.IsInstantQuery,
 	}
 }
 
@@ -121,29 +118,6 @@ func (s *Series) GetIdx() int {
 }
 
 func (s *Series) AddEntry(ts uint32, dp float64) {
-	if s.isInstantQuery {
-		idx := s.idx
-
-		// if instant query, we only need the latest value per series
-		if idx > 0 {
-			// Decrement the index to overwrite the previous entry
-			idx--
-		}
-
-		if ts > s.entries[idx].downsampledTime {
-			s.entries[idx].downsampledTime = ts
-			s.entries[idx].dpVal = dp
-		}
-
-		if s.idx == 0 {
-			// Since Instant query uses only one value, when the idx is 0, Increment the index to the next entry
-			// indicating that there is a valid entry in the series
-			s.idx++
-		}
-
-		return
-	}
-
 	s.entries[s.idx].downsampledTime = (ts / s.dsSeconds) * s.dsSeconds
 	s.entries[s.idx].dpVal = dp
 	s.idx++
@@ -172,29 +146,6 @@ func (s *Series) sortEntries() {
 }
 
 func (s *Series) Merge(toJoin *Series) error {
-	if s.isInstantQuery {
-		if s.idx != 1 || s.idx != toJoin.idx {
-			return fmt.Errorf("Merge: instant query series should have only one entry, but got %v and %v", s.idx, toJoin.idx)
-		}
-
-		// Decrement the index to overwrite the previous entry, since for instant only one entry is allowed
-		s.idx--
-		toJoin.idx--
-
-		maxTsEntry := s.entries[s.idx]
-		if maxTsEntry.downsampledTime < toJoin.entries[toJoin.idx].downsampledTime {
-			maxTsEntry = toJoin.entries[toJoin.idx]
-		}
-
-		s.entries[s.idx] = maxTsEntry
-
-		// Increment the index back
-		s.idx++
-		toJoin.idx++
-
-		return nil
-	}
-
 	toJoinEntries := toJoin.entries[:toJoin.idx]
 	s.entries = s.entries[:s.idx]
 	s.len = s.idx


### PR DESCRIPTION
# Description
- Fixes the issue with metrics instant query not showing any data for range vectors.

# Testing
- Tested with kubernetes dashboard on the UI
- All unit test cases pass

# Checklist:

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
