### PR TITLE
Handle range queries that return multiple series

### DIFF
--- a/pkg/segment/query/metricsevaluator/evaluator.go
+++ b/pkg/segment/query/metricsevaluator/evaluator.go
@@ -69,9 +69,9 @@ func NewEvaluator(reader DiskReader, startEpochSec, endEpochSec, step uint32, qu
 	}
 }
 
-func (sr *SeriesResult) GetSeriesId() SeriesId {
-	keys := make([]string, 0, len(sr.Labels))
-	for k := range sr.Labels {
+func GetSeriesId(labels map[string]string) SeriesId {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -80,7 +80,7 @@ func (sr *SeriesResult) GetSeriesId() SeriesId {
 	for _, k := range keys {
 		b.WriteString(k)
 		b.WriteString("=")
-		b.WriteString(sr.Labels[k])
+		b.WriteString(labels[k])
 		b.WriteString(",")
 	}
 	return SeriesId(b.String())
@@ -111,7 +111,7 @@ func (e *Evaluator) EvalExpr(expr parser.Expr) ([]*SeriesResult, error) {
 				continue
 			}
 
-			seriesId := series.GetSeriesId()
+			seriesId := GetSeriesId(series.Labels)
 			if i, ok := idToIndex[seriesId]; ok {
 				allSeries[i].Values = append(allSeries[i].Values, series.Values...)
 			} else {

--- a/pkg/segment/query/metricsquery.go
+++ b/pkg/segment/query/metricsquery.go
@@ -674,6 +674,14 @@ func asRangeQueryResponse(allSeries []*metricsevaluator.SeriesResult) *structs.M
 		data.Result = append(data.Result, matrixResult)
 	}
 
+	getKey := func(rvr structs.RangeVectorResult) metricsevaluator.SeriesId {
+		return metricsevaluator.GetSeriesId(rvr.Metric)
+	}
+	less := func(a, b metricsevaluator.SeriesId) bool {
+		return a < b
+	}
+	data.Result = toputils.SortByComputedKey(data.Result, getKey, less)
+
 	return &structs.MetricsPromQLRangeQueryResponse{
 		Status: "success",
 		Data:   &data,

--- a/pkg/segment/query/metricsquery_test.go
+++ b/pkg/segment/query/metricsquery_test.go
@@ -189,9 +189,12 @@ func Test_ExecuteRangeQuery(t *testing.T) {
 			},
 		}
 
-		assertRangeQueryYieldsJson(t, mockReader, 1699999998, 1700000002, 1, `metric`,
-			`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"metric","bucket":"b1"},"values":[[1700000000,"10"],[1700000001,"10"],[1700000002,"10"]]},{"metric":{"__name__":"metric","bucket":"b10"},"values":[[1700000000,"100"],[1700000001,"100"],[1700000002,"100"]]},{"metric":{"__name__":"metric","bucket":"b11"},"values":[[1700000000,"110"],[1700000001,"110"],[1700000002,"110"]]},{"metric":{"__name__":"metric","bucket":"b2"},"values":[[1700000000,"20"],[1700000001,"20"],[1700000002,"20"]]},{"metric":{"__name__":"metric","bucket":"b20"},"values":[[1700000000,"200"],[1700000001,"200"],[1700000002,"200"]]},{"metric":{"__name__":"metric","bucket":"b9"},"values":[[1700000000,"90"],[1700000001,"90"],[1700000002,"90"]]}]}}`,
-		)
+		// Loop to check for flakiness.
+		for i := 0; i < 50; i++ {
+			assertRangeQueryYieldsJson(t, mockReader, 1699999998, 1700000002, 1, `metric`,
+				`{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"metric","bucket":"b1"},"values":[[1700000000,"10"],[1700000001,"10"],[1700000002,"10"]]},{"metric":{"__name__":"metric","bucket":"b10"},"values":[[1700000000,"100"],[1700000001,"100"],[1700000002,"100"]]},{"metric":{"__name__":"metric","bucket":"b11"},"values":[[1700000000,"110"],[1700000001,"110"],[1700000002,"110"]]},{"metric":{"__name__":"metric","bucket":"b2"},"values":[[1700000000,"20"],[1700000001,"20"],[1700000002,"20"]]},{"metric":{"__name__":"metric","bucket":"b20"},"values":[[1700000000,"200"],[1700000001,"200"],[1700000002,"200"]]},{"metric":{"__name__":"metric","bucket":"b9"},"values":[[1700000000,"90"],[1700000001,"90"],[1700000002,"90"]]}]}}`,
+			)
+		}
 	})
 }
 

--- a/pkg/utils/sliceutils_test.go
+++ b/pkg/utils/sliceutils_test.go
@@ -18,6 +18,9 @@
 package utils
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,4 +318,46 @@ func Test_ReverseSlice(t *testing.T) {
 	slice2 := []string{"a", "b", "c", "d"}
 	ReverseSlice(slice2)
 	assert.Equal(t, []string{"d", "c", "b", "a"}, slice2)
+}
+
+func Test_SortByComputedKey(t *testing.T) {
+	items := []map[string]string{
+		{"name": "Alice", "state": "Georgia"},
+		{"name": "Bob", "state": "Alabama"},
+		{"name": "Charlie", "state": "Alabama"},
+		{"name": "Alice", "state": "Alabama"},
+		{"name": "Bob", "state": "Georgia"},
+		{"name": "Charlie", "state": "Georgia"},
+		{"name": "Alice"},
+		{"name": "Bob"},
+		{"state": "Georgia"},
+	}
+	getKey := func(item map[string]string) string {
+		keys := GetKeysOfMap(item)
+		sort.Strings(keys)
+
+		sortedValues := make([]string, len(keys))
+		for i, key := range keys {
+			sortedValues[i] = fmt.Sprintf("(%s, %s)", key, item[key])
+		}
+
+		return strings.Join(sortedValues, ", ")
+	}
+
+	less := func(a, b string) bool {
+		return a < b
+	}
+
+	sortedItems := SortByComputedKey(items, getKey, less)
+	assert.Equal(t, sortedItems, []map[string]string{
+		{"name": "Alice"},
+		{"name": "Alice", "state": "Alabama"},
+		{"name": "Alice", "state": "Georgia"},
+		{"name": "Bob"},
+		{"name": "Bob", "state": "Alabama"},
+		{"name": "Bob", "state": "Georgia"},
+		{"name": "Charlie", "state": "Alabama"},
+		{"name": "Charlie", "state": "Georgia"},
+		{"state": "Georgia"},
+	})
 }


### PR DESCRIPTION
# Description
See title. One interesting thing: Prometheus always returns the series for a range query in a certain order (see [the doc](https://prometheus.io/docs/prometheus/latest/querying/api/#range-vectors)), but while they say "Series are returned sorted by metric" and the [`sort_by_label`](https://prometheus.io/docs/prometheus/latest/querying/functions/#sort_by_label) function uses normal sort, it seems that Prometheus uses lexicographical sort rather than normal sort on the series for a range query.

# Testing
New unit test. Also ingested some test data and then queried:
```
curl -G 'http://localhost:5122/promql/api/v1/query_range' \
  --data-urlencode 'query=testmetric0' \
  --data-urlencode 'start=1745347400' \
  --data-urlencode 'end=1745347500' \
  --data-urlencode 'step=10s' | jq
```
and the results looked correct (and were sorted)