### PR TITLE
Float equality comparison in SPL parser tests

### DIFF
--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10204,7 +10204,7 @@ func testSingleAggregateFunction(t *testing.T, aggFunc sutils.AggregateFunctions
 	assert.Equal(t, aggregator.PipeCommandType, structs.MeasureAggsType)
 	assert.Len(t, aggregator.MeasureOperations, 1)
 	assert.Equal(t, aggregator.MeasureOperations[0].MeasureCol, measureCol)
-	assert.Equal(t, aggregator.MeasureOperations[0].Param, param)
+	assert.LessOrEqual(t, math.Abs(aggregator.MeasureOperations[0].Param-param), 1e-6)
 }
 
 func performCommon_aggEval_BoolExpr(t *testing.T, measureFunc sutils.AggregateFunctions) {


### PR DESCRIPTION
# Description
Pretty self-explanatory; I got the below error while running `make pr`
```
--- FAIL: Test_Aggs (0.07s)
    splParser_test.go:10207:
                Error Trace:    /siglens/pkg/ast/spl/tests/splParser_test.go:10207
                                                        /siglens/pkg/ast/spl/tests/splParser_test.go:10384
                Error:          Not equal:
                                expected: 47.895294267132456
                                actual  : 47.89529426713246
                Test:           Test_Aggs
```