### PR TITLE
Avoid needless IQR validation

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -126,6 +126,7 @@ func NewIQR(qid uint64) *IQR {
 		measureColumns:   make([]string, 0),
 		columnIndex:      make(map[string]int),
 		statsResults:     &IQRStatsResults{},
+		isDirty:          true,
 	}
 
 	return iqr
@@ -1843,8 +1844,6 @@ func (iqr *IQR) GobEncode() ([]byte, error) {
 
 // GobDecode deserializes bytes back to IQR struct
 func (iqr *IQR) GobDecode(data []byte) error {
-	iqr.isDirty = true
-
 	if len(data) == 0 {
 		return nil
 	}

--- a/pkg/segment/query/iqr/intermediateQueryResult_test.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult_test.go
@@ -35,7 +35,7 @@ func Test_initIQR(t *testing.T) {
 	err := iqr.validate()
 	assert.NoError(t, err)
 
-	iqr = &IQR{}
+	iqr = &IQR{isDirty: true}
 	err = iqr.validate()
 	assert.Error(t, err)
 }


### PR DESCRIPTION
# Description
For some queries we call `iqr.validate()` repeatedly even when the IQR didn't change since the last validation. Now we avoid this overhead by skipping future validations until the IQR actually changes.

# Testing
On this query with 100 million records:
```
* | eval height=ResolutionHeight / 10 | stats avg(height) as avg, count(height) as count, sum(height) as sum by ResolutionWidth | sort -ResolutionWidth
```
this reduced the time in `iqr.validate()` from 8.6% of CPU time to 0.2%, with a similar affect on real-time that the query takes.