### PR TITLE
SPL: Implement eval commands mvdedup + mvappend

### DIFF
--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -1136,13 +1136,13 @@ func handleSplit(self *MultiValueExpr, fieldToValue map[string]sutils.CValueEncl
 
 func handleMVDedup(self *MultiValueExpr, fieldToValue map[string]sutils.CValueEnclosure) ([]string, error) {
 	if self.MultiValueExprParams == nil || len(self.MultiValueExprParams) != 1 || self.MultiValueExprParams[0] == nil {
-		return []string{}, fmt.Errorf("MultiValueExpr.Evaluate: mvdedup requires one multiValueExpr argument")
+		return []string{}, fmt.Errorf("handleMVDedup: mvdedup requires one multiValueExpr argument")
 	}
 	mvSlice, err := self.MultiValueExprParams[0].Evaluate(fieldToValue)
 	if utils.IsNilValueError(err) {
 		return nil, err
 	} else if err != nil {
-		return []string{}, fmt.Errorf("TextExpr.EvaluateText -> handleMVDedup: %v", err)
+		return []string{}, fmt.Errorf("handleMVDedup: %v", err)
 	}
 
 	seen := make(map[string]string, len(mvSlice))
@@ -1160,7 +1160,7 @@ func handleMVDedup(self *MultiValueExpr, fieldToValue map[string]sutils.CValueEn
 
 func handleMVAppend(self *MultiValueExpr, fieldToValue map[string]sutils.CValueEnclosure) ([]string, error) {
 	if self.ValueExprParams == nil || len(self.ValueExprParams) < 1 || self.ValueExprParams[0] == nil {
-		return []string{}, fmt.Errorf("MultiValueExpr.Evaluate: mvappend requires atleast one argument")
+		return []string{}, fmt.Errorf("handleMVAppend: mvappend requires atleast one argument")
 	}
 
 	finalMVSlice := []string{}
@@ -1171,7 +1171,7 @@ func handleMVAppend(self *MultiValueExpr, fieldToValue map[string]sutils.CValueE
 			if utils.IsNilValueError(err) {
 				return nil, err
 			} else if err != nil {
-				return []string{}, fmt.Errorf("TextExpr.EvaluateText -> handleMVAppend: %v", err)
+				return []string{}, fmt.Errorf("handleMVAppend: %v", err)
 			}
 			finalMVSlice = append(finalMVSlice, mvSlice...)
 		case VEMStringExpr:
@@ -1182,7 +1182,7 @@ func handleMVAppend(self *MultiValueExpr, fieldToValue map[string]sutils.CValueE
 				if utils.IsNilValueError(err) {
 					return nil, err
 				} else if err != nil {
-					return []string{}, fmt.Errorf("TextExpr.EvaluateText -> handleMVAppend: %v", err)
+					return []string{}, fmt.Errorf("handleMVAppend: %v", err)
 				}
 				finalMVSlice = append(finalMVSlice, result)
 			}

--- a/tools/sigclient/functionalQueries/functionalQueries.yml
+++ b/tools/sigclient/functionalQueries/functionalQueries.yml
@@ -20,9 +20,11 @@ fillnull_with_eval.json
 stats_group_by_eval.json
 eval_groupby_2col_2stats.json
 eval_fields_timechart.json
-multi_value.json
 gentimes.json
 gentimes_2.json
+multi_value.json
+mvappend.json
+mvdedup.json
 mvexpand.json
 rex_stats_groupby_eval_stats.json
 eval_stats_sort_stats_groupby_where.json

--- a/tools/sigclient/functionalQueries/multi_value.json
+++ b/tools/sigclient/functionalQueries/multi_value.json
@@ -1,15 +1,27 @@
 {
-    "queryText": "app_name=Bracecould | eval multi_val = first_name.\",\".last_name.\",\".country.\",\".city.\" multi val\" | makemv delim=\",\" multi_val | eval mvindex2 = mvindex(multi_val, 2) | eval mvindex02 = mvindex(multi_val, 0, 2) | eval mvindex_1 = mvindex(multi_val, -1) | eval mvindex_3_1 = mvindex(multi_val, -3, -1) | eval mvcount = mvcount(multi_val) | eval mvjoin = mvjoin(multi_val, \":\") | eval mvfind = mvfind(multi_val, \"^N.*$\") | eval split = split(\"a:bc:123\", \":\") | eval split_join = mvjoin(split(\"a:bc:123\", \":\"), \"?\") | eval split_count = mvcount(split(\"a:bc:123\", \":\")) | eval split_index = mvindex(split(\"a:bc:123\", \":\"), -2, 2) | eval split_find = mvfind(split(\"a:bc:123\", \":\"), \"^b.*$\") | fields app_name, first_name, last_name, country, city, multi_val, mvindex2, mvindex02, mvindex_1, mvindex_3_1, mvcount, mvjoin, mvfind, split, split_join, split_count, split_index, split_find, ident",
+    "queryText": "app_name=Bracecould | eval multi_val = first_name.\",\".last_name.\",\".country.\",\".city.\" multi val\" | makemv delim=\",\" multi_val | eval mvindex2 = mvindex(multi_val, 2) | eval mvindex02 = mvindex(multi_val, 0, 2) | eval mvindex_1 = mvindex(multi_val, -1) | eval mvindex_3_1 = mvindex(multi_val, -3, -1) | eval mvcount = mvcount(multi_val) | eval mvjoin = mvjoin(multi_val, \":\") | eval mvfind = mvfind(multi_val, \"^N.*$\") | eval split = split(\"a:bc:123\", \":\") | eval split_join = mvjoin(split(\"a:bc:123\", \":\"), \"?\") | eval split_count = mvcount(split(\"a:bc:123\", \":\")) | eval split_index = mvindex(split(\"a:bc:123\", \":\"), -2, 2) | eval split_find = mvfind(split(\"a:bc:123\", \":\"), \"^b.*$\") | eval append_split = mvappend(multi_val, mvappend(\"new_val\", app_name.country, split(\"one:two\", \":\"))) | fields app_name, first_name, last_name, country, city, multi_val, mvindex2, mvindex02, mvindex_1, mvindex_3_1, mvcount, mvjoin, mvfind, split, split_join, split_count, split_index, split_find, ident, append_split",
     "expectedResult": {
-         "totalMatched": {
-             "value": 6,
-             "relation": "eq"
-         },
-         "qtype": "logs-query",
-         "uniqueKeyCols": ["ident"],
-         "records": [
-            {   
+        "totalMatched": {
+            "value": 6,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "uniqueKeyCols": [
+            "ident"
+        ],
+        "records": [
+            {
                 "app_name": "Bracecould",
+                "append_split": [
+                    "Dalton",
+                    "Gottlieb",
+                    "Martinique",
+                    "Norfolk multi val",
+                    "new_val",
+                    "BracecouldMartinique",
+                    "one",
+                    "two"
+                ],
                 "city": "Norfolk",
                 "country": "Martinique",
                 "first_name": "Dalton",
@@ -51,10 +63,188 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123"
+                "split_join": "a?bc?123",
+                "timestamp": 1749740369865
             },
             {
                 "app_name": "Bracecould",
+                "append_split": [
+                    "Jackson",
+                    "Marvin",
+                    "Dominican Republic",
+                    "Albuquerque multi val",
+                    "new_val",
+                    "BracecouldDominican Republic",
+                    "one",
+                    "two"
+                ],
+                "city": "Albuquerque",
+                "country": "Dominican Republic",
+                "first_name": "Jackson",
+                "ident": "46ea99d9-f3ff-4d1b-b6c1-85016484f1d9",
+                "last_name": "Marvin",
+                "multi_val": [
+                    "Jackson",
+                    "Marvin",
+                    "Dominican Republic",
+                    "Albuquerque multi val"
+                ],
+                "mvcount": "4",
+                "mvindex02": [
+                    "Jackson",
+                    "Marvin",
+                    "Dominican Republic"
+                ],
+                "mvindex2": [
+                    "Dominican Republic"
+                ],
+                "mvindex_1": [
+                    "Albuquerque multi val"
+                ],
+                "mvindex_3_1": [
+                    "Marvin",
+                    "Dominican Republic",
+                    "Albuquerque multi val"
+                ],
+                "mvjoin": "Jackson:Marvin:Dominican Republic:Albuquerque multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123",
+                "timestamp": 1749740359237
+            },
+            {
+                "app_name": "Bracecould",
+                "append_split": [
+                    "Hilton",
+                    "Kiehn",
+                    "Cuba",
+                    "Phoenix multi val",
+                    "new_val",
+                    "BracecouldCuba",
+                    "one",
+                    "two"
+                ],
+                "city": "Phoenix",
+                "country": "Cuba",
+                "first_name": "Hilton",
+                "ident": "9d833dd6-4e32-42b7-a108-1dfd35fc42fc",
+                "last_name": "Kiehn",
+                "multi_val": [
+                    "Hilton",
+                    "Kiehn",
+                    "Cuba",
+                    "Phoenix multi val"
+                ],
+                "mvcount": "4",
+                "mvindex02": [
+                    "Hilton",
+                    "Kiehn",
+                    "Cuba"
+                ],
+                "mvindex2": [
+                    "Cuba"
+                ],
+                "mvindex_1": [
+                    "Phoenix multi val"
+                ],
+                "mvindex_3_1": [
+                    "Kiehn",
+                    "Cuba",
+                    "Phoenix multi val"
+                ],
+                "mvjoin": "Hilton:Kiehn:Cuba:Phoenix multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123",
+                "timestamp": 1749740323510
+            },
+            {
+                "app_name": "Bracecould",
+                "append_split": [
+                    "Elwyn",
+                    "Waelchi",
+                    "Bonaire",
+                    " Sint Eustatius and Saba",
+                    "Cleveland multi val",
+                    "new_val",
+                    "BracecouldBonaire, Sint Eustatius and Saba",
+                    "one",
+                    "two"
+                ],
+                "city": "Cleveland",
+                "country": "Bonaire, Sint Eustatius and Saba",
+                "first_name": "Elwyn",
+                "ident": "9e2b2977-0ce9-42e1-b4d7-bf79cad9081b",
+                "last_name": "Waelchi",
+                "multi_val": [
+                    "Elwyn",
+                    "Waelchi",
+                    "Bonaire",
+                    " Sint Eustatius and Saba",
+                    "Cleveland multi val"
+                ],
+                "mvcount": "5",
+                "mvindex02": [
+                    "Elwyn",
+                    "Waelchi",
+                    "Bonaire"
+                ],
+                "mvindex2": [
+                    "Bonaire"
+                ],
+                "mvindex_1": [
+                    "Cleveland multi val"
+                ],
+                "mvindex_3_1": [
+                    "Bonaire",
+                    " Sint Eustatius and Saba",
+                    "Cleveland multi val"
+                ],
+                "mvjoin": "Elwyn:Waelchi:Bonaire: Sint Eustatius and Saba:Cleveland multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123",
+                "timestamp": 1749740309413
+            },
+            {
+                "app_name": "Bracecould",
+                "append_split": [
+                    "Tad",
+                    "Bins",
+                    "French Guiana",
+                    "Nashville-Davidson multi val",
+                    "new_val",
+                    "BracecouldFrench Guiana",
+                    "one",
+                    "two"
+                ],
                 "city": "Nashville-Davidson",
                 "country": "French Guiana",
                 "first_name": "Tad",
@@ -96,10 +286,21 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123"
+                "split_join": "a?bc?123",
+                "timestamp": 1749740308116
             },
             {
                 "app_name": "Bracecould",
+                "append_split": [
+                    "Elijah",
+                    "Gaylord",
+                    "Jersey",
+                    "Denver multi val",
+                    "new_val",
+                    "BracecouldJersey",
+                    "one",
+                    "two"
+                ],
                 "city": "Denver",
                 "country": "Jersey",
                 "first_name": "Elijah",
@@ -112,7 +313,6 @@
                     "Denver multi val"
                 ],
                 "mvcount": "4",
-                "mvfind": "",
                 "mvindex02": [
                     "Elijah",
                     "Gaylord",
@@ -141,146 +341,11 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123"
-            },
-            {
-                "app_name": "Bracecould",
-                "city": "Albuquerque",
-                "country": "Dominican Republic",
-                "first_name": "Jackson",
-                "ident": "46ea99d9-f3ff-4d1b-b6c1-85016484f1d9",
-                "last_name": "Marvin",
-                "multi_val": [
-                    "Jackson",
-                    "Marvin",
-                    "Dominican Republic",
-                    "Albuquerque multi val"
-                ],
-                "mvcount": "4",
-                "mvfind": "",
-                "mvindex02": [
-                    "Jackson",
-                    "Marvin",
-                    "Dominican Republic"
-                ],
-                "mvindex2": [
-                    "Dominican Republic"
-                ],
-                "mvindex_1": [
-                    "Albuquerque multi val"
-                ],
-                "mvindex_3_1": [
-                    "Marvin",
-                    "Dominican Republic",
-                    "Albuquerque multi val"
-                ],
-                "mvjoin": "Jackson:Marvin:Dominican Republic:Albuquerque multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123"
-            },
-            {
-                "app_name": "Bracecould",
-                "city": "Cleveland",
-                "country": "Bonaire, Sint Eustatius and Saba",
-                "first_name": "Elwyn",
-                "ident": "9e2b2977-0ce9-42e1-b4d7-bf79cad9081b",
-                "last_name": "Waelchi",
-                "multi_val": [
-                    "Elwyn",
-                    "Waelchi",
-                    "Bonaire",
-                    " Sint Eustatius and Saba",
-                    "Cleveland multi val"
-                ],
-                "mvcount": "5",
-                "mvfind": "",
-                "mvindex02": [
-                    "Elwyn",
-                    "Waelchi",
-                    "Bonaire"
-                ],
-                "mvindex2": [
-                    "Bonaire"
-                ],
-                "mvindex_1": [
-                    "Cleveland multi val"
-                ],
-                "mvindex_3_1": [
-                    "Bonaire",
-                    " Sint Eustatius and Saba",
-                    "Cleveland multi val"
-                ],
-                "mvjoin": "Elwyn:Waelchi:Bonaire: Sint Eustatius and Saba:Cleveland multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123"
-            },
-            {
-                "app_name": "Bracecould",
-                "city": "Phoenix",
-                "country": "Cuba",
-                "first_name": "Hilton",
-                "ident": "9d833dd6-4e32-42b7-a108-1dfd35fc42fc",
-                "last_name": "Kiehn",
-                "multi_val": [
-                    "Hilton",
-                    "Kiehn",
-                    "Cuba",
-                    "Phoenix multi val"
-                ],
-                "mvcount": "4",
-                "mvfind": "",
-                "mvindex02": [
-                    "Hilton",
-                    "Kiehn",
-                    "Cuba"
-                ],
-                "mvindex2": [
-                    "Cuba"
-                ],
-                "mvindex_1": [
-                    "Phoenix multi val"
-                ],
-                "mvindex_3_1": [
-                    "Kiehn",
-                    "Cuba",
-                    "Phoenix multi val"
-                ],
-                "mvjoin": "Hilton:Kiehn:Cuba:Phoenix multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123"
+                "split_join": "a?bc?123",
+                "timestamp": 1749740304935
             }
         ],
-         "allColumns": [
+        "allColumns": [
             "app_name",
             "first_name",
             "last_name",
@@ -299,9 +364,10 @@
             "split_count",
             "split_index",
             "split_find",
-            "ident"
+            "ident",
+            "append_split"
         ],
-         "columnsOrder": [
+        "columnsOrder": [
             "app_name",
             "first_name",
             "last_name",
@@ -320,8 +386,8 @@
             "split_count",
             "split_index",
             "split_find",
-            "ident"
+            "ident",
+            "append_split"
         ]
-     }
- }
- 
+    }
+}

--- a/tools/sigclient/functionalQueries/multi_value.json
+++ b/tools/sigclient/functionalQueries/multi_value.json
@@ -1,5 +1,5 @@
 {
-    "queryText": "app_name=Bracecould | eval multi_val = first_name.\",\".last_name.\",\".country.\",\".city.\" multi val\" | makemv delim=\",\" multi_val | eval mvindex2 = mvindex(multi_val, 2) | eval mvindex02 = mvindex(multi_val, 0, 2) | eval mvindex_1 = mvindex(multi_val, -1) | eval mvindex_3_1 = mvindex(multi_val, -3, -1) | eval mvcount = mvcount(multi_val) | eval mvjoin = mvjoin(multi_val, \":\") | eval mvfind = mvfind(multi_val, \"^N.*$\") | eval split = split(\"a:bc:123\", \":\") | eval split_join = mvjoin(split(\"a:bc:123\", \":\"), \"?\") | eval split_count = mvcount(split(\"a:bc:123\", \":\")) | eval split_index = mvindex(split(\"a:bc:123\", \":\"), -2, 2) | eval split_find = mvfind(split(\"a:bc:123\", \":\"), \"^b.*$\") | eval append_split = mvappend(multi_val, mvappend(\"new_val\", app_name.country, split(\"one:two\", \":\"))) | fields app_name, first_name, last_name, country, city, multi_val, mvindex2, mvindex02, mvindex_1, mvindex_3_1, mvcount, mvjoin, mvfind, split, split_join, split_count, split_index, split_find, ident, append_split",
+    "queryText": "app_name=Bracecould | eval multi_val = first_name.\",\".last_name.\",\".country.\",\".city.\" multi val\" | makemv delim=\",\" multi_val | eval mvindex2 = mvindex(multi_val, 2) | eval mvindex02 = mvindex(multi_val, 0, 2) | eval mvindex_1 = mvindex(multi_val, -1) | eval mvindex_3_1 = mvindex(multi_val, -3, -1) | eval mvcount = mvcount(multi_val) | eval mvjoin = mvjoin(multi_val, \":\") | eval mvfind = mvfind(multi_val, \"^N.*$\") | eval split = split(\"a:bc:123\", \":\") | eval split_join = mvjoin(split(\"a:bc:123\", \":\"), \"?\") | eval split_count = mvcount(split(\"a:bc:123\", \":\")) | eval split_index = mvindex(split(\"a:bc:123\", \":\"), -2, 2) | eval split_find = mvfind(split(\"a:bc:123\", \":\"), \"^b.*$\") | fields app_name, first_name, last_name, country, city, multi_val, mvindex2, mvindex02, mvindex_1, mvindex_3_1, mvcount, mvjoin, mvfind, split, split_join, split_count, split_index, split_find, ident",
     "expectedResult": {
         "totalMatched": {
             "value": 6,
@@ -12,16 +12,6 @@
         "records": [
             {
                 "app_name": "Bracecould",
-                "append_split": [
-                    "Dalton",
-                    "Gottlieb",
-                    "Martinique",
-                    "Norfolk multi val",
-                    "new_val",
-                    "BracecouldMartinique",
-                    "one",
-                    "two"
-                ],
                 "city": "Norfolk",
                 "country": "Martinique",
                 "first_name": "Dalton",
@@ -63,188 +53,10 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740369865
+                "split_join": "a?bc?123"
             },
             {
                 "app_name": "Bracecould",
-                "append_split": [
-                    "Jackson",
-                    "Marvin",
-                    "Dominican Republic",
-                    "Albuquerque multi val",
-                    "new_val",
-                    "BracecouldDominican Republic",
-                    "one",
-                    "two"
-                ],
-                "city": "Albuquerque",
-                "country": "Dominican Republic",
-                "first_name": "Jackson",
-                "ident": "46ea99d9-f3ff-4d1b-b6c1-85016484f1d9",
-                "last_name": "Marvin",
-                "multi_val": [
-                    "Jackson",
-                    "Marvin",
-                    "Dominican Republic",
-                    "Albuquerque multi val"
-                ],
-                "mvcount": "4",
-                "mvindex02": [
-                    "Jackson",
-                    "Marvin",
-                    "Dominican Republic"
-                ],
-                "mvindex2": [
-                    "Dominican Republic"
-                ],
-                "mvindex_1": [
-                    "Albuquerque multi val"
-                ],
-                "mvindex_3_1": [
-                    "Marvin",
-                    "Dominican Republic",
-                    "Albuquerque multi val"
-                ],
-                "mvjoin": "Jackson:Marvin:Dominican Republic:Albuquerque multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740359237
-            },
-            {
-                "app_name": "Bracecould",
-                "append_split": [
-                    "Hilton",
-                    "Kiehn",
-                    "Cuba",
-                    "Phoenix multi val",
-                    "new_val",
-                    "BracecouldCuba",
-                    "one",
-                    "two"
-                ],
-                "city": "Phoenix",
-                "country": "Cuba",
-                "first_name": "Hilton",
-                "ident": "9d833dd6-4e32-42b7-a108-1dfd35fc42fc",
-                "last_name": "Kiehn",
-                "multi_val": [
-                    "Hilton",
-                    "Kiehn",
-                    "Cuba",
-                    "Phoenix multi val"
-                ],
-                "mvcount": "4",
-                "mvindex02": [
-                    "Hilton",
-                    "Kiehn",
-                    "Cuba"
-                ],
-                "mvindex2": [
-                    "Cuba"
-                ],
-                "mvindex_1": [
-                    "Phoenix multi val"
-                ],
-                "mvindex_3_1": [
-                    "Kiehn",
-                    "Cuba",
-                    "Phoenix multi val"
-                ],
-                "mvjoin": "Hilton:Kiehn:Cuba:Phoenix multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740323510
-            },
-            {
-                "app_name": "Bracecould",
-                "append_split": [
-                    "Elwyn",
-                    "Waelchi",
-                    "Bonaire",
-                    " Sint Eustatius and Saba",
-                    "Cleveland multi val",
-                    "new_val",
-                    "BracecouldBonaire, Sint Eustatius and Saba",
-                    "one",
-                    "two"
-                ],
-                "city": "Cleveland",
-                "country": "Bonaire, Sint Eustatius and Saba",
-                "first_name": "Elwyn",
-                "ident": "9e2b2977-0ce9-42e1-b4d7-bf79cad9081b",
-                "last_name": "Waelchi",
-                "multi_val": [
-                    "Elwyn",
-                    "Waelchi",
-                    "Bonaire",
-                    " Sint Eustatius and Saba",
-                    "Cleveland multi val"
-                ],
-                "mvcount": "5",
-                "mvindex02": [
-                    "Elwyn",
-                    "Waelchi",
-                    "Bonaire"
-                ],
-                "mvindex2": [
-                    "Bonaire"
-                ],
-                "mvindex_1": [
-                    "Cleveland multi val"
-                ],
-                "mvindex_3_1": [
-                    "Bonaire",
-                    " Sint Eustatius and Saba",
-                    "Cleveland multi val"
-                ],
-                "mvjoin": "Elwyn:Waelchi:Bonaire: Sint Eustatius and Saba:Cleveland multi val",
-                "split": [
-                    "a",
-                    "bc",
-                    "123"
-                ],
-                "split_count": "3",
-                "split_find": "1",
-                "split_index": [
-                    "bc",
-                    "123"
-                ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740309413
-            },
-            {
-                "app_name": "Bracecould",
-                "append_split": [
-                    "Tad",
-                    "Bins",
-                    "French Guiana",
-                    "Nashville-Davidson multi val",
-                    "new_val",
-                    "BracecouldFrench Guiana",
-                    "one",
-                    "two"
-                ],
                 "city": "Nashville-Davidson",
                 "country": "French Guiana",
                 "first_name": "Tad",
@@ -286,21 +98,10 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740308116
+                "split_join": "a?bc?123"
             },
             {
                 "app_name": "Bracecould",
-                "append_split": [
-                    "Elijah",
-                    "Gaylord",
-                    "Jersey",
-                    "Denver multi val",
-                    "new_val",
-                    "BracecouldJersey",
-                    "one",
-                    "two"
-                ],
                 "city": "Denver",
                 "country": "Jersey",
                 "first_name": "Elijah",
@@ -313,6 +114,7 @@
                     "Denver multi val"
                 ],
                 "mvcount": "4",
+                "mvfind": "",
                 "mvindex02": [
                     "Elijah",
                     "Gaylord",
@@ -341,8 +143,143 @@
                     "bc",
                     "123"
                 ],
-                "split_join": "a?bc?123",
-                "timestamp": 1749740304935
+                "split_join": "a?bc?123"
+            },
+            {
+                "app_name": "Bracecould",
+                "city": "Albuquerque",
+                "country": "Dominican Republic",
+                "first_name": "Jackson",
+                "ident": "46ea99d9-f3ff-4d1b-b6c1-85016484f1d9",
+                "last_name": "Marvin",
+                "multi_val": [
+                    "Jackson",
+                    "Marvin",
+                    "Dominican Republic",
+                    "Albuquerque multi val"
+                ],
+                "mvcount": "4",
+                "mvfind": "",
+                "mvindex02": [
+                    "Jackson",
+                    "Marvin",
+                    "Dominican Republic"
+                ],
+                "mvindex2": [
+                    "Dominican Republic"
+                ],
+                "mvindex_1": [
+                    "Albuquerque multi val"
+                ],
+                "mvindex_3_1": [
+                    "Marvin",
+                    "Dominican Republic",
+                    "Albuquerque multi val"
+                ],
+                "mvjoin": "Jackson:Marvin:Dominican Republic:Albuquerque multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123"
+            },
+            {
+                "app_name": "Bracecould",
+                "city": "Cleveland",
+                "country": "Bonaire, Sint Eustatius and Saba",
+                "first_name": "Elwyn",
+                "ident": "9e2b2977-0ce9-42e1-b4d7-bf79cad9081b",
+                "last_name": "Waelchi",
+                "multi_val": [
+                    "Elwyn",
+                    "Waelchi",
+                    "Bonaire",
+                    " Sint Eustatius and Saba",
+                    "Cleveland multi val"
+                ],
+                "mvcount": "5",
+                "mvfind": "",
+                "mvindex02": [
+                    "Elwyn",
+                    "Waelchi",
+                    "Bonaire"
+                ],
+                "mvindex2": [
+                    "Bonaire"
+                ],
+                "mvindex_1": [
+                    "Cleveland multi val"
+                ],
+                "mvindex_3_1": [
+                    "Bonaire",
+                    " Sint Eustatius and Saba",
+                    "Cleveland multi val"
+                ],
+                "mvjoin": "Elwyn:Waelchi:Bonaire: Sint Eustatius and Saba:Cleveland multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123"
+            },
+            {
+                "app_name": "Bracecould",
+                "city": "Phoenix",
+                "country": "Cuba",
+                "first_name": "Hilton",
+                "ident": "9d833dd6-4e32-42b7-a108-1dfd35fc42fc",
+                "last_name": "Kiehn",
+                "multi_val": [
+                    "Hilton",
+                    "Kiehn",
+                    "Cuba",
+                    "Phoenix multi val"
+                ],
+                "mvcount": "4",
+                "mvfind": "",
+                "mvindex02": [
+                    "Hilton",
+                    "Kiehn",
+                    "Cuba"
+                ],
+                "mvindex2": [
+                    "Cuba"
+                ],
+                "mvindex_1": [
+                    "Phoenix multi val"
+                ],
+                "mvindex_3_1": [
+                    "Kiehn",
+                    "Cuba",
+                    "Phoenix multi val"
+                ],
+                "mvjoin": "Hilton:Kiehn:Cuba:Phoenix multi val",
+                "split": [
+                    "a",
+                    "bc",
+                    "123"
+                ],
+                "split_count": "3",
+                "split_find": "1",
+                "split_index": [
+                    "bc",
+                    "123"
+                ],
+                "split_join": "a?bc?123"
             }
         ],
         "allColumns": [
@@ -364,8 +301,7 @@
             "split_count",
             "split_index",
             "split_find",
-            "ident",
-            "append_split"
+            "ident"
         ],
         "columnsOrder": [
             "app_name",
@@ -386,8 +322,7 @@
             "split_count",
             "split_index",
             "split_find",
-            "ident",
-            "append_split"
+            "ident"
         ]
     }
 }

--- a/tools/sigclient/functionalQueries/mvappend.json
+++ b/tools/sigclient/functionalQueries/mvappend.json
@@ -1,0 +1,24 @@
+{
+    "queryText": "city=Boston | eval names=\"Frank,Grace,Heidi,Ivan\"| makemv delim=\",\" names | head 5 |eval ans=mvappend(names, mvappend(\"something\", app_name.city, 1234)) | fields ans",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 5,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "uniqueKeyCols": ["ans"],
+        "records": [
+            { "ans": ["Frank","Grace","Heidi","Ivan","something","LightGrayreamBoston","1234"] },
+            { "ans": ["Frank","Grace","Heidi","Ivan","something","KangaroocanBoston","1234"] },
+            { "ans": ["Frank","Grace","Heidi","Ivan","something","DarkMagentayogaBoston","1234"] },
+            { "ans": ["Frank","Grace","Heidi","Ivan","something","LightGreencoveyBoston","1234"] },
+            { "ans": ["Frank","Grace","Heidi","Ivan","something","DoorrideBoston","1234"] }
+        ],
+        "allColumns": [
+            "ans"
+        ],
+        "columnsOrder": [
+            "ans"
+        ]
+    }
+}

--- a/tools/sigclient/functionalQueries/mvdedup.json
+++ b/tools/sigclient/functionalQueries/mvdedup.json
@@ -1,0 +1,23 @@
+{
+    "queryText": "city=Boston | eval names=\"Frank,Frank,1,1,@,@,Grace,Grace,Heidi,Ivan\"| makemv delim=\",\" names | head 4 | eval ans=mvdedup(names) | fields ans",
+    "expectedResult": {
+        "totalMatched": {
+            "value": 4,
+            "relation": "eq"
+        },
+        "qtype": "logs-query",
+        "uniqueKeyCols": ["ans"],
+        "records": [
+            { "ans": ["Frank","1","@","Grace","Heidi","Ivan"] },
+            { "ans": ["Frank","1","@","Grace","Heidi","Ivan"] },
+            { "ans": ["Frank","1","@","Grace","Heidi","Ivan"] },
+            { "ans": ["Frank","1","@","Grace","Heidi","Ivan"] }
+        ],
+        "allColumns": [
+            "ans"
+        ],
+        "columnsOrder": [
+            "ans"
+        ]
+    }
+}


### PR DESCRIPTION
# Description
Implementation of `mvdedup` & `mvappend`. Docs can be found [here](https://docs.splunk.com/Documentation/Splunk/9.1.1/SearchReference/MultivalueEvalFunctions#mvappend.28.26lt.3Bvalues.26gt.3B.29)

# Testing
Added individual functional tests + updated `multi_value.json` functional test to include `mvappend`
