### PR TITLE
Add spl informational function getfields

### DIFF
--- a/pkg/segment/aggregations/nullif_func.go
+++ b/pkg/segment/aggregations/nullif_func.go
@@ -1,0 +1,90 @@
+package aggregations
+
+import (
+	"fmt"
+
+	"github.com/siglens/siglens/pkg/segment/structs"
+	sutils "github.com/siglens/siglens/pkg/segment/utils"
+)
+
+// EvalNullIf evaluates the nullif(expr1, expr2) function.
+// Returns nil if both values are equal, otherwise returns the first value.
+func EvalNullIf(args []*structs.ValueExpr, fieldToValue map[string]sutils.CValueEnclosure) (interface{}, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("nullif function requires exactly 2 arguments")
+	}
+
+	val1, err := args[0].EvaluateValueExpr(fieldToValue)
+	if err != nil {
+		return nil, err
+	}
+
+	val2, err := args[1].EvaluateValueExpr(fieldToValue)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle nil values
+	if val1 == nil && val2 == nil {
+		return nil, nil
+	}
+	if val1 == nil || val2 == nil {
+		return val1, nil
+	}
+
+	// Compare numeric values properly
+	v1Float, v1IsFloat := tryConvertToFloat64(val1)
+	v2Float, v2IsFloat := tryConvertToFloat64(val2)
+
+	if v1IsFloat && v2IsFloat {
+		// Both are numeric, compare as numbers
+		if v1Float == v2Float {
+			return nil, nil
+		}
+		return val1, nil
+	}
+
+	// Compare as strings as fallback
+	v1Str := fmt.Sprintf("%v", val1)
+	v2Str := fmt.Sprintf("%v", val2)
+	if v1Str == v2Str {
+		return nil, nil
+	}
+
+	return val1, nil
+}
+
+// tryConvertToFloat64 attempts to convert a value to float64
+// Returns the converted value and a boolean indicating success
+func tryConvertToFloat64(val interface{}) (float64, bool) {
+	if val == nil {
+		return 0, false
+	}
+
+	switch v := val.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case string:
+		// Try to parse the string as a number
+		f, err := sutils.ParseStringToFloat64(v)
+		if err == nil {
+			return f, true
+		}
+	}
+
+	return 0, false
+}

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -2716,28 +2716,6 @@ func handleCoalesceFunction(self *ConditionExpr, fieldToValue map[string]sutils.
 	return "", nil
 }
 
