### PR TITLE
Register custom Gob types

### DIFF
--- a/pkg/utils/gobutils.go
+++ b/pkg/utils/gobutils.go
@@ -28,6 +28,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+func init() {
+	gob.Register(&GobbableRegex{})
+	gob.Register(&GobbableList{})
+	gob.Register(&GobbableTDigest{})
+	gob.Register(&GobbableHll{})
+}
+
 type GobbableRegex struct {
 	rawRegex      string
 	compiledRegex *regexp.Regexp


### PR DESCRIPTION
# Description
This registers our custom types that implement the gob encode/decode interfaces so that these custom implementations get called even if these types are passed as `interface{}` values.

From the [documentation](https://pkg.go.dev/encoding/gob#Register)
> Register records a type, identified by a value for that type, under its internal type name. That name will identify the concrete type of a value sent or received as an interface variable. Only types that will be transferred as implementations of interface values need to be registered. Expecting to be used only during initialization, it panics if the mapping between types and names is not a bijection.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
