### PR TITLE
Reuse map to avoid allocations

### DIFF
--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -170,6 +170,7 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 
 	measureInfo, internalMops := blkResults.GetConvertedMeasureInfo()
 	measureResults := make([]utils.CValueEnclosure, len(internalMops))
+	unsetRecord := make(map[string]utils.CValueEnclosure)
 
 	for i := 0; i < numOfRecords; i++ {
 		record := inputIQR.GetRecord(i)
@@ -197,7 +198,8 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 				measureResults[idx] = *cValue
 			}
 		}
-		blkResults.AddMeasureResultsToKey(p.bucketKeyWorkingBuf[:bucketKeyBufIdx], measureResults, "", false, qid)
+		blkResults.AddMeasureResultsToKey(p.bucketKeyWorkingBuf[:bucketKeyBufIdx], measureResults,
+			"", false, qid, unsetRecord)
 	}
 
 	return nil, nil

--- a/pkg/segment/query/processor/timechartcommand.go
+++ b/pkg/segment/query/processor/timechartcommand.go
@@ -155,6 +155,7 @@ func (p *timechartProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 
 	measureInfo, internalMops := blkResults.GetConvertedMeasureInfo()
 	measureResults := make([]utils.CValueEnclosure, len(internalMops))
+	unsetRecord := make(map[string]utils.CValueEnclosure)
 
 	for i := 0; i < numOfRecords; i++ {
 		bucketKeyBufIdx := 0
@@ -220,7 +221,8 @@ func (p *timechartProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 				measureResults[idx] = *cValue
 			}
 		}
-		blkResults.AddMeasureResultsToKey(p.bucketKeyWorkingBuf[:bucketKeyBufIdx], measureResults, groupByColVal, true, qid)
+		blkResults.AddMeasureResultsToKey(p.bucketKeyWorkingBuf[:bucketKeyBufIdx], measureResults,
+			groupByColVal, true, qid, unsetRecord)
 	}
 
 	if len(byField) > 0 {

--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -525,6 +525,7 @@ func (str *AgileTreeReader) ApplyGroupByJit(grpColNames []string,
 		usedDictEncodings[i] = str.treeMeta.allDictEncodings[grpCol]
 	}
 
+	unsetRecord := make(map[string]utils.CValueEnclosure)
 	var retErr error
 	for mkey, ntAgvals := range combiner {
 		if len(ntAgvals) == 0 {
@@ -573,7 +574,7 @@ func (str *AgileTreeReader) ApplyGroupByJit(grpColNames []string,
 				resCvIdx++
 			}
 		}
-		blkResults.AddMeasureResultsToKeyAgileTree(string(rawVal), cvaggvalues, qid, colCntVal)
+		blkResults.AddMeasureResultsToKeyAgileTree(string(rawVal), cvaggvalues, qid, colCntVal, unsetRecord)
 	}
 
 	return retErr

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -388,7 +388,8 @@ func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncose
 
 }
 
