### PR TITLE
Parallelize the sort command

### DIFF
--- a/pkg/segment/query/iqr/intermediateQueryResult.go
+++ b/pkg/segment/query/iqr/intermediateQueryResult.go
@@ -264,6 +264,10 @@ func (iqr *IQR) AppendKnownValues(knownValues map[string][]sutils.CValueEnclosur
 }
 
 func (iqr *IQR) NumberOfRecords() int {
+	if iqr == nil {
+		return 0
+	}
+
 	if err := iqr.validate(); err != nil {
 		log.Errorf("IQR.NumberOfRecords: validation failed: %v", err)
 		return 0

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -935,7 +935,7 @@ func NewSortDP(options *structs.SortExpr) *DataProcessor {
 		isPermutingCmd:        true,
 		isBottleneckCmd:       true,
 		isTwoPassCmd:          false,
-		isMergeableBottleneck: false, // TODO: implement merging, then set to true.
+		isMergeableBottleneck: true,
 		processorLock:         &sync.Mutex{},
 	}
 }
@@ -1003,12 +1003,12 @@ func NewMergerDP(mergeSettings mergeSettings) *DataProcessor {
 		mergeSettings:         mergeSettings,
 		processor:             &mergeProcessor{mergeSettings: mergeSettings},
 		inputOrderMatters:     !mergeSettings.mergingStats,
-		ignoresInputOrder:     mergeSettings.mergingStats,
+		ignoresInputOrder:     true,
 		isPermutingCmd:        false,
 		isBottleneckCmd:       mergeSettings.mergingStats,
 		isTransformingCmd:     false,
 		isTwoPassCmd:          false,
-		isMergeableBottleneck: mergeSettings.mergingStats,
+		isMergeableBottleneck: true,
 		processorLock:         &sync.Mutex{},
 	}
 }

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -1002,13 +1002,13 @@ func NewMergerDP(mergeSettings mergeSettings, mergingBottlenecks bool) *DataProc
 		streams:               make([]*CachedStream, 0),
 		mergeSettings:         mergeSettings,
 		processor:             &mergeProcessor{mergeSettings: mergeSettings},
-		inputOrderMatters:     !mergingBottlenecks,
-		ignoresInputOrder:     mergingBottlenecks,
+		inputOrderMatters:     !mergeSettings.mergingStats,
+		ignoresInputOrder:     mergeSettings.mergingStats,
 		isPermutingCmd:        false,
-		isBottleneckCmd:       mergingBottlenecks,
+		isBottleneckCmd:       mergeSettings.mergingStats,
 		isTransformingCmd:     false,
 		isTwoPassCmd:          false,
-		isMergeableBottleneck: mergingBottlenecks,
+		isMergeableBottleneck: mergeSettings.mergingStats,
 		processorLock:         &sync.Mutex{},
 	}
 }

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -996,7 +996,12 @@ func NewPassThroughDPWithStreams(cachedStreams []*CachedStream) *DataProcessor {
 	}
 }
 
