### PR TITLE
Fix: Custom Timepicker Validation

### DIFF
--- a/static/component/infrastructure/header-component.js
+++ b/static/component/infrastructure/header-component.js
@@ -170,7 +170,7 @@ class DashboardHeader {
             window.history.pushState({}, '', currentUrl);
         });
         
-        this.container.on('click', '#customrange-btn', () => {
+        this.container.on('dateRangeValid', '#customrange-btn', () => {
             const currentUrl = new URL(window.location.href);
             currentUrl.searchParams.set('startEpoch', filterStartDate);
             currentUrl.searchParams.set('endEpoch', filterEndDate);

--- a/static/component/time-picker/time-picker.js
+++ b/static/component/time-picker/time-picker.js
@@ -167,11 +167,22 @@
         }
 
         function customRangeHandler(evt) {
-            evt.stopPropagation();
+            $('#date-range-error').remove();
 
             if (!tempStartDate || !tempEndDate) {
+                evt.preventDefault();
+                evt.stopPropagation();
                 if (!tempStartDate) $('#date-start').addClass('error');
                 if (!tempEndDate) $('#date-end').addClass('error');
+
+                $('#daterange-to').after('<div id="date-range-error" class="date-range-error">Please select both start and end dates</div>');
+
+                setTimeout(function () {
+                    $('#date-start, #date-end').removeClass('error');
+                    $('#date-range-error').fadeOut(300, function () {
+                        $(this).remove();
+                    });
+                }, 2000);
                 $(this).trigger('dateRangeInvalid');
                 return;
             } else {
@@ -199,9 +210,15 @@
                 evt.stopPropagation();
                 $('#date-start').addClass('error');
                 $('#date-end').addClass('error');
-
+                $('.panelEditor-container #date-start').addClass('error');
+                $('.panelEditor-container #date-end').addClass('error');
+                
+                $('#daterange-to').after('<div id="date-range-error" class="date-range-error">End date must be after start date</div>');
+        
                 setTimeout(function () {
                     $('#date-start, #date-end').removeClass('error');
+                    $('.panelEditor-container #date-start, .panelEditor-container #date-end').removeClass('error');
+                    $('#date-range-error').fadeOut(300, function() { $(this).remove(); });
                 }, 2000);
                 $(this).trigger('dateRangeInvalid');
                 return;

--- a/static/component/time-picker/time-picker.js
+++ b/static/component/time-picker/time-picker.js
@@ -172,6 +172,7 @@
             if (!tempStartDate || !tempEndDate) {
                 if (!tempStartDate) $('#date-start').addClass('error');
                 if (!tempEndDate) $('#date-end').addClass('error');
+                $(this).trigger('dateRangeInvalid');
                 return;
             } else {
                 $.each($('.range-item.active, .db-range-item.active'), function () {
@@ -193,42 +194,26 @@
             filterStartDate = startDate.getTime();
             filterEndDate = endDate.getTime();
 
+            if (filterEndDate <= filterStartDate) {
+                evt.preventDefault();
+                evt.stopPropagation();
+                $('#date-start').addClass('error');
+                $('#date-end').addClass('error');
+
+                setTimeout(function () {
+                    $('#date-start, #date-end').removeClass('error');
+                }, 2000);
+                $(this).trigger('dateRangeInvalid');
+                return;
+            }
+
             Cookies.set('customStartDate', appliedStartDate);
             Cookies.set('customStartTime', appliedStartTime);
             Cookies.set('customEndDate', appliedEndDate);
             Cookies.set('customEndTime', appliedEndTime);
 
             datePickerHandler(filterStartDate, filterEndDate, 'custom');
-            // For dashboards
-            const currentUrl = window.location.href;
-            if (currentUrl.includes('dashboard.html')) {
-                if (currentPanel) {
-                    if (currentPanel.queryData) {
-                        if (currentPanel.chartType === 'Line Chart' || currentPanel.queryType === 'metrics') {
-                            currentPanel.queryData.start = filterStartDate.toString();
-                            currentPanel.queryData.end = filterEndDate.toString();
-                        } else {
-                            currentPanel.queryData.startEpoch = filterStartDate;
-                            currentPanel.queryData.endEpoch = filterEndDate;
-                        }
-                    }
-                } else if (!currentPanel) {
-                    // if user is on dashboard screen
-                    localPanels.forEach((panel) => {
-                        delete panel.queryRes;
-                        if (panel.queryData) {
-                            if (panel.chartType === 'Line Chart' || panel.queryType === 'metrics') {
-                                panel.queryData.start = filterStartDate.toString();
-                                panel.queryData.end = filterEndDate.toString();
-                            } else {
-                                panel.queryData.startEpoch = filterStartDate;
-                                panel.queryData.endEpoch = filterEndDate;
-                            }
-                        }
-                    });
-                    displayPanels();
-                }
-            }
+
             $('#daterangepicker').removeClass('show').hide();
         }
 
@@ -242,7 +227,7 @@
             $(evt.currentTarget).addClass('active');
             datePickerHandler($(this).attr('id'), 'now', $(this).attr('id'));
             $('#daterangepicker').removeClass('show').hide();
-            $('#date-picker-btn').removeClass('active')
+            $('#date-picker-btn').removeClass('active');
         }
 
         function resetCustomDateRange() {

--- a/static/component/time-picker/time-picker.js
+++ b/static/component/time-picker/time-picker.js
@@ -133,11 +133,6 @@
             initializeDatePicker();
         }
 
-        function hideDatePickerHandler() {
-            $('#date-picker-btn').removeClass('active');
-            resetTempValues();
-        }
-
         function resetDatePickerHandler(evt) {
             evt.stopPropagation();
             resetCustomDateRange();

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2672,11 +2672,6 @@ hr {
     margin-left: 10px;
 }
 
-#date-start.error,
-#date-end.error {
-    border: 1px solid var(--error-trace);
-}
-
 #date-start:hover,
 #date-end:hover,
 #time-start:hover,
@@ -2727,31 +2722,42 @@ input[type="time"]::-webkit-calendar-picker-indicator {
     color: var(--search-bar-text-color-regular-or-hover);
 }
 
-
-#cstats-app-container .dropdown-menu.daterangepicker.show {
-    height: auto !important;
-    width: 300px !important;
-    padding: 8px;
+#date-start.error,
+#date-end.error {
+    border: 2px solid #dc3545;
+    box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
 }
 
-#cstats-app-container .inner-range {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    column-gap: 50px;
+.date-range-error {
+    color: #dc3545;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: flex;
+    align-items: center;
+    padding: 0.5rem;
+    background-color: rgba(220, 53, 69, 0.1);
+    border-radius: 0.25rem;
+    margin-bottom: 0.5rem;
 }
 
-#cstats-app-container hr {
-    height: 2px;
-    background: var(--alerting-table-line-color);
-    margin: 30px 0;
+.date-range-error::before {
+    content: "⚠️";
+    margin-right: 0.5rem;
 }
 
-#cstats-app-container .ranges {
-    display: grid;
-    grid-template-rows: repeat(2, 1fr);
-    float: none !important;
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
 }
 
+#date-range-error {
+    animation: fadeIn 0.3s ease-in-out;
+}
 
 .db-range-item.active {
     background-color: var(--index-drop-down-item-active-bg-color);
@@ -7452,7 +7458,7 @@ p#versionInfo {
     overflow-y: auto;
     min-width: 190px;
     max-width: 500px;
-    flex: 0 0 auto !important; 
+    flex: 0 0 auto !important;
 }
 
 .fields-sidebar.hidden {

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -68,7 +68,7 @@ function setupEventHandlers() {
     $('#customrange-btn').off('click').on('click', customRangeHandler);
 
     $('.range-item').on('click', rangeItemHandler);
-    $('.db-range-item').off('click').on('click', dashboardRangeItemHandler);
+    $('.db-range-item').off('click').on('click', rangeItemHandler);
 
     $('.ui-widget input').on('keyup', saveqInputHandler);
 
@@ -176,14 +176,27 @@ function customRangeHandler(evt) {
     if (!tempStartDate || !tempEndDate) {
         evt.preventDefault();
         evt.stopPropagation();
-        if (!tempStartDate) $('#date-start').addClass('error');
-        if (!tempEndDate) $('#date-end').addClass('error');
+        if (!tempStartDate) {
+            $('#date-start').addClass('error');
+            $('.panelEditor-container #date-start').addClass('error');
+        }
+        if (!tempEndDate) {
+            $('#date-end').addClass('error');
+            $('.panelEditor-container #date-end').addClass('error');
+        }
 
         $('#daterange-to').after('<div id="date-range-error" class="date-range-error">Please select both start and end dates</div>');
+        $('.panelEditor-container #daterange-to').after('<div id="date-range-error" class="date-range-error">Please select both start and end dates</div>');
 
         setTimeout(function () {
             $('#date-start, #date-end').removeClass('error');
-            $('#date-range-error').fadeOut(300, function() { $(this).remove(); });
+            $('.panelEditor-container #date-start,.panelEditor-container #date-end').removeClass('error');
+            $('#date-range-error').fadeOut(300, function () {
+                $(this).remove();
+            });
+            $('.panelEditor-container #date-range-error').fadeOut(300, function () {
+                $(this).remove();
+            });
         }, 2000);
         $(this).trigger('dateRangeInvalid');
         return;
@@ -214,13 +227,19 @@ function customRangeHandler(evt) {
         $('#date-end').addClass('error');
         $('.panelEditor-container #date-start').addClass('error');
         $('.panelEditor-container #date-end').addClass('error');
-        
+
         $('#daterange-to').after('<div id="date-range-error" class="date-range-error">End date must be after start date</div>');
+        $('.panelEditor-container #daterange-to').after('<div id="date-range-error" class="date-range-error">End date must be after start date</div>');
 
         setTimeout(function () {
             $('#date-start, #date-end').removeClass('error');
             $('.panelEditor-container #date-start, .panelEditor-container #date-end').removeClass('error');
-            $('#date-range-error').fadeOut(300, function() { $(this).remove(); });
+            $('#date-range-error').fadeOut(300, function () {
+                $(this).remove();
+            });
+            $('.panelEditor-container #date-range-error').fadeOut(300, function () {
+                $(this).remove();
+            });
         }, 2000);
         $(this).trigger('dateRangeInvalid');
         return;
@@ -236,77 +255,7 @@ function customRangeHandler(evt) {
     // For dashboards
     const currentUrl = window.location.href;
     if (currentUrl.includes('dashboard.html')) {
-        if (currentPanel) {
-            if (currentPanel.queryData) {
-                if (currentPanel.chartType === 'Line Chart' || currentPanel.queryType === 'metrics') {
-                    const startDateStr = filterStartDate.toString();
-                    const endDateStr = filterEndDate.toString();
-
-                    // Update start and end for queryData
-                    if (currentPanel.queryData) {
-                        currentPanel.queryData.start = startDateStr;
-                        currentPanel.queryData.end = endDateStr;
-
-                        // Update start and end for each item in queriesData
-                        if (Array.isArray(currentPanel.queryData.queriesData)) {
-                            currentPanel.queryData.queriesData.forEach((query) => {
-                                query.start = startDateStr;
-                                query.end = endDateStr;
-                            });
-                        }
-
-                        // Update start and end for each item in formulasData
-                        if (Array.isArray(currentPanel.queryData.formulasData)) {
-                            currentPanel.queryData.formulasData.forEach((formula) => {
-                                formula.start = startDateStr;
-                                formula.end = endDateStr;
-                            });
-                        }
-                    }
-                } else {
-                    currentPanel.queryData.startEpoch = filterStartDate;
-                    currentPanel.queryData.endEpoch = filterEndDate;
-                }
-                runQueryBtnHandler();
-            }
-        } else if (!currentPanel) {
-            // if user is on dashboard screen
-            localPanels.forEach((panel) => {
-                delete panel.queryRes;
-                if (panel.queryData) {
-                    if (panel.chartType === 'Line Chart' || panel.queryType === 'metrics') {
-                        const startDateStr = filterStartDate.toString();
-                        const endDateStr = filterEndDate.toString();
-
-                        // Update start and end for queryData
-                        if (panel.queryData) {
-                            panel.queryData.start = startDateStr;
-                            panel.queryData.end = endDateStr;
-
-                            // Update start and end for each item in queriesData
-                            if (Array.isArray(panel.queryData.queriesData)) {
-                                panel.queryData.queriesData.forEach((query) => {
-                                    query.start = startDateStr;
-                                    query.end = endDateStr;
-                                });
-                            }
-
-                            // Update start and end for each item in formulasData
-                            if (Array.isArray(panel.queryData.formulasData)) {
-                                panel.queryData.formulasData.forEach((formula) => {
-                                    formula.start = startDateStr;
-                                    formula.end = endDateStr;
-                                });
-                            }
-                        }
-                    } else {
-                        panel.queryData.startEpoch = filterStartDate;
-                        panel.queryData.endEpoch = filterEndDate;
-                    }
-                }
-            });
-            displayPanels();
-        }
+        updateDashboardDateRange(filterStartDate, filterEndDate);
     }
 }
 
@@ -317,29 +266,25 @@ function rangeItemHandler(evt) {
     });
     $(evt.currentTarget).addClass('active');
     datePickerHandler($(this).attr('id'), 'now', $(this).attr('id'));
+
+    const currentUrl = window.location.href;
+    if (currentUrl.includes('dashboard.html')) {
+        updateDashboardDateRange(filterStartDate, filterEndDate);
+    }
 }
 
-async function dashboardRangeItemHandler(evt) {
-    resetCustomDateRange();
-    $.each($('.db-range-item.active'), function () {
-        $(this).removeClass('active');
-    });
-    $(evt.currentTarget).addClass('active');
-    datePickerHandler($(this).attr('id'), 'now', $(this).attr('id'));
+function updateDashboardDateRange(startTimestamp, endTimestamp) {
+    const startDateStr = startTimestamp.toString();
+    const endDateStr = endTimestamp.toString();
 
     // if user is on edit panel screen
     if (currentPanel) {
         if (currentPanel.queryData) {
             if (currentPanel.chartType === 'Line Chart' || currentPanel.queryType === 'metrics') {
-                const startDateStr = filterStartDate.toString();
-                const endDateStr = filterEndDate.toString();
-
-                // Update start and end for queryData
                 if (currentPanel.queryData) {
                     currentPanel.queryData.start = startDateStr;
                     currentPanel.queryData.end = endDateStr;
 
-                    // Update start and end for each item in queriesData
                     if (Array.isArray(currentPanel.queryData.queriesData)) {
                         currentPanel.queryData.queriesData.forEach((query) => {
                             query.start = startDateStr;
@@ -347,7 +292,6 @@ async function dashboardRangeItemHandler(evt) {
                         });
                     }
 
-                    // Update start and end for each item in formulasData
                     if (Array.isArray(currentPanel.queryData.formulasData)) {
                         currentPanel.queryData.formulasData.forEach((formula) => {
                             formula.start = startDateStr;
@@ -356,26 +300,21 @@ async function dashboardRangeItemHandler(evt) {
                     }
                 }
             } else {
-                currentPanel.queryData.startEpoch = filterStartDate;
-                currentPanel.queryData.endEpoch = filterEndDate;
+                currentPanel.queryData.startEpoch = startTimestamp;
+                currentPanel.queryData.endEpoch = endTimestamp;
             }
             runQueryBtnHandler();
         }
     } else if (!currentPanel) {
-        // if user is on dashboard screen
+        // If user is on dashboard screen
         localPanels.forEach((panel) => {
             delete panel.queryRes;
             if (panel.queryData) {
                 if (panel.chartType === 'Line Chart' || panel.queryType === 'metrics') {
-                    const startDateStr = filterStartDate.toString();
-                    const endDateStr = filterEndDate.toString();
-
-                    // Update start and end for queryData
                     if (panel.queryData) {
                         panel.queryData.start = startDateStr;
                         panel.queryData.end = endDateStr;
 
-                        // Update start and end for each item in queriesData
                         if (Array.isArray(panel.queryData.queriesData)) {
                             panel.queryData.queriesData.forEach((query) => {
                                 query.start = startDateStr;
@@ -383,7 +322,6 @@ async function dashboardRangeItemHandler(evt) {
                             });
                         }
 
-                        // Update start and end for each item in formulasData
                         if (Array.isArray(panel.queryData.formulasData)) {
                             panel.queryData.formulasData.forEach((formula) => {
                                 formula.start = startDateStr;
@@ -392,12 +330,11 @@ async function dashboardRangeItemHandler(evt) {
                         }
                     }
                 } else {
-                    panel.queryData.startEpoch = filterStartDate;
-                    panel.queryData.endEpoch = filterEndDate;
+                    panel.queryData.startEpoch = startTimestamp;
+                    panel.queryData.endEpoch = endTimestamp;
                 }
             }
         });
-
         displayPanels();
     }
 }

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -180,6 +180,7 @@ function customRangeHandler(evt) {
         setTimeout(function () {
             $('#date-start, #date-end').removeClass('error');
         }, 2000);
+        $(this).trigger('dateRangeInvalid');
         return;
     } else {
         $.each($('.range-item.active, .db-range-item.active'), function () {
@@ -201,12 +202,29 @@ function customRangeHandler(evt) {
     filterStartDate = startDate.getTime();
     filterEndDate = endDate.getTime();
 
+    if (filterEndDate <= filterStartDate) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        $('#date-start').addClass('error');
+        $('#date-end').addClass('error');
+        $('.panelEditor-container #date-start').addClass('error');
+        $('.panelEditor-container #date-end').addClass('error');
+        
+        setTimeout(function () {
+            $('#date-start, #date-end').removeClass('error');
+            $('.panelEditor-container #date-start, .panelEditor-container #date-end').removeClass('error');
+        }, 2000);
+        $(this).trigger('dateRangeInvalid');
+        return;
+    }
+
     Cookies.set('customStartDate', appliedStartDate);
     Cookies.set('customStartTime', appliedStartTime);
     Cookies.set('customEndDate', appliedEndDate);
     Cookies.set('customEndTime', appliedEndTime);
 
     datePickerHandler(filterStartDate, filterEndDate, 'custom');
+    $(this).trigger('dateRangeValid');
     // For dashboards
     const currentUrl = window.location.href;
     if (currentUrl.includes('dashboard.html')) {

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -171,14 +171,19 @@ function getEndTimeHandler() {
 }
 
 function customRangeHandler(evt) {
+    $('#date-range-error').remove();
+
     if (!tempStartDate || !tempEndDate) {
         evt.preventDefault();
         evt.stopPropagation();
         if (!tempStartDate) $('#date-start').addClass('error');
         if (!tempEndDate) $('#date-end').addClass('error');
 
+        $('#daterange-to').after('<div id="date-range-error" class="date-range-error">Please select both start and end dates</div>');
+
         setTimeout(function () {
             $('#date-start, #date-end').removeClass('error');
+            $('#date-range-error').fadeOut(300, function() { $(this).remove(); });
         }, 2000);
         $(this).trigger('dateRangeInvalid');
         return;
@@ -210,9 +215,12 @@ function customRangeHandler(evt) {
         $('.panelEditor-container #date-start').addClass('error');
         $('.panelEditor-container #date-end').addClass('error');
         
+        $('#daterange-to').after('<div id="date-range-error" class="date-range-error">End date must be after start date</div>');
+
         setTimeout(function () {
             $('#date-start, #date-end').removeClass('error');
             $('.panelEditor-container #date-start, .panelEditor-container #date-end').removeClass('error');
+            $('#date-range-error').fadeOut(300, function() { $(this).remove(); });
         }, 2000);
         $(this).trigger('dateRangeInvalid');
         return;

--- a/static/js/kubernetes-overview.js
+++ b/static/js/kubernetes-overview.js
@@ -252,7 +252,7 @@ function setupRefreshHandlers() {
     });
 
     // Handle custom range apply button
-    $('#customrange-btn').on('click', function () {
+    $('#customrange-btn').on('dateRangeValid', function () {
         refreshDashboard();
     });
 

--- a/static/js/kubernetes-view.js
+++ b/static/js/kubernetes-view.js
@@ -92,7 +92,7 @@ class KubernetesView {
             this.loadEventsData();
         });
 
-        $(document).on('click', '#customrange-btn', () => {
+        $(document).on('dateRangeValid', '#customrange-btn', () => {
             this.startTime = filterStartDate;
             this.endTime = filterEndDate;
             this.currentFrom = 0;

--- a/static/js/metric-summary.js
+++ b/static/js/metric-summary.js
@@ -26,7 +26,8 @@ $(document).ready(() => {
     datePickerHandler(stDate, endDate, stDate);
     setupEventHandlers();
 
-    $('.range-item, #customrange-btn').on('click', fetchAllMetrics);
+    $('.range-item').on('click', fetchAllMetrics);
+    $('#customrange-btn').on('dateRangeValid', fetchAllMetrics);
 
     fetchAllMetrics();
 

--- a/static/js/metrics-cardinality.js
+++ b/static/js/metrics-cardinality.js
@@ -31,7 +31,7 @@ $(document).ready(function () {
         fetchData(filterStartDate, filterEndDate);
     });
 
-    $('#customrange-btn').on('click', function () {
+    $('#customrange-btn').on('dateRangeValid', function () {
         fetchData(filterStartDate / 1000, filterEndDate / 1000);
     });
 });

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -114,7 +114,7 @@ $(document).ready(async function () {
         isMetricsScreen = true;
     }
 
-    $('#metrics-container #customrange-btn').on('click', refreshMetricsGraphs);
+    $('#metrics-container #customrange-btn').on('dateRangeValid', refreshMetricsGraphs);
     $('.range-item').on('click', metricsExplorerDatePickerHandler);
 
     $('.theme-btn').on('click', themePickerHandler);

--- a/static/js/service-health-overview.js
+++ b/static/js/service-health-overview.js
@@ -62,7 +62,8 @@ $(document).ready(() => {
 
     setupEventHandlers();
     datePickerHandler(startDate, endDate, startDate);
-    $('.range-item, #customrange-btn').on('click', getOneServiceOverview);
+    $('.range-item').on('click', getOneServiceOverview);
+    $('#customrange-btn').on('dateRangeValid', getOneServiceOverview);
 
     getOneServiceOverview();
 });

--- a/static/js/service-health.js
+++ b/static/js/service-health.js
@@ -27,7 +27,8 @@ $(document).ready(() => {
 
     getAllServices();
     
-    $('.range-item, #customrange-btn').on('click', getAllServices);
+    $('.range-item').on('click', getAllServices);
+    $('#customrange-btn').on('dateRangeValid', getAllServices);
     $('.search-input').on('input', filterServicesBySearch);
 });
 

--- a/static/js/usage-stats.js
+++ b/static/js/usage-stats.js
@@ -30,7 +30,7 @@ $(document).ready(() => {
     datePickerHandler(stDate, endDate, stDate);
 
     $('.range-item').on('click', getUsageStats);
-    $('#customrange-btn').on('click', getUsageStats);
+    $('#customrange-btn').on('dateRangeValid', getUsageStats);
 
     getUsageStats();
 


### PR DESCRIPTION
# Description
Added validation to prevent users from selecting an end time earlier than the start time in the custom timepicker.
If such a selection is made:
- A warning message is shown.
- Search is not triggered.
- The warning auto-dismisses after a few milliseconds, allowing the user to correct their selection.

<img width="359" alt="image" src="https://github.com/user-attachments/assets/b19c802a-5043-4f05-a0e6-2433fb930a8e" />
<img width="333" alt="image" src="https://github.com/user-attachments/assets/a04a47b0-941a-4b10-9926-5d4371ca7858" />

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
