### PR TITLE
Remove redundant re-slicing

### DIFF
--- a/pkg/virtualtable/virtualtable.go
+++ b/pkg/virtualtable/virtualtable.go
@@ -753,7 +753,6 @@ func ExpandAndReturnIndexNames(indexNameIn string, orgid int64, isElastic bool) 
 			finalResults[i] = indexName
 			i++
 		}
-		finalResults = finalResults[:i]
 		sort.Strings(finalResults)
 		return finalResults
 	}


### PR DESCRIPTION
The length of finalResults is already set to be length of the finalResultsMap that the loop is iterating over without any escape path.
