### PR TITLE
Fix failing E2E tests

### DIFF
--- a/cicd/metrics_test.csv
+++ b/cicd/metrics_test.csv
@@ -25,9 +25,9 @@ rad(testmetric2),now-90d,now,"",approx,"","",false
 "clamp(testmetric1{car_type=""Passenger car compact"",color=""aqua"",group=""group 1""}, -10, 100)",now-90d,now,"100",eq,"","",false
 "clamp_max(testmetric3, 99)",now-90d,now,"",approx,"","",false
 "clamp_min(testmetric3, 0)",now-90d,now,"",approx,"","",false
-"rate(testmetric3{color='black'}[48h:15m])",now-1h,now,"",approx,"","",true
+"rate(testmetric3{color=""black""}[48h:15m])",now-1h,now,"",approx,"","",true
 irate(testmetric3[48h]),now-90d,now,"0.0009225785356323284,0.005768872166720863",approx,"","",true
-"increase(testmetric3{color='black'}[48h:15m])",now-1h,now,"",approx,"","",true
+"increase(testmetric3{color=""black""}[48h:15m])",now-1h,now,"",approx,"","",true
 delta(testmetric3[48h]),now-90d,now,"79.71078547863307,578.1413406833155",approx,"","",true
 idelta(testmetric3[48h]),now-90d,now,"79.71078547863327,498.4305552046825",approx,"","",true
 changes(testmetric4[24h]),now-90d,now,"0,1,1",eq,"","",true
@@ -60,14 +60,14 @@ day_of_week(testmetric0),now-90d,now,"",gt,"","",false
 day_of_year(testmetric0),now-90d,now,"",gt,"","",false
 "days_in_month(testmetric1{car_type=""Passenger car compact"",color=""aqua"",group=""group 1""})",now-90d,now,"32",lt,"","",false
 days_in_month(testmetric0),now-90d,now,"",gt,"","",false
-"avg({__name__=~'testmetric.*'})",now-90d,now,"163.13171934207875,133.61927559580516,-20.18911392543914",approx,"*","",false
-"avg ({__name__!~'testmetric(2)', fuel_type='LPG', color='maroon'}) by (__name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric3","",false
-"avg ({__name__=~'testmetric(0|1|2|3|4)', color='maroon'}) by (color, group, __name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric2,testmetric3,testmetric4","color:maroon,group:group 1,__,color:maroon,group:group 0",false
-"avg ({__name__=~'testmetric(0|1|2|3|4)', color='maroon'}) by (color, group)",now-90d,now,"",approx,"*","color:maroon,group:group 1,__,color:maroon,group:group 0",false
-"avg ({__name__=~'testmetric(2|3)', fuel_type='LPG', color=~'g.*'}) by (__name__)",now-90d,now,"",approx,"testmetric2,testmetric3","",false
-"count(testmetric0{car_type='Passenger car compact'})",now-90d,now,"11,8,21",eq,"","",false
+"avg({__name__=~""testmetric.*""})",now-90d,now,"163.13171934207875,133.61927559580516,-20.18911392543914",approx,"*","",false
+"avg ({__name__!~""testmetric(2)"", fuel_type=""LPG"", color=""maroon""}) by (__name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric3","",false
+"avg ({__name__=~""testmetric(0|1|2|3|4)"", color=""maroon""}) by (color, group, __name__)",now-90d,now,"",approx,"testmetric0,testmetric1,testmetric2,testmetric3,testmetric4","color=""maroon"",group=""group 1"",__,color=""maroon"",group=""group 0""",false
+"avg ({__name__=~""testmetric(0|1|2|3|4)"", color=""maroon""}) by (color, group)",now-90d,now,"",approx,"*","color=""maroon"",group=""group 1"",__,color=""maroon"",group=""group 0""",false
+"avg ({__name__=~""testmetric(2|3)"", fuel_type=""LPG"", color=~""g.*""}) by (__name__)",now-90d,now,"",approx,"testmetric2,testmetric3","",false
+"count(testmetric0{car_type=""Passenger car compact""})",now-90d,now,"11,8,21",eq,"","",false
 "count(group by (car_type) (testmetric0))",now-90d,now,"8,8,8",eq,"","",false
