### PR TITLE
Reduce allocations for combining buckets

### DIFF
--- a/pkg/segment/query/processor/timechartcommand_test.go
+++ b/pkg/segment/query/processor/timechartcommand_test.go
@@ -122,15 +122,16 @@ func Test_TimechartProcessor_NoByField(t *testing.T) {
 	assert.NotNil(t, iqr1)
 
 	resultValues, err := iqr1.ReadAllColumns()
+	t.Logf("resultValues: %+v", resultValues)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(resultValues["timestamp"]))
 	assert.Equal(t, 3, len(resultValues["sum_measurecol"]))
 	assert.Equal(t, startTime, resultValues["timestamp"][0].CVal)
 	assert.Equal(t, startTime+uint64(time.Minute.Milliseconds()), resultValues["timestamp"][1].CVal)
 	assert.Equal(t, startTime+2*uint64(time.Minute.Milliseconds()), resultValues["timestamp"][2].CVal)
-	assert.Equal(t, uint64(6), resultValues["sum_measurecol"][0].CVal)
-	assert.Equal(t, uint64(9), resultValues["sum_measurecol"][1].CVal)
-	assert.Equal(t, uint64(6), resultValues["sum_measurecol"][2].CVal)
+	assert.Equal(t, int64(6), resultValues["sum_measurecol"][0].CVal)
+	assert.Equal(t, int64(9), resultValues["sum_measurecol"][1].CVal)
+	assert.Equal(t, int64(6), resultValues["sum_measurecol"][2].CVal)
 }
 
 func Test_TimechartProcessor_WithByField(t *testing.T) {
@@ -164,15 +165,15 @@ func Test_TimechartProcessor_WithByField(t *testing.T) {
 	assert.Equal(t, startTime+uint64(time.Minute.Milliseconds()), resultValues["timestamp"][1].CVal)
 	assert.Equal(t, startTime+2*uint64(time.Minute.Milliseconds()), resultValues["timestamp"][2].CVal)
 
-	assert.Equal(t, uint64(4), resultValues["sum_measurecol: a"][0].CVal)
+	assert.Equal(t, int64(4), resultValues["sum_measurecol: a"][0].CVal)
 	assert.Equal(t, int64(0), resultValues["sum_measurecol: a"][1].CVal)
 	assert.Equal(t, int64(0), resultValues["sum_measurecol: a"][2].CVal)
 
-	assert.Equal(t, uint64(2), resultValues["sum_measurecol: b"][0].CVal)
+	assert.Equal(t, int64(2), resultValues["sum_measurecol: b"][0].CVal)
 	assert.Equal(t, int64(0), resultValues["sum_measurecol: b"][1].CVal)
-	assert.Equal(t, uint64(6), resultValues["sum_measurecol: b"][2].CVal)
+	assert.Equal(t, int64(6), resultValues["sum_measurecol: b"][2].CVal)
 
 	assert.Equal(t, int64(0), resultValues["sum_measurecol: c"][0].CVal)
-	assert.Equal(t, uint64(9), resultValues["sum_measurecol: c"][1].CVal)
+	assert.Equal(t, int64(9), resultValues["sum_measurecol: c"][1].CVal)
 	assert.Equal(t, int64(0), resultValues["sum_measurecol: c"][2].CVal)
 }

--- a/pkg/segment/results/blockresults/blockresult.go
+++ b/pkg/segment/results/blockresults/blockresult.go
@@ -661,6 +661,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			}
 
 			countIdx := gb.reverseMeasureIndex[idx]
+			runningStats[countIdx].syncRawValue()
 			countVal, err := runningStats[countIdx].rawVal.GetUIntValue()
 			if err != nil {
 				currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -710,6 +711,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			}
 
 			sumIdx := gb.reverseMeasureIndex[idx]
