### PR TITLE
Fix return type of commands that return null and update isNull and isNotNull to recognize null fields

### DIFF
--- a/pkg/common/option/option.go
+++ b/pkg/common/option/option.go
@@ -1,0 +1,30 @@
+package option
+
+type Option[T any] struct {
+    Valid bool
+    Value T
+}
+
+func Some[T any](val T) Option[T] {
+    return Option[T]{Valid: true, Value: val}
+}
+
+func None[T any]() Option[T] {
+    var zero T
+    return Option[T]{Valid: false, Value: zero}
+}
+
+func (opt Option[T]) IsSome() bool {
+    return opt.Valid
+}
+
+func (opt Option[T]) IsNone() bool {
+    return !opt.Valid
+}
+
+func (opt Option[T]) UnwrapOr(defaultVal T) T {
+    if opt.Valid {
+        return opt.Value
+    }
+    return defaultVal
+}

--- a/pkg/segment/aggregations/evalaggs_test.go
+++ b/pkg/segment/aggregations/evalaggs_test.go
@@ -9,6 +9,7 @@ import (
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	statswriter "github.com/siglens/siglens/pkg/segment/writer/stats"
 	"github.com/stretchr/testify/assert"
+	"github.com/siglens/siglens/pkg/common/option"
 )
 
 func getDummyMeasureAggregator() *structs.MeasureAggregator {
@@ -35,19 +36,20 @@ func getDummySegStats() *structs.SegStats {
 			StrList: []string{"1", "4", "10"},
 		},
 		Records: []*sutils.CValueEnclosure{
-			{
-				CVal:  1.0,
-				Dtype: sutils.SS_DT_FLOAT,
-			},
-			{
-				CVal:  4.0,
-				Dtype: sutils.SS_DT_FLOAT,
-			},
-			{
-				CVal:  10.0,
-				Dtype: sutils.SS_DT_FLOAT,
-			},
+		{
+			CVal:  option.Some[any](1.0),
+			Dtype: sutils.SS_DT_FLOAT,
 		},
+		{
+			CVal:  option.Some[any](4.0),
+			Dtype: sutils.SS_DT_FLOAT,
+		},
+		{
+			CVal:  option.Some[any](10.0),
+			Dtype: sutils.SS_DT_FLOAT,
+		},
+	},
+
 	}
 }
 
@@ -163,9 +165,9 @@ func TestComputeAggEvalForList_CorrectInputsWithoutField(t *testing.T) {
 	expected := []string{"100", "100", "100"}
 	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 1")
+	assert.Equal(t, 3, len(measureResults["vals"].CVal.UnwrapOr(nil).([]string)), "The length of the measureResults slice should be 1")
 	assert.Equal(t, 3, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 1")
-	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, measureResults["vals"].CVal.UnwrapOr(nil).([]string), "The measureResults slice should be equal to the expected slice")
 	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
 }
 
@@ -179,9 +181,9 @@ func TestComputeAggEvalForList_CorrectInputsWithField(t *testing.T) {
 	expected := []string{"0.5", "2", "5"}
 	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 3")
+	assert.Equal(t, 3, len(measureResults["vals"].CVal.UnwrapOr(nil).([]string)), "The length of the measureResults slice should be 3")
 	assert.Equal(t, 3, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 3")
-	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, measureResults["vals"].CVal.UnwrapOr(nil).([]string), "The measureResults slice should be equal to the expected slice")
 	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
 }
 
