### PR TITLE
use const errors, use fast float parsing

### DIFF
--- a/pkg/segment/aggregations/evalaggs.go
+++ b/pkg/segment/aggregations/evalaggs.go
@@ -22,10 +22,10 @@ import (
 	"math"
 	"sort"
 
-	"github.com/siglens/siglens/pkg/common/dtypeutils"
 	"github.com/siglens/siglens/pkg/config"
 	"github.com/siglens/siglens/pkg/segment/structs"
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
+	"github.com/siglens/siglens/pkg/utils"
 )
 
 func PerformEvalAggForMinOrMax(measureAgg *structs.MeasureAggregator, currResultExists bool, currResult sutils.CValueEnclosure, fieldToValue map[string]sutils.CValueEnclosure, isMin bool) (sutils.CValueEnclosure, error) {
@@ -272,7 +272,7 @@ func GetFloatValueAfterEvaluation(measureAgg *structs.MeasureAggregator, fieldTo
 		return 0, "", false, fmt.Errorf("GetFloatValueAfterEvaluation: Error while evaluating eval function: %v", err)
 	}
 
-	floatVal, err = dtypeutils.ConvertToFloat(valueStr, 64)
+	floatVal, err = utils.FastParseFloat([]byte(valueStr))
 	if err != nil {
 		return 0, valueStr, false, nil
 	}

--- a/pkg/segment/query/processor/rexcommand.go
+++ b/pkg/segment/query/processor/rexcommand.go
@@ -73,7 +73,7 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 		})
 	}
 