-func handleFunction(expr *ConditionExpr, fieldToValue map[string]sutils.CValueEnclosure) (interface{}, error) {
-	if len(expr.ValueList) != 2 {
-		return nil, fmt.Errorf("handleNullIfFunction: nullif requires exactly two arguments")
-	}
-
-	value1, err := expr.ValueList[0].EvaluateValueExpr(fieldToValue)
-	if err != nil {
-		return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value1, err: %v", err)
-	}
-
-	value2, err := expr.ValueList[1].EvaluateValueExpr(fieldToValue)
-	if err != nil {
-		return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value2, err: %v", err)
-	}
-
-	if value1 == value2 {
-		return nil, nil
-	}
-
-	return value1, nil
-}
-
 // Field may come from BoolExpr or ValueExpr
 func (expr *ConditionExpr) EvaluateCondition(fieldToValue map[string]sutils.CValueEnclosure) (interface{}, error) {
 

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -2716,7 +2716,7 @@ func handleCoalesceFunction(self *ConditionExpr, fieldToValue map[string]sutils.
 	return "", nil
 }
 
-func handleNullIfFunction(expr *ConditionExpr, fieldToValue map[string]sutils.CValueEnclosure) (interface{}, error) {
+func handleFunction(expr *ConditionExpr, fieldToValue map[string]sutils.CValueEnclosure) (interface{}, error) {
 	if len(expr.ValueList) != 2 {
 		return nil, fmt.Errorf("handleNullIfFunction: nullif requires exactly two arguments")
 	}
@@ -2772,33 +2772,27 @@ func (expr *ConditionExpr) EvaluateCondition(fieldToValue map[string]sutils.CVal
 		return handleCaseFunction(expr, fieldToValue)
 	case "coalesce":
 		return handleCoalesceFunction(expr, fieldToValue)
-		// Inside EvaluateCondition method in evaluationstructs.go
 	case "nullif":
 		if len(expr.ValueList) != 2 {
 			return nil, fmt.Errorf("nullif function requires exactly 2 arguments")
 		}
-
 		val1, err := expr.ValueList[0].EvaluateValueExpr(fieldToValue)
 		if err != nil {
 			return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value1, err: %v", err)
 		}
-
 		val2, err := expr.ValueList[1].EvaluateValueExpr(fieldToValue)
 		if err != nil {
 			return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value2, err: %v", err)
 		}
-
 		if fmt.Sprintf("%v", val1) == fmt.Sprintf("%v", val2) {
 			return nil, nil
 		}
-
 		return val1, nil
 	case "null":
 		return nil, nil
 	default:
 		return "", fmt.Errorf("ConditionExpr.EvaluateCondition: unsupported operation: %v", expr.Op)
 	}
-
 }
 
 func (self *TextExpr) GetFields() []string {

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -2772,8 +2772,27 @@ func (expr *ConditionExpr) EvaluateCondition(fieldToValue map[string]sutils.CVal
 		return handleCaseFunction(expr, fieldToValue)
 	case "coalesce":
 		return handleCoalesceFunction(expr, fieldToValue)
+		// Inside EvaluateCondition method in evaluationstructs.go
 	case "nullif":
-		return handleNullIfFunction(expr, fieldToValue)
+		if len(expr.ValueList) != 2 {
+			return nil, fmt.Errorf("nullif function requires exactly 2 arguments")
+		}
+
+		val1, err := expr.ValueList[0].EvaluateValueExpr(fieldToValue)
+		if err != nil {
+			return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value1, err: %v", err)
+		}
+
+		val2, err := expr.ValueList[1].EvaluateValueExpr(fieldToValue)
+		if err != nil {
+			return nil, utils.WrapErrorf(err, "handleNullIfFunction: Error while evaluating value2, err: %v", err)
+		}
+
+		if fmt.Sprintf("%v", val1) == fmt.Sprintf("%v", val2) {
+			return nil, nil
+		}
+
+		return val1, nil
 	case "null":
 		return nil, nil
 	default:

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -1479,7 +1479,6 @@ var unsupportedEvalFuncs = map[string]struct{}{
 	"printf":           {},
 	"tojson":           {},
 	"cluster":          {},
-	"getfields":        {},
 	"isnum":            {},
 	"isnotnull":        {},
 	"spath":            {},

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -307,6 +307,5 @@ func AppendWithLimit(dest []string, src []string, limit int) []string {
 
 // ParseStringToFloat64 tries to parse a string to a float64
 func ParseStringToFloat64(s string) (float64, error) {
-	// Implementation that parses the string to float64
 	return strconv.ParseFloat(s, 64)
 }

--- a/pkg/segment/utils/aggutils.go
+++ b/pkg/segment/utils/aggutils.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"fmt"
 	"math"
+	"strconv"
 )
 
 func Reduce(e1 CValueEnclosure, e2 CValueEnclosure, fun AggregateFunctions) (CValueEnclosure, error) {
@@ -302,4 +303,10 @@ func AppendWithLimit(dest []string, src []string, limit int) []string {
 		return append(dest, src[:remainingCapacity]...)
 	}
 	return append(dest, src...)
+}
+
+// ParseStringToFloat64 tries to parse a string to a float64
+func ParseStringToFloat64(s string) (float64, error) {
+	// Implementation that parses the string to float64
+	return strconv.ParseFloat(s, 64)
 }


### PR DESCRIPTION
# Description
Added the getfields SPL function to return a JSON array of field names and values, with optional filtering by patterns and wildcard support.

# Testing
 * | eval rowData = getfields()
[link ](https://help.splunk.com/en/splunk-cloud-platform/search/spl2-search-reference/evaluation-functions/informational-functions)
