### PR TITLE
Check for SSR equality

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -1481,6 +1481,16 @@ func getPQMR(blocks []*block) (*pqmr.SegmentPQMRResults, error) {
 	return finalPQMR, nil
 }
 
+// This should only be used on SSRs for the same query.
+func ssrsEqual(ssr1, ssr2 *structs.SegmentSearchRequest) bool {
+	if ssr1 == nil || ssr2 == nil {
+		return ssr1 == nil && ssr2 == nil
+	}
+
+	// For one query, there should be only one SSR per segment key.
+	return ssr1.SegmentKey == ssr2.SegmentKey
+}
+
 // All of the blocks should be for the same SSR.
 func getSSRs(blocks []*block, blockToValidRecNums map[uint16][]uint16) (map[string]*structs.SegmentSearchRequest, error) {
 
@@ -1491,7 +1501,7 @@ func getSSRs(blocks []*block, blockToValidRecNums map[uint16][]uint16) (map[stri
 	// Each block should have come from the same SSR.
 	firstSSR := blocks[0].parentSSR
 	for _, block := range blocks {
-		if block.parentSSR != firstSSR {
+		if !ssrsEqual(block.parentSSR, firstSSR) {
 			return nil, utils.TeeErrorf("getSSRs: blocks are from different SSRs")
 		}
 	}


### PR DESCRIPTION
# Description
With [this fix](https://github.com/siglens/siglens/pull/2643) in previous PR, sometimes the Searcher gets a batch of blocks to search, and has some leftover blocks when it gets the next batch of blocks. This revealed a new issue: we were comparing SSRs by pointers instead of doing a deep-equal type of comparison; this caused [this error](https://github.com/siglens/siglens/blob/d3b46e70ce5de6a1f59dab071123f4476481c3dc/pkg/segment/query/processor/searcher.go#L1495) to get triggered on a false positive when blocks from this batch and the previous batch have the same SSR underlying data, but different SSR pointers. This PR fixes that.

# Testing
I was able to trigger the error by ingesting 1 million records (so there's several blocks) into index 0, then another 1 million split between index 0 and 1 (and doing it so that each index had only one segment), and then adding `true ||` to [this if statement](https://github.com/siglens/siglens/blob/d3b46e70ce5de6a1f59dab071123f4476481c3dc/pkg/segment/query/processor/searcher.go#L756) to force there to be leftover blocks between batches. Then I ran this query on the UI: `* | dedup gender`. Originally, the query would fail with `getSSRs: blocks are from different SSRs`, but with this PR the query completes normally.