### PR TITLE
Fix Theme Update Not Reflecting on Dashboard Graphs

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -113,7 +113,7 @@ $(document).ready(async function () {
         }
     });
 
-    $('#theme-btn').click(() => displayPanels());
+    $('#theme-btn').click(() => updateDashboardTheme());
     getDashboardData();
 
     $('#favbutton').on('click', toggleFavorite);
@@ -1429,4 +1429,60 @@ function resetToOriginalQueries() {
         }
     });
     originalQueries = {};
+}
+
+function updateDashboardTheme() {
+    console.log('updateDashboardTheme function called');
+    const { gridLineColor, tickColor } = getGraphGridColors();
+
+    // Update Chart.js charts (Line and Bar Chart)
+    function updateChartJS(selector) {
+        $(selector).each(function () {
+            const chart = Chart.getChart(this);
+            if (chart?.options?.scales) {
+                const axes = ['x', 'y', 'y1'];
+
+                axes.forEach((axis) => {
+                    if (chart.options.scales[axis]) {
+                        chart.options.scales[axis].ticks.color = tickColor;
+
+                        if (!chart.options.scales[axis].grid) {
+                            chart.options.scales[axis].grid = {};
+                        }
+                        chart.options.scales[axis].grid.color = gridLineColor;
+                    }
+                });
+
+                if (chart.options.plugins?.legend?.labels) {
+                    chart.options.plugins.legend.labels.color = tickColor;
+                }
+
+                chart.update();
+            }
+        });
+    }
+
+    updateChartJS('.bar-chart-canvas');
+    updateChartJS('.metrics-canvas');
+
+    // Update ECharts instances (Pie charts)
+    $('.panEdit-panel').each(function () {
+        const instanceId = $(this).attr('_echarts_instance_');
+        if (instanceId) {
+            const instance = echarts.getInstanceById(instanceId);
+            if (instance) {
+                const option = instance.getOption();
+
+                // Update legend and label colors
+                if (option.legend?.[0]) {
+                    option.legend[0].textStyle = { ...option.legend[0].textStyle, color: tickColor };
+                }
+                if (option.series?.[0]?.label) {
+                    option.series[0].label = { ...option.series[0].label, color: tickColor };
+                }
+
+                instance.setOption(option);
+            }
+        }
+    });
 }

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -2320,7 +2320,7 @@ function mergeGraphs(chartType, panelId = -1) {
             panelChartEl.css('width', '100%').css('height', '100%');
 
             panelChartEl.empty(); // Clear any existing content
-            mergedCanvas = $('<canvas></canvas>');
+            mergedCanvas = $('<canvas class="metrics-canvas"></canvas>');
             panelChartEl.append(mergedCanvas);
         }
         mergedCtx = mergedCanvas[0].getContext('2d');
@@ -3117,12 +3117,13 @@ function updateChartColorsBasedOnTheme() {
     for (const queryName in chartDataCollection) {
         if (Object.prototype.hasOwnProperty.call(chartDataCollection, queryName)) {
             const lineChart = lineCharts[queryName];
-
-            lineChart.options.scales.x.ticks.color = tickColor;
-            lineChart.options.scales.y.ticks.color = tickColor;
-            lineChart.options.scales.x.grid.color = gridLineColor;
-            lineChart.options.scales.y.grid.color = gridLineColor;
-            lineChart.update();
+            if (lineChart) {
+                lineChart.options.scales.x.ticks.color = tickColor;
+                lineChart.options.scales.y.ticks.color = tickColor;
+                lineChart.options.scales.x.grid.color = gridLineColor;
+                lineChart.options.scales.y.grid.color = gridLineColor;
+                lineChart.update();
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
Resolved an issue where updating the theme on the main dashboards screen did not properly update the grid lines and labels of the graphs. Previously, this required an additional backend call to refresh the graph. Now, the theme is applied directly without triggering any backend call.