### PR TITLE
Log as warning when server may have duplicates

### DIFF
--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -219,7 +219,18 @@ func (dp *DataProcessor) IsDataGenerator() bool {
 	case *gentimesProcessor:
 		return true
 	case *inputlookupProcessor:
+		// TODO: why does IsFirstCommand matter here? Maybe this function
+		// should be renamed; maybe we can merge this with GeneratesData().
 		return dp.processor.(*inputlookupProcessor).options.IsFirstCommand
+	default:
+		return false
+	}
+}
+
+func (dp *DataProcessor) GeneratesData() bool {
+	switch dp.processor.(type) {
+	case *gentimesProcessor, *inputlookupProcessor:
+		return true
 	default:
 		return false
 	}

--- a/tools/sigclient/cmd/sigclient.go
+++ b/tools/sigclient/cmd/sigclient.go
@@ -597,8 +597,8 @@ var longevityCmd = &cobra.Command{
 		maxConcurrentQueries := int32(4)
 		queryManager := query.NewQueryManager(templates, maxConcurrentQueries, queryUrl, failOnError)
 
-		callback := func(logs []map[string]interface{}, allTs []uint64) {
-			queryManager.HandleIngestedLogs(logs, allTs)
+		callback := func(logs []map[string]interface{}, allTs []uint64, didRetry bool) {
+			queryManager.HandleIngestedLogs(logs, allTs, didRetry)
 		}
 
 		ingest.StartIngestion(ingest.ESBulk, generatorType, dataFile,

--- a/tools/sigclient/pkg/query/querymanager.go
+++ b/tools/sigclient/pkg/query/querymanager.go
@@ -80,7 +80,7 @@ func (qs *queryStats) Log() {
 	qs.lock.Lock()
 	defer qs.lock.Unlock()
 
-	log.Infof("QueryStats: %d queries failed to run, %d queries gave bad results, %d queries gave warnings, %d queries succeeded",
+	log.Infof("QueryStats: %d failed to run, %d gave bad results, %d gave warnings, %d succeeded",
 		qs.numFailedToRun, qs.numBadResults, qs.numWarnings, qs.numSuccess)
 
 	if qs.lastFailure != "" {

--- a/tools/sigclient/pkg/query/queryvalidator_test.go
+++ b/tools/sigclient/pkg/query/queryvalidator_test.go
@@ -806,7 +806,7 @@ func addLogsWithoutError(t *testing.T, validator queryValidator, logs []map[stri
 	t.Helper()
 
 	for _, log := range logs {
-		err := validator.HandleLog(log, log["timestamp"].(uint64))
+		err := validator.HandleLog(log, log["timestamp"].(uint64), false)
 		assert.NoError(t, err)
 	}
 }


### PR DESCRIPTION
# Description
When the longevity test suite encounters a failing query, if that query matched a record that siglens may have duplicate records for (because ingestion had to be retried), log that as a a warning instead of an error.

# Testing
Not tested