### PR TITLE
Remove unnecessary PQMR check

### DIFF
--- a/pkg/segment/query/processor/searcher.go
+++ b/pkg/segment/query/processor/searcher.go
@@ -1461,24 +1461,14 @@ func getPQMR(blocks []*block) (*pqmr.SegmentPQMRResults, error) {
 		return nil, nil
 	}
 
-	// Each block should have come from the same PQMR.
-	firstPQMR, ok := blocks[0].parentPQMR.Get()
-	if !ok {
-		return nil, utils.TeeErrorf("getPQMR: first block has no PQMR")
-	}
-
+	finalPQMR := pqmr.InitSegmentPQMResults()
 	for _, block := range blocks {
 		pqmr, ok := block.parentPQMR.Get()
 		if !ok {
 			return nil, utils.TeeErrorf("getPQMR: block has no PQMR")
-		} else if pqmr != firstPQMR {
-			return nil, utils.TeeErrorf("getPQMR: blocks are from different PQMRs")
 		}
-	}
 
-	finalPQMR := pqmr.InitSegmentPQMResults()
-	for _, block := range blocks {
-		blockResults, ok := firstPQMR.GetBlockResults(block.BlkNum)
+		blockResults, ok := pqmr.GetBlockResults(block.BlkNum)
 		if !ok {
 			return nil, utils.TeeErrorf("getPQMR: block %v not found", block.BlkNum)
 		}


### PR DESCRIPTION
# Description
This removes a check that was causing false-positive errors.

The old code stated that all the blocks should have the same PQMR, but that's not quite necessary. They should be PQMRs for the same segment (and if you look up the chain of callers, you'll see that they are) so they should have the same info, but it _is_ valid for them to be different actual PQMR structs. Since different blocks for the same segment can be added in multiple calls to `getBlocks()`, we'll sometimes have blocks for the same segment with different PQMR structs—this was the false-positive error getting triggered.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
