### PR TITLE
Optimize loop

### DIFF
--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -746,8 +746,8 @@ func (sfr *SegmentFileReader) AddRecNumsToMr(dwordIdx uint16, bsh *structs.Block
 
 	if validRecords == nil {
 		recCount := sfr.blockSummaries[sfr.currBlockNum].RecCount
-		for i := uint16(0); i < recCount; i++ {
-			if sfr.deRecToTlv[i] == dwordIdx {
+		for i, idx := range sfr.deRecToTlv[:recCount] {
+			if idx == dwordIdx {
 				bsh.AddMatchedRecord(uint(i))
 			}
 		}


### PR DESCRIPTION
# Description
Did CPU profiling on the query `SearchPhrase != "" | sort str(EventTime) | head 10 | fields SearchPhrase`.

Before:
```
  Total:       1.95s      2.02s (flat, cum)  8.51%
    737            .          .            
    738            .          .           	dWord := sfr.deTlv[dwIdx] 
    739            .          .           	return dWord, nil 
    740            .          .           } 
    741            .          .            
    742            .          .           func (sfr *SegmentFileReader) AddRecNumsToMr(dwordIdx uint16, bsh *structs.BlockSearchHelper) { 
    743            .          .           	// If validRecords is nil, then all records are considered valid; 
    744            .          .           	// otherwise, only those in validRecords can be added to the results. 
    745            .          .           	validRecords := bsh.GetValidRecords() 
    746            .          .            
    747            .          .           	if validRecords == nil { 
    748            .          .           		recCount := sfr.blockSummaries[sfr.currBlockNum].RecCount 
    749        910ms      960ms           		for i := uint16(0); i < recCount; i++ { 
    750        1.04s      1.06s           			if sfr.deRecToTlv[i] == dwordIdx { 
    751            .          .           				bsh.AddMatchedRecord(uint(i)) 
    752            .          .           			} 
    753            .          .           		} 
```

After:
```
  Total:       850ms      850ms (flat, cum)  3.85%
    737            .          .            
    738            .          .           	dWord := sfr.deTlv[dwIdx] 
    739            .          .           	return dWord, nil 
    740            .          .           } 
    741            .          .            
    742            .          .           func (sfr *SegmentFileReader) AddRecNumsToMr(dwordIdx uint16, bsh *structs.BlockSearchHelper) { 
    743            .          .           	// If validRecords is nil, then all records are considered valid; 
    744            .          .           	// otherwise, only those in validRecords can be added to the results. 
    745            .          .           	validRecords := bsh.GetValidRecords() 
    746            .          .            
    747            .          .           	if validRecords == nil { 
    748            .          .           		recCount := sfr.blockSummaries[sfr.currBlockNum].RecCount 
    749        840ms      840ms           		for i, idx := range sfr.deRecToTlv[:recCount] { 
    750         10ms       10ms           			if idx == dwordIdx { 
    751            .          .           				bsh.AddMatchedRecord(uint(i)) 
    752            .          .           			} 
    753            .          .           		} 
```
