### PR TITLE
Coalesce many small allocations to reduce GC work

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -1170,6 +1170,7 @@ func iterRecsAddRrc(recIT *BlockRecordIterator, mcr *segread.MultiColSegmentRead
 
 	segKeyEnc := allSearchResults.GetAddSegEnc(searchReq.SegmentKey)
 	numRecsMatched := uint16(0)
+	rrcs := make([]sutils.RecordResultContainer, recIT.AllRecLen)
 	for recNum := uint(0); recNum < uint(recIT.AllRecLen); recNum++ {
 		if !recIT.ShouldProcessRecord(recNum) {
 			continue
@@ -1189,16 +1190,16 @@ func iterRecsAddRrc(recIT *BlockRecordIterator, mcr *segread.MultiColSegmentRead
 		}
 		numRecsMatched++
 
-		rrc := &sutils.RecordResultContainer{
-			SegKeyInfo: sutils.SegKeyInfo{
-				SegKeyEnc: segKeyEnc,
-				IsRemote:  false,
-			},
-			BlockNum:         blockStatus.BlockNum,
-			RecordNum:        recNumUint16,
-			VirtualTableName: searchReq.VirtualTableName,
-			TimeStamp:        recTs,
+		rrc := &rrcs[recNumUint16]
+		rrc.SegKeyInfo = sutils.SegKeyInfo{
+			SegKeyEnc: segKeyEnc,
+			IsRemote:  false,
 		}
+		rrc.BlockNum = blockStatus.BlockNum
+		rrc.RecordNum = recNumUint16
+		rrc.VirtualTableName = searchReq.VirtualTableName
+		rrc.TimeStamp = recTs
+
 		blkResults.Add(rrc)
 
 	}


### PR DESCRIPTION
# Description
Instead of allocating one RRC at a time, allocate a block of them, then get a new block when needed. This could slightly increase total memory usage, but in general it reduces overhead costs because fewer mallocs are done, and GC has to track fewer objects.

# Testing
Tested with 100 million records on 
```
* | eval height=ResolutionHeight / 10 | stats avg(height) as avg, count(height) as count, sum(height) as sum by ResolutionWidth | sort -ResolutionWidth
```
Query time dropped about 10%, from 9.8 seconds to 8.8 seconds