### PR TITLE
Make Gantt chart ordering deterministic

### DIFF
--- a/pkg/segment/tracing/utils/buildspantree.go
+++ b/pkg/segment/tracing/utils/buildspantree.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/siglens/siglens/pkg/segment/tracing/structs"
 	log "github.com/sirupsen/logrus"
@@ -79,5 +80,27 @@ func BuildSpanTree(spanMap map[string]*structs.GanttChartSpan, idToParentId map[
 		}
 	}
 
+	sortGanttChart(res)
+
 	return res, nil
+}
+
+func sortGanttChart(span *structs.GanttChartSpan) {
+	if span == nil {
+		return
+	}
+
+	for _, child := range span.Children {
+		sortGanttChart(child)
+	}
+
+	sort.Slice(span.Children, func(i, j int) bool {
+		start1 := span.Children[i].StartTime
+		start2 := span.Children[j].StartTime
+		if start1 != start2 {
+			return start1 < start2
+		}
+
+		return span.Children[i].SpanID < span.Children[j].SpanID
+	})
 }

--- a/pkg/segment/tracing/utils/buildspantree.go
+++ b/pkg/segment/tracing/utils/buildspantree.go
@@ -47,7 +47,24 @@ func BuildSpanTree(spanMap map[string]*structs.GanttChartSpan, idToParentId map[
 
 	rootSpanStartTime := res.StartTime
 
-	for spanID, span := range spanMap {
+	spans := make([]*structs.GanttChartSpan, 0, len(spanMap))
+	for _, span := range spanMap {
+		spans = append(spans, span)
+	}
+
+	sort.Slice(spans, func(i, j int) bool {
+		start1 := spans[i].StartTime
+		start2 := spans[j].StartTime
+		if start1 != start2 {
+			return start1 < start2
+		}
+
+		return spans[i].SpanID < spans[j].SpanID
+	})
+
+	for _, span := range spans {
+		spanID := span.SpanID
+
 		// Calculate the relative start time and end time for each span
 		span.ActualStartTime = span.StartTime
 		span.StartTime -= rootSpanStartTime
@@ -80,27 +97,5 @@ func BuildSpanTree(spanMap map[string]*structs.GanttChartSpan, idToParentId map[
 		}
 	}
 
-	sortGanttChart(res)
-
 	return res, nil
-}
-
-func sortGanttChart(span *structs.GanttChartSpan) {
-	if span == nil {
-		return
-	}
-
-	for _, child := range span.Children {
-		sortGanttChart(child)
-	}
-
-	sort.Slice(span.Children, func(i, j int) bool {
-		start1 := span.Children[i].StartTime
-		start2 := span.Children[j].StartTime
-		if start1 != start2 {
-			return start1 < start2
-		}
-
-		return span.Children[i].SpanID < span.Children[j].SpanID
-	})
 }


### PR DESCRIPTION
# Description
Previously if you went to the Gantt chart view for a trace and refreshed the page, the spans would be in a different order (and sometimes get assigned different colors, as a result). Now refreshing the page doesn't change anything, and the chart flows from left to right better since we're sorting on start time
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/0222cbe3-9ada-4b72-b8ff-a25d8ef18ca3" />



# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
