### PR TITLE
do map lookup once

### DIFF
--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -409,12 +409,12 @@ func (b *BlockResults) AddMeasureResultsToKey(currKey []byte, measureResults []s
 
 	if usedByTimechart {
 		var gRunningStats []runningStats
-		_, exists := bucket.groupedRunningStats[groupByColVal]
+		var exists bool
+		gRunningStats, exists = bucket.groupedRunningStats[groupByColVal]
 		if !exists {
 			gRunningStats = initRunningStats(b.GroupByAggregation.internalMeasureFns)
 			bucket.groupedRunningStats[groupByColVal] = gRunningStats
 		}
-		gRunningStats = bucket.groupedRunningStats[groupByColVal]
 		bucket.AddMeasureResults(&gRunningStats, measureResults, qid, 1, true, b.batchErr, unsetRecord)
 	} else {
 		bucket.AddMeasureResults(&bucket.runningStats, measureResults, qid, 1, false, b.batchErr, unsetRecord)


### PR DESCRIPTION
# Description
- minor code change, but this part of the code now takes `410 ms` vs `640 ms` previously for the query `* | timechart span=1m count`


# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
