### PR TITLE
Improve sorting performance with small limit

### DIFF
--- a/pkg/utils/heap.go
+++ b/pkg/utils/heap.go
@@ -87,6 +87,14 @@ func (h *Heap[T]) PopValue() T {
 	return heap.Pop(h).(*HeapItem[T]).Value
 }
 
+func (h *Heap[T]) Peek() T {
+	if h.Len() == 0 {
+		var zero T
+		return zero
+	}
+	return h.items[0].Value
+}
+
 func GetTopN[T any](N int, items []T, less lessFunc[T]) []T {
 	// Create min-heap (smaller items at root)
 	h := NewHeap(func(a, b T) bool {
@@ -95,11 +103,15 @@ func GetTopN[T any](N int, items []T, less lessFunc[T]) []T {
 
 	// Process all items
 	for _, item := range items {
-		h.PushValue(item)
-
-		// If we have more than N items, remove the smallest
-		if h.Len() > N {
-			h.PopValue()
+		if h.Len() < N {
+			// Heap not at capacity, push directly
+			h.PushValue(item)
+		} else {
+			// Heap at capacity, only push if item is better than current minimum
+			if less(item, h.Peek()) {
+				h.PopValue()
+				h.PushValue(item)
+			}
 		}
 	}
 

--- a/pkg/utils/heap.go
+++ b/pkg/utils/heap.go
@@ -87,7 +87,7 @@ func (h *Heap[T]) PopValue() T {
 	return heap.Pop(h).(*HeapItem[T]).Value
 }
 
-func (h *Heap[T]) Peek() T {
+func (h *Heap[T]) peek() T {
 	if h.Len() == 0 {
 		var zero T
 		return zero
@@ -108,7 +108,7 @@ func GetTopN[T any](N int, items []T, less lessFunc[T]) []T {
 			h.PushValue(item)
 		} else {
 			// Heap at capacity, only push if item is better than current minimum
-			if less(item, h.Peek()) {
+			if less(item, h.peek()) {
 				h.PopValue()
 				h.PushValue(item)
 			}

--- a/pkg/utils/heap_test.go
+++ b/pkg/utils/heap_test.go
@@ -19,7 +19,10 @@ package utils
 
 import (
 	"container/heap"
+	"math/rand"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -99,4 +102,28 @@ func Test_TopN(t *testing.T) {
 
 	assert.Equal(t, 5, len(top5))
 	assert.Equal(t, []int{9, 9, 9, 8, 7}, top5)
+}
+
+func Test_TopN_Random(t *testing.T) {
+	seed := time.Now().UnixNano()
+	rng := rand.New(rand.NewSource(seed))
+	numItems := 50
+	data := make([]int, numItems)
+	for i := 0; i < numItems; i++ {
+		data[i] = rng.Intn(100)
+	}
+
+	compareFn := func(a, b int) bool {
+		return a > b
+	}
+
+	actualTop10 := GetTopN(10, data, compareFn)
+
+	// Find the expectd top 10 values.
+	sort.Slice(data, func(i, j int) bool {
+		return compareFn(data[i], data[j])
+	})
+	expectedTop10 := data[:10]
+
+	assert.Equal(t, expectedTop10, actualTop10, "Mismatch for seed %d", seed)
 }


### PR DESCRIPTION
# Description
To evaluate queries with a `sort` command where only the top `N` results are kept and `N` is small (< 1000), we use a heap to do the sorting. When the heap is at capacity, we were pushing each item and then popping an item. With this PR, we only push if we're not going to immediately pop the same item.

# Testing
Decreased this query time by about 15%
```
SearchPhrase != "" | sort 10 str(EventTime) | fields SearchPhrase, EventTime
```