### PR TITLE
Use a heap to sort faster

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -707,7 +707,7 @@ func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool, lim
 
 	// If we only want to keep a few records, use a heap to save CPU. If we
 	// want to keep a lot, sort in place to save memory.
-	threshold := 10000 // TODO: tune this
+	threshold := 1000 // TODO: tune this
 	if limit <= threshold {
 		records = toputils.GetTopN(limit, records, less)
 	} else {

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -675,7 +675,8 @@ func (iqr *IQR) GetRecord(index int) *Record {
 }
 
 // Only the first `limit` records are guaranteed to be in the correct order
-// when this function returns.
+// when this function returns. Records after that may not even exist
+// afterwards.
 func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool, limit int) error {
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.Sort: validation failed: %v", err)
@@ -706,7 +707,8 @@ func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool, lim
 
 	// If we only want to keep a few records, use a heap to save CPU. If we
 	// want to keep a lot, sort in place to save memory.
-	if limit <= 10000 /* TODO: tune this */ {
+	threshold := 10000 // TODO: tune this
+	if limit <= threshold {
 		records = toputils.GetTopN(limit, records, less)
 	} else {
 		sort.Slice(records, func(i, j int) bool {

--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -674,7 +674,9 @@ func (iqr *IQR) GetRecord(index int) *Record {
 	return &Record{iqr: iqr, Index: index}
 }
 
-func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool) error {
+// Only the first `limit` records are guaranteed to be in the correct order
+// when this function returns.
+func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool, limit int) error {
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.Sort: validation failed: %v", err)
 		return err
@@ -702,9 +704,15 @@ func (iqr *IQR) Sort(sortColumns []string, less func(*Record, *Record) bool) err
 		records[i] = &Record{iqr: iqr, Index: i, SortValues: sortColumnValues}
 	}
 
-	sort.Slice(records, func(i, j int) bool {
-		return less(records[i], records[j])
-	})
+	// If we only want to keep a few records, use a heap to save CPU. If we
+	// want to keep a lot, sort in place to save memory.
+	if limit <= 10000 /* TODO: tune this */ {
+		records = toputils.GetTopN(limit, records, less)
+	} else {
+		sort.Slice(records, func(i, j int) bool {
+			return less(records[i], records[j])
+		})
+	}
 
 	if iqr.mode == withRRCs {
 		newRRCs := make([]*utils.RecordResultContainer, iqr.NumberOfRecords())

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -453,7 +453,7 @@ func Test_Sort(t *testing.T) {
 		return aVal.CVal.(string) < bVal.CVal.(string)
 	}
 
-	err = iqr.Sort([]string{"col1", "col2"}, less)
+	err = iqr.Sort([]string{"col1", "col2"}, less, 100)
 	assert.NoError(t, err)
 
 	expected := map[string][]utils.CValueEnclosure{
@@ -529,7 +529,7 @@ func Test_Sort_multipleColumns(t *testing.T) {
 		return aVal2.CVal.(uint64) < bVal2.CVal.(uint64)
 	}
 
-	err = iqr.Sort([]string{"col1", "col2"}, less)
+	err = iqr.Sort([]string{"col1", "col2"}, less, 100)
 	assert.NoError(t, err)
 	values, err := iqr.ReadAllColumns()
 	assert.NoError(t, err)

--- a/pkg/segment/query/processor/sortcommand.go
+++ b/pkg/segment/query/processor/sortcommand.go
@@ -45,7 +45,7 @@ func (p *sortProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 	}
 
 	p.validate()
-	err := inputIQR.Sort(p.getSortColumns(), p.less)
+	err := inputIQR.Sort(p.getSortColumns(), p.less, int(p.options.Limit))
 	if err != nil {
 		log.Errorf("sort.Process: cannot sort IQR; err=%v", err)
 		return nil, err

--- a/pkg/utils/heap.go
+++ b/pkg/utils/heap.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// # This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import "container/heap"
+
+type HeapItem[T any] struct {
+	Value T
+	index int // Position in the heap, maintained by heap operations
+}
+
+type lessFunc[T any] func(a, b T) bool
+
+// Heap implements heap.Interface for a generic collection of items.
+type Heap[T any] struct {
+	items []*HeapItem[T]
+	less  lessFunc[T]
+}
+
+func NewHeap[T any](less lessFunc[T]) *Heap[T] {
+	if less == nil {
+		return nil
+	}
+
+	return &Heap[T]{
+		items: []*HeapItem[T]{},
+		less:  less,
+	}
+}
+
+func (h *Heap[T]) Len() int {
+	return len(h.items)
+}
+
+func (h *Heap[T]) Less(i, j int) bool {
+	return h.less(h.items[i].Value, h.items[j].Value)
+}
+
+func (h *Heap[T]) Swap(i, j int) {
+	h.items[i], h.items[j] = h.items[j], h.items[i]
+	h.items[i].index = i
+	h.items[j].index = j
+}
+
+func (h *Heap[T]) Push(x any) {
+	n := len(h.items)
+	item := x.(*HeapItem[T])
+	item.index = n
+	h.items = append(h.items, item)
+}
+
+// Remove and return the last item.
+func (h *Heap[T]) Pop() any {
+	old := h.items
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	h.items = old[0 : n-1]
+	return item
+}
+
+func (h *Heap[T]) PushValue(v T) *HeapItem[T] {
+	item := &HeapItem[T]{Value: v}
+	heap.Push(h, item)
+	return item
+}
+
+func (h *Heap[T]) PopValue() T {
+	return heap.Pop(h).(*HeapItem[T]).Value
+}
+
+func GetTopN[T any](N int, items []T, less lessFunc[T]) []T {
+	// Create min-heap (smaller items at root)
+	h := NewHeap(func(a, b T) bool {
+		return less(b, a) // Reverse the order for min-heap
+	})
+
+	// Process all items
+	for _, item := range items {
+		h.PushValue(item)
+
+		// If we have more than N items, remove the smallest
+		if h.Len() > N {
+			h.PopValue()
+		}
+	}
+
+	// Extract results in reverse order (smallest to largest)
+	result := make([]T, 0, h.Len())
+	for h.Len() > 0 {
+		result = append(result, h.PopValue())
+	}
+
+	// Reverse to get descending order
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result
+}

--- a/pkg/utils/heap.go
+++ b/pkg/utils/heap.go
@@ -69,15 +69,17 @@ func (h *Heap[T]) Pop() any {
 	old := h.items
 	n := len(old)
 	item := old[n-1]
-	old[n-1] = nil  // avoid memory leak
-	item.index = -1 // for safety
+	old[n-1] = nil
+	item.index = -1
 	h.items = old[0 : n-1]
+
 	return item
 }
 
 func (h *Heap[T]) PushValue(v T) *HeapItem[T] {
 	item := &HeapItem[T]{Value: v}
 	heap.Push(h, item)
+
 	return item
 }
 
@@ -101,13 +103,13 @@ func GetTopN[T any](N int, items []T, less lessFunc[T]) []T {
 		}
 	}
 
-	// Extract results in reverse order (smallest to largest)
+	// Extract results in reverse order
 	result := make([]T, 0, h.Len())
 	for h.Len() > 0 {
 		result = append(result, h.PopValue())
 	}
 
-	// Reverse to get descending order
+	// Reverse to get correct order
 	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
 		result[i], result[j] = result[j], result[i]
 	}

--- a/pkg/utils/heap_test.go
+++ b/pkg/utils/heap_test.go
@@ -28,7 +28,7 @@ func Test_ImplementsHeap(t *testing.T) {
 	var _ heap.Interface = NewHeap(func(a, b int) bool { return a < b })
 }
 
-func TestHeapBasicOperations(t *testing.T) {
+func Test_HeapBasicOperations(t *testing.T) {
 	// Max heap for integers
 	h := NewHeap(func(a, b int) bool { return a > b })
 
@@ -71,7 +71,7 @@ func TestHeapBasicOperations(t *testing.T) {
 	}
 }
 
-func TestHeapConvenienceMethods(t *testing.T) {
+func Test_HeapConvenienceMethods(t *testing.T) {
 	// Min heap for strings
 	h := NewHeap(func(a, b string) bool { return a < b })
 	heap.Init(h)
@@ -97,7 +97,7 @@ func TestHeapConvenienceMethods(t *testing.T) {
 	}
 }
 
-func TestTopN(t *testing.T) {
+func Test_TopN(t *testing.T) {
 	data := []int{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9}
 
 	top5 := GetTopN(5, data, func(a, b int) bool {

--- a/pkg/utils/heap_test.go
+++ b/pkg/utils/heap_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// # This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package utils
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ImplementsHeap(t *testing.T) {
+	var _ heap.Interface = NewHeap(func(a, b int) bool { return a < b })
+}
+
+func TestHeapBasicOperations(t *testing.T) {
+	// Max heap for integers
+	h := NewHeap(func(a, b int) bool { return a > b })
+
+	// Test empty heap
+	if h.Len() != 0 {
+		t.Errorf("Expected empty heap, got %d elements", h.Len())
+	}
+
+	// Add elements
+	heap.Init(h)
+	heap.Push(h, &HeapItem[int]{Value: 5})
+	heap.Push(h, &HeapItem[int]{Value: 3})
+	heap.Push(h, &HeapItem[int]{Value: 7})
+
+	// Check size
+	if h.Len() != 3 {
+		t.Errorf("Expected 3 elements, got %d", h.Len())
+	}
+
+	// Verify max element
+	max := heap.Pop(h).(*HeapItem[int])
+	if max.Value != 7 {
+		t.Errorf("Expected max value 7, got %d", max.Value)
+	}
+
+	// Verify remaining elements
+	secondMax := heap.Pop(h).(*HeapItem[int])
+	if secondMax.Value != 5 {
+		t.Errorf("Expected second max value 5, got %d", secondMax.Value)
+	}
+
+	thirdMax := heap.Pop(h).(*HeapItem[int])
+	if thirdMax.Value != 3 {
+		t.Errorf("Expected third max value 3, got %d", thirdMax.Value)
+	}
+
+	// Verify empty again
+	if h.Len() != 0 {
+		t.Errorf("Expected empty heap after popping all elements, got %d", h.Len())
+	}
+}
+
+func TestHeapConvenienceMethods(t *testing.T) {
+	// Min heap for strings
+	h := NewHeap(func(a, b string) bool { return a < b })
+	heap.Init(h)
+
+	// Use convenience methods
+	h.PushValue("banana")
+	h.PushValue("apple")
+	h.PushValue("cherry")
+
+	if h.Len() != 3 {
+		t.Errorf("Expected 3 elements, got %d", h.Len())
+	}
+
+	// Verify order with PopValue
+	if val := h.PopValue(); val != "apple" {
+		t.Errorf("Expected 'apple', got '%s'", val)
+	}
+	if val := h.PopValue(); val != "banana" {
+		t.Errorf("Expected 'banana', got '%s'", val)
+	}
+	if val := h.PopValue(); val != "cherry" {
+		t.Errorf("Expected 'cherry', got '%s'", val)
+	}
+}
+
+func TestTopN(t *testing.T) {
+	data := []int{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9}
+
+	top5 := GetTopN(5, data, func(a, b int) bool {
+		return a > b
+	})
+
+	assert.Equal(t, 5, len(top5))
+	assert.Equal(t, []int{9, 9, 9, 8, 7}, top5)
+}

--- a/pkg/utils/heap_test.go
+++ b/pkg/utils/heap_test.go
@@ -85,20 +85,13 @@ func Test_HeapConvenienceMethods(t *testing.T) {
 		t.Errorf("Expected 3 elements, got %d", h.Len())
 	}
 
-	// Verify order with PopValue
-	if val := h.PopValue(); val != "apple" {
-		t.Errorf("Expected 'apple', got '%s'", val)
-	}
-	if val := h.PopValue(); val != "banana" {
-		t.Errorf("Expected 'banana', got '%s'", val)
-	}
-	if val := h.PopValue(); val != "cherry" {
-		t.Errorf("Expected 'cherry', got '%s'", val)
-	}
+	assert.Equal(t, "apple", h.PopValue())
+	assert.Equal(t, "banana", h.PopValue())
+	assert.Equal(t, "cherry", h.PopValue())
 }
 
 func Test_TopN(t *testing.T) {
-	data := []int{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9}
+	data := []int{3, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 1, 4, 7, 9}
 
 	top5 := GetTopN(5, data, func(a, b int) bool {
 		return a > b


### PR DESCRIPTION
# Description
When sorting records and only taking the top few, this PR speeds up the query by using a heap instead of sorting all the records (in the batch).

This query: `SearchPhrase != "" | sort str(EventTime) | head 10 | fields SearchPhrase` takes about 11 seconds both before and after this PR. But changing it to `SearchPhrase != "" | sort 10 str(EventTime) | fields SearchPhrase`, it takes about 10.2 seconds before this PR and 7.8 seconds after the PR.
