### PR TITLE
Ignore SSL Cert validation in webhook

### DIFF
--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -298,7 +298,13 @@ func ProcessTestContactPointRequest(ctx *fasthttp.RequestCtx) {
 }
 
 func testWebhookURL(webhookURL string) error {
-	resp, err := http.Get(webhookURL)
+	client := alertutils.GetCertErrorForgivingHttpClient()
+	req, err := http.NewRequest("GET", webhookURL, nil)
+	if err != nil {
+		log.Errorf("testWebhookURL: failed to create a test webhook request - %v", err)
+		return err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		log.Errorf("testWebhookURL: failed to test webhook URL. URL: %v err: %v", webhookURL, err)
 		return err
@@ -442,7 +448,6 @@ func ProcessUpdateAlertRequest(ctx *fasthttp.RequestCtx) {
 	}
 
 	err = RemoveCronJob(alertToBeUpdated.AlertId)
-
 	if err != nil {
 		utils.SendError(ctx, fmt.Sprintf("Failed to remove cron job for alert. Error=%v", err), fmt.Sprintf("alert name: %v", alertToBeUpdated.AlertName), err)
 		return
@@ -641,7 +646,7 @@ func InitAlertingService(getMyIds func() []int64) {
 	myids := getMyIds()
 	for _, myid := range myids {
 
-		//get all alerts from database
+		// get all alerts from database
 		allAlerts, err := databaseObj.GetAllAlerts(myid)
 		if err != nil {
 			log.Errorf("InitAlertingService: unable to GetAllAlerts: ,err: %+v", err)
@@ -670,7 +675,7 @@ func InitMinionSearchService(getMyIds func() []int64) {
 	myids := getMyIds()
 	for _, myid := range myids {
 
-		//get all alerts from database
+		// get all alerts from database
 		allMinionSearches, err := databaseObj.GetAllMinionSearches(myid)
 		if err != nil {
 			log.Errorf("InitMinionSearchService: unable to GetAllAlerts: ,err: %+v", err)

--- a/pkg/alerts/alertsHandler/alertsHandler.go
+++ b/pkg/alerts/alertsHandler/alertsHandler.go
@@ -301,7 +301,7 @@ func testWebhookURL(webhookURL string) error {
 	client := alertutils.GetCertErrorForgivingHttpClient()
 	req, err := http.NewRequest("GET", webhookURL, nil)
 	if err != nil {
-		log.Errorf("testWebhookURL: failed to create a test webhook request - %v", err)
+		log.Errorf("testWebhookURL: failed to create a test webhook request. URL: %v err: %v", webhookURL, err)
 		return err
 	}
 	resp, err := client.Do(req)

--- a/pkg/alerts/alertsHandler/notificationHandler.go
+++ b/pkg/alerts/alertsHandler/notificationHandler.go
@@ -103,7 +103,6 @@ func NotifyAlertHandlerRequest(alertID string, alertState alertutils.AlertState,
 
 	if !emailSent && !slackSent && !webhookSent {
 		return false, errors.New("neither emails or slack message or webhook sent for this notification")
-
 	}
 
 	return true, nil
@@ -154,9 +153,10 @@ func sendAlertEmail(emailID, subject, message string, alertDataMessage string) e
 	err := smtp.SendMail(host+":"+strconv.Itoa(port), auth, senderEmail, []string{emailID}, []byte(body))
 	return err
 }
-func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, numEvaluationsCount uint64,
-	alertState alertutils.AlertState) error {
 
+func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, numEvaluationsCount uint64,
+	alertState alertutils.AlertState,
+) error {
 	var status string
 	switch alertState {
 	case alertutils.Normal:
@@ -193,7 +193,7 @@ func sendWebhooks(webhookUrl, subject, message string, alertDataMessage string, 
 	}
 
 	r.Header.Add("Content-Type", "application/json")
-	client := &http.Client{}
+	client := alertutils.GetCertErrorForgivingHttpClient()
 	resp, err := client.Do(r)
 	if err != nil {
 		log.Errorf("sendWebhooks: Error sending request. WebhookURL=%v, Error=%v", webhookUrl, err)
@@ -234,7 +234,6 @@ func getSlackMessageColor(alertState alertutils.AlertState) string {
 }
 
 func sendSlack(alertName string, message string, channel alertutils.SlackTokenConfig, alertState alertutils.AlertState, alertDataMessage string) error {
-
 	channelID := channel.ChannelId
 	token := channel.SlToken
 	client := slack.New(token, slack.OptionDebug(false))

--- a/pkg/alerts/alertutils/alertutils.go
+++ b/pkg/alerts/alertutils/alertutils.go
@@ -18,7 +18,9 @@
 package alertutils
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/go-co-op/gocron"
@@ -68,7 +70,7 @@ func (AlertDetails) TableName() string {
 }
 
 type AlertLabel struct {
-	LabelName  string `json:"label_name" gorm:"primaryKey;size:256;not null;"` //unique
+	LabelName  string `json:"label_name" gorm:"primaryKey;size:256;not null;"` // unique
 	LabelValue string `json:"label_value"`
 }
 
@@ -287,4 +289,14 @@ func (alert *AlertDetails) DecodeQueryParamFromBase64() error {
 	}
 
 	return nil
+}
+
+func GetCertErrorForgivingHttpClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 }


### PR DESCRIPTION
* Configures a http client to ignore ssl certificate validation / check
* Use the http client when verifying webhook config (contact point) and when invoking webhook to send alerts
