### PR TITLE
Parallelize timechart

### DIFF
--- a/pkg/segment/query/processor/dataprocessor.go
+++ b/pkg/segment/query/processor/dataprocessor.go
@@ -846,7 +846,7 @@ func NewTimechartDP(options *timechartOptions) *DataProcessor {
 		isBottleneckCmd:       true,
 		isTransformingCmd:     true,
 		isTwoPassCmd:          false,
-		isMergeableBottleneck: false, // TODO: implement merging, then set to true.
+		isMergeableBottleneck: true,
 		processorLock:         &sync.Mutex{},
 	}
 }

--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -438,7 +438,7 @@ func SetupQueryParallelism(firstAggHasStats bool, chainFactory func() []*DataPro
 
 		if mergeIndex > 0 {
 			switch dataProcessors[mergeIndex-1].processor.(type) {
-			case *statsProcessor:
+			case *statsProcessor, *timechartProcessor:
 				// We'll likely want to set this for other stats-like commands
 				// as well when we implement parallelizing those. But I'm not
 				// sure why this is an option because I'm not sure when we ever


### PR DESCRIPTION
# Description
Similar to #2772 and #2811 but for `timechart`

# Testing
Tested with 100 million records on
```
ResolutionHeight>1500 | eval height=ResolutionHeight / 10 | timechart span=10m avg(height) as avg, count(height) as count, sum(height) as sum by ResolutionWidth | fields "sum: other"
```
This PR dropped the query time from 10.0 seconds to 3.8 seconds.