+			runningStats[sumIdx].syncRawValue()
 			sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
 			if err != nil {
 				currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -718,6 +720,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 
 			if usedByTimechart {
 				sumIdx := gb.reverseMeasureIndex[idx]
+				runningStats[sumIdx].syncRawValue()
 				sumRawVal, err := runningStats[sumIdx].rawVal.GetFloatValue()
 				if err != nil {
 					currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -725,6 +728,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 				}
 
 				countIdx := gb.reverseMeasureIndex[idx+1]
+				runningStats[countIdx].syncRawValue()
 				countRawVal, err := runningStats[countIdx].rawVal.GetFloatValue()
 				if err != nil {
 					currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -769,6 +773,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			incrementIdxBy = 2
 
 			minIdx := gb.reverseMeasureIndex[idx]
+			runningStats[minIdx].syncRawValue()
 			minRawVal, err := runningStats[minIdx].rawVal.GetFloatValue()
 			if err != nil {
 				currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -776,6 +781,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			}
 
 			maxIdx := gb.reverseMeasureIndex[idx+1]
+			runningStats[maxIdx].syncRawValue()
 			maxRawVal, err := runningStats[maxIdx].rawVal.GetFloatValue()
 			if err != nil {
 				currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -794,6 +800,8 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 				batchErr.AddError("GroupByBuckets.AddResultToStatRes:CARDINALITY", fmt.Errorf("zero fields of ValueColRequest for cardinality: %v", mInfoStr))
 				return
 			}
+
+			runningStats[valIdx].syncRawValue()
 			strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
 			if !ok {
 				currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -819,6 +827,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 		}
 
 		valIdx := gb.reverseMeasureIndex[idx]
+		runningStats[valIdx].syncRawValue()
 		strSet, ok := runningStats[valIdx].rawVal.CVal.(map[string]struct{})
 		if !ok {
 			currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -845,6 +854,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			}
 		}
 		valIdx := gb.reverseMeasureIndex[idx]
+		runningStats[valIdx].syncRawValue()
 		strList, ok := runningStats[valIdx].rawVal.CVal.([]string)
 		if !ok {
 			currRes[mInfoStr] = sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
@@ -866,6 +876,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 			}
 		}
 		valIdx := gb.reverseMeasureIndex[idx]
+		runningStats[valIdx].syncRawValue()
 		cTypeVal := runningStats[valIdx].rawVal
 		eVal.CVal = cTypeVal.CVal
 		eVal.Dtype = cTypeVal.Dtype
@@ -873,6 +884,7 @@ func (gb *GroupByBuckets) updateEValFromRunningBuckets(mInfo *structs.MeasureAgg
 		incrementIdxBy = 1
 
 		valIdx := gb.reverseMeasureIndex[idx]
+		runningStats[valIdx].syncRawValue()
 		cTypeVal := runningStats[valIdx].rawVal
 		eVal.CVal = cTypeVal.CVal
 		eVal.Dtype = cTypeVal.Dtype

--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -499,6 +499,7 @@ func (rr *RunningBucketResults) AddEvalResultsForSum(runningStats *[]runningStat
 		return 0, utils.NewErrorWithCode("RunningBucketResults.AddEvalResultsForSum:PerformEvalAggForSum", err)
 	}
 	(*runningStats)[i].rawVal = result
+	(*runningStats)[i].number = nil
 
 	return numFields - 1, nil
 }
@@ -531,6 +532,7 @@ func (rr *RunningBucketResults) AddEvalResultsForAvg(runningStats *[]runningStat
 		Dtype: sutils.SS_DT_FLOAT,
 		CVal:  avg,
 	}
+	(*runningStats)[i].number = nil
 
 	return numFields - 1, nil
 }
@@ -552,6 +554,7 @@ func (rr *RunningBucketResults) AddEvalResultsForMinMax(runningStats *[]runningS
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForMinMax: failed to evaluate ValueColRequest, err: %v", err)
 	}
 	(*runningStats)[i].rawVal = result
+	(*runningStats)[i].number = nil
 
 	return numFields - 1, nil
 }
@@ -576,6 +579,7 @@ func (rr *RunningBucketResults) AddEvalResultsForRange(runningStats *[]runningSt
 		Dtype: sutils.SS_DT_FLOAT,
 		CVal:  result.Max - result.Min,
 	}
+	(*runningStats)[i].number = nil
 
 	return numFields - 1, nil
 }
@@ -611,6 +615,7 @@ func (rr *RunningBucketResults) AddEvalResultsForCount(runningStats *[]runningSt
 	}
 	if boolResult {
 		(*runningStats)[i].rawVal.CVal = (*runningStats)[i].rawVal.CVal.(int64) + 1
+		(*runningStats)[i].number = nil
 	}
 
 	return len(fieldToValue) - 1, nil
@@ -634,6 +639,7 @@ func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStat
 		}
 		strSet[strVal] = struct{}{}
 		(*runningStats)[i].rawVal.CVal = strSet
+		(*runningStats)[i].number = nil
 		return 0, nil
 	}
 
