### PR TITLE
Sig 1808 spl format command

### DIFF
--- a/pkg/segment/formatter/format.go
+++ b/pkg/segment/formatter/format.go
@@ -1,0 +1,110 @@
+package formatter
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+)
+
+// ProcessFormatResults formats the input records according to format command specifications
+// and returns a single record with a "search" field containing the formatted search string
+func ProcessFormatResults(records []map[string]interface{}, formatReq *structs.FormatResultsRequest) []map[string]interface{} {
+	// Set defaults if not provided
+	if formatReq == nil {
+		formatReq = getDefaultFormatResultsExpr()
+	} else {
+		// Fill in any missing options with defaults
+		if formatReq.MVSeparator == "" {
+			formatReq.MVSeparator = "OR"
+		}
+		if formatReq.EmptyString == "" {
+			formatReq.EmptyString = "NOT()"
+		}
+		if formatReq.RowColOptions == nil {
+			formatReq.RowColOptions = &structs.RowColOptions{
+				RowPrefix:       "(",
+				ColumnPrefix:    "(",
+				ColumnSeparator: "AND",
+				ColumnEnd:       ")",
+				RowSeparator:    "OR",
+				RowEnd:          ")",
+			}
+		}
+	}
+
+	// Limit results if MaxResults is specified
+	if formatReq.MaxResults > 0 && uint64(len(records)) > formatReq.MaxResults {
+		records = records[:formatReq.MaxResults]
+	}
+
+	// Check if there are any records to format
+	if len(records) == 0 {
+		// Return a single record containing the empty string
+		return []map[string]interface{}{
+			{"search": formatReq.EmptyString},
+		}
+	}
+
+	// Format the records
+	var formattedRows []string
+	for _, record := range records {
+		// Get sorted list of fields for consistent output order
+		var fields []string
+		for field := range record {
+			fields = append(fields, field)
+		}
+		sort.Strings(fields)
+
+		var formattedColumns []string
+		for _, field := range fields {
+			value := record[field]
+			// Handle multi-value fields
+			if mvSlice, ok := value.([]interface{}); ok {
+				// Format multiple values with the MVSeparator
+				var mvValues []string
+				for _, mvVal := range mvSlice {
+					mvValues = append(mvValues, fmt.Sprintf("%s=\"%v\"", field, mvVal))
+				}
+				formattedColumns = append(formattedColumns, fmt.Sprintf("(%s)", strings.Join(mvValues, " "+formatReq.MVSeparator+" ")))
+			} else {
+				// Format single value
+				formattedColumns = append(formattedColumns, fmt.Sprintf("%s=\"%v\"", field, value))
+			}
+		}
+
+		// Format the row
+		rowStr := formatReq.RowColOptions.ColumnPrefix +
+			strings.Join(formattedColumns, " "+formatReq.RowColOptions.ColumnSeparator+" ") +
+			formatReq.RowColOptions.ColumnEnd
+		formattedRows = append(formattedRows, rowStr)
+	}
+
+	// Format all rows together
+	searchStr := formatReq.RowColOptions.RowPrefix +
+		strings.Join(formattedRows, " "+formatReq.RowColOptions.RowSeparator+" ") +
+		formatReq.RowColOptions.RowEnd
+
+	// Return the formatted string in a record with key "search"
+	return []map[string]interface{}{
+		{"search": searchStr},
+	}
+}
+
+// getDefaultFormatResultsExpr returns default format command settings
+func getDefaultFormatResultsExpr() *structs.FormatResultsRequest {
+	return &structs.FormatResultsRequest{
+		MVSeparator: "OR",
+		MaxResults:  0,
+		EmptyString: "NOT()",
+		RowColOptions: &structs.RowColOptions{
+			RowPrefix:       "(",
+			ColumnPrefix:    "(",
+			ColumnSeparator: "AND",
+			ColumnEnd:       ")",
+			RowSeparator:    "OR",
+			RowEnd:          ")",
+		},
+	}
+}

--- a/pkg/segment/structs/format_type.go
+++ b/pkg/segment/structs/format_type.go
@@ -1,0 +1,18 @@
+package structs
+
+type FormatResultsRequest struct {
+	MVSeparator       string
+	MaxResults        uint64
+	EmptyString       string
+	RowColOptions     *RowColOptions
+	NumFormatPatterns map[string]string // Add this field
+}
+
+type RowColOptions struct {
+	RowPrefix       string
+	ColumnPrefix    string
+	ColumnSeparator string
+	ColumnEnd       string
+	RowSeparator    string
+	RowEnd          string
+}

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -409,23 +409,6 @@ type EventCountExpr struct {
 	ListVix    bool
 }
 
-// formats the results into a single result and places that result into a new field called search.
-type FormatResultsRequest struct {
-	MVSeparator   string         // separator for multi-value fields. Default= "OR"
-	MaxResults    uint64         // max number of results to return
-	EmptyString   string         // string to return if no results are found. Default= "NOT()"
-	RowColOptions *RowColOptions // options for row column
-}
-
-type RowColOptions struct {
-	RowPrefix       string // prefix for row. Default= "("
-	ColumnPrefix    string // prefix for column. Default= "("
-	ColumnSeparator string // separator for column. Default= "AND"
-	ColumnEnd       string // end for column. Default= ")"
-	RowSeparator    string // separator for row. Default= "OR"
-	RowEnd          string // end for row. Default= ")"
-}
-
 type MultiColLetRequest struct {
 	LeftCName  string
 	Oper       sutils.LogicalAndArithmeticOperator

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1500,7 +1500,7 @@ func (c EvalFuncChecker) IsUnsupported(funcName string) bool {
 	return found
 }
 
-var unsupportedLetColumnCommands = []string{"FormatResults", "EventCountRequest"}
+var unsupportedLetColumnCommands = []string{"EventCountRequest"}
 
 func CheckUnsupportedFunctions(post *QueryAggregators) error {
 


### PR DESCRIPTION
- This PR implements the SPL Format command as part of [SIG-1808](https://sigscalr.atlassian.net/browse/SIG-1808).
+ This PR adds initial implementation of the SPL Format command functionality.

### Summary
This PR adds support for formatting SPL queries.
Work is still in progress, and feedback is welcome.

### Changes
- Added `format.go` to handle SPL formatting logic
- Modular structure created for future extensions


