### PR TITLE
Optimize segstats queries on non-DE columns

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -966,8 +966,14 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 			nonDeColsKeyIndices[timestampColKeyIdx] = timestampKey
 		}
 
+		// Convert to slice to optimize read-only iteration.
+		nonDeIdxAndNames := utils.MapToSlice(nonDeColsKeyIndices)
+
 		for _, recNum := range sortedMatchedRecs {
-			for colKeyIdx, cname := range nonDeColsKeyIndices {
+			for _, kvPair := range nonDeIdxAndNames {
+				colKeyIdx := kvPair.Key
+				cname := kvPair.Value
+
 				isTsCol := colKeyIdx == timestampColKeyIdx
 				err := multiReader.ExtractValueFromColumnFile(colKeyIdx, blockStatus.BlockNum,
 					recNum, qid, isTsCol, &cValEnc)


### PR DESCRIPTION
# Description
Summarize the change. Link to an issue like "Fixes #{issue-number}" if applicable.

# Testing
Decreased query time by 10% for
```
ResolutionWidth>100 | stats max(ClientIP)
```