### PR TITLE
Double file parallelism

### DIFF
--- a/pkg/segment/query/segquery.go
+++ b/pkg/segment/query/segquery.go
@@ -262,7 +262,7 @@ func InitQueryInfoAndSummary(searchNode *structs.SearchNode, timeRange *dtu.Time
 		containsKibana = true
 	}
 	querytracker.UpdateQTUsage(nonKibanaIndices, searchNode, aggs, qc.RawQuery)
-	parallelismPerFile := int64(runtime.GOMAXPROCS(0) / 2)
+	parallelismPerFile := int64(runtime.GOMAXPROCS(0))
 	if parallelismPerFile < 1 {
 		parallelismPerFile = 1
 	}


### PR DESCRIPTION
# Description
This should improve query performance when:
1. The number of segments matching the query exceeds half the number of vCPUs, and
2. There's some idle CPUs

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
