### PR TITLE
Reduce repeated errors on invalid timestamp field

### DIFF
--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -37,6 +37,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var UninitializedTimeReaderErr = errors.New("uninitialized time reader")
+
 /*
 Defines holder struct and functions to construct & manage SegmentFileReaders
 across multiple columns
@@ -289,7 +291,7 @@ func (scr *SharedMultiColReaders) GetColumnsErrorsMap() map[string]error {
 
 func (mcsr *MultiColSegmentReader) GetTimeStampForRecord(blockNum uint16, recordNum uint16, qid uint64) (uint64, error) {
 	if mcsr.timeReader == nil {
-		return 0, fmt.Errorf("qid=%v, MultiColSegmentReader.GetTimeStampForRecord: Tried to get timestamp using a multi reader without an initialized timeReader, blockNum: %v recordNum: %v", qid, blockNum, recordNum)
+		return 0, UninitializedTimeReaderErr
 	}
 	return mcsr.timeReader.GetTimeStampForRecord(blockNum, recordNum, qid)
 }

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -250,6 +250,11 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			ts, err := multiColReader.GetTimeStampForRecord(blockNum, recNum, qid)
 			if err != nil {
 				nodeRes.StoreGlobalSearchError("addRecordToAggregations: Failed to extract timestamp from record", log.ErrorLevel, err)
+
+				if err == segread.UninitializedTimeReaderErr {
+					// We'll keep getting this error if we try other records.
+					break
+				}
 				continue
 			}
 			if ts < timeHistogram.StartTime || ts > timeHistogram.EndTime {


### PR DESCRIPTION
# Description
If a bad timestamp column is given in the config, timechart queries were very slow because they'd add an error for each record. Now we add just one error, so the query completes much faster.

# Testing
Ingest data, then in server.yaml change the `timestampKey` to something else, then restart and run a query like `* | timechart span=1m count`. Now the query completes much faster, and we see one of these errors in the logs:
```
ERRO[2025-05-15 15:31:32] qid=1, addRecordToAggregations: Failed to extract timestamp from record, Count: 7182, ExtraInfo: uninitialized time reader
```