### PR TITLE
Remove unnecessary final query in Gantt chart

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -1034,6 +1034,11 @@ func ProcessGanttChartRequest(ctx *fasthttp.RequestCtx, myid int64) {
 			span.Status = status.(string) // Populate Status from Span
 			idToSpanMap[span.SpanID] = span
 		}
+
+		if len(rawSpans) < searchRequestBody.Size {
+			break
+		}
+
 		searchRequestBody.From += 1000
 	}
 


### PR DESCRIPTION
# Description
When making the Gantt chart, we query for spans in chunks of 1000. Previously we'd only break out of the loop when a query returned 0 spans, which lead to the last query being unnecessary in most cases. This avoids that last query (unless this trace has a multiple of exactly 1000 spans).

# Testing
I didn't test this with 1000 spans in one trace. But I did view the Gantt chart for a trace with fewer spans and checked the logs. Before this we made 2 queries; now we make 1 query.