### PR TITLE
Optimize sort

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -675,7 +675,6 @@ func (iqr *IQR) GetRecord(index int) *Record {
 }
 
 func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool) error {
-	// log.Errorf("andrew sorting %v items in IQR", iqr.NumberOfRecords())
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.Sort: validation failed: %v", err)
 		return err

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -671,10 +671,11 @@ func (iqr *IQR) getColumnsInternal() (map[string]struct{}, error) {
 }
 
 func (iqr *IQR) GetRecord(index int) *Record {
-	return &Record{iqr: iqr, index: index}
+	return &Record{iqr: iqr, Index: index}
 }
 
-func (iqr *IQR) Sort(less func(*Record, *Record) bool) error {
+func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool) error {
+	// log.Errorf("andrew sorting %v items in IQR", iqr.NumberOfRecords())
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.Sort: validation failed: %v", err)
 		return err
@@ -688,9 +689,18 @@ func (iqr *IQR) Sort(less func(*Record, *Record) bool) error {
 		return nil
 	}
 
+	sortColumnValues := make([][]utils.CValueEnclosure, len(sortColumns))
+	for i, cname := range sortColumns {
+		var err error
+		sortColumnValues[i], err = iqr.ReadColumn(cname)
+		if err != nil {
+			return err
+		}
+	}
+
 	records := make([]*Record, iqr.NumberOfRecords())
 	for i := 0; i < iqr.NumberOfRecords(); i++ {
-		records[i] = &Record{iqr: iqr, index: i}
+		records[i] = &Record{iqr: iqr, Index: i, SortValues: sortColumnValues}
 	}
 
 	sort.Slice(records, func(i, j int) bool {
@@ -700,7 +710,7 @@ func (iqr *IQR) Sort(less func(*Record, *Record) bool) error {
 	if iqr.mode == withRRCs {
 		newRRCs := make([]*utils.RecordResultContainer, iqr.NumberOfRecords())
 		for i, record := range records {
-			newRRCs[i] = iqr.rrcs[record.index]
+			newRRCs[i] = iqr.rrcs[record.Index]
 		}
 
 		iqr.rrcs = newRRCs
@@ -709,7 +719,7 @@ func (iqr *IQR) Sort(less func(*Record, *Record) bool) error {
 	for cname, values := range iqr.knownValues {
 		newValues := make([]utils.CValueEnclosure, iqr.NumberOfRecords())
 		for i, record := range records {
-			newValues[i] = values[record.index]
+			newValues[i] = values[record.Index]
 		}
 
 		iqr.knownValues[cname] = newValues
@@ -812,7 +822,7 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 	nextRecords := make([]*Record, len(iqrs))
 	numRecordsTaken := make([]int, len(iqrs))
 	for i, iqr := range iqrs {
-		nextRecords[i] = &Record{iqr: iqr, index: 0}
+		nextRecords[i] = &Record{iqr: iqr, Index: 0}
 		numRecordsTaken[i] = 0
 	}
 
@@ -823,7 +833,7 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 
 		// Append the record.
 		if iqr.mode == withRRCs {
-			iqr.rrcs = append(iqr.rrcs, record.iqr.rrcs[record.index])
+			iqr.rrcs = append(iqr.rrcs, record.iqr.rrcs[record.Index])
 		}
 
 		for _, cname := range originalKnownColumns {
@@ -837,10 +847,10 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 		}
 
 		// Prepare for the next iteration.
-		record.index++
+		record.Index++
 
 		// Check if this IQR is out of records.
-		if iqrs[iqrIndex].NumberOfRecords() <= nextRecords[iqrIndex].index {
+		if iqrs[iqrIndex].NumberOfRecords() <= nextRecords[iqrIndex].Index {
 			// Discard all the records that were merged.
 			for i, numTaken := range numRecordsTaken {
 				err := iqrs[i].Discard(numTaken)

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -453,7 +453,7 @@ func Test_Sort(t *testing.T) {
 		return aVal.CVal.(string) < bVal.CVal.(string)
 	}
 
-	err = iqr.Sort(less)
+	err = iqr.Sort([]string{"col1", "col2"}, less)
 	assert.NoError(t, err)
 
 	expected := map[string][]utils.CValueEnclosure{
@@ -529,7 +529,7 @@ func Test_Sort_multipleColumns(t *testing.T) {
 		return aVal2.CVal.(uint64) < bVal2.CVal.(uint64)
 	}
 
-	err = iqr.Sort(less)
+	err = iqr.Sort([]string{"col1", "col2"}, less)
 	assert.NoError(t, err)
 	values, err := iqr.ReadAllColumns()
 	assert.NoError(t, err)

--- a/pkg/segment/query/iqr/record.go
+++ b/pkg/segment/query/iqr/record.go
@@ -25,8 +25,12 @@ import (
 
 type Record struct {
 	iqr       *IQR
-	index     int
+	Index     int
 	validated bool
+
+	// Outer slice is one column. Only "index" element of inner slice is
+	// relevant for this record.
+	SortValues [][]utils.CValueEnclosure
 }
 
 func (record *Record) ReadColumn(cname string) (*utils.CValueEnclosure, error) {
@@ -44,10 +48,10 @@ func (record *Record) ReadColumn(cname string) (*utils.CValueEnclosure, error) {
 		return nil, fmt.Errorf("Record.ReadColumn: cannot read column %v from IQR; err=%v", cname, err)
 	}
 
-	if record.index >= len(values) {
+	if record.Index >= len(values) {
 		return nil, fmt.Errorf("Record.ReadColumn: index %v out of range (len is %v) for column %v; iqr has %v records",
-			record.index, len(values), cname, record.iqr.NumberOfRecords())
+			record.Index, len(values), cname, record.iqr.NumberOfRecords())
 	}
 
-	return &values[record.index], nil
+	return &values[record.Index], nil
 }

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -95,7 +95,7 @@ func (dp *DataProcessor) SetLessFuncBasedOnStream(stream Streamer) {
 	if streamDP, ok := stream.(*DataProcessor); ok {
 		switch streamDP.processor.(type) {
 		case *sortProcessor:
-			dp.less = streamDP.processor.(*sortProcessor).less
+			dp.less = streamDP.processor.(*sortProcessor).lessDirectRead
 		default:
 			dp.setDefaultLessFunc()
 		}

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -412,7 +412,7 @@ func (s *Searcher) fetchSortedRRCsFromQSRs() (*iqr.IQR, error) {
 
 		var firstExhaustedIndex int
 		var err error
-		result, firstExhaustedIndex, err = iqr.MergeIQRs(iqrs, sorter.less)
+		result, firstExhaustedIndex, err = iqr.MergeIQRs(iqrs, sorter.lessDirectRead)
 		if err != nil {
 			log.Errorf("qid=%v, searcher.fetchColumnSortedRRCs: failed to merge IQRs: %v", s.qid, err)
 			return nil, err

--- a/pkg/segment/query/processor/sortcommand.go
+++ b/pkg/segment/query/processor/sortcommand.go
@@ -181,13 +181,6 @@ func getRank(CValEnc *segutils.CValueEnclosure, op string) dTypeRank {
 
 // Returns A comparison B
 func compareValues(valueA, valueB *segutils.CValueEnclosure, asc bool, op string) compare {
-	switch valueA.Dtype {
-	case segutils.SS_DT_STRING:
-		switch valueB.Dtype {
-		case segutils.SS_DT_STRING:
-			return compareString(valueA.CVal.(string), valueB.CVal.(string))
-		}
-	}
 	var result compare
 	rankA := getRank(valueA, op)
 	rankB := getRank(valueB, op)


### PR DESCRIPTION
# Description
This slightly improves the speed of `sort` queries. Previously to compare two records, we'd read the values for their sort columns on the fly; now we read all the values for the sort columns up front, and then reference them as needed.

# Testing
Did CPU profiling on this query:
```
SearchPhrase != "" 
| sort 10 str(EventTime)  
| fields SearchPhrase
```
with a 100 million record dataset. The response time varied some, but on average it was about 20 seconds previously, and 17 seconds with this PR.