### PR TITLE
Optimize regex searches

### DIFF
--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package regex
+
+import "regexp"
+
+type Regex interface {
+	Match([]byte) bool
+}
+
+type simpleRegex struct {
+	wildcardBefore bool
+	word           []byte
+	wildcardAfter  bool
+}
+
+func New(pattern string) (Regex, error) {
+	return regexp.Compile(pattern)
+}

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -26,6 +26,7 @@ import (
 
 type Regex interface {
 	Match([]byte) bool
+	String() string
 }
 
 type simpleRegex struct {
@@ -33,6 +34,8 @@ type simpleRegex struct {
 	word           []byte
 	caseSensitive  bool
 	wildcardAfter  bool
+
+	fullPattern string
 }
 
 var simpleRe = regexp.MustCompile(`^(\(\?i\))?` + // Optional case-insensitive flag
@@ -54,6 +57,7 @@ func New(pattern string) (Regex, error) {
 		wildcardBefore: matches[2] != "^" || matches[3] == ".*",
 		word:           []byte(matches[4]),
 		wildcardAfter:  matches[5] == ".*" || matches[6] != "$",
+		fullPattern:    pattern,
 	}, nil
 }
 
@@ -81,4 +85,8 @@ func (r *simpleRegex) Match(buf []byte) bool {
 	}
 
 	return equal(buf, r.word)
+}
+
+func (r *simpleRegex) String() string {
+	return r.fullPattern
 }

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 SigScalr, Inc.
+// Copyright (c) 2021-2025 SigScalr, Inc.
 //
 // This file is part of SigLens Observability Solution
 //

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -29,10 +29,12 @@ type Regex interface {
 type simpleRegex struct {
 	wildcardBefore bool
 	word           []byte
+	caseSensitive  bool
 	wildcardAfter  bool
 }
 
-var simpleRe = regexp.MustCompile(`^(\^)?` + // Optional anchor
+var simpleRe = regexp.MustCompile(`^(\(i\?\))?` + // Optional case-insensitive flag
+	`(\^)?` + // Optional anchor
 	`(\.\*)?` + // Optional wildcard
 	`([a-zA-Z0-9_]+)` + // Main word to find
 	`(\.\*)?` + // Optional wildcard
@@ -46,9 +48,10 @@ func New(pattern string) (Regex, error) {
 	}
 
 	return &simpleRegex{
-		wildcardBefore: matches[1] == "" || matches[2] == ".*",
-		word:           []byte(matches[3]),
-		wildcardAfter:  matches[4] == ".*" || matches[5] == "",
+		caseSensitive:  matches[1] == "(i?)",
+		wildcardBefore: matches[2] != "^" || matches[3] == ".*",
+		word:           []byte(matches[4]),
+		wildcardAfter:  matches[5] == ".*" || matches[6] != "$",
 	}, nil
 }
 

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -33,7 +33,7 @@ type simpleRegex struct {
 	wildcardAfter  bool
 }
 
-var simpleRe = regexp.MustCompile(`^(\(i\?\))?` + // Optional case-insensitive flag
+var simpleRe = regexp.MustCompile(`^(\(\?i\))?` + // Optional case-insensitive flag
 	`(\^)?` + // Optional anchor
 	`(\.\*)?` + // Optional wildcard
 	`([a-zA-Z0-9_]+)` + // Main word to find

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -18,31 +18,37 @@
 package regex
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_Match(t *testing.T) {
-	assertMatches(t, `.*`, `abc`, true)
-	assertMatches(t, `.*foo.*`, `abc`, false)
-	assertMatches(t, `.*foo.*`, `foo`, true)
-	assertMatches(t, `.*foo.*`, `abcfooxyz`, true)
-	assertMatches(t, `foo.*`, `foobar`, true)
-	assertMatches(t, `foo.*`, `abcfooxyz`, true)
-	assertMatches(t, `^foo.*`, `abcfooxyz`, false)
-	assertMatches(t, `^.*foo.*`, `abcfooxyz`, true)
-	assertMatches(t, `(?i).*bar$`, `abcBaR`, true)
-	assertMatches(t, `.*bar$`, `abcBaR`, false)
+	assertMatches(t, `.*`, `abc`)
+	assertMatches(t, `.*foo.*`, `abc`)
+	assertMatches(t, `.*foo.*`, `foo`)
+	assertMatches(t, `.*foo.*`, `abcfooxyz`)
+	assertMatches(t, `foo.*`, `foobar`)
+	assertMatches(t, `foo.*`, `abcfooxyz`)
+	assertMatches(t, `^foo.*`, `abcfooxyz`)
+	assertMatches(t, `^.*foo.*`, `abcfooxyz`)
+	assertMatches(t, `(?i).*bar$`, `abcBaR`)
+	assertMatches(t, `.*bar$`, `abcBaR`)
+
 }
 
-func assertMatches(t *testing.T, pattern string, str string, expectedMatch bool) {
+func assertMatches(t *testing.T, pattern string, str string) {
 	t.Helper()
 
 	regex, err := New(pattern)
 	assert.NoError(t, err)
 
-	if expectedMatch {
+	actualRegex, err := regexp.Compile(pattern)
+	assert.NoError(t, err)
+	shouldMatch := actualRegex.Match([]byte(str))
+
+	if shouldMatch {
 		assert.True(t, regex.Match([]byte(str)), "Pattern %s should match %s", pattern, str)
 	} else {
 		assert.False(t, regex.Match([]byte(str)), "Pattern %s should not match %s", pattern, str)

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 SigScalr, Inc.
+// Copyright (c) 2021-2025 SigScalr, Inc.
 //
 // This file is part of SigLens Observability Solution
 //

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -32,6 +32,7 @@ func Test_Match(t *testing.T) {
 	assertMatches(t, `foo.*`, `abcfooxyz`, true)
 	assertMatches(t, `^foo.*`, `abcfooxyz`, false)
 	assertMatches(t, `^.*foo.*`, `abcfooxyz`, true)
+	assertMatches(t, `(?i).*bar$`, `abcBaR`, true)
 }
 
 func assertMatches(t *testing.T, pattern string, str string, expectedMatch bool) {
@@ -56,6 +57,7 @@ func Test_UsesOptimizedRegex(t *testing.T) {
 	assertUsesOptimizedRegex(t, `^.*foo$`, true)
 	assertUsesOptimizedRegex(t, `^.*foo.*$`, true)
 	assertUsesOptimizedRegex(t, `^foo$`, true)
+	assertUsesOptimizedRegex(t, `(?i).*foo$`, true)
 
 	assertUsesOptimizedRegex(t, `foo.*bar.*`, false) // TODO: maybe we'll want to handle this.
 	assertUsesOptimizedRegex(t, `(.*foo.*|.*bar.*)`, false)

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -33,6 +33,7 @@ func Test_Match(t *testing.T) {
 	assertMatches(t, `^foo.*`, `abcfooxyz`, false)
 	assertMatches(t, `^.*foo.*`, `abcfooxyz`, true)
 	assertMatches(t, `(?i).*bar$`, `abcBaR`, true)
+	assertMatches(t, `.*bar$`, `abcBaR`, false)
 }
 
 func assertMatches(t *testing.T, pattern string, str string, expectedMatch bool) {

--- a/pkg/regex/regex_test.go
+++ b/pkg/regex/regex_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package regex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Regex_Match(t *testing.T) {
+	assertMatches(t, `.*`, `abc`, true)
+	assertMatches(t, `.*foo.*`, `abc`, false)
+	assertMatches(t, `.*foo.*`, `foo`, true)
+	assertMatches(t, `.*foo.*`, `abcfooxyz`, true)
+	assertMatches(t, `foo.*`, `foobar`, true)
+	assertMatches(t, `foo.*`, `abcfooxyz`, true)
+	assertMatches(t, `^foo.*`, `abcfooxyz`, false)
+	assertMatches(t, `^.*foo.*`, `abcfooxyz`, true)
+}
+
+func assertMatches(t *testing.T, pattern string, str string, expectedMatch bool) {
+	t.Helper()
+
+	regex, err := New(pattern)
+	assert.NoError(t, err)
+
+	if expectedMatch {
+		assert.True(t, regex.Match([]byte(str)), "Pattern %s should match %s", pattern, str)
+	} else {
+		assert.False(t, regex.Match([]byte(str)), "Pattern %s should not match %s", pattern, str)
+	}
+}

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
+	"github.com/siglens/siglens/pkg/regex"
 	toputils "github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -587,7 +588,7 @@ type DtypeEnclosure struct {
 	StringVal      string
 	StringValBytes []byte   // byte slice representation of StringVal
 	StringSliceVal []string // used for array dict
-	RexpCompiled   *regexp.Regexp
+	RexpCompiled   regex.Regex
 }
 
 func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {
@@ -647,7 +648,7 @@ func (dte *DtypeEnclosure) GobDecode(data []byte) error {
 			return err
 		}
 
-		dte.RexpCompiled, err = regexp.Compile(rexp)
+		dte.RexpCompiled, err = regex.New(rexp)
 		if err != nil {
 			log.Errorf("DtypeEnclosure.GobDecode: error compiling rexp %v: %v", rexp, err)
 			return err
@@ -659,9 +660,19 @@ func (dte *DtypeEnclosure) GobDecode(data []byte) error {
 
 func (dte *DtypeEnclosure) SetRegexp(exp *regexp.Regexp) {
 	dte.RexpCompiled = exp
+
+	if dte.RexpCompiled != nil {
+		r, err := regex.New(dte.RexpCompiled.String())
+		if err != nil {
+			// Ignore this; just use the passed `exp`.
+			return
+		}
+
+		dte.RexpCompiled = r
+	}
 }
 
-func (dte *DtypeEnclosure) GetRegexp() *regexp.Regexp {
+func (dte *DtypeEnclosure) GetRegexp() regex.Regex {
 	return dte.RexpCompiled
 }
 

--- a/pkg/utils/bufutils.go
+++ b/pkg/utils/bufutils.go
@@ -27,3 +27,21 @@ func ReadLine(buf []byte) ([]byte, []byte) {
 
 	return buf[:end], buf[end+1:]
 }
+
+func ContainsAnyCase(buf []byte, word []byte) bool {
+	if len(word) == 0 {
+		return true
+	}
+
+	if bytes.Contains(buf, word) {
+		return true
+	}
+
+	for i := 0; i < len(buf)-len(word)+1; i++ {
+		if bytes.EqualFold(buf[i:i+len(word)], word) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/utils/bufutils.go
+++ b/pkg/utils/bufutils.go
@@ -33,10 +33,6 @@ func ContainsAnyCase(buf []byte, word []byte) bool {
 		return true
 	}
 
-	if bytes.Contains(buf, word) {
-		return true
-	}
-
 	for i := 0; i < len(buf)-len(word)+1; i++ {
 		if EqualAnyCase(buf[i:i+len(word)], word) {
 			return true

--- a/pkg/utils/bufutils.go
+++ b/pkg/utils/bufutils.go
@@ -38,10 +38,38 @@ func ContainsAnyCase(buf []byte, word []byte) bool {
 	}
 
 	for i := 0; i < len(buf)-len(word)+1; i++ {
-		if bytes.EqualFold(buf[i:i+len(word)], word) {
+		if EqualAnyCase(buf[i:i+len(word)], word) {
 			return true
 		}
 	}
 
 	return false
+}
+
+func EqualAnyCase(s1, s2 []byte) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for i := 0; i < len(s1); i++ {
+		if !equalAsciiAnyCase(s1[i], s2[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalAsciiAnyCase(a, b byte) bool {
+	if a == b {
+		// Fast path for equals.
+		return true
+	}
+
+	if a^b != 32 {
+		// Fast path for not equals.
+		return false
+	}
+
+	return (a >= 'A' && a <= 'Z') || (a >= 'a' && a <= 'z')
 }

--- a/pkg/utils/bufutils_test.go
+++ b/pkg/utils/bufutils_test.go
@@ -71,3 +71,15 @@ func Test_ReadLine_BlankLines(t *testing.T) {
 	assert.Equal(t, "world", string(line))
 	assert.Len(t, rest, 0)
 }
+
+func Test_ContainsAnyCase(t *testing.T) {
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("h")))
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("hello")))
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("world")))
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("lo, wo")))
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("lO, Wo")))
+	assert.False(t, ContainsAnyCase([]byte("hello, world!"), []byte("x")))
+	assert.False(t, ContainsAnyCase([]byte("hello, world!"), []byte("hey")))
+	assert.False(t, ContainsAnyCase([]byte("hello, world!"), []byte("HELLO,!")))
+	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("HELLO, WORLD!")))
+}

--- a/pkg/utils/bufutils_test.go
+++ b/pkg/utils/bufutils_test.go
@@ -83,3 +83,13 @@ func Test_ContainsAnyCase(t *testing.T) {
 	assert.False(t, ContainsAnyCase([]byte("hello, world!"), []byte("HELLO,!")))
 	assert.True(t, ContainsAnyCase([]byte("hello, world!"), []byte("HELLO, WORLD!")))
 }
+
+func Test_equalAsciiAnyCase(t *testing.T) {
+	assert.True(t, equalAsciiAnyCase('a', 'a'))
+	assert.True(t, equalAsciiAnyCase('A', 'A'))
+	assert.True(t, equalAsciiAnyCase('a', 'A'))
+	assert.True(t, equalAsciiAnyCase('A', 'a'))
+	assert.False(t, equalAsciiAnyCase('*', '*'+32))
+	assert.False(t, equalAsciiAnyCase('*', '*'-32))
+	assert.False(t, equalAsciiAnyCase('a', 'b'))
+}


### PR DESCRIPTION
# Description
Many regex searches are simple wildcard searches. These are not optimized in Go's regexp library; this PR optimizes them, yielding a 10x improvement for some queries.

# Testing
Ingested 100 million records, then ran these queries:
```
* | regex URL = ".*google.*" | stats count
URL = "*google*" | stats count
```
(for the second query, we translate it to a regex query under the hood).

Previously, the queries took 32.9 and 29.9 seconds respectively. With this PR, they take 3.3 and 5.4 seconds.

There's one known issue: regex like `^.*foo.*$` won't match something like `line1\nline2fooinfo` because there's a line break, but the regex implementation in this PR doesn't consider line breaks at all (it treats them as any other character). This will be fixed in a later PR.


For the first query, CPU profiling gave
<img width="439" alt="image" src="https://github.com/user-attachments/assets/041286a9-0040-46a8-a570-ff9153dc9905" />
originally. But with this PR it became:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/cf86b11c-f0dd-451d-84ad-178efd7b3bd1" />
So about a 100x improvement for the `fopOnString()` function.
