### PR TITLE
Use constant errors in fast path to reduce allocs

### DIFF
--- a/pkg/segment/reader/metrics/series/seriesreader.go
+++ b/pkg/segment/reader/metrics/series/seriesreader.go
@@ -33,6 +33,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var ErrGiveBackToPool = fmt.Errorf("Error putting buffers back to the pool")
+var ErrInitReader = fmt.Errorf("failed to init reader for block")
+var ErrInitDecompressor = fmt.Errorf("failed to init decompressor")
+var ErrBadTsoVersion = fmt.Errorf("invalid TSO version")
+var ErrOpenFileForPoolBuffer = fmt.Errorf("failed to open file for pool buffer")
+var ErrReadFileForPoolBuffer = fmt.Errorf("failed to read file for pool buffer")
+var ErrLoadTsoFile = fmt.Errorf("failed to load TSO file")
+var ErrLoadTsgFile = fmt.Errorf("failed to load TSG file")
+var ErrBadTsgVersion = fmt.Errorf("bad TSG version")
+
 /*
 Holder struct to read a single time series segment
 
@@ -171,8 +181,6 @@ func InitTimeSeriesReader(mKey string) (*TimeSeriesSegmentReader, error) {
 	}, nil
 }
 
-var ErrGiveBackToPool = fmt.Errorf("Error putting buffers back to the pool")
-
 /*
 Closes the iterator by returning all buffers back to the pool
 */
@@ -218,8 +226,6 @@ func (stssr *SharedTimeSeriesSegmentReader) Close() error {
 	}
 	return nil
 }