-	for i, value := range values {
+	for idx, value := range values {
 		valueStr, err := value.GetValueAsString()
 		if err != nil {
 			log.Errorf("rex.Process: cannot convert value %v to string; err=%v",
@@ -81,15 +81,11 @@ func (p *rexProcessor) Process(iqr *iqr.IQR) (*iqr.IQR, error) {
 			return nil, err
 		}
 
-		rexResultMap, err := structs.MatchAndExtractNamedGroups(valueStr, p.compiledRegex)
+		err = structs.MatchAndPopulateNamedGroups(valueStr, p.compiledRegex, newColValues,
+			idx)
 		if err != nil {
 			// If there are no matches we will skip this row
 			continue
-		}
-
-		for rexColName, rexValue := range rexResultMap {
-			newColValues[rexColName][i].Dtype = sutils.SS_DT_STRING
-			newColValues[rexColName][i].CVal = rexValue
 		}
 	}
 

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -2903,7 +2903,7 @@ func getValueAsString(fieldToValue map[string]sutils.CValueEnclosure, field stri
 func getValueAsFloat(fieldToValue map[string]sutils.CValueEnclosure, field string) (float64, error) {
 	enclosure, ok := fieldToValue[field]
 	if !ok {
-		return 0, ErrFloatMissingField
+		return 0, utils.NewErrorWithCode(utils.NIL_VALUE_ERR, ErrFloatMissingField)
 	}
 
 	if enclosure.IsNull() {
@@ -2923,7 +2923,7 @@ func getValueAsFloat(fieldToValue map[string]sutils.CValueEnclosure, field strin
 		}
 	}
 
-	return 0, sutils.ErrFloatConversionFailed
+	return 0, utils.NewErrorWithCode(utils.CONVERSION_ERR, sutils.ErrFloatConversionFailed)
 }
 
 func (self *SortValue) Compare(other *SortValue) (int, error) {

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -1829,6 +1829,28 @@ func MatchAndExtractNamedGroups(str string, rexExp *regexp.Regexp) (map[string]s
 	return result, nil
 }
 
+func MatchAndPopulateNamedGroups(str string, rexExp *regexp.Regexp,
+	newColValues map[string][]sutils.CValueEnclosure, idx int) error {
+	match := rexExp.FindStringSubmatch(str)
+	if len(match) == 0 {
+		return fmt.Errorf("MatchAndPopulateNamedGroups: no str in field match the pattern")
+	}
+
+	names := rexExp.SubexpNames()
+	if len(names) == 0 {
+		return fmt.Errorf("MatchAndPopulateNamedGroups: no field create from the pattern")
+	}
+
+	for i, name := range names {
+		if i != 0 && name != "" {
+			newColValues[name][idx].Dtype = sutils.SS_DT_STRING
+			newColValues[name][idx].CVal = match[i]
+		}
+	}
+
+	return nil
+}
+
 func MatchAndExtractGroups(str string, rexExp *regexp.Regexp) (map[string]string, []string, error) {
 	match := rexExp.FindStringSubmatch(str)
 	if len(match) == 0 {

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -469,6 +469,15 @@ var timeFormatReplacements = []struct {
 var ErrFloatMissingField = fmt.Errorf("Missing field")
 var ErrFloatFieldNull = fmt.Errorf("field was null")
 
+var ErrWithCodeConversionErr = utils.NewErrorWithCode(utils.CONVERSION_ERR,
+	sutils.ErrFloatConversionFailed)
+
+var ErrWithCodeFloatMissingField = utils.NewErrorWithCode(utils.NIL_VALUE_ERR,
+	ErrFloatMissingField)
+
+var ErrWithCodeFieldNull = utils.NewErrorWithCode(utils.NIL_VALUE_ERR,
+	ErrFloatFieldNull)
+
 func (self *DedupExpr) AcquireProcessedSegmentsLock() {
 	self.processedSegmentsLock.Lock()
 }
@@ -1835,7 +1844,6 @@ func MatchAndPopulateNamedGroups(str string, rexExp *regexp.Regexp,
 	if len(match) == 0 {
 		return fmt.Errorf("MatchAndPopulateNamedGroups: no str in field match the pattern")
 	}
-
 	names := rexExp.SubexpNames()
 	if len(names) == 0 {
 		return fmt.Errorf("MatchAndPopulateNamedGroups: no field create from the pattern")
@@ -2925,11 +2933,11 @@ func getValueAsString(fieldToValue map[string]sutils.CValueEnclosure, field stri
 func getValueAsFloat(fieldToValue map[string]sutils.CValueEnclosure, field string) (float64, error) {
 	enclosure, ok := fieldToValue[field]
 	if !ok {
-		return 0, utils.NewErrorWithCode(utils.NIL_VALUE_ERR, ErrFloatMissingField)
+		return 0, ErrWithCodeFloatMissingField
 	}
 
 	if enclosure.IsNull() {
-		return 0, utils.NewErrorWithCode(utils.NIL_VALUE_ERR, ErrFloatFieldNull)
+		return 0, ErrWithCodeFieldNull
 	}
 
 	if value, err := enclosure.GetFloatValue(); err == nil {
@@ -2945,7 +2953,7 @@ func getValueAsFloat(fieldToValue map[string]sutils.CValueEnclosure, field strin
 		}
 	}
 
-	return 0, utils.NewErrorWithCode(utils.CONVERSION_ERR, sutils.ErrFloatConversionFailed)
+	return 0, ErrWithCodeConversionErr
 }
 
 func (self *SortValue) Compare(other *SortValue) (int, error) {

--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -591,6 +591,10 @@ type DtypeEnclosure struct {
 	RexpCompiled   regex.Regex
 }
 
+var ErrFloatConversionFailed = fmt.Errorf("Cannot convert CValueEnclosure to float")
+var ErrFloatUnsupportedType = fmt.Errorf("CValueEnclosure GetFloatValue: unsupported Dtype")
+var ErrFloatNilValue = fmt.Errorf("CValueEnclosure GetFloatValue: nil value")
+
 func (dte *DtypeEnclosure) GobEncode() ([]byte, error) {
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
@@ -1067,7 +1071,7 @@ func (e *CValueEnclosure) GetValueAsString() (string, error) {
 func (e *CValueEnclosure) GetFloatValue() (float64, error) {
 	switch e.Dtype {
 	case SS_DT_STRING, SS_DT_BOOL:
-		return 0, errors.New("CValueEnclosure GetFloatValue: cannot convert to float")
+		return 0, ErrFloatConversionFailed
 	case SS_DT_UNSIGNED_NUM:
 		return float64(e.CVal.(uint64)), nil
 	case SS_DT_SIGNED_NUM:
@@ -1075,9 +1079,9 @@ func (e *CValueEnclosure) GetFloatValue() (float64, error) {
 	case SS_DT_FLOAT:
 		return e.CVal.(float64), nil
 	case SS_DT_BACKFILL:
-		return 0, utils.NewErrorWithCode(utils.NIL_VALUE_ERR, fmt.Errorf("CValueEnclosure GetFloatValue: nil value"))
+		return 0, ErrFloatNilValue
 	default:
-		return 0, errors.New("CValueEnclosure GetFloatValue: unsupported Dtype")
+		return 0, ErrFloatUnsupportedType
 	}
 }
 


### PR DESCRIPTION
# Description
- Use constant errors
- Use fast float parsing, the strconv.ParseFloat constructs a syntaxError struct which is expensive in hot path, avoid it
- minor optimzations in `MatchAndExtractNamedGroups`

This query `Referer != "" | rex field=Referer "^https?://(?:www\.)?(?<k>[^/]+)" | stats avg(eval(len(Referer))) as l, count as c, min(eval(Referer)) by k | where c > 100000 | sort 25 -l`

develop: takes `85 s` 
with this PR: `55 s`
with this PR and #2748 : takes `27 s`



# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
