### PR TITLE
Fix: Console Error When No Index Is Present

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -31,7 +31,7 @@ async function getListIndices() {
             return response.json();
         })
         .then(function (res) {
-            if (!res) {
+            if (!res || !Array.isArray(res) || res.length === 0) {
                 return null;
             }
             sortedListIndices = res.sort();


### PR DESCRIPTION
# Description
- Previously, the backend returned `null` when no indexes were available, which was handled correctly.
- Now it returns an empty array `[]`, but the frontend was not updated accordingly.
- This fix updates the code to handle an empty array properly and prevents console errors when no index is present.