-
-var ErrInitReader = fmt.Errorf("failed to init reader for block")
 
 /*
 Exposes init functions for timeseries block readers.
@@ -297,8 +303,6 @@ func (tssr *TimeSeriesSegmentReader) InitReaderForBlock(blkNum uint16, queryMetr
 	}, nil
 }
 
-var ErrInitDecompressor = fmt.Errorf("failed to init decompressor")
-
 /*
 Exposes function that will return a TimeSeriesIterator for a given tsid
 
@@ -344,8 +348,6 @@ func (tsbr *TimeSeriesBlockReader) GetTimeSeriesIterator(tsid uint64) (*compress
 	return it, true, nil
 }
 
-var ErrBadTsoVersion = fmt.Errorf("invalid TSO version")
-
 // returns bool if found. If true, returns the tsidx and offset in the TSG file
 func getOffsetFromTsoFile(tsoVersion byte, low uint32, high uint32, nTsids uint32, tsid uint64,
 	tsoBuf []byte) (bool, uint32, uint32) {
@@ -382,9 +384,6 @@ func getOffsetFromTsoFile(tsoVersion byte, low uint32, high uint32, nTsids uint3
 	return false, 0, 0
 }
 
-var ErrOpenFileForPoolBuffer = fmt.Errorf("failed to open file for pool buffer")
-var ErrReadFileForPoolBuffer = fmt.Errorf("failed to read file for pool buffer")
-
 func loadFileIntoPoolBuffer(fileName string, bufferFromPool []byte) error {
 	fd, err := os.OpenFile(fileName, os.O_RDONLY, 0644)
 	if err != nil {
@@ -401,8 +400,6 @@ func loadFileIntoPoolBuffer(fileName string, bufferFromPool []byte) error {
 
 	return nil
 }
-
-var ErrLoadTsoFile = fmt.Errorf("failed to load TSO file")
 
 func (tssr *TimeSeriesSegmentReader) loadTSOFile(fileName string) (byte, []byte, uint64, error) {
 
@@ -425,9 +422,6 @@ func (tssr *TimeSeriesSegmentReader) loadTSOFile(fileName string) (byte, []byte,
 
 	return tsoVersion, tssr.tsoBuf, nEntries, nil
 }
-
-var ErrLoadTsgFile = fmt.Errorf("failed to load TSG file")
-var ErrBadTsgVersion = fmt.Errorf("bad TSG version")
 
 func (tssr *TimeSeriesSegmentReader) loadTSGFile(fileName string) ([]byte, error) {
 	err := loadFileIntoPoolBuffer(fileName, tssr.tsgBuf)

--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -37,6 +37,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var ErrDownload = fmt.Errorf("failed to download file")
+var ErrReadFromBlob = fmt.Errorf("failed to read file from blob")
+var ErrSetNotInUse = fmt.Errorf("failed to set file as not in use")
+var ErrReadColumn = fmt.Errorf("failed to read column from file")
+var ErrMetadataMissingSegKey = fmt.Errorf("globalMetadata does not have segKey")
+var ErrGetBlockSummary = fmt.Errorf("failed to get block summary")
+var ErrGetBlockSearchInfo = fmt.Errorf("failed to get block search info")
+var ErrGetNodeResult = fmt.Errorf("failed to get or create query search node result")
+var ErrInitSharedReaders = fmt.Errorf("failed to initialize shared readers")
+var ErrReadColumns = fmt.Errorf("failed to read columns for records")
+var ErrNotOneColumn = fmt.Errorf("didn't get exactly one column")
+var ErrShouldNotReach = fmt.Errorf("should not reach here")
+var ErrReadBlock = fmt.Errorf("failed to read and validate block")
+var ErrExtractValue = fmt.Errorf("failed to extract value from column")
+var ErrEvaluateMathOp = fmt.Errorf("failed to evaluate math operation")
+
 type RRCsReaderI interface {
 	ReadAllColsForRRCs(segKey string, vTable string, rrcs []*sutils.RecordResultContainer,
 		qid uint64, ignoredCols map[string]struct{}) (map[string][]sutils.CValueEnclosure, error)
@@ -50,8 +66,6 @@ type RRCsReader struct{}
 func (reader *RRCsReader) GetReaderId() sutils.T_SegReaderId {
 	return sutils.T_SegReaderId(0)
 }
-
-var ErrDownload = fmt.Errorf("failed to download file")
 
 func (reader *RRCsReader) ReadSegFilesFromBlob(segKey string, allCols map[string]struct{}) ([]string, error) {
 	bulkDownloadFiles := make(map[string]string)
@@ -71,10 +85,6 @@ func (reader *RRCsReader) ReadSegFilesFromBlob(segKey string, allCols map[string
 
 	return allFiles, nil
 }
-
-var ErrReadFromBlob = fmt.Errorf("failed to read file from blob")
-var ErrSetNotInUse = fmt.Errorf("failed to set file as not in use")
-var ErrReadColumn = fmt.Errorf("failed to read column from file")
 
 func (reader *RRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs []*sutils.RecordResultContainer,
 	qid uint64, ignoredCols map[string]struct{}) (map[string][]sutils.CValueEnclosure, error) {
@@ -120,8 +130,6 @@ func (reader *RRCsReader) ReadAllColsForRRCs(segKey string, vTable string, rrcs 
 
 	return colToValues, err
 }
-
-var ErrMetadataMissingSegKey = fmt.Errorf("globalMetadata does not have segKey")
 
 func (reader *RRCsReader) GetColsForSegKey(segKey string, vTable string) (map[string]struct{}, error) {
 	allCols := make(map[string]struct{})
@@ -171,11 +179,6 @@ func readIndexForRRCs(rrcs []*sutils.RecordResultContainer) ([]sutils.CValueEncl
 
 	return result, nil
 }
-
-var ErrGetBlockSummary = fmt.Errorf("failed to get block summary")
-var ErrGetBlockSearchInfo = fmt.Errorf("failed to get block search info")
-var ErrGetNodeResult = fmt.Errorf("failed to get or create query search node result")
-var ErrInitSharedReaders = fmt.Errorf("failed to initialize shared readers")
 
 // All the RRCs must belong to the same segment.
 func readUserDefinedColForRRCs(segKey string, rrcs []*sutils.RecordResultContainer,
@@ -255,10 +258,6 @@ func readUserDefinedColForRRCs(segKey string, rrcs []*sutils.RecordResultContain
 	enclosures, _ := utils.BatchProcess(rrcs, batchingFunc, batchKeyLess, operation, maxParallelism)
 	return enclosures, nil
 }
-
-var ErrReadColumns = fmt.Errorf("failed to read columns for records")
-var ErrNotOneColumn = fmt.Errorf("didn't get exactly one column")
-var ErrShouldNotReach = fmt.Errorf("should not reach here")
 
 func handleBlock(multiReader *segread.MultiColSegmentReader, blockNum uint16,
 	rrcs []*sutils.RecordResultContainer, qid uint64) ([]sutils.CValueEnclosure, error) {
@@ -346,10 +345,6 @@ func isDictCol(col string, esQuery bool) bool {
 	}
 	return false
 }
-
-var ErrReadBlock = fmt.Errorf("failed to read and validate block")
-var ErrExtractValue = fmt.Errorf("failed to extract value from column")
-var ErrEvaluateMathOp = fmt.Errorf("failed to evaluate math operation")
 
 // TODO: remove calls to this function so that only readColsForRecords calls
 // this function. Then remove the parameters that are not needed.

--- a/pkg/segment/reader/segread/agiletreereader.go
+++ b/pkg/segment/reader/segread/agiletreereader.go
@@ -31,6 +31,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var ErrReturnBufferToPool = fmt.Errorf("failed to return buffer to pool")
+var ErrLegacyEncoding = fmt.Errorf("legacy encoding")
+
 const MAX_NODE_PTRS = 80_000
 
 type AgileTreeReader struct {
@@ -112,8 +115,6 @@ func (str *AgileTreeReader) Close() error {
 	return nil
 }
 
-var ErrReturnBufferToPool = fmt.Errorf("failed to return buffer to pool")
-
 func (str *AgileTreeReader) returnBuffers() {
 	if err := segreader.PutBufToPool(str.metaFileBuffer); str.metaFileBuffer != nil && err != nil {
 		log.Error(ErrReturnBufferToPool)
@@ -124,8 +125,6 @@ func (str *AgileTreeReader) resetBlkVars() {
 	str.treeMeta = nil
 	str.isMetaLoaded = false
 }
-
-var ErrLegacyEncoding = fmt.Errorf("legacy encoding")
 
 func validateTreeEncodingVersion(version byte) error {
 	switch version {

--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -18,7 +18,6 @@
 package segread
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -27,6 +26,8 @@ import (
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/segment/writer"
 )
+
+var ErrNilRegex = fmt.Errorf("got nil regex")
 
 /*
 parameters:
@@ -51,7 +52,7 @@ func ApplySearchToMatchFilterDictCsg(sfr *segreader.SegmentFileReader, match *st
 	if match.MatchType == structs.MATCH_PHRASE {
 		compiledRegex, err = match.GetRegexp()
 		if err != nil {
-			return false, fmt.Errorf("ApplySearchToMatchFilterDictCsg: error getting match regex: %v", err)
+			return false, ErrNilRegex
 		}
 	}
 
@@ -89,7 +90,7 @@ func ApplySearchToExpressionFilterDictCsg(sfr *segreader.SegmentFileReader, qVal
 	}
 
 	if isRegexSearch && qValDte.GetRegexp() == nil {
-		return false, errors.New("ApplySearchToExpressionFilterDictCsg: qValDte had nil regexp compilation")
+		return false, ErrNilRegex
 	}
 
 	dte := &sutils.DtypeEnclosure{}

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -37,7 +37,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var UninitializedTimeReaderErr = errors.New("uninitialized time reader")
+var ErrNilTimeReader = errors.New("uninitialized time reader")
 
 /*
 Defines holder struct and functions to construct & manage SegmentFileReaders
@@ -291,14 +291,14 @@ func (scr *SharedMultiColReaders) GetColumnsErrorsMap() map[string]error {
 
 func (mcsr *MultiColSegmentReader) GetTimeStampForRecord(blockNum uint16, recordNum uint16, qid uint64) (uint64, error) {
 	if mcsr.timeReader == nil {
-		return 0, UninitializedTimeReaderErr
+		return 0, ErrNilTimeReader
 	}
 	return mcsr.timeReader.GetTimeStampForRecord(blockNum, recordNum, qid)
 }
 
 func (mcsr *MultiColSegmentReader) GetAllTimeStampsForBlock(blockNum uint16) ([]uint64, error) {
 	if mcsr.timeReader == nil {
-		return nil, errors.New("MultiColSegmentReader.GetAllTimeStampsForBlock: uninitialized timerange reader")
+		return nil, ErrNilTimeReader
 	}
 	return mcsr.timeReader.GetAllTimeStampsForBlock(blockNum)
 }
@@ -469,6 +469,8 @@ func (mcsr *MultiColSegmentReader) GetColKeyIndex(cname string) (int, bool) {
 	return idx, ok
 }
 
+var ErrReadBlock = errors.New("failed to read and validate block")
+
 func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]struct{}, blockNum uint16) error {
 	for keyIndex := range colsIndexMap {
 		if keyIndex >= len(mcsr.allFileReaders) {
@@ -477,7 +479,7 @@ func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]str
 
 		err := mcsr.allFileReaders[keyIndex].ValidateAndReadBlock(blockNum)
 		if err != nil {
-			return fmt.Errorf("MultiColSegmentReader.ValidateAndReadBlock: error loading blockNum: %v. Error: %+v", blockNum, err)
+			return ErrReadBlock
 		}
 	}
 

--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -38,6 +38,7 @@ import (
 )
 
 var ErrNilTimeReader = errors.New("uninitialized time reader")
+var ErrReadBlock = errors.New("failed to read and validate block")
 
 /*
 Defines holder struct and functions to construct & manage SegmentFileReaders
@@ -468,8 +469,6 @@ func (mcsr *MultiColSegmentReader) GetColKeyIndex(cname string) (int, bool) {
 	idx, ok := mcsr.allColsReverseIndex[cname]
 	return idx, ok
 }
-
-var ErrReadBlock = errors.New("failed to read and validate block")
 
 func (mcsr *MultiColSegmentReader) ValidateAndReadBlock(colsIndexMap map[int]struct{}, blockNum uint16) error {
 	for keyIndex := range colsIndexMap {

--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -35,6 +35,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var ErrGetSearchInfo = fmt.Errorf("failed to get search info")
+var ErrReadBlock = fmt.Errorf("failed to read block")
+var ErrReadRecord = fmt.Errorf("failed to read record")
+var ErrReturnBufferToPool = fmt.Errorf("failed to return buffer to pool")
+var ErrColumnNotInBlock = fmt.Errorf("column not in block")
+var ErrNilParam = fmt.Errorf("nil parameter")
+var ErrBlockNotFound = fmt.Errorf("block not found")
+var ErrBlockNil = fmt.Errorf("block is nil")
+var ErrInvalidMetadata = fmt.Errorf("invalid metadata")
+var ErrReadFile = fmt.Errorf("failed to read file")
+var ErrBadEncoding = fmt.Errorf("bad encoding type")
+var ErrResetSegFileReader = fmt.Errorf("failed to reset SegmentFileReader")
+var ErrRecordNotFound = fmt.Errorf("reached end of block before finding record")
+var ErrDecompress = fmt.Errorf("failed to decompress")
+var ErrInvalidIndex = fmt.Errorf("invalid index")
+
 const (
 	// TODO do some heuristics to figure out what buffer sizes are typically needed
 	S_1_KB   = 1024
@@ -195,10 +211,6 @@ func PutBufToPool(buf []byte) error {
 	}
 }
 
-var ErrGetSearchInfo = fmt.Errorf("failed to get search info")
-var ErrReadBlock = fmt.Errorf("failed to read block")
-var ErrReadRecord = fmt.Errorf("failed to read record")
-
 // Returns a map of blockNum -> slice, where each element of the slice has the
 // raw data for the corresponding record.
 func ReadAllRecords(segkey string, cname string) (map[uint16][][]byte, error) {
@@ -292,8 +304,6 @@ func (sfr *SegmentFileReader) Close() error {
 	return sfr.currFD.Close()
 }
 
-var ErrReturnBufferToPool = fmt.Errorf("failed to return buffer to pool")
-
 func (sfr *SegmentFileReader) ReturnBuffers() error {
 	var errorMessages []string
 	if err := PutBufToPool(sfr.currFileBuffer); sfr.currFileBuffer != nil && err != nil {
@@ -312,8 +322,6 @@ func (sfr *SegmentFileReader) ReturnBuffers() error {
 	return nil
 }
 
-var ErrColumnNotInBlock = fmt.Errorf("column not in block")
-
 // returns a bool indicating if blockNum is valid, and any error encountered
 func (sfr *SegmentFileReader) readBlock(blockNum uint16) (bool, error) {
 	validBlock, err := sfr.loadBlockUsingBuffer(blockNum)
@@ -328,13 +336,6 @@ func (sfr *SegmentFileReader) readBlock(blockNum uint16) (bool, error) {
 	sfr.isBlockLoaded = true
 	return true, nil
 }
-
-var ErrNilParam = fmt.Errorf("nil parameter")
-var ErrBlockNotFound = fmt.Errorf("block not found")
-var ErrBlockNil = fmt.Errorf("block is nil")
-var ErrInvalidMetadata = fmt.Errorf("invalid metadata")
-var ErrReadFile = fmt.Errorf("failed to read file")
-var ErrBadEncoding = fmt.Errorf("bad encoding type")
 
 // Helper function to decompresses and loads block using passed buffers.
 // Returns whether the block is valid, and any error encountered.
@@ -405,9 +406,6 @@ func (sfr *SegmentFileReader) loadBlockUsingBuffer(blockNum uint16) (bool, error
 		return true, ErrBadEncoding
 	}
 }
-
-var ErrResetSegFileReader = fmt.Errorf("failed to reset SegmentFileReader")
-var ErrRecordNotFound = fmt.Errorf("reached end of block before finding record")
 
 // Returns the raw bytes of the record in the currently loaded block
 func (sfr *SegmentFileReader) ReadRecord(recordNum uint16) ([]byte, error) {
@@ -599,8 +597,6 @@ func (sfr *SegmentFileReader) ReadDictEnc(buf []byte, blockNum uint16) error {
 	return err
 }
 
-var ErrDecompress = fmt.Errorf("failed to decompress")
-
 func (sfr *SegmentFileReader) unpackRawCsg(buf []byte, blockNum uint16) error {
 	initialBufferPtr := unsafe.SliceData(sfr.currRawBlockBuffer)
 	uncompressed, err := decoder.DecodeAll(buf[0:], sfr.currRawBlockBuffer[:0])
@@ -732,8 +728,6 @@ func (sfr *SegmentFileReader) deToResults(results map[string][]sutils.CValueEncl
 
 	return true
 }
-
-var ErrInvalidIndex = fmt.Errorf("invalid index")
 
 func (sfr *SegmentFileReader) deGetRec(rn uint16) ([]byte, error) {
 	if int(rn) >= len(sfr.deRecToTlv) {

--- a/pkg/segment/reader/segread/timereader.go
+++ b/pkg/segment/reader/segread/timereader.go
@@ -35,6 +35,22 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var ErrRecordOutOfRange = fmt.Errorf("record number is out of range")
+var ErrBlockNotFound = fmt.Errorf("failed to find block")
+var ErrInvalidOffsetAndLength = fmt.Errorf("invalid block offset and length")
+var ErrReturnToPool = fmt.Errorf("error putting buffer back to pool")
+var ErrInvalidBlockNum = fmt.Errorf("invalid block number")
+var ErrCloseUnopenedTimeReader = fmt.Errorf("tried to close an unopened time reader")
+var ErrSetNotInUse = fmt.Errorf("failed to set segment files as not in use")
+var ErrBufferTooSmall = fmt.Errorf("buffer is too small to contain valid data")
+var ErrBadEncoding = fmt.Errorf("bad encoding type for timestamp column")
+var ErrTooFewRecords = fmt.Errorf("found fewer records than expected")
+var ErrConvertRawRecords = fmt.Errorf("failed to convert raw records to timestamps")
+var ErrDownload = fmt.Errorf("failed to download file")
+var ErrGetSearchInfo = fmt.Errorf("failed to get search info")
+var ErrTimestampKeyNotFound = fmt.Errorf("failed to find timestamp key")
+var ErrReadChunk = fmt.Errorf("failed to read chunk from file")
+
 var rawTimestampsBufferPool = sync.Pool{
 	New: func() interface{} {
 		// The Pool's New function should generally only return pointer
@@ -132,8 +148,6 @@ func InitNewTimeReaderFromBlockSummaries(segKey string, tsKey string,
 	return InitNewTimeReader(segKey, tsKey, allBlocksToSearch, blkRecCount, qid, allBmi)
 }
 
-var ErrRecordOutOfRange = fmt.Errorf("record number is out of range")
-
 // highly optimized for subsequent calls to handle the same blockNum
 func (trr *TimeRangeReader) GetTimeStampForRecord(blockNum uint16, recordNum uint16, qid uint64) (uint64, error) {
 	if !trr.loadedBlock || trr.loadedBlockNum != blockNum {
@@ -159,10 +173,6 @@ func (trr *TimeRangeReader) GetAllTimeStampsForBlock(blockNum uint16) ([]uint64,
 
 	return trr.blockTimestamps[:trr.numBlockReadTimestamps], nil
 }
-
-var ErrBlockNotFound = fmt.Errorf("failed to find block")
-var ErrInvalidOffsetAndLength = fmt.Errorf("invalid block offset and length")
-var ErrReturnToPool = fmt.Errorf("error putting buffer back to pool")
 
 func (trr *TimeRangeReader) readAllTimestampsForBlock(blockNum uint16) error {
 	err := trr.resizeSliceForBlock(blockNum)
@@ -215,8 +225,6 @@ func (trr *TimeRangeReader) readAllTimestampsForBlock(blockNum uint16) error {
 	return nil
 }
 
-var ErrInvalidBlockNum = fmt.Errorf("invalid block number")
-
 func (trr *TimeRangeReader) resizeSliceForBlock(blockNum uint16) error {
 	numRecs, ok := trr.blockRecCount[blockNum]
 	if !ok {
@@ -227,9 +235,6 @@ func (trr *TimeRangeReader) resizeSliceForBlock(blockNum uint16) error {
 
 	return nil
 }
-
-var ErrCloseUnopenedTimeReader = fmt.Errorf("tried to close an unopened time reader")
-var ErrSetNotInUse = fmt.Errorf("failed to set segment files as not in use")
 
 func (trr *TimeRangeReader) Close() error {
 	if trr.timeFD == nil {
@@ -252,10 +257,6 @@ func (trr *TimeRangeReader) returnBuffers() {
 		log.Error(ErrReturnToPool)
 	}
 }
-
-var ErrBufferTooSmall = fmt.Errorf("buffer is too small to contain valid data")
-var ErrBadEncoding = fmt.Errorf("bad encoding type for timestamp column")
-var ErrTooFewRecords = fmt.Errorf("found fewer records than expected")
 
 func convertRawRecordsToTimestamps(rawRec []byte, numRecs uint16, bufToUse []uint64) ([]uint64, error) {
 	if bufToUse == nil {
@@ -336,8 +337,6 @@ func readChunkFromFile(fd *os.File, buf []byte, blkLen uint32, blkOff int64) ([]
 	return buf, nil
 }
 
-var ErrConvertRawRecords = fmt.Errorf("failed to convert raw records to timestamps")
-
 // When the caller of this function is done with retVal, they should call
 // ReturnTimeBuffers(retVal) to return the buffers to rawTimestampsBufferPool.
 func processTimeBlocks(allRequests chan *timeBlockRequest, wg *sync.WaitGroup, retVal map[uint16][]uint64,
@@ -361,11 +360,6 @@ func processTimeBlocks(allRequests chan *timeBlockRequest, wg *sync.WaitGroup, r
 		log.Error(ErrConvertRawRecords)
 	}
 }
-
-var ErrDownload = fmt.Errorf("failed to download file")
-var ErrGetSearchInfo = fmt.Errorf("failed to get search info")
-var ErrTimestampKeyNotFound = fmt.Errorf("failed to find timestamp key")
-var ErrReadChunk = fmt.Errorf("failed to read chunk from file")
 
 // When the caller of this function is done with the returned map, they should
 // call ReturnTimeBuffers() on it to return the buffers to rawTimestampsBufferPool.

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -251,7 +251,7 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 			if err != nil {
 				nodeRes.StoreGlobalSearchError("addRecordToAggregations: Failed to extract timestamp from record", log.ErrorLevel, err)
 
-				if err == segread.UninitializedTimeReaderErr {
+				if err == segread.ErrNilTimeReader {
 					// We'll keep getting this error if we try other records.
 					break
 				}


### PR DESCRIPTION
# Description
If we get errors in the common path, we will likely get a lot of them. This PR uses constant errors for those to avoid needing to allocate heap memory for each error, which could cause GC pressure and slow down the system.

# Testing
Not tested