### PR TITLE
Fix: printf humanize flag, wrong answers when using in a combination

### DIFF
--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -2377,7 +2377,18 @@ func (self *NumericExpr) getSigFigs(strVal string, fltVal float64) int {
 func splPrintfHumanizeHelper(verbCounter int, value any, formatValues []any, buffer *[]byte, verb byte, parseInt func(string) (int64, error), parseFloat func(string) (float64, error)) {
 	var strVal string
 	formatValues[verbCounter] = value
-	formattedVal := fmt.Sprintf(string(append(*buffer, verb)), formatValues...)
+	numFlagsWConsumeArgs := 0
+	lastPercentPos := -1
+	for i := len(*buffer) - 1; i >= 0; i-- {
+		if (*buffer)[i] == '%' {
+			lastPercentPos = i
+			break
+		} else if (*buffer)[i] == '*' {
+			numFlagsWConsumeArgs++
+		}
+	}
+	//  only use the last verb for formatting. i.e the buffer from the lastPercentPos
+	formattedVal := fmt.Sprintf(string(append((*buffer)[lastPercentPos:], verb)), formatValues[(verbCounter-numFlagsWConsumeArgs):verbCounter+1]...)
 	// can't use precomputed hasDecimal since formatting may remove the decimal
 	hasDecimal := strings.Contains(formattedVal, ".")
 	// remove spaces, leading zeros, signs from the left.
@@ -2435,6 +2446,11 @@ func splPrintfHumanizeHelper(verbCounter int, value any, formatValues []any, buf
 	}
 	strVal = removedLeft + strVal + removedRight
 	formatValues[verbCounter] = strVal
+	if numFlagsWConsumeArgs != 0 {
+		for i := verbCounter - numFlagsWConsumeArgs; i < verbCounter; i++ {
+			formatValues[i] = nil
+		}
+	}
 	// Clear any formatting flags from the previous '%' token.
 	// For example, consider the format string "%.5g": the rounding has already been applied earlier
 	// when we initially processed this format using sprintf.
@@ -2442,13 +2458,7 @@ func splPrintfHumanizeHelper(verbCounter int, value any, formatValues []any, buf
 	// If we now substitute the formatted value 's' directly into the format string, like replacing %g with %s,
 	// the format string becomes "%.5s". This causes the final sprintf call to re-apply formatting (like rounding or truncation),
 	// which is incorrect because the value has already been rounded once.
-	lastPercentPos := -1
-	for i := len(*buffer) - 1; i >= 0; i-- {
-		if (*buffer)[i] == '%' {
-			lastPercentPos = i
-			break
-		}
-	}
+
 	if lastPercentPos != -1 {
 		*buffer = (*buffer)[:lastPercentPos]
 	}
@@ -3127,8 +3137,15 @@ func handlePrintf(self *TextExpr, fieldToValue map[string]sutils.CValueEnclosure
 			return "", err
 		}
 		verbCounter++
+		humanizeRes = false
 	}
-	val := fmt.Sprintf(string(formatResult), formatValues...)
+	cleanedFormattedArr := formatValues[:0]
+	for _, v := range formatValues {
+		if v != nil {
+			cleanedFormattedArr = append(cleanedFormattedArr, v)
+		}
+	}
+	val := fmt.Sprintf(string(formatResult), cleanedFormattedArr...)
 	return val, nil
 }
 

--- a/pkg/segment/structs/evaluationtests/evalfuncs_test.go
+++ b/pkg/segment/structs/evaluationtests/evalfuncs_test.go
@@ -179,6 +179,34 @@ func getTestCasesPrintf() []TestCase {
 			EquationString: `eval result=printf("%'20.0f", 1234567890.0)`,
 			ExpectedAnswer: `          1,234,567,890`,
 		},
+		{
+			EquationString: `eval result=printf("%'d %'+10.2f %g", 123456, 987654.321, 0.0000123)`,
+			ExpectedAnswer: "123,456 +987,654.32 1.23e-05",
+		},
+		{
+			EquationString: `eval result=printf("%'+15d %'10.2f %0.1g", 1000000, 987654.32, 3.14159)`,
+			ExpectedAnswer: "       +1,000,000  987,654.32 3",
+		},
+		{
+			EquationString: `eval result=printf("%'10d %'+#12.0f %'g", 100000, 1234567.0, 999999.99)`,
+			ExpectedAnswer: "   100,000     +1,234,567 1,000,000",
+		},
+		{
+			EquationString: `eval result=printf("%0+10d %'12.3f %'10g", 4567, 123456.789, 7654321.1)`,
+			ExpectedAnswer: "+000004567   123,456.789 1.0000e+06",
+		},
+		{
+			EquationString: `eval result=printf("%'+d %'+f %'.2f", 1000000, 12345.67, 9876543.21)`,
+			ExpectedAnswer: "+1,000,000 +12345.670000 9,876,543.21",
+		},
+		{
+			EquationString: `eval result=printf("%'+#10.0f %'15.2f %0+8d", 1000000.0, 12345678.9, 99)`,
+			ExpectedAnswer: " +1,000,000     12,345,678.90 +0000099",
+		},
+		{
+			EquationString: `eval result=printf("Rain Percentage: %+12.2f/%*.*f. Sample of: %'d Date: %d-0%d-%d", 92.233433, 3, 1, 100.011111, 10000000000, 12, 1, 25)`,
+			ExpectedAnswer: "Rain Percentage:       +92.23/100.0. Sample of: 10,000,000,000 Date: 12-01-25",
+		},
 	}
 }
 


### PR DESCRIPTION
# Description
When the humanize flag was used with a combination with other verbs that did not have humanize flags, the parser skipped verbs which had occurred before the current humanize flag, resulting in not enough arguments error

# Testing
Added more unit tests to check the above case
