### PR TITLE
Init map with correct size

### DIFF
--- a/pkg/segment/reader/segread/multicolreader.go
+++ b/pkg/segment/reader/segread/multicolreader.go
@@ -119,7 +119,7 @@ func initNewMultiColumnReader(segKey string, colFDs map[string]*os.File,
 
 	for colName, colFD := range colFDs {
 		if colName == tsKey {
-			blkRecCount := make(map[uint16]uint16)
+			blkRecCount := make(map[uint16]uint16, len(blockSummaries))
 			for blkIdx, blkSum := range blockSummaries {
 				blkRecCount[uint16(blkIdx)] = blkSum.RecCount
 			}


### PR DESCRIPTION
# Description
Summarize the change. Link to an issue like "Fixes #{issue-number}" if applicable.

# Testing
With 100 million records, this query
```
CounterID=62 DontCountHits = 0 IsRefresh = 0 
| eval ptime = strptime(EventDate,"%Y-%m-%d") 
| where ptime >= 1372636800 AND ptime <= 1375228800
| stats count
```
response time dropped from 1.58 to 1.18 seconds