### PR TITLE
Avoid repeated map iteration

### DIFF
--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -180,6 +180,10 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 	unsetRecord := make(map[string]sutils.CValueEnclosure)
 	timestampkey := config.GetTimeStampKey()
 
+	// We're going to to iterate measureInfo many times.
+	// Convert to a slice once to avoid map iteration overhead.
+	measureInfoSlice := utils.MapToSlice(measureInfo)
+
 	for i := 0; i < numOfRecords; i++ {
 		record := inputIQR.GetRecord(i)
 
@@ -195,7 +199,8 @@ func (p *statsProcessor) processGroupByRequest(inputIQR *iqr.IQR) (*iqr.IQR, err
 			p.bucketKeyWorkingBuf, bucketKeyBufIdx = cValue.WriteToBytesWithType(p.bucketKeyWorkingBuf, bucketKeyBufIdx)
 		}
 
-		for cname, indices := range measureInfo {
+		for _, kvPair := range measureInfoSlice {
+			cname, indices := kvPair.Key, kvPair.Value
 			cValue, err := record.ReadColumn(cname)
 			if err != nil {
 				p.errorData.readColumns[cname] = err

--- a/pkg/utils/maputils.go
+++ b/pkg/utils/maputils.go
@@ -23,6 +23,11 @@ import (
 	"sync"
 )
 
+type KVPair[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
 // GetOrCreateNestedMap returns the inner map corresponding to key1 from the outer map.
 // If the key1 does not exist in the outer map, a new inner map is created and returned.
 func GetOrCreateNestedMap[K1 comparable, K2 comparable, V any](m map[K1]map[K2]V, key1 K1) map[K2]V {
@@ -82,11 +87,6 @@ func MapsConflict[K comparable, V comparable](map1 map[K]V, map2 map[K]V) bool {
 	}
 
 	return false
-}
-
-type KVPair[K comparable, V any] struct {
-	Key   K
-	Value V
 }
 
 func MapToSlice[K comparable, V any](m map[K]V) []KVPair[K, V] {

--- a/pkg/utils/maputils.go
+++ b/pkg/utils/maputils.go
@@ -84,6 +84,21 @@ func MapsConflict[K comparable, V comparable](map1 map[K]V, map2 map[K]V) bool {
 	return false
 }
 
+type KVPair[K comparable, V any] struct {
+	Key   K
+	Value V
+}
+
+func MapToSlice[K comparable, V any](m map[K]V) []KVPair[K, V] {
+	slice := make([]KVPair[K, V], 0, len(m))
+
+	for key, value := range m {
+		slice = append(slice, KVPair[K, V]{Key: key, Value: value})
+	}
+
+	return slice
+}
+
 func MapToSet[K comparable, V any](m map[K]V) map[K]struct{} {
 	set := make(map[K]struct{}, len(m))
 


### PR DESCRIPTION
# Description
Improve performance by converting a read-only map to a slice before we iterate it several times. Map iteration has more overhead than slice iteration

# Testing
Saw about 5% faster response time on this query with 100 million records:
```
* | eval height=ResolutionHeight / 10 | stats avg(height) as avg, count(height) as count, sum(height) as sum by ResolutionWidth | sort -ResolutionWidth
```
CPU time of `processGroupByRequest()` dropped from 14.2 seconds to 12.7 seconds.