### PR TITLE
Avoid realloc from appending to slice

### DIFF
--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -37,7 +37,8 @@ type scorePair struct {
 }
 
 func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) []uint64 {
-	timeRangeBuckets := make([]uint64, 0)
+	numBuckets := (timeHistogram.EndTime-timeHistogram.StartTime)/timeHistogram.IntervalMillis + 1
+	timeRangeBuckets := make([]uint64, 0, numBuckets)
 	currentTime := timeHistogram.StartTime
 	for currentTime < timeHistogram.EndTime {
 		timeRangeBuckets = append(timeRangeBuckets, currentTime)


### PR DESCRIPTION
# Description
It's clear here how many elements the slice will have. By sizing it appropriately on init, we avoid reallocating when it grows too large.

# Testing
Ran with `url_c1=http* | timechart span=1m count`

Before:
```
(pprof) top
Showing nodes accounting for 4535.52MB, 98.60% of 4599.72MB total
Dropped 179 nodes (cum <= 23MB)
Showing top 10 nodes out of 45
      flat  flat%   sum%        cum   cum%
 3730.41MB 81.10% 81.10%  3730.41MB 81.10%  github.com/siglens/siglens/pkg/segment/aggregations.GenerateTimeRangeBuckets
```

After:
```
(pprof) top
Showing nodes accounting for 1493.17MB, 95.80% of 1558.60MB total
Dropped 236 nodes (cum <= 7.79MB)
Showing top 10 nodes out of 78
      flat  flat%   sum%        cum   cum%
  712.27MB 45.70% 45.70%   712.27MB 45.70%  github.com/siglens/siglens/pkg/segment/aggregations.GenerateTimeRangeBuckets
```

Also the query time improved from by 20%, from 2.2 seconds to 1.8.