### PR TITLE
Add Line Chart for Event Count and Span Count in Usage Stats

### DIFF
--- a/static/usage-stats.html
+++ b/static/usage-stats.html
@@ -148,7 +148,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div>
                     <div class="chart-container">
                         <div class="stats-header">
-                            <div>Logs Volume</div>
+                            <div>Logs Volume and Event Count</div>
                             <div>Selected Range Total: <span class="logs-total"></span></div>
                         </div>
                         <div class="canvas-container">
@@ -157,7 +157,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </div>
                     <div class="chart-container mt-5">
                         <div class="stats-header">
-                            <div>Traces Volume</div>
+                            <div>Traces Volume and Span Count</div>
                             <div>Selected Range Total: <span class="traces-total"></span></div>
                         </div>
                         <div class="canvas-container">


### PR DESCRIPTION
# Description
- Dual Y-Axis Support: Added event count (for logs) and span count (for traces) as secondary metrics.
- Tooltips display both volume and count on hover.
- When downloading graph data, both volume and count values are included in the exported file.

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/0b51ca9e-668d-4184-b218-0300767b861f" />
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/458c5374-c200-4f08-ade8-f8b751d65211" />
