### PR TITLE
Download All Records for Logs Query

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2468,9 +2468,12 @@ div#save-queries {
 
 div#download-info,
 .download-result {
-    height: 40px !important;
     margin: 20px !important;
     padding: 0 !important;
+}
+
+div#download-info .form-check-input[type=radio] {
+    border: 1px solid var(--border-color-regular);
 }
 
 .ui-dialog-title {
@@ -7878,6 +7881,6 @@ p#versionInfo {
     color: #FF6C6B !important;
 }
 
-[data-theme="dark"] .ace-tm .ace_indent-guide{
+[data-theme="dark"] .ace-tm .ace_indent-guide {
     background: none;
 }

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -656,6 +656,18 @@
     font-weight: bold;
 }
 
+.warning-alert {
+    display: flex;
+    align-items: flex-start;
+    margin-top: 12px;
+    padding: 12px 16px;
+    background-color: #fffbeb;
+    border: 1px solid #fef3c7;
+    border-left: 2px solid #f59e0b;
+    border-radius: 0 5px 5px 0;
+    color: #92400e;
+}
+
 /* Upper Navbar Tabs */
 .section-buttons {
     display: flex;

--- a/static/index.html
+++ b/static/index.html
@@ -629,8 +629,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <p class="validateTips" id="validateTips"></p>
             <form>
                 <fieldset>
-                    <input type="text" name="qnameDL" id="qnameDL" placeholder="Name"
-                        class="text ui-widget-content ui-corner-all">
+                    <div>
+                        <label class="mb-1">File Name</label>
+                        <input type="text" name="qnameDL" id="qnameDL" placeholder="logs_export"
+                            class="text ui-widget-content ui-corner-all">
+                        <small class="grey-text mb-0 mt-1 ">Name may consist of a-z, 0-9, period, dash, underscores</small>
+                    </div>
+                    <div class="mb-3">
+                        <label class="mb-1 mt-4">Format</label>
+                        <input readonly id="format">
+                    </div>
                     <!-- Allow form submission with keyboard without duplicating the dialog button -->
                     <input type="submit" tabindex="-1" style="position:absolute; top:-1000px">
                 </fieldset>

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -67,6 +67,24 @@ function setDownloadLogsDialog() {
         </div>
     `);
 
+    $('#download-info').append(`
+        <div class="scope-selection mt-4 mb-3 mx-1">
+            <label class="form-label">Download Scope:</label>
+            <div class="form-check d-flex align-items-end">
+                <input class="form-check-input" type="radio" name="downloadScope" id="currentScope" value="current" checked>
+                <label class="form-check-label mx-2" for="currentScope">
+                    Current View (<span id="current-record-count">0</span> records)
+                </label>
+            </div>
+            <div class="form-check d-flex align-items-end mt-1">
+                <input class="form-check-input" type="radio" name="downloadScope" id="allScope" value="all">
+                <label class="form-check-label mx-2" for="allScope">
+                    All Records (up to 10,000 records)
+                </label>
+            </div>
+        </div>
+    `);
+
     let dialog = null;
     let form = null;
     let qname = $('#qnameDL');
@@ -370,6 +388,24 @@ function setDownloadLogsDialog() {
                 click: download,
             },
         },
+        open: function () {
+            if (curChoose === '.csv') {
+                $('#format').val('CSV');
+            } else if (curChoose === '.json') {
+                $('#format').val('JSON');
+            } else if (curChoose === '.xml') {
+                $('#format').val('XML');
+            } else if (curChoose === '.sql') {
+                $('#format').val('SQL');
+            }
+
+            if (lastQType === 'logs-query') {
+                $('.scope-selection').show();
+                $('#current-record-count').html(totalLoadedRecords);
+            } else {
+                $('.scope-selection').hide();
+            }
+        },
         close: function () {
             form[0].reset();
             allFields.removeClass('ui-state-error');
@@ -385,35 +421,21 @@ function setDownloadLogsDialog() {
         download();
     });
 
-    $('#csv-block').on('click', function () {
-        curChoose = '.csv';
-        $('#validateTips').hide();
-        $('#download-info').dialog('open');
-        $('.ui-widget-overlay').addClass('opacity-75');
-        return false;
-    });
+    const downloadOptionToExtension = {
+        'csv-block': '.csv',
+        'json-block': '.json',
+        'xml-block': '.xml',
+        'sql-block': '.sql',
+    };
 
-    $('#json-block').on('click', function () {
-        curChoose = '.json';
-        $('#validateTips').hide();
-        $('#download-info').dialog('open');
-        $('.ui-widget-overlay').addClass('opacity-75');
-        return false;
-    });
-
-    $('#xml-block').on('click', function () {
-        curChoose = '.xml';
-        $('#validateTips').hide();
-        $('#download-info').dialog('open');
-        $('.ui-widget-overlay').addClass('opacity-75');
-        return false;
-    });
-    $('#sql-block').on('click', function () {
-        curChoose = '.sql';
-        $('#validateTips').hide();
-        $('#download-info').dialog('open');
-        $('.ui-widget-overlay').addClass('opacity-75');
-        return false;
+    Object.keys(downloadOptionToExtension).forEach((optionId) => {
+        $(`#${optionId}`).on('click', function () {
+            curChoose = downloadOptionToExtension[optionId];
+            $('#validateTips').hide();
+            $('#download-info').dialog('open');
+            $('.ui-widget-overlay').addClass('opacity-75');
+            return false;
+        });
     });
 
     function downloadData(json, fileName) {

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -85,6 +85,14 @@ function setDownloadLogsDialog() {
         </div>
     `);
 
+    $('#download-info').find('.scope-selection').append(`
+        <div id="all-records-warning" class="warning-alert" style="display:none;">
+            <i class="fas fa-exclamation-triangle" style="margin-right: 8px; color: #ffc107; font-size:16px;"></i>
+            <span>Warning: Downloading all records may take longer and consume more resources.</span>
+        </div>
+    `);
+
+
     let dialog = null;
     let form = null;
     let qname = $('#qnameDL');
@@ -255,6 +263,14 @@ function setDownloadLogsDialog() {
         document.body.removeChild(downloadLink);
     }
 
+    $('input[name="downloadScope"]').on('change', function() {
+        if ($(this).val() === 'all') {
+          $('#all-records-warning').show();
+        } else {
+          $('#all-records-warning').hide();
+        }
+      });
+
     function download() {
         confirmDownload = true;
         let valid = true;
@@ -278,7 +294,14 @@ function setDownloadLogsDialog() {
             $('.download-progress-bar').css('width', '0%');
             $('.download-progress-label').text('0%');
 
+            const useAllRecords = $('#allScope').is(':checked');
+
             let params = getSearchFilter(false, false);
+            if (useAllRecords) {
+                params.size = 10000;
+            } else {
+                params.size = totalLoadedRecords;
+            }
             let searchText = params.searchText;
             let n = searchText.indexOf('BY');
             if (n != -1) {
@@ -392,8 +415,9 @@ function setDownloadLogsDialog() {
             $('#format').val(curChoose.replace('.', '').toUpperCase());
 
             $('#currentScope').prop('checked', true);
+            $('#all-records-warning').hide();
 
-            if (lastQType === 'logs-query' && totalLoadedRecords >= 100) {
+            if (lastQType === 'logs-query' && totalLoadedRecords >= 100 && totalLoadedRecords >= 100) {
                 $('.scope-selection').show();
                 $('#current-record-count').html(totalLoadedRecords);
             } else {

--- a/static/js/download-logs.js
+++ b/static/js/download-logs.js
@@ -389,17 +389,11 @@ function setDownloadLogsDialog() {
             },
         },
         open: function () {
-            if (curChoose === '.csv') {
-                $('#format').val('CSV');
-            } else if (curChoose === '.json') {
-                $('#format').val('JSON');
-            } else if (curChoose === '.xml') {
-                $('#format').val('XML');
-            } else if (curChoose === '.sql') {
-                $('#format').val('SQL');
-            }
+            $('#format').val(curChoose.replace('.', '').toUpperCase());
 
-            if (lastQType === 'logs-query') {
+            $('#currentScope').prop('checked', true);
+
+            if (lastQType === 'logs-query' && totalLoadedRecords >= 100) {
                 $('.scope-selection').show();
                 $('#current-record-count').html(totalLoadedRecords);
             } else {

--- a/static/js/pagination.js
+++ b/static/js/pagination.js
@@ -100,18 +100,12 @@ function updatePaginationState(results) {
             }
         }
     } else if (results.qtype === 'aggs-query' || results.qtype === 'segstats-query') {
-        if (results.state === 'QUERY_UPDATE' && results.measure) {
-            if (totalLoadedRecords === 0) {
-                currentPage = 1;
-            }
-        } else if (results.state === 'COMPLETE') {
-            if (results.bucketCount) {
-                totalLoadedRecords = results.bucketCount;
-                hasMoreRecords = false;
-            }
+        if (results.state === 'COMPLETE') {
+            currentPage = 1;
+            totalLoadedRecords = results.bucketCount;
+            hasMoreRecords = false;
         }
     }
-
     updatePaginationDisplay();
 
     if (results.state === 'COMPLETE') {


### PR DESCRIPTION
# Description
- Added a new option to select the download scope when exporting logs:
    - Current View – Downloads only the data currently loaded in the UI.
    - All Records – Downloads up to a maximum of 10,000 records.
   
- When "All Records" is selected, a warning is shown.

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/e3ef9556-693a-42d0-96b0-3e7edc7b7a93" />