-func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []utils.CValueEnclosure, groupByColVal string, usedByTimechart bool, qid uint64) {
+func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []utils.CValueEnclosure,
+	groupByColVal string, usedByTimechart bool, qid uint64, unsetRecord map[string]utils.CValueEnclosure) {
 
 	if b.GroupByAggregation == nil {
 		return
@@ -421,9 +422,9 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 			bucket.groupedRunningStats[groupByColVal] = gRunningStats
 		}
 		gRunningStats = bucket.groupedRunningStats[groupByColVal]
-		bucket.AddMeasureResults(&gRunningStats, measureResults, qid, 1, true, b.batchErr)
+		bucket.AddMeasureResults(&gRunningStats, measureResults, qid, 1, true, b.batchErr, unsetRecord)
 	} else {
-		bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, 1, false, b.batchErr)
+		bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, 1, false, b.batchErr, unsetRecord)
 	}
 
 }

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -430,7 +430,9 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []u
 }
 
 func (b *BlockResults) AddMeasureResultsToKeyAgileTree(bKey string,
-	measureResults []utils.CValueEnclosure, qid uint64, cnt uint64) {
+	measureResults []utils.CValueEnclosure, qid uint64, cnt uint64,
+	unsetRecord map[string]utils.CValueEnclosure) {
+
 	if b.GroupByAggregation == nil {
 		return
 	}
@@ -448,7 +450,7 @@ func (b *BlockResults) AddMeasureResultsToKeyAgileTree(bKey string,
 	} else {
 		bucket = b.GroupByAggregation.AllRunningBuckets[bucketIdx]
 	}
-	bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, cnt, false, b.batchErr)
+	bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, cnt, false, b.batchErr, unsetRecord)
 }
 
 func (b *BlockResults) AddKeyToTimeBucket(bucketKey uint64, count uint16) {

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -112,18 +112,25 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 	}
 
 	for i := 0; i < len(*runningStats); i++ {
+		fields := rr.currStats[i].ValueColRequest.GetFields()
+		fieldToValue, err := PopulateFieldToValueFromMeasureResults(unsetRecord, fields, measureResults, i)
+		if err != nil {
+			batchErr.AddError("RunningBucketResults.AddMeasureResults: failed to populate field to value", err)
+			continue
+		}
+
 		measureFunc := rr.currStats[i].MeasureFunc
 		// TODO: Change All the Eval functions to return error
 		// of type *ErrorWithCode
 		switch measureFunc {
 		case utils.Sum:
-			step, err := rr.AddEvalResultsForSum(runningStats, measureResults, i)
+			step, err := rr.AddEvalResultsForSum(runningStats, measureResults, i, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:Sum", err)
 			}
 			i += step
 		case utils.Avg:
-			step, err := rr.AddEvalResultsForAvg(runningStats, measureResults, i, unsetRecord)
+			step, err := rr.AddEvalResultsForAvg(runningStats, measureResults, i, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:Avg", err)
 			}
@@ -132,19 +139,19 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 			fallthrough
 		case utils.Min:
 			isMin := measureFunc == utils.Min
-			step, err := rr.AddEvalResultsForMinMax(runningStats, measureResults, i, isMin)
+			step, err := rr.AddEvalResultsForMinMax(runningStats, measureResults, i, isMin, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:MinMax", err)
 			}
 			i += step
 		case utils.Range:
-			step, err := rr.AddEvalResultsForRange(runningStats, measureResults, i)
+			step, err := rr.AddEvalResultsForRange(runningStats, measureResults, i, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:Range", err)
 			}
 			i += step
 		case utils.Count:
-			step, err := rr.AddEvalResultsForCount(runningStats, measureResults, i, usedByTimechart, cnt)
+			step, err := rr.AddEvalResultsForCount(runningStats, measureResults, i, usedByTimechart, cnt, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:Count", err)
 			}
@@ -161,13 +168,13 @@ func (rr *RunningBucketResults) AddMeasureResults(runningStats *[]runningStats, 
 			}
 			fallthrough
 		case utils.Values:
-			step, err := rr.AddEvalResultsForValuesOrCardinality(runningStats, measureResults, i)
+			step, err := rr.AddEvalResultsForValuesOrCardinality(runningStats, measureResults, i, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:Values", err)
 			}
 			i += step
 		case utils.List:
-			step, err := rr.AddEvalResultsForList(runningStats, measureResults, i)
+			step, err := rr.AddEvalResultsForList(runningStats, measureResults, i, fieldToValue)
 			if err != nil {
 				batchErr.AddError("RunningBucketResults.AddMeasureResults:List", err)
 			}
@@ -415,7 +422,7 @@ func PopulateFieldToValueFromMeasureResults(fieldToValue map[string]utils.CValue
 	return fieldToValue, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	if rr.currStats[i].ValueColRequest == nil {
 		return 0, rr.ProcessReduce(runningStats, measureResults[i], i)
 	}
@@ -423,10 +430,6 @@ func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStat
 	if len(fields) == 0 {
 		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:NON_ZERO_FIELDS",
 			fmt.Errorf("need non zero number of fields in expression for eval stats for sum for aggCol: %v", rr.currStats[i].String()))
-	}
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, putils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:POPULATE_FIELD_TO_VALUE", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
@@ -440,7 +443,7 @@ func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStat
 }
 
 func (rr *RunningBucketResults) AddEvalResultsForAvg(runningStats *[]runningStats,
-	measureResults []utils.CValueEnclosure, i int, unsetRecord map[string]utils.CValueEnclosure) (int, error) {
+	measureResults []utils.CValueEnclosure, i int, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 
 	if rr.currStats[i].ValueColRequest == nil {
 		return 0, rr.ProcessReduce(runningStats, measureResults[i], i)
@@ -448,10 +451,6 @@ func (rr *RunningBucketResults) AddEvalResultsForAvg(runningStats *[]runningStat
 	fields := rr.currStats[i].ValueColRequest.GetFields()
 	if len(fields) == 0 {
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForAvg: Need non zero number of fields in expression for eval stats for avg for aggCol: %v", rr.currStats[i].String())
-	}
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(unsetRecord, fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForAvg: failed to populate field to value, err: %v", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
@@ -472,17 +471,13 @@ func (rr *RunningBucketResults) AddEvalResultsForAvg(runningStats *[]runningStat
 	return len(fields) - 1, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForMinMax(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, isMin bool) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForMinMax(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, isMin bool, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	if rr.currStats[i].ValueColRequest == nil {
 		return 0, rr.ProcessReduce(runningStats, measureResults[i], i)
 	}
 	fields := rr.currStats[i].ValueColRequest.GetFields()
 	if len(fields) == 0 {
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForMinMax: Need non zero number of fields in expression for eval stats for min/max for aggCol: %v", rr.currStats[i].String())
-	}
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForMinMax: failed to populate field to value, err: %v", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
@@ -495,17 +490,13 @@ func (rr *RunningBucketResults) AddEvalResultsForMinMax(runningStats *[]runningS
 	return len(fields) - 1, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForRange(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForRange(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	if rr.currStats[i].ValueColRequest == nil {
 		return 0, rr.ProcessReduce(runningStats, measureResults[i], i)
 	}
 	fields := rr.currStats[i].ValueColRequest.GetFields()
 	if len(fields) == 0 {
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForRange: Need non zero number of fields in expression for eval stats for range for aggCol: %v", rr.currStats[i].String())
-	}
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForRange: failed to populate field to value, err: %v", err)
 	}
 	exists := (*runningStats)[i].rawVal.Dtype != utils.SS_INVALID
 
@@ -522,7 +513,7 @@ func (rr *RunningBucketResults) AddEvalResultsForRange(runningStats *[]runningSt
 	return len(fields) - 1, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForCount(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, usedByTimechart bool, cnt uint64) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForCount(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, usedByTimechart bool, cnt uint64, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	var err error
 	if rr.currStats[i].ValueColRequest == nil {
 		if usedByTimechart {
@@ -537,10 +528,6 @@ func (rr *RunningBucketResults) AddEvalResultsForCount(runningStats *[]runningSt
 	}
 
 	fields := rr.currStats[i].ValueColRequest.GetFields()
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForCount: failed to populate field to value, err: %v", err)
-	}
 
 	boolResult := true
 	if rr.currStats[i].ValueColRequest.BooleanExpr != nil {
@@ -562,7 +549,7 @@ func (rr *RunningBucketResults) AddEvalResultsForCount(runningStats *[]runningSt
 	return len(fields) - 1, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	if (*runningStats)[i].rawVal.CVal == nil {
 		(*runningStats)[i].rawVal = utils.CValueEnclosure{
 			Dtype: utils.SS_DT_STRING_SET,
@@ -582,12 +569,8 @@ func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStat
 	}
 
 	fields := rr.currStats[i].ValueColRequest.GetFields()
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForValuesOrCardinality: failed to populate field to value, err: %v", err)
-	}
 
-	_, err = agg.PerformAggEvalForCardinality(rr.currStats[i], strSet, fieldToValue)
+	_, err := agg.PerformAggEvalForCardinality(rr.currStats[i], strSet, fieldToValue)
 	if err != nil {
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForValuesOrCardinality: failed to evaluate ValueColRequest to string, err: %v", err)
 	}
@@ -596,7 +579,7 @@ func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStat
 	return len(fields) - 1, nil
 }
 
-func (rr *RunningBucketResults) AddEvalResultsForList(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int) (int, error) {
+func (rr *RunningBucketResults) AddEvalResultsForList(runningStats *[]runningStats, measureResults []utils.CValueEnclosure, i int, fieldToValue map[string]utils.CValueEnclosure) (int, error) {
 	if (*runningStats)[i].rawVal.CVal == nil {
 		(*runningStats)[i].rawVal = utils.CValueEnclosure{
 			Dtype: utils.SS_DT_STRING_SLICE,
@@ -618,10 +601,6 @@ func (rr *RunningBucketResults) AddEvalResultsForList(runningStats *[]runningSta
 	}
 
 	fields := rr.currStats[i].ValueColRequest.GetFields()
-	fieldToValue, err := PopulateFieldToValueFromMeasureResults(fields, measureResults, i)
-	if err != nil {
-		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForList: failed to populate field to value, err: %v", err)
-	}
 
 	result, err := agg.PerformAggEvalForList(rr.currStats[i], strList, fieldToValue)
 	if err != nil {

--- a/pkg/segment/results/blockresults/runningstats_test.go
+++ b/pkg/segment/results/blockresults/runningstats_test.go
@@ -65,7 +65,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		bRes.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
+		bRes.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5, nil)
 	}
 	assert.NotNil(t, bRes.GroupByAggregation)
 	assert.Len(t, bRes.GroupByAggregation.AllRunningBuckets, 10)
@@ -85,7 +85,7 @@ func Test_JoinStats(t *testing.T) {
 			{CVal: uint64(1), Dtype: utils.SS_DT_UNSIGNED_NUM},
 			{CVal: i, Dtype: utils.SS_DT_UNSIGNED_NUM},
 		}
-		toMerge.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5)
+		toMerge.AddMeasureResultsToKey(buf.Bytes(), mRes, "", false, 5, nil)
 	}
 
 	bRes.MergeBuckets(toMerge)

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -236,6 +236,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 	}
 
 	groupByCache := make(map[string][]string)
+	unsetRecord := make(map[string]utils.CValueEnclosure) // Make this once instead of each iteration.
 
 	for recNum := uint16(0); recNum < recIT.AllRecLen; recNum++ {
 		if !recIT.ShouldProcessRecord(uint(recNum)) {
@@ -334,7 +335,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			}
 		}
 		blockRes.AddMeasureResultsToKey(aggsKeyWorkingBuf[:aggsKeyBufIdx], measureResults,
-			groupByColVal, usedByTimechart, qid)
+			groupByColVal, usedByTimechart, qid, unsetRecord)
 	}
 
 	if usedByTimechart && len(timeHistogram.Timechart.ByField) > 0 {
@@ -387,6 +388,7 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 		}
 	}
 
+	unsetRecord := make(map[string]utils.CValueEnclosure)
 	measureResults := make([]utils.CValueEnclosure, len(internalMops))
 
 	if nodeResult.RecsAggsColumnKeysMap == nil {
@@ -446,7 +448,7 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 			}
 		}
 
-		blockRes.AddMeasureResultsToKey(currKey.Bytes(), measureResults, "", false, qid)
+		blockRes.AddMeasureResultsToKey(currKey.Bytes(), measureResults, "", false, qid, unsetRecord)
 	}
 
 	if nodeResult.RecsAggResults.RecsAggsBlockResults == nil {

--- a/pkg/utils/sliceutils.go
+++ b/pkg/utils/sliceutils.go
@@ -26,6 +26,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func SliceHas[T comparable](slice []T, item T) bool {
+	for _, v := range slice {
+		if v == item {
+			return true
+		}
+	}
+
+	return false
+}
+
 func SliceContainsString(slice []string, s string) bool {
 	for _, v := range slice {
 		if v == s {


### PR DESCRIPTION
# Description
Previously when computing aggregations, we'd make a map for each record, mapping the measure columns to their values. These short-lived maps caused a lot of allocations and work for the garbage collector. With this PR, we make just one map per batch of records.

# Testing
Tested on this query:
```
URL != "" | stats avg(eval(len(URL))) as l, count as c by CounterID | where c > 100000 | sort -l | head 25
```

Before: took 16 seconds and 60 GB
```
(pprof) top
Showing nodes accounting for 59922.54MB, 98.72% of 60699.58MB total
```

After: took 13 seconds and 23.5 GB
```
(pprof) top
Showing nodes accounting for 23.27GB, 99.28% of 23.44GB total
```