### PR TITLE
Refactor query setup to separate side-effect

### DIFF
--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -830,8 +830,7 @@ func NewStatsDP(options *structs.StatsExpr) *DataProcessor {
 }
 
 func NewStatisticExprDP(options *structs.QueryAggregators) *DataProcessor {
-	statsExpr := &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
-	options.StatsExpr = statsExpr
+	options.StatsExpr = &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
 
 	if options.HasTopExpr() {
 		return NewTopDP(options)

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -835,20 +835,6 @@ func NewStatisticExprDP(options *structs.QueryAggregators, isDistributed bool) *
 	statsExpr := &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
 	options.StatsExpr = statsExpr
 
-	if isDistributed && !options.StatisticExpr.ExprSplitDone {
-		// Split the Aggs into two data processors, the first one is the stats processor
-		// and the second one will perform the actual statisticExpr.
-		nextAgg := &structs.QueryAggregators{
-			GroupByRequest: options.GroupByRequest,
-			StatisticExpr:  options.StatisticExpr,
-		}
-		nextAgg.Next = options.Next
-		options.Next = nextAgg
-		nextAgg.StatisticExpr.ExprSplitDone = true
-
-		return NewStatsDP(statsExpr)
-	}
-
 	if options.HasTopExpr() {
 		return NewTopDP(options)
 	} else if options.HasRareExpr() {

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -829,8 +829,6 @@ func NewStatsDP(options *structs.StatsExpr) *DataProcessor {
 	}
 }
 
-// Note: this has side-effects.
-// TODO: remove the side-effects.
 func NewStatisticExprDP(options *structs.QueryAggregators, isDistributed bool) *DataProcessor {
 	statsExpr := &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
 	options.StatsExpr = statsExpr

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -829,7 +829,7 @@ func NewStatsDP(options *structs.StatsExpr) *DataProcessor {
 	}
 }
 
-func NewStatisticExprDP(options *structs.QueryAggregators, isDistributed bool) *DataProcessor {
+func NewStatisticExprDP(options *structs.QueryAggregators) *DataProcessor {
 	statsExpr := &structs.StatsExpr{GroupByRequest: options.GroupByRequest}
 	options.StatsExpr = statsExpr
 

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -472,7 +472,7 @@ func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryI
 	} else if queryAgg.MVExpandExpr != nil {
 		return NewMVExpandDP(queryAgg.MVExpandExpr)
 	} else if queryAgg.StatisticExpr != nil {
-		return NewStatisticExprDP(queryAgg, queryInfo.IsDistributed())
+		return NewStatisticExprDP(queryAgg)
 	} else if queryAgg.RegexExpr != nil {
 		return NewRegexDP(queryAgg.RegexExpr)
 	} else if queryAgg.RexExpr != nil {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -119,8 +119,6 @@ func MutateForSearchSorter(queryAgg *structs.QueryAggregators) *structs.SortExpr
 	return sortExpr
 }
 
-// Note: this has side-effects; see asDataProcessor().
-// TODO: remove the side-effects.
 func AggsToDataProcessors(firstAgg *structs.QueryAggregators, queryInfo *query.QueryInformation) []*DataProcessor {
 	dataProcessors := make([]*DataProcessor, 0)
 	for curAgg := firstAgg; curAgg != nil; curAgg = curAgg.Next {
@@ -444,8 +442,6 @@ func newQueryProcessorHelper(queryType structs.QueryType, input Streamer,
 	}, nil
 }
 
-// Note: this has side-effects for a NewStatisticExprDP.
-// TODO: remove the side-effects.
 func asDataProcessor(queryAgg *structs.QueryAggregators, queryInfo *query.QueryInformation) *DataProcessor {
 	if queryAgg == nil {
 		return nil


### PR DESCRIPTION
# Description
We call `AggsToDataProcessors()` when setting up a query, and it used to have side-effects for certain queries. This made it difficult to correctly call it multiple times, which we want to do when parallelizing a query.

This PR separates the side-effect part of the code so we can call that just once and then call `AggsToDataProcessors()` multiple times without worrying about additional side-effects. This PR shouldn't cause any behavior changes.

# Testing
CICD