### PR TITLE
Reduce allocations for slice movement

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -524,7 +524,7 @@ func (iqr *IQR) Append(other *IQR) error {
 
 	if iqr.mode == withRRCs && other.mode == withoutRRCs {
 		if iqr.qid != other.qid {
-			return toputils.TeeErrorf("mergeMetadata: inconsistent qids (%v and %v)", iqr.qid, other.qid)
+			return toputils.TeeErrorf("IQR.Append: inconsistent qids (%v and %v)", iqr.qid, other.qid)
 		}
 		newIQR, err := other.getRRCIQR()
 		if err != nil {

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -864,7 +864,7 @@ func MergeIQRs(iqrs []*IQR, less func(*Record, *Record) bool) (*IQR, int, error)
 	}
 }
 
-func mergeMetadata(iqrs []*IQR, willUseRecords bool) (*IQR, error) {
+func mergeMetadata(iqrs []*IQR, allocateForAllRecords bool) (*IQR, error) {
 	if len(iqrs) == 0 {
 		return nil, fmt.Errorf("mergeMetadata: no IQRs to merge")
 	}
@@ -878,7 +878,7 @@ func mergeMetadata(iqrs []*IQR, willUseRecords bool) (*IQR, error) {
 	}
 
 	numRecords := 0
-	if willUseRecords {
+	if allocateForAllRecords {
 		for _, iqr := range iqrs {
 			numRecords += iqr.NumberOfRecords()
 		}

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -133,7 +133,7 @@ func Test_mergeMetadata(t *testing.T) {
 	iqr1.encodingToSegKey = map[uint32]string{1: "segKey1"}
 	iqr2.encodingToSegKey = map[uint32]string{2: "segKey2"}
 
-	iqr, err := mergeMetadata([]*IQR{iqr1, iqr2})
+	iqr, err := mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, map[uint32]string{1: "segKey1", 2: "segKey2"}, iqr.encodingToSegKey)
 
@@ -141,7 +141,7 @@ func Test_mergeMetadata(t *testing.T) {
 	iqr1.encodingToSegKey = map[uint32]string{1: "segKey1", 2: "segKey2"}
 	iqr2.encodingToSegKey = map[uint32]string{2: "segKey2", 3: "segKey3"}
 
-	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2})
+	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, map[uint32]string{1: "segKey1", 2: "segKey2", 3: "segKey3"}, iqr.encodingToSegKey)
 
@@ -149,7 +149,7 @@ func Test_mergeMetadata(t *testing.T) {
 	iqr1.encodingToSegKey = map[uint32]string{1: "segKey1", 2: "segKey2"}
 	iqr2.encodingToSegKey = map[uint32]string{2: "segKey100", 3: "segKey3"}
 
-	_, err = mergeMetadata([]*IQR{iqr1, iqr2})
+	_, err = mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.Error(t, err)
 }
 
@@ -160,27 +160,27 @@ func Test_mergeMetadata_modes(t *testing.T) {
 	// Incompatible modes.
 	iqr1.mode = withRRCs
 	iqr2.mode = withoutRRCs
-	_, err := mergeMetadata([]*IQR{iqr1, iqr2})
+	_, err := mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.Error(t, err)
 
 	// Same modes.
 	iqr1.mode = withRRCs
 	iqr2.mode = withRRCs
-	iqr, err := mergeMetadata([]*IQR{iqr1, iqr2})
+	iqr, err := mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, withRRCs, iqr.mode)
 
 	// First is unset.
 	iqr1.mode = notSet
 	iqr2.mode = withoutRRCs
-	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2})
+	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, withoutRRCs, iqr.mode)
 
 	// Second is unset.
 	iqr1.mode = withoutRRCs
 	iqr2.mode = notSet
-	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2})
+	iqr, err = mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, withoutRRCs, iqr.mode)
 }
@@ -189,7 +189,7 @@ func Test_mergeMetadata_differentQids(t *testing.T) {
 	iqr1 := NewIQR(0)
 	iqr2 := NewIQR(1)
 
-	_, err := mergeMetadata([]*IQR{iqr1, iqr2})
+	_, err := mergeMetadata([]*IQR{iqr1, iqr2}, false)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
# Description

Reduce memory allocations for moving slices by allocating the right amount the first time. This doesn't seem to have an affect on the query execution time.

Tested on this query: `SearchPhrase != "" | sort str(EventTime) | head 10 | fields SearchPhrase` and used the `allocs` pprof profile

Before
```
(pprof) top
Showing nodes accounting for 9744.24MB, 86.15% of 11311.12MB total
```

After
```
(pprof) top
Showing nodes accounting for 8793.45MB, 87.49% of 10050.94MB total
```