### PR TITLE
Increase performance of reading all columns

### DIFF
--- a/pkg/utils/sliceutils_test.go
+++ b/pkg/utils/sliceutils_test.go
@@ -18,6 +18,7 @@
 package utils
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -332,4 +333,25 @@ func Test_ShallowCopySlice(t *testing.T) {
 	// modify new slice and make sure original one is unchanged
 	newSlice[4] = 456
 	assert.Equal(t, 5, slice[4])
+}
+
+func Test_ProcessWithParallelism(t *testing.T) {
+	slice := []int{1, 3, 5, 7, 9, 11, 13, 15}
+	results := make([]int, 0, len(slice))
+	lock := &sync.Mutex{}
+
+	operation := func(i int) error {
+		lock.Lock()
+		results = append(results, i*2)
+		lock.Unlock()
+
+		return nil
+	}
+
+	err := ProcessWithParallelism(3, slice, operation)
+	assert.NoError(t, err)
+	assert.Len(t, results, len(slice))
+	for _, original := range slice {
+		assert.Contains(t, results, original*2)
+	}
 }


### PR DESCRIPTION
# Description
For logs queries without a `stats` block, at the end of the query we have to read all the columns for all records that matched. We were doing this one column at a time; with this PR it's done in parallel. This improves query response times, but allocates about 50% more memory.

# Testing
1. Ingest:
```
go -C tools/sigclient run main.go ingest esbulk -n 2 -g benchmark -d http://localhost:8081/elastic -t 1_600_000 --enableVariableNumColumns --maxColumns 200
```
2. Run queries:
```
latency_c1<100000 AND question_c1="*truck*to*"
question_c1="*truck*to*"
*
```
3. Check the response time from the logs like:
```
INFO[2025-04-25 16:27:16] qid=2, Finished execution in 931.176292ms
```


With this PR, the corresponding query response times were: 1080 ms, 109 ms, 61 ms

Without this PR, the response times were: 6680 ms, 270 ms, 142 ms

After running all three queries, this PR had allocated 239 MB, while without this PR only 168 MB was allocated.

I ran these queries with `curl`