### PR TITLE
Alerts UI: Edit Fixes, Loading Indicators and Auto-Refresh

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -2613,6 +2613,7 @@ input[type="text"].active {
     color: var(--table-or-regular-text-color);
     display: block;
     padding: 8px;
+    z-index: 2;
 }
 
 #daterangepicker.active {
@@ -6691,6 +6692,7 @@ p#versionInfo {
     padding: 8px;
     display: none;
     padding-top: 0;
+    position: relative;
 }
 
 .total-unique-series {

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -311,6 +311,9 @@ function saveAlert() {
 
     const url = isEditMode && !isFromMetrics ? 'api/alerts/update' : 'api/alerts/create';
 
+    const saveButton = $('#save-alert-btn');
+    const originalText = saveButton.text();
+
     $.ajax({
         method: 'post',
         url: url,
@@ -323,10 +326,14 @@ function saveAlert() {
         crossDomain: true,
     })
         .then(() => {
+            saveButton.text('Saving...');
+            setTimeout(() => {
+                window.location.href = '../all-alerts.html';
+            }, 1000);
             $('#alert-form')[0].reset();
-            window.location.href = '../all-alerts.html';
         })
         .catch((err) => {
+            saveButton.prop('disabled', false).text(originalText);
             showToast(err.responseJSON?.error || 'Failed to save alert', 'error');
         });
 }

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -430,6 +430,7 @@ async function fillAlertForm(res) {
             queryLanguage: 'Splunk QL',
         };
 
+        showLogsLoading();
         fetchLogsPanelData(data, -1)
             .then((res) => {
                 alertChart(res);
@@ -516,6 +517,7 @@ function createAlertFromLogs(queryLanguage, searchText, startEpoch, endEpoch, fi
         indexName: selectedSearchIndex,
         queryLanguage: queryLanguage,
     };
+    showLogsLoading();
     fetchLogsPanelData(data, -1)
         .then((res) => {
             alertChart(res);
@@ -906,4 +908,10 @@ function showEmptyChart(logsExplorer) {
             },
         },
     });
+}
+
+function showLogsLoading() {
+    const logsExplorer = document.getElementById('logs-explorer');
+    logsExplorer.style.display = 'flex';
+    logsExplorer.innerHTML = '<div class="panel-loading"></div>';
 }

--- a/static/js/alert.js
+++ b/static/js/alert.js
@@ -213,6 +213,9 @@ async function initializeFromUrl() {
     const params = new URLSearchParams(window.location.search);
     let alertType = params.get('type') || 'logs';
 
+    await toggleAlertTypeUI(alertType);
+    handleFormValidationTooltip(alertType);
+
     // Edit Mode
     if (params.has('id')) {
         alertType = await loadExistingAlert(params.get('id'));
@@ -242,9 +245,6 @@ async function initializeFromUrl() {
     if (!isEditMode && !isFromMetrics && alertType !== 'logs') {
         addQueryElement();
     }
-
-    handleFormValidationTooltip(alertType);
-    toggleAlertTypeUI(alertType);
 }
 
 async function loadExistingAlert(alertId) {
@@ -408,6 +408,7 @@ async function fillAlertForm(res) {
         if (index === '') {
             setIndexDisplayValue('*');
         } else {
+            selectedSearchIndex = index;
             setIndexDisplayValue(index);
         }
 
@@ -847,7 +848,7 @@ function prepareLogsChartData(res, hits) {
 function handleErrors(error) {
     const logsExplorer = document.getElementById('logs-explorer');
     const errorText = error.responseJSON?.error || error.statusText || 'Failed to fetch logs data';
-    
+
     logsExplorer.style.display = 'flex';
     logsExplorer.innerHTML = `
         <div style="color: #666; text-align: center; padding: 20px; font-size: 16px; font-style: italic;">

--- a/static/js/all-alerts.js
+++ b/static/js/all-alerts.js
@@ -244,7 +244,7 @@ class btnRenderer {
         const now = new Date();
 
         if (endDateTime <= now) {
-            showToast('End time must be in the future', 'error');
+            showToast('End time must be in the future', 'error', 5000);
             return;
         }
 
@@ -626,38 +626,3 @@ function onRowClicked(event) {
     event.stopPropagation();
 }
 
-function updateMutedForValues() {
-    let hasMutedAlerts = false;
-    const currentTime = Math.floor(Date.now() / 1000);
-    alertGridOptions.api.forEachNode((node) => {
-        if (node.data.silenceEndTime) {
-            //eslint-disable-next-line no-undef
-            const mutedFor = calculateMutedFor(node.data.silenceEndTime);
-            node.setDataValue('mutedFor', mutedFor);
-
-            if (node.data.silenceEndTime > currentTime) {
-                hasMutedAlerts = true;
-            } else {
-                // Silence period has ended
-                node.setDataValue('silenceEndTime', null);
-                node.setDataValue('silenceMinutes', 0);
-                node.setDataValue('mutedFor', '');
-
-                // Update the mute icon
-                const cellRenderer = alertGridOptions.api.getCellRendererInstances({
-                    rowNodes: [node],
-                    columns: ['Actions'],
-                })[0];
-                if (cellRenderer && cellRenderer.instance instanceof btnRenderer) {
-                    cellRenderer.instance.updateMuteIcon(false);
-                }
-            }
-        }
-    });
-
-    alertGridOptions.columnApi.setColumnVisible('mutedFor', hasMutedAlerts);
-    alertGridOptions.api.sizeColumnsToFit();
-}
-
-// Update muted for column every 1 minutes
-setInterval(updateMutedForValues, 60000);

--- a/static/js/event-handlers.js
+++ b/static/js/event-handlers.js
@@ -443,6 +443,9 @@ function runFilterBtnHandler(evt) {
     var currentPage = window.location.pathname;
     if (currentPage === '/alert.html') {
         let data = getQueryParamsData();
+        
+        //eslint-disable-next-line no-undef
+        showLogsLoading();
         fetchLogsPanelData(data, -1)
             .then((res) => {
                 alertChart(res);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -44,7 +44,6 @@ async function getListIndices() {
         });
 }
 
-// Dashboards Index Dropdown
 // Function to initialize autocomplete with original index values
 //eslint-disable-next-line no-unused-vars
 async function initializeIndexAutocomplete() {


### PR DESCRIPTION
- Fixed Logs Alert Editing Issue: When editing a logs alert, the index field now correctly shows the saved index..

- Loading Icon for Logs Graph: Added a loading spinner on the logs graph within the alert screen to indicate data is being fetched.

- Display correct state for edited alert: Added a 1-second delay when saving alerts to allow backend evaluation to complete, preventing the display of the wrong alert state. Shows a clear `Saving...` message during this process for better user feedback.

- Auto-Refresh on All Alerts Page: The all-alerts page now automatically refreshes every 30 seconds by fetching the latest alert states and details from the backend.

- Real-Time Silenced Duration Update: With auto-refresh enabled, the `silencedFor` value (showing how long an alert has been silenced) updates every 30 seconds to reflect real-time changes.

- Auto-Refresh on Alert History Page: The alert history page also refreshes automatically every 30 seconds to display the latest alert history data.
