### PR TITLE
FIX: Make PQS Query Text Selectable

### DIFF
--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -6751,6 +6751,11 @@ p#versionInfo {
 
 #pqs-id-details {
     height: 80vh;
+    width: 514px !important;
+}
+
+.text-cursor {
+    cursor: text !important;
 }
 
 #clear-pqs-info,

--- a/static/js/pqs-settings.js
+++ b/static/js/pqs-settings.js
@@ -152,7 +152,7 @@ function createTable(data) {
             flex: 0,
             valueFormatter: (params) => formatEpochToReadable(params.value),
         },
-        { headerName: 'Search Text', field: 'search_text', sortable: true, filter: true, flex: 1 },
+        { headerName: 'Search Text', field: 'search_text', sortable: true, filter: true, flex: 1, cellClass: 'text-cursor align-center-grid' },
     ];
 
     const aggregationRowData = data.promoted_aggregations.map((item) => ({
@@ -172,8 +172,8 @@ function createTable(data) {
     const aggregationGridOptions = {
         columnDefs: columnDefs,
         rowData: aggregationRowData,
-        onRowClicked: function (event) {
-            if (event.data.id && event.data.id !== 'Total Tracked Aggregations') {
+        onCellClicked: function (event) {
+            if (event.data.id && event.data.id !== 'Total Tracked Aggregations' && event.colDef.field !== 'search_text') {
                 fetchDetails(event.data.id);
             }
         },
@@ -185,6 +185,8 @@ function createTable(data) {
         rowHeight: 34,
         pinnedBottomRowData: [aggregationTotalRow],
         suppressDragLeaveHidesColumns: true,
+        suppressRowClickSelection: true,
+        enableCellTextSelection: true,
     };
 
     const searchRowData = data.promoted_searches.map((item) => ({
@@ -204,8 +206,8 @@ function createTable(data) {
     const searchGridOptions = {
         columnDefs: columnDefs,
         rowData: searchRowData,
-        onRowClicked: function (event) {
-            if (event.data.id && event.data.id !== 'Total Tracked Searches') {
+        onCellClicked: function (event) {
+            if (event.data.id && event.data.id !== 'Total Tracked Searches' && event.colDef.field !== 'search_text') {
                 fetchDetails(event.data.id);
             }
         },
@@ -216,6 +218,8 @@ function createTable(data) {
         headerHeight: 26,
         rowHeight: 34,
         pinnedBottomRowData: [searchTotalRow],
+        suppressRowClickSelection: true,
+        enableCellTextSelection: true,
         suppressDragLeaveHidesColumns: true,
     };
 


### PR DESCRIPTION
# Description
- Fixed an issue on the My Org → PQS page where users were unable to copy the displayed query text.
- Updated the behavior so that:
  - Users can now select and copy the query text directly.
  - The PQS details popup only opens when clicking on other columns, not on the query text itself.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/4e8d9213-c04e-4fa7-8742-b765b1203aa6" />
