### PR TITLE
Read blocks in parallel

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -484,7 +484,7 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 		return values, nil
 	}
 
-	results, err := toputils.BatchProcess(iqr.rrcs, getBatchKey, batchKeyLess, batchOperation, false)
+	results, err := toputils.BatchProcess(iqr.rrcs, getBatchKey, batchKeyLess, batchOperation, 1)
 	if err != nil {
 		return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error in batch operation: %v", err)
 	}

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -484,7 +484,7 @@ func (iqr *IQR) readColumnWithRRCs(cname string) ([]utils.CValueEnclosure, error
 		return values, nil
 	}
 
-	results, err := toputils.BatchProcess(iqr.rrcs, getBatchKey, batchKeyLess, batchOperation)
+	results, err := toputils.BatchProcess(iqr.rrcs, getBatchKey, batchKeyLess, batchOperation, false)
 	if err != nil {
 		return nil, toputils.TeeErrorf("IQR.readColumnWithRRCs: error in batch operation: %v", err)
 	}

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -775,7 +775,7 @@ func (s *Searcher) fetchRRCs() (*iqr.IQR, error) {
 		return nil, nil
 	}
 
-	_, err = toputils.BatchProcess(nextBlocks, getBatchKey, batchKeyLess, batchOperation)
+	_, err = toputils.BatchProcess(nextBlocks, getBatchKey, batchKeyLess, batchOperation, false)
 	if err != nil {
 		log.Errorf("qid=%v, searcher.fetchRRCs: failed to batch process blocks: %v", s.qid, err)
 		return nil, err

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -775,7 +775,7 @@ func (s *Searcher) fetchRRCs() (*iqr.IQR, error) {
 		return nil, nil
 	}
 
-	_, err = toputils.BatchProcess(nextBlocks, getBatchKey, batchKeyLess, batchOperation, false)
+	_, err = toputils.BatchProcess(nextBlocks, getBatchKey, batchKeyLess, batchOperation, 1)
 	if err != nil {
 		log.Errorf("qid=%v, searcher.fetchRRCs: failed to batch process blocks: %v", s.qid, err)
 		return nil, err

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -210,21 +210,6 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*utils.RecordResultContaine
 		log.Errorf("qid=%v, readUserDefinedColForRRCs: failed to get or create query search node result; err=%v", qid, err)
 		nodeRes = &structs.NodeResult{}
 	}
-	consistentCValLen := map[string]uint32{cname: utils.INCONSISTENT_CVAL_SIZE} // TODO: use correct value
-	sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, map[string]bool{cname: fetchFromBlob},
-		allBlocksToSearch, blockSummary, 1, consistentCValLen, qid, nodeRes)
-	if err != nil {
-		log.Errorf("qid=%v, readUserDefinedColForRRCs: failed to initialize shared readers for segkey %v; err=%v", qid, segKey, err)
-		return nil, err
-	}
-	defer sharedReader.Close()
-
-	colErrorMap := sharedReader.GetColumnsErrorsMap()
-	if len(colErrorMap) > 0 {
-		return nil, colErrorMap[cname]
-	}
-
-	multiReader := sharedReader.MultiColReaders[0]
 
 	batchingFunc := func(rrc *utils.RecordResultContainer) uint16 {
 		return rrc.BlockNum
@@ -238,10 +223,26 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*utils.RecordResultContaine
 			return nil, nil
 		}
 
+		consistentCValLen := map[string]uint32{cname: utils.INCONSISTENT_CVAL_SIZE} // TODO: use correct value
+		sharedReader, err := segread.InitSharedMultiColumnReaders(segKey, map[string]bool{cname: fetchFromBlob},
+			allBlocksToSearch, blockSummary, 1, consistentCValLen, qid, nodeRes)
+		if err != nil {
+			log.Errorf("qid=%v, readUserDefinedColForRRCs: failed to initialize shared readers for segkey %v; err=%v", qid, segKey, err)
+			return nil, err
+		}
+		defer sharedReader.Close()
+
+		colErrorMap := sharedReader.GetColumnsErrorsMap()
+		if len(colErrorMap) > 0 {
+			return nil, colErrorMap[cname]
+		}
+
+		multiReader := sharedReader.MultiColReaders[0]
+
 		return handleBlock(multiReader, rrcsInBatch[0].BlockNum, rrcsInBatch, qid)
 	}
 
-	enclosures, _ := toputils.BatchProcess(rrcs, batchingFunc, batchKeyLess, operation)
+	enclosures, _ := toputils.BatchProcess(rrcs, batchingFunc, batchKeyLess, operation, true)
 	return enclosures, nil
 }
 

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -242,7 +242,8 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*utils.RecordResultContaine
 		return handleBlock(multiReader, rrcsInBatch[0].BlockNum, rrcsInBatch, qid)
 	}
 
-	enclosures, _ := toputils.BatchProcess(rrcs, batchingFunc, batchKeyLess, operation, true)
+	maxParallelism := runtime.GOMAXPROCS(0)
+	enclosures, _ := toputils.BatchProcess(rrcs, batchingFunc, batchKeyLess, operation, maxParallelism)
 	return enclosures, nil
 }
 

--- a/pkg/utils/sliceutils_test.go
+++ b/pkg/utils/sliceutils_test.go
@@ -126,7 +126,7 @@ func Test_BatchProcess(t *testing.T) {
 	input := []int{1, 2, 3, 20, 42, 100, 47}
 	expected := []int{4, 5, 6, 21, 44, 101, 49}
 	expectedBatchSizes := []int{1, 2, 1, 3} // Batches should be 100s, 40s, 20s, 0s
-	actual, err := BatchProcess(input, batchingFunc, batchOrderingFunc, operation)
+	actual, err := BatchProcess(input, batchingFunc, batchOrderingFunc, operation, false)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, actual)
 	assert.Equal(t, expectedBatchSizes, actualBatchSizes)

--- a/pkg/utils/sliceutils_test.go
+++ b/pkg/utils/sliceutils_test.go
@@ -126,7 +126,7 @@ func Test_BatchProcess(t *testing.T) {
 	input := []int{1, 2, 3, 20, 42, 100, 47}
 	expected := []int{4, 5, 6, 21, 44, 101, 49}
 	expectedBatchSizes := []int{1, 2, 1, 3} // Batches should be 100s, 40s, 20s, 0s
-	actual, err := BatchProcess(input, batchingFunc, batchOrderingFunc, operation, false)
+	actual, err := BatchProcess(input, batchingFunc, batchOrderingFunc, operation, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, actual)
 	assert.Equal(t, expectedBatchSizes, actualBatchSizes)


### PR DESCRIPTION
# Description
Read blocks in parallel. This reduced the query time for `SearchPhrase != "" | sort str(EventTime) | head 10 | fields SearchPhrase` from about 17 seconds to about 13 seconds.
