### PR TITLE
Fix: prevent panic during hll merging for timechart queries

### DIFF
--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -376,13 +376,17 @@ func MergeVal(eVal *sutils.CValueEnclosure, eValToMerge sutils.CValueEnclosure, 
 		if useAdditionForMerge {
 			aggFunc = sutils.Sum
 		} else {
-			err := hll.StrictUnion(hllToMerge.Hll)
-			if err != nil {
-				batchErr.AddError("MergeVal:HLL_STATS", err)
+			if hllToMerge != nil {
+				err := hll.StrictUnion(hllToMerge.Hll)
+				if err != nil {
+					batchErr.AddError("MergeVal:HLL_STATS", err)
+				}
+				eVal.CVal = hll.Cardinality()
+				eVal.Dtype = sutils.SS_DT_UNSIGNED_NUM
+				return
+			} else {
+				batchErr.AddError("MergeVal:HLL_STATS", errors.New("hllToMerge is nil"))
 			}
-			eVal.CVal = hll.Cardinality()
-			eVal.Dtype = sutils.SS_DT_UNSIGNED_NUM
-			return
 		}
 	case sutils.Values:
 		// Can not do addition for values func

--- a/pkg/segment/aggregations/timechartagg.go
+++ b/pkg/segment/aggregations/timechartagg.go
@@ -42,6 +42,8 @@ type Range struct {
 	step  uint64
 }
 
+var errHllMerge error = errors.New("hllToMerge is nil")
+
 func GenerateTimeRangeBuckets(timeHistogram *structs.TimeBucket) *Range {
 	return &Range{
 		start: timeHistogram.StartTime,
@@ -385,7 +387,7 @@ func MergeVal(eVal *sutils.CValueEnclosure, eValToMerge sutils.CValueEnclosure, 
 				eVal.Dtype = sutils.SS_DT_UNSIGNED_NUM
 				return
 			} else {
-				batchErr.AddError("MergeVal:HLL_STATS", errors.New("hllToMerge is nil"))
+				batchErr.AddError("MergeVal:HLL_STATS", errHllMerge)
 			}
 		}
 	case sutils.Values:


### PR DESCRIPTION
# Description
1. timechart queries without eval work fine.
2. timechart queries with distinct_count  and eval  cause siglens to crash. eg -> `* | timechart span=1m dc(eval('account.balance'>5000)) BY account.created_data.country` crashes but `* | timechart span=1m avg(eval('account.balance'>5000)) BY account.created_data.country` works fine.
3. only happens during merging of time buckets when `useAdditionForMerge=false` [here](https://github.com/vsharma-va/siglens/blob/90715059ce2df2af2f028c085addb2757f59ac55/pkg/segment/aggregations/timechartagg.go#L449).
4. which activates [this](https://github.com/vsharma-va/siglens/blob/90715059ce2df2af2f028c085addb2757f59ac55/pkg/segment/aggregations/timechartagg.go#L379) block in the code. `(hllToMerge = nil)`