### PR TITLE
Avoid unneeded record iteration in timechart

### DIFF
--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -356,29 +356,20 @@ func (b *BlockResults) WillValueBeAdded(valToAdd float64) bool {
 	}
 }
 
-// return true if:
-// 1.   if block not fuly enclosed
-// 2  if time-HT but we did not use the rollup info to add time-HT
-// 3.   if sort present and low/high ts can be added
-// 4.   if rrcs left to be filled
 func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncosed bool,
-	lowTs uint64, highTs uint64, addedTimeHt bool) bool {
+	lowTs uint64, highTs uint64) bool {
+
+	if !isBlkFullyEncosed {
+		// We only want some records.
+		return true
+	}
 
 	if aggsHasTimeHt {
 		return false
 	}
 
-	// case 1
-	if !isBlkFullyEncosed {
-		return true
-	}
-
-	if aggsHasTimeHt && !addedTimeHt {
-		return true // case 2
-	}
-
-	// case 3
 	if b.aggs != nil && b.aggs.Sort != nil {
+		// Check if some records will be added.
 		if b.aggs.Sort.Ascending {
 			return b.WillValueBeAdded(float64(lowTs))
 		} else {
@@ -386,9 +377,8 @@ func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncose
 		}
 	}
 
-	// case 4
+	// Check if there's space to add more records.
 	return b.nextUnsortedIdx < b.sizeLimit
-
 }
 
 func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []sutils.CValueEnclosure,

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -364,6 +364,10 @@ func (b *BlockResults) WillValueBeAdded(valToAdd float64) bool {
 func (b *BlockResults) ShouldIterateRecords(aggsHasTimeHt bool, isBlkFullyEncosed bool,
 	lowTs uint64, highTs uint64, addedTimeHt bool) bool {
 
+	if aggsHasTimeHt {
+		return false
+	}
+
 	// case 1
 	if !isBlkFullyEncosed {
 		return true

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -160,9 +160,8 @@ func applyAggregationsToSingleBlock(multiReader *segread.MultiColSegmentReader, 
 			addedTimeHt = true
 		}
 
-		if blkResults.ShouldIterateRecords(aggsHasTimeHt, isBlkFullyEncosed,
-			blockSummaries[blockStatus.BlockNum].LowTs,
-			blockSummaries[blockStatus.BlockNum].HighTs) {
+		blockSum := blockSummaries[blockStatus.BlockNum]
+		if blkResults.ShouldIterateRecords(aggsHasTimeHt, isBlkFullyEncosed, blockSum.LowTs, blockSum.HighTs) {
 			iterRecsAddRrc(recIT, multiReader, blockStatus, queryRange, aggs, aggsHasTimeHt,
 				addedTimeHt, blkResults, queryMetrics, allSearchResults, searchReq, qid, nodeRes)
 		} else {

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -162,7 +162,7 @@ func applyAggregationsToSingleBlock(multiReader *segread.MultiColSegmentReader, 
 
 		if blkResults.ShouldIterateRecords(aggsHasTimeHt, isBlkFullyEncosed,
 			blockSummaries[blockStatus.BlockNum].LowTs,
-			blockSummaries[blockStatus.BlockNum].HighTs, addedTimeHt) {
+			blockSummaries[blockStatus.BlockNum].HighTs) {
 			iterRecsAddRrc(recIT, multiReader, blockStatus, queryRange, aggs, aggsHasTimeHt,
 				addedTimeHt, blkResults, queryMetrics, allSearchResults, searchReq, qid, nodeRes)
 		} else {

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -397,7 +397,7 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 		}
 
 		isBlkFullyEncosed := tRange.AreTimesFullyEnclosed(blkSum.LowTs, blkSum.HighTs)
-		if blkResults.ShouldIterateRecords(aggsHasTimeHt, isBlkFullyEncosed, blkSum.LowTs, blkSum.HighTs, false) {
+		if blkResults.ShouldIterateRecords(aggsHasTimeHt, isBlkFullyEncosed, blkSum.LowTs, blkSum.HighTs) {
 
 			var recordNums []uint16
 			if req.BlockToValidRecNums != nil {


### PR DESCRIPTION
# Description
This avoids iterating all the records (and allocating memory for RRCs, which causes significant GC cycles) for timechart queries. This reduces query time by about 25%

# Testing
Manually verified these queries gave the same results with and without this PR:
```
* | timechart span=1m count

* | timechart span=1m avg(ConnectTiming)

* | timechart span=1m count by ConnectTiming
```