### PR TITLE
Improve performance by swapping nested loops

### DIFF
--- a/pkg/segment/reader/record/recordreader.go
+++ b/pkg/segment/reader/record/recordreader.go
@@ -402,17 +402,15 @@ func readAllRawRecords(orderedRecNums []uint16, blockNum uint16, segReader *segr
 	}
 
 	var isTsCol bool
-	for idx, recNum := range orderedRecNums {
+	for colKeyIdx, cname := range allColKeyIndices {
+		_, ok := dictEncCols[cname]
+		if ok {
+			continue
+		}
 
-		for colKeyIdx, cname := range allColKeyIndices {
+		isTsCol = (config.GetTimeStampKey() == cname)
 
-			_, ok := dictEncCols[cname]
-			if ok {
-				continue
-			}
-
-			isTsCol = (config.GetTimeStampKey() == cname)
-
+		for idx, recNum := range orderedRecNums {
 			var cValEnc sutils.CValueEnclosure
 
 			err := segReader.ExtractValueFromColumnFile(colKeyIdx, blockNum, recNum,


### PR DESCRIPTION
# Description
We were doing:
```
for each item in slice:
    for key, value in map:
```

This PR switches it to:
```
for key, value in map:
    for each item in slice:
```
Because iterating maps in Go has more overhead than iterating slices, so we want to reduce the amount of map iterations.

# Testing
Tested on 100 million records:
```
* | eval height=ResolutionHeight / 10 | stats avg(height) as avg, count(height) as count, sum(height) as sum by ResolutionWidth | sort -ResolutionWidth
```
This PR decreased the total real time from 10.8 seconds to 9.7 seconds. The CPU time of `readAllRawRecords()` dropped from 6.7 seconds to 3.3 seconds.