### PR TITLE
Fix: Display error messages during Logs Alert creation

### DIFF
--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -444,9 +444,13 @@ function runFilterBtnHandler(evt) {
     var currentPage = window.location.pathname;
     if (currentPage === '/alert.html') {
         let data = getQueryParamsData();
-        fetchLogsPanelData(data, -1).then((res) => {
-            alertChart(res);
-        });
+        fetchLogsPanelData(data, -1)
+            .then((res) => {
+                alertChart(res);
+            })
+            .catch(function (xhr, _err) {
+                handleErrors(xhr);
+            });
     } else if (currentPage === '/dashboard.html') {
         runQueryBtnHandler();
     } else {
@@ -476,7 +480,7 @@ function runFilterBtnHandler(evt) {
                 <div>Searching for matching records...</div>
                 <div></div>
             `);
-            
+
             wsState = 'query';
             data = getSearchFilter(false, false);
             initialSearchData = data;


### PR DESCRIPTION
# Description
Previously, if an error occurred during the creation of a logs-based alert, the UI failed silently and didn’t provide clear feedback.
This update ensures any backend error received during alert creation is now shown in graph area.
<img width="1429" alt="image" src="https://github.com/user-attachments/assets/0b679c21-38bb-4533-b499-9d26051cdc15" />