-"count(group by (car_type) (testmetric0{color=~'.+'}))",now-90d,now,"8,8,8",eq,"","",false
-"count(testmetric0{color=~'.+'})",now-90d,now,"69,68,90",eq,"","",false
-"label_replace(testmetric0{model=~'.*[0-9]+ci.*', group='group 1'}, 'model_number', '$1', 'model', '([0-9]+)ci.*')",now-90d,now,"","approx","testmetric0","group:group 1,model: 330ci Convertible,car_type:Passenger car mini,color:aqua,fuel_type:Diesel,model_number:330,__,group:group 1,model: 650ci Convertible,car_type:Van,color:maroon,fuel_type:Gasoline,model_number:650",false
-"label_replace(testmetric0{model=~'.*[0-9]+ci.*', group='group 1'}, 'model', '$number', 'model', '(?P<number>[0-9]+)ci.*')",now-90d,now,"","approx","testmetric0","group:group 1,model:650,car_type:Van,color:maroon,fuel_type:Gasoline,__,group:group 1,model:330,car_type:Passenger car mini,color:aqua,fuel_type:Diesel",false
+"count(group by (car_type) (testmetric0{color=~"".+""}))",now-90d,now,"8,8,8",eq,"","",false
+"count(testmetric0{color=~"".+""})",now-90d,now,"69,68,90",eq,"","",false
+"label_replace(testmetric0{model=~"".*[0-9]+ci.*"", group=""group 1""}, ""model_number"", ""$1"", ""model"", ""([0-9]+)ci.*"")",now-90d,now,"","approx","testmetric0","group=""group 1"",model="" 330ci Convertible"",car_type=""Passenger car mini"",color=""aqua"",fuel_type=""Diesel"",model_number=""330"",__,group=""group 1"",model="" 650ci Convertible"",car_type=""Van"",color=""maroon"",fuel_type=""Gasoline"",model_number=""650""",false
+"label_replace(testmetric0{model=~"".*[0-9]+ci.*"", group=""group 1""}, ""model"", ""$number"", ""model"", ""(?P<number>[0-9]+)ci.*"")",now-90d,now,"","approx","testmetric0","group=""group 1"",model=""650"",car_type=""Van"",color=""maroon"",fuel_type=""Gasoline"",__,group=""group 1"",model=""330"",car_type=""Passenger car mini"",color=""aqua"",fuel_type=""Diesel""",false

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -353,9 +353,9 @@ func GetSeriesIdWithoutFields(seriesId string, fields []string) string {
 }
 
 // getAggSeriesId returns the group seriesId for the aggregated series based on the given seriesId and groupByFields
-// The seriesId is in the format of "metricName{key1:value1,key2:value2,..."
+// The seriesId is in the format of "metricName{key1="value1",key2="value2",..."
 // If groupByFields is empty, it returns the "metricName{" as the group seriesId
