### PR TITLE
Delete unnecessary allocations

### DIFF
--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -36,7 +36,9 @@ type scorePair struct {
 	index         int
 }
 
-func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) []uint64 {
+type timeBuckets = []uint64
+
+func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) timeBuckets {
 	numBuckets := (timeHistogram.EndTime-timeHistogram.StartTime)/timeHistogram.IntervalMillis + 1
 	timeRangeBuckets := make([]uint64, 0, numBuckets)
 	currentTime := timeHistogram.StartTime

--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -36,9 +36,22 @@ type scorePair struct {
 	index         int
 }
 
-type timeBuckets = []uint64
+type Range struct {
+	start uint64
+	end   uint64 // Exclusive
+	step  uint64
+}
 
-func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) timeBuckets {
+func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) *Range {
+	return &Range{
+		start: timeHistogram.StartTime,
+		end:   timeHistogram.EndTime,
+		step:  timeHistogram.IntervalMillis,
+	}
+}
+
+// TODO: delete this once we have confidence in the new implementation.
+func oldGenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) []uint64 {
 	numBuckets := (timeHistogram.EndTime-timeHistogram.StartTime)/timeHistogram.IntervalMillis + 1
 	timeRangeBuckets := make([]uint64, 0, numBuckets)
 	currentTime := timeHistogram.StartTime
@@ -56,7 +69,21 @@ func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) timeBuckets {
 }
 
 // Find correct time range bucket for timestamp
-func FindTimeRangeBucket(timePoints []uint64, timestamp uint64, intervalMillis uint64) uint64 {
+func FindTimeRangeBucket(r *Range, timestamp uint64) uint64 {
+	if timestamp < r.start {
+		return r.start
+	}
+	if timestamp >= r.end {
+		return r.end - r.step
+	}
+
+	index := ((timestamp - r.start) / r.step)
+
+	return r.start + index*r.step
+}
+
+// TODO: delete this once we have confidence in the new implementation.
+func oldFindTimeRangeBucket(timePoints []uint64, timestamp uint64, intervalMillis uint64) uint64 {
 	index := ((timestamp - timePoints[0]) / intervalMillis)
 	if index >= uint64(len(timePoints)) {
 		index = uint64(len(timePoints) - 1)

--- a/pkg/segment/aggregations/timechartagg_test.go
+++ b/pkg/segment/aggregations/timechartagg_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2021-2025 SigScalr, Inc.
+//
+// This file is part of SigLens Observability Solution
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package aggregations
+
+import (
+	"testing"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Range(t *testing.T) {
+	r := &Range{
+		start: 10,
+		end:   20,
+		step:  2,
+	}
+
+	assert.Equal(t, 10, int(FindTimeRangeBucket(r, 10)))
+	assert.Equal(t, 10, int(FindTimeRangeBucket(r, 11)))
+	assert.Equal(t, 12, int(FindTimeRangeBucket(r, 12)))
+	assert.Equal(t, 18, int(FindTimeRangeBucket(r, 18)))
+	assert.Equal(t, 18, int(FindTimeRangeBucket(r, 19)))
+	assert.Equal(t, 18, int(FindTimeRangeBucket(r, 20))) // end is exclusive
+}
+
+func Test_RangeMatchesFindBucket(t *testing.T) {
+	timeBucket := &structs.TimeBucket{
+		StartTime:      10,
+		EndTime:        20,
+		IntervalMillis: 3, // Will not land exactly on the end time.
+	}
+
+	newBuckets := GenerateTimeRangeBuckets(timeBucket)
+	oldBuckets := oldGenerateTimeRangeBuckets(timeBucket)
+
+	// Check if the new buckets are the same as the old buckets
+	for i := timeBucket.StartTime; i < timeBucket.EndTime; i++ {
+		newBucket := FindTimeRangeBucket(newBuckets, i)
+		oldBucket := oldFindTimeRangeBucket(oldBuckets, i, timeBucket.IntervalMillis)
+
+		assert.Equal(t, oldBucket, newBucket, "failed for i=%v", i)
+	}
+
+	timeBucket = &structs.TimeBucket{
+		StartTime:      10,
+		EndTime:        20,
+		IntervalMillis: 5, // Will land exactly on the end time.
+	}
+
+	newBuckets = GenerateTimeRangeBuckets(timeBucket)
+	oldBuckets = oldGenerateTimeRangeBuckets(timeBucket)
+
+	// Check if the new buckets are the same as the old buckets
+	for i := timeBucket.StartTime; i < timeBucket.EndTime; i++ {
+		newBucket := FindTimeRangeBucket(newBuckets, i)
+		oldBucket := oldFindTimeRangeBucket(oldBuckets, i, timeBucket.IntervalMillis)
+
+		assert.Equal(t, oldBucket, newBucket, "failed for i=%v", i)
+	}
+}

--- a/pkg/segment/query/processor/timechartcommand.go
+++ b/pkg/segment/query/processor/timechartcommand.go
@@ -53,7 +53,7 @@ type timechartProcessor struct {
 	qid                  uint64
 	searchResults        *segresults.SearchResults
 	bucketKeyWorkingBuf  []byte
-	timeRangeBuckets     []uint64
+	timeRangeBuckets     *aggregations.Range
 	errorData            *errorData
 	hasFinalResult       bool
 	setAsIqrStatsResults bool
@@ -180,7 +180,7 @@ func (p *timechartProcessor) Process(inputIQR *iqr.IQR) (*iqr.IQR, error) {
 			}
 		}
 
-		timePoint := aggregations.FindTimeRangeBucket(p.timeRangeBuckets, ts, p.options.timeBucket.IntervalMillis)
+		timePoint := aggregations.FindTimeRangeBucket(p.timeRangeBuckets, ts)
 
 		copy(p.bucketKeyWorkingBuf[bucketKeyBufIdx:], sutils.VALTYPE_ENC_UINT64[:])
 		bucketKeyBufIdx += 1

--- a/pkg/segment/search/segsearch.go
+++ b/pkg/segment/search/segsearch.go
@@ -359,7 +359,7 @@ func rawSearchSingleSPQMR(multiReader *segread.MultiColSegmentReader, req *struc
 
 	// start off with 256 bytes and caller will resize it and return back the new resized buf
 	aggsKeyWorkingBuf := make([]byte, 256)
-	var timeRangeBuckets []uint64
+	var timeRangeBuckets *aggregations.Range
 	if aggs != nil && aggs.TimeHistogram != nil && aggs.TimeHistogram.Timechart != nil {
 		timeRangeBuckets = aggregations.GenerateTimeRangeBuckets(aggs.TimeHistogram)
 	}


### PR DESCRIPTION
# Description
For `url_c1=http* | timechart span=1m count` we would create a slice of equally-spaced buckets (1 minute apart in this case) for each block. This caused some unnecessary allocations to keep creating this slice. Moreover, we only used the slice to determine which bucket a particular timestamp belongs in. Since the buckets are equally spaced, this PR replaces the slice with a struct, and we can find the correct bucket for a timestamp with simple arithmetic instead of binary search.


# Testing
Added unit tests to ensure no behavior change.

pprof reported about 50% fewer bytes allocated, and the query ran about 5% faster.