### PR TITLE
UI Fix: JSON Popup and Pagination

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1469,6 +1469,7 @@ progress.hidden {
     justify-content: center;
     align-items: center;
     padding: 0px;
+    z-index: 0;
 }
 
 #log-opt-single-btn {
@@ -7342,8 +7343,6 @@ p#versionInfo {
     border-top: 1px solid var(--panel-table-line-color);
     border-radius: 4px 0 0 0;
     display: block !important;
-    opacity: 0;
-    visibility: hidden;
 }
 
 .json-popup.active {
@@ -7351,8 +7350,6 @@ p#versionInfo {
     margin-left: 5px;
     border-left: 1px solid var(--panel-table-line-color);
     border-bottom: 1px solid var(--panel-table-line-color);
-    opacity: 1;
-    visibility: visible;
 }
 
 .json-popup-header {
@@ -7881,6 +7878,7 @@ p#versionInfo {
     background-color: var(--white-1) !important;
     color: var(--white-4);
     border: none;
+    z-index: 0;
 }
 
 .ace_string {

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -135,6 +135,9 @@ function resetDashboard() {
 
     $('#LogResultsGrid').html('');
     $('#measureAggGrid').html('');
+
+    $('.json-popup').removeClass('active');
+
     columnCount = 0;
     gridDiv = null;
     eGridDiv = null;

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -425,7 +425,6 @@ function runLiveTailBtnHandler(evt) {
     if ($('#live-tail-btn').text() === 'Live Tail') {
         resetDashboard();
         $('#live-tail-btn').html('Cancel Live Tail');
-        logsRowData = [];
         total_liveTail_searched = 0;
         wsState = 'query';
         data = getLiveTailFilter(false, false, 1800);
@@ -471,7 +470,6 @@ function runFilterBtnHandler(evt) {
                 hasSearchSinceHistogramClosed = true;
             }
             resetDashboard();
-            logsRowData = [];
             accumulatedRecords = [];
             lastColumnsOrder = [];
             totalLoadedRecords = 0;

--- a/static/js/log-results-grid.js
+++ b/static/js/log-results-grid.js
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-let logsRowData = [];
 let logsColumnDefs = [
     {
         field: 'timestamp',
@@ -42,7 +41,6 @@ let total_liveTail_searched = 0;
 //eslint-disable-next-line no-unused-vars
 const gridOptions = {
     columnDefs: logsColumnDefs,
-    rowData: logsRowData,
     readOnlyEdit: true,
     singleClickEdit: true,
     headerHeight: 26,

--- a/static/js/logs-histogram.js
+++ b/static/js/logs-histogram.js
@@ -350,7 +350,6 @@ function triggerZoomSearch(startTime, endTime, isZoomTriggered = true) {
     updateDatePickerAndUrl(data.startEpoch, data.endEpoch);
 
     resetDashboard();
-    logsRowData = [];
     accumulatedRecords = [];
     lastColumnsOrder = [];
     totalLoadedRecords = 0;

--- a/static/js/pagination.js
+++ b/static/js/pagination.js
@@ -4,6 +4,8 @@ let totalLoadedRecords = 0;
 let hasMoreRecords = false;
 let accumulatedRecords = [];
 let isLoadingMore = false;
+//eslint-disable-next-line no-unused-vars
+let isLoadMoreOperation = false;
 
 //eslint-disable-next-line no-unused-vars
 function initializePagination() {
@@ -54,6 +56,7 @@ function goToPage(page) {
         paginateAggsData(segStatsRowData);
     } else {
         const startIndex = (currentPage - 1) * pageSize;
+        $('.json-popup').removeClass('active');
 
         if (startIndex + pageSize > totalLoadedRecords && hasMoreRecords) {
             loadMoreResults();
@@ -200,6 +203,7 @@ function loadMoreResults() {
     if (isLoadingMore) return;
 
     isLoadingMore = true;
+    isLoadMoreOperation = true;
     updateLoadMoreMessage();
 
     const data = getSearchFilter(true, true, false);
@@ -215,6 +219,7 @@ function loadMoreResults() {
 
     doSearch(data).finally(() => {
         isLoadingMore = false;
+        isLoadMoreOperation = false;
         updateLoadMoreMessage();
     });
 }

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -20,12 +20,11 @@
 let lastQType = '';
 let lastColumnsOrder = [];
 //eslint-disable-next-line no-unused-vars
-let timechartComplete= null;
-let isHistogramViewActive= false;
-let isSearchButtonTriggered= false;
+let timechartComplete = null;
+let isHistogramViewActive = false;
+let isSearchButtonTriggered = false;
 //eslint-disable-next-line no-unused-vars
-let hasSearchSinceHistogramClosed= false;
-
+let hasSearchSinceHistogramClosed = false;
 
 function wsURL(path) {
     var protocol = location.protocol === 'https:' ? 'wss://' : 'ws://';
@@ -93,7 +92,7 @@ function doSearch(data) {
                 <div id="percent-value">1%</div>
             `);
             $('#record-searched').html(`<div><span>Starting search...</span></div>`);
-            
+
             try {
                 socket.send(JSON.stringify(data));
             } catch (e) {
@@ -441,7 +440,7 @@ function getInitialSearchFilter(skipPushState, scrollingTrigger) {
         sFrom = scrollFrom;
     }
 
-    const runTimechartValue = isSearchButtonTriggered && isHistogramViewActive ;
+    const runTimechartValue = isSearchButtonTriggered && isHistogramViewActive;
 
     return {
         state: 'query',
@@ -830,7 +829,7 @@ function processCompleteUpdate(res, eventType, totalEventsSearched, timeToFirstB
         } else if (res.qtype === 'logs-query' && accumulatedRecords.length > 0) {
             renderLogsGrid(lastColumnsOrder, accumulatedRecords);
             //eslint-disable-next-line no-undef
-           initializeAvailableFieldsSidebar(lastColumnsOrder);
+            initializeAvailableFieldsSidebar(lastColumnsOrder);
         }
         timeChart(res.qtype, res.measure, res.isTimechart);
     }
@@ -840,7 +839,7 @@ function processCompleteUpdate(res, eventType, totalEventsSearched, timeToFirstB
         if (isHistogramViewActive && $('.histo-container').is(':visible')) {
             //eslint-disable-next-line no-undef
             renderHistogram(res.timechartComplete);
-            hasSearchSinceHistogramClosed = false; 
+            hasSearchSinceHistogramClosed = false;
         }
     } else if (isSearchButtonTriggered && isHistogramViewActive && $('.histo-container').is(':visible')) {
         timechartComplete = null;
@@ -892,7 +891,7 @@ function processEmptyQueryResults() {
 
     $('#save-query-div').children().hide();
     $('#custom-chart-tab').show().css({ height: 'auto' });
-    $('.json-popup').hide();
+    $('.json-popup').removeClass('active');
 
     $('#show-record-intro-btn').show();
     $('#empty-response').empty().show();
@@ -908,7 +907,7 @@ function showErrorResponse(res) {
 
     $('#save-query-div').children().hide();
     $('#custom-chart-tab').hide();
-    $('.json-popup').hide();
+    $('.json-popup').removeClass('active');
 
     $('#empty-response').empty().show();
     if (res && res.no_data_err && res.no_data_err.includes('No data found')) {
@@ -1174,9 +1173,11 @@ function renderLogsGrid(columnOrder, hits) {
         }
     });
     if (hits.length !== 0) {
-        logsRowData = hits;
         totalLoadedRecords = hits.length;
-        updateGridView();
+        //eslint-disable-next-line no-undef
+        if (!isLoadMoreOperation) {
+            updateGridView();
+        }
     }
 
     const logsColumnDefsMap = new Map(logsColumnDefs.map((logCol) => [logCol.field, logCol]));
@@ -1196,8 +1197,6 @@ function renderLogsGrid(columnOrder, hits) {
         allColumnIds.push(column.getId());
     });
     gridOptions.columnApi.autoSizeColumns(allColumnIds, false);
-
-    gridOptions.api.setRowData(logsRowData);
 
     //eslint-disable-next-line no-undef
     handleLogOptionChange(logView);


### PR DESCRIPTION
# Description
1. Hide JSON Popup on Error/Empty Results
The JSON viewer popup will now automatically hide if - the query returns an error or the result set is empty.

2. Pagination Fixes
Previously, the UI - displayed 100 records per page regardless of the selected page size and on Load more we are showing all the records instead of the selected page size. 
Fixed these two issues in the PR.
