### PR TITLE
Write CSG files in checksummed chunks

### DIFF
--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -228,7 +228,12 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 	}
 
 	sfr.currFileBuffer = toputils.ResizeSlice(sfr.currFileBuffer, int(colBlockLen))
-	_, err := sfr.currFD.ReadAt(sfr.currFileBuffer[:colBlockLen], colBlockOffset)
+	checksumFile, err := toputils.NewChecksumFile(sfr.currFD)
+	if err != nil {
+		return true, fmt.Errorf("SegmentFileReader.loadBlockUsingBuffer: error creating checksum file reader for %s. Error: %+v",
+			sfr.fileName, err)
+	}
+	_, err = checksumFile.ReadAt(sfr.currFileBuffer[:colBlockLen], colBlockOffset)
 	if err != nil {
 		return true, fmt.Errorf("SegmentFileReader.loadBlockUsingBuffer: read file error at offset: %v, err: %+v", colBlockOffset, err)
 	}

--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -228,12 +228,8 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 	}
 
 	sfr.currFileBuffer = toputils.ResizeSlice(sfr.currFileBuffer, int(colBlockLen))
-	checksumFile, err := toputils.NewChecksumFile(sfr.currFD)
-	if err != nil {
-		return true, fmt.Errorf("SegmentFileReader.loadBlockUsingBuffer: error creating checksum file reader for %s. Error: %+v",
-			sfr.fileName, err)
-	}
-	_, err = checksumFile.ReadAt(sfr.currFileBuffer[:colBlockLen], colBlockOffset)
+	checksumFile := toputils.ChecksumFile{Fd: sfr.currFD}
+	_, err := checksumFile.ReadAt(sfr.currFileBuffer[:colBlockLen], colBlockOffset)
 	if err != nil {
 		return true, fmt.Errorf("SegmentFileReader.loadBlockUsingBuffer: read file error at offset: %v, err: %+v", colBlockOffset, err)
 	}

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -303,7 +303,8 @@ func readChunkFromFile(fd *os.File, buf []byte, blkLen uint32, blkOff int64) ([]
 		buf = append(buf, newArr...)
 	}
 	buf = buf[:blkLen]
-	_, err := fd.ReadAt(buf, blkOff)
+	checksumFile := &toputils.ChecksumFile{Fd: fd}
+	_, err := checksumFile.ReadAt(buf, blkOff)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -172,7 +172,8 @@ func (trr *TimeRangeReader) readAllTimestampsForBlock(blockNum uint16) error {
 	}
 
 	trr.blockReadBuffer = toputils.ResizeSlice(trr.blockReadBuffer, int(blkLen))
