### PR TITLE
Optimize segstats on dict encoded columns

### DIFF
--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -404,29 +404,7 @@ func (mcsr *MultiColSegmentReader) IsBlkDictEncoded(cname string,
 	return mcsr.allFileReaders[keyIndex].IsBlkDictEncoded(blkNum)
 }
 
-/*
-parameters:
-
-	results:  map of recNum -> colName -> colValue to be filled in.
-	col:      columnName
-	blockNum: blocknum to search for
-	rnMap:    map of recordNumbers to for which to find the colValue for the given colname
-
-returns:
-
-	bool: if we are able to find the requested column in dict encoding
-*/
-func (mcsr *MultiColSegmentReader) GetDictEncCvalsFromColFileOldPipeline(results map[uint16]map[string]interface{},
-	col string, blockNum uint16, orderedRecNums []uint16, qid uint64,
-) bool {
-	keyIndex, ok := mcsr.allColsReverseIndex[col]
-	if !ok {
-		return false
-	}
-
-	return mcsr.allFileReaders[keyIndex].GetDictEncCvalsFromColFileOldPipeline(results, blockNum, orderedRecNums)
-}
-
+// The results maps column name to the values for the records corresponding to orderedRecNums.
 func (mcsr *MultiColSegmentReader) GetDictEncCvalsFromColFile(results map[string][]sutils.CValueEnclosure,
 	col string, blockNum uint16, orderedRecNums []uint16, qid uint64,
 ) bool {

--- a/pkg/segment/reader/segread/segreader/segreader.go
+++ b/pkg/segment/reader/segread/segreader/segreader.go
@@ -630,26 +630,6 @@ func (sfr *SegmentFileReader) unpackRawCsg(buf []byte, blockNum uint16) error {
 	return nil
 }
 
-func (sfr *SegmentFileReader) GetDictEncCvalsFromColFileOldPipeline(results map[uint16]map[string]interface{},
-	blockNum uint16, orderedRecNums []uint16,
-) bool {
-	if !sfr.isBlockLoaded || sfr.currBlockNum != blockNum {
-		valid, err := sfr.readBlock(blockNum)
-		if !valid {
-			return false
-		}
-		if err != nil {
-			return false
-		}
-	}
-
-	if sfr.encType != sutils.ZSTD_DICTIONARY_BLOCK[0] {
-		return false
-	}
-
-	return sfr.DeToResultOldPipeline(results, orderedRecNums)
-}
-
 func (sfr *SegmentFileReader) GetDictEncCvalsFromColFile(results map[string][]sutils.CValueEnclosure,
 	blockNum uint16, orderedRecNums []uint16,
 ) bool {

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -1066,14 +1066,18 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 			retVal[colName] = true
 			continue
 		}
-		results := make(map[uint16]map[string]interface{})
-		ok := mcr.GetDictEncCvalsFromColFileOldPipeline(results, colName, blockNum, filterdRecNums, qid)
+		results := map[string][]sutils.CValueEnclosure{
+			colName: make([]sutils.CValueEnclosure, len(filterdRecNums)),
+		}
+		ok := mcr.GetDictEncCvalsFromColFile(results, colName, blockNum, filterdRecNums, qid)
 		if !ok {
 			log.Errorf("qid=%d, segmentStatsWorker failed to get dict cvals for col %s", qid, colName)
 			continue
 		}
-		for recNum, cMap := range results {
-			for colName, rawVal := range cMap {
+
+		for colName, rawVals := range results {
+			for i, rawVal := range rawVals {
+				recNum := filterdRecNums[i]
 				addValsToTimeStats(lStats, colName, latestTs, earliestTs, rawVal, mcr, needLatestOrEarliest, blockNum, recNum, qid)
 				colUsage, exists := aggColUsage[colName]
 				if !exists {
@@ -1113,7 +1117,7 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 					}
 				}
 
-				if rawVal == nil {
+				if rawVal.IsNull() {
 					continue
 				}
 
@@ -1130,12 +1134,15 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 					hasPercFunc = false
 				}
 
-				switch val := rawVal.(type) {
-				case string:
+				switch rawVal.Dtype {
+				case sutils.SS_DT_STRING:
+					val := rawVal.CVal.(string)
 					stats.AddSegStatsStr(lStats, colName, val, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
-				case int64:
+				case sutils.SS_DT_SIGNED_NUM:
+					val := rawVal.CVal.(int64)
 					stats.AddSegStatsNums(lStats, colName, sutils.SS_INT64, val, 0, 0, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
-				case float64:
+				case sutils.SS_DT_FLOAT:
+					val := rawVal.CVal.(float64)
 					stats.AddSegStatsNums(lStats, colName, sutils.SS_FLOAT64, 0, 0, val, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				default:
 					// This means the column is not dict encoded. So add it to the return value


### PR DESCRIPTION
# Description
Computing segment stats on dict encoded measure columns was using an old pipeline flow that was causing a lot of map iteration. This PR updates it to the new flow; this uses slice iteration and results in much better CPU performance.

# Testing
Tested on 
```
ResolutionWidth>100 | stats avg(Age)
```
This PR decreased the query time from 11.8 to 3.5 seconds.