### PR TITLE
Reduce time to initialize bitset

### DIFF
--- a/pkg/segment/pqmr/pqmatchresults.go
+++ b/pkg/segment/pqmr/pqmatchresults.go
@@ -67,6 +67,10 @@ func (pqmr *PQMatchResults) ClearBit(recNum uint) {
 	pqmr.b.Clear(recNum)
 }
 
+func (pqmr *PQMatchResults) FlipRange(start, end uint) {
+	pqmr.b.FlipRange(start, end)
+}
+
 func (pqmr *PQMatchResults) ResetAll() {
 	pqmr.b.ClearAll()
 }

--- a/pkg/segment/search/searchstatus.go
+++ b/pkg/segment/search/searchstatus.go
@@ -67,7 +67,8 @@ func init() {
 // Inits blocks & records to search based on input blkSum and tRange.
 // We will generously raw search all records in a block with a HighTS and LowTs inside tRange
 // It is up to the caller to call .Close()
-func InitBlocksToSearch(searchReq *structs.SegmentSearchRequest, blkSum []*structs.BlockSummary, allSearchResults *segresults.SearchResults, tRange *dtu.TimeRange) *SegmentSearchStatus {
+func InitBlocksToSearch(searchReq *structs.SegmentSearchRequest, blkSum []*structs.BlockSummary,
+	allSearchResults *segresults.SearchResults, tRange *dtu.TimeRange) *SegmentSearchStatus {
 
 	allBlocks := make(map[uint16]*BlockSearchStatus, len(blkSum))
 
@@ -95,9 +96,10 @@ func InitBlocksToSearch(searchReq *structs.SegmentSearchRequest, blkSum []*struc
 					passedRecs.AddMatchedRecord(j)
 				}
 			} else {
-				for j := uint(bSum.RecCount); j < PQMR_INITIAL_SIZE; j++ {
-					passedRecs.ClearBit(j)
-				}
+				// Clear the bits from RecCount to PQMR_INITIAL_SIZE. Above, we
+				// cloned the bits from pqmrAllMatchedConst, which are all set
+				// to 1. So we can flip them to 0.
+				passedRecs.FlipRange(uint(bSum.RecCount), PQMR_INITIAL_SIZE)
 			}
 
 			allBlocks[currBlk] = &BlockSearchStatus{


### PR DESCRIPTION
# Description
For the query `* | timechart span=1m count` this reduced the time from 1.50 seconds to 1.35 seconds.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
