### PR TITLE
Fix for panic when segment blockNum reaches MaxUint16

### DIFF
--- a/pkg/segment/writer/segstore.go
+++ b/pkg/segment/writer/segstore.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -778,7 +779,7 @@ func (segstore *SegStore) checkAndRotateColFiles(streamid string, forceRotate bo
 	}
 	maxSegFileSize := config.GetMaxSegFileSize()
 
-	if segstore.OnDiskBytes > maxSegFileSize || forceRotate || onTimeRotate || onTreeRotate {
+	if segstore.OnDiskBytes > maxSegFileSize || forceRotate || onTimeRotate || onTreeRotate || (segstore.numBlocks >= math.MaxUint16-2) {
 		if hook := hooks.GlobalHooks.RotateSegment; hook != nil {
 			alreadyHandled, err := hook(segstore, streamid, forceRotate)
 			if err != nil {


### PR DESCRIPTION
The [panic](https://sigscalr.slack.com/archives/C02999B0A49/p1746267979762769) in addMicroIndicesToUnrotatedInfo occurs when [blockNum](https://github.com/siglens/siglens/blob/f8b214cd84aec683c80b6275d258436ebe99349d/pkg/segment/writer/unrotatedquery.go#L271) reaches 65535. The fix is to rotating segment when about to reach it.