### PR TITLE
UI: Resizable Fields Sidebar

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -728,6 +728,7 @@ div.show-record-popup .ui-dialog-buttonpane button {
     background-color: var(--myOrg-input);
     padding: 3px !important;
     width: fit-content;
+    margin-left: 4px !important;
 }
 
 #logs-view-controls {

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2972,7 +2972,7 @@ input[type="time"]::-webkit-calendar-picker-indicator {
 }
 
 .expand-svg-container.before-tabs {
-    margin-right: 10px;
+    margin-right: 4px;
     padding: 0;
 }
 
@@ -7200,7 +7200,7 @@ p#versionInfo {
 }
 
 .json-popup.active {
-    width: 700px;
+    min-width: 400px;
     margin-left: 5px;
     border-left: 1px solid var(--panel-table-line-color);
     border-bottom: 1px solid var(--panel-table-line-color);
@@ -7443,15 +7443,16 @@ p#versionInfo {
 }
 
 .fields-sidebar {
-    min-width: 180px;
     width: 250px;
     background-color: var(--black1-to-white0);
-    border: 1px solid var(--panel-table-line-color);
+    border-top: 1px solid var(--panel-table-line-color);
+    border-right: 1px solid var(--panel-table-line-color);
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-    margin-right: 5px;
-    border-radius: 0 4px 0 0;
+    min-width: 190px;
+    max-width: 500px;
+    flex: 0 0 auto !important; 
 }
 
 .fields-sidebar.hidden {
@@ -7544,6 +7545,22 @@ p#versionInfo {
 .field-action-remove {
     color: var(--error);
     background-color: var(--black1-to-white0);
+}
+
+.fields-resizer {
+    width: 4px;
+    background: var(--datatable-header-bg-color);
+    cursor: col-resize;
+    margin: 0;
+    height: 100%;
+    position: relative;
+    flex: 0 0 4px;
+    z-index: 10;
+}
+
+.fields-resizer:hover,
+.fields-resizer.active {
+    background-color: #a0a0a0;
 }
 
 .sl-header {

--- a/static/js/available-fields.js
+++ b/static/js/available-fields.js
@@ -201,3 +201,57 @@ function updateAvailableFieldsUI() {
         }
     });
 }
+
+jQuery(document).ready(function() {
+    //Resizing Fields Sidebar
+    const fieldsSidebar = jQuery('.fields-sidebar');
+    const chartContainer = jQuery('.custom-chart-container');
+
+    if (fieldsSidebar.length === 0 || chartContainer.length === 0) return;
+
+    const resizer = jQuery('<div>', {
+        class: 'fields-resizer'
+    });
+    fieldsSidebar.after(resizer);
+
+    let initialWidth = localStorage.getItem('fieldsSidebarWidth') || 250;
+    fieldsSidebar.css('width', initialWidth + 'px');
+
+    resizer.on('mousedown', function(e) {
+        e.preventDefault();
+        resizer.addClass('active');
+
+        const startX = e.clientX;
+        const sidebarWidth = fieldsSidebar.outerWidth();
+
+        function handleMouseMove(e) {
+            const newWidth = sidebarWidth + (e.clientX - startX);
+
+            if (newWidth >= 190 && newWidth <= 500) {
+                fieldsSidebar.css('width', newWidth + 'px');
+                localStorage.setItem('fieldsSidebarWidth', newWidth);
+            }
+        }
+
+        function handleMouseUp() {
+            resizer.removeClass('active');
+            jQuery(document).off('mousemove', handleMouseMove);
+            jQuery(document).off('mouseup', handleMouseUp);
+        }
+
+        jQuery(document).on('mousemove', handleMouseMove);
+        jQuery(document).on('mouseup', handleMouseUp);
+    });
+
+    const savedWidth = localStorage.getItem('fieldsSidebarWidth');
+    if (savedWidth) {
+        fieldsSidebar.css('width', savedWidth + 'px');
+    }
+
+    jQuery(window).on('resize', function() {
+        const savedWidth = localStorage.getItem('fieldsSidebarWidth');
+        if (savedWidth) {
+            fieldsSidebar.css('width', savedWidth + 'px');
+        }
+    });
+});

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -454,6 +454,8 @@ function applyFieldsSidebarState(isHidden) {
     const fieldsSidebar = document.querySelector('.fields-sidebar');
     const customChartTab = document.querySelector('.custom-chart-tab');
     const container = document.querySelector('.custom-chart-container');
+    const resizer = document.querySelector('.fields-resizer');
+
 
     if (!fieldsSidebar) return;
 
@@ -465,6 +467,9 @@ function applyFieldsSidebarState(isHidden) {
         if (container) {
             container.classList.add('full-width-container');
         }
+        if (resizer) {
+            resizer.style.display = 'none';
+        }
     } else {
         fieldsSidebar.classList.remove('hidden');
         if (customChartTab) {
@@ -472,6 +477,9 @@ function applyFieldsSidebarState(isHidden) {
         }
         if (container) {
             container.classList.remove('full-width-container');
+        }
+        if (resizer) {
+            resizer.style.display = 'block';
         }
     }
 }


### PR DESCRIPTION
# Description
**Issue**: Previously, long field names in the fields sidebar were truncated with no way for the user to view the full name.
**Fix:**
- Added functionality to resize the fields sidebar.
- User can now drag to adjust the width.
- The selected width is saved in `localStorage` to persist the sidebar state across sessions.


https://github.com/user-attachments/assets/b89c6d69-0f69-4890-9571-2fcf6c899bde

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
