### PR TITLE
Fix race condition during suffix file creation for metric segment sha…

### DIFF
--- a/pkg/segment/writer/suffix/suffix.go
+++ b/pkg/segment/writer/suffix/suffix.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/hooks"
@@ -31,6 +32,8 @@ import (
 type entry struct {
 	NextSuffix uint64 `json:"suffix"`
 }
+
+var suffixWriteLock sync.Mutex
 
 func getSuffix(fileName string) (*entry, error) {
 	jsonBytes, err := os.ReadFile(fileName)
@@ -64,6 +67,9 @@ func writeSuffix(fileName string, entry *entry) error {
 		log.Errorf("writeSuffix: Cannot marshal entry=%v to json; err=%v", entry, err)
 		return err
 	}
+
+	suffixWriteLock.Lock()
+	defer suffixWriteLock.Unlock()
 
 	tempFileName := fileName + ".tmp"
 	err = os.WriteFile(tempFileName, jsonBytes, 0644)


### PR DESCRIPTION

# Description
Resolved issue where multiple threads creating new metric segments on bootup could cause suffix file renaming to fail due to concurrent writes.








# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