@@ -194,7 +196,7 @@ func TestComputeAggEvalForList_largeLists(t *testing.T) {
 
 	for i := range list {
 		list[i] = &sutils.CValueEnclosure{
-			CVal:  1.0,
+			CVal:  option.Some[any](1.0),
 			Dtype: sutils.SS_DT_FLOAT,
 		}
 	}
@@ -203,7 +205,7 @@ func TestComputeAggEvalForList_largeLists(t *testing.T) {
 	measureResults := make(map[string]sutils.CValueEnclosure)
 	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
 	assert.NoError(t, err)
-	assert.Equal(t, sutils.MAX_SPL_LIST_SIZE, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be MAX_SPL_LIST_SIZE")
+	assert.Equal(t, sutils.MAX_SPL_LIST_SIZE, len(measureResults["vals"].CVal.UnwrapOr(nil).([]string)), "The length of the measureResults slice should be MAX_SPL_LIST_SIZE")
 	assert.Equal(t, sutils.MAX_SPL_LIST_SIZE, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be MAX_SPL_LIST_SIZE")
 }
 
@@ -217,18 +219,18 @@ func TestComputeAggEvalForList_TestUpdateWithMultipleEvals(t *testing.T) {
 	expected := []string{"0.5", "2", "5"}
 	err := ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
 	assert.NoError(t, err)
-	assert.Equal(t, 3, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 3")
+	assert.Equal(t, 3, len(measureResults["vals"].CVal.UnwrapOr(nil).([]string)), "The length of the measureResults slice should be 3")
 	assert.Equal(t, 3, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 3")
-	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, measureResults["vals"].CVal.UnwrapOr(nil).([]string), "The measureResults slice should be equal to the expected slice")
 	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
 
 	expected = []string{"0.5", "2", "5", "0.5", "2", "5"}
 	measureResults = make(map[string]sutils.CValueEnclosure)
 	err = ComputeAggEvalForList(dummyMeasureAggr, sstMap, measureResults, runningEvalStats)
 	assert.NoError(t, err)
-	assert.Equal(t, 6, len(measureResults["vals"].CVal.([]string)), "The length of the measureResults slice should be 6")
+	assert.Equal(t, 6, len(measureResults["vals"].CVal.UnwrapOr(nil).([]string)), "The length of the measureResults slice should be 6")
 	assert.Equal(t, 6, len(runningEvalStats["vals"].([]string)), "The length of the runningEvalStats slice should be 6")
-	assert.Equal(t, expected, measureResults["vals"].CVal.([]string), "The measureResults slice should be equal to the expected slice")
+	assert.Equal(t, expected, measureResults["vals"].CVal.UnwrapOr(nil).([]string), "The measureResults slice should be equal to the expected slice")
 	assert.Equal(t, expected, runningEvalStats["vals"].([]string), "The runningEvalStats slice should be equal to the expected slice")
 
 }
@@ -291,7 +293,7 @@ func TestComputeAggEvalForValues_WithFieldsAndValidData(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok := result.CVal.([]string)
+	uniqueStrings, ok := result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	assert.Equal(t, expected, uniqueStrings)
 }
@@ -311,7 +313,7 @@ func TestComputeAggEvalForValues_WithoutFieldsAndValidData(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok := result.CVal.([]string)
+	uniqueStrings, ok := result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	assert.Equal(t, expected, uniqueStrings)
 }
@@ -331,7 +333,7 @@ func TestComputeAggEvalForValues_UpdateWithMultipleEvals(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok := result.CVal.([]string)
+	uniqueStrings, ok := result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	assert.Equal(t, expected, uniqueStrings)
 
@@ -341,7 +343,7 @@ func TestComputeAggEvalForValues_UpdateWithMultipleEvals(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok = result.CVal.([]string)
+	uniqueStrings, ok = result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	// expected remains the same
 	assert.Equal(t, expected, uniqueStrings)
@@ -362,7 +364,7 @@ func TestComputeAggEvalForValues_UpdateWithMultipleEvalsWithoutField(t *testing.
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok := result.CVal.([]string)
+	uniqueStrings, ok := result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	assert.Equal(t, expected, uniqueStrings)
 
@@ -372,7 +374,7 @@ func TestComputeAggEvalForValues_UpdateWithMultipleEvalsWithoutField(t *testing.
 	assert.True(t, ok)
 	assert.Equal(t, sutils.SS_DT_STRING_SLICE, result.Dtype)
 
-	uniqueStrings, ok = result.CVal.([]string)
+	uniqueStrings, ok = result.CVal.UnwrapOr(nil).([]string)
 	assert.True(t, ok)
 	// expected remains the same
 	assert.Equal(t, expected, uniqueStrings)

--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -34,6 +34,7 @@ import (
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"github.com/siglens/siglens/pkg/common/option"
 )
 
 func applyTimeRangeHistogram(nodeResult *structs.NodeResult, rangeHistogram *structs.TimeBucket, aggName string) {
@@ -371,7 +372,7 @@ func performInputLookupOnHistogram(nodeResult *structs.NodeResult, agg *structs.
 			for col, recordValue := range record {
 				statRes[col] = sutils.CValueEnclosure{
 					Dtype: sutils.SS_DT_STRING,
-					CVal:  fmt.Sprintf("%v", recordValue),
+					CVal:  option.Some[any](fmt.Sprintf("%v", recordValue)),
 				}
 			}
 			// Add the record as bucket result to aggregation results
@@ -2362,7 +2363,7 @@ func performStatisticColRequestOnHistogram(nodeResult *structs.NodeResult, letCo
 			bucketKey := make([]string, len(groupByKeys))
 			otherEnclosure := sutils.CValueEnclosure{
 				Dtype: sutils.SS_DT_STRING,
-				CVal:  letColReq.StatisticColRequest.StatisticOptions.OtherStr,
+				CVal:  option.Some[any](letColReq.StatisticColRequest.StatisticOptions.OtherStr),
 			}
 			for i := 0; i < len(groupByKeys); i++ {
 				if groupByKeys[i] == letColReq.StatisticColRequest.StatisticOptions.CountField || groupByKeys[i] == letColReq.StatisticColRequest.StatisticOptions.PercentField {
@@ -2637,7 +2638,7 @@ func performRexColRequestOnHistogram(nodeResult *structs.NodeResult, letColReq *
 				} else {
 					aggregationResult.Results[rowIndex].StatRes[rexColName] = sutils.CValueEnclosure{
 						Dtype: sutils.SS_DT_STRING,
-						CVal:  rexColVal,
+						CVal:  option.Some[any](rexColVal),
 					}
 				}
 			}
@@ -3274,7 +3275,7 @@ func performBinRequestOnHistogram(nodeResult *structs.NodeResult, letColReq *str
 			} else {
 				aggregationResult.Results[rowIndex].StatRes[letColReq.NewColName] = sutils.CValueEnclosure{
 					Dtype: valType,
-					CVal:  binValue,
+					CVal:  option.Some[any](binValue),
 				}
 			}
 		}
@@ -3391,7 +3392,7 @@ func getRecordFieldValues(fieldToValue map[string]sutils.CValueEnclosure, fields
 			value = fmt.Sprintf("%v", value)
 		}
 
-		fieldToValue[field] = sutils.CValueEnclosure{Dtype: dVal.Dtype, CVal: value}
+		fieldToValue[field] = sutils.CValueEnclosure{Dtype: dVal.Dtype, CVal: option.Some[any](value)}
 	}
 
 	return nil
@@ -3533,17 +3534,17 @@ func performValueColRequestOnHistogram(nodeResult *structs.NodeResult, letColReq
 				if len(cellValueSlice) > 0 {
 					aggregationResult.Results[rowIndex].StatRes[letColReq.NewColName] = sutils.CValueEnclosure{
 						Dtype: sutils.SS_DT_STRING_SLICE,
-						CVal:  cellValueSlice,
+						CVal:  option.Some[any](cellValueSlice),
 					}
 				} else if len(cellValueStr) > 0 {
 					aggregationResult.Results[rowIndex].StatRes[letColReq.NewColName] = sutils.CValueEnclosure{
 						Dtype: sutils.SS_DT_STRING,
-						CVal:  cellValueStr,
+						CVal:  option.Some[any](cellValueStr),
 					}
 				} else {
 					aggregationResult.Results[rowIndex].StatRes[letColReq.NewColName] = sutils.CValueEnclosure{
 						Dtype: sutils.SS_DT_FLOAT,
-						CVal:  cellValueFloat,
+						CVal:  option.Some[any](cellValueFloat),
 					}
 				}
 			}
@@ -3804,16 +3805,16 @@ func getMeasureResultsFieldValues(fieldToValue map[string]sutils.CValueEnclosure
 		switch value := value.(type) {
 		case string:
 			enclosure.Dtype = sutils.SS_DT_STRING
-			enclosure.CVal = value
+			enclosure.CVal = option.Some[any](value)
 		case float64:
 			enclosure.Dtype = sutils.SS_DT_FLOAT
-			enclosure.CVal = value
+			enclosure.CVal = option.Some[any](value)
 		case uint64:
 			enclosure.Dtype = sutils.SS_DT_UNSIGNED_NUM
-			enclosure.CVal = value
+			enclosure.CVal = option.Some[any](value)
 		case int64:
 			enclosure.Dtype = sutils.SS_DT_SIGNED_NUM
-			enclosure.CVal = value
+			enclosure.CVal = option.Some[any](value)
 		default:
 			return fmt.Errorf("getMeasureResultsFieldValues: expected field to have a string or float value but got %T", value)
 		}
@@ -3839,7 +3840,7 @@ func getAggregationResultFieldValues(fieldToValue map[string]sutils.CValueEnclos
 		switch value := value.(type) {
 		case string:
 			enclosure.Dtype = sutils.SS_DT_STRING
-			enclosure.CVal = value
+			enclosure.CVal = option.Some[any](value)
 		case sutils.CValueEnclosure:
 			enclosure = value
 		default:

--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -27,6 +27,7 @@ import (
 	"github.com/siglens/siglens/pkg/segment/structs"
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/siglens/siglens/pkg/utils"
+	"github.com/siglens/siglens/pkg/common/option"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -286,8 +287,12 @@ func InitialScoreMap(timechart *structs.TimechartExpr, groupByColValCnt map[stri
 
 	groupByColValScoreMap := make(map[string]*sutils.CValueEnclosure, 0)
 	for groupByColVal := range groupByColValCnt {
-		groupByColValScoreMap[groupByColVal] = &sutils.CValueEnclosure{CVal: nil, Dtype: sutils.SS_INVALID}
+		groupByColValScoreMap[groupByColVal] = &sutils.CValueEnclosure{
+			CVal:  option.None[any](),
+			Dtype: sutils.SS_INVALID,
+		}
 	}
+
 
 	return groupByColValScoreMap
 }
@@ -380,7 +385,7 @@ func MergeVal(eVal *sutils.CValueEnclosure, eValToMerge sutils.CValueEnclosure, 
 			if err != nil {
 				batchErr.AddError("MergeVal:HLL_STATS", err)
 			}
-			eVal.CVal = hll.Cardinality()
+			eVal.CVal = option.Some[any](hll.Cardinality())
 			eVal.Dtype = sutils.SS_DT_UNSIGNED_NUM
 			return
 		}
@@ -398,7 +403,7 @@ func MergeVal(eVal *sutils.CValueEnclosure, eValToMerge sutils.CValueEnclosure, 
 		}
 		sort.Strings(uniqueStrings)
 
-		eVal.CVal = uniqueStrings
+		eVal.CVal = option.Some[any](uniqueStrings)
 		eVal.Dtype = sutils.SS_DT_STRING_SLICE
 		return
 	default:

--- a/pkg/segment/utils/number.go
+++ b/pkg/segment/utils/number.go
@@ -22,6 +22,7 @@ import (
 	"math"
 
 	"github.com/siglens/siglens/pkg/utils"
+	"github.com/siglens/siglens/pkg/common/option"
 )
 
 type numberType = byte
@@ -239,23 +240,23 @@ func (n *Number) ToCVal(enclosure *CValueEnclosure) error {
 	switch n.ntype() {
 	case invalidType:
 		enclosure.Dtype = SS_INVALID
-		enclosure.CVal = nil
+		enclosure.CVal = option.None[any]()
 	case backfillType:
 		enclosure.Dtype = SS_DT_BACKFILL
-		enclosure.CVal = nil
+		enclosure.CVal = option.None[any]()
 	case int64Type:
 		i, err := n.Int64()
 		if err != nil {
 			return err
 		}
-		enclosure.CVal = i
+		enclosure.CVal = option.Some[any](i)
 		enclosure.Dtype = SS_DT_SIGNED_NUM
 	case float64Type:
 		f, err := n.Float64()
 		if err != nil {
 			return err
 		}
-		enclosure.CVal = f
+		enclosure.CVal = option.Some[any](f)
 		enclosure.Dtype = SS_DT_FLOAT
 	}
 

--- a/pkg/segment/utils/segconsts_test.go
+++ b/pkg/segment/utils/segconsts_test.go
@@ -22,65 +22,66 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/siglens/siglens/pkg/common/option"
 )
 
 func Test_CVal_Equal(t *testing.T) {
-	c1 := &CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"}
-	c2 := &CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"}
+	c1 := &CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")}
+	c2 := &CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")}
 	assert.True(t, c1.Equal(c2))
 
-	c1 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: int64(123)}
-	c2 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: int64(123)}
+	c1 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: option.Some[any](int64(123))}
+	c2 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: option.Some[any](int64(123))}
 	assert.True(t, c1.Equal(c2))
 
-	c1 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: uint64(123)}
-	c2 = &CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: uint64(123)}
+	c1 = &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: option.Some[any](uint64(123))}
+	c2 = &CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: option.Some[any](uint64(123))}
 	assert.False(t, c1.Equal(c2))
 
-	c1 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.456)}
-	c2 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.456001)}
+	c1 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: option.Some[any](float64(123.456))}
+	c2 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: option.Some[any](float64(123.456001))}
 	assert.True(t, c1.Equal(c2))
 
-	c1 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.456)}
-	c2 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.457)}
+	c1 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: option.Some[any](float64(123.456))}
+	c2 = &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: option.Some[any](float64(123.457))}
 	assert.False(t, c1.Equal(c2))
 }
 
 func Test_CVal_Hash(t *testing.T) {
 	assert.NotEqual(t,
-		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"}).Hash(),
-		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: "world"}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("world")}).Hash(),
 	)
 
 	assert.NotEqual(t,
-		(&CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: int64(123)}).Hash(),
-		(&CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: uint64(123)}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: option.Some[any](int64(123))}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: option.Some[any](uint64(123))}).Hash(),
 	)
 
 	assert.NotEqual(t,
-		(&CValueEnclosure{Dtype: SS_DT_BOOL, CVal: false}).Hash(),
-		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: nil}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_BOOL, CVal: option.Some[any](false)}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: option.None[any]()}).Hash(),
 	)
 
 	assert.Equal(t,
-		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"}).Hash(),
-		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")}).Hash(),
 	)
 
 	assert.Equal(t,
-		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: nil}).Hash(),
-		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: 123}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: option.None[any]()}).Hash(),
+		(&CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: option.Some[any](123)}).Hash(),
 	)
 }
 
 func Test_CValFromBytes(t *testing.T) {
 	original := make([]*CValueEnclosure, 0)
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_STRING, CVal: "hello"})
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: int64(-123)})
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: uint64(123)})
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: float64(123.456)})
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_BOOL, CVal: true})
-	original = append(original, &CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: nil})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_STRING, CVal: option.Some[any]("hello")})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_SIGNED_NUM, CVal: option.Some[any](int64(-123))})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_UNSIGNED_NUM, CVal: option.Some[any](uint64(123))})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_FLOAT, CVal: option.Some[any](float64(123.456))})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_BOOL, CVal: option.Some[any](true)})
+	original = append(original, &CValueEnclosure{Dtype: SS_DT_BACKFILL, CVal: option.None[any]()})
 
 	var bytes []byte
 	idx := 0


### PR DESCRIPTION
# Description
Jira issue : Create a new generic type like Option[T] that will either store a value or indicate that there's no value there. (Similar to Option in Rust, if you're familiar). Then to return a NULL string we'd just return a Option[string] with no string value.

Implemented according to this doc : https://doc.rust-lang.org/std/option/ 
