### PR TITLE
Cleanup misleading code

### DIFF
--- a/pkg/segment/reader/segread/dechecker.go
+++ b/pkg/segment/reader/segread/dechecker.go
@@ -56,17 +56,19 @@ func ApplySearchToMatchFilterDictCsg(sfr *segreader.SegmentFileReader, match *st
 		}
 	}
 
+	anyMatched := false
 	for dwordIdx, dWord := range sfr.GetDeTlv() {
 		matched, err := writer.ApplySearchToMatchFilterRawCsg(match, dWord, compiledRegex, isCaseInsensitive)
 		if err != nil {
 			return false, err
 		}
 		if matched {
+			anyMatched = true
 			sfr.AddRecNumsToMr(uint16(dwordIdx), bsh)
 		}
 	}
 
-	return false, nil
+	return anyMatched, nil
 }
 
 /*
@@ -94,15 +96,17 @@ func ApplySearchToExpressionFilterDictCsg(sfr *segreader.SegmentFileReader, qVal
 	}
 
 	dte := &sutils.DtypeEnclosure{}
+	anyMatched := false
 	for dwordIdx, dWord := range sfr.GetDeTlv() {
 		matched, err := writer.ApplySearchToExpressionFilterSimpleCsg(qValDte, fop, dWord, isRegexSearch, dte, isCaseInsensitive)
 		if err != nil {
 			return false, err
 		}
 		if matched {
+			anyMatched = true
 			sfr.AddRecNumsToMr(uint16(dwordIdx), bsh)
 		}
 	}
 
-	return false, nil
+	return anyMatched, nil
 }

--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -230,12 +230,12 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			return true, dictEncColNames, nil
 		}
 
-		found, err := mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInsensitive)
+		_, err = mcr.ApplySearchToMatchFilterDictCsg(sq.MatchFilter, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInsensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: matchwords dict search failed, err=%v", err)
 			return false, dictEncColNames, err
 		}
-		return found, dictEncColNames, err
+		return false, dictEncColNames, err
 
 	case MatchWordsAllColumns:
 		for cname := range cmiPassedCnames {
@@ -273,13 +273,13 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 			regex = true
 		}
 
-		found, err := mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
+		_, err = mcr.ApplySearchToExpressionFilterDictCsg(sq.QueryInfo.QValDte,
 			sq.ExpressionFilter.FilterOp, regex, bsh, sq.QueryInfo.ColName, sq.FilterIsCaseInsensitive)
 		if err != nil {
 			log.Errorf("applyColumnarSearchUsingDictEnc: simpleexp/wildrexp dict search failed, err=%v", err)
 			return false, dictEncColNames, err
 		}
-		return found, dictEncColNames, err
+		return false, dictEncColNames, err
 
 	case RegexExpressionAllColumns:
 		for cname := range cmiPassedCnames {


### PR DESCRIPTION
# Description
Some cases in https://github.com/siglens/siglens/blob/5db0233beaaefdba6eacad2283928fbe29b2edca/pkg/segment/search/conditioncheck.go#L190 were misleading because they'd have `found, err := ...` and then return `found`; that return value was used to determine if record-level searching is necessary, and in all queries we'd get `found = false`. This is sort of correct (because we don't want to do record-level searching), but misleading—and the inner function calls had comments saying they return true if a match is found, but instead always returned false.

I think the only change in behavior is a few calls to https://github.com/siglens/siglens/blob/5db0233beaaefdba6eacad2283928fbe29b2edca/pkg/segment/search/conditioncheck.go#L303 will be correct now (since `found` is sometimes `true`; previously it was always `false`).

# Testing
Just existing CICD