### PR TITLE
Fix: Clear Query Info on New Search & Show Waiting Message

### DIFF
--- a/static/alert.html
+++ b/static/alert.html
@@ -168,7 +168,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <div class="query-container position-relative">
                                 <div id = "custom-code-tab" class="custom-code-tab">
                                     <div class="query-builder-container">
-                                        <div class="d-flex justify-content-end">
+                                        <div class="d-flex justify-content-end mb-3">
                                             <ul class="tab-list">
                                                 <li class="tab-li tab-li-query" id = "tab-title1"><a href="#tabs-1" class="custom-query-builder">Builder</a></li>
                                                 <li class="tab-li tab-li-code" id = "tab-title2"><a href="#tabs-2"  class="custom-query-builder">Code</a></li>

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -199,6 +199,8 @@ async function toggleAlertTypeUI(type) {
         initializeIndexAutocomplete();
         setIndexDisplayValue(selectedSearchIndex);
 
+        initializeFilterInputEvents();
+
         //Show empty chart initially
         const logsExplorer = document.getElementById('logs-explorer');
         showEmptyChart(logsExplorer);
@@ -418,8 +420,6 @@ async function fillAlertForm(res) {
             $('#custom-code-tab').tabs('option', 'active', 1);
             $('#filter-input').val(queryText);
         }
-
-        initializeFilterInputEvents();
 
         let data = {
             state: wsState,

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -463,49 +463,28 @@ function runFilterBtnHandler(evt) {
         } else {
             isSearchButtonTriggered = true;
             if (!isHistogramViewActive) {
-                hasSearchSinceHistogramClosed = true; 
+                hasSearchSinceHistogramClosed = true;
             }
             resetDashboard();
             logsRowData = [];
             accumulatedRecords = [];
             lastColumnsOrder = [];
             totalLoadedRecords = 0;
+
             wsState = 'query';
             data = getSearchFilter(false, false);
             initialSearchData = data;
             $('#pagination-container').hide();
-            doSearch(data).finally(() => {
-                //eslint-disable-next-line no-undef
-                isSearchButtonTriggered = false; 
-            });
+            doSearch(data);
         }
         $('#daterangepicker').hide();
     }
 }
 
 function filterInputHandler(evt) {
-    if ( !evt.shiftKey && evt.keyCode === 13) {
-        const currentUrl = window.location.href;
-        const url = new URL(currentUrl);
-        const pathOnly = url.pathname;
-
-        const isIndexPage = pathOnly === '/' || pathOnly === '' || pathOnly.endsWith('index.html');
-        const isDashboardPage = pathOnly.includes('dashboard.html');
-
-        if (isIndexPage) {
-            evt.preventDefault();
-            resetDashboard();
-            logsRowData = [];
-            accumulatedRecords = [];
-            lastColumnsOrder = [];
-            totalLoadedRecords = 0;
-            data = getSearchFilter(false, false);
-            initialSearchData = data;
-            doSearch(data);
-        }else if (isDashboardPage) {
-            evt.preventDefault();
-            runQueryBtnHandler();
-        }
+    if (!evt.shiftKey && evt.keyCode === 13) {
+        evt.preventDefault();
+        runFilterBtnHandler(evt);
     }
 }
 

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -471,6 +471,12 @@ function runFilterBtnHandler(evt) {
             lastColumnsOrder = [];
             totalLoadedRecords = 0;
 
+            $('#hits-summary').html(`
+                <div><b>Processing query</b></div>
+                <div>Searching for matching records...</div>
+                <div></div>
+            `);
+            
             wsState = 'query';
             data = getSearchFilter(false, false);
             initialSearchData = data;


### PR DESCRIPTION
# Description
Problem:
- After running a query and clicking the info icon, response times are displayed.
- When a new query is triggered, if the backend takes time to send any query_update, clicking the info icon still shows the previous query's info.

Fix:
- Cleared query info state when a new query is initiated.
- If no query_update has been received yet, clicking the info icon now shows:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/9dddb4b9-f072-496b-823f-577abf49d673" />

-Also, few small fixes