-	_, err = trr.timeFD.ReadAt(trr.blockReadBuffer[:blkLen], blkOff)
+	checksumFile := &toputils.ChecksumFile{Fd: trr.timeFD}
+	_, err = checksumFile.ReadAt(trr.blockReadBuffer[:blkLen], blkOff)
 	if err != nil {
 		if err != io.EOF {
 			trr.loadedBlock = false

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -409,12 +409,13 @@ func ReadAllTimestampsForBlock(blks map[uint16]*structs.BlockMetadataHolder, seg
 			continue
 		}
 
+		readOffset := int64(0)
 		for currBlk := minBlkNum; currBlk <= allBlocks[maxIdx]; currBlk++ {
-			readOffset := blks[currBlk].ColumnBlockOffset[tsKey] - firstBlkOff
 			readLen := int64(blks[currBlk].ColumnBlockLen[tsKey])
 			rawBlock := rawChunk[readOffset : readOffset+readLen]
 			numRecs := blockSummaries[currBlk].RecCount
 			allReadJob <- &timeBlockRequest{tsRec: rawBlock, blkNum: currBlk, numRecs: numRecs}
+			readOffset += readLen
 		}
 	}
 	close(allReadJob)

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -242,7 +242,7 @@ func convertRawRecordsToTimestamps(rawRec []byte, numRecs uint16, bufToUse []uin
 
 	oPtr := uint32(0)
 	if rawRec[oPtr] != utils.TIMESTAMP_TOPDIFF_VARENC[0] {
-		return nil, fmt.Errorf("convertRawRecordsToTimestamps: received an unknown encoding type for typestamp column! expected %+v got %+v",
+		return nil, fmt.Errorf("convertRawRecordsToTimestamps: received an unknown encoding type for timestamp column! expected %+v got %+v",
 			utils.TIMESTAMP_TOPDIFF_VARENC[0], rawRec[oPtr])
 	}
 	oPtr++

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -281,6 +281,7 @@ func RawSearchPQMResults(req *structs.SegmentSearchRequest, fileParallelism int6
 	allTimestamps, err := segread.ReadAllTimestampsForBlock(req.AllBlocksToSearch, req.SegmentKey,
 		req.SearchMetadata.BlockSummaries, fileParallelism)
 	if err != nil {
+		log.Errorf("qid=%d, RawSearchPQMResults: failed to read all timestamps; err=%v", qid, err)
 		allSearchResults.AddError(err)
 		return
 	}

--- a/pkg/segment/segexecution_test.go
+++ b/pkg/segment/segexecution_test.go
@@ -408,7 +408,12 @@ func Test_EncodeDecodeBlockSummary(t *testing.T) {
 		// cnames start from key0..key11
 		// key1 stores "value1", and the blockLen was calculated by running thw writemock.. func with print statement
 		assert.Equal(t, uint32(30), readAllBmh[uint16(i)].ColumnBlockLen["key1"])
-		assert.Equal(t, int64(i*30), readAllBmh[uint16(i)].ColumnBlockOffset["key1"])
+
+		// For the block offset, i*30 is from the block size. We write the
+		// blocks using utils.ChecksumFile, which has an additional header for
+		// each chunk; that header is 12 bytes. So the total offset is
+		// i*(30+12)
+		assert.Equal(t, int64(i*(30+12)), readAllBmh[uint16(i)].ColumnBlockOffset["key1"])
 	}
 }
 

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -903,7 +903,7 @@ func writeWip(colWip *ColWip, encType []byte, compBuf []byte) (uint32, int64, er
 
 	blkLen := uint32(0)
 	// todo better error handling should not exit
-	fd, err := os.OpenFile(colWip.csgFname, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	fd, err := os.OpenFile(colWip.csgFname, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		log.Errorf("WriteWip: open failed fname=%v, err=%v", colWip.csgFname, err)
 		return 0, 0, err

--- a/pkg/segment/writer/segwriter.go
+++ b/pkg/segment/writer/segwriter.go
@@ -916,7 +916,8 @@ func writeWip(colWip *ColWip, encType []byte, compBuf []byte) (uint32, int64, er
 		return 0, 0, err
 	}
 
-	_, err = fd.Write(encType)
+	checksumFile := utils.ChecksumFile{Fd: fd}
+	err = checksumFile.AppendPartialChunk(encType)
 	if err != nil {
 		log.Errorf("WriteWip: compression Type write failed fname=%v, err=%v", colWip.csgFname, err)
 		return 0, blkOffset, err
@@ -928,12 +929,17 @@ func writeWip(colWip *ColWip, encType []byte, compBuf []byte) (uint32, int64, er
 		log.Errorf("WriteWip: compression of wip failed fname=%v, err=%v", colWip.csgFname, err)
 		return 0, blkOffset, err
 	}
-	_, err = fd.Write(compressed)
+	err = checksumFile.AppendPartialChunk(compressed)
 	if err != nil {
 		log.Errorf("WriteWip: compressed write failed fname=%v, err=%v", colWip.csgFname, err)
 		return 0, blkOffset, err
 	}
 	blkLen += compLen
+
+	err = checksumFile.Flush()
+	if err != nil {
+		return 0, blkOffset, fmt.Errorf("WriteWip: flush failed fname=%v, err=%v", colWip.csgFname, err)
+	}
 
 	return blkLen, blkOffset, nil
 }

--- a/pkg/utils/checksumfile.go
+++ b/pkg/utils/checksumfile.go
@@ -46,10 +46,6 @@ func NewChecksumFile(fd *os.File) (*checksumFile, error) {
 	return &checksumFile{fd: fd}, nil
 }
 
-func (csf *checksumFile) Close() error {
-	return csf.fd.Close()
-}
-
 // This is not thread-safe.
 func (csf *checksumFile) AppendChunk(data []byte) error {
 	if len(data) == 0 {

--- a/pkg/utils/checksumfile.go
+++ b/pkg/utils/checksumfile.go
@@ -38,10 +38,9 @@ type checksumFile struct {
 	fd *os.File
 }
 
-func NewChecksumFile(fileName string) (*checksumFile, error) {
-	fd, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, 0644)
-	if err != nil {
-		return nil, fmt.Errorf("NewChecksumFile: Cannot open file %v, err=%v", fileName, err)
+func NewChecksumFile(fd *os.File) (*checksumFile, error) {
+	if fd == nil {
+		return nil, fmt.Errorf("NewChecksumFile: File descriptor is nil")
 	}
 
 	return &checksumFile{fd: fd}, nil

--- a/pkg/utils/checksumfile.go
+++ b/pkg/utils/checksumfile.go
@@ -134,17 +134,17 @@ func (csf *ChecksumFile) Flush() error {
 
 	_, err := csf.Fd.WriteAt(Uint32ToBytesLittleEndian(magicNumber), csf.chunkOffset)
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.Fd.Name(), err)
+		return fmt.Errorf("checksumFile.Flush: Cannot write magic number to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	_, err = csf.Fd.WriteAt(Uint32ToBytesLittleEndian(csf.checksum), csf.chunkOffset+checksumOffset)
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.Fd.Name(), err)
+		return fmt.Errorf("checksumFile.Flush: Cannot write checksum to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	_, err = csf.Fd.WriteAt(Uint32ToBytesLittleEndian(uint32(csf.curChunkLen)), csf.chunkOffset+lengthOffset)
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.Fd.Name(), err)
+		return fmt.Errorf("checksumFile.Flush: Cannot write length to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	csf.chunkOffset = 0

--- a/pkg/utils/checksumfile.go
+++ b/pkg/utils/checksumfile.go
@@ -129,24 +129,17 @@ func (csf *ChecksumFile) Flush() error {
 		return fmt.Errorf("checksumFile.Flush: File descriptor is nil")
 	}
 
-	// Go to the beginning of this chunk.
-	_, err := csf.Fd.Seek(csf.chunkOffset, 0)
-	if err != nil {
-		return fmt.Errorf("checksumFile.Flush: Cannot seek to chunk offset %d in file %v, err=%v",
-			csf.chunkOffset, csf.Fd.Name(), err)
-	}
-
-	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(magicNumber))
+	_, err := csf.Fd.WriteAt(Uint32ToBytesLittleEndian(magicNumber), csf.chunkOffset)
 	if err != nil {
 		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(csf.checksum))
+	_, err = csf.Fd.WriteAt(Uint32ToBytesLittleEndian(csf.checksum), csf.chunkOffset+4)
 	if err != nil {
 		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(uint32(csf.curChunkLen)))
+	_, err = csf.Fd.WriteAt(Uint32ToBytesLittleEndian(uint32(csf.curChunkLen)), csf.chunkOffset+8)
 	if err != nil {
 		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.Fd.Name(), err)
 	}

--- a/pkg/utils/checksumfile.go
+++ b/pkg/utils/checksumfile.go
@@ -34,8 +34,8 @@ const magicNumber uint32 = 0x87654321
 //   - checksum (4 bytes)
 //   - length (4 bytes)
 //   - data (length bytes)
-type checksumFile struct {
-	fd *os.File
+type ChecksumFile struct {
+	Fd *os.File
 
 	// These are used for partial chunk writes.
 	chunkOffset int64 // Start offset of the chunk (so the offset of the magic number).
@@ -43,21 +43,13 @@ type checksumFile struct {
 	curChunkLen int
 }
 
-func NewChecksumFile(fd *os.File) (*checksumFile, error) {
-	if fd == nil {
-		return nil, fmt.Errorf("NewChecksumFile: File descriptor is nil")
-	}
-
-	return &checksumFile{fd: fd}, nil
-}
-
 // This is not thread-safe.
-func (csf *checksumFile) AppendChunk(data []byte) error {
+func (csf *ChecksumFile) AppendChunk(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 
-	if csf.fd == nil {
+	if csf.Fd == nil {
 		return fmt.Errorf("checksumFile.AppendChunk: File descriptor is nil")
 	}
 
@@ -65,30 +57,30 @@ func (csf *checksumFile) AppendChunk(data []byte) error {
 		return fmt.Errorf("checksumFile.AppendChunk: Last chunk is not flushed")
 	}
 
-	_, err := csf.fd.Seek(0, 2) // Seek to the end of the file
+	_, err := csf.Fd.Seek(0, 2) // Seek to the end of the file
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot seek to end of file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot seek to end of file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(magicNumber))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(magicNumber))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	checksum := crc32.ChecksumIEEE(data)
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(checksum))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(checksum))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(uint32(len(data))))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(uint32(len(data))))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(data)
+	_, err = csf.Fd.Write(data)
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write data to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write data to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	return nil
@@ -96,67 +88,67 @@ func (csf *checksumFile) AppendChunk(data []byte) error {
 
 // Use this instead of AppendChunk() if you want to have multiple write calls
 // but combine them into one chunk. You MUST call Flush() to finish the chunk.
-func (csf *checksumFile) AppendPartialChunk(data []byte) error {
+func (csf *ChecksumFile) AppendPartialChunk(data []byte) error {
 	if len(data) == 0 {
 		return nil
 	}
 
-	if csf.fd == nil {
+	if csf.Fd == nil {
 		return fmt.Errorf("checksumFile.AppendPartialChunk: File descriptor is nil")
 	}
 
-	offset, err := csf.fd.Seek(0, 2) // Seek to the end of the file
+	offset, err := csf.Fd.Seek(0, 2) // Seek to the end of the file
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendPartialChunk: Cannot seek to end of file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendPartialChunk: Cannot seek to end of file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	if csf.curChunkLen == 0 {
 		// We want to write the data now, but we don't know what checksum or
 		// length to write. So skip some bytes, and we'll write them later.
 		csf.chunkOffset = offset
-		_, err = csf.fd.Write(make([]byte, 12)) // magic, checksum, and length
+		_, err = csf.Fd.Write(make([]byte, 12)) // magic, checksum, and length
 		if err != nil {
 			return fmt.Errorf("checksumFile.AppendPartialChunk: Cannot write placeholders to file %v, err=%v",
-				csf.fd.Name(), err)
+				csf.Fd.Name(), err)
 		}
 	}
 
 	csf.checksum = crc32.Update(csf.checksum, crc32.IEEETable, data)
 	csf.curChunkLen += len(data)
 
-	_, err = csf.fd.Write(data)
+	_, err = csf.Fd.Write(data)
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendPartialChunk: Cannot write data to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendPartialChunk: Cannot write data to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	return nil
 }
 
-func (csf *checksumFile) Flush() error {
-	if csf.fd == nil {
+func (csf *ChecksumFile) Flush() error {
+	if csf.Fd == nil {
 		return fmt.Errorf("checksumFile.Flush: File descriptor is nil")
 	}
 
 	// Go to the beginning of this chunk.
-	_, err := csf.fd.Seek(csf.chunkOffset, 0)
+	_, err := csf.Fd.Seek(csf.chunkOffset, 0)
 	if err != nil {
 		return fmt.Errorf("checksumFile.Flush: Cannot seek to chunk offset %d in file %v, err=%v",
-			csf.chunkOffset, csf.fd.Name(), err)
+			csf.chunkOffset, csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(magicNumber))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(magicNumber))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write magic number to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(csf.checksum))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(csf.checksum))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write checksum to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
-	_, err = csf.fd.Write(Uint32ToBytesLittleEndian(uint32(csf.curChunkLen)))
+	_, err = csf.Fd.Write(Uint32ToBytesLittleEndian(uint32(csf.curChunkLen)))
 	if err != nil {
-		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.fd.Name(), err)
+		return fmt.Errorf("checksumFile.AppendChunk: Cannot write length to file %v, err=%v", csf.Fd.Name(), err)
 	}
 
 	csf.chunkOffset = 0
@@ -166,53 +158,53 @@ func (csf *checksumFile) Flush() error {
 	return nil
 }
 
-func (csf *checksumFile) ReadAt(buf []byte, offset int64) (int, error) {
-	if csf.fd == nil {
+func (csf *ChecksumFile) ReadAt(buf []byte, offset int64) (int, error) {
+	if csf.Fd == nil {
 		return 0, fmt.Errorf("checksumFile.ReadAt: File descriptor is nil")
 	}
 
-	_, err := csf.fd.Seek(offset, 0)
+	_, err := csf.Fd.Seek(offset, 0)
 	if err != nil {
 		return 0, fmt.Errorf("checksumFile.ReadAt: Cannot seek to offset %d in file %v, err=%v",
-			offset, csf.fd.Name(), err)
+			offset, csf.Fd.Name(), err)
 	}
 
-	magic, err := readUint32(csf.fd)
+	magic, err := readUint32(csf.Fd)
 	if err != nil {
 		return 0, fmt.Errorf("checksumFile.ReadAt: Cannot read magic number from file %v, err=%v",
-			csf.fd.Name(), err)
+			csf.Fd.Name(), err)
 	}
 
 	if magic != magicNumber {
 		// Check if this is a checksum file. If it is, it will have the magic
 		// number at the start.
-		_, err := csf.fd.Seek(0, 0) // Seek to the start of the file.
+		_, err := csf.Fd.Seek(0, 0) // Seek to the start of the file.
 		if err != nil {
 			return 0, fmt.Errorf("checksumFile.ReadAt: Cannot seek to start of file %v, err=%v",
-				csf.fd.Name(), err)
+				csf.Fd.Name(), err)
 		}
 
-		if magic, err := readUint32(csf.fd); err != nil {
+		if magic, err := readUint32(csf.Fd); err != nil {
 			return 0, fmt.Errorf("checksumFile.ReadAt: Cannot read magic number from start of file %v, err=%v",
-				csf.fd.Name(), err)
+				csf.Fd.Name(), err)
 		} else if magic == magicNumber {
 			return 0, fmt.Errorf("checksumFile.ReadAt: offset is not the start of a chunk")
 		}
 
 		// It's not a checksum file, so read the data directly for backward compatibility.
-		return csf.fd.ReadAt(buf, offset)
+		return csf.Fd.ReadAt(buf, offset)
 	}
 
-	checksum, err := readUint32(csf.fd)
+	checksum, err := readUint32(csf.Fd)
 	if err != nil {
 		return 0, fmt.Errorf("checksumFile.ReadAt: Cannot read checksum from file %v, err=%v",
-			csf.fd.Name(), err)
+			csf.Fd.Name(), err)
 	}
 
-	length, err := readUint32(csf.fd)
+	length, err := readUint32(csf.Fd)
 	if err != nil {
 		return 0, fmt.Errorf("checksumFile.ReadAt: Cannot read length from file %v, err=%v",
-			csf.fd.Name(), err)
+			csf.Fd.Name(), err)
 	}
 
 	if length != uint32(len(buf)) {
@@ -220,10 +212,10 @@ func (csf *checksumFile) ReadAt(buf []byte, offset int64) (int, error) {
 		return 0, fmt.Errorf("checksumFile.ReadAt: buffer length mismatch: expected %d, got %d", length, len(buf))
 	}
 
-	numBytesRead, err := csf.fd.Read(buf)
+	numBytesRead, err := csf.Fd.Read(buf)
 	if err != nil && err != io.EOF {
 		return 0, fmt.Errorf("checksumFile.ReadAt: Cannot read data from file %v, err=%v",
-			csf.fd.Name(), err)
+			csf.Fd.Name(), err)
 	}
 
 	// Verify the checksum

--- a/pkg/utils/checksumfile_test.go
+++ b/pkg/utils/checksumfile_test.go
@@ -32,7 +32,9 @@ func Test_checksumFile_ReadAndWrite(t *testing.T) {
 	fileName := filepath.Join(dir, "test")
 	data := []byte("Hello, world!")
 
-	csf, err := NewChecksumFile(fileName)
+	fd, err := os.Create(fileName)
+	require.NoError(t, err)
+	csf, err := NewChecksumFile(fd)
 	require.NoError(t, err)
 	defer csf.Close()
 
@@ -82,7 +84,9 @@ func Test_checksumFile_BackwardCompatibility(t *testing.T) {
 	err := os.WriteFile(fileName, data, 0644)
 	require.NoError(t, err)
 
-	csf, err := NewChecksumFile(fileName)
+	fd, err := os.OpenFile(fileName, os.O_RDWR, 0644)
+	require.NoError(t, err)
+	csf, err := NewChecksumFile(fd)
 	require.NoError(t, err)
 	defer csf.Close()
 

--- a/pkg/utils/checksumfile_test.go
+++ b/pkg/utils/checksumfile_test.go
@@ -193,6 +193,13 @@ func Test_checksumFile_ReadMultipleChunks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 6, n)
 	assert.Equal(t, []byte("barbaz"), buf)
+
+	// Read all the chunks.
+	buf = make([]byte, 9)
+	n, err = csf.ReadAt(buf, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 9, n)
+	assert.Equal(t, []byte("foobarbaz"), buf)
 }
 
 func appendChunksNoError(t *testing.T, csf *ChecksumFile, data [][]byte) {

--- a/pkg/utils/checksumfile_test.go
+++ b/pkg/utils/checksumfile_test.go
@@ -34,9 +34,9 @@ func Test_checksumFile_ReadAndWrite(t *testing.T) {
 
 	fd, err := os.Create(fileName)
 	require.NoError(t, err)
+	defer fd.Close()
 	csf, err := NewChecksumFile(fd)
 	require.NoError(t, err)
-	defer csf.Close()
 
 	err = csf.AppendChunk(data)
 	require.NoError(t, err)
@@ -86,9 +86,9 @@ func Test_checksumFile_BackwardCompatibility(t *testing.T) {
 
 	fd, err := os.OpenFile(fileName, os.O_RDWR, 0644)
 	require.NoError(t, err)
+	defer fd.Close()
 	csf, err := NewChecksumFile(fd)
 	require.NoError(t, err)
-	defer csf.Close()
 
 	actualData := make([]byte, len(data))
 	n, err := csf.ReadAt(actualData, 0)

--- a/pkg/utils/checksumfile_test.go
+++ b/pkg/utils/checksumfile_test.go
@@ -35,8 +35,7 @@ func Test_checksumFile_ReadAndWrite(t *testing.T) {
 	fd, err := os.Create(fileName)
 	require.NoError(t, err)
 	defer fd.Close()
-	csf, err := NewChecksumFile(fd)
-	require.NoError(t, err)
+	csf := ChecksumFile{Fd: fd}
 
 	err = csf.AppendChunk(data)
 	require.NoError(t, err)
@@ -61,7 +60,7 @@ func Test_checksumFile_ReadAndWrite(t *testing.T) {
 	t.Run("ReadSecondChunk", func(t *testing.T) {
 		// Write another chunk.
 		data2 := []byte("Goodbye!")
-		offset, err := csf.fd.Seek(0, io.SeekEnd)
+		offset, err := csf.Fd.Seek(0, io.SeekEnd)
 		require.NoError(t, err)
 
 		err = csf.AppendChunk(data2)
@@ -87,8 +86,7 @@ func Test_checksumFile_BackwardCompatibility(t *testing.T) {
 	fd, err := os.OpenFile(fileName, os.O_RDWR, 0644)
 	require.NoError(t, err)
 	defer fd.Close()
-	csf, err := NewChecksumFile(fd)
-	require.NoError(t, err)
+	csf := ChecksumFile{Fd: fd}
 
 	actualData := make([]byte, len(data))
 	n, err := csf.ReadAt(actualData, 0)
@@ -108,10 +106,8 @@ func Test_checksumFile_PartialWrites(t *testing.T) {
 	require.NoError(t, err)
 	defer fd2.Close()
 
-	csf1, err := NewChecksumFile(fd1)
-	require.NoError(t, err)
-	csf2, err := NewChecksumFile(fd2)
-	require.NoError(t, err)
+	csf1 := &ChecksumFile{Fd: fd1}
+	csf2 := &ChecksumFile{Fd: fd2}
 
 	// Write the same data to both files (and chunked the the same way), but
 	// using different methods.
@@ -131,7 +127,7 @@ func Test_checksumFile_PartialWrites(t *testing.T) {
 	assert.Equal(t, content1, content2)
 }
 
-func appendChunksNoError(t *testing.T, csf *checksumFile, data [][]byte) {
+func appendChunksNoError(t *testing.T, csf *ChecksumFile, data [][]byte) {
 	t.Helper()
 	for _, chunk := range data {
 		err := csf.AppendChunk(chunk)
@@ -139,7 +135,7 @@ func appendChunksNoError(t *testing.T, csf *checksumFile, data [][]byte) {
 	}
 }
 
-func appendPartialChunksNoError(t *testing.T, csf *checksumFile, data [][]byte) {
+func appendPartialChunksNoError(t *testing.T, csf *ChecksumFile, data [][]byte) {
 	t.Helper()
 	for _, chunk := range data {
 		err := csf.AppendPartialChunk(chunk)


### PR DESCRIPTION
# Description
Use https://github.com/siglens/siglens/pull/2484 to read/write .csg files with checksum validation. Reading is backward compatible.

# Testing
New and existing unit tests. I also manually tested by ingesting 2 blocks of data on `develop`, then ingesting 2 more blocks on the tip of this feature branch and running queries, to verify backward compatibility. All the queries worked as expected.

# Checklist:
Before marking your pull request as ready for review, complete the following.

- [x] I have self-reviewed this PR.
- [x] I have removed all print-debugging and commented-out code that should not be merged.
- [x] I have added sufficient comments in my code, particularly in hard-to-understand areas.
- [x] I have formatted the code, if applicable. For Go, I have run `goimports -w .`.
