### PR TITLE
Fix: Display Correct Custom Time with Timezone

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -626,9 +626,9 @@ async function runMetricsQuery(data, panelId, currentPanel, _queryRes) {
 //eslint-disable-next-line no-unused-vars
 function loadCustomDateTimeFromEpoch(startEpoch, endEpoch) {
     function setDateTimeInputs(epochTime, dateId, timeId) {
-        let dateVal = new Date(epochTime);
-        let dateString = dateVal.toISOString().split('T')[0];
-        let timeString = dateVal.toTimeString().substring(0, 5);
+        let momentDate = moment(epochTime);
+        let dateString = momentDate.format('YYYY-MM-DD');
+        let timeString = momentDate.format('HH:mm');
 
         $(`#${dateId}, .panelEditor-container #${dateId}`).val(dateString).addClass('active');
         $(`#${timeId}, .panelEditor-container #${timeId}`).val(timeString).addClass('active');


### PR DESCRIPTION
# Description
Problem: The code was using `toISOString()` on a Date object, which always returns time in UTC, leading to incorrect custom time display for users in different time zones.

Fix: Correctly format and display the custom time based on the user’s local timezone.

