### PR TITLE
UI: Improved Progress Bar Feedback

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -88,6 +88,12 @@ function doSearch(data) {
             $('#run-filter-btn').addClass('cancel-search').addClass('active');
             $('#query-builder-btn').addClass('cancel-search').addClass('active');
 
+            $('#progress-div').html(`
+                <progress id="percent-complete" value="1" max="100">1</progress>
+                <div id="percent-value">1%</div>
+            `);
+            $('#record-searched').html(`<div><span>Starting search...</span></div>`);
+            
             try {
                 socket.send(JSON.stringify(data));
             } catch (e) {
@@ -542,17 +548,15 @@ function getSearchFilter(skipPushState, scrollingTrigger, isInitialLoad = false)
     let queryLanguage = $('#query-language-options .query-language-option.active').html();
 
     setIndexDisplayValue(selIndexName);
-
     selectedSearchIndex = selIndexName.split(',').join(',');
-    Cookies.set('IndexList', selIndexName.split(',').join(','));
+    Cookies.set('IndexList', selectedSearchIndex);
 
     if (!isNaN(stDate)) {
         datePickerHandler(Number(stDate), Number(endDate), 'custom');
-    } else if (stDate !== 'now-15m') {
-        datePickerHandler(stDate, endDate, stDate);
     } else {
-        datePickerHandler(stDate, endDate, '');
+        datePickerHandler(stDate, endDate, stDate);
     }
+
     let filterValue = '';
     if (currentTab == 0) {
         queryLanguage = 'Splunk QL';
@@ -592,8 +596,6 @@ function getSearchFilter(skipPushState, scrollingTrigger, isInitialLoad = false)
         sFrom = totalLoadedRecords;
     }
 
-    const runTimechartValue = isSearchButtonTriggered && isHistogramViewActive ;
-
     return {
         state: wsState,
         searchText: filterValue,
@@ -602,9 +604,10 @@ function getSearchFilter(skipPushState, scrollingTrigger, isInitialLoad = false)
         indexName: selIndexName,
         from: sFrom,
         queryLanguage: queryLanguage,
-        runTimechart: runTimechartValue ,
+        runTimechart: isSearchButtonTriggered && isHistogramViewActive,
     };
 }
+
 //eslint-disable-next-line no-unused-vars
 function getSearchFilterForSave(qname, qdesc) {
     let currentTab = $('#custom-code-tab').tabs('option', 'active');


### PR DESCRIPTION
# Description
Problem:
When the backend takes too long to respond with the first query_update, users had no indication of progress.

Fix: 
As soon as a query is initiated, we now immediately show a progress bar and set it to 1%.

<img width="934" alt="image" src="https://github.com/user-attachments/assets/5661132d-b603-4a83-81b9-4feb592aaa05" />