-// If groupByFields is not empty, it returns the "metricName{key1:value1,key2:value2,..." as the group seriesId
+// If groupByFields is not empty, it returns the "metricName{key1="value1",key2="value2",..." as the group seriesId
 // Where key1, key2, ... are the groupByFields and value1, value2, ... are the values of the groupByFields in the seriesId
 // The groupByFields are extracted from the seriesId
 func getAggSeriesId(seriesId string, aggregation *structs.Aggregation) string {

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -297,19 +297,15 @@ func ExtractGroupByFieldsFromSeriesId(seriesId string, groupByFields []string) (
 	var groupKeyValuePairs []string
 	var values []string
 	for _, field := range groupByFields {
-		start := strings.Index(seriesId, field+":")
-		if start == -1 {
+		pattern := field + "=\"([^\"]+)\""
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(seriesId)
+		if len(matches) < 2 {
 			continue
 		}
-		start += len(field) + 1 // +1 to skip the ':'
-		end := strings.Index(seriesId[start:], ",")
-		if end == -1 {
-			end = len(seriesId)
-		} else {
-			end += start
-		}
-		keyValuePair := fmt.Sprintf("%s:%s", field, seriesId[start:end])
-		values = append(values, seriesId[start:end])
+		value := matches[1]
+		keyValuePair := fmt.Sprintf("%s=\"%s\"", field, value)
+		values = append(values, value)
 		groupKeyValuePairs = append(groupKeyValuePairs, keyValuePair)
 	}
 	return groupKeyValuePairs, values
@@ -325,31 +321,34 @@ func GetSeriesIdWithoutFields(seriesId string, fields []string) string {
 		fieldsSet[field] = struct{}{}
 	}
 
-	parts := strings.Split(seriesId, ",")
-	var filteredParts []string
-	var metricName string
+	splitVals := strings.SplitN(seriesId, "{", 2)
+	metricName := splitVals[0]
+	
+	if len(splitVals) < 2 {
+		return seriesId
+	}
+	
+	tagsString := splitVals[1]
+	tags := strings.Split(tagsString, ",")
+	var filteredTags []string
 
-	for i, part := range parts {
-		if i == 0 {
-			splitVals := strings.SplitN(part, "{", 2)
-			metricName = splitVals[0]
-
-			if len(splitVals) == 2 {
-				part = splitVals[1]
-			}
-		}
-
-		keyValue := strings.SplitN(part, ":", 2)
-		if len(keyValue) == 2 {
-			if _, exists := fieldsSet[keyValue[0]]; exists {
+	for _, tag := range tags {
+		// Extract the tag key using regex
+		re := regexp.MustCompile(`^([^=]+)=`)
+		matches := re.FindStringSubmatch(tag)
+		if len(matches) >= 2 {
+			key := matches[1]
+			if _, exists := fieldsSet[key]; exists {
 				continue
 			}
 		}
-
-		filteredParts = append(filteredParts, part)
+		
+		if len(tag) > 0 {
+			filteredTags = append(filteredTags, tag)
+		}
 	}
 
-	return metricName + "{" + strings.Join(filteredParts, ",")
+	return metricName + "{" + strings.Join(filteredTags, ",")
 }
 
 // getAggSeriesId returns the group seriesId for the aggregated series based on the given seriesId and groupByFields
@@ -625,7 +624,7 @@ func getHistogramBins(seriesIds []string, results map[string]map[uint32]float64)
 
 func extractAndRemoveLeFromSeriesId(seriesId string) (string, float64, bool, error) {
 	// Regex pattern to find le="VALUE" and capture the VALUE
-	re := regexp.MustCompile(`le:(\+?Inf|-?Inf|-?[0-9.]+),?`)
+	re := regexp.MustCompile(`le="(\+?Inf|-?Inf|-?[0-9.]+)",?`)
 
 	matches := re.FindStringSubmatch(seriesId)
 	var leValueStr string
@@ -754,20 +753,18 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 }
 
 func getPromQLSeriesFormat(seriesId string) map[string]string {
-	tagValues := strings.Split(RemoveTrailingComma(seriesId), tsidtracker.TAG_VALUE_DELIMITER_STR)
-
-	var keyValue []string
 	metric := make(map[string]string)
 	metric["__name__"] = ExtractMetricNameFromGroupID(seriesId)
-	for idx, val := range tagValues {
-		if idx == 0 {
-			keyValue = strings.SplitN(removeMetricNameFromGroupID(val), ":", 2)
-		} else {
-			keyValue = strings.SplitN(val, ":", 2)
-		}
-
-		if len(keyValue) > 1 {
-			metric[keyValue[0]] = keyValue[1]
+	
+	// Extract tags using regex
+	re := regexp.MustCompile(`([^,{]+)="([^"]+)"`)
+	matches := re.FindAllStringSubmatch(seriesId, -1)
+	
+	for _, match := range matches {
+		if len(match) == 3 {
+			key := match[1]
+			value := match[2]
+			metric[key] = value
 		}
 	}
 

--- a/pkg/segment/results/mresults/metricresults.go
+++ b/pkg/segment/results/mresults/metricresults.go
@@ -297,14 +297,14 @@ func ExtractGroupByFieldsFromSeriesId(seriesId string, groupByFields []string) (
 	var groupKeyValuePairs []string
 	var values []string
 	for _, field := range groupByFields {
-		pattern := field + "=\"([^\"]+)\""
+		pattern := regexp.QuoteMeta(field) + `="([^"]+)"`
 		re := regexp.MustCompile(pattern)
 		matches := re.FindStringSubmatch(seriesId)
 		if len(matches) < 2 {
 			continue
 		}
 		value := matches[1]
-		keyValuePair := fmt.Sprintf("%s=\"%s\"", field, value)
+		keyValuePair := fmt.Sprintf(`%s="%s"`, field, value)
 		values = append(values, value)
 		groupKeyValuePairs = append(groupKeyValuePairs, keyValuePair)
 	}
@@ -323,11 +323,11 @@ func GetSeriesIdWithoutFields(seriesId string, fields []string) string {
 
 	splitVals := strings.SplitN(seriesId, "{", 2)
 	metricName := splitVals[0]
-	
+
 	if len(splitVals) < 2 {
 		return seriesId
 	}
-	
+
 	tagsString := splitVals[1]
 	tags := strings.Split(tagsString, ",")
 	var filteredTags []string
@@ -342,7 +342,7 @@ func GetSeriesIdWithoutFields(seriesId string, fields []string) string {
 				continue
 			}
 		}
-		
+
 		if len(tag) > 0 {
 			filteredTags = append(filteredTags, tag)
 		}
@@ -755,11 +755,11 @@ func (r *MetricsResult) GetOTSDBResults(mQuery *structs.MetricsQuery) ([]*struct
 func getPromQLSeriesFormat(seriesId string) map[string]string {
 	metric := make(map[string]string)
 	metric["__name__"] = ExtractMetricNameFromGroupID(seriesId)
-	
+
 	// Extract tags using regex
 	re := regexp.MustCompile(`([^,{]+)="([^"]+)"`)
 	matches := re.FindAllStringSubmatch(seriesId, -1)
-	
+
 	for _, match := range matches {
 		if len(match) == 3 {
 			key := match[1]

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
-	seriesId := "test{tk1:v1,tk2:v2"
+	seriesId := `test{tk1:v1,tk2:v2`
 	groupByFields := []string{"tk1", "tk2"}
 
 	aggregation := &structs.Aggregation{
@@ -36,23 +36,23 @@ func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
+	assert.Equal(t, `test{tk1:v1,tk2:v2`, aggSeriesId)
 
 	// trailing comma
-	seriesId = "test{tk1:v1,tk2:v2,"
+	seriesId = `test{tk1:v1,tk2:v2,`
 	aggSeriesId = getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{tk1:v1,tk2:v2", aggSeriesId)
+	assert.Equal(t, `test{tk1:v1,tk2:v2`, aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupBy(t *testing.T) {
-	seriesId := "test{"
+	seriesId := `test{`
 
 	aggSeriesId := getAggSeriesId(seriesId, nil)
-	assert.Equal(t, "test{", aggSeriesId)
+	assert.Equal(t, `test{`, aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithGroupByAndNoGroupByFields(t *testing.T) {
-	seriesId := "test{tk1:v1,tk2:v2"
+	seriesId := `test{tk1:v1,tk2:v2`
 	groupByFields := make([]string, 0)
 
 	aggregation := &structs.Aggregation{
@@ -60,22 +60,22 @@ func Test_getAggSeriesId_SeriesWithGroupByAndNoGroupByFields(t *testing.T) {
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{", aggSeriesId)
+	assert.Equal(t, `test{`, aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupByAndEmptyGroupByFields(t *testing.T) {
-	seriesId := "test{"
+	seriesId := `test{`
 
 	aggregation := &structs.Aggregation{
 		GroupByFields: []string{},
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{", aggSeriesId)
+	assert.Equal(t, `test{`, aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
-	seriesId := "test{tk1:v1,tk2:v2,tk3:v3,tk4:v4,tk5:v5"
+	seriesId := `test{tk1:v1,tk2:v2,tk3:v3,tk4:v4,tk5:v5`
 
 	aggregation := &structs.Aggregation{
 		Without: true,
@@ -87,12 +87,12 @@ func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{tk2:v2,tk4:v4", aggSeriesId)
+	assert.Equal(t, `test{tk2:v2,tk4:v4`, aggSeriesId)
 
 	// value has `:` in it
-	seriesId = "test{tk1:v1:1,tk2:v2,tk3:v3:3,tk4:v4,tk5:v5:5"
+	seriesId = `test{tk1:v1:1,tk2:v2,tk3:v3:3,tk4:v4,tk5:v5:5`
 	aggSeriesId = getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, "test{tk2:v2,tk4:v4", aggSeriesId)
+	assert.Equal(t, `test{tk2:v2,tk4:v4`, aggSeriesId)
 }
 
 func Test_ApplyAggregationToResults_NoGroupBy_Single_Series(t *testing.T) {
@@ -105,7 +105,7 @@ func Test_ApplyAggregationToResults_NoGroupBy_Single_Series(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId := "test{"
+	seriesId := `test{`
 
 	results[seriesId] = make(map[uint32]float64, 0)
 	results[seriesId][1] = 1.0
@@ -137,8 +137,8 @@ func Test_ApplyAggregationToResults_NoGroupBy_Multiple_Series(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := "test{tk1:v1,tk2:v2}"
-	seriesId2 := "test{tk1:v1,tk2:v3}"
+	seriesId1 := `test{tk1:v1,tk2:v2}`
+	seriesId2 := `test{tk1:v1,tk2:v3}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -150,7 +150,7 @@ func Test_ApplyAggregationToResults_NoGroupBy_Multiple_Series(t *testing.T) {
 	results[seriesId2][2] = 5.0
 	results[seriesId2][3] = 6.0
 
-	aggSeriesId := "test{"
+	aggSeriesId := `test{`
 
 	mResult.Results = results
 
@@ -177,7 +177,7 @@ func Test_ApplyAggregationToResults_GroupBy_Single_Series(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId := "test{tk1:v1,tk2:v2"
+	seriesId := `test{tk1:v1,tk2:v2`
 
 	results[seriesId] = make(map[uint32]float64, 0)
 	results[seriesId][1] = 1.0
@@ -191,7 +191,7 @@ func Test_ApplyAggregationToResults_GroupBy_Single_Series(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId := "test{tk1:v1"
+	aggSeriesId := `test{tk1:v1`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -214,8 +214,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v1(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := "test{tk1:v1,tk2:v2}"
-	seriesId2 := "test{tk1:v1,tk2:v3}"
+	seriesId1 := `test{tk1:v1,tk2:v2}`
+	seriesId2 := `test{tk1:v1,tk2:v3}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -234,7 +234,7 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v1(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId := "test{tk1:v1"
+	aggSeriesId := `test{tk1:v1`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -257,8 +257,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v2(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := "test{tk1:v1,tk2:v2}"
-	seriesId2 := "test{tk1:v2,tk2:v3}"
+	seriesId1 := `test{tk1:v1,tk2:v2}`
+	seriesId2 := `test{tk1:v2,tk2:v3}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -277,8 +277,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v2(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId1 := "test{tk1:v1"
-	aggSeriesId2 := "test{tk1:v2"
+	aggSeriesId1 := `test{tk1:v1`
+	aggSeriesId2 := `test{tk1:v2`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -306,10 +306,10 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v3(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := "test{tk1:v1,tk2:v2"
-	seriesId2 := "test{tk1:v2,tk2:v3,"
-	seriesId3 := "test{tk1:v1,tk2:v2,tk3:v1"
-	seriesId4 := "test{tk1:v2,tk3:v3"
+	seriesId1 := `test{tk1:v1,tk2:v2`
+	seriesId2 := `test{tk1:v2,tk2:v3,`
+	seriesId3 := `test{tk1:v1,tk2:v2,tk3:v1`
+	seriesId4 := `test{tk1:v2,tk3:v3`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -338,9 +338,9 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v3(t *testing.T) {
 		GroupByFields:      []string{"tk1", "tk2"},
 	}
 
-	aggSeriesId1 := "test{tk1:v1,tk2:v2"
-	aggSeriesId2 := "test{tk1:v2,tk2:v3"
-	aggSeriesId3 := "test{tk1:v2"
+	aggSeriesId1 := `test{tk1:v1,tk2:v2`
+	aggSeriesId2 := `test{tk1:v2,tk2:v3`
+	aggSeriesId3 := `test{tk1:v2`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -360,9 +360,9 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v3(t *testing.T) {
 }
 
 func Test_extractAndRemoveleFromSeriesId(t *testing.T) {
-	seriesId := "demo_api_request_duration_seconds_bucket{instance:demo.promlabs.com:10000,job:demo,le:0.14778918800354002,method:POST,path:/api/foo,status:200,"
+	seriesId := `demo_api_request_duration_seconds_bucket{instance="demo.promlabs.com:10000",job="demo",le="0.14778918800354002",method="POST",path="/api/foo",status="200",`
 	expectedLeValue := 0.14778918800354002
-	expectedSeriesId := "demo_api_request_duration_seconds_bucket{instance:demo.promlabs.com:10000,job:demo,method:POST,path:/api/foo,status:200"
+	expectedSeriesId := `demo_api_request_duration_seconds_bucket{instance="demo.promlabs.com:10000",job="demo",method="POST",path="/api/foo",status="200"`
 
 	newSeriesId, leValue, hasLe, err := extractAndRemoveLeFromSeriesId(seriesId)
 	assert.Nil(t, err)
@@ -370,9 +370,9 @@ func Test_extractAndRemoveleFromSeriesId(t *testing.T) {
 	assert.Equal(t, expectedLeValue, leValue)
 	assert.Equal(t, expectedSeriesId, newSeriesId)
 
-	seriesId = "metric{k1:v1,k2:v2,le:+Inf,"
+	seriesId = `metric{k1="v1",k2="v2",le="+Inf",`
 	expectedLeValue = math.Inf(1)
-	expectedSeriesId = "metric{k1:v1,k2:v2"
+	expectedSeriesId = `metric{k1="v1",k2="v2"`
 
 	newSeriesId, leValue, hasLe, err = extractAndRemoveLeFromSeriesId(seriesId)
 	assert.Nil(t, err)
@@ -380,9 +380,9 @@ func Test_extractAndRemoveleFromSeriesId(t *testing.T) {
 	assert.Equal(t, expectedLeValue, leValue)
 	assert.Equal(t, expectedSeriesId, newSeriesId)
 
-	seriesId = "metric{k1:v1,k2:v2,le:-Inf,"
+	seriesId = `metric{k1="v1",k2="v2",le="-Inf",`
 	expectedLeValue = math.Inf(-1)
-	expectedSeriesId = "metric{k1:v1,k2:v2"
+	expectedSeriesId = `metric{k1="v1",k2="v2"`
 
 	newSeriesId, leValue, hasLe, err = extractAndRemoveLeFromSeriesId(seriesId)
 	assert.Nil(t, err)
@@ -390,9 +390,9 @@ func Test_extractAndRemoveleFromSeriesId(t *testing.T) {
 	assert.Equal(t, expectedLeValue, leValue)
 	assert.Equal(t, expectedSeriesId, newSeriesId)
 
-	seriesId = "metric{k1:v1,k2:v2,le:-0.134433,k3:v3,"
+	seriesId = `metric{k1="v1",k2="v2",le="-0.134433",k3="v3",`
 	expectedLeValue = -0.134433
-	expectedSeriesId = "metric{k1:v1,k2:v2,k3:v3"
+	expectedSeriesId = `metric{k1="v1",k2="v2",k3="v3"`
 
 	newSeriesId, leValue, hasLe, err = extractAndRemoveLeFromSeriesId(seriesId)
 	assert.Nil(t, err)
@@ -403,12 +403,12 @@ func Test_extractAndRemoveleFromSeriesId(t *testing.T) {
 
 func Test_getHistogramBins(t *testing.T) {
 	seriesIds := []string{
-		"test1{tk1:v1,tk2:v2,le:0.1,tk3:v3",
-		"test2{tk1:v1,tk2:v2,le:0.2,tk3:v3",
-		"test3{tk1:v1,tk2:v2,le:0.3,",
-		"test4{tk1:v1,tk2:v2,tk5:v5,", // missing le, should be ignored
-		"test1{tk1:v1,tk2:v2,le:0.2,tk3:v3",
-		"test2{tk1:v1,tk2:v2,le:0.3,tk3:v3",
+		`test1{tk1="v1",tk2="v2",le="0.1",tk3="v3"`,
+		`test2{tk1="v1",tk2="v2",le="0.2",tk3="v3"`,
+		`test3{tk1="v1",tk2="v2",le="0.3",`,
+		`test4{tk1="v1",tk2="v2",tk5="v5",`, // missing le, should be ignored
+		`test1{tk1="v1",tk2="v2",le="0.2",tk3="v3"`,
+		`test2{tk1="v1",tk2="v2",le="0.3",tk3="v3"`,
 	}
 
 	results := make(map[string]map[uint32]float64, 0)
@@ -424,7 +424,7 @@ func Test_getHistogramBins(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(binsPerSeries))
 
-	bins1 := binsPerSeries["test1{tk1:v1,tk2:v2,tk3:v3"]
+	bins1 := binsPerSeries[`test1{tk1="v1",tk2="v2",tk3="v3"`]
 	assert.Equal(t, 3, len(bins1))
 	assert.Contains(t, bins1, uint32(1))
 	assert.Contains(t, bins1, uint32(2))
@@ -445,7 +445,7 @@ func Test_getHistogramBins(t *testing.T) {
 	assert.Equal(t, 3.0, bins1[3][1].count)
 	assert.Equal(t, 0.2, bins1[3][1].upperBound)
 
-	bins2 := binsPerSeries["test2{tk1:v1,tk2:v2,tk3:v3"]
+	bins2 := binsPerSeries[`test2{tk1="v1",tk2="v2",tk3="v3"`]
 	assert.Equal(t, 3, len(bins2))
 	assert.Contains(t, bins2, uint32(1))
 	assert.Contains(t, bins2, uint32(2))
@@ -466,7 +466,7 @@ func Test_getHistogramBins(t *testing.T) {
 	assert.Equal(t, 3.0, bins2[3][1].count)
 	assert.Equal(t, 0.3, bins2[3][1].upperBound)
 
-	bins3 := binsPerSeries["test3{tk1:v1,tk2:v2"]
+	bins3 := binsPerSeries[`test3{tk1="v1",tk2="v2"`]
 	assert.Equal(t, 3, len(bins3))
 	assert.Contains(t, bins3, uint32(1))
 	assert.Contains(t, bins3, uint32(2))

--- a/pkg/segment/results/mresults/metricresults_test.go
+++ b/pkg/segment/results/mresults/metricresults_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
-	seriesId := `test{tk1:v1,tk2:v2`
+	seriesId := `test{tk1="v1",tk2="v2"`
 	groupByFields := []string{"tk1", "tk2"}
 
 	aggregation := &structs.Aggregation{
@@ -36,12 +36,12 @@ func Test_getAggSeriesId_SeriesWithGroupBy(t *testing.T) {
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, `test{tk1:v1,tk2:v2`, aggSeriesId)
+	assert.Equal(t, `test{tk1="v1",tk2="v2"`, aggSeriesId)
 
 	// trailing comma
-	seriesId = `test{tk1:v1,tk2:v2,`
+	seriesId = `test{tk1="v1",tk2="v2",`
 	aggSeriesId = getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, `test{tk1:v1,tk2:v2`, aggSeriesId)
+	assert.Equal(t, `test{tk1="v1",tk2="v2"`, aggSeriesId)
 }
 
 func Test_getAggSeriesId_SeriesWithoutGroupBy(t *testing.T) {
@@ -52,7 +52,7 @@ func Test_getAggSeriesId_SeriesWithoutGroupBy(t *testing.T) {
 }
 
 func Test_getAggSeriesId_SeriesWithGroupByAndNoGroupByFields(t *testing.T) {
-	seriesId := `test{tk1:v1,tk2:v2`
+	seriesId := `test{tk1="v1",tk2="v2"`
 	groupByFields := make([]string, 0)
 
 	aggregation := &structs.Aggregation{
@@ -75,7 +75,7 @@ func Test_getAggSeriesId_SeriesWithoutGroupByAndEmptyGroupByFields(t *testing.T)
 }
 
 func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
-	seriesId := `test{tk1:v1,tk2:v2,tk3:v3,tk4:v4,tk5:v5`
+	seriesId := `test{tk1="v1",tk2="v2",tk3="v3",tk4="v4",tk5="v5"`
 
 	aggregation := &structs.Aggregation{
 		Without: true,
@@ -87,12 +87,12 @@ func Test_getAggSeriesId_SeriesWithoutFlagSet(t *testing.T) {
 	}
 
 	aggSeriesId := getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, `test{tk2:v2,tk4:v4`, aggSeriesId)
+	assert.Equal(t, `test{tk2="v2",tk4="v4"`, aggSeriesId)
 
 	// value has `:` in it
-	seriesId = `test{tk1:v1:1,tk2:v2,tk3:v3:3,tk4:v4,tk5:v5:5`
+	seriesId = `test{tk1="v1"="1",tk2="v2",tk3="v3"="3",tk4="v4",tk5="v5"="5"`
 	aggSeriesId = getAggSeriesId(seriesId, aggregation)
-	assert.Equal(t, `test{tk2:v2,tk4:v4`, aggSeriesId)
+	assert.Equal(t, `test{tk2="v2",tk4="v4"`, aggSeriesId)
 }
 
 func Test_ApplyAggregationToResults_NoGroupBy_Single_Series(t *testing.T) {
@@ -137,8 +137,8 @@ func Test_ApplyAggregationToResults_NoGroupBy_Multiple_Series(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := `test{tk1:v1,tk2:v2}`
-	seriesId2 := `test{tk1:v1,tk2:v3}`
+	seriesId1 := `test{tk1="v1",tk2="v2"}`
+	seriesId2 := `test{tk1="v1",tk2="v3"}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -177,7 +177,7 @@ func Test_ApplyAggregationToResults_GroupBy_Single_Series(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId := `test{tk1:v1,tk2:v2`
+	seriesId := `test{tk1="v1",tk2="v2"`
 
 	results[seriesId] = make(map[uint32]float64, 0)
 	results[seriesId][1] = 1.0
@@ -191,7 +191,7 @@ func Test_ApplyAggregationToResults_GroupBy_Single_Series(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId := `test{tk1:v1`
+	aggSeriesId := `test{tk1="v1"`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -214,8 +214,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v1(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := `test{tk1:v1,tk2:v2}`
-	seriesId2 := `test{tk1:v1,tk2:v3}`
+	seriesId1 := `test{tk1="v1",tk2="v2"}`
+	seriesId2 := `test{tk1="v1",tk2="v3"}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -234,7 +234,7 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v1(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId := `test{tk1:v1`
+	aggSeriesId := `test{tk1="v1"`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -257,8 +257,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v2(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := `test{tk1:v1,tk2:v2}`
-	seriesId2 := `test{tk1:v2,tk2:v3}`
+	seriesId1 := `test{tk1="v1",tk2="v2"}`
+	seriesId2 := `test{tk1="v2",tk2="v3"}`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -277,8 +277,8 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v2(t *testing.T) {
 		GroupByFields:      []string{"tk1"},
 	}
 
-	aggSeriesId1 := `test{tk1:v1`
-	aggSeriesId2 := `test{tk1:v2`
+	aggSeriesId1 := `test{tk1="v1"`
+	aggSeriesId2 := `test{tk1="v2"`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))
@@ -306,10 +306,10 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v3(t *testing.T) {
 
 	results := make(map[string]map[uint32]float64, 0)
 
-	seriesId1 := `test{tk1:v1,tk2:v2`
-	seriesId2 := `test{tk1:v2,tk2:v3,`
-	seriesId3 := `test{tk1:v1,tk2:v2,tk3:v1`
-	seriesId4 := `test{tk1:v2,tk3:v3`
+	seriesId1 := `test{tk1="v1",tk2="v2"`
+	seriesId2 := `test{tk1="v2",tk2="v3",`
+	seriesId3 := `test{tk1="v1",tk2="v2",tk3="v1"`
+	seriesId4 := `test{tk1="v2",tk3="v3"`
 
 	results[seriesId1] = make(map[uint32]float64, 0)
 	results[seriesId1][1] = 1.0
@@ -338,9 +338,9 @@ func Test_ApplyAggregationToResults_GroupBy_Multiple_Series_v3(t *testing.T) {
 		GroupByFields:      []string{"tk1", "tk2"},
 	}
 
-	aggSeriesId1 := `test{tk1:v1,tk2:v2`
-	aggSeriesId2 := `test{tk1:v2,tk2:v3`
-	aggSeriesId3 := `test{tk1:v2`
+	aggSeriesId1 := `test{tk1="v1",tk2="v2"`
+	aggSeriesId2 := `test{tk1="v2",tk2="v3"`
+	aggSeriesId3 := `test{tk1="v2"`
 
 	errors := mResult.ApplyAggregationToResults(parallelism, aggregation)
 	assert.Equal(t, 0, len(errors))

--- a/pkg/segment/results/mresults/seriesresult.go
+++ b/pkg/segment/results/mresults/seriesresult.go
@@ -354,7 +354,7 @@ func applyLabelReplace(seriesId string, labelFunction *structs.LabelFunctionExpr
 	}
 
 	if labelFunction.SourceLabel == "" {
-		seriesId = fmt.Sprintf("%s,%s:%s", seriesId, labelFunction.DestinationLabel, labelFunction.Replacement.NameBasedVal)
+		seriesId = fmt.Sprintf(`%s,%s="%s"`, seriesId, labelFunction.DestinationLabel, labelFunction.Replacement.NameBasedVal)
 		return seriesId, nil
 	}
 
@@ -388,10 +388,10 @@ func applyLabelReplace(seriesId string, labelFunction *structs.LabelFunctionExpr
 		return seriesId, fmt.Errorf("applyLabelReplace: unsupported key type %v", labelFunction.Replacement.KeyType)
 	}
 
-	pattern := fmt.Sprintf(`\b%s:[^,]*`, labelFunction.DestinationLabel)
-	replacement := fmt.Sprintf("%s:%s", labelFunction.DestinationLabel, replacementValue)
+	pattern := fmt.Sprintf(`\b%s="[^"]*"`, labelFunction.DestinationLabel)
+	replacement := fmt.Sprintf(`%s="%s"`, labelFunction.DestinationLabel, replacementValue)
 
-	// Use regex to replace the entire "key:value" pair
+	// Use regex to replace the entire "key="value"" pair
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return seriesId, fmt.Errorf("applyLabelReplace:  Error compiling regex pattern with destination label. Err=%v", err)
@@ -400,7 +400,7 @@ func applyLabelReplace(seriesId string, labelFunction *structs.LabelFunctionExpr
 		seriesId = re.ReplaceAllString(seriesId, replacement)
 	} else {
 		// If the key is not found, append it
-		seriesId = fmt.Sprintf("%s%s,", seriesId, replacement)
+		seriesId = fmt.Sprintf(`%s%s,`, seriesId, replacement)
 	}
 
 	return seriesId, nil

--- a/pkg/segment/results/mresults/seriesresult_test.go
+++ b/pkg/segment/results/mresults/seriesresult_test.go
@@ -2024,7 +2024,7 @@ func Test_applyRangeFunctionMADOverTime(t *testing.T) {
 }
 
 func Test_applyLabelReplace(t *testing.T) {
-	initSeriesId := `process_runtime_go_goroutines{job:product-catalog,`
+	initSeriesId := `process_runtime_go_goroutines{job="product-catalog",`
 
 	labelFunctionExpr := &structs.LabelFunctionExpr{
 		FunctionType:     segutils.LabelReplace,
@@ -2042,7 +2042,7 @@ func Test_applyLabelReplace(t *testing.T) {
 	err := labelFunctionExpr.GobRegexp.SetRegex(rawRegex)
 	assert.Nil(t, err)
 
-	expectedSeriesId := `process_runtime_go_goroutines{job:product-catalog,newLabel:product,`
+	expectedSeriesId := `process_runtime_go_goroutines{job="product-catalog",newLabel="product",`
 
 	seriesId, err := applyLabelReplace(initSeriesId, labelFunctionExpr)
 	assert.Nil(t, err)
@@ -2055,7 +2055,7 @@ func Test_applyLabelReplace(t *testing.T) {
 	labelFunctionExpr.Replacement.KeyType = structs.IndexBased
 	labelFunctionExpr.Replacement.IndexBasedVal = 1
 
-	expectedSeriesId = `process_runtime_go_goroutines{job:product,`
+	expectedSeriesId = `process_runtime_go_goroutines{job="product",`
 
 	seriesId, err = applyLabelReplace(initSeriesId, labelFunctionExpr)
 	assert.Nil(t, err)


### PR DESCRIPTION
# Description
https://github.com/siglens/siglens/pull/2548 broke some E2E tests when converting the series Id format from `metric{key1:value1` to `metric{key1="value1"`. This PR fixes those tests.

# Testing
Ran unit and E2E tests