@@ -642,6 +648,7 @@ func (rr *RunningBucketResults) AddEvalResultsForValuesOrCardinality(runningStat
 		return 0, fmt.Errorf("RunningBucketResults.AddEvalResultsForValuesOrCardinality: failed to evaluate ValueColRequest to string, err: %v", err)
 	}
 	(*runningStats)[i].rawVal.CVal = strSet
+	(*runningStats)[i].number = nil
 
 	return len(fieldToValue) - 1, nil
 }
@@ -666,6 +673,7 @@ func (rr *RunningBucketResults) AddEvalResultsForList(runningStats *[]runningSta
 		}
 		strList = append(strList, strVal)
 		(*runningStats)[i].rawVal.CVal = strList
+		(*runningStats)[i].number = nil
 		return 0, nil
 	}
 
@@ -677,6 +685,7 @@ func (rr *RunningBucketResults) AddEvalResultsForList(runningStats *[]runningSta
 		result = result[:sutils.MAX_SPL_LIST_SIZE]
 	}
 	(*runningStats)[i].rawVal.CVal = result
+	(*runningStats)[i].number = nil
 
 	return len(fieldToValue) - 1, nil
 }

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -230,3 +230,34 @@ func (n *Number) ReduceFast(other *Number, fun AggregateFunctions) error {
 
 	return nil
 }
+
+func (n *Number) ToCVal(enclosure *CValueEnclosure) error {
+	if enclosure == nil {
+		return fmt.Errorf("enclosure is nil")
+	}
+
+	switch n.ntype() {
+	case invalidType:
+		enclosure.Dtype = SS_INVALID
+		enclosure.CVal = nil
+	case backfillType:
+		enclosure.Dtype = SS_DT_BACKFILL
+		enclosure.CVal = nil
+	case int64Type:
+		i, err := n.Int64()
+		if err != nil {
+			return err
+		}
+		enclosure.CVal = i
+		enclosure.Dtype = SS_DT_SIGNED_NUM
+	case float64Type:
+		f, err := n.Float64()
+		if err != nil {
+			return err
+		}
+		enclosure.CVal = f
+		enclosure.Dtype = SS_DT_FLOAT
+	}
+
+	return nil
+}

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -142,6 +142,7 @@ func (n *Number) Reset() {
 	n.bytes[8] = invalidType
 }
 
+//go:inline
 func (n *Number) ntype() numberType {
 	return n.bytes[8]
 }

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -730,11 +730,11 @@ func (cval *CValueEnclosure) ToNumber(number *Number) error {
 		}
 		number.SetInt64(int64(val))
 	case SS_DT_UNSIGNED_NUM:
-		val, ok := cval.CVal.(int64)
+		val, ok := cval.CVal.(uint64)
 		if !ok {
 			return fmt.Errorf("ToNumber: unexpected Dtype: %v", cval.Dtype)
 		}
-		number.SetInt64(val)
+		number.SetInt64(int64(val))
 	case SS_DT_BACKFILL:
 		number.SetBackfillType()
 		return nil


### PR DESCRIPTION
# Description
In timechart/stats queries we have multiple buckets whose values get aggregated into corresponding buckets for other segments. This was happening in `Reduce()`, which uses `CValueEnclosure` parameters. This caused unnecessary allocations when assigning the value (e.g., `e.Cval = e.Cval + other.Cval`) because `Cval` is an `interface{}` and Go allocates a new `interface{}` on each assignment (see https://github.com/golang/go/issues/65348#issuecomment-1915376922).

This PR avoids those allocations for some numeric aggregations by using our `Number` type which avoids using `interface{}` but can still handle float and integer values.

Now we have
```
	rawVal sutils.CValueEnclosure // raw value
	number *sutils.Number         // If this is not nil, it's always correct
	dirty  bool                   // If true, "number" is correct but "rawVal" is not
```
The idea behind this is we updated `number` multiple times, and then only copy it over to `rawVal` when we need to use `rawVal`, since writing `rawVal` will cause an allocation when we set `rawVal.CVal`


# Testing
For `url_c1=http* | timechart span=1m count`:
Before: 743 MB, 1.79 s
After: 485 MB, 1.77 s (it's a small difference, but I ran these multiple times and on average it was slightly faster with the changes in this PR)

For `* | timechart span=1m count`
Before: 464 MB, 1.23 s
After: 90 MB, 1.09 s