### PR TITLE
improve query perf

### DIFF
--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -745,7 +745,8 @@ func (sfr *SegmentFileReader) AddRecNumsToMr(dwordIdx uint16, bsh *structs.Block
 	validRecords := bsh.GetValidRecords()
 
 	if validRecords == nil {
-		for i := uint16(0); i < sfr.blockSummaries[sfr.currBlockNum].RecCount; i++ {
+		recCount := sfr.blockSummaries[sfr.currBlockNum].RecCount
+		for i := uint16(0); i < recCount; i++ {
 			if sfr.deRecToTlv[i] == dwordIdx {
 				bsh.AddMatchedRecord(uint(i))
 			}


### PR DESCRIPTION
# Description
This small changes saves about `2.2s /13 s` on the below query: 

```
SearchPhrase != "" | regex Title = ".*Google.*" | regex URL != ".*\.google\..*" | stats count as c, min(eval(URL)), min(eval(Title)), dc(UserID) by SearchPhrase | sort -c | head 10
```

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
