### PR TITLE
Fix: Styling Improvements for Popups

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -667,6 +667,7 @@ div.show-record-popup .ui-dialog-buttonpane button {
 
 .ui-dialog-buttonpane {
     position: relative;
+    padding: 16px;
 }
 
 .ag-theme-mycustomtheme .ag-root-wrapper {

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -620,6 +620,42 @@
     border: none !important;
 }
 
+.border-bottom {
+    border-bottom: 1px solid var(--search-input-border) !important;
+}
+
+.grey-text {
+    color: var(--empty-response-text-color);
+}
+
+.note-box {
+    padding: 15px 20px 15px 50px;
+    border-left: 1px solid #418CE4;
+    background: rgba(65, 140, 228, 0.30);
+    color: var(--text-color);
+    border-radius: 0 5px 5px 0;
+    position: relative;
+}
+
+.note-box::before {
+    content: "i";
+    position: absolute;
+    left: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    background-color: #418CE4;
+    color: white;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: bold;
+}
+
 /* Upper Navbar Tabs */
 .section-buttons {
     display: flex;
@@ -1221,11 +1257,24 @@ input {
     color: var(--text-color)
 }
 
-input.form-control:focus {
+input.form-control:focus,
+textarea.focus {
     color: var(--search-bar-text-color-active);
     border-radius: 5px;
     background: var(--search-bar-bg);
     border-color: var(--purple-1);
+}
+
+textarea {
+    border: 1px solid var(--search-input-border);
+    background: var(--search-bar-bg);
+    font-size: 12px;
+    border-radius: 5px;
+    padding: 8px;
+}
+
+textarea:focus-visible {
+    outline: none;
 }
 
 /* Logs Screen */
@@ -1513,7 +1562,7 @@ progress.hidden {
 
 .ui-dialog-buttonset {
     display: flex;
-    padding: 8px;
+    gap: 16px;
     float: inline-end;
 }
 
@@ -1540,6 +1589,14 @@ progress.hidden {
     font-weight: bold;
 }
 
+.ui-widget-content a{
+    color: #0d6efd;
+}
+
+.ui-widget.ui-widget-content{
+    border: 1px solid var(--ui-widget-border-color);
+}
+
 /* Corner radius */
 
 .ui-corner-all {
@@ -1548,8 +1605,10 @@ progress.hidden {
 
 .ui-widget-content .ui-state-highlight {
     border: 1px solid var(--error);
-    background: var(--accent-color);
-    color: var(--white-0);
+    background: var(--bg-color);
+    color: var(--accent-color);
+    font-size: 11px !important;
+    font-weight: 500;
 }
 
 .ui-widget-header .ui-state-highlight {
@@ -2122,17 +2181,14 @@ table.dataTable thead td {
 }
 
 .rule-name-error {
-    color: #6449D6;
     display: none;
-    font-size: 13px;
-    margin-bottom: 6px;
-
 }
 
 .rule-name-error.active {
     display: block;
     color: #6449D6;
-    font-size: 13px;
+    font-size: 11px;
+    font-weight: 500;
     margin-bottom: 4px;
 }
 
@@ -2180,8 +2236,8 @@ table.dataTable thead td {
 .mypopupContent .header {
     color: var(--text-color);
     margin-bottom: 16px;
-    font-weight: bold;
-    font-size: 14px;
+    font-weight: 600;
+    font-size: 18px;
 }
 
 #buttons-popupContent {
@@ -2402,17 +2458,15 @@ table.dataTable thead td {
 }
 
 div#save-queries {
-    width: 280px !important;
-    height: 90px !important;
+    height: 220px !important;
     margin: 16px !important;
     padding: 0 !important;
     overflow-x: hidden;
 }
 
 div#download-info {
-    width: 280px !important;
     height: 40px !important;
-    margin: 16px !important;
+    margin: 20px !important;
     padding: 0 !important;
 }
 
@@ -2454,26 +2508,9 @@ input[type="text"].active {
     color: var(--search-bar-text-color-active);
 }
 
-#qname,
-#qnameDL,
-#description {
-    width: 280px;
-    /* height: 32px; */
-    border-radius: 5px;
-}
-
-#description {
-    margin-top: 20px !important;
-}
-
-
-div[aria-describedby="save-queries"],
 div[aria-describedby="download-info"] {
     width: 320px !important;
 }
-
-
-
 
 /* end save query dialog  */
 
@@ -5296,21 +5333,9 @@ p#versionInfo {
     margin-bottom: 2px;
 }
 
-#create-db-popup .create-db {
-    width: 195px !important;
-    border-radius: 5px;
-    border: none;
-    background: var(--btn-regular-bg-color);
-    color: var(--component-text-color) !important;
-    margin-left: 20px;
-}
-
-#create-db-popup #cancel-dbbtn {
-    width: 195px !important;
-    border-radius: 5px;
-    border: none;
-    background: var(--component-bg-color);
-    color: var(--component-text-color) !important;
+#create-db-popup {
+    padding: 0;
+    width: 464px !important;
 }
 
 #create-db-popup .error-tip {
@@ -5320,13 +5345,15 @@ p#versionInfo {
 #create-db-popup .error-tip.active {
     display: block;
     color: #6449D6;
-    font-size: 10px;
+    font-size: 11px;
     margin-bottom: 0px;
+    font-weight: 500;
 }
 
 #create-db-popup .section-buttons,
 #create-db-popup .section-button {