-func NewMergerDP(mergeSettings mergeSettings, mergingBottlenecks bool) *DataProcessor {
+func NewMergerDP(mergeSettings mergeSettings) *DataProcessor {
+	// Note that many of the settings refer to mergingStats rather than a more
+	// general mergingBottleneck variable. This is because even if we're
+	// merging bottlenecks, this mergerDP doesn't necessarily have the same
+	// properties as the commands we're merging (e.g., if we're merging sorted
+	// results, we can stream the result instead of bottlenecking).
 	return &DataProcessor{
 		name:                  "merger",
 		streams:               make([]*CachedStream, 0),

--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -996,19 +996,19 @@ func NewPassThroughDPWithStreams(cachedStreams []*CachedStream) *DataProcessor {
 	}
 }
 
-func NewMergerDP(mergeSettings mergeSettings) *DataProcessor {
+func NewMergerDP(mergeSettings mergeSettings, mergingBottlenecks bool) *DataProcessor {
 	return &DataProcessor{
 		name:                  "merger",
 		streams:               make([]*CachedStream, 0),
 		mergeSettings:         mergeSettings,
 		processor:             &mergeProcessor{mergeSettings: mergeSettings},
-		inputOrderMatters:     !mergeSettings.mergingStats,
-		ignoresInputOrder:     true,
+		inputOrderMatters:     !mergingBottlenecks,
+		ignoresInputOrder:     mergingBottlenecks,
 		isPermutingCmd:        false,
-		isBottleneckCmd:       mergeSettings.mergingStats,
+		isBottleneckCmd:       mergingBottlenecks,
 		isTransformingCmd:     false,
 		isTwoPassCmd:          false,
-		isMergeableBottleneck: true,
+		isMergeableBottleneck: mergingBottlenecks,
 		processorLock:         &sync.Mutex{},
 	}
 }

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -832,6 +832,7 @@ func setMergeSettings(dpChain []*DataProcessor) mergeSettings {
 				curMergeSettings.sortExpr = processor.options
 				curMergeSettings.reverse = false
 				curMergeSettings.less = processor.lessDirectRead
+				curMergeSettings.limit = utils.NewOptionWithValue[uint64](processor.options.Limit)
 			case *tailProcessor:
 				curMergeSettings.reverse = !curMergeSettings.reverse
 				if curMergeSettings.less != nil {

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -407,7 +407,7 @@ func SetupQueryParallelism(firstAggHasStats bool, chainFactory func() []*DataPro
 				limit:        firstDpChain[mergeIndex].mergeSettings.limit,
 			}
 		}
-		firstDpChain = utils.Insert(firstDpChain, mergeIndex+1, NewMergerDP(settings, true))
+		firstDpChain = utils.Insert(firstDpChain, mergeIndex+1, NewMergerDP(settings))
 		mergeIndex++
 	}
 

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -407,7 +407,7 @@ func SetupQueryParallelism(firstAggHasStats bool, chainFactory func() []*DataPro
 				limit:        firstDpChain[mergeIndex].mergeSettings.limit,
 			}
 		}
-		firstDpChain = utils.Insert(firstDpChain, mergeIndex+1, NewMergerDP(settings))
+		firstDpChain = utils.Insert(firstDpChain, mergeIndex+1, NewMergerDP(settings, true))
 		mergeIndex++
 	}
 

--- a/pkg/segment/query/processor/queryprocessor_test.go
+++ b/pkg/segment/query/processor/queryprocessor_test.go
@@ -303,6 +303,7 @@ func Test_setMergeSettings(t *testing.T) {
 			SortEles: []*structs.SortElement{
 				{Field: "foo", Op: "", SortByAsc: true},
 			},
+			Limit: 42,
 		}
 
 		dpChain := []*DataProcessor{
@@ -316,10 +317,14 @@ func Test_setMergeSettings(t *testing.T) {
 		assert.Equal(t, anyOrder, *searcherMergeSettings.sortMode)
 		assert.NotNil(t, dpChain[0].mergeSettings.sortMode)
 		assert.Equal(t, anyOrder, *dpChain[0].mergeSettings.sortMode)
+		_, ok := dpChain[0].mergeSettings.limit.Get()
+		assert.False(t, ok)
 		assert.NotNil(t, dpChain[1].mergeSettings.sortExpr)
 		assert.True(t, sortExpr.Equal(dpChain[1].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr.Limit, must(t, dpChain[1].mergeSettings.limit.Get))
 		assert.NotNil(t, dpChain[2].mergeSettings.sortExpr)
 		assert.True(t, sortExpr.Equal(dpChain[2].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr.Limit, must(t, dpChain[2].mergeSettings.limit.Get))
 	})
 
 	t.Run("Multiple sorts", func(t *testing.T) {
@@ -327,11 +332,13 @@ func Test_setMergeSettings(t *testing.T) {
 			SortEles: []*structs.SortElement{
 				{Field: "foo", Op: "", SortByAsc: true},
 			},
+			Limit: 10,
 		}
 		sortExpr2 := &structs.SortExpr{
 			SortEles: []*structs.SortElement{
 				{Field: "bar", Op: "", SortByAsc: false},
 			},
+			Limit: 20,
 		}
 
 		dpChain := []*DataProcessor{
@@ -347,13 +354,27 @@ func Test_setMergeSettings(t *testing.T) {
 		assert.Equal(t, anyOrder, *searcherMergeSettings.sortMode)
 		assert.NotNil(t, dpChain[0].mergeSettings.sortExpr)
 		assert.True(t, sortExpr1.Equal(dpChain[0].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr1.Limit, must(t, dpChain[0].mergeSettings.limit.Get))
 		assert.NotNil(t, dpChain[1].mergeSettings.sortExpr)
 		assert.True(t, sortExpr1.Equal(dpChain[1].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr1.Limit, must(t, dpChain[1].mergeSettings.limit.Get))
 		assert.NotNil(t, dpChain[2].mergeSettings.sortExpr)
 		assert.True(t, sortExpr1.Equal(dpChain[2].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr1.Limit, must(t, dpChain[2].mergeSettings.limit.Get))
 		assert.NotNil(t, dpChain[3].mergeSettings.sortExpr)
 		assert.True(t, sortExpr2.Equal(dpChain[3].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr2.Limit, must(t, dpChain[3].mergeSettings.limit.Get))
 		assert.NotNil(t, dpChain[4].mergeSettings.sortExpr)
 		assert.True(t, sortExpr2.Equal(dpChain[4].mergeSettings.sortExpr))
+		assert.Equal(t, sortExpr2.Limit, must(t, dpChain[4].mergeSettings.limit.Get))
 	})
+}
+
+func must[V any](t *testing.T, fn func() (V, bool)) V {
+	t.Helper()
+
+	value, ok := fn()
+	assert.True(t, ok)
+
+	return value
 }


### PR DESCRIPTION
# Description
Similar to #2772 but for `sort`

# Testing
Correctness: CICD
Performance: query time dropped from 5.0 seconds to 1.8 seconds for 100 million records on
```
SearchPhrase != "" | sort 10 str(SearchPhrase) | fields SearchPhrase
```