### PR TITLE
Upgrading OTEL collector config to the latest

### DIFF
--- a/ssmetrics-otel-collector-config.yaml
+++ b/ssmetrics-otel-collector-config.yaml
@@ -14,12 +14,12 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   prometheusremotewrite:
-    endpoint: 'http://siglens:8081/promql/api/v1/write'
+    endpoint: 'http://localhost:8081/promql/api/v1/write'
   otlphttp: # Add an OTLP exporter to send traces to SigLens
-    endpoint: 'http://siglens:8081/otlp' # SigLens trace endpoint
+    endpoint: 'http://localhost:8081/otlp' # SigLens trace endpoint
     tls:
       insecure: true # Use this only if the connection does not use TLS
 


### PR DESCRIPTION
# Description
The OTEL collector's logging exporter has been replaced with debug exporter. Changed the config we need to use with newer version as per [the details](https://github.com/open-telemetry/opentelemetry-collector/issues/11337#issue-2563588147) of the change.