-    background-color: var(--dashboard-tab-bg);
+    background-color: var(--alert-background);
+    width: 100%;
 }
 
 #create-db-popup .section-button.active {
@@ -6011,7 +6038,7 @@ p#versionInfo {
 }
 
 .addrulepopupContent {
-    width: 326px !important;
+    width: 464px !important;
 }
 
 .form-control.error-border {

--- a/static/index.html
+++ b/static/index.html
@@ -368,10 +368,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <p class="validateTips"></p>
             <form>
                 <fieldset>
-                    <input type="text" name="qname" id="qname" placeholder="Name"
-                        class="text ui-widget-content ui-corner-all">
-                    <input type="text" name="description" id="description" placeholder="Description (Optional)"
-                        class="text ui-widget-content ui-corner-all">
+                    <div>
+                        <label class="mb-1">Name</label>
+                        <input type="text" name="qname" id="qname" placeholder="Address Lookup"
+                            class="text ui-widget-content ui-corner-all">
+                    </div>
+                    <div>
+                        <div class="d-flex mt-4"><label class="mb-1">Description</label><span class="grey-text mx-1">(Optional)</span></div>
+                        <textarea rows="2" type="text" name="description" id="description" placeholder="Add a description..."
+                            class="text ui-widget-content ui-corner-all w-100"></textarea>
+                    </div>
+                    <div>
+                        <div class="fst-italic mt-3 note-box">Manage all queries in the <a href="./saved-queries.html">Saved Queries</a> library</div>
+                    </div>
                     <!-- Allow form submission with keyboard without duplicating the dialog button -->
                     <input type="submit" tabindex="-1" style="position:absolute; top:-1000px">
                 </fieldset>
@@ -403,46 +412,55 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <!-- Dashboard Popup-->
         <div class="popupOverlay"></div>
         <div class="popupContent" id="create-db-popup">
-            <h3 class="header mb-2">Add panel to dashboard</h3>
-            <p>Choose where to add the panel</p>
-            <div class="section-buttons mt-2">
-                <div class="section-button active new-dashboard-btn"><a>New Dashboard</a></div>
-                <div class="section-button existing-dashboard-btn"><a>Existing Dashboard</a></div>
+            <div class="p-4 border-bottom">
+                <h3 class="header mb-2">Add panel to dashboard</h3>
+                <p class="mb-0">Create a new dashboard or add to an existing one</p>
             </div>
-            <div class="new-dashboard">
-                <div>
-                    <input type="text" placeholder="Name" class="input mt-3" id="db-name">
-                    <p class="error-tip">Dashboard name is required!</p>
-                    <input type="text" placeholder="Description (Optional)" class="input mt-3" id="db-description">
+            <div class="p-4 border-bottom">
+                <div class="section-buttons mb-3">
+                    <div class="section-button active new-dashboard-btn"><a>New Dashboard</a></div>
+                    <div class="section-button existing-dashboard-btn"><a>Existing Dashboard</a></div>
                 </div>
-            </div>
-            <div class="existing-dashboard">
-                <p for="" class="mt-3 mb-3"><small>Select in which dashboard the panel will be created.</small></p>
-                <div class="dropdown w-100">
-                    <button class="btn dropdown-toggle btn-grey w-100" type="button" id="selected-dashboard" data-toggle="dropdown"
-                        aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" >
-                        <span>Choose Dashboard</span>
-                        <i class="dropdown-arrow"></i>
-                    </button>
-                    <div class="dropdown-menu box-shadow" aria-labelledby="index-btn" id="dashboard-options">
+                <div class="new-dashboard">
+                    <div>
+                        <label class="mb-1">Dashboard name</label>
+                        <input type="text" placeholder="New dashboard" class="input" id="db-name">
+                        <p class="error-tip">Dashboard name is required!</p>
+                        <div class="d-flex mt-4"><label class="mb-1">Description</label><span class="grey-text mx-1">(Optional)</span></div>
+                        <textarea rows="2" type="text" placeholder="Add a description..." class="input w-100" id="db-description"></textarea>
+                    </div>
+                </div>
+                <div class="existing-dashboard">
+                    <p class="mt-3 mb-3">Select in which dashboard the panel will be created.</p>
+                    <div class="dropdown w-100">
+                        <button class="btn dropdown-toggle btn-grey w-100" type="button" id="selected-dashboard"
+                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">
+                            <span>Choose Dashboard</span>
+                            <i class="dropdown-arrow"></i>
+                        </button>
+                        <div class="dropdown-menu box-shadow" aria-labelledby="index-btn" id="dashboard-options">
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="d-flex align-items-center justify-content-center mt-4">
+            <div class="d-flex align-items-center justify-content-end gap-4 p-4">
                 <button type="button" id="cancel-dbbtn" class="my-0 btn btn-secondary">Cancel</button>
-                <button type="button" id="create-db" class="btn create-db">Create Dashboard</button>
-                <button type="button" id="create-panel" class="btn create-db">Create Panel</button>
+                <button type="button" id="create-db" class="btn btn-primary">Create Dashboard</button>
+                <button type="button" id="create-panel" class="btn btn-primary">Create Panel</button>
             </div>
         </div>
         <div class="addrulepopupOverlay"></div>
-            <div class="addrulepopupContent popupContent">
-                <h3 class="header">Create Alert</h3>
-                <div class="popupcont mt-3">
-                <label>Enter alert rule name</label>
+            <div class="addrulepopupContent popupContent p-0">
+                <div class="p-4 border-bottom">
+                    <h3 class="header mb-0">Create Alert</h3>
+                </div>
+                <div class="popupcont p-4 border-bottom">
+                <label class="mb-1">Enter alert rule name</label>
                 <input type="text" id="rule-name" name="rule-name" required placeholder="Name">
                 <p class="rule-name-error"></p>
+                <div class="fst-italic mt-3 note-box">You'll be able to configure alert conditions in the next step.</div>
                 </div>
-                <div class="btncontainer mt-3">
+                <div class="d-flex gap-4 justify-content-end p-4">
                     <button type="button" id="addrule-cancel-btn" class="btn btn-secondary">Cancel</button>
                     <button type="button" id="addrule-save-btn" class="btn btn-primary">Add
                         <img src="assets/new-tab-white-icon.svg">

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -350,8 +350,9 @@ function setDownloadLogsDialog() {
     dialog = $('#download-info').dialog({
         autoOpen: false,
         resizable: false,
-        width: 460,
+        width: 464,
         modal: true,
+        title: 'Download Logs',
         position: {
             my: 'center',
             at: 'center',
@@ -374,6 +375,9 @@ function setDownloadLogsDialog() {
         close: function () {
             form[0].reset();
             allFields.removeClass('ui-state-error');
+        },
+        create: function () {
+            $(this).parent().find('.ui-dialog-titlebar').show().addClass('border-bottom p-4');
         },
     });
 

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -668,7 +668,7 @@ function setShowColumnInfoDialog() {
     $('#show-record-popup').dialog({
         autoOpen: false,
         resizable: false,
-        title: false,
+        title: 'Query Results Information',
         maxHeight: 307,
         height: 307,
         width: 464,
@@ -690,6 +690,9 @@ function setShowColumnInfoDialog() {
                     }
                 },
             },
+        },
+        create: function (event, ui) {
+            $(this).parent().find('.ui-dialog-titlebar').show().addClass('border-bottom p-4');
         },
     });
     $('#show-record-intro-btn').on('click', function () {

--- a/static/js/query-builder.js
+++ b/static/js/query-builder.js
@@ -691,7 +691,7 @@ function setShowColumnInfoDialog() {
                 },
             },
         },
-        create: function (event, ui) {
+        create: function () {
             $(this).parent().find('.ui-dialog-titlebar').show().addClass('border-bottom p-4');
         },
     });

--- a/static/js/saved-query.js
+++ b/static/js/saved-query.js
@@ -102,7 +102,7 @@ function setSaveQueriesDialog() {
         height: 307,
         width: 464,
         modal: true,
-        title: 'Saved Query',
+        title: 'Save Query',
         position: {
             my: 'center',
             at: 'center',

--- a/static/js/saved-query.js
+++ b/static/js/saved-query.js
@@ -102,6 +102,7 @@ function setSaveQueriesDialog() {
         height: 307,
         width: 464,
         modal: true,
+        title: 'Saved Query',
         position: {
             my: 'center',
             at: 'center',
@@ -129,6 +130,9 @@ function setSaveQueriesDialog() {
             form[0].reset();
             allFields.removeClass('ui-state-error');
             hideTooltip();
+        },
+        create: function () {
+            $(this).parent().find('.ui-dialog-titlebar').show().addClass('border-bottom p-4');
         },
     });
 

--- a/static/metrics-explorer.html
+++ b/static/metrics-explorer.html
@@ -201,10 +201,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <p class="validateTips"></p>
                         <form>
                             <fieldset>
-                                <input type="text" name="qname" id="qname" placeholder="Name"
-                                    class="text ui-widget-content ui-corner-all">
-                                <input type="text" name="description" id="description" placeholder="Description (Optional)"
-                                    class="text ui-widget-content ui-corner-all">
+                                <div>
+                                    <label class="mb-1">Name</label>
+                                    <input type="text" name="qname" id="qname" placeholder="Address Lookup"
+                                        class="text ui-widget-content ui-corner-all">
+                                </div>
+                                <div>
+                                    <div class="d-flex mt-4"><label class="mb-1">Description</label><span class="grey-text mx-1">(Optional)</span></div>
+                                    <textarea rows="2" type="text" name="description" id="description" placeholder="Add a description..."
+                                        class="text ui-widget-content ui-corner-all w-100"></textarea>
+                                </div>
+                                <div>
+                                    <div class="fst-italic mt-3 note-box">Manage all queries in the <a href="./saved-queries.html">Saved Queries</a> library</div>
+                                </div>
                                 <!-- Allow form submission with keyboard without duplicating the dialog button -->
                                 <input type="submit" tabindex="-1" style="position:absolute; top:-1000px">
                             </fieldset>
@@ -219,37 +228,43 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </div>
 
 
-    <div class="popupOverlay"></div>
+        <div class="popupOverlay"></div>
         <div class="popupContent" id="create-db-popup">
-            <h3 class="header mb-2">Add panel to dashboard</h3>
-            <p>Choose where to add the panel</p>
-            <div class="section-buttons mt-2">
-                <div class="section-button active new-dashboard-btn"><a>New Dashboard</a></div>
-                <div class="section-button existing-dashboard-btn"><a>Existing Dashboard</a></div>
+            <div class="p-4 border-bottom">
+                <h3 class="header mb-2">Add panel to dashboard</h3>
+                <p class="mb-0">Create a new dashboard or add to an existing one</p>
             </div>
-            <div class="new-dashboard">
-                <div>
-                    <input type="text" placeholder="Name" class="input mt-3" id="db-name">
-                    <p class="error-tip">Dashboard name is required!</p>
-                    <input type="text" placeholder="Description (Optional)" class="input mt-3" id="db-description">
+            <div class="p-4 border-bottom">
+                <div class="section-buttons mb-3">
+                    <div class="section-button active new-dashboard-btn"><a>New Dashboard</a></div>
+                    <div class="section-button existing-dashboard-btn"><a>Existing Dashboard</a></div>
                 </div>
-            </div>
-            <div class="existing-dashboard">
-                <p for="" class="mt-3 mb-3"><small>Select in which dashboard the panel will be created.</small></p>
-                <div class="dropdown w-100">
-                    <button class="btn dropdown-toggle btn-grey w-100" type="button" id="selected-dashboard" data-toggle="dropdown"
-                        aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" >
-                        <span>Choose Dashboard</span>
-                        <i class="dropdown-arrow"></i>
-                    </button>
-                    <div class="dropdown-menu box-shadow" aria-labelledby="index-btn" id="dashboard-options">
+                <div class="new-dashboard">
+                    <div>
+                        <label class="mb-1">Dashboard name</label>
+                        <input type="text" placeholder="New dashboard" class="input" id="db-name">
+                        <p class="error-tip">Dashboard name is required!</p>
+                        <div class="d-flex mt-4"><label class="mb-1">Description</label><span class="grey-text mx-1">(Optional)</span></div>
+                        <textarea rows="2" type="text" placeholder="Add a description..." class="input w-100" id="db-description"></textarea>
+                    </div>
+                </div>
+                <div class="existing-dashboard">
+                    <p class="mt-3 mb-3">Select in which dashboard the panel will be created.</p>
+                    <div class="dropdown w-100">
+                        <button class="btn dropdown-toggle btn-grey w-100" type="button" id="selected-dashboard"
+                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">
+                            <span>Choose Dashboard</span>
+                            <i class="dropdown-arrow"></i>
+                        </button>
+                        <div class="dropdown-menu box-shadow" aria-labelledby="index-btn" id="dashboard-options">
+                        </div>
                     </div>
                 </div>
             </div>
-            <div class="d-flex align-items-center justify-content-center mt-4">
-                <button type="button" id="cancel-dbbtn" class="my-0 btn">Cancel</button>
-                <button type="button" id="create-db" class="btn create-db">Create Dashboard</button>
-                <button type="button" id="create-panel" class="btn create-db">Create Panel</button>
+            <div class="d-flex align-items-center justify-content-end gap-4 p-4">
+                <button type="button" id="cancel-dbbtn" class="my-0 btn btn-secondary">Cancel</button>
+                <button type="button" id="create-db" class="btn btn-primary">Create Dashboard</button>
+                <button type="button" id="create-panel" class="btn btn-primary">Create Panel</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Description
Styling Improvements for Popups on Logs and Metrics Screen
1. Create Dashboard Popup - 
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/0b2fdf53-10e2-4fef-adba-34cfea7f0a52" />

2. Create Alert Popup - 
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/1507488e-8efe-46a9-a928-35e707c4723e" />

3. Save Query popup- 
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/d95ff833-8177-4da3-a4bd-f0bda460be94" />
