### PR TITLE
Fix bug causing records to be read out of order

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -737,6 +737,10 @@ func (s *Searcher) fetchRRCs() (*iqr.IQR, error) {
 		return nil, err
 	}
 
+	// We chose the blocks using s.cutOffTimestampInMs, so we can only return
+	// RRCs up to that time; if we returned records past that time, then we
+	// can't guarantee the records we return are in the correct order
+	// considering ALL data we have.
 	switch s.sortMode {
 	case recentFirst:
 		endTime = max(endTime, s.cutOffTimestampInMs)

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -1190,8 +1190,7 @@ func makeBlocksFromSSR(qsr *query.QuerySegmentRequest, segkeyFname string,
 type sortMode int
 
 const (
-	invalidSortMode sortMode = iota
-	recentFirst
+	recentFirst sortMode = iota + 1
 	recentLast
 	anyOrder
 )

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -293,6 +293,7 @@ func (s *Searcher) Fetch() (*iqr.IQR, error) {
 				return nil, err
 			}
 
+			blocks = append(blocks, s.remainingBlocksSorted...)
 			err = sortBlocks(blocks, s.sortMode)
 			if err != nil {
 				log.Errorf("qid=%v, searcher.Fetch: failed to sort blocks: %v", s.qid, err)
@@ -736,13 +737,22 @@ func (s *Searcher) fetchRRCs() (*iqr.IQR, error) {
 		return nil, err
 	}
 
+	switch s.sortMode {
+	case recentFirst:
+		endTime = max(endTime, s.cutOffTimestampInMs)
+	case recentLast:
+		endTime = min(endTime, s.cutOffTimestampInMs)
+	case anyOrder:
+		// Do nothing.
+	}
+
 	// Remove the blocks we're going to process. Since the blocks are sorted,
 	// we always take blocks from the front of the list.
 	s.remainingBlocksSorted = s.remainingBlocksSorted[len(nextBlocks):]
 
-	if len(s.remainingBlocksSorted) == 0 {
-		// Since we are fetching blocks in batches based on cutOffTimestampInMs, we need to fetch more
-		// blocks to process if we have processed all the blocks in the current batch.
+	if len(s.remainingBlocksSorted) == 0 || endTime == s.cutOffTimestampInMs {
+		// We've processed all the blocks that we safely can, so we need to
+		// fetch more.
 		s.gotBlocks = false
 	}
 

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -1283,11 +1283,11 @@ func getNextBlocks(sortedBlocks []*block, maxBlocks int, mode sortMode) ([]*bloc
 
 			switch mode {
 			case recentFirst:
-				if endTime < overallEndTime {
+				if overallEndTime > endTime {
 					overallEndTime = endTime
 				}
 			case recentLast:
-				if endTime > overallEndTime {
+				if overallEndTime < endTime {
 					overallEndTime = endTime
 				}
 			default:

--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -1283,13 +1283,9 @@ func getNextBlocks(sortedBlocks []*block, maxBlocks int, mode sortMode) ([]*bloc
 
 			switch mode {
 			case recentFirst:
-				if overallEndTime > endTime {
-					overallEndTime = endTime
-				}
+				overallEndTime = min(overallEndTime, endTime)
 			case recentLast:
-				if overallEndTime < endTime {
-					overallEndTime = endTime
-				}
+				overallEndTime = max(overallEndTime, endTime)
 			default:
 				return nil, 0, toputils.TeeErrorf("getNextBlocks: invalid sort mode: %v", mode)
 			}


### PR DESCRIPTION
# Description
See this comment:
```
	// We chose the blocks using s.cutOffTimestampInMs, so we can only return
	// RRCs up to that time; if we returned records past that time, then we
	// can't guarantee the records we return are in the correct order
	// considering ALL data we have.
```
The issue was that we'd determine a cutoff time, then use that to determine which blocks we needed to search, and then we'd search all of those blocks and return the records from them before getting the next batch of blocks. This lead to some records getting returned out of order.

For example, say we're returning records in the recent-first order, and we have blocks
```
block 1: lowTs=10, highTs=20
block 2: lowTs=15, highTs=25
block 3: lowTs=25, highTs=30
```
and our cutoff time is 23—so we want to return all records with a timestamp >= 23. Then we have to search blocks 2 and 3, but don't have to search block 1 yet. Previously, we would return all the records (after sorting them) from blocks 2 and 3, and then repeat the process (get a cutoff time, get the blocks to search, and search them). This erroneously caused us to return a record from block 2 with timestamp 15 before we returned the record with timestamp 20 from block 1.

With this PR, we'd still have blocks 2 and 3 in the first batch, but only return records with a timestamp >= 23. Block 2 will have some records leftover, and in the next round we'll update the cutoff to include block 1, search block 1, sort those records with the leftover ones from block 2, and finally return the records in the correct order.