### PR TITLE
UI: Default Search on Logs Screen

### DIFF
--- a/static/cluster-stats.html
+++ b/static/cluster-stats.html
@@ -100,8 +100,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <div class="popupContent" id="confirm-del-index-prompt">
                             <h3 class="header">Delete Index</h3>
                             <div class="del-org-prompt-text-container">
-                                <div class="prompt-text">Are you sure you want to delete the "<span></span>" index?</div>
-                                <div class="prompt-text prompt-text-bottom">To confirm the action, please type "<b>delete </b><span></span>".</div>
+                                <div class="prompt-text">Are you sure you want to delete the "<strong><span></span></strong>" index?</div>
+                                <div class="prompt-text prompt-text-bottom">To confirm the action, please type "<b>delete </b><strong><span></span></strong>".</div>
                             </div>
                             <input type="text" id="del-index-name-input" class="prompt-input">
                             <div class="btncontainer">

--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -869,18 +869,6 @@ div.show-record-popup .ui-dialog-buttonpane button {
     background-color: var(--selected-filter-red);
 }
 
-#initial-response {
-    width: 100%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 24px;
-    color: var(--empty-response-text-color);
-    display: none;
-    text-align: center;
-}
-
 #empty-response {
     display: none;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -348,10 +348,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div class="json-popup"></div>
             </div>
             <div id="empty-response"></div>
-            <div id="initial-response">Create a query using the builder to access and view the logs.</div>
-
-
-
             <div id="corner-popup">
                 <div class="corner-container">
                     <div class="corner-text" id="corner-text"></div>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -95,7 +95,6 @@ function showError(errorMsg) {
     $('#agg-result-container').hide();
     $('#data-row-container').hide();
     $('#empty-response').hide();
-    $('#initial-response').hide();
     $('#pagination-container').hide();
     let currentTab = $('#custom-chart-tab').tabs('option', 'active');
     if (currentTab == 0) {

--- a/static/js/log-search.js
+++ b/static/js/log-search.js
@@ -105,7 +105,6 @@ $(document).ready(async () => {
     if (window.location.search) {
         data = getInitialSearchFilter(false, false);
         initialSearchData = data;
-        doSearch(data);
     } else {
         setIndexDisplayValue(selectedSearchIndex);
         let stDate = Cookies.get('startEpoch') || 'now-15m';
@@ -123,8 +122,12 @@ $(document).ready(async () => {
         $('#run-filter-btn').html(' ');
         $('#query-builder-btn').html(' ');
         $('#custom-chart-tab').hide();
-        $('#initial-response').show();
+
+        //No query string found, using default search filter
+        data = getSearchFilter(false, false, true);
     }
+
+    doSearch(data);
 
     initializePagination();
     const pageSizeSelect = document.getElementById('page-size-select');
@@ -225,5 +228,3 @@ $(document).ready(async () => {
 
     initializeFilterInputEvents();
 });
-
-


### PR DESCRIPTION
# Description
- Implemented a default search when the user lands on the Logs screen, now automatically runs: `* | head 10`.
- Improves user experience by immediately showing sample data.
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/0669b80d-5b25-4b86-9818-8ad69441820f" />
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/b3f77f99-e69e-43ff-a872-a75d59a85d95" />

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
