### PR TITLE
Fix: Search Textarea Auto-Collapse Issue

### DIFF
--- a/static/css/query-builder.css
+++ b/static/css/query-builder.css
@@ -289,6 +289,7 @@ input.form-control {
 
 #custom-code-tab.ui-widget.ui-widget-content {
     width: 100% !important;
+    z-index: 1;
 }
 
 .custom-code-tab {


### PR DESCRIPTION
# Description
Fixed issue where the search textarea would collapse unexpectedly when the user clicked on the last line, especially if the query has a lot of lines.