### PR TITLE
Speedup trace search

### DIFF
--- a/pkg/segment/tracing/handler/tracehandler.go
+++ b/pkg/segment/tracing/handler/tracehandler.go
@@ -433,43 +433,6 @@ func ExtractSpanID(searchText string) (bool, string) {
 	return true, matches[1]
 }
 
-func AddTrace(pipeSearchResponseOuter *segstructs.PipeSearchResponseOuter, traces *[]*structs.Trace, traceId string, traceStartTime uint64,
-	traceEndTime uint64, serviceName string, operationName string) {
-	spanCnt := 0
-	errorCnt := 0
-	for _, bucket := range pipeSearchResponseOuter.MeasureResults {
-		if len(bucket.GroupByValues) == 1 {
-			statusCode := bucket.GroupByValues[0]
-			count, exists := bucket.MeasureVal["count(*)"]
-			if !exists {
-				log.Error("AddTrace: Unable to extract 'count(*)' from measure results")
-				return
-			}
-			countVal, isFloat := count.(float64)
-			if !isFloat {
-				log.Error("AddTrace: count is not a float64")
-				return
-			}
-			spanCnt += int(countVal)
-			if statusCode == string(structs.Status_STATUS_CODE_ERROR) {
-				errorCnt += int(countVal)
-			}
-		}
-	}
-
-	trace := &structs.Trace{
-		TraceId:         traceId,
-		StartTime:       traceStartTime,
-		EndTime:         traceEndTime,
-		SpanCount:       spanCnt,
-		SpanErrorsCount: errorCnt,
-		ServiceName:     serviceName,
-		OperationName:   operationName,
-	}
-
-	*traces = append(*traces, trace)
-}
-
 // Call /api/search endpoint
 func processSearchRequest(searchRequestBody *structs.SearchRequestBody, myid int64) (*segstructs.PipeSearchResponseOuter, error) {
 

--- a/pkg/utils/sliceutils.go
+++ b/pkg/utils/sliceutils.go
@@ -463,3 +463,12 @@ func ProcessWithParallelism[T any](parallelism int, items []T, processor func(T)
 
 	return finalErr
 }
+
+func Transform[T any, R any](slice []T, transform func(T) R) []R {
+	result := make([]R, len(slice))
+	for i, item := range slice {
+		result[i] = transform(item)
+	}
+
+	return result
+}


### PR DESCRIPTION
# Description
Speed up searching on the /search-traces.html page by running fewer queries.

Previously when doing a search on that page, we'd get a batch of traceIDs and then do two additional queries per trace ID. With this PR, we combine the queries so we do two additional queries total for the batch, instead of two additional per trace.

# Testing
With 4 million spans and about 840k traces, doing a basic search for the traces used to take about 11 seconds. Now it takes 2.5 seconds.