### PR TITLE
Optimize column reading

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -478,7 +478,7 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 				// The column doesn't exist.
 				return nil, nil
 			}
-			return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error reading column %s: %w", cname, err)
+			return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error reading column %s: %v", cname, err)
 		}
 
 		return values, nil

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"sort"
 
@@ -449,22 +450,20 @@ func (iqr *IQR) readAllColumnsWithRRCs() (map[string][]utils.CValueEnclosure, er
 
 // If the column doesn't exist, `nil, nil` is returned.
 func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error) {
-	allColumns, err := iqr.getColumnsInternal()
-	if err != nil {
-		return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error getting all columns: %v", err)
-	}
-
-	if _, ok := allColumns[cname]; !ok {
+	if _, ok := iqr.deletedColumns[cname]; ok {
 		return nil, nil
 	}
 
 	// Prepare to call BatchProcess().
 	getBatchKey := func(rrc *utils.RecordResultContainer) uint32 {
+		if rrc == nil {
+			return NIL_RRC_SEGKEY
+		}
 		return rrc.SegKeyInfo.SegKeyEnc
 	}
 	batchKeyLess := toputils.NewUnsetOption[func(uint32, uint32) bool]()
 	batchOperation := func(rrcs []*utils.RecordResultContainer) ([]utils.CValueEnclosure, error) {
-		if len(rrcs) == 0 {
+		if len(rrcs) == 0 || rrcs[0] == nil {
 			return nil, nil
 		}
 
@@ -475,7 +474,11 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 
 		values, err := iqr.reader.ReadColForRRCs(segKey, rrcs, cname, iqr.qid)
 		if err != nil {
-			return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error reading column %s: %v", cname, err)
+			if os.IsNotExist(toputils.FullUnwrapError(err)) {
+				// The column doesn't exist.
+				return nil, nil
+			}
+			return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error reading column %s: %w", cname, err)
 		}
 
 		return values, nil

--- a/pkg/segment/query/iqr/iqrreader.go
+++ b/pkg/segment/query/iqr/iqrreader.go
@@ -259,7 +259,7 @@ func (iqrRdr *IQRReader) readColumnsForRRCs(segKey string, vTable string, rrcs [
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("iqrReader.ReadAllColsForRRCs: cannot read columns for segKey=%v; err=%v", segKey, err)
+		return nil, fmt.Errorf("iqrReader.ReadAllColsForRRCs: cannot read columns for segKey=%v; err=%w", segKey, err)
 	}
 
 	return knownValues, nil
@@ -312,7 +312,7 @@ func (iqrRdr *IQRReader) ReadColForRRCs(segKey string, rrcs []*utils.RecordResul
 
 	knownValues, err := iqrRdr.readColumnsForRRCs(segKey, "", rrcs, qid, nil, &cname)
 	if err != nil {
-		return nil, fmt.Errorf("iqrReader.ReadColForRRCs: cannot read column %v for segKey=%v; err=%v", cname, segKey, err)
+		return nil, fmt.Errorf("iqrReader.ReadColForRRCs: cannot read column %v for segKey=%v; err=%w", cname, segKey, err)
 	}
 
 	if values, ok := knownValues[cname]; ok {

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -82,7 +82,7 @@ func (reader *RRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs 
 
 	allFiles, err := reader.ReadSegFilesFromBlob(segKey, allCols)
 	if err != nil {
-		return nil, toputils.TeeErrorf("qid=%d, ReadAllColsForRRCs: failed to read seg files from blob; err=%v", qid, err)
+		return nil, toputils.TeeErrorf("qid=%d, ReadAllColsForRRCs: failed to read seg files from blob; err=%w", qid, err)
 	}
 
 	defer func() {

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -229,7 +229,7 @@ func InitSharedMultiColumnReaders(segKey string, colNames map[string]bool,
 			currFd, rotatedErr = os.OpenFile(rotatedFName, os.O_RDONLY, 0644)
 			if rotatedErr != nil {
 				err := fmt.Errorf("qid=%d, InitSharedMultiColumnReaders: failed to open file %s for column %s."+
-					" Error: %v. Also failed to open rotated file %s with error: %v",
+					" Error: %w. Also failed to open rotated file %s with error: %v",
 					qid, fName, colName, err, rotatedFName, rotatedErr)
 				if len(sharedReader.columnErrorMap) < utils.MAX_SIMILAR_ERRORS_TO_LOG {
 					sharedReader.columnErrorMap[colName] = err

--- a/pkg/utils/errorutils.go
+++ b/pkg/utils/errorutils.go
@@ -18,6 +18,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -234,4 +235,15 @@ func IsNotExistError(err error) bool {
 	}
 
 	return os.IsNotExist(err)
+}
+
+func FullUnwrapError(err error) error {
+	for {
+		e := errors.Unwrap(err)
+		if e == nil {
+			return err
+		}
+
+		err = e
+	}
 }

--- a/pkg/utils/errorutils_test.go
+++ b/pkg/utils/errorutils_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2021-2024 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FullUnwrapError(t *testing.T) {
+	assert.Equal(t, FullUnwrapError(nil), nil)
+
+	err1 := fmt.Errorf("first error")
+	err2 := fmt.Errorf("first wrap: %w", err1)
+	err3 := fmt.Errorf("second wrap: %w", err2)
+	assert.Equal(t, FullUnwrapError(err3), err1)
+}


### PR DESCRIPTION
# Description
There was a call to `iqr.getColumnsInternal()` that was both expensive (for certain queries) and largely unneeded (we only used the result to check for one specific column). This PR removes that.


# Testing
Ingested 100 million records and ran
```
CounterID = 62 AND IsRefresh = 0 
| where strptime(EventDate,"%Y-%m-%d") >= strptime("2013-07-01", "%Y-%m-%d") AND strptime(EventDate,"%Y-%m-%d") <= strptime("2013-07-31", "%Y-%m-%d") 
| eval Src=if(SearchEngineID=0 AND AdvEngineID=0, Referer, "") 
| rename URL as Dst 
| stats count as PageViews by TraficSourceID, SearchEngineID, AdvEngineID, Src, Dst 
| sort -PageViews 
| head 1010 
| tail 10 
| tail 10
```

This used to take ~100 seconds; now it takes ~8 seconds.