### PR TITLE
Fix: rawVal not passed in dict encoded columns for latest/earliest

### DIFF
--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -1088,7 +1088,7 @@ func applySegmentStatsUsingDictEncoding(mcr *segread.MultiColSegmentReader, filt
 		for colName, rawVals := range results {
 			for i, rawVal := range rawVals {
 				recNum := filterdRecNums[i]
-				addValsToTimeStats(lStats, colName, latestTs, earliestTs, rawVal, mcr, needLatestOrEarliest, blockNum, recNum, qid)
+				addValsToTimeStats(lStats, colName, latestTs, earliestTs, rawVal.CVal, mcr, needLatestOrEarliest, blockNum, recNum, qid)
 				colUsage, exists := aggColUsage[colName]
 				if !exists {
 					colUsage = sutils.NoEvalUsage


### PR DESCRIPTION
# Description
In dict encoded columns rawVal was incorrectly passed resulting in datatype to be set to `SS_DT_INVALID`.
