### PR TITLE
Remove string allocation for inserting into HLL

### DIFF
--- a/pkg/segment/query/processor/statscommand.go
+++ b/pkg/segment/query/processor/statscommand.go
@@ -18,7 +18,6 @@
 package processor
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/siglens/siglens/pkg/config"
@@ -320,15 +319,9 @@ func (p *statsProcessor) processMeasureOperations(inputIQR *iqr.IQR) (*iqr.IQR, 
 			if values[i].IsString() {
 				stats.AddSegStatsStr(segStatsMap, colName, values[i].CVal.(string), p.byteBuffer, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 			} else if values[i].IsNumeric() {
-				stringVal, err := values[i].GetString()
-				if err != nil {
-					p.errorData.cValueGetStringErr[colName] = err
-					stringVal = fmt.Sprintf("%v", values[i].CVal)
-				}
-
 				if values[i].IsFloat() {
 					stats.AddSegStatsNums(segStatsMap, colName, sutils.SS_FLOAT64, 0, 0, values[i].CVal.(float64),
-						stringVal, p.byteBuffer, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+						p.byteBuffer, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				} else {
 					intVal, err := values[i].GetIntValue()
 					if err != nil {
@@ -337,7 +330,7 @@ func (p *statsProcessor) processMeasureOperations(inputIQR *iqr.IQR) (*iqr.IQR, 
 						intVal = 0
 					}
 
-					stats.AddSegStatsNums(segStatsMap, colName, sutils.SS_INT64, intVal, 0, 0, stringVal, p.byteBuffer, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+					stats.AddSegStatsNums(segStatsMap, colName, sutils.SS_INT64, intVal, 0, 0, p.byteBuffer, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				}
 			} else {
 				p.errorData.notSupportedStatsType[colName] = struct{}{}

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -1012,16 +1012,13 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 					var floatVal float64
 					var intVal int64
 					var valueType sutils.SS_IntUintFloatTypes
-					var numStr string
 					var err error
 					if cValEnc.IsFloat() {
 						valueType = sutils.SS_FLOAT64
 						floatVal, err = cValEnc.GetFloatValue()
-						numStr = fmt.Sprintf("%v", floatVal)
 					} else {
 						valueType = sutils.SS_INT64
 						intVal, err = cValEnc.GetIntValue()
-						numStr = fmt.Sprintf("%v", intVal)
 					}
 
 					if err != nil {
@@ -1029,7 +1026,7 @@ func segmentStatsWorker(statRes *segresults.StatsResults, mCols map[string]bool,
 						continue
 					}
 
-					stats.AddSegStatsNums(localStats, cname, valueType, intVal, 0, floatVal, numStr, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+					stats.AddSegStatsNums(localStats, cname, valueType, intVal, 0, floatVal, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				}
 			}
 		}
@@ -1145,10 +1142,10 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 					stats.AddSegStatsStr(lStats, colName, val, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				case sutils.SS_DT_SIGNED_NUM:
 					val := rawVal.CVal.(int64)
-					stats.AddSegStatsNums(lStats, colName, sutils.SS_INT64, val, 0, 0, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+					stats.AddSegStatsNums(lStats, colName, sutils.SS_INT64, val, 0, 0, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				case sutils.SS_DT_FLOAT:
 					val := rawVal.CVal.(float64)
-					stats.AddSegStatsNums(lStats, colName, sutils.SS_FLOAT64, 0, 0, val, fmt.Sprintf("%v", val), bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+					stats.AddSegStatsNums(lStats, colName, sutils.SS_FLOAT64, 0, 0, val, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 				default:
 					// This means the column is not dict encoded. So add it to the return value
 					retVal[colName] = true

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -46,7 +46,7 @@ func GetDefaultTimeStats() *TimeStats {
 
 func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 	inNumType SS_IntUintFloatTypes, intVal int64, uintVal uint64,
-	fltVal float64, numstr string, bb *bbp.ByteBuffer, aggColUsage map[string]AggColUsageMode, hasValuesFunc bool, hasListFunc bool, hasPercFunc bool) {
+	fltVal float64, bb *bbp.ByteBuffer, aggColUsage map[string]AggColUsageMode, hasValuesFunc bool, hasListFunc bool, hasPercFunc bool) {
 
 	var stats *SegStats
 	var ok bool
@@ -377,7 +377,7 @@ func AddSegStatsStr(segstats map[string]*SegStats, cname string, strVal string,
 
 	floatVal, err := strconv.ParseFloat(strVal, 64)
 	if err == nil {
-		AddSegStatsNums(segstats, cname, SS_FLOAT64, 0, 0, floatVal, strVal, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
+		AddSegStatsNums(segstats, cname, SS_FLOAT64, 0, 0, floatVal, bb, aggColUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 		return
 	}
 

--- a/pkg/segment/writer/stats/segstats.go
+++ b/pkg/segment/writer/stats/segstats.go
@@ -74,9 +74,19 @@ func AddSegStatsNums(segstats map[string]*SegStats, cname string,
 		}
 	}
 
-	bb.Reset()
-	_, _ = bb.WriteString(numstr)
-	stats.InsertIntoHll(bb.B)
+	bytes := [8]byte{}
+	switch inNumType {
+	case SS_UINT8, SS_UINT16, SS_UINT32, SS_UINT64:
+		utils.Uint64ToBytesLittleEndianInplace(uintVal, bytes[:])
+	case SS_INT8, SS_INT16, SS_INT32, SS_INT64:
+		utils.Int64ToBytesLittleEndianInplace(intVal, bytes[:])
+	case SS_FLOAT64:
+		utils.Float64ToBytesLittleEndianInplace(fltVal, bytes[:])
+	default:
+		log.Warnf("AddSegStatsNums: unsupported inNumType: %v", inNumType)
+		return
+	}
+	stats.InsertIntoHll(bytes[:])
 	processStats(stats, inNumType, intVal, uintVal, fltVal, colUsage, hasValuesFunc, hasListFunc, hasPercFunc)
 }
 

--- a/pkg/segment/writer/stats/segstats_test.go
+++ b/pkg/segment/writer/stats/segstats_test.go
@@ -49,11 +49,11 @@ func Test_addSegStatsNums(t *testing.T) {
 	sst := make(map[string]*SegStats)
 	bb := bbp.Get()
 
-	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(2345), 0, "2345", bb, nil, false, false, false)
+	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(2345), 0, bb, nil, false, false, false)
 	assert.NotEqual(t, SS_DT_FLOAT, sst[cname].Min.Dtype)
 	assert.Equal(t, int64(2345), sst[cname].Min.CVal)
 
-	AddSegStatsNums(sst, cname, SS_FLOAT64, 0, 0, float64(345.1), "345.1", bb, nil, false, false, false)
+	AddSegStatsNums(sst, cname, SS_FLOAT64, 0, 0, float64(345.1), bb, nil, false, false, false)
 	assert.Equal(t, SS_DT_FLOAT, sst[cname].Min.Dtype)
 	assert.Equal(t, float64(345.1), sst[cname].Min.CVal)
 
@@ -69,9 +69,9 @@ func Test_addSegStatsNumsMixed(t *testing.T) {
 	bb := bbp.Get()
 
 	AddSegStatsStr(sst, cname, "abc", bb, nil, false, false, false)
-	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(100), 0, "100", bb, nil, false, false, false)
+	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(100), 0, bb, nil, false, false, false)
 	AddSegStatsStr(sst, cname, "def", bb, nil, false, false, false)
-	AddSegStatsNums(sst, cname, SS_FLOAT64, 0, 0, float64(123.45), "123.45", bb, nil, false, false, false)
+	AddSegStatsNums(sst, cname, SS_FLOAT64, 0, 0, float64(123.45), bb, nil, false, false, false)
 	AddSegStatsStr(sst, cname, "20", bb, nil, false, false, false)
 	AddSegStatsStr(sst, cname, "xyz", bb, nil, false, false, false)
 
@@ -98,17 +98,17 @@ func Test_addSegStatsNumsForEvalFunc(t *testing.T) {
 	aggColUsage["duration"] = WithEvalUsage
 	aggColUsage["latitude"] = NoEvalUsage
 
-	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(111), 0, "111", bb, aggColUsage, false, false, false)
-	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(333), 0, "333", bb, aggColUsage, false, false, false)
-	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(222), 0, "222", bb, aggColUsage, false, false, false)
+	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(111), 0, bb, aggColUsage, false, false, false)
+	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(333), 0, bb, aggColUsage, false, false, false)
+	AddSegStatsNums(sst, cname, SS_UINT64, 0, uint64(222), 0, bb, aggColUsage, false, false, false)
 	assert.Len(t, sst[cname].Records, 3)
 	assert.Equal(t, int64(111), sst[cname].Records[0].CVal)
 	assert.Equal(t, int64(333), sst[cname].Records[1].CVal)
 	assert.Equal(t, int64(222), sst[cname].Records[2].CVal)
 
 	aggColUsage["latitude"] = NoEvalUsage
-	AddSegStatsNums(sst, cname2, SS_FLOAT64, 0, 0, 40.7128, "40.7128", bb, aggColUsage, false, false, false)
-	AddSegStatsNums(sst, cname2, SS_FLOAT64, 0, 0, -10.5218, "-10.5218", bb, aggColUsage, false, false, false)
+	AddSegStatsNums(sst, cname2, SS_FLOAT64, 0, 0, 40.7128, bb, aggColUsage, false, false, false)
+	AddSegStatsNums(sst, cname2, SS_FLOAT64, 0, 0, -10.5218, bb, aggColUsage, false, false, false)
 	assert.Len(t, sst[cname2].Records, 0)
 }
 


### PR DESCRIPTION
# Description
For numeric stats, we were converting the number to a string, getting `[]byte` from the string, and inserting that into an HLL. With this PR we go directly from number to `[]byte` by using little endian encoding. This avoids making a lot of strings, which gives a significant performance improvement.

# Testing
Decreased query time for
```
ResolutionWidth>100 | stats max(ClientIP)
```
from 4.1 to 2.6 seconds.