### PR TITLE
Remove unneeded alloc for some DE-column queries

### DIFF
--- a/pkg/segment/search/conditioncheck.go
+++ b/pkg/segment/search/conditioncheck.go
@@ -194,6 +194,7 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 	dictEncColNames := make(map[string]bool)
 
 	var validRecords []uint
+	var allRecordsAreValid bool
 	if searchReq.BlockToValidRecNums != nil {
 		records, ok := searchReq.BlockToValidRecNums[blockNum]
 		if !ok {
@@ -207,16 +208,19 @@ func applyColumnarSearchUsingDictEnc(sq *SearchQuery, mcr *segread.MultiColSegme
 
 		bsh.SetValidRecords(validRecords)
 	} else {
-		validRecords = make([]uint, bri.AllRecLen)
-		for i := uint16(0); i < bri.AllRecLen; i++ {
-			validRecords[i] = uint(i)
-		}
+		allRecordsAreValid = true
 	}
 
 	switch sq.SearchType {
 	case MatchAll:
-		for _, recNum := range validRecords {
-			bsh.AddMatchedRecord(uint(recNum))
+		if allRecordsAreValid {
+			for i := uint16(0); i < bri.AllRecLen; i++ {
+				bsh.AddMatchedRecord(uint(i))
+			}
+		} else {
+			for _, recNum := range validRecords {
+				bsh.AddMatchedRecord(uint(recNum))
+			}
 		}
 		return false, dictEncColNames, nil
 


### PR DESCRIPTION
# Description
See title

# Testing
With 100 million records, this PR saved around 600 MB of allocations for
```
CounterID=62 DontCountHits = 0 IsRefresh = 0 
| eval ptime = strptime(EventDate,"%Y-%m-%d") 
| where ptime >= 1372636800 AND ptime <= 1375228800
| stats count
```
Very little effect on query response time.